### PR TITLE
Fix up remove tile call params

### DIFF
--- a/js/ui/vectortile.js
+++ b/js/ui/vectortile.js
@@ -68,7 +68,7 @@ VectorTile.prototype.onTileLoad = function(data) {
 };
 
 VectorTile.prototype.remove = function() {
-    this.map.dispatcher.send('remove tile', this.id, null, this.workerID);
+    this.map.dispatcher.send('remove tile', { id: this.id, source: this.source.id }, null, this.workerID);
     this.map.painter.glyphAtlas.removeGlyphs(this.id);
 
     var gl = this.map.painter.gl;

--- a/js/worker/worker.js
+++ b/js/worker/worker.js
@@ -56,7 +56,9 @@ util.extend(Worker.prototype, {
         WorkerTile.cancel(params.id, params.source);
     },
 
-    'remove tile': function(id, source) {
+    'remove tile': function(params) {
+        var id = params.id;
+        var source = params.source;
         if (WorkerTile.loaded[source] && WorkerTile.loaded[source][id]) {
             delete WorkerTile.loaded[source][id];
         }


### PR DESCRIPTION
Looks like this got lost in the shuffle of a refactor. Fixes unbounded memory growth from tiles not being reaped.
