### PR TITLE
Fix #1101 Support unicode range 65280-65535

### DIFF
--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -79,7 +79,7 @@ function SimpleGlyph(glyph, rect, buffer) {
 
 GlyphSource.prototype.loadRange = function(fontstack, range, callback) {
 
-    if (range * 256 >= 65280) return callback('gyphs > 65280 not supported');
+    if (range * 256 > 65535) return callback('gyphs > 65535 not supported');
 
     if (this.loading[fontstack] === undefined) this.loading[fontstack] = {};
     var loading = this.loading[fontstack];

--- a/js/symbol/resolve_text.js
+++ b/js/symbol/resolve_text.js
@@ -14,7 +14,6 @@ function resolveText(features, layoutProperties, glyphs) {
 
     for (var i = 0, fl = features.length; i < fl; i++) {
         var text = resolveTokens(features[i].properties, layoutProperties['text-field']);
-        var hastext = false;
         if (!text) {
             textFeatures[i] = null;
             continue;
@@ -29,15 +28,11 @@ function resolveText(features, layoutProperties, glyphs) {
         }
 
         for (var j = 0, jl = text.length; j < jl; j++) {
-            if (text.charCodeAt(j) <= 65535) {
-                codepoints.push(text.charCodeAt(j));
-                hastext = true;
-            }
+            codepoints.push(text.charCodeAt(j));
         }
+
         // Track indexes of features with text.
-        if (hastext) {
-            textFeatures[i] = text;
-        }
+        textFeatures[i] = text;
     }
 
     // get a list of unique codepoints we are missing

--- a/js/symbol/resolve_text.js
+++ b/js/symbol/resolve_text.js
@@ -29,7 +29,7 @@ function resolveText(features, layoutProperties, glyphs) {
         }
 
         for (var j = 0, jl = text.length; j < jl; j++) {
-            if (text.charCodeAt(j) <= 65533) {
+            if (text.charCodeAt(j) <= 65535) {
                 codepoints.push(text.charCodeAt(j));
                 hastext = true;
             }

--- a/test/js/symbol/resolve_text.test.js
+++ b/test/js/symbol/resolve_text.test.js
@@ -60,15 +60,16 @@ test('resolveText', function(t) {
         'text-field': '{city}'
     }, {}));
 
-    // Excludes unicode beyond 65533.
+    // Includes unicode up to 65535.
     t.deepEqual({
         textFeatures: [
-            '\ufff0'
+            '\ufff0',
+            '\uffff'
         ],
-        codepoints: [ 65520 ]
+        codepoints: [ 65520, 65535 ]
     }, resolveText([
-        mockFeature({ 'text': '\ufff0' }), // included
-        mockFeature({ 'text': '\uffff' })  // excluded
+        mockFeature({ 'text': '\ufff0' }),
+        mockFeature({ 'text': '\uffff' })
     ], {
         'text-field': '{text}'
     }, {}));


### PR DESCRIPTION
Fixes #1101.

I changed the test to check for support of this range (rather than if characters beyond the range are excluded) because the entire basic range is now supported. 

`charCodeAt()` [will always return <= 65535](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt), so that check shouldn't be necessary now. If there needs to be a check for codepoints > 0x10000 (like emoji), that'll have to be done some other way.