### PR TITLE
Move featuresAt ref work out of the worker/featureTree, contained in style

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -461,7 +461,7 @@ Style.prototype = util.inherit(Evented, {
             if (Object.keys(this.refs).length) features.forEach((feature) => {
                 if (this.refs[feature.layer.id] && this.refs[feature.layer.id].length) {
                     this.refs[feature.layer.id].forEach(refLayer => {
-                        var copiedFeature = JSON.parse(JSON.stringify(feature));
+                        var copiedFeature = util.extend({}, feature);
                         copiedFeature.layer = this.layerMap[refLayer];
                         refFeatures.push(copiedFeature);
                     });


### PR DESCRIPTION
This essentially reverts #901, moving the featuresAt refs work to be contained within the Style so the worker doesn't parse ref layers into the featureTree.