### PR TITLE
Throttle tile loading

### DIFF
--- a/js/ui/source.js
+++ b/js/ui/source.js
@@ -39,6 +39,8 @@ function Source(options) {
         this.enabled = true;
         this.update();
     }.bind(this));
+
+    this._updateTiles = util.throttle(this._updateTiles, 50, this);
 }
 
 Source.prototype = Object.create(Evented);

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -66,3 +66,31 @@ var id = 1;
 exports.uniqueId = function () {
     return id++;
 };
+
+exports.throttle = function (fn, time, context) {
+    var lock, args, wrapperFn, later;
+
+    later = function () {
+        // reset lock and call if queued
+        lock = false;
+        if (args) {
+            wrapperFn.apply(context, args);
+            args = false;
+        }
+    };
+
+    wrapperFn = function () {
+        if (lock) {
+            // called too soon, queue to call later
+            args = arguments;
+
+        } else {
+            // call and lock until later
+            fn.apply(context, arguments);
+            setTimeout(later, time);
+            lock = true;
+        }
+    };
+
+    return wrapperFn;
+};


### PR DESCRIPTION
`_updateTiles` was taking a good portion of CPU time so I suggest throttling it. 50ms looks good enough to not introduce a big visual difference while making things a bit faster. @ansis @edenh 
