### PR TITLE
Expose `preserveDrawingBuffer` canvas context creation attribute to enable image export.

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -527,7 +527,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     _setupPainter: function() {
-;
         var gl = this._canvas.getWebGLContext({
             failIfMajorPerformanceCaveat: this.options.failIfMajorPerformanceCaveat,
             preserveDrawingBuffer: this.options.preserveDrawingBuffer

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -31,6 +31,7 @@ var Attribution = require('./control/attribution');
  * @param {Boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners are attached to the map, so it will not respond to input
  * @param {Array} options.classes Style class names with which to initialize the map
  * @param {Boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than expected.
+ * @param {Boolean} [options.preserveDrawingBuffer=false] If `true`, The maps canvas can be exported to a PNG using `map.getCanvas().toDataURL();`. This is false by default as a performance optimization.
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',
@@ -114,7 +115,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
 
         attributionControl: true,
 
-        failIfMajorPerformanceCaveat: false
+        failIfMajorPerformanceCaveat: false,
+        preserveDrawingBuffer: false
     },
 
     addControl: function(control) {
@@ -525,7 +527,11 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     _setupPainter: function() {
-        var gl = this._canvas.getWebGLContext(this.options.failIfMajorPerformanceCaveat);
+;
+        var gl = this._canvas.getWebGLContext({
+            failIfMajorPerformanceCaveat: this.options.failIfMajorPerformanceCaveat,
+            preserveDrawingBuffer: this.options.preserveDrawingBuffer
+        });
 
         if (!gl) {
             console.error('Failed to initialize WebGL');

--- a/js/util/browser/canvas.js
+++ b/js/util/browser/canvas.js
@@ -36,10 +36,8 @@ Canvas.prototype._contextAttributes = {
     depth: false
 };
 
-Canvas.prototype.getWebGLContext = function(failIfMajorPerformanceCaveat) {
-    var attributes = util.inherit(this._contextAttributes, {
-        failIfMajorPerformanceCaveat: failIfMajorPerformanceCaveat
-    });
+Canvas.prototype.getWebGLContext = function(attributes) {
+    attributes = util.inherit(this._contextAttributes, attributes);
 
     return this.canvas.getContext('webgl', attributes) ||
         this.canvas.getContext('experimental-webgl', attributes);


### PR DESCRIPTION
see feature request: https://github.com/mapbox/mapbox-gl-js/issues/1216

example usage:

````js
var map = new Map({
  container: 'map',
  zoom: 12.5,
  center: [38.888, -77.01866], // Washington, DC
  style: 'https://www.mapbox.com/mapbox-gl-styles/styles/bright-v7.json',
  hash: true,
  preserveDrawingBuffer: true
});

setTimeout(function() {
	var dataURL = map.getCanvas().toDataURL();
}, 5000);
````