### PR TITLE
Improve mousewheel performance when zooming

### DIFF
--- a/js/ui/handlers.js
+++ b/js/ui/handlers.js
@@ -132,7 +132,7 @@ function Handlers(map) {
             if (e.delta < 0 && scale !== 0) scale = 1 / scale;
 
             var fromScale = map.ease && isFinite(e.delta) ? map.ease.to : map.transform.scale,
-                duration = !isFinite(e.delta) ? 800 : e.source === 'trackpad' ? 0 : 300;
+                duration = !isFinite(e.delta) ? 800 : 0;
 
             map.zoomTo(map.transform.scaleZoom(fromScale * scale), {
                 duration: duration,

--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -201,6 +201,8 @@ function Interaction(el) {
             if (value !== 0 && (value % 4.000244140625) === 0) {
                 // This one is definitely a mouse wheel event.
                 type = 'wheel';
+                // Normalize this value to match trackpad.
+                value = Math.floor(value / 4);
             } else if (value !== 0 && Math.abs(value) < 4) {
                 // This one is definitely a trackpad event because it is so small.
                 type = 'trackpad';


### PR DESCRIPTION
- Normalize mousewheel deltaY value to match trackwheel
- Drop duration condition that just targets `trackzoom`
- Fixes #1058

### Before merge

Performs as expected in:
- [x]  Firefox, Opera, IE
- [x] Windows
- [x] Non-Apple trackpads
- [x] A variety of different physical hardware (mice)
