### PR TITLE
Return ref layers in featuresAt, refs #847

### DIFF
--- a/js/data/feature_tree.js
+++ b/js/data/feature_tree.js
@@ -47,7 +47,7 @@ FeatureTree.prototype.query = function(args, callback) {
 };
 
 FeatureTree.prototype.formatResults = function(bucketInfo) {
-    return {
+    var results = {
         $type: bucketInfo.$type,
         layer: {
             id: bucketInfo.id,
@@ -57,6 +57,8 @@ FeatureTree.prototype.formatResults = function(bucketInfo) {
             layout: bucketInfo.layout
         }
     };
+    if (bucketInfo.ref) results.layer.ref = bucketInfo.ref;
+    return results;
 };
 
 FeatureTree.prototype.queryFeatures = function(matching, x, y, radius, params, callback) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -233,9 +233,9 @@ Style.prototype = util.inherit(Evented, {
         var i,
             layer,
             id,
-            prop, 
+            prop,
             paintProp;
-            
+
         var constants = this.stylesheet.constants;
         var globalTrans = this.stylesheet.transition;
 
@@ -248,7 +248,7 @@ Style.prototype = util.inherit(Evented, {
                 if (layer.layers) {
                     buckets = getBuckets(buckets, ordered, layer.layers);
                 }
-                if (!layer.source || !layer.type) {
+                if (!layer.ref && (!layer.source || !layer.type)) {
                     continue;
                 }
                 var bucket = {id: layer.id};
@@ -285,7 +285,7 @@ Style.prototype = util.inherit(Evented, {
         for (i = 0; i < flattened.length; i++) {
             flattened[i] = resolveLayer(layerMap, flattened[i]);
         }
-        
+
         // pre-calculate style declarations and transition properties for all layers x all classes
         var processedPaintProps = this.processedPaintProps = {};
         for (i = 0; i < flattened.length; i++) {
@@ -297,9 +297,9 @@ Style.prototype = util.inherit(Evented, {
             for (prop in layer) {
                 if (!(/^paint/).test(prop)) continue;
                 var paint = StyleConstant.resolve(layer[prop], constants);
-                
+
                 // makes "" the key for the default paint property, which is a bit
-                // unusual, but is valid JS and should work in all browsers 
+                // unusual, but is valid JS and should work in all browsers
                 var className = (prop === "paint") ? "" : prop.slice(6);
                 var classProps = processedPaintProps[id][className] = {};
                 for (paintProp in paint) {
@@ -309,10 +309,10 @@ Style.prototype = util.inherit(Evented, {
                         classProps[match[1]].transition = paint[paintProp];
                     } else {
                         if (!classProps[paintProp]) classProps[paintProp] = {};
-                        classProps[paintProp].styleDeclaration = new StyleDeclaration(renderType, paintProp, paint[paintProp]); 
+                        classProps[paintProp].styleDeclaration = new StyleDeclaration(renderType, paintProp, paint[paintProp]);
                     }
                 }
-                
+
                 // do a second pass to fill in missing transition properties & remove
                 // transition properties without matching style declaration
                 for (paintProp in classProps) {
@@ -321,19 +321,19 @@ Style.prototype = util.inherit(Evented, {
                     } else {
                         var trans = classProps[paintProp].transition;
                         var newTrans = {};
-                        newTrans.duration = trans && trans.duration >= 0 ? trans.duration : 
+                        newTrans.duration = trans && trans.duration >= 0 ? trans.duration :
                             globalTrans && globalTrans.duration >= 0 ? globalTrans.duration : 300;
-                        newTrans.delay = trans && trans.delay >= 0 ? trans.delay : 
+                        newTrans.delay = trans && trans.delay >= 0 ? trans.delay :
                             globalTrans && globalTrans.delay >= 0 ? globalTrans.delay : 0;
                         classProps[paintProp].transition = newTrans;
                     }
                 }
             }
         }
-        
+
         this.layerGroups = this._groupLayers(this.stylesheet.layers);
         this.cascadeClasses(options);
-        
+
         // Resolve layer references.
         function resolveLayer(layerMap, layer) {
             if (!layer.ref || !layerMap[layer.ref]) return layer;
@@ -379,7 +379,7 @@ Style.prototype = util.inherit(Evented, {
             var layer = flattened[i];
             var id = layer.id;
             transitions[id] = {};
-            
+
             for (var className in processedPaintProps[id]) {
                 if (!(className === "" || classes[className])) continue;
                 var paintProps = processedPaintProps[id][className];

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -203,6 +203,12 @@ test('Style#featuresAt', function(t) {
             "paint": {
                 "line-color": "red"
             }
+        }, {
+            "id": "landref",
+            "ref": "land",
+            "paint": {
+                "line-color": "blue"
+            }
         }]
     });
 
@@ -217,6 +223,19 @@ test('Style#featuresAt', function(t) {
                     type: 'line',
                     layout: {
                         'line-cap': 'round'
+                    }
+                }
+            }, {
+                $type: 'Polygon',
+                layer: {
+                    id: 'landref',
+                    ref: 'land',
+                    type: 'line',
+                    layout: {
+                        'line-cap': 'round'
+                    },
+                    paint: {
+                        'line-color': 'blue'
                     }
                 }
             }]);
@@ -253,6 +272,21 @@ test('Style#featuresAt', function(t) {
                 t.deepEqual(
                     Object.getPrototypeOf(paint),
                     PaintProperties.line.prototype);
+
+                t.end();
+            });
+        });
+
+        t.test('ref layer inherits properties', function(t) {
+            style.featuresAt([256, 256], {}, function(err, results) {
+                t.error(err);
+
+                var layer = results[0].layer;
+                var refLayer = results[1].layer;
+                t.deepEqual(layer.layout, refLayer.layout);
+                t.deepEqual(layer.type, refLayer.type);
+                t.deepEqual(layer.id, refLayer.ref);
+                t.notEqual(layer.paint, refLayer.paint);
 
                 t.end();
             });


### PR DESCRIPTION
#847 : 

> For example, I'm making a map where I define a road casing in the traditional manner, and then define the road itself via a ref to its casing.
> 
> When I featuresAt() at that position, only the casing shows up. I want to get both, while enjoying the performance benefits of ref