### PR TITLE
Support loading http(s) sources.

### DIFF
--- a/js/source/source.js
+++ b/js/source/source.js
@@ -13,10 +13,18 @@ var util = require('../util/util.js'),
 module.exports = Source;
 
 Source.protocols = {
-    "mapbox": function(url, callback) {
+    mapbox: function(url, callback) {
         ajax.getJSON(tileJSON(url.split('://')[1]), callback);
+    },
+    http: function(url, callback) {
+        callback(null,{
+            tiles: [url],
+            minzoom: 0,
+            maxzoom: 14
+        });
     }
 };
+Source.protocols.https = Source.protocols.http;
 
 function Source(options) {
     this.tiles = {};


### PR DESCRIPTION
 Its seems that minzoom and maxzoom are required in tilejson. Should they be?
 If so, what should the defaults be, or is there somewhere else they should come from?

 ref #535 
