### PR TITLE
reparse overscaled tiles

### DIFF
--- a/js/data/create_bucket.js
+++ b/js/data/create_bucket.js
@@ -9,7 +9,7 @@ var LayoutProperties = require('../style/layout_properties');
 var featureFilter = require('feature-filter');
 var StyleDeclarationSet = require('../style/style_declaration_set');
 
-function createBucket(layer, buffers, collision, z) {
+function createBucket(layer, buffers, collision, z, overscaling) {
     var values = new StyleDeclarationSet('layout', layer.type, layer.layout, {}).values(),
         fakeZoomHistory = { lastIntegerZoom: Infinity, lastIntegerZoomTime: 0, lastZoom: 0 },
         layout = {};
@@ -23,7 +23,7 @@ function createBucket(layer, buffers, collision, z) {
         layer.type === 'fill' ? FillBucket :
         layer.type === 'symbol' ? SymbolBucket : null;
 
-    var bucket = new BucketClass(buffers, new LayoutProperties[layer.type](layout), collision);
+    var bucket = new BucketClass(buffers, new LayoutProperties[layer.type](layout), collision, overscaling);
 
     bucket.id = layer.id;
     bucket.type = layer.type;

--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -4,10 +4,11 @@ var ElementGroups = require('./element_groups');
 
 module.exports = LineBucket;
 
-function LineBucket(buffers, layoutProperties) {
+function LineBucket(buffers, layoutProperties, _, overscaling) {
     this.buffers = buffers;
     this.elementGroups = new ElementGroups(buffers.lineVertex, buffers.lineElement);
     this.layoutProperties = layoutProperties;
+    this.overscaling = overscaling;
 }
 
 LineBucket.prototype.addFeatures = function() {
@@ -90,7 +91,7 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
         currentVertex = vertices[i];
 
         // Calculate how far along the line the currentVertex is
-        if (prevVertex) distance += currentVertex.dist(prevVertex);
+        if (prevVertex) distance += currentVertex.dist(prevVertex) * this.overscaling;
 
         // Calculate the normal towards the next vertex in this line. In case
         // there is no next vertex, pretend that the line is continuing straight,

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -12,7 +12,7 @@ function drawFill(painter, layer, posMatrix, tile) {
     if (!elementGroups) return;
 
     var gl = painter.gl;
-    var translatedPosMatrix = painter.translateMatrix(posMatrix, tile.zoom, layer.paint['fill-translate'], layer.paint['fill-translate-anchor']);
+    var translatedPosMatrix = painter.translateMatrix(posMatrix, tile, layer.paint['fill-translate'], layer.paint['fill-translate-anchor']);
 
     var color = layer.paint['fill-color'];
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -35,7 +35,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
 
     var color = layer.paint['line-color'];
     var ratio = painter.transform.scale / (1 << tile.zoom) / 8;
-    var vtxMatrix = painter.translateMatrix(posMatrix, tile.zoom, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
+    var vtxMatrix = painter.translateMatrix(posMatrix, tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
 
     var shader;
 

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -30,7 +30,7 @@ var defaultSizes = {
 function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf) {
     var gl = painter.gl;
 
-    posMatrix = painter.translateMatrix(posMatrix, tile.zoom, layer.paint[prefix + '-translate'], layer.paint[prefix + '-translate-anchor']);
+    posMatrix = painter.translateMatrix(posMatrix, tile, layer.paint[prefix + '-translate'], layer.paint[prefix + '-translate-anchor']);
 
     var exMatrix = mat4.clone(painter.projectionMatrix);
     var alignedWithMap = layer.layout[prefix + '-rotation-alignment'] === 'map';

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -282,7 +282,7 @@ GLPainter.prototype.drawStencilBuffer = function() {
     gl.blendFunc(gl.ONE_MINUS_DST_ALPHA, gl.ONE);
 };
 
-GLPainter.prototype.translateMatrix = function(matrix, z, translate, anchor) {
+GLPainter.prototype.translateMatrix = function(matrix, tile, translate, anchor) {
     if (!translate[0] && !translate[1]) return matrix;
 
     if (anchor === 'viewport') {
@@ -294,7 +294,7 @@ GLPainter.prototype.translateMatrix = function(matrix, z, translate, anchor) {
         ];
     }
 
-    var tilePixelRatio = this.transform.scale / (1 << z) / 8;
+    var tilePixelRatio = this.transform.scale / (1 << tile.zoom) / (tile.tileExtent / tile.tileSize);
     var translation = [
         translate[0] / tilePixelRatio,
         translate[1] / tilePixelRatio,

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -22,6 +22,7 @@ exports._loadTileJSON = function(options) {
             cacheSize: 20,
             minzoom: this.minzoom,
             maxzoom: this.maxzoom,
+            reparseOverscaled: this.reparseOverscaled,
             load: this._loadTile.bind(this),
             abort: this._abortTile.bind(this),
             unload: this._unloadTile.bind(this),
@@ -51,6 +52,10 @@ exports._renderTiles = function(layers, painter) {
             x = pos.x,
             y = pos.y,
             w = pos.w;
+
+        // if z > maxzoom then the tile is actually a overscaled maxzoom tile,
+        // so calculate the matrix the maxzoom tile would use.
+        z = Math.min(z, this.maxzoom);
 
         x += w * (1 << z);
         tile.calculateMatrices(z, x, y, painter.transform, painter);

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -10,12 +10,13 @@ var BufferSet = require('../data/buffer/buffer_set');
 
 module.exports = Tile;
 
-function Tile(id) {
+function Tile(id, size) {
     this.id = id;
     this.uid = util.uniqueId();
     this.loaded = false;
     this.zoom = TileCoord.fromID(id).z;
     this.uses = 0;
+    this.tileSize = size;
 }
 
 Tile.prototype = {

--- a/js/source/tile_coord.js
+++ b/js/source/tile_coord.js
@@ -41,12 +41,12 @@ TileCoord.zoom = function(id) {
 };
 
 // Given an id and a list of urls, choose a url template and return a tile URL
-TileCoord.url = function(id, urls) {
+TileCoord.url = function(id, urls, sourceMaxZoom) {
     var pos = TileCoord.fromID(id);
 
     return urls[(pos.x + pos.y) % urls.length]
         .replace('{prefix}', (pos.x % 16).toString(16) + (pos.y % 16).toString(16))
-        .replace('{z}', pos.z)
+        .replace('{z}', Math.min(pos.z, sourceMaxZoom || pos.z))
         .replace('{x}', pos.x)
         .replace('{y}', pos.y);
 };
@@ -54,9 +54,15 @@ TileCoord.url = function(id, urls) {
 /*
  * Given a packed integer id, return the id of its parent tile
  */
-TileCoord.parent = function(id) {
+TileCoord.parent = function(id, sourceMaxZoom) {
     var pos = TileCoord.fromID(id);
     if (pos.z === 0) return null;
+
+    // the id represents an overscaled tile, return the same coordinates with a lower z
+    if (pos.z > sourceMaxZoom) {
+        return TileCoord.toID(pos.z - 1, pos.x, pos.y, pos.w);
+    }
+
     return TileCoord.toID(pos.z - 1, Math.floor(pos.x / 2), Math.floor(pos.y / 2), pos.w);
 };
 
@@ -74,8 +80,14 @@ TileCoord.parentWithZoom = function(id, zoom) {
  * Given a packed integer id, return an array of integer ids representing
  * its four children.
  */
-TileCoord.children = function(id) {
+TileCoord.children = function(id, sourceMaxZoom) {
     var pos = TileCoord.fromID(id);
+
+    if (pos.z >= sourceMaxZoom) {
+        // return a single tile id representing a an overscaled tile
+        return [TileCoord.toID(pos.z + 1, pos.x, pos.y, pos.w)];
+    }
+
     pos.z += 1;
     pos.x *= 2;
     pos.y *= 2;
@@ -149,7 +161,7 @@ function scanTriangle(a, b, c, ymin, ymax, scanLine) {
     if (bc.dy) scanSpans(ca, bc, ymin, ymax, scanLine);
 }
 
-TileCoord.cover = function(z, bounds) {
+TileCoord.cover = function(z, bounds, actualZ) {
     var tiles = 1 << z;
     var t = {};
 
@@ -158,7 +170,7 @@ TileCoord.cover = function(z, bounds) {
         if (y >= 0 && y <= tiles) {
             for (x = x0; x < x1; x++) {
                 wx = (x + tiles) % tiles;
-                t[TileCoord.toID(z, wx, y, Math.floor(x / tiles))] = {x: wx, y: y};
+                t[TileCoord.toID(actualZ, wx, y, Math.floor(x / tiles))] = {x: wx, y: y};
             }
         }
     }

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -12,6 +12,7 @@ function TilePyramid(options) {
     this.tileSize = options.tileSize;
     this.minzoom = options.minzoom;
     this.maxzoom = options.maxzoom;
+    this.reparseOverscaled = options.reparseOverscaled;
 
     this._load = options.load;
     this._abort = options.abort;
@@ -66,6 +67,7 @@ TilePyramid.prototype = {
 
     coveringTiles: function(transform) {
         var z = this.coveringZoomLevel(transform);
+        var actualZ = z;
 
         if (z < this.minzoom) return [];
         if (z > this.maxzoom) z = this.maxzoom;
@@ -79,7 +81,7 @@ TilePyramid.prototype = {
             TileCoord.zoomTo(tr.pointCoordinate(tileCenter, {x: tr.width, y: 0}), z),
             TileCoord.zoomTo(tr.pointCoordinate(tileCenter, {x: tr.width, y: tr.height}), z),
             TileCoord.zoomTo(tr.pointCoordinate(tileCenter, {x: 0, y: tr.height}), z)
-        ]).sort(function(a, b) {
+        ], this.reparseOverscaled ? actualZ : z).sort(function(a, b) {
             return centerPoint.dist(TileCoord.fromID(a)) -
                 centerPoint.dist(TileCoord.fromID(b));
         });
@@ -90,7 +92,7 @@ TilePyramid.prototype = {
     findLoadedChildren: function(id, maxCoveringZoom, retain) {
         var complete = true;
         var z = TileCoord.fromID(id).z;
-        var ids = TileCoord.children(id);
+        var ids = TileCoord.children(id, this.maxzoom);
         for (var i = 0; i < ids.length; i++) {
             if (this._tiles[ids[i]] && this._tiles[ids[i]].loaded) {
                 retain[ids[i]] = true;
@@ -109,7 +111,7 @@ TilePyramid.prototype = {
     // adds the found tile to retain object and returns the tile if found
     findLoadedParent: function(id, minCoveringZoom, retain) {
         for (var z = TileCoord.fromID(id).z; z >= minCoveringZoom; z--) {
-            id = TileCoord.parent(id);
+            id = TileCoord.parent(id, this.maxzoom);
             var tile = this._tiles[id];
             if (tile && tile.loaded) {
                 retain[id] = true;
@@ -185,7 +187,9 @@ TilePyramid.prototype = {
         tile = this._tiles[wrapped] || this._cache.get(wrapped);
 
         if (!tile) {
-            tile = new Tile(wrapped);
+            var zoom = TileCoord.fromID(id).z;
+            var overscaling = zoom > this.maxzoom ? Math.pow(2, zoom - this.maxzoom) : 1;
+            tile = new Tile(wrapped, this.tileSize * overscaling);
             this._load(tile);
         }
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -21,6 +21,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
     minzoom: 0,
     maxzoom: 22,
     tileSize: 512,
+    reparseOverscaled: true,
     _loaded: false,
 
     onAdd: function(map) {
@@ -45,15 +46,16 @@ VectorTileSource.prototype = util.inherit(Evented, {
     featuresAt: Source._vectorFeaturesAt,
 
     _loadTile: function(tile) {
+        var overscaling = tile.zoom > this.maxzoom ? Math.pow(2, tile.zoom - this.maxzoom) : 1;
         var params = {
-            url: TileCoord.url(tile.id, this.tiles),
+            url: TileCoord.url(tile.id, this.tiles, this.maxzoom),
             id: tile.uid,
             tileId: tile.id,
             zoom: tile.zoom,
             maxZoom: this.maxzoom,
-            tileSize: this.tileSize,
+            tileSize: this.tileSize * overscaling,
             source: this.id,
-            depth: tile.zoom >= this.maxzoom ? this.map.options.maxZoom - tile.zoom : 1
+            overscaling: overscaling
         };
 
         if (tile.workerID) {

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -41,7 +41,7 @@ util.extend(Worker.prototype, {
 
             var tile = new WorkerTile(
                 params.id, params.zoom, params.maxZoom,
-                params.tileSize, params.source, params.depth);
+                params.tileSize, params.source, params.overscaling);
 
             tile.data = new vt.VectorTile(new Protobuf(new Uint8Array(data)));
             tile.parse(tile.data, this.layers, this.actor, callback);

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -16,13 +16,13 @@ function getType(feature) {
 
 module.exports = WorkerTile;
 
-function WorkerTile(id, zoom, maxZoom, tileSize, source, depth) {
+function WorkerTile(id, zoom, maxZoom, tileSize, source, overscaling) {
     this.id = id;
     this.zoom = zoom;
     this.maxZoom = maxZoom;
     this.tileSize = tileSize;
     this.source = source;
-    this.depth = depth;
+    this.overscaling = overscaling;
 }
 
 WorkerTile.prototype.parse = function(data, layers, actor, callback) {
@@ -33,7 +33,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         layer,
         bucket,
         buffers = new BufferSet(),
-        collision = new Collision(this.zoom, 4096, this.tileSize, this.depth),
+        collision = new Collision(this.zoom, 4096, this.tileSize),
         buckets = {},
         bucketsInOrder = [],
         bucketsBySourceLayer = {};
@@ -60,7 +60,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         if (visibility === 'none')
             continue;
 
-        bucket = createBucket(layer, buffers, collision, this.zoom);
+        bucket = createBucket(layer, buffers, collision, this.zoom, this.overscaling);
         bucket.layers = [layer.id];
 
         buckets[bucket.id] = bucket;

--- a/js/symbol/collision.js
+++ b/js/symbol/collision.js
@@ -6,7 +6,7 @@ var rbush = require('rbush'),
 
 module.exports = Collision;
 
-function Collision(zoom, tileExtent, tileSize, placementDepth) {
+function Collision(zoom, tileExtent, tileSize) {
     this.hTree = rbush(); // tree for horizontal labels
     this.cTree = rbush(); // tree for glyphs from curved labels
 
@@ -23,8 +23,7 @@ function Collision(zoom, tileExtent, tileSize, placementDepth) {
     // We don't want to place labels all the way to 25.5. This lets too many
     // glyphs be placed, slowing down collision checking. Only place labels if
     // they will show up within the intended zoom range of the tile.
-    placementDepth = Math.min(3, placementDepth || 1, 25.5 - this.zoom);
-    this.maxPlacementScale = Math.exp(Math.LN2 * placementDepth);
+    this.maxPlacementScale = 2;
 
     var m = 4096;
     var edge = m * this.tilePixelRatio * 2;


### PR DESCRIPTION
Fixes #1004 

@jfirebaugh this was easier to handle by adding a couple special cases in Source and TileCoord than by loading multiple copies and clipping.

- It uses the maxzoom to generate a cover, but creates tiles with the current zoom's z.
- When generating the url, it uses maxzoom if z > maxzoom.
- TileCoord's .parent() and .children() have a special case when z > maxzoom.

---

When the current zoom is past the vectortile source's maxzoom, load overscaled tiles and parse them specifically for the current integer zoom level. This is necessary to:
- make layout property functions work
- let us place labels only 1 zoom level deep (for performance)

Overscaled tile id's have the same x/y/w as their corresponding tiles from the source's maxzoom.

For example:

currentzoom: 18
maxzoom: 16

The overscaled tile { z: 18, x: 123, y: 456 }
loads the real tile { x: 16, x: 123, y: 456 }