### PR TITLE
Get geojson from url if one is specified

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var util = require('../util/util');
+var ajax = require('../util/ajax');
 var Source = require('./source');
 var GeoJSONTile = require('./geojson_tile');
 
@@ -13,7 +14,14 @@ function GeoJSONSource(options) {
     this.zooms = [1, 5, 9, 13];
     this.minTileZoom = this.zooms[0];
     this.maxTileZoom = this.zooms[this.zooms.length - 1];
-    this.data = options.data;
+
+    if (options.url) {
+        ajax.getJSON(options.url, function(err, data) {
+            this.setData(data);
+        }.bind(this));
+    } else {
+        this.data = options.data;
+    }
 }
 
 GeoJSONSource.prototype = util.inherit(Source, {
@@ -35,6 +43,8 @@ GeoJSONSource.prototype = util.inherit(Source, {
     },
 
     _updateData: function() {
+        if (!this.data) return;
+
         var source = this;
         this.workerID = this.map.dispatcher.send('parse geojson', {
             data: this.data,


### PR DESCRIPTION
I noticed that `GeoJSONSource` only works if you provide raw data to it as `data` param. I really like declarative approach of `style.json` files and thought it would be great if one could specify GeoJSON datasources as urls to geojson files and not having to do the fetching in application code.

Here's a basic example I've been using: 

``` javascript
mapboxgl.util.getJSON('http://localhost/lab/style.json', function (err, style) {
  var map = new mapboxgl.Map({
    container: 'map',
    style: style,
    center: [58.5793159, 16.190499],
    zoom: 10
  });
});
```

And here's the style file:

``` javascript
{
  "sources": {
    "parks": {
      "type": "geojson",
      "url": "data/parks.geojson"
    }
  },
  "layers": [
    {
      "id": "parks",
      "source": "parks",
      "style": { "fill-color": "#98E97F" },
      "type": "fill"
    }
  ]
}
```
