### PR TITLE
Preprocess class styles in cascade

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -233,8 +233,8 @@ Style.prototype = util.inherit(Evented, {
         this.orderedBuckets = [];
         this.buckets = getBuckets({}, this.orderedBuckets, this.stylesheet.layers);
         function getBuckets(buckets, ordered, layers) {
-            for (i = 0; i < layers.length; i++) {
-                var layer = layers[i];
+            for (var a = 0; a < layers.length; a++) {
+                var layer = layers[a];
                 if (layer.layers) {
                     buckets = getBuckets(buckets, ordered, layer.layers);
                 }


### PR DESCRIPTION
Continuing along the lines of #831, this moves more preprocessing of style declarations into cascade() from cascadeClasses(), to avoid redoing this work each time a class is changed.  On my Mac, this gets me another 3-6x speed improvement: cascadeClasses() is down to < 15ms for me in most situations.  

This allows class changes to be used for pretty smooth interactivity and animation, like [this little visualization](http://michaelsteffen.github.io/rides-gl) I've been playing with (GPX traces of bike rides around Houston). It should be easy to see the improvement in responsiveness compared to [this version](http://michaelsteffen.github.io/rides-gl/old.html), which is identical but uses mapbox-gl-js 0.4.2, or the [Urban Layers visualization](http://io.morphocode.com/urban-layers/), on which mine is based.

These changes moderately slow down cascade(), since all layer paint properties are preprocessed (vs. just currently active classes), but hopefully a small delay is tolerable on changing the map stylesheet, and is a small price to pay for very fast subsequent class changes.

Also fixes #789.
