### PR TITLE
Call source.update() when tilejson is loaded

### DIFF
--- a/js/ui/source.js
+++ b/js/ui/source.js
@@ -37,6 +37,7 @@ function Source(options) {
         this.tileJSON = tileJSON;
         this.loadNewTiles = true;
         this.enabled = true;
+        this.update();
     }.bind(this));
 }
 
@@ -230,7 +231,7 @@ util.extend(Source.prototype, {
 
     // Removes tiles that are outside the viewport and adds new tiles that are inside the viewport.
     _updateTiles: function() {
-        if (!this.map.loadNewTiles || !this.loadNewTiles || !this.map.style.sources[this.id]) return;
+        if (!this.map || !this.map.loadNewTiles || !this.loadNewTiles || !this.map.style.sources[this.id]) return;
 
         var zoom = Math.floor(this._getZoom());
         var required = this._getCoveringTiles().sort(this._centerOut.bind(this));


### PR DESCRIPTION
As part of the https://github.com/mapbox/mapbox-gl-js/pull/455 refactor tile sources loading TileJSON became asynchronous in a way where the first map calls to `render()` may happen before the source is ready. If the timing here is not right (this occurs to me often) the map appears blank until some interaction (click/drag/etc.) makes a call to `render()` bringing the thing to life again.

I've added a call to `update()` after tilejson loads occur to address this -- a review would be great to make sure there are no unintended problems/consequences I'm not aware of.

cc @ansis @mourner @edenh 
