### PR TITLE
allow characters outside \w to be used in token

### DIFF
--- a/js/util/token.js
+++ b/js/util/token.js
@@ -2,7 +2,7 @@
 
 module.exports = resolveTokens;
 
-var tokenPattern = /{([\w-]+)}/;
+var tokenPattern = /{([^{^}]+)}/;
 
 function resolveTokens(properties, expression) {
     var match;

--- a/js/util/token.js
+++ b/js/util/token.js
@@ -2,7 +2,7 @@
 
 module.exports = resolveTokens;
 
-var tokenPattern = /{([^{^}]+)}/;
+var tokenPattern = /{([^{}:;.,^]+)}/;
 
 function resolveTokens(properties, expression) {
     var match;

--- a/test/js/util/token.test.js
+++ b/test/js/util/token.test.js
@@ -15,6 +15,7 @@ test('token', function(t) {
     t.equal('3 Fine Fields', resolveTokens({a:3, b:'Fine', c:'Fields'}, '{a} {b} {c}'));
     t.equal(' but still', resolveTokens({}, '{notset} but still'));
     t.equal('dashed', resolveTokens({'dashed-property': 'dashed'}, '{dashed-property}'));
+    t.equal('150 m', resolveTokens({'HØYDE': 150}, '{HØYDE} m'));
 
     t.end();
 });

--- a/test/js/util/token.test.js
+++ b/test/js/util/token.test.js
@@ -16,6 +16,7 @@ test('token', function(t) {
     t.equal(' but still', resolveTokens({}, '{notset} but still'));
     t.equal('dashed', resolveTokens({'dashed-property': 'dashed'}, '{dashed-property}'));
     t.equal('150 m', resolveTokens({'HØYDE': 150}, '{HØYDE} m'));
+    t.equal('reserved {for:future} use', resolveTokens({'for:future': 'unknown'}, 'reserved {for:future} use'));
 
     t.end();
 });


### PR DESCRIPTION
Some data set may have attribute name with characters outside of [\w-]. One example is the attribute "HØYDE" (=altitude) used in Norwegian Topographical map.