### PR TITLE
[don't merge] Account for antialiasing in line-gap inset calculations

### DIFF
--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -11,7 +11,7 @@ module.exports = function drawLine(gl, painter, bucket, layerStyle, posMatrix, p
     var offset = layerStyle['line-gap-width'] > 0 ? layerStyle['line-gap-width'] / 2 + width / 2 : 0;
     var blur = layerStyle['line-blur'] + antialiasing;
 
-    var inset = Math.max(-1, offset - width / 2 - antialiasing / 2) + 1;
+    var inset = Math.max(-1, (offset ? offset - antialiasing : offset) - width / 2 - antialiasing / 2) + 1;
     var outset = offset + width / 2 + antialiasing / 2;
 
     var color = layerStyle['line-color'];


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-js/issues/858

* I can't decide if this is a bit hacky or not.
* On a somewhat related note, **this doesn't fix the issue on retina devices** because of ([source](https://github.com/mapbox/mapbox-gl-js/blob/74c7e49a5e5d2aedc954fa9d0d5288dd1a8e29d1/js/render/draw_line.js#L9)):
``` js
var antialiasing = 1 / browser.devicePixelRatio;
```
So, non-retina:
![image](https://cloud.githubusercontent.com/assets/3170312/5292073/5a1553de-7b11-11e4-826d-812059a1087f.png)
Retina:
![image](https://cloud.githubusercontent.com/assets/3170312/5292075/5dccc354-7b11-11e4-9bdc-aa7f3c3dc3e8.png)

(those represent two layers from the same source-layer styled as such:)
``` json
{
      ...
      "paint": {
        "line-color": "#6d6d6d",
        "line-width": 10,
        "line-gap-width": 10
      }
    },
    {
      ...
      "paint": {
        "line-color": "#6d6d6d",
        "line-width": 10
      }
    },
```

— so I'm not sure why the antialiasing var is as it is. If `antialiasing = 1` it works on both retina and non-retina devices.
/cc @jfirebaugh @kkaefer 