### PR TITLE
Rationalize map view method options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ An in-progress version being developed in the `master` branch.
 
 * `mapboxgl.Source` is no longer exported. Use `map.addSource()` instead.
 * `mapboxgl.util.supported()` moved to `mapboxgl.supported()
-* map#setView(latlng, zoom, bearing) changed to map#setView(latlng, zoom, bearing, pitch)
-* map#easeTo(latlng, zoom, bearing, options) changed to map#easeTo(latlng, zoom, bearing, pitch, options)
+* map#setView(latlng, zoom, bearing) changed to map#jumpTo(options)
+* map#easeTo(latlng, zoom, bearing, options) changed to map#easeTo(options)
+* map#flyTo(latlng, zoom, bearing, options) changed to map#flyTo(options)
 
 
 

--- a/docs/_posts/examples/3400-01-03-flyto.html
+++ b/docs/_posts/examples/3400-01-03-flyto.html
@@ -35,8 +35,8 @@ var map = new mapboxgl.Map({
 function fly() {
     // Fly to a random location by offsetting the point 40, -74.50
     // by up to 5 degrees.
-    map.flyTo([
+    map.flyTo({ center: [
         40 + (Math.random() - 0.5) * 10,
-        -74.50 + (Math.random() - 0.5) * 10]);
+        -74.50 + (Math.random() - 0.5) * 10] });
 }
 </script>

--- a/js/ui/hash.js
+++ b/js/ui/hash.js
@@ -44,7 +44,11 @@ Hash.prototype = {
     _onHashChange: function() {
         var loc = location.hash.replace('#', '').split('/');
         if (loc.length >= 3) {
-            this._map.setView([+loc[1], +loc[2]], +loc[0], +(loc[3] || 0), this._map.getPitch());
+            this._map.jumpTo({
+                center: [+loc[1], +loc[2]],
+                zoom: +loc[0],
+                bearing: +(loc[3] || 0)
+            });
             return true;
         }
         return false;

--- a/test/js/ui/easings.test.js
+++ b/test/js/ui/easings.test.js
@@ -280,28 +280,28 @@ test('Map', function(t) {
     t.test('#easeTo', function(t) {
         t.test('pans to specified location', function(t) {
             var map = createMap();
-            map.easeTo([0, 100], undefined, undefined, undefined, { duration: 0 });
+            map.easeTo({ center: [0, 100], duration: 0 });
             t.deepEqual(map.getCenter(), { lat: 0, lng: 100 });
             t.end();
         });
 
         t.test('zooms to specified level', function(t) {
             var map = createMap();
-            map.easeTo(undefined, 3.2, undefined, undefined, { duration: 0 });
+            map.easeTo({ zoom: 3.2, duration: 0 });
             t.equal(map.getZoom(), 3.2);
             t.end();
         });
 
         t.test('rotates to specified bearing', function(t) {
             var map = createMap();
-            map.easeTo(undefined, undefined, 90, undefined, { duration: 0 });
+            map.easeTo({ bearing: 90, duration: 0 });
             t.equal(map.getBearing(), 90);
             t.end();
         });
 
         t.test('pans and zooms', function(t) {
             var map = createMap();
-            map.easeTo([0, 100], 3.2, undefined, undefined, { duration: 0 });
+            map.easeTo({ center: [0, 100], zoom: 3.2, duration: 0 });
             t.deepEqual(fixedLatLng(map.getCenter()), fixedLatLng({ lat: 0, lng: 100 }));
             t.equal(map.getZoom(), 3.2);
             t.end();
@@ -309,7 +309,7 @@ test('Map', function(t) {
 
         t.test('pans and rotates', function(t) {
             var map = createMap();
-            map.easeTo([0, 100], undefined, 90, undefined, { duration: 0 });
+            map.easeTo({ center: [0, 100], bearing: 90, duration: 0 });
             t.deepEqual(map.getCenter(), { lat: 0, lng: 100 });
             t.equal(map.getBearing(), 90);
             t.end();
@@ -317,7 +317,7 @@ test('Map', function(t) {
 
         t.test('zooms and rotates', function(t) {
             var map = createMap();
-            map.easeTo(undefined, 3.2, 90, undefined, { duration: 0 });
+            map.easeTo({ zoom: 3.2, bearing: 90, duration: 0 });
             t.equal(map.getZoom(), 3.2);
             t.equal(map.getBearing(), 90);
             t.end();
@@ -325,7 +325,7 @@ test('Map', function(t) {
 
         t.test('pans, zooms, and rotates', function(t) {
             var map = createMap();
-            map.easeTo([0, 100], 3.2, 90, undefined, { duration: 0 });
+            map.easeTo({ center: [0, 100], zoom: 3.2, bearing: 90, duration: 0 });
             t.deepEqual(fixedLatLng(map.getCenter()), fixedLatLng({ lat: 0, lng: 100 }));
             t.equal(map.getZoom(), 3.2);
             t.equal(map.getBearing(), 90);
@@ -334,7 +334,7 @@ test('Map', function(t) {
 
         t.test('noop', function(t) {
             var map = createMap();
-            map.easeTo(undefined, undefined, undefined, undefined, { duration: 0 });
+            map.easeTo({ duration: 0 });
             t.deepEqual(map.getCenter(), { lat: 0, lng: 0 });
             t.equal(map.getZoom(), 0);
             t.equal(map.getBearing(), 0);
@@ -343,7 +343,7 @@ test('Map', function(t) {
 
         t.test('noop with offset', function(t) {
             var map = createMap();
-            map.easeTo(undefined, undefined, undefined, undefined, { offset: [100, 0], duration: 0 });
+            map.easeTo({ offset: [100, 0], duration: 0 });
             t.deepEqual(map.getCenter(), { lat: 0, lng: 0 });
             t.equal(map.getZoom(), 0);
             t.equal(map.getBearing(), 0);
@@ -352,14 +352,14 @@ test('Map', function(t) {
 
         t.test('pans with specified offset', function(t) {
             var map = createMap();
-            map.easeTo([0, 100], undefined, undefined, undefined, { offset: [100, 0], duration: 0 });
+            map.easeTo({ center: [0, 100], offset: [100, 0], duration: 0 });
             t.deepEqual(map.getCenter(), { lat: 0, lng: 29.6875 });
             t.end();
         });
 
         t.test('pans with specified offset relative to viewport on a rotated map', function(t) {
             var map = createMap({bearing: 180});
-            map.easeTo([0, 100], undefined, undefined, undefined, { offset: [100, 0], duration: 0 });
+            map.easeTo({ center: [0, 100], offset: [100, 0], duration: 0 });
             t.deepEqual(map.getCenter(), { lat: 0, lng: 170.3125 });
             t.end();
         });
@@ -395,13 +395,13 @@ test('Map', function(t) {
                 t.end();
             });
 
-            map.easeTo([0, 100], 3.2, 90, undefined, { duration: 0 });
+            map.easeTo({ center: [0, 100], zoom: 3.2, bearing: 90, duration: 0 });
         });
 
         t.test('stops existing ease', function(t) {
             var map = createMap();
-            map.easeTo([0, 200], undefined, undefined, undefined, { duration: 100 });
-            map.easeTo([0, 100], undefined, undefined, undefined, { duration: 0 });
+            map.easeTo({ center: [0, 200], duration: 100 });
+            map.easeTo({ center: [0, 100], duration: 0 });
             t.deepEqual(map.getCenter(), { lat: 0, lng: 100 });
             t.end();
         });

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -98,24 +98,68 @@ test('Map', function(t) {
         t.end();
     });
 
-    t.test('#setView', function(t) {
+    t.test('#jumpTo', function(t) {
         var map = createMap();
 
         t.test('sets center', function(t) {
-            map.setView([1, 2], 3, 4);
+            map.jumpTo({center: [1, 2]});
+            t.deepEqual(map.getCenter(), { lat: 1, lng: 2 });
+            t.end();
+        });
+
+        t.test('keeps current center if not specified', function(t) {
+            map.jumpTo({});
             t.deepEqual(map.getCenter(), { lat: 1, lng: 2 });
             t.end();
         });
 
         t.test('sets zoom', function(t) {
-            map.setView([1, 2], 3, 4);
+            map.jumpTo({zoom: 3});
+            t.deepEqual(map.getZoom(), 3);
+            t.end();
+        });
+
+        t.test('keeps current zoom if not specified', function(t) {
+            map.jumpTo({});
             t.deepEqual(map.getZoom(), 3);
             t.end();
         });
 
         t.test('sets bearing', function(t) {
-            map.setView([1, 2], 3, 4);
+            map.jumpTo({bearing: 4});
             t.deepEqual(map.getBearing(), 4);
+            t.end();
+        });
+
+        t.test('keeps current bearing if not specified', function(t) {
+            map.jumpTo({});
+            t.deepEqual(map.getBearing(), 4);
+            t.end();
+        });
+
+        t.test('sets pitch', function(t) {
+            map.jumpTo({pitch: 45});
+            t.deepEqual(map.getPitch(), 45);
+            t.end();
+        });
+
+        t.test('keeps current pitch if not specified', function(t) {
+            map.jumpTo({});
+            t.deepEqual(map.getPitch(), 45);
+            t.end();
+        });
+
+        t.test('sets multiple properties', function(t) {
+            map.jumpTo({
+                center: [1, 2],
+                zoom: 3,
+                bearing: 180,
+                pitch: 45
+            });
+            t.deepEqual(map.getCenter(), { lat: 1, lng: 2 });
+            t.deepEqual(map.getZoom(), 3);
+            t.deepEqual(map.getBearing(), 180);
+            t.deepEqual(map.getPitch(), 45);
             t.end();
         });
 
@@ -123,7 +167,7 @@ test('Map', function(t) {
             var started, ended;
             map.on('movestart', function() { started = true; })
                 .on('moveend', function() { ended = true; });
-            map.setView([1, 2], 3, 4);
+            map.jumpTo({center: [1, 2]});
             t.ok(started);
             t.ok(ended);
             t.end();
@@ -132,7 +176,7 @@ test('Map', function(t) {
         t.test('cancels in-progress easing', function(t) {
             map.panTo([3, 4]);
             t.ok(map.isEasing());
-            map.setView([1, 2], 3, 4);
+            map.jumpTo({center: [1, 2]});
             t.ok(!map.isEasing());
             t.end();
         });


### PR DESCRIPTION
* Map#setView is replaced with Map#jumpTo.
* Map#jumpTo, Map#easeTo, and Map#flyTo now all accept the
  same set of view options.

Fixes #1051