### PR TITLE
IE11

### DIFF
--- a/js/data/buffer/buffer.js
+++ b/js/data/buffer/buffer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var isIE11 = require('../../util/util').isIE11;
+
 // a simple wrapper around a single arraybuffer
 
 module.exports = Buffer;
@@ -41,8 +43,9 @@ Buffer.prototype = {
         var type = gl[this.arrayType];
         if (!this.buffer) {
             this.buffer = gl.createBuffer();
+            var data = isIE11 ? this.array : new DataView(this.array, 0, this.pos);
             gl.bindBuffer(type, this.buffer);
-            gl.bufferData(type, new DataView(this.array, 0, this.pos), gl.STATIC_DRAW);
+            gl.bufferData(type, data, gl.STATIC_DRAW);
 
             // dump array buffer once it's bound to gl
             this.array = null;

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -2,6 +2,7 @@
 
 var browser = require('../util/browser');
 var mat3 = require('../lib/glmatrix').mat3;
+var isIE11 = require('../util/util').isIE11;
 
 module.exports = drawFill;
 
@@ -70,7 +71,9 @@ function drawFill(gl, painter, bucket, layerStyle, posMatrix, params, imageSprit
     // below, we have to draw the outline first (!)
     if (layerStyle['fill-antialias'] === true && params.antialiasing && !(layerStyle['fill-image'] && !strokeColor)) {
         gl.switchShader(painter.outlineShader, translatedPosMatrix, painter.tile.exMatrix);
-        gl.lineWidth(2 * browser.devicePixelRatio);
+        if (!isIE11) {
+            gl.lineWidth(2 * browser.devicePixelRatio);
+        }
 
         if (strokeColor) {
             // If we defined a different color for the fill outline, we are

--- a/js/util/actor.js
+++ b/js/util/actor.js
@@ -1,6 +1,17 @@
 'use strict';
 
+var isIE11 = require('./util.js').isIE11;
+
 module.exports = Actor;
+
+function postMessage(target, msg, buffers) {
+    if (isIE11) {
+            target.postMessage(msg);
+        } else {
+        target.postMessage(msg, buffers);
+    }
+}
+
 
 function Actor(target, parent) {
     this.target = target;
@@ -23,7 +34,7 @@ Actor.prototype.receive = function(message) {
         var id = data.id;
         this.parent[data.type](data.data, function response(err, data, buffers) {
             // console.warn('trying to clone', data, buffers, message.target);
-            message.target.postMessage({
+            postMessage(message.target, {
                 type: '<response>',
                 id: String(id),
                 error: err ? String(err) : null,
@@ -38,5 +49,5 @@ Actor.prototype.receive = function(message) {
 Actor.prototype.send = function(type, data, callback, buffers) {
     var id = null;
     if (callback) this.callbacks[id = this.callbackID++] = callback;
-    this.target.postMessage({ type: type, id: String(id), data: data }, buffers);
+    postMessage(this.target, { type: type, id: String(id), data: data }, buffers);
 };

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -2,6 +2,8 @@
 
 var UnitBezier = require('unitbezier');
 
+exports.isIE11 = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./);
+
 exports.easeCubicInOut = function (t) {
     if (t <= 0) return 0;
     if (t >= 1) return 1;


### PR DESCRIPTION
Finally I've made this PR.

Everything in here is a hack, and you can't build mapbox-gl-js on windows currently, so I can't test this to work on it.

@jfirebaugh has some good suggestions on fixing these hacks over here, I've included them below.
https://github.com/mapbox/mapbox-gl-js/pull/808#issuecomment-61739889

**buffer.js DataView**
IE11 doesn't let you pass a DataView to gl.bufferData.
@jfirebaugh suggests we could just set the length on the this.array. (Will need to check if the array is even a different size? or if it is used in other places)

Otherwise this probably needs browser detection, not sure if this can be feature detected.

**draw_fill.js gl.lineWidth**
Calling gl.lineWidth raises a warning on IE11, it is [not supported.](http://msdn.microsoft.com/en-us/library/ie/dn455128%28v=vs.85%29.aspx)
It is also not supported on any other browser on windows, but they blindly ignore it (Chrome, firefox)
Test: http://alteredqualia.com/tmp/webgl-linewidth-test/
https://code.google.com/p/angleproject/issues/detail?id=119
https://code.google.com/p/angleproject/issues/detail?id=334
Can we reconsider its usage or is it really required here? I assume it won't render correctly in highdpi on windows.

If required, we could feature detect if it can be set by testing [`gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE)`](https://github.com/AnalyticalGraphicsInc/webglreport/blob/master/webglreport.js#L245)

**postMessage**
IE11 doesn't support passing an array as the second argument. Apparently it supports a single argument, but I haven't been able to make it work.
https://developer.mozilla.org/en-US/docs/Web/API/Worker.postMessage
https://connect.microsoft.com/IE/feedback/details/783468/ie10-window-postmessage-throws-datacloneerror-for-transferrable-arraybuffers

This probably needs browser detection, not sure if this can be feature detected.
