### PR TITLE
Add raw event data to click and mouse move events.

### DIFF
--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -49,12 +49,12 @@ function Interaction(el) {
         now = null;
     }
 
-    function click(point) {
-        interaction.fire('click', {point: point});
+    function click(point, ev) {
+        interaction.fire('click', {point: point, raw: ev});
     }
 
-    function mousemove(point) {
-        interaction.fire('mousemove', {point: point});
+    function mousemove(point, ev) {
+        interaction.fire('mousemove', {point: point, raw: ev});
     }
 
     function pan(point) {
@@ -162,13 +162,13 @@ function Interaction(el) {
             var target = ev.toElement || ev.target;
             while (target && target !== el && target.parentNode) target = target.parentNode;
             if (target === el) {
-                mousemove(point);
+                mousemove(point, ev);
             }
         }
     }
 
     function onclick(ev) {
-        if (!panned) click(mousePos(ev));
+        if (!panned) click(mousePos(ev), ev);
     }
 
     function ondoubleclick(ev) {

--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -50,11 +50,11 @@ function Interaction(el) {
     }
 
     function click(point, ev) {
-        interaction.fire('click', {point: point, raw: ev});
+        interaction.fire('click', {point: point, originalEvent: ev});
     }
 
     function mousemove(point, ev) {
-        interaction.fire('mousemove', {point: point, raw: ev});
+        interaction.fire('mousemove', {point: point, originalEvent: ev});
     }
 
     function pan(point) {


### PR DESCRIPTION
It'd be useful to have access to raw javascript mouse event objects for map events.

I know that mapbox-gl-js design must maintain parity with mapbox-gl native. I hope that this change or a version of it is possible with that constraint.