### PR TITLE
bad rendering in IE

### DIFF
--- a/js/util/browser/canvas.js
+++ b/js/util/browser/canvas.js
@@ -29,7 +29,7 @@ Canvas.prototype.resize = function(width, height) {
     this.canvas.style.height = height + 'px';
 };
 
-Canvas.prototype._contextAttributes = {
+var requiredContextAttributes = {
     antialias: false,
     alpha: true,
     stencil: true,
@@ -37,16 +37,16 @@ Canvas.prototype._contextAttributes = {
 };
 
 Canvas.prototype.getWebGLContext = function(attributes) {
-    attributes = util.inherit(this._contextAttributes, attributes);
+    attributes = util.extend({}, attributes, requiredContextAttributes);
 
     return this.canvas.getContext('webgl', attributes) ||
         this.canvas.getContext('experimental-webgl', attributes);
 };
 
 Canvas.prototype.supportsWebGLContext = function(failIfMajorPerformanceCaveat) {
-    var attributes = util.inherit(this._contextAttributes, {
+    var attributes = util.extend({
         failIfMajorPerformanceCaveat: failIfMajorPerformanceCaveat
-    });
+    }, requiredContextAttributes);
 
     if ('probablySupportsContext' in this.canvas) {
         return this.canvas.probablySupportsContext('webgl', attributes) ||


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/98601/7925589/86e66bbc-087b-11e5-9dc2-83ee0d6bc956.png)

Bisect implicates 9289a2c069b68149899c1d987c716ad217e32cc0 - "add failIfMajorPerformanceCaveat option". I totally would not have guessed that, but indeed in my IE11/Win7 VM it works before and fails starting at that commit.