### PR TITLE
switch to unpacked representation of tile id

### DIFF
--- a/js/data/feature_tree.js
+++ b/js/data/feature_tree.js
@@ -4,12 +4,11 @@ var rbush = require('rbush');
 var Point = require('point-geometry');
 var vt = require('vector-tile');
 var util = require('../util/util');
-var TileCoord = require('../source/tile_coord');
 
 module.exports = FeatureTree;
 
-function FeatureTree(tileId) {
-    this.coord = TileCoord.fromID(tileId);
+function FeatureTree(tileID) {
+    this.coord = tileID;
     this.rtree = rbush(9);
     this.toBeInserted = [];
 }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -22,9 +22,9 @@ function drawPlacementDebug(painter, layer, posMatrix, tile) {
     gl.vertexAttribPointer(shader.a_extrude, 2, gl.SHORT, false, stride, 4);
     gl.vertexAttribPointer(shader.a_data, 2, gl.UNSIGNED_BYTE, false, stride, 8);
 
-    gl.uniform1f(shader.u_scale, Math.pow(2, painter.transform.zoom - tile.zoom));
+    gl.uniform1f(shader.u_scale, Math.pow(2, painter.transform.zoom - tile.coord.z));
     gl.uniform1f(shader.u_zoom, painter.transform.zoom * 10);
-    gl.uniform1f(shader.u_maxzoom, (tile.zoom + 1) * 10);
+    gl.uniform1f(shader.u_maxzoom, (tile.coord.z + 1) * 10);
 
     var begin = elementGroups.groups[0].vertexStartIndex;
     var len = elementGroups.groups[0].vertexLength;

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -2,13 +2,11 @@
 
 var textVertices = require('../lib/debugtext');
 var browser = require('../util/browser');
-var TileCoord = require('../source/tile_coord');
 
 module.exports = drawDebug;
 
 function drawDebug(painter, tile) {
     var gl = painter.gl;
-    var pos = TileCoord.fromID(tile.id);
 
     // Blend to the front, not the back.
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
@@ -22,10 +20,7 @@ function drawDebug(painter, tile) {
     gl.lineWidth(4);
     gl.drawArrays(gl.LINE_STRIP, 0, painter.debugBuffer.itemCount);
 
-    // draw tile coordinate
-    var coord = pos.z + '/' + pos.x + '/' + pos.y;
-
-    var vertices = textVertices(coord, 50, 200, 5);
+    var vertices = textVertices(tile.coord.toString(), 50, 200, 5);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, painter.debugTextBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Int16Array(vertices), gl.STREAM_DRAW);

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -131,7 +131,7 @@ function drawFill(painter, layer, posMatrix, tile) {
         gl.uniform1f(shader.u_opacity, opacity);
         gl.uniform1f(shader.u_mix, image.t);
 
-        var factor = (4096 / tile.tileSize) / Math.pow(2, painter.transform.tileZoom - tile.zoom);
+        var factor = (4096 / tile.tileSize) / Math.pow(2, painter.transform.tileZoom - tile.coord.z);
 
         var matrixA = mat3.create();
         mat3.scale(matrixA, matrixA, [

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -35,7 +35,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
     var outset = offset + edgeWidth + antialiasing / 2 + shift;
 
     var color = layer.paint['line-color'];
-    var ratio = painter.transform.scale / (1 << tile.zoom) / (4096 / tile.tileSize);
+    var ratio = painter.transform.scale / (1 << tile.coord.z) / (4096 / tile.tileSize);
     var vtxMatrix = painter.translateMatrix(posMatrix, tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
 
     var tr = painter.transform;
@@ -71,7 +71,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         var posB = painter.lineAtlas.getDash(dasharray.to, layer.layout['line-cap'] === 'round');
         painter.lineAtlas.bind(gl);
 
-        var patternratio = Math.pow(2, Math.floor(Math.log(painter.transform.scale) / Math.LN2) - tile.zoom) / 8;
+        var patternratio = Math.pow(2, Math.floor(Math.log(painter.transform.scale) / Math.LN2) - tile.coord.z) / 8;
         var scaleA = [patternratio / posA.width / dasharray.fromScale, -posA.height / 2];
         var gammaA = painter.lineAtlas.width / (dasharray.fromScale * posA.width * 256 * browser.devicePixelRatio) / 2;
         var scaleB = [patternratio / posB.width / dasharray.toScale, -posB.height / 2];
@@ -90,7 +90,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         var imagePosA = painter.spriteAtlas.getPosition(image.from, true);
         var imagePosB = painter.spriteAtlas.getPosition(image.to, true);
         if (!imagePosA || !imagePosB) return;
-        var factor = 4096 / tile.tileSize / Math.pow(2, painter.transform.tileZoom - tile.zoom);
+        var factor = 4096 / tile.tileSize / Math.pow(2, painter.transform.tileZoom - tile.coord.z);
 
         painter.spriteAtlas.bind(gl, true);
 

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -43,7 +43,7 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
 
     if (skewed) {
         exMatrix = mat4.create();
-        s = 4096 / tile.tileSize / Math.pow(2, painter.transform.zoom - tile.zoom);
+        s = 4096 / tile.tileSize / Math.pow(2, painter.transform.zoom - tile.coord.z);
         gammaScale = 1 / Math.cos(tr._pitch);
     } else {
         exMatrix = mat4.clone(tile.exMatrix);

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -296,7 +296,7 @@ GLPainter.prototype.translateMatrix = function(matrix, tile, translate, anchor) 
         ];
     }
 
-    var tilePixelRatio = this.transform.scale / (1 << tile.zoom) / (tile.tileExtent / tile.tileSize);
+    var tilePixelRatio = this.transform.scale / (1 << tile.coord.z) / (tile.tileExtent / tile.tileSize);
     var translation = [
         translate[0] / tilePixelRatio,
         translate[1] / tilePixelRatio,

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -121,11 +121,11 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     },
 
     _loadTile: function(tile) {
-        var overscaling = tile.zoom > this.maxzoom ? Math.pow(2, tile.zoom - this.maxzoom) : 1;
+        var overscaling = tile.coord.z > this.maxzoom ? Math.pow(2, tile.coord.z - this.maxzoom) : 1;
         var params = {
             uid: tile.uid,
-            id: tile.id,
-            zoom: tile.zoom,
+            coord: tile.coord,
+            zoom: tile.coord.z,
             maxZoom: this.maxzoom,
             tileSize: 512,
             source: this.id,

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -3,7 +3,6 @@
 var util = require('../util/util');
 var ajax = require('../util/ajax');
 var Evented = require('../util/evented');
-var TileCoord = require('./tile_coord');
 var Source = require('./source');
 var normalizeURL = require('../util/mapbox').normalizeTileURL;
 
@@ -38,7 +37,7 @@ RasterTileSource.prototype = util.inherit(Evented, {
     render: Source._renderTiles,
 
     _loadTile: function(tile) {
-        ajax.getImage(normalizeURL(TileCoord.url(tile.id, this.tiles), this.url), function(err, img) {
+        ajax.getImage(normalizeURL(tile.coord.url(this.tiles), this.url), function(err, img) {
             if (tile.aborted)
                 return;
 

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -3,8 +3,8 @@
 var util = require('../util/util');
 var ajax = require('../util/ajax');
 var browser = require('../util/browser');
-var TileCoord = require('./tile_coord');
 var TilePyramid = require('./tile_pyramid');
+var TileCoord = require('./tile_coord');
 var normalizeURL = require('../util/mapbox').normalizeSourceURL;
 
 exports._loadTileJSON = function(options) {
@@ -47,12 +47,14 @@ exports._renderTiles = function(layers, painter) {
 
     var ids = this._pyramid.renderedIDs();
     for (var i = 0; i < ids.length; i++) {
-        var pos = TileCoord.fromID(ids[i]),
-            tile = this._pyramid.getTile(ids[i]),
-            z = pos.z,
-            x = pos.x,
-            y = pos.y,
-            w = pos.w;
+        var tile = this._pyramid.getTile(ids[i]),
+            // coord is different than tile.coord for wrapped tiles since the actual
+            // tile object is shared between all the visible copies of that tile.
+            coord = TileCoord.fromID(ids[i]),
+            z = coord.z,
+            x = coord.x,
+            y = coord.y,
+            w = coord.w;
 
         // if z > maxzoom then the tile is actually a overscaled maxzoom tile,
         // so calculate the matrix the maxzoom tile would use.

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -3,17 +3,15 @@
 var glmatrix = require('gl-matrix');
 var mat2 = glmatrix.mat2;
 var mat4 = glmatrix.mat4;
-var TileCoord = require('./tile_coord');
 var util = require('../util/util');
 var BufferSet = require('../data/buffer/buffer_set');
 
 module.exports = Tile;
 
-function Tile(id, size) {
-    this.id = id;
+function Tile(coord, size) {
+    this.coord = coord;
     this.uid = util.uniqueId();
     this.loaded = false;
-    this.zoom = TileCoord.fromID(id).z;
     this.uses = 0;
     this.tileSize = size;
 }
@@ -54,10 +52,9 @@ Tile.prototype = {
 
     positionAt: function(coord) {
         coord = coord.zoomTo(this.zoom);
-        var pos = TileCoord.fromID(this.id);
         return {
-            x: (coord.column - pos.x) * 4096,
-            y: (coord.row - pos.y) * 4096,
+            x: (coord.column - this.coord.x) * 4096,
+            y: (coord.row - this.coord.y) * 4096,
             scale: this.scale
         };
     },

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -74,34 +74,34 @@ TilePyramid.prototype = {
         if (z > this.maxzoom) z = this.maxzoom;
 
         var tr = transform,
-            tileCenter = TileCoord.zoomTo(tr.locationCoordinate(tr.center), z),
+            tileCenter = tr.locationCoordinate(tr.center)._zoomTo(z),
             centerPoint = new Point(tileCenter.column - 0.5, tileCenter.row - 0.5);
 
         return TileCoord.cover(z, [
-            TileCoord.zoomTo(tr.pointCoordinate(new Point(0, 0)), z),
-            TileCoord.zoomTo(tr.pointCoordinate(new Point(tr.width, 0)), z),
-            TileCoord.zoomTo(tr.pointCoordinate(new Point(tr.width, tr.height)), z),
-            TileCoord.zoomTo(tr.pointCoordinate(new Point(0, tr.height)), z)
+            tr.pointCoordinate(new Point(0, 0))._zoomTo(z),
+            tr.pointCoordinate(new Point(tr.width, 0))._zoomTo(z),
+            tr.pointCoordinate(new Point(tr.width, tr.height))._zoomTo(z),
+            tr.pointCoordinate(new Point(0, tr.height))._zoomTo(z)
         ], this.reparseOverscaled ? actualZ : z).sort(function(a, b) {
-            return centerPoint.dist(TileCoord.fromID(a)) -
-                centerPoint.dist(TileCoord.fromID(b));
+            return centerPoint.dist(a) - centerPoint.dist(b);
         });
     },
 
     // Recursively find children of the given tile (up to maxCoveringZoom) that are already loaded;
     // adds found tiles to retain object; returns true if children completely cover the tile
-    findLoadedChildren: function(id, maxCoveringZoom, retain) {
+    findLoadedChildren: function(coord, maxCoveringZoom, retain) {
         var complete = true;
-        var z = TileCoord.fromID(id).z;
-        var ids = TileCoord.children(id, this.maxzoom);
-        for (var i = 0; i < ids.length; i++) {
-            if (this._tiles[ids[i]] && this._tiles[ids[i]].loaded) {
-                retain[ids[i]] = true;
+        var z = coord.z;
+        var coords = coord.children(this.maxzoom);
+        for (var i = 0; i < coords.length; i++) {
+            var id = coords[i].id;
+            if (this._tiles[id] && this._tiles[id].loaded) {
+                retain[id] = true;
             } else {
                 complete = false;
                 if (z < maxCoveringZoom) {
                     // Go further down the hierarchy to find more unloaded children.
-                    this.findLoadedChildren(ids[i], maxCoveringZoom, retain);
+                    this.findLoadedChildren(coords[i], maxCoveringZoom, retain);
                 }
             }
         }
@@ -110,12 +110,12 @@ TilePyramid.prototype = {
 
     // Find a loaded parent of the given tile (up to minCoveringZoom);
     // adds the found tile to retain object and returns the tile if found
-    findLoadedParent: function(id, minCoveringZoom, retain) {
-        for (var z = TileCoord.fromID(id).z; z >= minCoveringZoom; z--) {
-            id = TileCoord.parent(id, this.maxzoom);
-            var tile = this._tiles[id];
+    findLoadedParent: function(coord, minCoveringZoom, retain) {
+        for (var z = coord.z - 1; z >= minCoveringZoom; z--) {
+            coord = coord.parent(this.maxzoom);
+            var tile = this._tiles[coord.id];
             if (tile && tile.loaded) {
-                retain[id] = true;
+                retain[coord.id] = true;
                 return tile;
             }
         }
@@ -124,7 +124,7 @@ TilePyramid.prototype = {
     // Removes tiles that are outside the viewport and adds new tiles that are inside the viewport.
     update: function(used, transform, fadeDuration) {
         var i;
-        var id;
+        var coord;
         var tile;
 
         // Determine the overzooming/underzooming amounts.
@@ -144,30 +144,31 @@ TilePyramid.prototype = {
 
         var required = used ? this.coveringTiles(transform) : [];
         for (i = 0; i < required.length; i++) {
-            id = +required[i];
-            tile = this.addTile(id);
+            coord = required[i];
+            tile = this.addTile(coord);
 
-            retain[id] = true;
+            retain[coord.id] = true;
 
             if (tile.loaded)
                 continue;
 
             // The tile we require is not yet loaded.
             // Retain child or parent tiles that cover the same area.
-            if (!this.findLoadedChildren(id, maxCoveringZoom, retain)) {
-                this.findLoadedParent(id, minCoveringZoom, retain);
+            if (!this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
+                this.findLoadedParent(coord, minCoveringZoom, retain);
             }
         }
 
-        for (id in retain) {
+        for (var id in retain) {
+            coord = TileCoord.fromID(id);
             tile = this._tiles[id];
             if (tile && tile.timeAdded > now - (fadeDuration || 0)) {
                 // This tile is still fading in. Find tiles to cross-fade with it.
-                if (this.findLoadedChildren(id, maxCoveringZoom, retain)) {
+                if (this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
                     this._coveredTiles[id] = true;
                     retain[id] = true;
                 } else {
-                    this.findLoadedParent(id, minCoveringZoom, retain);
+                    this.findLoadedParent(coord, minCoveringZoom, retain);
                 }
             }
         }
@@ -179,31 +180,31 @@ TilePyramid.prototype = {
         }
     },
 
-    addTile: function(id) {
-        var tile = this._tiles[id];
+    addTile: function(coord) {
+        var tile = this._tiles[coord.id];
         if (tile)
             return tile;
 
-        var wrapped = this._wrappedID(id);
-        tile = this._tiles[wrapped];
+        var wrapped = coord.wrapped();
+        tile = this._tiles[wrapped.id];
 
         if (!tile) {
-            tile = this._cache.get(wrapped);
+            tile = this._cache.get(wrapped.id);
             if (tile && this._redoPlacement) {
                 this._redoPlacement(tile);
             }
         }
 
         if (!tile) {
-            var zoom = TileCoord.fromID(id).z;
+            var zoom = coord.z;
             var overscaling = zoom > this.maxzoom ? Math.pow(2, zoom - this.maxzoom) : 1;
             tile = new Tile(wrapped, this.tileSize * overscaling);
             this._load(tile);
         }
 
         tile.uses++;
-        this._tiles[id] = tile;
-        this._add(tile, id);
+        this._tiles[coord.id] = tile;
+        this._add(tile, coord);
 
         return tile;
     },
@@ -215,13 +216,13 @@ TilePyramid.prototype = {
 
         tile.uses--;
         delete this._tiles[id];
-        this._remove(tile, id);
+        this._remove(tile);
 
         if (tile.uses > 0)
             return;
 
         if (tile.loaded) {
-            this._cache.add(this._wrappedID(id), tile);
+            this._cache.add(tile.coord.wrapped().id, tile);
         } else {
             this._abort(tile);
             this._unload(tile);
@@ -250,10 +251,5 @@ TilePyramid.prototype = {
                 };
             }
         }
-    },
-
-    _wrappedID: function(id) {
-        var pos = TileCoord.fromID(id);
-        return pos.w === 0 ? id : TileCoord.toID(pos.z, pos.x, pos.y, 0);
     }
 };

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -2,7 +2,6 @@
 
 var util = require('../util/util');
 var Evented = require('../util/evented');
-var TileCoord = require('./tile_coord');
 var Source = require('./source');
 
 module.exports = VectorTileSource;
@@ -58,12 +57,12 @@ VectorTileSource.prototype = util.inherit(Evented, {
     featuresAt: Source._vectorFeaturesAt,
 
     _loadTile: function(tile) {
-        var overscaling = tile.zoom > this.maxzoom ? Math.pow(2, tile.zoom - this.maxzoom) : 1;
+        var overscaling = tile.coord.z > this.maxzoom ? Math.pow(2, tile.coord.z - this.maxzoom) : 1;
         var params = {
-            url: TileCoord.url(tile.id, this.tiles, this.maxzoom),
+            url: tile.coord.url(this.tiles, this.maxzoom),
             uid: tile.uid,
-            id: tile.id,
-            zoom: tile.zoom,
+            coord: tile.coord,
+            zoom: tile.coord.z,
             maxZoom: this.maxzoom,
             tileSize: this.tileSize * overscaling,
             source: this.id,

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -2,10 +2,10 @@
 
 var util = require('../util/util');
 var Tile = require('./tile');
-var TileCoord = require('./tile_coord');
 var LatLng = require('../geo/lat_lng');
 var Point = require('point-geometry');
 var Evented = require('../util/evented');
+var Coordinate = require('../geo/coordinate');
 var ajax = require('../util/ajax');
 
 module.exports = VideoSource;
@@ -83,7 +83,7 @@ VideoSource.prototype = util.inherit(Evented, {
         var map = this.map;
         var coords = this.coordinates.map(function(latlng) {
             var loc = LatLng.convert(latlng);
-            return TileCoord.zoomTo(map.transform.locationCoordinate(loc), 0);
+            return map.transform.locationCoordinate(loc).zoomTo(0);
         });
 
         var minX = Infinity;
@@ -101,15 +101,12 @@ VideoSource.prototype = util.inherit(Evented, {
         var dx = maxX - minX;
         var dy = maxY - minY;
         var dMax = Math.max(dx, dy);
-        var center = TileCoord.zoomTo({
-            column: (minX + maxX) / 2,
-            row: (minY + maxY) / 2,
-            zoom: 0
-        }, Math.floor(-Math.log(dMax) / Math.LN2));
+        var center = new Coordinate((minX + maxX) / 2, (minY + maxY) / 2, 0)
+            .zoomTo(Math.floor(-Math.log(dMax) / Math.LN2));
 
         var tileExtent = 4096;
         var tileCoords = coords.map(function(coord) {
-            var zoomedCoord = TileCoord.zoomTo(coord, center.zoom);
+            var zoomedCoord = coord.zoomTo(center.zoom);
             return new Point(
                 Math.round((zoomedCoord.column - center.column) * tileExtent),
                 Math.round((zoomedCoord.row - center.row) * tileExtent));

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -6,7 +6,6 @@ var util = require('../util/util');
 var ajax = require('../util/ajax');
 var vt = require('vector-tile');
 var Protobuf = require('pbf');
-var TileCoord = require('./tile_coord');
 
 var geojsonvt = require('geojson-vt');
 var GeoJSONWrapper = require('./geojson_wrapper');
@@ -111,7 +110,7 @@ util.extend(Worker.prototype, {
 
     'load geojson tile': function(params, callback) {
         var source = params.source,
-            coord = TileCoord.fromID(params.id);
+            coord = params.coord;
 
         // console.time('tile ' + coord.z + ' ' + coord.x + ' ' + coord.y);
 

--- a/test/js/source/tile_coord.test.js
+++ b/test/js/source/tile_coord.test.js
@@ -4,88 +4,52 @@ var test = require('tape');
 var TileCoord = require('../../../js/source/tile_coord');
 
 test('TileCoord', function(t) {
-    t.test('.toID', function(t) {
-        t.test('calculates an iD', function(t) {
-            t.deepEqual(TileCoord.toID(0, 0, 0), 0);
-            t.deepEqual(TileCoord.toID(1, 0, 0), 1);
-            t.deepEqual(TileCoord.toID(1, 1, 0), 33);
-            t.deepEqual(TileCoord.toID(1, 1, 1), 97);
-            t.deepEqual(TileCoord.toID(1, 1, 1, -1), 225);
-            t.end();
-        });
+    t.test('.id', function(t) {
+        t.deepEqual(new TileCoord(0, 0, 0).id, 0);
+        t.deepEqual(new TileCoord(1, 0, 0).id, 1);
+        t.deepEqual(new TileCoord(1, 1, 0).id, 33);
+        t.deepEqual(new TileCoord(1, 1, 1).id, 97);
+        t.deepEqual(new TileCoord(1, 1, 1, -1).id, 225);
+        t.end();
     });
 
-    t.test('.asString', function(t) {
+    t.test('.toString', function(t) {
         t.test('calculates strings', function(t) {
-            t.deepEqual(TileCoord.asString(TileCoord.toID(1, 1, 1)), '1/1/1');
+            t.deepEqual(new TileCoord(1, 1, 1).toString(), '1/1/1');
             t.end();
         });
     });
 
     t.test('.fromID', function(t) {
         t.test('forms a loop', function(t) {
-            t.deepEqual(TileCoord.fromID(TileCoord.toID(1, 1, 1)), { z: 1, x: 1, y: 1, w: 0 });
-            t.deepEqual(TileCoord.fromID(0), { z: 0, x: 0, y: 0, w: 0 });
+            t.deepEqual(TileCoord.fromID(new TileCoord(1, 1, 1).id), new TileCoord(1, 1, 1));
+            t.deepEqual(TileCoord.fromID(0), new TileCoord(0, 0, 0, 0));
             t.end();
         });
     });
 
     t.test('.url', function(t) {
-        t.equal(TileCoord.url(1, ['{z}/{x}/{y}.json']), '1/0/0.json', 'gets a url');
-        t.end();
-    });
-
-    t.test('.zoom', function(t) {
-        for (var i = 0; i < 20; i++) {
-            t.equal(TileCoord.zoom(TileCoord.toID(i, 1, 1)), i);
-        }
+        t.equal(new TileCoord(1, 0, 0).url(['{z}/{x}/{y}.json']), '1/0/0.json', 'gets a url');
         t.end();
     });
 
     t.test('.children', function(t) {
-        t.deepEqual(TileCoord.children(TileCoord.toID(0, 0, 0)),
-                    [ 1, 33, 65, 97 ]);
+        t.deepEqual(new TileCoord(0, 0, 0).children(),
+            [ 1, 33, 65, 97 ].map(TileCoord.fromID));
         t.end();
     });
 
     t.test('.parent', function(t) {
         t.test('returns a parent id', function(t) {
-            t.equal(TileCoord.parent(33), 0);
+            t.equal(TileCoord.fromID(33).parent().id, 0);
             t.end();
         });
 
         t.test('returns null for z0', function(t) {
-            t.equal(TileCoord.parent(0), null);
-            t.equal(TileCoord.parent(32), null);
+            t.equal(TileCoord.fromID(0).parent(), null);
+            t.equal(TileCoord.fromID(32).parent(), null);
             t.end();
         });
     });
 
-    t.test('.parentWithZoom', function(t) {
-        t.deepEqual(TileCoord.parentWithZoom(TileCoord.toID(10, 10, 10), 0),
-                    TileCoord.toID(0, 0, 0));
-        t.deepEqual(TileCoord.parentWithZoom(TileCoord.toID(10, 10, 10), 1),
-                    TileCoord.toID(1, 0, 0));
-        t.deepEqual(TileCoord.parentWithZoom(TileCoord.toID(10, 50, 20), 5),
-                    37);
-        t.end();
-    });
-
-    test('.zoomTo', function(t) {
-        var coord = {
-            column: 1,
-            row: 1,
-            zoom: 2
-        };
-        var zoomed = {
-            column: 64,
-            row: 64,
-            zoom: 8
-        };
-
-        t.deepEqual(TileCoord.zoomTo(coord, 8), zoomed, 'zoomTo');
-        t.deepEqual(coord, zoomed, 'changed by reference');
-
-        t.end();
-    });
 });


### PR DESCRIPTION
The standard representation of a tile id used to be a number with x, y, z, and w packed into it. It was being constantly unpacked to get at the individual components.

This switches from the packed representation to just an object. The packed representation is now only used as a key to index the tile.

This is also more similar to -native.

The main changes are here: https://github.com/mapbox/mapbox-gl-js/blob/0d828f7be984f5e9e86ee8dbd47006ffe50d9891/js/source/tile_id.js

@jfirebaugh 