### PR TITLE
fix sprite atlas leaking

### DIFF
--- a/js/symbol/glyph_atlas.js
+++ b/js/symbol/glyph_atlas.js
@@ -125,8 +125,9 @@ GlyphAtlas.prototype.addGlyph = function(id, name, glyph, buffer) {
     var bufferedHeight = glyph.height + buffer * 2;
 
     // Add a 1px border around every image.
-    var packWidth = bufferedWidth;
-    var packHeight = bufferedHeight;
+    var padding = 1;
+    var packWidth = bufferedWidth + 2 * padding;
+    var packHeight = bufferedHeight + 2 * padding;
 
     // Increase to next number divisible by 4, but at least 1.
     // This is so we can scale down the texture coordinates and pack them
@@ -146,7 +147,7 @@ GlyphAtlas.prototype.addGlyph = function(id, name, glyph, buffer) {
     var target = this.data;
     var source = glyph.bitmap;
     for (var y = 0; y < bufferedHeight; y++) {
-        var y1 = this.width * (rect.y + y) + rect.x;
+        var y1 = this.width * (rect.y + y + padding) + rect.x + padding;
         var y2 = bufferedWidth * y;
         for (var x = 0; x < bufferedWidth; x++) {
             target[y1 + x] = source[y2 + x];

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -79,9 +79,10 @@ GlyphSource.prototype.getSimpleGlyphs = function(fontstack, glyphIDs, uid, callb
 
 // A simplified representation of the glyph containing only the properties needed for shaping.
 function SimpleGlyph(glyph, rect, buffer) {
+    var padding = 1;
     this.advance = glyph.advance;
-    this.left = glyph.left - buffer;
-    this.top = glyph.top + buffer;
+    this.left = glyph.left - buffer - padding;
+    this.top = glyph.top + buffer + padding;
     this.rect = rect;
 }
 

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -137,11 +137,12 @@ function align(positionedGlyphs, justify, horizontalAlign, verticalAlign, maxLin
 function shapeIcon(image, layout) {
     if (!image || !image.rect) return null;
 
+    var padding = 1;
     var dx = layout['icon-offset'][0];
     var dy = layout['icon-offset'][1];
-    var x1 = dx - image.width / 2;
+    var x1 = dx - image.width / 2 - padding;
     var x2 = x1 + image.rect.w;
-    var y1 = dy - image.height / 2;
+    var y1 = dy - image.height / 2 - padding;
     var y2 = y1 + image.rect.h;
 
     return new PositionedIcon(image, y1, y2, x1, x2);

--- a/js/symbol/sprite_atlas.js
+++ b/js/symbol/sprite_atlas.js
@@ -168,11 +168,12 @@ SpriteAtlas.prototype.getPosition = function(name, repeating) {
     // one rounded up to 4 pixels.
     var width = repeating ? image.width : rect.w;
     var height = repeating ? image.height : rect.h;
+    var padding = 1;
 
     return {
         size: [width, height],
-        tl: [(rect.x)         / this.width, (rect.y)          / this.height],
-        br: [(rect.x + width) / this.width, (rect.y + height) / this.height]
+        tl: [(rect.x + padding)         / this.width, (rect.y + padding)          / this.height],
+        br: [(rect.x + padding + width) / this.width, (rect.y + padding + height) / this.height]
     };
 };
 
@@ -197,6 +198,8 @@ SpriteAtlas.prototype.copy = function(dst, src, wrap) {
     this.allocate();
     var dstImg = this.data;
 
+    var padding = 1;
+
     copyBitmap(
         /* source buffer */  srcImg,
         /* source stride */  this.sprite.img.width,
@@ -204,8 +207,8 @@ SpriteAtlas.prototype.copy = function(dst, src, wrap) {
         /* source y */       src.y,
         /* dest buffer */    dstImg,
         /* dest stride */    this.width * this.pixelRatio,
-        /* dest x */         dst.x * this.pixelRatio,
-        /* dest y */         dst.y * this.pixelRatio,
+        /* dest x */         (dst.x + padding) * this.pixelRatio,
+        /* dest y */         (dst.y + padding) * this.pixelRatio,
         /* icon dimension */ src.width,
         /* icon dimension */ src.height,
         /* wrap */ wrap


### PR DESCRIPTION
fixes #1067 and fixes #1136

The sprite atlas already had two empty pixels between each each icon.
But the icon's real boundary isn't used for drawing. Drawing uses an
icon's box rounded up to the nearest multiple of four. Sometimes this
rounded boundary was directly on the edge of another icon. When the icon
was sampled with linear interpolation it's edge would get polluted with
values from the other icon.

This commit shifts all icons and glyphs by 1px so that there is padding
on all sides of the box being drawn. The quads used for drawing are
shifted in the opposite direction by 1px to compensate for this.

test-suite pr: https://github.com/mapbox/mapbox-gl-test-suite/pull/23

@kkaefer want to do a quick review? since all the rendering tests that should pass do, I'm fairly sure this works properly.