### PR TITLE
calculate tile pos matrix like native does

### DIFF
--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -24,16 +24,19 @@ Tile.prototype = {
         this.scale = scale;
 
         // The position matrix
-        // Use 64 bit floats to avoid precision issues.
-        this.posMatrix = new Float64Array(16);
+        this.posMatrix = new Float32Array(16);
         mat4.identity(this.posMatrix);
         mat4.translate(this.posMatrix, this.posMatrix, [transform.centerPoint.x, transform.centerPoint.y, 0]);
         mat4.rotateZ(this.posMatrix, this.posMatrix, transform.angle);
-        mat4.translate(this.posMatrix, this.posMatrix, [-transform.x, -transform.y, 0]);
-        mat4.translate(this.posMatrix, this.posMatrix, [scale * x, scale * y, 1]);
+        mat4.translate(this.posMatrix, this.posMatrix, [-transform.centerPoint.x, -transform.centerPoint.y, 0]);
+
+        var pixelX = transform.width / 2 - transform.x,
+            pixelY = transform.height / 2 - transform.y;
+
+        mat4.translate(this.posMatrix, this.posMatrix, [pixelX + x * scale, pixelY + y * scale, 1]);
 
         // Create inverted matrix for interaction
-        this.invPosMatrix = new Float64Array(16);
+        this.invPosMatrix = new Float32Array(16);
         mat4.invert(this.invPosMatrix, this.posMatrix);
 
         mat4.scale(this.posMatrix, this.posMatrix, [ scale / this.tileExtent, scale / this.tileExtent, 1 ]);
@@ -46,10 +49,6 @@ Tile.prototype = {
         // 2x2 matrix for rotating points
         this.rotationMatrix = mat2.create();
         mat2.rotate(this.rotationMatrix, this.rotationMatrix, transform.angle);
-
-        // Convert to 32-bit floats after we're done with all the transformations.
-        this.posMatrix = new Float32Array(this.posMatrix);
-        this.exMatrix = new Float32Array(this.exMatrix);
     },
 
     positionAt: function(id, point) {


### PR DESCRIPTION
I traced the slight offset on many tests between native in js down to a difference in how the two calculate the transformation matrix for a tile.
- [JS code](https://github.com/mapbox/mapbox-gl-js/blob/bb6a7dbceae6a7963af36545a770f7550e6bf072/js/source/tile.js#L28-40)
- [Native code](https://github.com/mapbox/mapbox-gl-native/blob/29bc7152f582e37fe34f0257e5ccd1976c01140d/src/map/transform_state.cpp#L9-22)

Note the symmetry of the first three operations (translate, rotate, translate) on native vs the asymmetry of js.

Native winds up doing operations with reasonably sized integers:

```
translate1 256,128
rotate -0
translate2 -256,-128
translate3 -1117,-1460
scale 0.5
```

While the values that js uses are large floating point numbers:

```
translate1: 256,128
rotate: 0
translate2: -18027869.465622757, -11007539.554400524
translate3: 18026496, 11005952
scale: 0.5
```

Also, js uses 64-bit floats and then converts to 32-bit at the end, while native uses 32-bits throughout. I tried switching to 32-bits in js but the offset was still there.
