### PR TITLE
Glyphsproto err return

### DIFF
--- a/js/worker/workertile.js
+++ b/js/worker/workertile.js
@@ -297,7 +297,7 @@ WorkerTile.prototype.parseTextBucket = function(features, bucket, info, faces, l
     }
 
     Loader.whenLoaded(tile, fontstack, ranges, function(err) {
-        if (err) callback(err);
+        if (err) return callback(err);
 
         var stacks = {};
         stacks[fontstack] = {};
@@ -310,7 +310,7 @@ WorkerTile.prototype.parseTextBucket = function(features, bucket, info, faces, l
             id: tile.id,
             stacks: stacks
         }, function(err, rects) {
-            if (err) callback(err);
+            if (err) return callback(err);
 
             // Merge the rectangles of the glyph positions into the face object
             for (var name in rects) {


### PR DESCRIPTION
For quick review -- was seeing some JS errors in cases where workers were continuing on even though things had errored out (usually this case https://github.com/mapbox/llmr/blob/master/js/ui/map.js#L305).
