### PR TITLE
Pass `latLng` to the event object

### DIFF
--- a/js/ui/handlers.js
+++ b/js/ui/handlers.js
@@ -28,9 +28,11 @@ function Handlers(map) {
 
     this.interaction = new Interaction(map.getCanvas())
         .on('click', function(e) {
+            e.latLng = map.unproject(e.point);
             map.fire('click', e);
         })
         .on('mousemove', function(e) {
+            e.latLng = map.unproject(e.point);
             map.fire('mousemove', e);
         })
         .on('down', function() {


### PR DESCRIPTION
Not sure if the better place to add this is from `js/ui/interaction.js` but the map object is passed to the handler. 

- Fixes #716 
