### PR TITLE
labeling changes made while porting to -native

### DIFF
--- a/js/data/buffer/collision_box_vertex_buffer.js
+++ b/js/data/buffer/collision_box_vertex_buffer.js
@@ -28,8 +28,8 @@ CollisionBoxVertexBuffer.prototype = util.inherit(Buffer, {
 
         this.shorts[pos2 + 2] = Math.round(extrude.x);
         this.shorts[pos2 + 3] = Math.round(extrude.y);
-        this.bytes[pos + 8] = Math.floor(maxZoom * 10) - 128;
-        this.bytes[pos + 9] = Math.floor(placementZoom * 10) - 128;
+        this.ubytes[pos + 8] = Math.floor(maxZoom * 10);
+        this.ubytes[pos + 9] = Math.floor(placementZoom * 10);
 
         this.pos += this.itemSize;
         return index;

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -154,7 +154,7 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
         // Calculate the anchor points around which you want to place labels
         var anchors = layout['symbol-placement'] === 'line' ?
             getAnchors(line, symbolMinDistance, textMaxAngle, shapedText, glyphSize, textBoxScale, this.overscaling) :
-            [ new Anchor(line[0].x, line[0].y, 0, collision.minScale) ];
+            [ new Anchor(line[0].x, line[0].y, 0) ];
 
         // For each potential label, create the placement features used to check for collisions, and the quads use for rendering.
         for (var j = 0, len = anchors.length; j < len; j++) {

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -152,7 +152,7 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
         var line = lines[i];
 
         // Calculate the anchor points around which you want to place labels
-        var anchors = line.length > 1 ?
+        var anchors = layout['symbol-placement'] === 'line' ?
             getAnchors(line, symbolMinDistance, textMaxAngle, shapedText, glyphSize, textBoxScale, this.overscaling) :
             [ new Anchor(line[0].x, line[0].y, 0, collision.minScale) ];
 

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -27,7 +27,7 @@ function SymbolBucket(buffers, layoutProperties, collision, overscaling, collisi
     this.overscaling = overscaling;
     this.collisionDebug = collisionDebug;
 
-    this.symbolFeatures = [];
+    this.symbolInstances = [];
 
 }
 
@@ -141,8 +141,8 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
         textPadding = layout['text-padding'] * collision.tilePixelRatio,
         iconPadding = layout['icon-padding'] * collision.tilePixelRatio,
         textMaxAngle = layout['text-max-angle'] / 180 * Math.PI,
-        textAlongLine = layout['text-rotation-alignment'] !== 'viewport' && layout['symbol-placement'] === 'line',
-        iconAlongLine = layout['icon-rotation-alignment'] !== 'viewport' && layout['symbol-placement'] === 'line';
+        textAlongLine = layout['text-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line',
+        iconAlongLine = layout['icon-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';
 
     if (layout['symbol-placement'] === 'line') {
         lines = clipLine(lines, 0, 0, 4096, 4096);
@@ -164,7 +164,7 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
 
             if (avoidEdges && !inside) continue;
 
-            this.symbolFeatures.push(new SymbolFeature(anchor, line, shapedText, shapedIcon, layout, inside,
+            this.symbolInstances.push(new SymbolInstance(anchor, line, shapedText, shapedIcon, layout, inside,
                         textBoxScale, textPadding, textAlongLine,
                         iconBoxScale, iconPadding, iconAlongLine));
         }
@@ -191,10 +191,10 @@ SymbolBucket.prototype.placeFeatures = function(buffers, collisionDebug) {
     var textAlongLine = layout['text-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';
     var iconAlongLine = layout['icon-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';
 
-    for (var p = 0; p < this.symbolFeatures.length; p++) {
-        var symbolFeature = this.symbolFeatures[p];
-        var hasText = symbolFeature.hasText;
-        var hasIcon = symbolFeature.hasIcon;
+    for (var p = 0; p < this.symbolInstances.length; p++) {
+        var symbolInstance = this.symbolInstances[p];
+        var hasText = symbolInstance.hasText;
+        var hasIcon = symbolInstance.hasIcon;
 
         var iconWithoutText = layout['text-optional'] || !hasText,
             textWithoutIcon = layout['icon-optional'] || !hasIcon;
@@ -203,10 +203,10 @@ SymbolBucket.prototype.placeFeatures = function(buffers, collisionDebug) {
         // Calculate the scales at which the text and icon can be placed without collision.
 
         var glyphScale = hasText && !layout['text-allow-overlap'] ?
-            collision.placeFeature(symbolFeature.textCollisionFeature) : collision.minScale;
+            collision.placeFeature(symbolInstance.textCollisionFeature) : collision.minScale;
 
         var iconScale = hasIcon && !layout['icon-allow-overlap'] ?
-            collision.placeFeature(symbolFeature.iconCollisionFeature) : collision.minScale;
+            collision.placeFeature(symbolInstance.iconCollisionFeature) : collision.minScale;
 
 
         // Combine the scales for icons and text.
@@ -224,19 +224,19 @@ SymbolBucket.prototype.placeFeatures = function(buffers, collisionDebug) {
 
         if (hasText) {
             if (!layout['text-ignore-placement']) {
-                collision.insertFeature(symbolFeature.textCollisionFeature, glyphScale);
+                collision.insertFeature(symbolInstance.textCollisionFeature, glyphScale);
             }
             if (glyphScale <= maxScale) {
-                this.addSymbols(buffers.glyphVertex, elementGroups.text, symbolFeature.glyphQuads, glyphScale, layout['text-keep-upright'], textAlongLine);
+                this.addSymbols(buffers.glyphVertex, elementGroups.text, symbolInstance.glyphQuads, glyphScale, layout['text-keep-upright'], textAlongLine);
             }
         }
 
         if (hasIcon) {
             if (!layout['icon-ignore-placement']) {
-                collision.insertFeature(symbolFeature.iconCollisionFeature, iconScale);
+                collision.insertFeature(symbolInstance.iconCollisionFeature, iconScale);
             }
             if (iconScale <= maxScale) {
-                this.addSymbols(buffers.iconVertex, elementGroups.icon, symbolFeature.iconQuads, iconScale, layout['icon-keep-upright'], iconAlongLine);
+                this.addSymbols(buffers.iconVertex, elementGroups.icon, symbolInstance.iconQuads, iconScale, layout['icon-keep-upright'], iconAlongLine);
             }
         }
 
@@ -360,9 +360,9 @@ SymbolBucket.prototype.addToDebugBuffers = function() {
     var angle = -this.collision.angle;
     var yStretch = this.collision.yStretch;
 
-    for (var j = 0; j < this.symbolFeatures.length; j++) {
+    for (var j = 0; j < this.symbolInstances.length; j++) {
         for (var i = 0; i < 2; i++) {
-            var feature = this.symbolFeatures[j][i === 0 ? 'textCollisionFeature' : 'iconCollisionFeature'];
+            var feature = this.symbolInstances[j][i === 0 ? 'textCollisionFeature' : 'iconCollisionFeature'];
             if (!feature) continue;
             var boxes = feature.boxes;
 
@@ -393,7 +393,7 @@ SymbolBucket.prototype.addToDebugBuffers = function() {
     }
 };
 
-function SymbolFeature(anchor, line, shapedText, shapedIcon, layout, inside,
+function SymbolInstance(anchor, line, shapedText, shapedIcon, layout, inside,
                         textBoxScale, textPadding, textAlongLine,
                         iconBoxScale, iconPadding, iconAlongLine) {
 

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -170,16 +170,16 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
                 iconQuads;
 
             if (shapedText) {
-                glyphQuads = getGlyphQuads(anchor, shapedText, textBoxScale, line, layout, textAlongLine);
+                glyphQuads = inside ? getGlyphQuads(anchor, shapedText, textBoxScale, line, layout, textAlongLine) : [];
                 textCollisionFeature = new CollisionFeature(line, anchor, shapedText, textBoxScale, textPadding, textAlongLine);
             }
 
             if (shapedIcon) {
-                iconQuads = getIconQuads(anchor, shapedIcon, iconBoxScale, line, layout, iconAlongLine);
+                iconQuads = inside ? getIconQuads(anchor, shapedIcon, iconBoxScale, line, layout, iconAlongLine) : [];
                 iconCollisionFeature = new CollisionFeature(line, anchor, shapedIcon, iconBoxScale, iconPadding, iconAlongLine);
             }
 
-            this.symbolFeatures.push(new SymbolFeature(textCollisionFeature, iconCollisionFeature, glyphQuads, iconQuads, inside));
+            this.symbolFeatures.push(new SymbolFeature(textCollisionFeature, iconCollisionFeature, glyphQuads, iconQuads));
         }
     }
 };
@@ -208,7 +208,6 @@ SymbolBucket.prototype.placeFeatures = function(buffers, collisionDebug) {
         var symbolFeature = this.symbolFeatures[p];
         var text = symbolFeature.text;
         var icon = symbolFeature.icon;
-        var inside = symbolFeature.inside;
 
         var iconWithoutText = layout['text-optional'] || !text,
             textWithoutIcon = layout['icon-optional'] || !icon;
@@ -240,7 +239,7 @@ SymbolBucket.prototype.placeFeatures = function(buffers, collisionDebug) {
             if (!layout['text-ignore-placement']) {
                 collision.insertFeature(text, glyphScale);
             }
-            if (inside && glyphScale <= maxScale) {
+            if (glyphScale <= maxScale) {
                 this.addSymbols(buffers.glyphVertex, elementGroups.text, symbolFeature.glyphQuads, glyphScale, layout['text-keep-upright'], textAlongLine);
             }
         }
@@ -249,7 +248,7 @@ SymbolBucket.prototype.placeFeatures = function(buffers, collisionDebug) {
             if (!layout['icon-ignore-placement']) {
                 collision.insertFeature(icon, iconScale);
             }
-            if (inside && iconScale <= maxScale) {
+            if (iconScale <= maxScale) {
                 this.addSymbols(buffers.iconVertex, elementGroups.icon, symbolFeature.iconQuads, iconScale, layout['icon-keep-upright'], iconAlongLine);
             }
         }
@@ -407,10 +406,9 @@ SymbolBucket.prototype.addToDebugBuffers = function() {
     }
 };
 
-function SymbolFeature(textCollisionFeature, iconCollisionFeature, glyphQuads, iconQuads, inside) {
+function SymbolFeature(textCollisionFeature, iconCollisionFeature, glyphQuads, iconQuads) {
     this.text = textCollisionFeature;
     this.icon = iconCollisionFeature;
     this.glyphQuads = glyphQuads;
     this.iconQuads = iconQuads;
-    this.inside = inside;
 }

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -362,7 +362,7 @@ SymbolBucket.prototype.addToDebugBuffers = function() {
 
     for (var j = 0; j < this.symbolFeatures.length; j++) {
         for (var i = 0; i < 2; i++) {
-            var feature = this.symbolFeatures[j][i === 0 ? 'text' : 'icon'];
+            var feature = this.symbolFeatures[j][i === 0 ? 'textCollisionFeature' : 'iconCollisionFeature'];
             if (!feature) continue;
             var boxes = feature.boxes;
 

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -20,7 +20,7 @@ function drawPlacementDebug(painter, layer, posMatrix, tile) {
     var stride = 12;
     gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, stride, 0);
     gl.vertexAttribPointer(shader.a_extrude, 2, gl.SHORT, false, stride, 4);
-    gl.vertexAttribPointer(shader.a_data, 2, gl.BYTE, false, stride, 8);
+    gl.vertexAttribPointer(shader.a_data, 2, gl.UNSIGNED_BYTE, false, stride, 8);
 
     gl.uniform1f(shader.u_scale, Math.pow(2, painter.transform.zoom - tile.zoom));
     gl.uniform1f(shader.u_zoom, painter.transform.zoom * 10);

--- a/js/symbol/anchor.js
+++ b/js/symbol/anchor.js
@@ -4,11 +4,10 @@ var Point = require('point-geometry');
 
 module.exports = Anchor;
 
-function Anchor(x, y, angle, scale, segment) {
+function Anchor(x, y, angle, segment) {
     this.x = x;
     this.y = y;
     this.angle = angle;
-    this.scale = scale;
 
     if (segment !== undefined) {
         this.segment = segment;
@@ -18,5 +17,5 @@ function Anchor(x, y, angle, scale, segment) {
 Anchor.prototype = Object.create(Point.prototype);
 
 Anchor.prototype.clone = function() {
-    return new Anchor(this.x, this.y, this.angle, this.scale, this.segment);
+    return new Anchor(this.x, this.y, this.angle, this.segment);
 };

--- a/js/symbol/collision_feature.js
+++ b/js/symbol/collision_feature.js
@@ -45,7 +45,7 @@ CollisionFeature.prototype.bboxifyLabel = function(line, anchor, labelLength, bo
     var anchorDistance = firstBoxOffset;
 
     // move backwards along the line to the first segment the label appears on
-    while (anchorDistance > -labelLength / 2) {
+    do {
         index--;
 
         // there isn't enough room for the label after the beginning of the line
@@ -54,7 +54,7 @@ CollisionFeature.prototype.bboxifyLabel = function(line, anchor, labelLength, bo
 
         anchorDistance -= line[index].dist(p);
         p = line[index];
-    }
+    } while (anchorDistance > -labelLength / 2);
 
     var segmentLength = line[index].dist(line[index + 1]);
 

--- a/js/symbol/get_anchors.js
+++ b/js/symbol/get_anchors.js
@@ -29,8 +29,7 @@ function getAnchors(line, spacing, maxAngle, shapedText, glyphSize, boxScale, ov
 function resample(line, offset, spacing, angleWindowSize, maxAngle, labelLength, placeAtMiddle) {
 
     var distance = 0,
-        markedDistance = offset ? offset - spacing : 0,
-        added = 0;
+        markedDistance = offset ? offset - spacing : 0;
 
     var anchors = [];
 
@@ -50,14 +49,12 @@ function resample(line, offset, spacing, angleWindowSize, maxAngle, labelLength,
                 y = interpolate(a.y, b.y, t);
 
             if (x >= 0 && x < 4096 && y >= 0 && y < 4096) {
-                var anchor = new Anchor(x, y, angle, 0.5, i);
+                var anchor = new Anchor(x, y, angle, i);
 
                 if (!angleWindowSize || checkMaxAngle(line, anchor, labelLength, angleWindowSize, maxAngle)) {
                     anchors.push(anchor);
                 }
             }
-
-            added++;
         }
 
         distance += segmentDist;

--- a/js/symbol/quads.js
+++ b/js/symbol/quads.js
@@ -58,13 +58,13 @@ function getGlyphQuads(anchor, shaping, boxScale, line, layout, alongLine) {
     var quads = [];
 
     for (var k = 0; k < positionedGlyphs.length; k++) {
-        var shape = positionedGlyphs[k];
-        var glyph = shape.glyph;
+        var positionedGlyph = positionedGlyphs[k];
+        var glyph = positionedGlyph.glyph;
         var rect = glyph.rect;
 
         if (!rect) continue;
 
-        var centerX = (shape.x + glyph.advance / 2) * boxScale;
+        var centerX = (positionedGlyph.x + glyph.advance / 2) * boxScale;
 
         var glyphInstances;
         var labelMinScale = minScale;
@@ -85,8 +85,8 @@ function getGlyphQuads(anchor, shaping, boxScale, line, layout, alongLine) {
             }];
         }
 
-        var x1 = shape.x + glyph.left,
-            y1 = shape.y - glyph.top,
+        var x1 = positionedGlyph.x + glyph.left,
+            y1 = positionedGlyph.y - glyph.top,
             x2 = x1 + rect.w,
             y2 = y1 + rect.h,
 

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -38,7 +38,7 @@ function shapeText(text, glyphs, maxWidth, lineHeight, horizontalAlign, vertical
         var codePoint = text.charCodeAt(i);
         var glyph = glyphs[codePoint];
 
-        if (codePoint === 0 || !glyph) continue;
+        if (!glyph) continue;
 
         positionedGlyphs.push(new PositionedGlyph(codePoint, x, y, glyph));
         x += glyph.advance + spacing;

--- a/shaders/collisionbox.vertex.glsl
+++ b/shaders/collisionbox.vertex.glsl
@@ -11,6 +11,6 @@ varying float v_placement_zoom;
 void main() {
      gl_Position = u_matrix * vec4(a_pos + a_extrude / u_scale, 0.0, 1.0);
 
-     v_max_zoom = a_data.x + 128.0;
-     v_placement_zoom = a_data.y + 128.0;
+     v_max_zoom = a_data.x;
+     v_placement_zoom = a_data.y;
 }

--- a/test/js/symbol/check_max_angle.test.js
+++ b/test/js/symbol/check_max_angle.test.js
@@ -7,7 +7,7 @@ var Anchor = require('../../../js/symbol/anchor');
 
 test('line with no sharp angles', function(t) {
     var line = [ new Point(0, 0), new Point(20, -1), new Point(40, 1), new Point(60, 0) ];
-    var anchor = new Anchor(30, 0, 0, undefined, 1);
+    var anchor = new Anchor(30, 0, 0, 1);
     t.ok(checkMaxAngle(line, anchor, 25, 20, Math.PI / 8));
     t.notOk(checkMaxAngle(line, anchor, 25, 20, 0));
     t.end();
@@ -15,7 +15,7 @@ test('line with no sharp angles', function(t) {
 
 test('one sharp corner', function(t) {
     var line = [ new Point(0, 0), new Point(0, 10), new Point(10, 10) ];
-    var anchor = new Anchor(0, 10, 0, undefined, 1);
+    var anchor = new Anchor(0, 10, 0, 1);
     t.ok(checkMaxAngle(line, anchor, 10, 5, Math.PI / 2));
     t.notOk(checkMaxAngle(line, anchor, 10, 5, Math.PI / 2 - 0.01));
     t.end();
@@ -25,7 +25,7 @@ test('many small corners close together', function(t) {
     var line = [
         new Point(0, 0), new Point(10, 0), new Point(11, 0.1),
         new Point(12, 0.3), new Point(13, 0.6), new Point(14, 1), new Point(13.9, 10)];
-    var anchor = new Anchor(12, 0.3, 0, undefined, 3);
+    var anchor = new Anchor(12, 0.3, 0, 3);
     t.notOk(checkMaxAngle(line, anchor, 10, 5, Math.PI / 2), 'not allowed if angle within window is big');
     t.ok(checkMaxAngle(line, anchor, 10, 2, Math.PI / 2), 'allowed if window is small enough');
     t.end();
@@ -33,14 +33,14 @@ test('many small corners close together', function(t) {
 
 test('label appears on the first line segment', function(t) {
     var line = [ new Point(0, 0), new Point(100, 0) ];
-    var anchor = new Point(50, 0, 0, undefined, 0);
+    var anchor = new Point(50, 0, 0, 0);
     t.ok(checkMaxAngle(line, anchor, 30, 5, Math.PI / 2));
     t.end();
 });
 
 test('not enough space before the end of the line', function(t) {
     var line = [ new Point(0, 0), new Point(10, 0), new Point(20, 0), new Point(30, 0) ];
-    var anchor = new Anchor(5, 0, 0, undefined, 0);
+    var anchor = new Anchor(5, 0, 0, 0);
     t.notOk(checkMaxAngle(line, anchor, 11, 5, Math.PI));
     t.ok(checkMaxAngle(line, anchor, 10, 5, Math.PI));
     t.end();
@@ -48,7 +48,7 @@ test('not enough space before the end of the line', function(t) {
 
 test('not enough space after the beginning of the line', function(t) {
     var line = [ new Point(0, 0), new Point(10, 0), new Point(20, 0), new Point(30, 0) ];
-    var anchor = new Anchor(25, 0, 0, undefined, 2);
+    var anchor = new Anchor(25, 0, 0, 2);
     t.notOk(checkMaxAngle(line, anchor, 11, 5, Math.PI));
     t.ok(checkMaxAngle(line, anchor, 10, 5, Math.PI));
     t.end();

--- a/test/js/symbol/collision_feature.js
+++ b/test/js/symbol/collision_feature.js
@@ -16,7 +16,7 @@ test('CollisionFeature', function(t) {
 
     test('point label', function(t) {
         var point = new Point(500, 0);
-        var anchor = new Anchor(point.x, point.y, 0, 0.5, undefined);
+        var anchor = new Anchor(point.x, point.y, 0, undefined);
 
         var cf = new CollisionFeature([point], anchor, shapedText, 1, 0, false);
         t.equal(cf.boxes.length, 1);
@@ -31,7 +31,7 @@ test('CollisionFeature', function(t) {
 
     test('line label', function(t) {
         var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
-        var anchor = new Anchor(505, 95, 0, 0.5, 1);
+        var anchor = new Anchor(505, 95, 0, 1);
         var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
         var boxPoints = cf.boxes.map(pluckAnchorPoint);
         t.deepEqual(boxPoints, [
@@ -40,17 +40,17 @@ test('CollisionFeature', function(t) {
             { x: 487.32213893899694, y: 97.4644277877994 },
             { x: 497.12794569590613, y: 99.42558913918124 },
             { x: 505, y: 95 },
-            { x: 512.6469868459703, y: 88.74616412559298 },
-            { x: 521.6843652349057, y: 84.46530067820254 },
-            { x: 530.7217436238411, y: 80.1844372308121 },
-            { x: 539.7591220127765, y: 75.90357378342165 },
-            { x: 548.7965004017119, y: 71.62271033603119 } ]);
+            { x: 512.6469868459704, y: 88.74616412559295 },
+            { x: 521.6843652349058, y: 84.46530067820251 },
+            { x: 530.7217436238412, y: 80.18443723081207 },
+            { x: 539.7591220127766, y: 75.90357378342162 },
+            { x: 548.7965004017119, y: 71.62271033603116 } ]);
         t.end();
     });
 
     test('vertical line label', function(t) {
         var line = [new Point(0, 0), new Point(0, 100), new Point(0, 111), new Point(0, 112), new Point(0, 200)];
-        var anchor = new Anchor(0, 110, 0, 0.5, 1);
+        var anchor = new Anchor(0, 110, 0, 1);
         var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
         var boxPoints = cf.boxes.map(pluckAnchorPoint);
         t.deepEqual(boxPoints, [
@@ -76,7 +76,7 @@ test('CollisionFeature', function(t) {
         };
 
         var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
-        var anchor = new Anchor(505, 95, 0, 0.5, 1);
+        var anchor = new Anchor(505, 95, 0, 1);
         var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
         t.equal(cf.boxes.length, 0);
         t.end();
@@ -91,7 +91,7 @@ test('CollisionFeature', function(t) {
         };
 
         var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
-        var anchor = new Anchor(505, 95, 0, 0.5, 1);
+        var anchor = new Anchor(505, 95, 0, 1);
         var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
         t.equal(cf.boxes.length, 0);
         t.end();
@@ -106,7 +106,7 @@ test('CollisionFeature', function(t) {
         };
 
         var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
-        var anchor = new Anchor(505, 95, 0, 0.5, 1);
+        var anchor = new Anchor(505, 95, 0, 1);
         var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
         t.ok(cf.boxes.length < 30);
         t.end();

--- a/test/js/symbol/collision_feature.js
+++ b/test/js/symbol/collision_feature.js
@@ -112,6 +112,15 @@ test('CollisionFeature', function(t) {
         t.end();
     });
 
+    test('height is big enough that first box can be placed *after* anchor', function(t) {
+        var line = [new Point(3103, 4068), new Point(3225.6206896551726, 4096)];
+        var anchor = new Anchor(3144.5959947505007, 4077.498298013894, 0.22449735614507618, 0);
+        var shaping = { right: 256, left: 0, bottom: 256, top: 0 };
+        var cf = new CollisionFeature(line, anchor, shaping, 1, 0, true);
+        t.equal(cf.boxes.length, 1);
+        t.end();
+    });
+
     t.end();
 });
 

--- a/test/js/symbol/get_anchors.test.js
+++ b/test/js/symbol/get_anchors.test.js
@@ -19,22 +19,18 @@ test('getAnchors', function(t) {
     t.deepEqual(anchors, [ { x: 0,
         y: 1.2,
         angle: 1.5707963267948966,
-        scale: 0.5,
         segment: 1 },
         { x: 0,
             y: 3.2,
         angle: 1.5707963267948966,
-        scale: 0.5,
         segment: 3 },
         { x: 0,
             y: 5.2,
         angle: 1.5707963267948966,
-        scale: 0.5,
         segment: 5 },
         { x: 0,
             y: 7.2,
         angle: 1.5707963267948966,
-        scale: 0.5,
         segment: 7 } ]);
 
     t.ok(labelLength / 2 < anchors[0].y && anchors[0].y < labelLength / 2 + 3 * glyphSize,
@@ -64,7 +60,6 @@ test('getAnchors', function(t) {
             { x: 0,
             y: 1.05,
             angle: 1.5707963267948966,
-            scale: 0.5,
             segment: 0 }]);
         t.end();
     });

--- a/test/js/symbol/shaping.test.js
+++ b/test/js/symbol/shaping.test.js
@@ -45,7 +45,7 @@ test('shaping', function(t) {
     shaped = shaping.shapeText('', glyphs, 15 * oneEm, oneEm, 0.5, 0.5, 0.5, 0 * oneEm, [0, 0]);
     t.equal(false, shaped);
 
-    shaped = shaping.shapeText(String.fromCharCode(0), name, glyphs, 15 * oneEm, oneEm, 0.5, 0.5, 0.5, 0 * oneEm, [0, 0]);
+    shaped = shaping.shapeText(String.fromCharCode(0), glyphs, 15 * oneEm, oneEm, 0.5, 0.5, 0.5, 0 * oneEm, [0, 0]);
     t.equal(false, shaped);
 
     t.end();


### PR DESCRIPTION
These are the changes that were made while porting labeling to -native. The most significant change is that bboxifyLabel was optimized to be 3x faster.

The bboxifyLabel changes also had a couple of rendering changes, so https://github.com/mapbox/mapbox-gl-test-suite/pull/21 needs to be merged.