### PR TITLE
Viewport-relative popup arrows

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -93,7 +93,87 @@
 
 .mapboxgl-popup {
     position: absolute;
+    display: -webkit-flex;
+    display: flex;
     will-change: transform;
+}
+.mapboxgl-popup-anchor-top,
+.mapboxgl-popup-anchor-top-left,
+.mapboxgl-popup-anchor-top-right {
+    -webkit-flex-direction: column;
+    flex-direction: column;
+}
+.mapboxgl-popup-anchor-bottom,
+.mapboxgl-popup-anchor-bottom-left,
+.mapboxgl-popup-anchor-bottom-right {
+    -webkit-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+}
+.mapboxgl-popup-anchor-left {
+    -webkit-flex-direction: row;
+    flex-direction: row;
+}
+.mapboxgl-popup-anchor-right {
+    -webkit-flex-direction: row-reverse;
+    flex-direction: row-reverse;
+}
+.mapboxgl-popup-tip {
+    width: 0;
+    height: 0;
+    border: 10px solid transparent;
+    z-index: 1;
+}
+.mapboxgl-popup-anchor-top .mapboxgl-popup-tip {
+    -webkit-align-self: center;
+    align-self: center;
+    border-top: none;
+    border-bottom-color: #fff;
+}
+.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip {
+    -webkit-align-self: flex-start;
+    align-self: flex-start;
+    border-top: none;
+    border-left: none;
+    border-bottom-color: #fff;
+}
+.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+    -webkit-align-self: flex-end;
+    align-self: flex-end;
+    border-top: none;
+    border-right: none;
+    border-bottom-color: #fff;
+}
+.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip {
+    -webkit-align-self: center;
+    align-self: center;
+    border-bottom: none;
+    border-top-color: #fff;
+}
+.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip {
+    -webkit-align-self: flex-start;
+    align-self: flex-start;
+    border-bottom: none;
+    border-left: none;
+    border-top-color: #fff;
+}
+.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+    -webkit-align-self: flex-end;
+    align-self: flex-end;
+    border-bottom: none;
+    border-right: none;
+    border-top-color: #fff;
+}
+.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+    -webkit-align-self: center;
+    align-self: center;
+    border-left: none;
+    border-right-color: #fff;
+}
+.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+    -webkit-align-self: center;
+    align-self: center;
+    border-right: none;
+    border-left-color: #fff;
 }
 .mapboxgl-popup-close-button {
     position: absolute;
@@ -108,20 +188,25 @@
     background-color: rgba(0,0,0,0.05);
 }
 .mapboxgl-popup-content {
+    position: relative;
     background: #fff;
     border-radius: 3px;
     box-shadow: 0 1px 2px rgba(0,0,0,0.10);
     padding: 10px 10px 15px;
 }
-.mapboxgl-popup-tip {
-    width: 0;
-    height: 0;
-    margin: 0 auto;
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    border-top: 10px solid #fff;
-    box-shadow: none;
+.mapboxgl-popup-anchor-top-left .mapboxgl-popup-content {
+    border-top-left-radius: 0;
 }
+.mapboxgl-popup-anchor-top-right .mapboxgl-popup-content {
+    border-top-right-radius: 0;
+}
+.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-content {
+    border-bottom-left-radius: 0;
+}
+.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-content {
+    border-bottom-right-radius: 0;
+}
+
 .mapboxgl-crosshair,
 .mapboxgl-crosshair .mapboxgl-interactive,
 .mapboxgl-crosshair .mapboxgl-interactive:active {

--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -96,6 +96,7 @@
     display: -webkit-flex;
     display: flex;
     will-change: transform;
+    pointer-events: none;
 }
 .mapboxgl-popup-anchor-top,
 .mapboxgl-popup-anchor-top-left,
@@ -193,6 +194,7 @@
     border-radius: 3px;
     box-shadow: 0 1px 2px rgba(0,0,0,0.10);
     padding: 10px 10px 15px;
+    pointer-events: auto;
 }
 .mapboxgl-popup-anchor-top-left .mapboxgl-popup-content {
     border-top-left-radius: 0;

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -18,8 +18,7 @@ function Popup(options) {
 Popup.prototype = util.inherit(Evented, {
     options: {
         closeButton: true,
-        closeOnClick: true,
-        anchor: 'bottom'
+        closeOnClick: true
     },
 
     addTo: function(map) {
@@ -113,8 +112,35 @@ Popup.prototype = util.inherit(Evented, {
     _updatePosition: function() {
         if (!this._latLng || !this._container) { return; }
 
-        var anchor = this.options.anchor,
-            classList = this._container.classList;
+        var pos = this._map.project(this._latLng).round(),
+            anchor = this.options.anchor;
+
+        if (!anchor) {
+            var width = this._container.offsetWidth,
+                height = this._container.offsetHeight;
+
+            if (pos.y < height) {
+                anchor = ['top'];
+            } else if (pos.y > this._map.transform.height - height) {
+                anchor = ['bottom'];
+            } else {
+                anchor = [];
+            }
+
+            if (pos.x < width / 2) {
+                anchor.push('left');
+            } else if (pos.x > this._map.transform.width - width / 2) {
+                anchor.push('right');
+            }
+
+            if (anchor.length === 0) {
+                anchor = 'bottom';
+            } else {
+                anchor = anchor.join('-');
+            }
+
+            this.options.anchor = anchor;
+        }
 
         var anchorTranslate = {
             'top': 'translate(-50%,0)',
@@ -133,7 +159,6 @@ Popup.prototype = util.inherit(Evented, {
         }
         classList.add('mapboxgl-popup-anchor-' + anchor);
 
-        var pos = this._map.project(this._latLng).round();
         DOM.setTransform(this._container, anchorTranslate[anchor] + ' translate(' + pos.x + 'px,' + pos.y + 'px)');
     },
 

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -18,7 +18,8 @@ function Popup(options) {
 Popup.prototype = util.inherit(Evented, {
     options: {
         closeButton: true,
-        closeOnClick: true
+        closeOnClick: true,
+        anchor: 'bottom'
     },
 
     addTo: function(map) {
@@ -82,14 +83,14 @@ Popup.prototype = util.inherit(Evented, {
         if (!this._container) {
             this._container = DOM.create('div', 'mapboxgl-popup', this._map.getContainer());
 
+            this._tip     = DOM.create('div', 'mapboxgl-popup-tip',     this._container);
+            this._wrapper = DOM.create('div', 'mapboxgl-popup-content', this._container);
+
             if (this.options.closeButton) {
-                this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', this._container);
+                this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', this._wrapper);
                 this._closeButton.innerHTML = '&#215;';
                 this._closeButton.addEventListener('click', this._onClickClose);
             }
-
-            this._wrapper = DOM.create('div', 'mapboxgl-popup-content', this._container);
-            this._tip     = DOM.create('div', 'mapboxgl-popup-tip',     this._container);
         }
 
         this._updateContent();
@@ -105,14 +106,35 @@ Popup.prototype = util.inherit(Evented, {
             node.removeChild(node.firstChild);
         }
 
+        node.appendChild(this._closeButton);
         node.appendChild(this._content);
     },
 
     _updatePosition: function() {
         if (!this._latLng || !this._container) { return; }
 
+        var anchor = this.options.anchor,
+            classList = this._container.classList;
+
+        var anchorTranslate = {
+            'top': 'translate(-50%,0)',
+            'top-left': 'translate(0,0)',
+            'top-right': 'translate(-100%,0)',
+            'bottom': 'translate(-50%,-100%)',
+            'bottom-left': 'translate(0,-100%)',
+            'bottom-right': 'translate(-100%,-100%)',
+            'left': 'translate(0,-50%)',
+            'right': 'translate(-100%,-50%)'
+        };
+
+        var classList = this._container.classList;
+        for (var key in anchorTranslate) {
+            classList.remove('mapboxgl-popup-anchor-' + key);
+        }
+        classList.add('mapboxgl-popup-anchor-' + anchor);
+
         var pos = this._map.project(this._latLng).round();
-        DOM.setTransform(this._container, 'translate(-50%,-100%) translate(' + pos.x + 'px,' + pos.y + 'px)');
+        DOM.setTransform(this._container, anchorTranslate[anchor] + ' translate(' + pos.x + 'px,' + pos.y + 'px)');
     },
 
     _onClickClose: function() {

--- a/test/manual/popup.html
+++ b/test/manual/popup.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel='stylesheet' href='../../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<script src='../../dist/mapbox-gl-dev.js'></script>
+<script>
+    mapboxgl.accessToken = 'pk.eyJ1IjoiYWlicmFtIiwiYSI6IkZfak1UWW8ifQ.czocTs_bwAYlC_JxXijA2A';
+
+    var map = new mapboxgl.Map({
+        container: 'map',
+        style: 'https://www.mapbox.com/mapbox-gl-styles/styles/bright-v7.json'
+    });
+
+    var width = map.getContainer().offsetWidth,
+        height = map.getContainer().offsetHeight;
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([10, 10]))
+        .setText("Top Left")
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([width / 2, 10]))
+        .setText("Top")
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([width - 10, 10]))
+        .setText("Top Right")
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([width - 10, height / 2]))
+        .setText("Right")
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([width - 10, height - 10]))
+        .setText("Bottom Right")
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([width / 2, height - 10]))
+        .setText("Bottom")
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([10, height - 10]))
+        .setText("Bottom Left")
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([10, height / 2]))
+        .setText("Left")
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLatLng(map.unproject([width / 2, height / 2]))
+        .setText("Center")
+        .addTo(map);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #1052

By default, popups will anchor to their initial location in a way that ensures they are visible within the viewport.

![image](https://cloud.githubusercontent.com/assets/98601/6534690/30d12a58-c3f4-11e4-9d23-485abc4afb74.png)

This behavior can be overridden with the `anchor` option. Values and semantics for this option follow the `text-anchor` property in GL styles.

Would appreciate a JS+API review from @mourner and design review from @tristen.