### PR TITLE
Try flipping RTL text (#472)

### DIFF
--- a/debug/style.json
+++ b/debug/style.json
@@ -4,7 +4,7 @@
   "sprite": "img/sprite",
   "glyphs": "https://mapbox.s3.amazonaws.com/gl-glyphs-256/{fontstack}/{range}.pbf",
   "constants": {
-    "@name": "{name_en}",
+    "@name": "{name}",
     "@sans": "Open Sans Regular, Arial Unicode MS Regular",
     "@sans_it": "Open Sans Italic, Arial Unicode MS Regular",
     "@sans_md": "Open Sans Semibold, Arial Unicode MS Bold",

--- a/js/symbol/resolvetext.js
+++ b/js/symbol/resolvetext.js
@@ -25,6 +25,27 @@ function resolveText(features, info, glyphs) {
             text = text.toLocaleLowerCase();
         }
 
+        if (isRTL(text)) {
+          var textWords = text.split(' ');
+          var ltrText = '';
+          var rtlBuffer = '';
+          for (var t = 0; t < textWords.length; t++) {
+            if (isRTL(textWords[t])) {
+              var rtlWord = textWords[t].split('').reverse().join('');
+              rtlBuffer = rtlWord + ' ' + rtlBuffer;
+            }
+            else {
+              ltrText += rtlBuffer + ' ' + textWords[t];
+              rtlBuffer = '';
+            }
+          }
+          if (ltrText.length && rtlBuffer.length) {
+            ltrText += ' ';
+          }
+          ltrText += rtlBuffer;
+          text = ltrText;
+        }
+
         for (var j = 0, jl = text.length; j < jl; j++) {
             if (text.charCodeAt(j) <= 65533) {
                 codepoints.push(text.charCodeAt(j));
@@ -46,6 +67,12 @@ function resolveText(features, info, glyphs) {
     };
 }
 
+function isRTL(s) {
+  var rtlChars = '\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC',
+  rtlDirCheck = new RegExp('^[^'+rtlChars+']*?['+rtlChars+']');
+  return rtlDirCheck.test(s);
+}
+
 function uniq(ids, alreadyHave) {
     var u = [];
     var last;
@@ -62,4 +89,3 @@ function uniq(ids, alreadyHave) {
 function sortNumbers(a, b) {
     return a - b;
 }
-


### PR DESCRIPTION
I was interested in right-to-left labels for my project, so I tried out a couple of things. This code essentially 'flips' any RTL text and multi-word phrases.

It unfortunately only works on bidirectional text if there is a space between LTR and RTL words, so Casablanca shows up wrong. It's tough for me to know if the rest of the Arabic labels are written properly, but I might be breaking connections between letters by flipping it like this.

![screen shot 2014-08-17 at 10 26 13 pm](https://cloud.githubusercontent.com/assets/643918/3946912/1905d148-267f-11e4-8382-bb65bda9cf5d.png)
