### PR TITLE
Fix for brittle fontstack name convention

### DIFF
--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -10,7 +10,7 @@ module.exports = GlyphSource;
 function GlyphSource(url, glyphAtlas) {
     this.url = url && normalizeURL(url);
     this.glyphAtlas = glyphAtlas;
-    this.stacks = {};
+    this.stacks = [];
     this.loading = {};
 }
 
@@ -52,7 +52,7 @@ GlyphSource.prototype.getRects = function(fontstack, glyphIDs, uid, callback) {
     var onRangeLoaded = function(err, range, data) {
         // TODO not be silent about errors
         if (!err) {
-            var stack = this.stacks[fontstack][range] = data.stacks[Object.keys(data.stacks)[0]];
+            var stack = this.stacks[fontstack][range] = data.stacks[0];
             for (var i = 0; i < missing[range].length; i++) {
                 var glyphID = missing[range][i];
                 var glyph = stack.glyphs[glyphID];

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -52,7 +52,7 @@ GlyphSource.prototype.getRects = function(fontstack, glyphIDs, uid, callback) {
     var onRangeLoaded = function(err, range, data) {
         // TODO not be silent about errors
         if (!err) {
-            var stack = this.stacks[fontstack][range] = data.stacks[fontstack];
+            var stack = this.stacks[fontstack][range] = data.stacks[Object.keys(data.stacks)[0]];
             for (var i = 0; i < missing[range].length; i++) {
                 var glyphID = missing[range][i];
                 var glyph = stack.glyphs[glyphID];

--- a/js/util/glyphs.js
+++ b/js/util/glyphs.js
@@ -3,13 +3,13 @@
 module.exports = Glyphs;
 
 function Glyphs(pbf, end) {
-    this.stacks = pbf.readFields(readFontstacks, {}, end);
+    this.stacks = pbf.readFields(readFontstacks, [], end);
 }
 
 function readFontstacks(tag, stacks, pbf) {
     if (tag === 1) {
         var fontstack = pbf.readMessage(readFontstack, {glyphs: {}});
-        stacks[fontstack.name] = fontstack;
+        stacks.push(fontstack);
     }
 }
 


### PR DESCRIPTION
In the process of switching from a node-fontnik backend to an S3 backend that uses [glyph-pbf-composite](https://github.com/mapbox/glyph-pbf-composite) we discovered that `glyph_source.js` reads stacks using the style-provided name as a key in the decoded PBF, but the PBFs always return a composited stack, so there's only ever one object in `data.stacks` — meaning the lack of perfect spaces in a fontstack string break everything (glyph-pbf-composite returns stacks like `Open Sans Bold, Arial Sans MS Unicode`; if you specify `Open Sans Bold,Arial Sans MS Unicode` without a space in a style, the PBF `GET` is fine, but breaks gl-js entirely.)

Eventually we should reformat [`glyphs.proto`](https://github.com/mapbox/node-fontnik/blob/master/proto/glyphs.proto) to make this nicer, but this fixes for now.