### PR TITLE
example fix - inclusion of map.unproject

### DIFF
--- a/docs/_posts/examples/3400-01-03-mouse-latlng.html
+++ b/docs/_posts/examples/3400-01-03-mouse-latlng.html
@@ -32,6 +32,6 @@ var map = new mapboxgl.Map({
 });
 
 map.on('mousemove', function(event) {
-  document.getElementById('latlng').innerHTML = event.latLng.lat + ', ' + event.latLng.lng;
+  document.getElementById('latlng').innerHTML = map.unproject(event.point).lat + ', ' + map.unproject(event.point).lng;
 });
 </script>


### PR DESCRIPTION
Fix for missing map.unproject.
referencing: https://github.com/mapbox/mapbox-gl-js/issues/1171