### PR TITLE
Add position opt to navigation controls, closes #918

### DIFF
--- a/API.md
+++ b/API.md
@@ -236,14 +236,17 @@ Option | Description
 `url` | A string or array of URL(s) to video files
 `coordinates` | lat,lng coordinates in order clockwise starting at the top left: tl, tr, br, bl
 
-## new mapboxgl.Navigation()
+## new mapboxgl.Navigation(options)
 
 Creates a navigation control with zoom buttons and a compass.
 
 ```js
-map.addControl(new mapboxgl.Navigation());
+map.addControl(new mapboxgl.Navigation({position: 'topleft'})); // position is optional
 ```
 
+Option | Description
+------ | ------
+`position` | A string indicating the control's position on the map. Options are `topright`, `topleft`, `bottomright`, `bottomleft` (defaults to `topright`)
 
 ## mapboxgl.Evented
 

--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -14,16 +14,29 @@
     cursor: -moz-grabbing;
     cursor: grabbing;
 }
+.mapboxgl-ctrl-topleft {
+    left: 10px;
+    top: 10px;
+}
+.mapboxgl-ctrl-topright {
+    right: 10px;
+    top: 10px;
+}
+.mapboxgl-ctrl-bottomleft {
+    left: 10px;
+    bottom: 10px;
+}
+.mapboxgl-ctrl-bottomright {
+    right: 10px;
+    bottom: 10px;
+}
 .mapboxgl-ctrl-nav {
     position: absolute;
     border-radius: 4px;
     border: 1px solid #ccc;
     overflow: hidden;
     background: #fff;
-    right: 10px;
-    top: 10px;
 }
-
 .mapboxgl-ctrl-nav > a {
     width: 26px;
     height: 26px;

--- a/docs/_posts/3400-01-01-api.html
+++ b/docs/_posts/3400-01-01-api.html
@@ -56,7 +56,7 @@ navigation:
     subnav:
   - title: mapboxgl.Navigation
     url: /api
-    id: new-mapboxgl-navigation-
+    id: new-mapboxgl-navigation-options-
     subnav:
   - title: mapboxgl.Evented
     url: /api
@@ -628,9 +628,23 @@ map.removeSource('some id');  // remove
 </tr>
 </tbody>
 </table>
-<h2 id="new-mapboxgl-navigation-">new mapboxgl.Navigation()</h2><p>Creates a navigation control with zoom buttons and a compass.</p>
-{% highlight js %}map.addControl(new mapboxgl.Navigation());
+<h2 id="new-mapboxgl-navigation-options-">new mapboxgl.Navigation(options)</h2><p>Creates a navigation control with zoom buttons and a compass.</p>
+{% highlight js %}map.addControl(new mapboxgl.Navigation({position: 'topleft'})); // position is optional
 {% endhighlight %}
+<table>
+<thead>
+<tr>
+<th>Option</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>position</code></td>
+<td>A string indicating the control&#39;s position on the map. Options are <code>topright</code>, <code>topleft</code>, <code>bottomright</code>, <code>bottomleft</code> (defaults to <code>topright</code>)</td>
+</tr>
+</tbody>
+</table>
 <h2 id="mapboxgl-evented">mapboxgl.Evented</h2><p>A class inherited by most other classes (<code>Map</code>, <code>Source</code> etc.) to get event capabilities.</p>
 <h3 id="mapboxgl-evented-methods">Methods</h3><table>
 <thead>

--- a/js/ui/control/control.js
+++ b/js/ui/control/control.js
@@ -8,6 +8,7 @@ Control.prototype = {
 	addTo(map) {
 		this._map = map;
 		this._container = this.onAdd(map);
+		if (this.opts && this.opts.position) this._container.className += ' mapboxgl-ctrl-' + this.opts.position;
 		return this;
 	},
 

--- a/js/ui/control/navigation.js
+++ b/js/ui/control/navigation.js
@@ -6,10 +6,12 @@ var util = require('../../util/util');
 
 module.exports = Navigation;
 
-function Navigation() {}
+function Navigation(opts) { this.opts = opts || {}; }
 
 Navigation.prototype = util.inherit(Control, {
     onAdd(map) {
+        if (!this.opts.position) this.opts.position = 'topright';
+
         var className = 'mapboxgl-ctrl-nav';
 
         var container = this._container = DOM.create('div', className, map.container);


### PR DESCRIPTION
Ref https://github.com/mapbox/mapbox-gl-js/issues/918 — navigation would now take a `position` option, a la [leaflet](https://www.mapbox.com/mapbox.js/api/v2.1.4/l-control/) (defaults to `topright`). This doesn't include `setPosition` but there are several other method differences already. Should we add all corresponding methods or does this suffice?
