### PR TITLE
Append accessToken to GlyphSource url

### DIFF
--- a/debug/style.json
+++ b/debug/style.json
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "sprite": "img/sprite",
-  "glyphs": "http://localhost:8889/v4/fontstack/{fontstack}/{range}.pbf",
+  "glyphs": "http://mapbox.s3.amazonaws.com/gl-glyphs-256/{fontstack}/{range}.pbf",
   "constants": {
     "@red": "#f00",
     "@land": "#eee",

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -225,7 +225,7 @@ util.extend(Map.prototype, {
             this.addSource(id, Source.create(sources[id]));
         }
 
-        this.glyphSource = new GlyphSource(this.style.stylesheet.glyphs + "?access_token=" + "pk.eyJ1IjoiZm9vIiwiYSI6IkdZU3ptREUifQ.d2zO3rtmlDdLAgMxPSnA4w", this.painter.glyphAtlas);
+        this.glyphSource = new GlyphSource(this.style.stylesheet.glyphs + "?access_token=" + window.mapboxgl.accessToken, this.painter.glyphAtlas);
 
         this.style.on('change', this._onStyleChange);
 


### PR DESCRIPTION
To access `/v4/fontstack` endpoint protected by API keys.

Is there a better way to do this conditionally to not unnecessarily append for endpoints that don't require an access token?
