### PR TITLE
fix: fixes the bug when defer or async attribute set in the html "script...

### DIFF
--- a/js/util/browser/dispatcher.js
+++ b/js/util/browser/dispatcher.js
@@ -3,7 +3,7 @@
 var Actor = require('../actor');
 
 var scripts = document.getElementsByTagName("script");
-var workerFile = scripts[scripts.length - 1].getAttribute('src');
+var workerFile = document.currentScript && document.currentScript.getAttribute('src') || scripts[scripts.length - 1].getAttribute('src');
 var absolute = workerFile.indexOf('http') !== -1;
 
 


### PR DESCRIPTION
how to reproduce bug  in google chrome

``` html
<script defer src='/libs/mapbox-gl.js'></script>
<script defer src='any_other_lib.js'></script>
```

---

modern browsers support [document.currentScript](https://developer.mozilla.org/en/docs/Web/API/document.currentScript) property  
we need this fix
