### PR TITLE
avoid creating too many collision boxes

### DIFF
--- a/js/symbol/collision_feature.js
+++ b/js/symbol/collision_feature.js
@@ -11,19 +11,26 @@ function CollisionFeature(geometry, anchor, shaped, boxScale, padding, alignLine
     var left = shaped.left * boxScale - padding;
     var right = shaped.right * boxScale + padding;
 
+    this.boxes = [];
+
     if (alignLine) {
 
         var height = bottom - top;
         var length = right - left;
 
-        this.boxes = bboxifyLabel(geometry, anchor, length, height);
+        if (height <= 0) return;
+
+        // set minimum box height to avoid very many small labels
+        height = Math.max(10 * boxScale, height);
+
+        this.bboxifyLabel(geometry, anchor, length, height);
 
     } else {
-        this.boxes = [new CollisionBox(anchor, left, top, right, bottom, Infinity)];
+        this.boxes.push(new CollisionBox(anchor, left, top, right, bottom, Infinity));
     }
 }
 
-function bboxifyLabel(line, anchor, labelLength, boxSize) {
+CollisionFeature.prototype.bboxifyLabel = function(line, anchor, labelLength, boxSize) {
     // Determine the bounding boxes needed to cover the label in the
     // neighborhood of the anchor.
 
@@ -40,7 +47,7 @@ function bboxifyLabel(line, anchor, labelLength, boxSize) {
     // offset the center of the first box by half a box
     labelStartLineCoordinate += boxSize / 2;
 
-    var bboxes = [];
+    var bboxes = this.boxes;
     var nBoxes = Math.floor(labelLength / step);
     for (var i = 0; i < nBoxes; i++) {
 
@@ -53,9 +60,7 @@ function bboxifyLabel(line, anchor, labelLength, boxSize) {
 
         bboxes.push(new CollisionBox(p, -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, maxScale));
     }
-
-    return bboxes;
-}
+};
 
 function getPointAtDistance(cumulativeDistances, lineDistance, points) {
     // Determine when the line distance exceeds the cumulative distance

--- a/test/js/symbol/collision_feature.js
+++ b/test/js/symbol/collision_feature.js
@@ -67,6 +67,51 @@ test('CollisionFeature', function(t) {
         t.end();
     });
 
+    test('doesnt create any boxes for features with zero height', function(t) {
+        var shapedText = {
+            left: -50,
+            top: -10,
+            right: 50,
+            bottom: -10
+        };
+
+        var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
+        var anchor = new Anchor(505, 95, 0, 0.5, 1);
+        var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
+        t.equal(cf.boxes.length, 0);
+        t.end();
+    });
+
+    test('doesnt create any boxes for features with negative height', function(t) {
+        var shapedText = {
+            left: -50,
+            top: 10,
+            right: 50,
+            bottom: -10
+        };
+
+        var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
+        var anchor = new Anchor(505, 95, 0, 0.5, 1);
+        var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
+        t.equal(cf.boxes.length, 0);
+        t.end();
+    });
+
+    test('doesnt create way too many tiny boxes for features with really low height', function(t) {
+        var shapedText = {
+            left: -50,
+            top: 10,
+            right: 50,
+            bottom: 10.00001
+        };
+
+        var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
+        var anchor = new Anchor(505, 95, 0, 0.5, 1);
+        var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
+        t.ok(cf.boxes.length < 30);
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
don't create infinitely many boxes for zero or negative height symbols

line-height or padding can make the height of a shaped object <= 0. In these cases either create no boxes, or create boxes with a minimum height to avoid creating too many of them.

fixes https://github.com/mapbox/mapbox-gl-js/issues/1140. A worker was stuck in an infinite loop.