### PR TITLE
[wip] layer-by-layer rendering

### DIFF
--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -8,7 +8,6 @@ var pyramid = new TilePyramid({ tileSize: 512 });
 module.exports = drawBackground;
 
 function drawBackground(painter, layer, posMatrix) {
-    return;
     var gl = painter.gl;
     var transform = painter.transform;
     var color = layer.paint['background-color'];

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -8,6 +8,7 @@ var pyramid = new TilePyramid({ tileSize: 512 });
 module.exports = drawBackground;
 
 function drawBackground(painter, layer, posMatrix) {
+    return;
     var gl = painter.gl;
     var transform = painter.transform;
     var color = layer.paint['background-color'];
@@ -18,7 +19,11 @@ function drawBackground(painter, layer, posMatrix) {
     var imagePosA = image ? painter.spriteAtlas.getPosition(image.from, true) : null;
     var imagePosB = image ? painter.spriteAtlas.getPosition(image.to, true) : null;
 
+    painter.setSublayer(0);
     if (imagePosA && imagePosB) {
+
+        if (painter.opaquePass) return;
+
         // Draw texture fill
         shader = painter.patternShader;
         gl.switchShader(shader, posMatrix);
@@ -47,6 +52,9 @@ function drawBackground(painter, layer, posMatrix) {
 
     } else {
         // Draw filling rectangle.
+
+        if (painter.opaquePass !== (color[3] === 1)) return;
+
         shader = painter.fillShader;
         gl.switchShader(shader, posMatrix);
         gl.uniform4fv(shader.u_color, color);

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -12,8 +12,10 @@ function drawPlacementDebug(painter, layer, posMatrix, tile) {
     var shader = painter.collisionBoxShader;
 
     gl.enable(gl.STENCIL_TEST);
+    painter.setClippingMask(tile);
 
-    gl.switchShader(shader, posMatrix);
+    gl.switchShader(shader);
+    gl.uniformMatrix4fv(shader.u_matrix, false, posMatrix);
     buffer.bind(gl, shader);
     gl.lineWidth(3);
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -46,7 +46,7 @@ function drawFill(painter, layer, posMatrix, tile) {
     // and incrementing all areas where polygons are
     gl.colorMask(false, false, false, false);
     gl.disable(gl.DEPTH_TEST);
-    gl.depthMask(false);
+    painter.depthMask(false);
 
     // Draw the actual triangle fan into the stencil buffer.
     gl.switchShader(painter.fillShader, translatedPosMatrix);
@@ -72,7 +72,7 @@ function drawFill(painter, layer, posMatrix, tile) {
     // Now that we have the stencil mask in the stencil buffer, we can start
     // writing to the color buffer.
     gl.colorMask(true, true, true, true);
-    gl.depthMask(true);
+    painter.depthMask(true);
     gl.enable(gl.DEPTH_TEST);
 
     // From now on, we don't want to update the stencil buffer anymore.
@@ -83,7 +83,7 @@ function drawFill(painter, layer, posMatrix, tile) {
 
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // below, we have to draw the outline first (!)
-    if (layer.paint['fill-antialias'] === true && !(layer.paint['fill-image'] && !strokeColor)) {
+    if (false && layer.paint['fill-antialias'] === true && !(layer.paint['fill-image'] && !strokeColor)) {
         gl.switchShader(painter.outlineShader, translatedPosMatrix);
         gl.lineWidth(2 * browser.devicePixelRatio);
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -21,92 +21,146 @@ function drawFillTile(painter, layer, posMatrix, tile) {
     var color = layer.paint['fill-color'];
     var image = layer.paint['fill-image'];
 
-    if (image && painter.opaquePass) return;
-    if (!image && painter.opaquePass !== (color[3] === 1)) return;
+    var drawFillThisPass = image ?
+        !painter.opaquePass :
+        painter.opaquePass === (color[3] === 1);
 
-    painter.setSublayer(0);
 
     var gl = painter.gl;
     var translatedPosMatrix = painter.translateMatrix(posMatrix, tile, layer.paint['fill-translate'], layer.paint['fill-translate-anchor']);
 
     var vertex, elements, group, count;
 
-    // Draw the stencil mask.
+    if (drawFillThisPass) {
+        // Draw the stencil mask.
+        painter.setSublayer(1);
 
-    // We're only drawing to the first seven bits (== support a maximum of
-    // 8 overlapping polygons in one place before we get rendering errors).
-    gl.stencilMask(0x07);
-    gl.clear(gl.STENCIL_BUFFER_BIT);
+        // We're only drawing to the first seven bits (== support a maximum of
+        // 8 overlapping polygons in one place before we get rendering errors).
+        gl.stencilMask(0x07);
+        gl.clear(gl.STENCIL_BUFFER_BIT);
 
-    // Draw front facing triangles. Wherever the 0x80 bit is 1, we are
-    // increasing the lower 7 bits by one if the triangle is a front-facing
-    // triangle. This means that all visible polygons should be in CCW
-    // orientation, while all holes (see below) are in CW orientation.
-    gl.stencilFunc(gl.EQUAL, tile.clipID, 0xF8);
+        // Draw front facing triangles. Wherever the 0x80 bit is 1, we are
+        // increasing the lower 7 bits by one if the triangle is a front-facing
+        // triangle. This means that all visible polygons should be in CCW
+        // orientation, while all holes (see below) are in CW orientation.
+        gl.stencilFunc(gl.EQUAL, tile.clipID, 0xF8);
 
-    // When we do a nonzero fill, we count the number of times a pixel is
-    // covered by a counterclockwise polygon, and subtract the number of
-    // times it is "uncovered" by a clockwise polygon.
-    gl.stencilOpSeparate(gl.FRONT, gl.KEEP, gl.KEEP, gl.INCR_WRAP);
-    gl.stencilOpSeparate(gl.BACK, gl.KEEP, gl.KEEP, gl.DECR_WRAP);
+        // When we do a nonzero fill, we count the number of times a pixel is
+        // covered by a counterclockwise polygon, and subtract the number of
+        // times it is "uncovered" by a clockwise polygon.
+        gl.stencilOpSeparate(gl.FRONT, gl.KEEP, gl.KEEP, gl.INCR_WRAP);
+        gl.stencilOpSeparate(gl.BACK, gl.KEEP, gl.KEEP, gl.DECR_WRAP);
 
-    // When drawing a shape, we first draw all shapes to the stencil buffer
-    // and incrementing all areas where polygons are
-    gl.colorMask(false, false, false, false);
-    painter.depthMask(false);
+        // When drawing a shape, we first draw all shapes to the stencil buffer
+        // and incrementing all areas where polygons are
+        gl.colorMask(false, false, false, false);
+        painter.depthMask(false);
 
-    // Draw the actual triangle fan into the stencil buffer.
-    gl.switchShader(painter.fillShader);
-    gl.uniformMatrix4fv(painter.fillShader.u_matrix, false, translatedPosMatrix);
+        // Draw the actual triangle fan into the stencil buffer.
+        gl.switchShader(painter.fillShader);
+        gl.uniformMatrix4fv(painter.fillShader.u_matrix, false, translatedPosMatrix);
 
-    // Draw all buffers
-    vertex = tile.buffers.fillVertex;
-    vertex.bind(gl);
-    elements = tile.buffers.fillElement;
-    elements.bind(gl);
+        // Draw all buffers
+        vertex = tile.buffers.fillVertex;
+        vertex.bind(gl);
+        elements = tile.buffers.fillElement;
+        elements.bind(gl);
 
-    var offset, elementOffset;
+        var offset, elementOffset;
 
-    for (var i = 0; i < elementGroups.groups.length; i++) {
-        group = elementGroups.groups[i];
-        offset = group.vertexStartIndex * vertex.itemSize;
-        gl.vertexAttribPointer(painter.fillShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
+        for (var i = 0; i < elementGroups.groups.length; i++) {
+            group = elementGroups.groups[i];
+            offset = group.vertexStartIndex * vertex.itemSize;
+            gl.vertexAttribPointer(painter.fillShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
 
-        count = group.elementLength * 3;
-        elementOffset = group.elementStartIndex * elements.itemSize;
-        gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
+            count = group.elementLength * 3;
+            elementOffset = group.elementStartIndex * elements.itemSize;
+            gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
+        }
+
+        // Now that we have the stencil mask in the stencil buffer, we can start
+        // writing to the color buffer.
+        gl.colorMask(true, true, true, true);
+        painter.depthMask(true);
+
+        // From now on, we don't want to update the stencil buffer anymore.
+        gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+        gl.stencilMask(0x0);
+        var opacity = layer.paint['fill-opacity'] || 1;
+        var shader;
+
+        if (image) {
+            // Draw texture fill
+            var imagePosA = painter.spriteAtlas.getPosition(image.from, true);
+            var imagePosB = painter.spriteAtlas.getPosition(image.to, true);
+            if (!imagePosA || !imagePosB) return;
+
+            shader = painter.patternShader;
+            gl.switchShader(shader);
+            gl.uniformMatrix4fv(shader.u_matrix, false, posMatrix);
+            gl.uniform1i(shader.u_image, 0);
+            gl.uniform2fv(shader.u_pattern_tl_a, imagePosA.tl);
+            gl.uniform2fv(shader.u_pattern_br_a, imagePosA.br);
+            gl.uniform2fv(shader.u_pattern_tl_b, imagePosB.tl);
+            gl.uniform2fv(shader.u_pattern_br_b, imagePosB.br);
+            gl.uniform1f(shader.u_opacity, opacity);
+            gl.uniform1f(shader.u_mix, image.t);
+
+            var factor = (4096 / tile.tileSize) / Math.pow(2, painter.transform.tileZoom - tile.coord.z);
+
+            gl.uniform2fv(shader.u_patternscale_a, [
+                    1 / (imagePosA.size[0] * factor * image.fromScale),
+                    1 / (imagePosA.size[1] * factor * image.fromScale)
+                    ]);
+
+            gl.uniform2fv(shader.u_patternscale_b, [
+                    1 / (imagePosB.size[0] * factor * image.toScale),
+                    1 / (imagePosB.size[1] * factor * image.toScale)
+                    ]);
+
+            painter.spriteAtlas.bind(gl, true);
+
+        } else {
+            // Draw filling rectangle.
+            shader = painter.fillShader;
+            gl.switchShader(shader);
+            gl.uniformMatrix4fv(shader.u_matrix, false, posMatrix);
+            gl.uniform4fv(shader.u_color, color);
+        }
+
+        // Only draw regions that we marked
+        gl.stencilFunc(gl.NOTEQUAL, 0x0, 0x07);
+        gl.bindBuffer(gl.ARRAY_BUFFER, painter.tileExtentBuffer);
+        gl.vertexAttribPointer(shader.a_pos, painter.tileExtentBuffer.itemSize, gl.SHORT, false, 0, 0);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
+
+        gl.stencilMask(0x00);
+        gl.stencilFunc(gl.EQUAL, tile.clipID, 0xF8);
     }
-
-    // Now that we have the stencil mask in the stencil buffer, we can start
-    // writing to the color buffer.
-    gl.colorMask(true, true, true, true);
-    painter.depthMask(true);
-
-    // From now on, we don't want to update the stencil buffer anymore.
-    gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
-    gl.stencilMask(0x0);
 
     var strokeColor = layer.paint['fill-outline-color'];
 
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // below, we have to draw the outline first (!)
-    if (false && layer.paint['fill-antialias'] === true && !(layer.paint['fill-image'] && !strokeColor)) {
+    if (!painter.opaquePass && layer.paint['fill-antialias'] === true && !(layer.paint['fill-image'] && !strokeColor)) {
         gl.switchShader(painter.outlineShader);
         gl.uniformMatrix4fv(painter.outlineShader.u_matrix, false, translatedPosMatrix);
-        gl.lineWidth(2 * browser.devicePixelRatio);
+        gl.lineWidth(2 * browser.devicePixelRatio * 10);
 
         if (strokeColor) {
             // If we defined a different color for the fill outline, we are
             // going to ignore the bits in 0x07 and just care about the global
             // clipping mask.
-            gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
+            painter.setSublayer(2);
+
         } else {
             // Otherwise, we only want to draw the antialiased parts that are
             // *outside* the current shape. This is important in case the fill
             // or stroke color is translucent. If we wouldn't clip to outside
             // the current shape, some pixels from the outline stroke overlapped
             // the (non-antialiased) fill.
-            gl.stencilFunc(gl.EQUAL, 0x80, 0xBF);
+            painter.setSublayer(0);
         }
 
         gl.uniform2f(painter.outlineShader.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
@@ -114,6 +168,7 @@ function drawFillTile(painter, layer, posMatrix, tile) {
 
         // Draw all buffers
         vertex = tile.buffers.fillVertex;
+        vertex.bind(gl);
         elements = tile.buffers.outlineElement;
         elements.bind(gl);
 
@@ -128,54 +183,5 @@ function drawFillTile(painter, layer, posMatrix, tile) {
         }
     }
 
-    var opacity = layer.paint['fill-opacity'] || 1;
-    var shader;
 
-    if (image) {
-        // Draw texture fill
-        var imagePosA = painter.spriteAtlas.getPosition(image.from, true);
-        var imagePosB = painter.spriteAtlas.getPosition(image.to, true);
-        if (!imagePosA || !imagePosB) return;
-
-        shader = painter.patternShader;
-        gl.switchShader(shader);
-        gl.uniformMatrix4fv(shader.u_matrix, false, posMatrix);
-        gl.uniform1i(shader.u_image, 0);
-        gl.uniform2fv(shader.u_pattern_tl_a, imagePosA.tl);
-        gl.uniform2fv(shader.u_pattern_br_a, imagePosA.br);
-        gl.uniform2fv(shader.u_pattern_tl_b, imagePosB.tl);
-        gl.uniform2fv(shader.u_pattern_br_b, imagePosB.br);
-        gl.uniform1f(shader.u_opacity, opacity);
-        gl.uniform1f(shader.u_mix, image.t);
-
-        var factor = (4096 / tile.tileSize) / Math.pow(2, painter.transform.tileZoom - tile.coord.z);
-
-        gl.uniform2fv(shader.u_patternscale_a, [
-            1 / (imagePosA.size[0] * factor * image.fromScale),
-            1 / (imagePosA.size[1] * factor * image.fromScale)
-        ]);
-
-        gl.uniform2fv(shader.u_patternscale_b, [
-            1 / (imagePosB.size[0] * factor * image.toScale),
-            1 / (imagePosB.size[1] * factor * image.toScale)
-        ]);
-
-        painter.spriteAtlas.bind(gl, true);
-
-    } else {
-        // Draw filling rectangle.
-        shader = painter.fillShader;
-        gl.switchShader(shader);
-        gl.uniformMatrix4fv(shader.u_matrix, false, posMatrix);
-        gl.uniform4fv(shader.u_color, color);
-    }
-
-    // Only draw regions that we marked
-    gl.stencilFunc(gl.NOTEQUAL, 0x0, 0x07);
-    gl.bindBuffer(gl.ARRAY_BUFFER, painter.tileExtentBuffer);
-    gl.vertexAttribPointer(shader.a_pos, painter.tileExtentBuffer.itemSize, gl.SHORT, false, 0, 0);
-    gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
-
-    gl.stencilMask(0x00);
-    gl.stencilFunc(gl.EQUAL, tile.clipID, 0xF8);
 }

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var browser = require('../util/browser');
-var mat3 = require('gl-matrix').mat3;
 
 module.exports = drawFill;
 
@@ -133,20 +132,15 @@ function drawFill(painter, layer, posMatrix, tile) {
 
         var factor = (4096 / tile.tileSize) / Math.pow(2, painter.transform.tileZoom - tile.coord.z);
 
-        var matrixA = mat3.create();
-        mat3.scale(matrixA, matrixA, [
+        gl.uniform2fv(shader.u_patternscale_a, [
             1 / (imagePosA.size[0] * factor * image.fromScale),
             1 / (imagePosA.size[1] * factor * image.fromScale)
         ]);
 
-        var matrixB = mat3.create();
-        mat3.scale(matrixB, matrixB, [
+        gl.uniform2fv(shader.u_patternscale_b, [
             1 / (imagePosB.size[0] * factor * image.toScale),
             1 / (imagePosB.size[1] * factor * image.toScale)
         ]);
-
-        gl.uniformMatrix3fv(shader.u_patternmatrix_a, false, matrixA);
-        gl.uniformMatrix3fv(shader.u_patternmatrix_b, false, matrixB);
 
         painter.spriteAtlas.bind(gl, true);
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -20,15 +20,15 @@ function drawFill(painter, layer, posMatrix, tile) {
     // Draw the stencil mask.
 
     // We're only drawing to the first seven bits (== support a maximum of
-    // 127 overlapping polygons in one place before we get rendering errors).
-    gl.stencilMask(0x3F);
+    // 8 overlapping polygons in one place before we get rendering errors).
+    gl.stencilMask(0x07);
     gl.clear(gl.STENCIL_BUFFER_BIT);
 
     // Draw front facing triangles. Wherever the 0x80 bit is 1, we are
     // increasing the lower 7 bits by one if the triangle is a front-facing
     // triangle. This means that all visible polygons should be in CCW
     // orientation, while all holes (see below) are in CW orientation.
-    gl.stencilFunc(gl.NOTEQUAL, 0x80, 0x80);
+    gl.stencilFunc(gl.NOTEQUAL, tile.clipID, 0xF8);
 
     // When we do a nonzero fill, we count the number of times a pixel is
     // covered by a counterclockwise polygon, and subtract the number of
@@ -79,7 +79,7 @@ function drawFill(painter, layer, posMatrix, tile) {
 
         if (strokeColor) {
             // If we defined a different color for the fill outline, we are
-            // going to ignore the bits in 0x3F and just care about the global
+            // going to ignore the bits in 0x07 and just care about the global
             // clipping mask.
             gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
         } else {
@@ -152,11 +152,11 @@ function drawFill(painter, layer, posMatrix, tile) {
     }
 
     // Only draw regions that we marked
-    gl.stencilFunc(gl.NOTEQUAL, 0x0, 0x3F);
+    gl.stencilFunc(gl.NOTEQUAL, 0x0, 0x07);
     gl.bindBuffer(gl.ARRAY_BUFFER, painter.tileExtentBuffer);
     gl.vertexAttribPointer(shader.a_pos, painter.tileExtentBuffer.itemSize, gl.SHORT, false, 0, 0);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
 
     gl.stencilMask(0x00);
-    gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
+    gl.stencilFunc(gl.EQUAL, tile.clipID, 0xF8);
 }

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -13,6 +13,10 @@ var mat2 = require('gl-matrix').mat2;
  * @returns {undefined} draws with the painter
  */
 module.exports = function drawLine(painter, layer, posMatrix, tile) {
+
+    if (painter.opaquePass) return;
+    painter.setSublayer(0);
+
     // No data
     if (!tile.buffers) return;
     var elementGroups = tile.elementGroups[layer.ref || layer.id];

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -16,6 +16,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
 
     if (painter.opaquePass) return;
     painter.setSublayer(0);
+    painter.depthMask(false);
 
     // No data
     if (!tile.buffers) return;

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -11,6 +11,10 @@ function drawRaster(painter, layer, tiles) {
 }
 
 function drawRasterTile(painter, layer, posMatrix, tile) {
+    if (painter.opaquePass) return;
+
+    painter.setSublayer(0);
+
     var gl = painter.gl;
 
     gl.disable(gl.STENCIL_TEST);

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -4,13 +4,20 @@ var util = require('../util/util');
 
 module.exports = drawRaster;
 
-function drawRaster(painter, layer, posMatrix, tile) {
+function drawRaster(painter, layer, tiles) {
+    for (var t = 0; t < tiles.length; t++) {
+        drawRasterTile(painter, layer, tiles[t].posMatrix, tiles[t]);
+    }
+}
+
+function drawRasterTile(painter, layer, posMatrix, tile) {
     var gl = painter.gl;
 
     gl.disable(gl.STENCIL_TEST);
 
     var shader = painter.rasterShader;
-    gl.switchShader(shader, posMatrix);
+    gl.switchShader(shader);
+    gl.uniformMatrix4fv(shader.u_matrix, false, posMatrix);
 
     // color parameters
     gl.uniform1f(shader.u_brightness_low, layer.paint['raster-brightness-min']);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -8,6 +8,9 @@ var drawCollisionDebug = require('./draw_collision_debug');
 module.exports = drawSymbols;
 
 function drawSymbols(painter, layer, posMatrix, tile) {
+
+    if (painter.opaquePass) return;
+
     // No data
     if (!tile.buffers) return;
     var elementGroups = tile.elementGroups[layer.ref || layer.id];
@@ -132,20 +135,6 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
         var haloOffset = 6;
         var gamma = 0.105 * defaultSizes[prefix] / fontSize / browser.devicePixelRatio;
 
-        gl.uniform1f(shader.u_gamma, gamma * gammaScale);
-        gl.uniform4fv(shader.u_color, layer.paint[prefix + '-color']);
-        gl.uniform1f(shader.u_buffer, (256 - 64) / 256);
-
-        for (var i = 0; i < elementGroups.groups.length; i++) {
-            group = elementGroups.groups[i];
-            offset = group.vertexStartIndex * vertex.itemSize;
-            vertex.bind(gl, shader, offset);
-
-            count = group.elementLength * 3;
-            elementOffset = group.elementStartIndex * elements.itemSize;
-            gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
-        }
-
         if (layer.paint[prefix + '-halo-color']) {
             // Draw halo underneath the text.
             gl.uniform1f(shader.u_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
@@ -162,6 +151,21 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
                 gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
             }
         }
+
+        gl.uniform1f(shader.u_gamma, gamma * gammaScale);
+        gl.uniform4fv(shader.u_color, layer.paint[prefix + '-color']);
+        gl.uniform1f(shader.u_buffer, (256 - 64) / 256);
+
+        for (var i = 0; i < elementGroups.groups.length; i++) {
+            group = elementGroups.groups[i];
+            offset = group.vertexStartIndex * vertex.itemSize;
+            vertex.bind(gl, shader, offset);
+
+            count = group.elementLength * 3;
+            elementOffset = group.elementStartIndex * elements.itemSize;
+            gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
+        }
+
     } else {
         gl.uniform1f(shader.u_opacity, layer.paint['icon-opacity']);
         for (var k = 0; k < elementGroups.groups.length; k++) {

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -34,11 +34,11 @@ function drawSymbols(painter, layer, posMatrix, tile) {
     painter.depthMask(false);
     gl.disable(gl.DEPTH_TEST);
 
-    if (elementGroups.text.groups.length) {
-        drawSymbol(painter, layer, posMatrix, tile, elementGroups.text, 'text', true);
-    }
     if (elementGroups.icon.groups.length) {
         drawSymbol(painter, layer, posMatrix, tile, elementGroups.icon, 'icon', elementGroups.sdfIcons);
+    }
+    if (elementGroups.text.groups.length) {
+        drawSymbol(painter, layer, posMatrix, tile, elementGroups.text, 'text', true);
     }
 
     drawCollisionDebug(painter, layer, posMatrix, tile);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -30,6 +30,10 @@ function drawSymbols(painter, layer, posMatrix, tile) {
         gl.disable(gl.STENCIL_TEST);
     }
 
+    painter.setSublayer(0);
+    painter.depthMask(false);
+    gl.disable(gl.DEPTH_TEST);
+
     if (elementGroups.text.groups.length) {
         drawSymbol(painter, layer, posMatrix, tile, elementGroups.text, 'text', true);
     }
@@ -42,6 +46,7 @@ function drawSymbols(painter, layer, posMatrix, tile) {
     if (drawAcrossEdges) {
         gl.enable(gl.STENCIL_TEST);
     }
+    gl.enable(gl.DEPTH_TEST);
 }
 
 var defaultSizes = {

--- a/js/render/gl_util.js
+++ b/js/render/gl_util.js
@@ -53,10 +53,7 @@ exports.extend = function(context) {
     };
 
     // Switches to a different shader program.
-    context.switchShader = function(shader, posMatrix, exMatrix) {
-        if (!posMatrix) {
-            console.trace('posMatrix does not have required argument');
-        }
+    context.switchShader = function(shader) {
 
         if (this.currentShader !== shader) {
             this.useProgram(shader.program);
@@ -80,18 +77,6 @@ exports.extend = function(context) {
             }
 
             this.currentShader = shader;
-        }
-
-        // Update the matrices if necessary. Note: This relies on object identity!
-        // This means changing the matrix values without the actual matrix object
-        // will FAIL to update the matrix properly.
-        if (shader.posMatrix !== posMatrix) {
-            this.uniformMatrix4fv(shader.u_matrix, false, posMatrix);
-            shader.posMatrix = posMatrix;
-        }
-        if (exMatrix && shader.exMatrix !== exMatrix && shader.u_exmatrix) {
-            this.uniformMatrix4fv(shader.u_exmatrix, false, exMatrix);
-            shader.exMatrix = exMatrix;
         }
     };
 

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -236,14 +236,16 @@ GLPainter.prototype._prepareTile = function(tile) {
 };
 
 GLPainter.prototype._prepareSource = function(source) {
-    if (source) {
+    if (!source) return [];
+
+    var tiles = source.renderedTiles();
+
+    for (var t = 0; t < tiles.length; t++) {
+        this._prepareTile(tiles[t]);
+    }
+
+    if (source.useStencilClipping) {
         this.clearStencil();
-        var tiles = source.renderedTiles();
-
-        for (var t = 0; t < tiles.length; t++) {
-            this._prepareTile(tiles[t]);
-        }
-
         this._drawClippingMasks(tiles);
     }
 

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -55,6 +55,9 @@ GLPainter.prototype.setup = function() {
     gl.enable(gl.DEPTH_TEST);
     gl.depthFunc(gl.LEQUAL);
 
+    this._depthMask = false;
+    gl.depthMask(false);
+
     // Initialize shaders
     this.debugShader = gl.initializeShader('debug',
         ['a_pos'],
@@ -169,14 +172,14 @@ GLPainter.prototype.clearStencil = function() {
 GLPainter.prototype.clearDepth = function() {
     var gl = this.gl;
     gl.clearDepth(1);
-    gl.depthMask(true);
+    this.depthMask(true);
     gl.clear(gl.DEPTH_BUFFER_BIT);
 };
 
 GLPainter.prototype._drawClippingMasks = function(tiles) {
     var gl = this.gl;
     gl.colorMask(false, false, false, false);
-    gl.depthMask(false);
+    this.depthMask(false);
     gl.disable(gl.DEPTH_TEST);
 
     // Only write clipping IDs to the last 5 bits. The first three are used for drawing fills.
@@ -195,7 +198,7 @@ GLPainter.prototype._drawClippingMasks = function(tiles) {
 
     gl.stencilMask(0x00);
     gl.colorMask(true, true, true, true);
-    gl.depthMask(true);
+    this.depthMask(true);
     gl.enable(gl.DEPTH_TEST);
 };
 
@@ -334,13 +337,19 @@ GLPainter.prototype.render = function(style, options) {
 
 GLPainter.prototype.setOpaque = function() {
     this.gl.disable(this.gl.BLEND);
-    this.gl.depthMask(true);
     this.opaquePass = true;
 };
 
 GLPainter.prototype.setTranslucent = function() {
     this.gl.enable(this.gl.BLEND);
     this.opaquePass = false;
+};
+
+GLPainter.prototype.depthMask = function(mask) {
+    if (mask !== this._depthMask) {
+        this._depthMask = mask;
+        this.gl.depthMask(mask);
+    }
 };
 
 GLPainter.prototype.drawLayer = function(layer, tiles) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -312,7 +312,7 @@ GLPainter.prototype.render = function(style, options) {
         }
     }
 
-    this.currentLayer = 0;
+    this.currentLayer = -1;
 
     for (var m = 0; m < style._groups.length; m++) {
         group = style._groups[m];

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -73,7 +73,7 @@ GLPainter.prototype.setup = function() {
 
     this.lineShader = gl.initializeShader('line',
         ['a_pos', 'a_data'],
-        ['u_matrix', 'u_linewidth', 'u_color', 'u_ratio', 'u_blur', 'u_extra', 'u_antialiasingmatrix']);
+        ['u_matrix', 'u_exmatrix', 'u_linewidth', 'u_color', 'u_ratio', 'u_blur', 'u_extra', 'u_antialiasingmatrix']);
 
     this.linepatternShader = gl.initializeShader('linepattern',
         ['a_pos', 'a_data'],

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -206,7 +206,8 @@ GLPainter.prototype._drawClippingMask = function(tile) {
     var gl = this.gl;
     gl.stencilFunc(gl.ALWAYS, tile.clipID, 0xF8);
 
-    gl.switchShader(this.fillShader, tile.posMatrix);
+    gl.switchShader(this.fillShader);
+    gl.uniformMatrix4fv(this.fillShader.u_matrix, false, tile.posMatrix);
 
     // Draw the clipping mask
     gl.bindBuffer(gl.ARRAY_BUFFER, this.tileExtentBuffer);
@@ -214,7 +215,7 @@ GLPainter.prototype._drawClippingMask = function(tile) {
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, this.tileExtentBuffer.itemCount);
 };
 
-GLPainter.prototype._setClippingMask = function(tile) {
+GLPainter.prototype.setClippingMask = function(tile) {
     var gl = this.gl;
     gl.stencilFunc(gl.EQUAL, tile.clipID, 0xF8);
 };
@@ -267,6 +268,7 @@ var draw = {
 };
 
 GLPainter.prototype.render = function(style, options) {
+
     this.style = style;
     this.options = options;
 
@@ -353,20 +355,8 @@ GLPainter.prototype.depthMask = function(mask) {
 };
 
 GLPainter.prototype.drawLayer = function(layer, tiles) {
-    for (var t = 0; t < tiles.length; t++) {
-        var tile = tiles[t];
-
-        this._setClippingMask(tile);
-        draw[layer.type](this, layer, tile.posMatrix, tile);
-
-        if (this.options.vertices) {
-            draw.vertices(this, layer, tile.posMatrix, tile);
-        }
-
-        if (this.options.debug) {
-            draw.debug(this, tile);
-        }
-    }
+    if (!tiles.length) return;
+    draw[layer.type](this, layer, tiles);
 };
 
 GLPainter.prototype.setSublayer = function(n) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -94,7 +94,7 @@ GLPainter.prototype.setup = function() {
 
     this.patternShader = gl.initializeShader('pattern',
         ['a_pos'],
-        ['u_matrix', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_mix', 'u_patternmatrix_a', 'u_patternmatrix_b', 'u_opacity', 'u_image']
+        ['u_matrix', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_mix', 'u_patternscale_a', 'u_patternscale_b', 'u_opacity', 'u_image']
     );
 
     this.fillShader = gl.initializeShader('fill',

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -24,6 +24,7 @@ function GLPainter(gl, transform) {
     this.setup();
 
     this.depthEpsilon = 1 / Math.pow(2, 16);
+    this.numSublayers = 3;
 }
 
 /*
@@ -289,7 +290,7 @@ GLPainter.prototype.render = function(style, options) {
     this.clearDepth();
 
     var numLayers = style._order.length;
-    this.depthRangeSize = 1 - numLayers * 3 * this.depthEpsilon;
+    this.depthRangeSize = 1 - (numLayers + 2) * this.numSublayers * this.depthEpsilon;
     this.currentLayer = numLayers;
 
     var group, layer, tiles;
@@ -362,8 +363,7 @@ GLPainter.prototype.drawLayer = function(layer, tiles) {
 };
 
 GLPainter.prototype.setSublayer = function(n) {
-    var maxSublayers = 3;
-    var farDepth = 1 - ((1 + this.currentLayer) * maxSublayers + n) * this.depthEpsilon;
+    var farDepth = 1 - ((1 + this.currentLayer) * this.numSublayers + n) * this.depthEpsilon;
     var nearDepth = farDepth - this.depthRangeSize;
     this.gl.depthRange(nearDepth, farDepth);
 };

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -56,6 +56,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     minzoom: 0,
     maxzoom: 14,
     _dirty: true,
+    useStencilClipping: true,
 
     /**
      * Update source geojson data and rerender map

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -97,7 +97,8 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
         this._pyramid.reload();
     },
 
-    render: Source._renderTiles,
+    renderedTiles: Source._renderedTiles,
+
     featuresAt: Source._vectorFeaturesAt,
 
     _updateData: function() {

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -34,7 +34,7 @@ RasterTileSource.prototype = util.inherit(Evented, {
         }
     },
 
-    render: Source._renderTiles,
+    renderedTiles: Source._renderedTiles,
 
     _loadTile: function(tile) {
         ajax.getImage(normalizeURL(tile.coord.url(this.tiles), this.url), function(err, img) {

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -45,6 +45,7 @@ exports._renderTiles = function(layers, painter) {
     if (!this._pyramid)
         return;
 
+    var tiles = [];
     var ids = this._pyramid.renderedIDs();
     for (var i = 0; i < ids.length; i++) {
         var tile = this._pyramid.getTile(ids[i]),
@@ -63,7 +64,13 @@ exports._renderTiles = function(layers, painter) {
         x += w * (1 << z);
         tile.calculateMatrices(z, x, y, painter.transform, painter);
 
-        painter.drawTile(tile, layers);
+        tiles.push(tile);
+    }
+
+    painter.drawClippingMasks(tiles);
+
+    for (var t = 0; t < tiles.length; t++) {
+        painter.drawTile(tiles[t], layers);
     }
 };
 

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -4,7 +4,6 @@ var util = require('../util/util');
 var ajax = require('../util/ajax');
 var browser = require('../util/browser');
 var TilePyramid = require('./tile_pyramid');
-var TileCoord = require('./tile_coord');
 var normalizeURL = require('../util/mapbox').normalizeSourceURL;
 
 exports._loadTileJSON = function(options) {

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -41,37 +41,18 @@ exports._loadTileJSON = function(options) {
     }
 };
 
-exports._renderTiles = function(layers, painter) {
-    if (!this._pyramid)
-        return;
-
+exports._renderedTiles = function() {
     var tiles = [];
+
+    if (!this._pyramid)
+        return tiles;
+
     var ids = this._pyramid.renderedIDs();
     for (var i = 0; i < ids.length; i++) {
-        var tile = this._pyramid.getTile(ids[i]),
-            // coord is different than tile.coord for wrapped tiles since the actual
-            // tile object is shared between all the visible copies of that tile.
-            coord = TileCoord.fromID(ids[i]),
-            z = coord.z,
-            x = coord.x,
-            y = coord.y,
-            w = coord.w;
-
-        // if z > maxzoom then the tile is actually a overscaled maxzoom tile,
-        // so calculate the matrix the maxzoom tile would use.
-        z = Math.min(z, this.maxzoom);
-
-        x += w * (1 << z);
-        tile.calculateMatrices(z, x, y, painter.transform, painter);
-
-        tiles.push(tile);
+        tiles.push(this._pyramid.getTile(ids[i]));
     }
 
-    painter.drawClippingMasks(tiles);
-
-    for (var t = 0; t < tiles.length; t++) {
-        painter.drawTile(tiles[t], layers);
-    }
+    return tiles;
 };
 
 exports._vectorFeaturesAt = function(coord, params, callback) {

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -144,5 +144,14 @@ Tile.prototype = {
             this.buffers[b].destroy(painter.gl);
         }
         this.buffers = null;
+    },
+
+    /**
+     * Return whether this tile has any data for the given layer.
+     * @param {Object} style layer object
+     * @returns {boolean}
+     */
+    hasLayerData: function(layer) {
+        return Boolean(this.buffers && this.elementGroups[layer.ref || layer.id]);
     }
 };

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -14,13 +14,15 @@ module.exports = Tile;
  *
  * @param {Coordinate} coord
  * @param {number} size
+ * @param {sourceMaxZoom} the tile's source's maximum zoom level
  */
-function Tile(coord, size) {
+function Tile(coord, size, sourceMaxZoom) {
     this.coord = coord;
     this.uid = util.uniqueId();
     this.loaded = false;
     this.uses = 0;
     this.tileSize = size;
+    this.sourceMaxZoom = sourceMaxZoom;
 }
 
 Tile.prototype = {

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -263,7 +263,7 @@ TilePyramid.prototype = {
         if (!tile) {
             var zoom = coord.z;
             var overscaling = zoom > this.maxzoom ? Math.pow(2, zoom - this.maxzoom) : 1;
-            tile = new Tile(wrapped, this.tileSize * overscaling);
+            tile = new Tile(wrapped, this.tileSize * overscaling, this.maxzoom);
             this._load(tile);
         }
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -22,6 +22,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
     tileSize: 512,
     reparseOverscaled: true,
     _loaded: false,
+    useStencilClipping: true,
 
     onAdd: function(map) {
         this.map = map;

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -53,7 +53,8 @@ VectorTileSource.prototype = util.inherit(Evented, {
         }
     },
 
-    render: Source._renderTiles,
+    renderedTiles: Source._renderedTiles,
+
     featuresAt: Source._vectorFeaturesAt,
 
     _loadTile: function(tile) {

--- a/js/util/browser/canvas.js
+++ b/js/util/browser/canvas.js
@@ -36,7 +36,7 @@ Canvas.prototype._contextAttributes = {
     antialias: false,
     alpha: true,
     stencil: true,
-    depth: false
+    depth: true
 };
 
 Canvas.prototype.getWebGLContext = function(failIfMajorPerformanceCaveat) {

--- a/shaders/pattern.vertex.glsl
+++ b/shaders/pattern.vertex.glsl
@@ -1,6 +1,6 @@
 uniform mat4 u_matrix;
-uniform mat3 u_patternmatrix_a;
-uniform mat3 u_patternmatrix_b;
+uniform vec2 u_patternscale_a;
+uniform vec2 u_patternscale_b;
 
 attribute vec2 a_pos;
 
@@ -9,6 +9,6 @@ varying vec2 v_pos_b;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
-    v_pos_a = (u_patternmatrix_a * vec3(a_pos, 1)).xy;
-    v_pos_b = (u_patternmatrix_b * vec3(a_pos, 1)).xy;
+    v_pos_a = u_patternscale_a * a_pos;
+    v_pos_b = u_patternscale_b * a_pos;
 }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -62,6 +62,10 @@ function renderTest(style, info, base, key) {
 
         var gl = map.painter.gl;
 
+        // Add missing constants (https://github.com/stackgl/headless-gl/issues/12)
+        gl.DEPTH_STENCIL = 0x84F9;
+        gl.DEPTH_STENCIL_ATTACHMENT = 0x821A;
+
         map.painter.prepareBuffers = function() {
             var gl = this.gl;
 
@@ -72,11 +76,11 @@ function renderTest(style, info, base, key) {
                 gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA, gl.drawingBufferWidth, gl.drawingBufferHeight);
             }
 
-            if (!gl.stencilbuffer) {
+            if (!gl.depthStencilBuffer) {
                 // Create default stencilbuffer
-                gl.stencilbuffer = gl.createRenderbuffer();
-                gl.bindRenderbuffer(gl.RENDERBUFFER, gl.stencilbuffer);
-                gl.renderbufferStorage(gl.RENDERBUFFER, gl.STENCIL_INDEX8, gl.drawingBufferWidth, gl.drawingBufferHeight);
+                gl.depthStencilBuffer = gl.createRenderbuffer();
+                gl.bindRenderbuffer(gl.RENDERBUFFER, gl.depthStencilBuffer);
+                gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, gl.drawingBufferWidth, gl.drawingBufferHeight);
             }
 
             if (!gl.framebuffer) {
@@ -86,7 +90,7 @@ function renderTest(style, info, base, key) {
 
             gl.bindFramebuffer(gl.FRAMEBUFFER, gl.framebuffer);
             gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, gl.renderbuffer);
-            gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.RENDERBUFFER, gl.stencilbuffer);
+            gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, gl.depthStencilBuffer);
 
             this.clearColor();
         };


### PR DESCRIPTION
This fixes #193 and fixes #757 and fixes #1156.

Rendering tests are all currently failing because it's lacking a depth buffer. I tried adding it with https://gist.github.com/ansis/d07edada904fad335520 but it's not working. The framebuffer status check is returning 36061 (FRAMEBUFFER_UNSUPPORTED). @kkaefer any ideas?

what my attempt at setting up a depth buffer looked like:
![screen shot 2015-05-01 at 2 12 38 pm](https://cloud.githubusercontent.com/assets/1421652/7439259/9ef89a96-f029-11e4-8cd9-a5d63585fe55.png)


Performance: It seems similar. Needs more careful testing. @mourner 

With these changes rendering works more similarly to -native. All layers are drawn in two passes: opaque and then transparent. Tile clip ids are drawn to the stencil at the same time to allow for fast switching between tiles. The depth buffer is used to drop fragments below opaque fills..

I did not make any effort to name and structure things similarly to -native. We should reorganize things in both so that they are more similar.

Clip ids work a bit differently than in -native. Each source as it's own set of clip ids and the stencil mask is redrawn whenever it switches between sources. This approach us use less stencil bits (5). With only 5 bits we have 3 left over for drawing fills. This is what let me implement this before we merge the fill triangulation work. I also have concerns about whether -native's stencil clipping works properly across multiple sources.