### PR TITLE
fix line-blur

### DIFF
--- a/js/render/drawline.js
+++ b/js/render/drawline.js
@@ -9,9 +9,12 @@ module.exports = function drawLine(gl, painter, bucket, layerStyle, posMatrix, p
     // don't draw zero-width lines
     if (layerStyle['line-width'] <= 0) return;
 
+    var gamma = 1;
+    var antialiasing = gamma / browser.devicePixelRatio;
+
     var lineOffset = layerStyle['line-offset'] / 2;
-    var inset = Math.max(-1, lineOffset - layerStyle['line-width'] / 2 - 0.5) + 1;
-    var outset = lineOffset + layerStyle['line-width'] / 2 + 0.5;
+    var inset = Math.max(-1, lineOffset - layerStyle['line-width'] / 2 - antialiasing / 2) + 1;
+    var outset = lineOffset + layerStyle['line-width'] / 2 + antialiasing / 2;
 
     var imagePos = layerStyle['line-image'] && imageSprite.getPosition(layerStyle['line-image']);
     var shader;
@@ -34,13 +37,12 @@ module.exports = function drawLine(gl, painter, bucket, layerStyle, posMatrix, p
         gl.switchShader(shader, posMatrix, painter.tile.exMatrix);
         gl.uniform2fv(shader.u_dasharray, layerStyle['line-dasharray']);
         gl.uniform4fv(shader.u_color, layerStyle['line-color']);
-        gl.uniform1f(shader.u_blur, layerStyle['line-blur']);
     }
 
     var tilePixelRatio = painter.transform.scale / (1 << params.z) / 8;
     gl.uniform2fv(shader.u_linewidth, [ outset, inset ]);
     gl.uniform1f(shader.u_ratio, tilePixelRatio);
-    gl.uniform1f(shader.u_gamma, browser.devicePixelRatio);
+    gl.uniform1f(shader.u_blur, layerStyle['line-blur'] + antialiasing);
 
 
     var vertex = bucket.buffers.lineVertex;

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -99,11 +99,11 @@ GLPainter.prototype.setup = function() {
 
     this.lineShader = gl.initializeShader('line',
         ['a_pos', 'a_extrude', 'a_linesofar'],
-        ['u_posmatrix', 'u_exmatrix', 'u_linewidth', 'u_color', 'u_debug', 'u_ratio', 'u_dasharray', 'u_gamma', 'u_blur']);
+        ['u_posmatrix', 'u_exmatrix', 'u_linewidth', 'u_color', 'u_debug', 'u_ratio', 'u_dasharray', 'u_blur']);
 
     this.linepatternShader = gl.initializeShader('linepattern',
         ['a_pos', 'a_extrude', 'a_linesofar'],
-        ['u_posmatrix', 'u_exmatrix', 'u_linewidth', 'u_ratio', 'u_pattern_size', 'u_pattern_tl', 'u_pattern_br', 'u_point', 'u_gamma', 'u_fade']);
+        ['u_posmatrix', 'u_exmatrix', 'u_linewidth', 'u_ratio', 'u_pattern_size', 'u_pattern_tl', 'u_pattern_br', 'u_point', 'u_blur', 'u_fade']);
 
     this.pointShader = gl.initializeShader('point',
         ['a_pos', 'a_angle', 'a_minzoom', 'a_tl', 'a_br'],

--- a/shaders/line.fragment.glsl
+++ b/shaders/line.fragment.glsl
@@ -2,7 +2,6 @@
 uniform float u_debug;
 uniform vec2 u_linewidth;
 uniform vec4 u_color;
-uniform float u_gamma;
 uniform float u_blur;
 
 uniform vec2 u_dasharray;
@@ -20,7 +19,7 @@ void main() {
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp((min(dist - (u_linewidth.t - u_blur), u_linewidth.s - dist) / u_blur) * u_gamma, 0.0, 1.0);
+    float alpha = clamp(min(dist - (u_linewidth.t - u_blur), u_linewidth.s - dist) / u_blur, 0.0, 1.0);
 
     // Calculate the antialiasing fade factor based on distance to the dash.
     // Only affects alpha when line is dashed

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -2,7 +2,7 @@
 uniform float u_debug;
 uniform vec2 u_linewidth;
 uniform float u_point;
-uniform float u_gamma;
+uniform float u_blur;
 
 uniform vec2 u_pattern_size;
 uniform vec2 u_pattern_tl;
@@ -23,7 +23,7 @@ void main() {
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp(min(dist - (u_linewidth.t - 1.0), u_linewidth.s - dist) * u_gamma, 0.0, 1.0);
+    float alpha = clamp(min(dist - (u_linewidth.t - u_blur), u_linewidth.s - dist) / u_blur, 0.0, 1.0);
 
     float x = mod(v_linesofar / u_pattern_size.x, 1.0);
     float y = 0.5 + (v_normal.y * u_linewidth.s / u_pattern_size.y);


### PR DESCRIPTION
This changes line-blur so that it isn't affected by devicePixelRatio.

This also switches to `0` instead of `1` meaning an antialiased line without extra blur. This should wait for https://github.com/mapbox/mapbox-gl-style-spec/pull/129#issuecomment-50181980 which changes the default in the spec.
