### PR TITLE
Normalize reload method across source types

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -34,6 +34,10 @@ RasterTileSource.prototype = util.inherit(Evented, {
         }
     },
 
+    reload: function() {
+        // noop
+    },
+
     render: Source._renderTiles,
 
     _loadTile: function(tile) {

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -148,6 +148,10 @@ VideoSource.prototype = util.inherit(Evented, {
         // noop
     },
 
+    reload: function() {
+        // noop
+    },
+
     render: function(layers, painter) {
         if (!this._loaded) return;
         if (this.video.readyState < 2) return; // not enough data for current position

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -370,7 +370,9 @@ Style.prototype = util.inherit(Evented, {
         layer = this.getReferentLayer(layer);
         layer.setLayoutProperty(name, value);
         this._broadcastLayers();
-        this.sources[layer.source].reload();
+        if (layer.source) {
+            this.sources[layer.source].reload();
+        }
     },
 
     /**

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -354,6 +354,7 @@ Style.prototype = util.inherit(Evented, {
         layer.filter = filter;
         this._broadcastLayers();
         this.sources[layer.source].reload();
+        this.fire('change');
     },
 
     /**
@@ -373,6 +374,7 @@ Style.prototype = util.inherit(Evented, {
         if (layer.source) {
             this.sources[layer.source].reload();
         }
+        this.fire('change');
     },
 
     /**
@@ -388,6 +390,7 @@ Style.prototype = util.inherit(Evented, {
 
     setPaintProperty: function(layer, name, value, klass) {
         this.getLayer(layer).setPaintProperty(name, value, klass);
+        this.fire('change');
     },
 
     getPaintProperty: function(layer, name, klass) {

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -444,6 +444,32 @@ test('Style#setLayoutProperty', function(t) {
         });
     });
 
+    t.test('fires a change event', function (t) {
+        // background layers do not have a source
+        var style = new Style({
+            "version": 7,
+            "sources": {},
+            "layers": [{
+                "id": "background",
+                "type": "background",
+                "layout": {
+                    "visibility": "none"
+                }
+            }]
+        });
+
+        style.on('load', function() {
+            style.on('change', function(e) {
+                t.ok(e, 'change event');
+
+                t.end();
+            });
+
+            style.setLayoutProperty('background', 'visibility', 'visible');
+
+        });
+    });
+
     t.test('sets visibility on background layer', function (t) {
         // background layers do not have a source
         var style = new Style({

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -444,6 +444,26 @@ test('Style#setLayoutProperty', function(t) {
         });
     });
 
+    t.test('sets visibility on background layer', function (t) {
+        // background layers do not have a source
+        var style = new Style({
+            "version": 7,
+            "sources": {},
+            "layers": [{
+                "id": "background",
+                "type": "background",
+                "layout": {
+                    "visibility": "none"
+                }
+            }]
+        });
+
+        style.on('load', function() {
+            style.setLayoutProperty('background', 'visibility', 'visible');
+            t.deepEqual(style.getLayoutProperty('background', 'visibility'), 'visible');
+            t.end();
+        });
+    });
     t.test('sets visibility on raster layer', function (t) {
         var style = new Style({
             "version": 7,

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -443,6 +443,63 @@ test('Style#setLayoutProperty', function(t) {
             t.end();
         });
     });
+
+    t.test('sets visibility on raster layer', function (t) {
+        var style = new Style({
+            "version": 7,
+            "sources": {
+                "mapbox://mapbox.satellite": {
+                    "type": "raster",
+                    "tiles": ["local://tiles/{z}-{x}-{y}.png"]
+                }
+            },
+            "layers": [{
+                "id": "satellite",
+                "type": "raster",
+                "source": "mapbox://mapbox.satellite",
+                "layout": {
+                    "visibility": "none"
+                }
+            }]
+        });
+
+        style.on('load', function() {
+            style.setLayoutProperty('satellite', 'visibility', 'visible');
+            t.deepEqual(style.getLayoutProperty('satellite', 'visibility'), 'visible');
+            t.end();
+        });
+    });
+    t.test('sets visibility on video layer', function (t) {
+        var style = new Style({
+            "version": 7,
+            "sources": {
+                "drone": {
+                    "type": "video",
+                    "url": [ "https://www.mapbox.com/drone/video/drone.mp4", "https://www.mapbox.com/drone/video/drone.webm" ],
+                    "coordinates": [
+                        [37.56238816766053, -122.51596391201019],
+                        [37.56410183312965, -122.51467645168304],
+                        [37.563391708549425, -122.51309394836426],
+                        [37.56161849366671, -122.51423120498657]
+                    ]
+                }
+            },
+            "layers": [{
+                "id": "shore",
+                "type": "raster",
+                "source": "drone",
+                "layout": {
+                    "visibility": "none"
+                }
+            }]
+        });
+
+        style.on('load', function() {
+            style.setLayoutProperty('shore', 'visibility', 'visible');
+            t.deepEqual(style.getLayoutProperty('shore', 'visibility'), 'visible');
+            t.end();
+        });
+    });
 });
 
 test('Style#setPaintProperty', function(t) {


### PR DESCRIPTION
- added a no-op reload method to video and raster sources
- guard against a layers without sources (background layers)
- fire 'change' event to trigger updates for visibility changes on raster,
  video and background layers

Issue: #1198