### PR TITLE
race condition on ImageSprite load

### DIFF
--- a/js/render/drawsymbol.js
+++ b/js/render/drawsymbol.js
@@ -42,6 +42,9 @@ function drawSymbol(gl, painter, bucket, layerStyle, posMatrix, params, imageSpr
     var sdf = text || bucket.elementGroups.sdfIcons;
     var shader, buffer, texsize;
 
+    if (!text && !imageSprite.loaded())
+        return;
+
     gl.activeTexture(gl.TEXTURE0);
 
     if (sdf) {

--- a/js/style/imagesprite.js
+++ b/js/style/imagesprite.js
@@ -61,6 +61,10 @@ ImageSprite.prototype.resize = function(gl) {
 
 ImageSprite.prototype.bind = function(gl, linear) {
     var sprite = this;
+
+    if (!sprite.loaded())
+        return;
+
     if (!sprite.texture) {
         sprite.texture = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D, sprite.texture);


### PR DESCRIPTION
If the image takes a long time to load, drawSymbol will produce errors due to trying to use the uninitialized `sprite.img`.

To reproduce, wrap the `ajax.getImage` callback in a 5 second `setTimeout`.

```
Uncaught TypeError: Failed to execute 'texImage2D' on 'WebGLRenderingContext': No function was found that matched the signature provided. imagesprite.js:75
```

If you bypass that error by checking `sprite.loaded()`:

```
Uncaught TypeError: Cannot read property 'width' of undefined drawsymbol.js:60
```
