### PR TITLE
Initialize layerGroups member to an empty array

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -29,6 +29,7 @@ function Style(stylesheet, animationLoop) {
     this.orderedBuckets = [];
     this.flattened = [];
     this.layerMap = {};
+    this.layerGroups = [];
     this.processedPaintProps = {};
     this.transitions = {};
     this.computed = {};


### PR DESCRIPTION
Otherwise, a call to renderGroups fails when it tries
to iterate on an undefined object
