### PR TITLE
premultiply sprite

### DIFF
--- a/js/style/imagesprite.js
+++ b/js/style/imagesprite.js
@@ -24,6 +24,18 @@ function ImageSprite(base) {
     ajax.getImage(base + '.png', function(err, img) {
         // @TODO handle errors via sprite event.
         if (err) return;
+
+        // premultiply the sprite
+        var data = img.getData();
+        var newdata = img.data = new Uint8Array(data.length);
+        for (var i = 0; i < data.length; i+=4) {
+            var alpha = data[i + 3] / 255;
+            newdata[i + 0] = data[i + 0] * alpha;
+            newdata[i + 1] = data[i + 1] * alpha;
+            newdata[i + 2] = data[i + 2] * alpha;
+            newdata[i + 3] = data[i + 3];
+        }
+
         sprite.img = img;
         if (sprite.data) sprite.fire('loaded');
     });
@@ -70,7 +82,8 @@ ImageSprite.prototype.bind = function(gl, linear) {
         gl.bindTexture(gl.TEXTURE_2D, sprite.texture);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, sprite.img);
+        var img = sprite.img;
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, img.width, img.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, img.data);
 
     } else {
         gl.bindTexture(gl.TEXTURE_2D, sprite.texture);

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -39,7 +39,8 @@ exports.getImage = function(url, callback) {
                 callback(null, {
                     width: png.width,
                     height: png.height,
-                    data: png.data
+                    data: png.data,
+                    getData: function() { return this.data; }
                 });
             });
         } else {

--- a/js/util/browser/ajax.js
+++ b/js/util/browser/ajax.js
@@ -39,5 +39,15 @@ exports.getImage = function(url, callback) {
         callback(null, img);
     };
     img.src = url;
+    img.getData = function() { return getImageData(this); };
     return img;
 };
+
+function getImageData(img) {
+    var canvas = document.createElement('canvas');
+    var context = canvas.getContext('2d');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    context.drawImage(img, 0, 0);
+    return context.getImageData(0, 0, img.width, img.height).data;
+}

--- a/shaders/icon.fragment.glsl
+++ b/shaders/icon.fragment.glsl
@@ -4,7 +4,5 @@ varying vec2 v_tex;
 varying float v_alpha;
 
 void main() {
-    gl_FragColor = texture2D(u_texture, v_tex);
-    gl_FragColor.a *= v_alpha;
-    gl_FragColor.rgb *= gl_FragColor.a;
+    gl_FragColor = texture2D(u_texture, v_tex) * v_alpha;
 }

--- a/shaders/pattern.fragment.glsl
+++ b/shaders/pattern.fragment.glsl
@@ -12,14 +12,10 @@ void main() {
     vec2 imagecoord = mod(v_pos, 1.0);
     vec2 pos = mix(u_pattern_tl, u_pattern_br, imagecoord);
     vec4 color1 = texture2D(u_image, pos);
-    color1.rgb *= color1.a;
 
     vec2 imagecoord2 = mod(imagecoord * 2.0, 1.0);
     vec2 pos2 = mix(u_pattern_tl, u_pattern_br, imagecoord2);
     vec4 color2 = texture2D(u_image, pos2);
-    color2.rgb *= color2.a;
 
-    vec4 color = mix(color1, color2, u_mix);
-    color *= u_opacity;
-    gl_FragColor = color;
+    gl_FragColor = mix(color1, color2, u_mix) * u_opacity;
 }


### PR DESCRIPTION
Fixes #624

Previously colors were premultiplied in the shader. Texture reads would interpolate the color before the premultiplication. Since completely transparent pixels could have any rgb values (often 0, 0, 0), the interpolation would bleed this value into pixels.

For example if rgba(255, 0, 0, 1) was next to rgba(0, 0, 0, 0) then the interpolated value would be (127, 0, 0, 0.5) instead of (255, 0, 0, 0.5). Premultiplying before the interpolation solves this.

Premultiplying the sprite also means a bit less work needs to be done in the fragment shader.

@jfirebaugh 
