### PR TITLE
functions for pattern properties

### DIFF
--- a/js/data/create_bucket.js
+++ b/js/data/create_bucket.js
@@ -19,7 +19,8 @@ function createBucket(layer, buffers, collision, z) {
 
     var calculatedLayout = util.extend({}, layer.layout);
     for (var k in calculatedLayout) {
-        calculatedLayout[k] = new StyleDeclaration('layout', layer.type, k, calculatedLayout[k]).calculate(z);
+        var fakeZoomHistory = { lastIntegerZoom: Infinity, lastIntegerZoomTime: 0, lastZoom: 0 };
+        calculatedLayout[k] = new StyleDeclaration('layout', layer.type, k, calculatedLayout[k]).calculate(z, fakeZoomHistory);
     }
 
     var layoutProperties = new LayoutProperties[layer.type](calculatedLayout);

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -14,8 +14,8 @@ function drawRaster(painter, layer, posMatrix, tile) {
     gl.switchShader(shader, posMatrix);
 
     // color parameters
-    gl.uniform1f(shader.u_brightness_low, layer.paint['raster-brightness'][0]);
-    gl.uniform1f(shader.u_brightness_high, layer.paint['raster-brightness'][1]);
+    gl.uniform1f(shader.u_brightness_low, layer.paint['raster-brightness-min']);
+    gl.uniform1f(shader.u_brightness_high, layer.paint['raster-brightness-max']);
     gl.uniform1f(shader.u_saturation_factor, saturationFactor(layer.paint['raster-saturation']));
     gl.uniform1f(shader.u_contrast_factor, contrastFactor(layer.paint['raster-contrast']));
     gl.uniform3fv(shader.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -72,7 +72,7 @@ GLPainter.prototype.setup = function() {
 
     this.linepatternShader = gl.initializeShader('linepattern',
         ['a_pos', 'a_data'],
-        ['u_matrix', 'u_exmatrix', 'u_linewidth', 'u_ratio', 'u_pattern_size', 'u_pattern_tl', 'u_pattern_br', 'u_point', 'u_blur', 'u_fade', 'u_opacity']);
+        ['u_matrix', 'u_exmatrix', 'u_linewidth', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_blur', 'u_fade', 'u_opacity']);
 
     this.linesdfpatternShader = gl.initializeShader('linesdfpattern',
         ['a_pos', 'a_data'],
@@ -97,7 +97,7 @@ GLPainter.prototype.setup = function() {
 
     this.patternShader = gl.initializeShader('pattern',
         ['a_pos'],
-        ['u_matrix', 'u_pattern_tl', 'u_pattern_br', 'u_mix', 'u_patternmatrix', 'u_opacity', 'u_image']
+        ['u_matrix', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_mix', 'u_patternmatrix_a', 'u_patternmatrix_b', 'u_opacity', 'u_image']
     );
 
     this.fillShader = gl.initializeShader('fill',
@@ -219,7 +219,7 @@ GLPainter.prototype.render = function(style, options) {
     this.glyphAtlas = style.glyphAtlas;
     this.glyphAtlas.bind(this.gl);
 
-    this.recordZoom(this.transform.zoom);
+    this.frameHistory.record(this.transform.zoom);
 
     this.prepareBuffers();
     this.clearColor();
@@ -319,28 +319,4 @@ GLPainter.prototype.saveTexture = function(texture) {
 GLPainter.prototype.getTexture = function(size) {
     var textures = this.reusableTextures[size];
     return textures && textures.length > 0 ? textures.pop() : null;
-};
-
-GLPainter.prototype.recordZoom = function(zoom) {
-
-    this.frameHistory.record(zoom);
-
-    if (this.lastIntegerZoom === undefined) {
-        this.lastIntegerZoom = Math.floor(this.transform.zoom);
-        this.lastIntegerZoomTime = 0;
-        this.lastZoom = zoom;
-    }
-
-    // check whether an integer zoom level as passed since the last frame
-    // and if yes, record it with the time. Used for transitioning patterns.
-    if (Math.floor(this.lastZoom) < Math.floor(zoom)) {
-        this.lastIntegerZoom = Math.floor(zoom);
-        this.lastIntegerZoomTime = Date.now();
-
-    } else if (Math.floor(this.lastZoom) > Math.floor(zoom)) {
-        this.lastIntegerZoom = Math.floor(zoom + 1);
-        this.lastIntegerZoomTime = Date.now();
-    }
-
-    this.lastZoom = this.transform.zoom;
 };

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -2,9 +2,12 @@ uniform vec2 u_linewidth;
 uniform float u_point;
 uniform float u_blur;
 
-uniform vec2 u_pattern_size;
-uniform vec2 u_pattern_tl;
-uniform vec2 u_pattern_br;
+uniform vec2 u_pattern_size_a;
+uniform vec2 u_pattern_size_b;
+uniform vec2 u_pattern_tl_a;
+uniform vec2 u_pattern_br_a;
+uniform vec2 u_pattern_tl_b;
+uniform vec2 u_pattern_br_b;
 uniform float u_fade;
 uniform float u_opacity;
 
@@ -15,22 +18,21 @@ varying float v_linesofar;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * (1.0 - u_point) + u_point * length(gl_PointCoord * 2.0 - 1.0);
-
-    dist *= u_linewidth.s;
+    float dist = length(v_normal) * u_linewidth.s;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
     float alpha = clamp(min(dist - (u_linewidth.t - u_blur), u_linewidth.s - dist) / u_blur, 0.0, 1.0);
 
-    float x = mod(v_linesofar / u_pattern_size.x, 1.0);
-    float y = 0.5 + (v_normal.y * u_linewidth.s / u_pattern_size.y);
-    vec2 pos = mix(u_pattern_tl, u_pattern_br, vec2(x, y));
-    float x2 = mod(x * 2.0, 1.0);
-    vec2 pos2 = mix(u_pattern_tl, u_pattern_br, vec2(x2, y));
+    float x_a = mod(v_linesofar / u_pattern_size_a.x, 1.0);
+    float x_b = mod(v_linesofar / u_pattern_size_b.x, 1.0);
+    float y_a = 0.5 + (v_normal.y * u_linewidth.s / u_pattern_size_a.y);
+    float y_b = 0.5 + (v_normal.y * u_linewidth.s / u_pattern_size_b.y);
+    vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, vec2(x_a, y_a));
+    vec2 pos2 = mix(u_pattern_tl_b, u_pattern_br_b, vec2(x_b, y_b));
 
-    vec4 color = texture2D(u_image, pos) * (1.0 - u_fade) + u_fade * texture2D(u_image, pos2);
+    vec4 color = mix(texture2D(u_image, pos), texture2D(u_image, pos2), u_fade);
 
     alpha *= u_opacity;
 

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -18,7 +18,6 @@ uniform mat4 u_exmatrix;
 uniform float u_ratio;
 uniform vec2 u_linewidth;
 uniform vec4 u_color;
-uniform float u_point;
 
 varying vec2 v_normal;
 varying float v_linesofar;
@@ -38,23 +37,13 @@ void main() {
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
     vec2 extrude = a_extrude * scale;
-    vec2 dist = u_linewidth.s * extrude * (1.0 - u_point);
-
-    // If the x coordinate is the maximum integer, we move the z coordinates out
-    // of the view plane so that the triangle gets clipped. This makes it easier
-    // for us to create degenerate triangle strips.
-    float z = step(32767.0, a_pos.x);
-
-    // When drawing points, skip every other vertex
-    z += u_point * step(1.0, v_normal.y);
+    vec2 dist = u_linewidth.s * extrude;
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
     // because we're extruding the line in pixel space, regardless of the current
     // tile's zoom level.
-    gl_Position = u_matrix * vec4(floor(a_pos / 2.0), 0.0, 1.0) + u_exmatrix * vec4(dist, z, 0.0);
+    gl_Position = u_matrix * vec4(floor(a_pos / 2.0), 0.0, 1.0) + u_exmatrix * vec4(dist, 0.0, 0.0);
     v_linesofar = a_linesofar;// * u_ratio;
 
-
-    gl_PointSize = 2.0 * u_linewidth.s - 1.0;
 }

--- a/shaders/pattern.fragment.glsl
+++ b/shaders/pattern.fragment.glsl
@@ -1,20 +1,23 @@
 uniform float u_opacity;
-uniform vec2 u_pattern_tl;
-uniform vec2 u_pattern_br;
+uniform vec2 u_pattern_tl_a;
+uniform vec2 u_pattern_br_a;
+uniform vec2 u_pattern_tl_b;
+uniform vec2 u_pattern_br_b;
 uniform float u_mix;
 
 uniform sampler2D u_image;
 
-varying vec2 v_pos;
+varying vec2 v_pos_a;
+varying vec2 v_pos_b;
 
 void main() {
 
-    vec2 imagecoord = mod(v_pos, 1.0);
-    vec2 pos = mix(u_pattern_tl, u_pattern_br, imagecoord);
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, imagecoord);
     vec4 color1 = texture2D(u_image, pos);
 
-    vec2 imagecoord2 = mod(imagecoord * 2.0, 1.0);
-    vec2 pos2 = mix(u_pattern_tl, u_pattern_br, imagecoord2);
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(u_pattern_tl_b, u_pattern_br_b, imagecoord_b);
     vec4 color2 = texture2D(u_image, pos2);
 
     gl_FragColor = mix(color1, color2, u_mix) * u_opacity;

--- a/shaders/pattern.vertex.glsl
+++ b/shaders/pattern.vertex.glsl
@@ -1,11 +1,14 @@
 uniform mat4 u_matrix;
-uniform mat3 u_patternmatrix;
+uniform mat3 u_patternmatrix_a;
+uniform mat3 u_patternmatrix_b;
 
 attribute vec2 a_pos;
 
-varying vec2 v_pos;
+varying vec2 v_pos_a;
+varying vec2 v_pos_b;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
-    v_pos = (u_patternmatrix * vec3(a_pos, 1)).xy;
+    v_pos_a = (u_patternmatrix_a * vec3(a_pos, 1)).xy;
+    v_pos_b = (u_patternmatrix_b * vec3(a_pos, 1)).xy;
 }

--- a/test/js/style/style_declaration.test.js
+++ b/test/js/style/style_declaration.test.js
@@ -11,8 +11,8 @@ test('styledeclaration', function(t) {
     });
 
     t.test('image', function(t) {
-        t.equal((new StyleDeclaration('paint', 'fill', 'fill-image', 'smilingclownstaringatyou.png')).calculate(0),
-            'smilingclownstaringatyou.png');
+        t.deepEqual((new StyleDeclaration('paint', 'fill', 'fill-image', 'smilingclownstaringatyou.png', { duration: 300 })).calculate(0, { lastIntegerZoomTime: 0, lastIntegerZoom: 0 }),
+            { to: 'smilingclownstaringatyou.png', toScale: 1, from: 'smilingclownstaringatyou.png', fromScale: 0.5, t: 1 });
         t.end();
     });
 
@@ -23,9 +23,10 @@ test('styledeclaration', function(t) {
     });
 
     t.test('parseWidthArray', function(t) {
-        var dashFn = new StyleDeclaration('paint', 'line', 'line-dasharray', [0, 10, 5]);
+        var dashFn = new StyleDeclaration('paint', 'line', 'line-dasharray', [0, 10, 5], { duration: 300 });
         t.ok(dashFn instanceof StyleDeclaration);
-        t.deepEqual(dashFn.calculate(0), [0, 10, 5]);
+        t.deepEqual(dashFn.calculate(0, { lastIntegerZoomTime: 0, lastIntegerZoom: 0 }),
+            { to: [ 0, 10, 5 ], toScale: 1, from: [ 0, 10, 5 ], fromScale: 0.5, t: 1 });
         t.end();
     });
 
@@ -52,7 +53,7 @@ test('styledeclaration', function(t) {
         t.equal((new StyleDeclaration('layout', 'line', 'line-miter-limit', { stops: [] })).calculate(0), 1);
         t.equal((new StyleDeclaration('layout', 'symbol', 'symbol-min-distance', { stops: [[8, 0], [12, 250]] })).calculate(6), 0);
         t.equal((new StyleDeclaration('layout', 'symbol', 'icon-rotate', { stops: [[8, 0], [12, 360]] })).calculate(11), 270);
-        t.deepEqual((new StyleDeclaration('layout', 'symbol', 'text-offset', [{ stops: [[8, 0], [12, 10]] }, 10])).calculate(10), [5, 10]);
+        t.deepEqual((new StyleDeclaration('layout', 'symbol', 'text-offset', { stops: [[8, [0, 10]], [12, [10, 10]]] })).calculate(10), [5, 10]);
 
         t.end();
     });


### PR DESCRIPTION
This implements functions for line, fill and background patterns. They look like this:
```
"fill-image": {
    "stops": [[0, "waves-small"], [10, "waves-medium"], [15, "waves-large"]],
    "duration": 300
}
```
Duration is optional.

todo:
- [x] style spec changes so that linting works https://github.com/mapbox/mapbox-gl-style-spec/pull/243
- [x] add more specific types so parsing doesn't need to [depend on property names](https://github.com/mapbox/mapbox-gl-js/blob/a47aeb875ced1e1c03d0b6ba0e15574de63b9d8c/js/style/style_declaration.js#L35). This could be done later
- [x] native https://github.com/mapbox/mapbox-gl-native/tree/pattern-functions