### PR TITLE
API for mutating style properties

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -57,6 +57,10 @@ GeoJSONSource.prototype = util.inherit(Evented, {
         }
     },
 
+    reload: function() {
+        this._updateData();
+    },
+
     render: Source._renderTiles,
     featuresAt: Source._vectorFeaturesAt,
 

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -43,11 +43,17 @@ util.extend(Worker.prototype, {
                 params.id, params.zoom, params.maxZoom,
                 params.tileSize, params.source, params.depth);
 
-            tile.parse(new vt.VectorTile(new Protobuf(new Uint8Array(data))), this.layers, this.actor, callback);
+            tile.data = new vt.VectorTile(new Protobuf(new Uint8Array(data)));
+            tile.parse(tile.data, this.layers, this.actor, callback);
 
             this.loaded[source] = this.loaded[source] || {};
             this.loaded[source][id] = tile;
         }.bind(this));
+    },
+
+    'reload tile': function(params, callback) {
+        var tile = this.loaded[params.source][params.id];
+        tile.parse(tile.data, this.layers, this.actor, callback);
     },
 
     'abort tile': function(params) {

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -23,10 +23,11 @@ function WorkerTile(id, zoom, maxZoom, tileSize, source, depth) {
     this.tileSize = tileSize;
     this.source = source;
     this.depth = depth;
-    this.featureTree = new FeatureTree(getGeometry, getType);
 }
 
 WorkerTile.prototype.parse = function(data, layers, actor, callback) {
+    this.featureTree = new FeatureTree(getGeometry, getType);
+
     var i, k,
         tile = this,
         layer,

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -89,7 +89,7 @@ Style.prototype = util.inherit(Evented, {
     },
 
     _resolve: function() {
-        var id, layer, group, ordered = [];
+        var id, layer, group;
 
         this._layers = {};
         this._groups = [];
@@ -114,8 +114,6 @@ Style.prototype = util.inherit(Evented, {
         for (id in this._layers) {
             layer = this._layers[id];
 
-            ordered.push(layer.json());
-
             if (!group || layer.source !== group.source) {
                 group = [];
                 group.source = layer.source;
@@ -123,6 +121,16 @@ Style.prototype = util.inherit(Evented, {
             }
 
             group.push(layer);
+        }
+
+        this._broadcastLayers();
+    },
+
+    _broadcastLayers: function() {
+        var ordered = [];
+
+        for (var id in this._layers) {
+            ordered.push(this._layers[id].json());
         }
 
         this.dispatcher.broadcast('set layers', ordered);
@@ -246,6 +254,17 @@ Style.prototype = util.inherit(Evented, {
 
     getPaintProperty: function(layer, name, klass) {
         return this.getLayer(layer).getPaintProperty(name, klass);
+    },
+
+    setLayoutProperty: function(layer, name, value) {
+        layer = this.getLayer(layer);
+        layer.setLayoutProperty(name, value);
+        this._broadcastLayers();
+        this.sources[layer.source].reload();
+    },
+
+    getLayoutProperty: function(layer, name) {
+        return this.getLayer(layer).getLayoutProperty(name);
     },
 
     featuresAt: function(point, params, callback) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -95,7 +95,7 @@ Style.prototype = util.inherit(Evented, {
         this._groups = [];
 
         for (var i = 0; i < this.stylesheet.layers.length; i++) {
-            layer = new StyleLayer(this.stylesheet.layers[i], this.stylesheet.constants);
+            layer = new StyleLayer(this.stylesheet.layers[i], this.stylesheet.constants || {});
             this._layers[layer.id] = layer;
         }
 
@@ -107,7 +107,7 @@ Style.prototype = util.inherit(Evented, {
         // Resolve reference and paint properties.
         for (id in this._layers) {
             this._layers[id].resolveReference(this._layers);
-            this._layers[id].resolvePaint(this.stylesheet.transition);
+            this._layers[id].resolvePaint();
         }
 
         // Split into groups of consecutive top-level layers with the same source.
@@ -136,7 +136,9 @@ Style.prototype = util.inherit(Evented, {
         };
 
         for (var id in this._layers) {
-            this._layers[id].cascade(classes, options, this.animationLoop);
+            this._layers[id].cascade(classes, options,
+                this.stylesheet.transition || {},
+                this.animationLoop);
         }
 
         this.fire('change');
@@ -236,6 +238,14 @@ Style.prototype = util.inherit(Evented, {
 
     getLayer: function(id) {
         return this._layers[id];
+    },
+
+    setPaintProperty: function(layer, name, value, klass) {
+        this.getLayer(layer).setPaintProperty(name, value, klass);
+    },
+
+    getPaintProperty: function(layer, name, klass) {
+        return this.getLayer(layer).getPaintProperty(name, klass);
     },
 
     featuresAt: function(point, params, callback) {

--- a/js/style/style_declaration_set.js
+++ b/js/style/style_declaration_set.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var util = require('../util/util');
+var reference = require('./reference');
+var StyleConstant = require('./style_constant');
+var StyleDeclaration = require('./style_declaration');
+
+var lookup = {
+    paint: {},
+    layout: {}
+};
+
+reference.layer.type.values.forEach(function(type) {
+    lookup.paint[type] = makeConstructor(reference['paint_' + type]);
+    lookup.layout[type] = makeConstructor(reference['layout_' + type]);
+});
+
+function makeConstructor(reference) {
+    function StyleDeclarationSet(properties, constants) {
+        this._values      = {};
+        this._transitions = {};
+
+        this._constants = constants;
+
+        for (var k in properties) {
+            this[k] = StyleConstant.resolve(properties[k], this._constants);
+        }
+    }
+
+    Object.keys(reference).forEach(function(k) {
+        var property = reference[k];
+
+        Object.defineProperty(StyleDeclarationSet.prototype, k, {
+            set: function(v) {
+                this._values[k] = new StyleDeclaration(property, StyleConstant.resolve(v, this._constants));
+            },
+            get: function() {
+                return this._values[k].value;
+            }
+        });
+
+        if (property.transition) {
+            Object.defineProperty(StyleDeclarationSet.prototype, k + '-transition', {
+                set: function(v) {
+                    this._transitions[k] = v;
+                },
+                get: function() {
+                    return this._transitions[k];
+                }
+            });
+        }
+    });
+
+    StyleDeclarationSet.prototype.values = function() {
+        return this._values;
+    };
+
+    StyleDeclarationSet.prototype.transition = function(k, global) {
+        var t = this._transitions[k] || {};
+        return {
+            duration: util.coalesce(t.duration, global.duration, 300),
+            delay: util.coalesce(t.delay, global.delay, 0)
+        };
+    };
+
+    StyleDeclarationSet.prototype.json = function() {
+        var result = {};
+
+        for (var v in this._values) {
+            result[v] = this._values[v].value;
+        }
+
+        for (var t in this._transitions) {
+            result[t + '-transition'] = this._transitions[v];
+        }
+
+        return result;
+    };
+
+    return StyleDeclarationSet;
+}
+
+module.exports = function(renderType, layerType, properties, constants) {
+    return new lookup[renderType][layerType](properties, constants);
+};

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -41,6 +41,14 @@ StyleLayer.prototype = {
         }
     },
 
+    setLayoutProperty: function(name, value) {
+        this.layout[name] = StyleConstant.resolve(value, this._constants);
+    },
+
+    getLayoutProperty: function(name) {
+        return this.layout[name];
+    },
+
     resolveReference: function(layers) {
         if (this.ref) {
             this.assign(layers[this.ref]);

--- a/js/style/style_transition.js
+++ b/js/style/style_transition.js
@@ -46,7 +46,7 @@ StyleTransition.prototype.instant = function() {
  */
 StyleTransition.prototype.at = function(z, zoomHistory, t) {
 
-    var value = this.declaration.calculate(z, zoomHistory);
+    var value = this.declaration.calculate(z, zoomHistory, this.duration);
 
     if (this.instant()) return value;
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -258,6 +258,15 @@ util.extend(Map.prototype, {
         return this.style.getPaintProperty(layer, name, klass);
     },
 
+    setLayoutProperty: function(layer, name, value) {
+        this.style.setLayoutProperty(layer, name, value);
+        return this;
+    },
+
+    getLayoutProperty: function(layer, name) {
+        return this.style.getLayoutProperty(layer, name);
+    },
+
     _move: function(zoom, rotate) {
 
         this.update(zoom).fire('move');

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -247,6 +247,17 @@ util.extend(Map.prototype, {
         return this;
     },
 
+    setPaintProperty: function(layer, name, value, klass) {
+        this.style.setPaintProperty(layer, name, value, klass);
+        this.style._cascade(this._classes);
+        this.update(true);
+        return this;
+    },
+
+    getPaintProperty: function(layer, name, klass) {
+        return this.style.getPaintProperty(layer, name, klass);
+    },
+
     _move: function(zoom, rotate) {
 
         this.update(zoom).fire('move');

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -240,6 +240,37 @@ test('Style#setPaintProperty', function(t) {
     });
 });
 
+test('Style#setLayoutProperty', function(t) {
+    t.test('sets property', function(t) {
+        var style = new Style({
+            "version": 7,
+            "sources": {
+                "geojson": {
+                    "type": "geojson",
+                    "data": {
+                        "type": "FeatureCollection",
+                        "features": []
+                    }
+                }
+            },
+            "layers": [{
+                "id": "symbol",
+                "type": "symbol",
+                "source": "geojson",
+                "layout": {
+                    "text-transform": "uppercase"
+                }
+            }]
+        });
+
+        style.on('load', function() {
+            style.setLayoutProperty('symbol', 'text-transform', 'lowercase');
+            t.deepEqual(style.getLayoutProperty('symbol', 'text-transform'), 'lowercase');
+            t.end();
+        });
+    });
+});
+
 test('Style#featuresAt', function(t) {
     var style = new Style({
         "version": 7,

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -222,6 +222,24 @@ test('Style#removeSource', function(t) {
     });
 });
 
+test('Style#setPaintProperty', function(t) {
+    t.test('sets property', function(t) {
+        var style = new Style({
+            "version": 7,
+            "layers": [{
+                "id": "background",
+                "type": "background"
+            }]
+        });
+
+        style.on('load', function() {
+            style.setPaintProperty('background', 'background-color', 'red');
+            t.deepEqual(style.getPaintProperty('background', 'background-color'), [1, 0, 0, 1]);
+            t.end();
+        });
+    });
+});
+
 test('Style#featuresAt', function(t) {
     var style = new Style({
         "version": 7,

--- a/test/js/style/style_declaration.test.js
+++ b/test/js/style/style_declaration.test.js
@@ -3,77 +3,60 @@
 var test = require('tape');
 var StyleDeclaration = require('../../../js/style/style_declaration');
 
-test('styledeclaration', function(t) {
-
+test('StyleDeclaration', function(t) {
     t.test('boolean', function(t) {
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-antialias', false)).calculate(0), false);
+        var decl = new StyleDeclaration({type: "boolean"}, false);
+        t.equal(decl.calculate(0), false);
         t.end();
     });
 
     t.test('image', function(t) {
-        t.deepEqual((new StyleDeclaration('paint', 'fill', 'fill-image', 'smilingclownstaringatyou.png', { duration: 300 })).calculate(0, { lastIntegerZoomTime: 0, lastIntegerZoom: 0 }),
+        var decl = new StyleDeclaration({type: "image", transition: true}, 'smilingclownstaringatyou.png');
+        t.deepEqual(decl.calculate(0, { lastIntegerZoomTime: 0, lastIntegerZoom: 0 }, 300),
             { to: 'smilingclownstaringatyou.png', toScale: 1, from: 'smilingclownstaringatyou.png', fromScale: 0.5, t: 1 });
         t.end();
     });
 
-    t.test('keywords', function(t) {
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-translate-anchor', 'viewport')).calculate(0),
-            'viewport');
+    t.test('enum', function(t) {
+        var decl = new StyleDeclaration({type: "enum"}, 'viewport');
+        t.equal(decl.calculate(0), 'viewport');
         t.end();
     });
 
-    t.test('parseWidthArray', function(t) {
-        var dashFn = new StyleDeclaration('paint', 'line', 'line-dasharray', [0, 10, 5], { duration: 300 });
-        t.ok(dashFn instanceof StyleDeclaration);
-        t.deepEqual(dashFn.calculate(0, { lastIntegerZoomTime: 0, lastIntegerZoom: 0 }),
+    t.test('array', function(t) {
+        var decl = new StyleDeclaration({type: "array", transition: true}, [0, 10, 5]);
+        t.deepEqual(decl.calculate(0, { lastIntegerZoomTime: 0, lastIntegerZoom: 0 }, 300),
             { to: [ 0, 10, 5 ], toScale: 1, from: [ 0, 10, 5 ], fromScale: 0.5, t: 1 });
         t.end();
     });
 
     t.test('constant', function(t) {
-        t.equal((new StyleDeclaration('paint', 'line', 'line-width', 5)).calculate(0), 5);
-        t.equal((new StyleDeclaration('paint', 'line', 'line-width', 5)).calculate(100), 5);
+        t.equal((new StyleDeclaration({type: "number"}, 5)).calculate(0), 5);
+        t.equal((new StyleDeclaration({type: "number"}, 5)).calculate(100), 5);
         t.end();
     });
 
-    t.test('paint functions', function(t) {
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-opacity', { stops: [] })).calculate(0), 1);
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-opacity', { stops: [[2, 2], [5, 10]] })).calculate(0), 2);
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-opacity', { stops: [[0, 0], [5, 10]] })).calculate(12), 10);
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-opacity', { stops: [[0, 0], [5, 10]] })).calculate(6), 10);
-        t.equal(Math.round((new StyleDeclaration('paint', 'fill', 'fill-opacity', { stops: [[0, 0], [5, 10]], base: 1.01 })).calculate(2.5)), 5);
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-opacity', { stops: [[0, 0], [1, 10], [2, 20]] })).calculate(2), 20);
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-opacity', { stops: [[0, 0], [1, 10], [2, 20]] })).calculate(1), 10);
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-opacity', { stops: [[0, 0]] })).calculate(6), 0);
-
-        t.end();
-    });
-
-    t.test('layout functions', function(t) {
-        t.equal((new StyleDeclaration('layout', 'line', 'line-miter-limit', { stops: [] })).calculate(0), 1);
-        t.equal((new StyleDeclaration('layout', 'symbol', 'symbol-min-distance', { stops: [[8, 0], [12, 250]] })).calculate(6), 0);
-        t.equal((new StyleDeclaration('layout', 'symbol', 'icon-rotate', { stops: [[8, 0], [12, 360]] })).calculate(11), 270);
-        t.deepEqual((new StyleDeclaration('layout', 'symbol', 'text-offset', { stops: [[8, [0, 10]], [12, [10, 10]]] })).calculate(10), [5, 10]);
-
+    t.test('functions', function(t) {
+        var reference = {type: "number", function: "interpolated"};
+        t.equal((new StyleDeclaration(reference, { stops: [] })).calculate(0), 1);
+        t.equal((new StyleDeclaration(reference, { stops: [[2, 2], [5, 10]] })).calculate(0), 2);
+        t.equal((new StyleDeclaration(reference, { stops: [[0, 0], [5, 10]] })).calculate(12), 10);
+        t.equal((new StyleDeclaration(reference, { stops: [[0, 0], [5, 10]] })).calculate(6), 10);
+        t.equal(Math.round((new StyleDeclaration(reference, { stops: [[0, 0], [5, 10]], base: 1.01 })).calculate(2.5)), 5);
+        t.equal((new StyleDeclaration(reference, { stops: [[0, 0], [1, 10], [2, 20]] })).calculate(2), 20);
+        t.equal((new StyleDeclaration(reference, { stops: [[0, 0], [1, 10], [2, 20]] })).calculate(1), 10);
+        t.equal((new StyleDeclaration(reference, { stops: [[0, 0]] })).calculate(6), 0);
         t.end();
     });
 
     t.test('color parsing', function(t) {
-        t.deepEqual(new StyleDeclaration('paint', 'line', 'line-color', 'red').calculate(0), [ 1, 0, 0, 1 ]);
-        t.deepEqual(new StyleDeclaration('paint', 'line', 'line-color', '#ff00ff').calculate(0), [ 1, 0, 1, 1 ]);
-        t.deepEqual(new StyleDeclaration('paint', 'line', 'line-color', { stops: [[0, '#f00'], [1, '#0f0']] }).calculate(0), [1, 0, 0, 1]);
+        var reference = {type: "color", function: "interpolated"};
+        t.deepEqual(new StyleDeclaration(reference, 'red').calculate(0), [ 1, 0, 0, 1 ]);
+        t.deepEqual(new StyleDeclaration(reference, '#ff00ff').calculate(0), [ 1, 0, 1, 1 ]);
+        t.deepEqual(new StyleDeclaration(reference, { stops: [[0, '#f00'], [1, '#0f0']] }).calculate(0), [1, 0, 0, 1]);
         // cached
-        t.deepEqual(new StyleDeclaration('paint', 'line', 'line-color', '#ff00ff').calculate(0), [ 1, 0, 1, 1 ]);
-        t.deepEqual(new StyleDeclaration('paint', 'line', 'line-color', 'rgba(255, 51, 0, 1)').calculate(0), [ 1, 0.2, 0, 1 ]);
+        t.deepEqual(new StyleDeclaration(reference, '#ff00ff').calculate(0), [ 1, 0, 1, 1 ]);
+        t.deepEqual(new StyleDeclaration(reference, 'rgba(255, 51, 0, 1)').calculate(0), [ 1, 0.2, 0, 1 ]);
         t.end();
     });
-
-    t.equal((new StyleDeclaration('paint', '', 'unknown-prop')).prop, undefined, 'unknown prop');
-
-    var widthfn = new StyleDeclaration('paint', 'line', 'line-width', function(z) {
-        return Math.pow(z, 2);
-    });
-    t.equal(widthfn.calculate(10), 100);
-
-    t.end();
 });

--- a/test/js/style/style_declaration_set.test.js
+++ b/test/js/style/style_declaration_set.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var test = require('tape');
+var StyleDeclarationSet = require('../../../js/style/style_declaration_set');
+
+test('StyleDeclarationSet', function(t) {
+    t.test('creates value setters', function(t) {
+        var set = new StyleDeclarationSet('paint', 'background');
+        set['background-color'] = 'blue';
+        t.deepEqual(set._values['background-color'].value, [0, 0, 1, 1]);
+        t.end();
+    });
+
+    t.test('creates transition setters', function(t) {
+        var set = new StyleDeclarationSet('paint', 'background');
+        set['background-color-transition'] = {duration: 400};
+        t.deepEqual(set._transitions, {'background-color': {duration: 400}});
+        t.end();
+    });
+
+    t.test('constructs with a property set', function(t) {
+        var set = new StyleDeclarationSet('paint', 'background', {
+            'background-color': 'blue'
+        });
+        t.deepEqual(set._values['background-color'].value, [0, 0, 1, 1]);
+        t.end();
+    });
+
+    t.test('resolves constants', function(t) {
+        var set = new StyleDeclarationSet('paint', 'background', {
+            'background-color': '@blue'
+        }, {
+            '@blue': 'blue'
+        });
+        t.deepEqual(set._values['background-color'].value, [0, 0, 1, 1]);
+        t.end();
+    });
+
+    t.test('returns external representation', function(t) {
+        var set = new StyleDeclarationSet('paint', 'background');
+        set['background-color'] = 'blue';
+        set['background-color-transition'] = {duration: 400};
+        t.deepEqual(set.json(), {
+            'background-color': [0, 0, 1, 1],
+            'background-color-transition': {duration: 400}
+        });
+        t.end();
+    });
+});

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -195,3 +195,67 @@ test('StyleLayer#setPaintProperty', function(t) {
         t.end();
     });
 });
+
+test('StyleLayer#setLayoutProperty', function(t) {
+    t.test('sets new property value', function(t) {
+        var layer = new StyleLayer({
+            "id": "symbol",
+            "type": "symbol"
+        });
+
+        layer.resolveLayout();
+        layer.setLayoutProperty('text-transform', 'lowercase');
+
+        t.deepEqual(layer.getLayoutProperty('text-transform'), 'lowercase');
+        t.end();
+    });
+
+    t.test('updates property value', function(t) {
+        var layer = new StyleLayer({
+            "id": "symbol",
+            "type": "symbol",
+            "layout": {
+                "text-transform": "uppercase"
+            }
+        });
+
+        layer.resolveLayout();
+        layer.setLayoutProperty('text-transform', 'lowercase');
+
+        t.deepEqual(layer.getLayoutProperty('text-transform'), 'lowercase');
+        t.end();
+    });
+
+    t.test('resolves constants (create)', function(t) {
+        var layer = new StyleLayer({
+            "id": "symbol",
+            "type": "symbol"
+        }, {
+            '@lowercase': 'lowercase'
+        });
+
+        layer.resolveLayout();
+        layer.setLayoutProperty('text-transform', '@lowercase');
+
+        t.deepEqual(layer.getLayoutProperty('text-transform'), 'lowercase');
+        t.end();
+    });
+
+    t.test('resolves constants (update)', function(t) {
+        var layer = new StyleLayer({
+            "id": "symbol",
+            "type": "symbol",
+            "layout": {
+                "text-transform": "uppercase"
+            }
+        }, {
+            '@lowercase': 'lowercase'
+        });
+
+        layer.resolveLayout();
+        layer.setLayoutProperty('text-transform', '@lowercase');
+
+        t.deepEqual(layer.getLayoutProperty('text-transform'), 'lowercase');
+        t.end();
+    });
+});

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -61,76 +61,137 @@ test('StyleLayer#resolvePaint', function(t) {
         t.deepEqual(Object.keys(layer._resolved), ['', 'night']);
         t.end();
     });
+});
 
-    t.test('matches paint properties with their transitions', function(t) {
+//test('StyleLayer#cascade', function(t) {
+//    t.test('applies default transitions', function(t) {
+//        var layer = new StyleLayer({
+//            type: 'fill',
+//            paint: {
+//                'fill-color': 'blue'
+//            }
+//        });
+//
+//        layer.resolvePaint({});
+//
+//        var declaration = layer._resolved['']['fill-color'];
+//        t.deepEqual(declaration.value, [0, 0, 1, 1]);
+//        t.deepEqual(declaration.transition, {delay: 0, duration: 300});
+//
+//        t.end();
+//    });
+//});
+
+test('StyleLayer#setPaintProperty', function(t) {
+    t.test('sets new property value', function(t) {
         var layer = new StyleLayer({
-            type: 'fill',
-            paint: {
-                'fill-color': 'blue',
-                'fill-color-transition': {
-                    delay: 10,
-                    duration: 20
+            "id": "background",
+            "type": "background"
+        });
+
+        layer.setPaintProperty('background-color', 'blue');
+
+        t.deepEqual(layer.getPaintProperty('background-color'), [0, 0, 1, 1]);
+        t.end();
+    });
+
+    t.test('updates property value', function(t) {
+        var layer = new StyleLayer({
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "red"
+            }
+        });
+
+        layer.resolvePaint({});
+        layer.setPaintProperty('background-color', 'blue');
+
+        t.deepEqual(layer.getPaintProperty('background-color'), [0, 0, 1, 1]);
+        t.end();
+    });
+
+    t.test('sets classed paint value', function(t) {
+        var layer = new StyleLayer({
+            "id": "background",
+            "type": "background",
+            "paint.night": {
+                "background-color": "red"
+            }
+        });
+
+        layer.resolvePaint({});
+        layer.setPaintProperty('background-color', 'blue', 'night');
+
+        t.deepEqual(layer.getPaintProperty('background-color', 'night'), [0, 0, 1, 1]);
+        t.end();
+    });
+
+    t.test('preserves existing transition', function(t) {
+        var layer = new StyleLayer({
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "red",
+                "background-color-transition": {
+                    duration: 600
                 }
             }
         });
 
         layer.resolvePaint({});
+        layer.setPaintProperty('background-color', 'blue');
 
-        var declaration = layer._resolved['']['fill-color'];
-        t.deepEqual(declaration.value, [0, 0, 1, 1]);
-        t.deepEqual(declaration.transition, {delay: 10, duration: 20});
-
+        t.deepEqual(layer.getPaintProperty('background-color-transition'), {duration: 600});
         t.end();
     });
 
-    t.test('applies default transitions', function(t) {
+    t.test('sets transition', function(t) {
         var layer = new StyleLayer({
-            type: 'fill',
-            paint: {
-                'fill-color': 'blue'
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "red"
             }
         });
 
         layer.resolvePaint({});
+        layer.setPaintProperty('background-color-transition', {duration: 400});
 
-        var declaration = layer._resolved['']['fill-color'];
-        t.deepEqual(declaration.value, [0, 0, 1, 1]);
-        t.deepEqual(declaration.transition, {delay: 0, duration: 300});
-
+        t.deepEqual(layer.getPaintProperty('background-color-transition'), {duration: 400});
         t.end();
     });
 
-    t.test('ignores transitions without a matching base value', function(t) {
+    t.test('resolves constants (create)', function(t) {
         var layer = new StyleLayer({
-            type: 'fill',
-            paint: {
-                'fill-color-transition': {
-                    delay: 10,
-                    duration: 20
-                }
-            }
+            "id": "background",
+            "type": "background"
+        }, {
+            '@blue': 'blue'
         });
 
-        layer.resolvePaint({});
+        layer.resolvePaint();
+        layer.setPaintProperty('background-color', '@blue');
 
-        t.equal(layer._resolved['']['fill-color'], undefined);
+        t.deepEqual(layer.getPaintProperty('background-color'), [0, 0, 1, 1]);
         t.end();
     });
 
-    t.test('resolves paint constants', function(t) {
+    t.test('resolves constants (update)', function(t) {
         var layer = new StyleLayer({
-            type: 'fill',
-            paint: {
-                'fill-color': '@blue'
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "red"
             }
         }, {
             '@blue': 'blue'
         });
 
         layer.resolvePaint();
+        layer.setPaintProperty('background-color', '@blue');
 
-        var declaration = layer._resolved['']['fill-color'];
-        t.deepEqual(declaration.value, [0, 0, 1, 1]);
+        t.deepEqual(layer.getPaintProperty('background-color'), [0, 0, 1, 1]);
         t.end();
     });
 });


### PR DESCRIPTION
So, it appears that it's only possible to cascade style changes made from an external tool if you change the stylesheet passed into mapbox-gl-js by reference, which is yucky.

Either let's have an API to do this, or maybe it'll be necessary to hack this in by using `_.assign` with `map.style.stylesheet`