### PR TITLE
Return any extra layer keys provided in the stylesheet in featuresAt

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -515,6 +515,10 @@ Style.prototype = util.inherit(Evented, {
                 var layer = feature.layer;
                 layer.paint = this.computed[layer.id];
                 layer.layout = new LayoutProperties[layer.type](layer.layout);
+                var rawLayer = this.layerMap[layer.id];
+                Object.keys(rawLayer).forEach(key => {
+                    if (!layer[key]) layer[key] = rawLayer[key];
+                });
             });
 
             callback(null, features);

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -202,7 +202,8 @@ test('Style#featuresAt', function(t) {
             "source-layer": "water",
             "paint": {
                 "line-color": "red"
-            }
+            },
+            "something": "else"
         }, {
             "id": "landref",
             "ref": "land",
@@ -287,6 +288,17 @@ test('Style#featuresAt', function(t) {
                 t.deepEqual(layer.type, refLayer.type);
                 t.deepEqual(layer.id, refLayer.ref);
                 t.notEqual(layer.paint, refLayer.paint);
+
+                t.end();
+            });
+        });
+
+        t.test('includes arbitrary keys', function(t) {
+            style.featuresAt([256, 256], {}, function(err, results) {
+                t.error(err);
+
+                var layer = results[0].layer;
+                t.equal(layer.something, 'else');
 
                 t.end();
             });


### PR DESCRIPTION
Per chat with @edenh, `featuresAt` should return any extra keys provided in the stylesheet. So:
*stylesheet:*
``` json
{
    "id": "building",
    "type": "fill",
    "amazing": true,
    "source": "mapbox",
    "interactive": true,
    "source-layer": "building",
    "paint": {
      "fill-color": "#555"
    }
  }
```

*before:*
![image](https://cloud.githubusercontent.com/assets/3170312/5620513/780f756a-94e1-11e4-9b0d-25651a58b3f1.png)

*after:*
![image](https://cloud.githubusercontent.com/assets/3170312/5620438/ec38c546-94e0-11e4-98c8-8d03a7cdc35d.png)

cc @jfirebaugh 