### PR TITLE
add failIfMajorPerformanceCaveat option

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -29,6 +29,7 @@ var Attribution = require('./control/attribution');
  * @param {Boolean} [options.hash=false] If `true`, the map will track and update the page URL according to map position
  * @param {Boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners are attached to the map, so it will not respond to input
  * @param {Array} options.classes Style class names with which to initialize the map
+ * @param {Boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than expected.
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',
@@ -103,7 +104,9 @@ util.extend(Map.prototype, {
         interactive: true,
         hash: false,
 
-        attributionControl: true
+        attributionControl: true,
+
+        failIfMajorPerformanceCaveat: false
     },
 
     addControl: function(control) {
@@ -542,7 +545,7 @@ util.extend(Map.prototype, {
     },
 
     _setupPainter: function() {
-        var gl = this._canvas.getWebGLContext();
+        var gl = this._canvas.getWebGLContext(this.options.failIfMajorPerformanceCaveat);
 
         if (!gl) {
             console.error('Failed to initialize WebGL');

--- a/js/util/browser/browser.js
+++ b/js/util/browser/browser.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Canvas = require('./canvas');
+
 var frame = window.requestAnimationFrame ||
     window.mozRequestAnimationFrame ||
     window.webkitRequestAnimationFrame ||
@@ -46,9 +48,12 @@ exports.timed = function (fn, dur, ctx) {
 
 /**
  * Test whether the basic JavaScript and DOM features required for Mapbox GL are present.
+ * @param {Object} options
+ * @param {Boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than expected.
  * @return {Boolean} Returns true if Mapbox GL should be expected to work, and false if not.
  */
-exports.supported = function() {
+exports.supported = function(options) {
+
     var supports = [
 
         function() { return typeof window !== 'undefined'; },
@@ -91,12 +96,7 @@ exports.supported = function() {
         },
 
         function() {
-            var canvas = document.createElement('canvas');
-            if ('supportsContext' in canvas) {
-                return canvas.supportsContext('webgl') || canvas.supportsContext('experimental-webgl');
-            }
-            return !!window.WebGLRenderingContext &&
-                (!!canvas.getContext('webgl') || !!canvas.getContext('experimental-webgl'));
+            return new Canvas().supportsWebGLContext((options && options.failIfMajorPerformanceCaveat) || false);
         },
 
         function() { return 'Worker' in window; }

--- a/js/util/browser/canvas.js
+++ b/js/util/browser/canvas.js
@@ -1,18 +1,23 @@
 'use strict';
 
+var util = require('../util');
+
 module.exports = Canvas;
 
 function Canvas(parent, container) {
     this.canvas = document.createElement('canvas');
-    this.canvas.style.position = 'absolute';
-    this.canvas.classList.add('mapboxgl-canvas');
-    if (parent.options.interactive) {
-        this.canvas.classList.add('mapboxgl-interactive');
+
+    if (parent && container) {
+        this.canvas.style.position = 'absolute';
+        this.canvas.classList.add('mapboxgl-canvas');
+        if (parent.options.interactive) {
+            this.canvas.classList.add('mapboxgl-interactive');
+        }
+        this.canvas.addEventListener('webglcontextlost', parent._contextLost.bind(parent), false);
+        this.canvas.addEventListener('webglcontextrestored', parent._contextRestored.bind(parent), false);
+        this.canvas.setAttribute('tabindex', 0);
+        container.appendChild(this.canvas);
     }
-    this.canvas.addEventListener('webglcontextlost', parent._contextLost.bind(parent), false);
-    this.canvas.addEventListener('webglcontextrestored', parent._contextRestored.bind(parent), false);
-    this.canvas.setAttribute('tabindex', 0);
-    container.appendChild(this.canvas);
 }
 
 Canvas.prototype.resize = function(width, height) {
@@ -27,13 +32,36 @@ Canvas.prototype.resize = function(width, height) {
     this.canvas.style.height = height + 'px';
 };
 
-Canvas.prototype.getWebGLContext = function() {
-    return this.canvas.getContext("experimental-webgl", {
-        antialias: false,
-        alpha: true,
-        stencil: true,
-        depth: false
+Canvas.prototype._contextAttributes = {
+    antialias: false,
+    alpha: true,
+    stencil: true,
+    depth: false
+};
+
+Canvas.prototype.getWebGLContext = function(failIfMajorPerformanceCaveat) {
+    var attributes = util.inherit(this._contextAttributes, {
+        failIfMajorPerformanceCaveat: failIfMajorPerformanceCaveat
     });
+
+    return this.canvas.getContext('webgl', attributes) ||
+        this.canvas.getContext('experimental-webgl', attributes);
+};
+
+Canvas.prototype.supportsWebGLContext = function(failIfMajorPerformanceCaveat) {
+    var attributes = util.inherit(this._contextAttributes, {
+        failIfMajorPerformanceCaveat: failIfMajorPerformanceCaveat
+    });
+
+    if ('probablySupportsContext' in this.canvas) {
+        return this.canvas.probablySupportsContext('webgl', attributes) ||
+            this.canvas.probablySupportsContext('experimental-webgl', attributes);
+    } else if ('supportsContext' in this.canvas) {
+        return this.canvas.supportsContext('webgl', attributes) ||
+            this.canvas.supportsContext('experimental-webgl', attributes);
+    }
+
+    return !!window.WebGLRenderingContext && !!this.getWebGLContext(failIfMajorPerformanceCaveat);
 };
 
 Canvas.prototype.getElement = function() {

--- a/js/util/canvas.js
+++ b/js/util/canvas.js
@@ -21,5 +21,9 @@ Canvas.prototype.getWebGLContext = function() {
     return this.context;
 };
 
+Canvas.prototype.supportsWebGLContext = function() {
+    return true;
+};
+
 Canvas.prototype.getElement = function() {
 };


### PR DESCRIPTION
Adds at `failIfMajorPerformanceCaveat` as a map option. The option is used when creating the WebGL context.

When true:

> If the value is true, context creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than that of a native application making equivalent OpenGL calls. This could happen for a number of reasons, including:
- An implementation might switch to a software rasterizer if the user's GPU driver is known to be unstable.
- An implementation might require reading back the framebuffer from GPU memory to system memory before compositing it with the rest of the page, significantly reducing performance.

https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2.1


The default value is false. It should only be enabled if there is a Leaflet/other fallback.