### PR TITLE
Add visibility property in v7

### DIFF
--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -55,6 +55,10 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         if (maxzoom && this.zoom >= maxzoom)
             continue;
 
+        var visibility = layer.layout.visibility;
+        if (visibility === 'none')
+            continue;
+
         bucket = createBucket(layer, buffers, collision);
         bucket.layers = [layer.id];
 

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -113,7 +113,9 @@ StyleLayer.prototype = {
         }
 
         this.hidden = (this.minzoom && z < this.minzoom) ||
-                      (this.maxzoom && z >= this.maxzoom);
+                      (this.maxzoom && z >= this.maxzoom) ||
+                      // include visibility check for non-bucketed background layers
+                      (this.layout.visibility === 'none');
 
         if (type === 'symbol') {
             if ((calculated['text-opacity'] === 0 || !this.layout['text-field']) &&

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -9,6 +9,7 @@ test('basic', function(t) {
         id: 'test',
         source: 'source',
         type: 'fill',
+        layout: {},
         compare: function () { return true; }
     }];
 
@@ -19,9 +20,26 @@ test('basic', function(t) {
     }];
 
     var tile = new WorkerTile('', 0, 20, 512, 'source', 1);
-    tile.parse(new Wrapper(features), buckets, {}, function(err, result) {
-        t.ok(result.buffers, 'buffers');
-        t.ok(result.elementGroups, 'element groups');
-        t.end();
+
+    t.test('basic worker tile', function(t) {
+        tile.parse(new Wrapper(features), buckets, {}, function(err, result) {
+            t.ok(result.buffers, 'buffers');
+            t.ok(result.elementGroups, 'element groups');
+            t.end();
+        });
+    });
+
+    t.test('hidden layers', function(t) {
+        buckets.push({
+            id: 'test-hidden',
+            source: 'source',
+            type: 'fill',
+            layout: { visibility: 'none' },
+            compare: function () { return true; }
+        });
+        tile.parse(new Wrapper(features), buckets, {}, function(err, result) {
+            t.equal(Object.keys(result.elementGroups).length, 1, 'element groups exclude hidden layer');
+            t.end();
+        });
     });
 });


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-gl-style-spec/issues/212, adds a `visibility` layout property:
`visibility: [visible, placement, none]`

`placement` prevents a layer from rendering but affects other layers' placement; `none` suppresses a layer altogether.