### PR TITLE
Add strokeWidth property to control text halo radius. Fixes #308

### DIFF
--- a/STYLING.md
+++ b/STYLING.md
@@ -147,7 +147,7 @@ Values of all properties can also be the name of a constant defined earlier.
 Some properties are only supported by some types:
 
 #### Line
-`color`, `width`, `image`, `translate`, `dasharray`, `opacity`, `antialias`
+`color`, `width`, `image`, `translate`, `dasharray`, `opacity`, `antialias`, `blur`
 
 #### Fill
 `color`, `image`, `stroke`, `translate`, `opacity`, `antialias`
@@ -159,7 +159,7 @@ Some properties are only supported by some types:
 #### Text
 `color`, `translate`, `opacity`
 `stroke` is the color of the halo
-
+`strokeWidth` is the radius of the halo
 
 ### Functions
 Functions are used to change values according to zoom level. There are four types of functions:

--- a/debug/debug.js
+++ b/debug/debug.js
@@ -35,6 +35,7 @@ function addColors(map, style) {
     var colors = gui.addFolder('Colors');
     var stylesheet = map.style.stylesheet;
     colors.add(stylesheet.constants, 'road_blur', 0, 50).name('Road Blur').onChange(rerender);
+    colors.add(stylesheet.constants, 'stroke_width', 0, 1).name('Text Halo').onChange(rerender);
     colors.add(stylesheet.constants, 'satellite_brightness_low', 0, 1).name('Low').onChange(rerender);
     colors.add(stylesheet.constants, 'satellite_brightness_high', 0, 1).name('High').onChange(rerender);
     colors.add(stylesheet.constants, 'satellite_saturation', 0, 4).name('Saturation').onChange(rerender);

--- a/debug/style.js
+++ b/debug/style.js
@@ -176,7 +176,8 @@ var style_json = {
         "satellite_brightness_high": 1,
         "satellite_saturation": 1,
         "satellite_spin": 0,
-        "road_blur": 1
+        "road_blur": 1,
+        "stroke_width": 0.25
     },
     "structure": [
     {
@@ -436,15 +437,18 @@ var style_json = {
             },
             "country_label": {
                 "stroke": [1,1,1,0.7],
+                "strokeWidth": "stroke_width",
                 "color": "text"
             },
             "place_label": {
                 "stroke": [1,1,1,0.7],
+                "strokeWidth": "stroke_width",
                 "color": "text"
             },
             "road_label": {
                 "color": "text",
                 "stroke": [1,1,1,0.7],
+                "strokeWidth": "stroke_width",
                 "size": ["exponential", 14, 8, 1, 8, 12]
             }
         }

--- a/js/render/drawtext.js
+++ b/js/render/drawtext.js
@@ -107,7 +107,8 @@ function drawText(gl, painter, bucket, layerStyle, params) {
     if (layerStyle.stroke) {
         // Draw halo underneath the text.
         gl.uniform4fv(shader.u_color, layerStyle.stroke);
-        gl.uniform1f(shader.u_buffer, 64 / 256);
+        gl.uniform1f(shader.u_buffer, layerStyle.strokeWidth === undefined ?
+            64 / 256 : layerStyle.strokeWidth);
 
         gl.drawArrays(gl.TRIANGLES, begin, len);
     }

--- a/js/style/styledeclaration.js
+++ b/js/style/styledeclaration.js
@@ -41,6 +41,7 @@ StyleDeclaration.prototype.parsers = {
     offset: parseWidth,
     radius: parseWidth,
     blur: parseWidth,
+    strokeWidth: parseWidth,
     size: parseWidth,
     rotate: parseWidth,
 


### PR DESCRIPTION
Seems ready to go. This could be called `halo_radius` or `stroke_width` or `strokeWidth` or `width`. I went for strokeWidth because it is explicit about not being text width, and there were a few other camelcase properties, and we already have stroke instead of halo terminology.
