### PR TITLE
don't draw zero-width lines

### DIFF
--- a/js/render/drawline.js
+++ b/js/render/drawline.js
@@ -7,7 +7,7 @@ module.exports = function drawLine(gl, painter, bucket, layerStyle, posMatrix, p
     posMatrix = painter.translateMatrix(posMatrix, layerStyle['line-translate'], params.z);
 
     // don't draw zero-width lines
-    if (layerStyle['line-width'] === 0) return;
+    if (layerStyle['line-width'] <= 0) return;
 
     var lineOffset = layerStyle['line-offset'] / 2;
     var inset = Math.max(-1, lineOffset - layerStyle['line-width'] / 2 - 0.5) + 1;


### PR DESCRIPTION
Because of antialiasing [here](https://github.com/mapbox/mapbox-gl-js/blob/noline/js/render/drawline.js#L14)

```
var outset = lineOffset + layerStyle['line-width'] / 2 + 0.5;
```

currently line-width 0 is being drawn as 0.5.
Any reason not to do this?
