### PR TITLE
Remove old tiles when setting new data in GeoJSONSource. Fixes #905

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -30,6 +30,15 @@ GeoJSONSource.prototype = util.inherit(Source, {
     setData(data) {
         this._data = data;
         this._dirty = true;
+
+        // remove all tiles in current source, these contain old data
+        for (var tileId in this._tiles) {
+            this._removeTile(tileId);
+        }
+
+        // empty cache, since _removeTile adds removed tiles to this._cache for later use
+        this._cache.reset();
+
         this.fire('change');
         return this;
     },


### PR DESCRIPTION
Either aren't removed and/or stay cached. As a result, the source is not (fully) updated when setting new data through `setData()`.

This patch fixes the issue by removed all tiles, and then clearing the cache.