### PR TITLE
Round one of changing shaders for data-driven styling

### DIFF
--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -82,8 +82,6 @@ function drawBackground(painter, layer, posMatrix) {
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.backgroundBuffer.itemCount);
     gl.enable(gl.STENCIL_TEST);
 
-    if (shader.a_color !== undefined) gl.enableVertexAttribArray(shader.a_color);
-
     gl.stencilMask(0x00);
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
 }

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -72,7 +72,8 @@ function drawBackground(painter, layer, posMatrix) {
         // Draw filling rectangle.
         shader = painter.fillShader;
         gl.switchShader(shader, posMatrix);
-        gl.uniform4fv(shader.u_color, color);
+        gl.disableVertexAttribArray(shader.a_color);
+        gl.vertexAttrib4fv(shader.a_color, color);
     }
 
     gl.disable(gl.STENCIL_TEST);
@@ -83,4 +84,5 @@ function drawBackground(painter, layer, posMatrix) {
 
     gl.stencilMask(0x00);
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
+
 }

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -82,7 +82,8 @@ function drawBackground(painter, layer, posMatrix) {
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.backgroundBuffer.itemCount);
     gl.enable(gl.STENCIL_TEST);
 
+    if (shader.a_color !== undefined) gl.enableVertexAttribArray(shader.a_color);
+
     gl.stencilMask(0x00);
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
-
 }

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -57,7 +57,6 @@ function drawFill(painter, layer, posMatrix, tile) {
     for (var i = 0; i < elementGroups.groups.length; i++) {
         group = elementGroups.groups[i];
         offset = group.vertexStartIndex * vertex.itemSize;
-
         gl.vertexAttribPointer(painter.fillShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
 
         count = group.elementLength * 3;

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -98,7 +98,6 @@ function drawFill(painter, layer, posMatrix, tile) {
         }
 
         gl.uniform2f(painter.outlineShader.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
-        gl.uniform4fv(painter.outlineShader.u_color, strokeColor ? strokeColor : color);
 
         // Draw all buffers
         vertex = tile.buffers.fillVertex;
@@ -109,6 +108,9 @@ function drawFill(painter, layer, posMatrix, tile) {
             group = elementGroups.groups[k];
             offset = group.vertexStartIndex * vertex.itemSize;
             gl.vertexAttribPointer(painter.outlineShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
+
+            gl.disableVertexAttribArray(painter.outlineShader.a_color);
+            gl.vertexAttrib4fv(painter.outlineShader.a_color, strokeColor ? strokeColor : color);
 
             count = group.secondElementLength * 2;
             elementOffset = group.secondElementStartIndex * elements.itemSize;

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -53,18 +53,17 @@ function drawFill(painter, layer, posMatrix, tile) {
     var offset, elementOffset;
 
     gl.disableVertexAttribArray(painter.fillShader.a_color);
-    gl.vertexAttribPointer(painter.fillShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
 
     for (var i = 0; i < elementGroups.groups.length; i++) {
         group = elementGroups.groups[i];
         offset = group.vertexStartIndex * vertex.itemSize;
 
+        gl.vertexAttribPointer(painter.fillShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
+
         count = group.elementLength * 3;
         elementOffset = group.elementStartIndex * elements.itemSize;
         gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
     }
-
-    gl.enableVertexAttribArray(painter.fillShader.a_color);
 
     // Now that we have the stencil mask in the stencil buffer, we can start
     // writing to the color buffer.
@@ -115,8 +114,6 @@ function drawFill(painter, layer, posMatrix, tile) {
             elementOffset = group.secondElementStartIndex * elements.itemSize;
             gl.drawElements(gl.LINES, count, gl.UNSIGNED_SHORT, elementOffset);
         }
-
-        gl.enableVertexAttribArray(painter.fillShader.a_color);
     }
 
     var image = layer.paint['fill-image'];
@@ -171,8 +168,6 @@ function drawFill(painter, layer, posMatrix, tile) {
     gl.bindBuffer(gl.ARRAY_BUFFER, painter.tileExtentBuffer);
     gl.vertexAttribPointer(shader.a_pos, painter.tileExtentBuffer.itemSize, gl.SHORT, false, 0, 0);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
-
-    if (shader.a_color !== undefined) gl.enableVertexAttribArray(shader.a_color);
 
     gl.stencilMask(0x00);
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -55,11 +55,16 @@ function drawFill(painter, layer, posMatrix, tile) {
     for (var i = 0; i < elementGroups.groups.length; i++) {
         group = elementGroups.groups[i];
         offset = group.vertexStartIndex * vertex.itemSize;
+        gl.disableVertexAttribArray(painter.fillShader.a_color);
         gl.vertexAttribPointer(painter.fillShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
 
         count = group.elementLength * 3;
         elementOffset = group.elementStartIndex * elements.itemSize;
+
+        gl.disableVertexAttribArray(painter.fillShader.a_color);
         gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
+
+        gl.enableVertexAttribArray(painter.fillShader.a_color);
     }
 
     // Now that we have the stencil mask in the stencil buffer, we can start
@@ -154,13 +159,15 @@ function drawFill(painter, layer, posMatrix, tile) {
         // Draw filling rectangle.
         shader = painter.fillShader;
         gl.switchShader(shader, posMatrix);
-        gl.uniform4fv(shader.u_color, color);
+        gl.disableVertexAttribArray(shader.a_color);
+        gl.vertexAttrib4fv(shader.a_color, color);
     }
 
     // Only draw regions that we marked
     gl.stencilFunc(gl.NOTEQUAL, 0x0, 0x3F);
     gl.bindBuffer(gl.ARRAY_BUFFER, painter.tileExtentBuffer);
     gl.vertexAttribPointer(shader.a_pos, painter.tileExtentBuffer.itemSize, gl.SHORT, false, 0, 0);
+
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
 
     gl.stencilMask(0x00);

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -52,20 +52,19 @@ function drawFill(painter, layer, posMatrix, tile) {
 
     var offset, elementOffset;
 
+    gl.disableVertexAttribArray(painter.fillShader.a_color);
+    gl.vertexAttribPointer(painter.fillShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
+
     for (var i = 0; i < elementGroups.groups.length; i++) {
         group = elementGroups.groups[i];
         offset = group.vertexStartIndex * vertex.itemSize;
-        gl.disableVertexAttribArray(painter.fillShader.a_color);
-        gl.vertexAttribPointer(painter.fillShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
 
         count = group.elementLength * 3;
         elementOffset = group.elementStartIndex * elements.itemSize;
-
-        gl.disableVertexAttribArray(painter.fillShader.a_color);
         gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
-
-        gl.enableVertexAttribArray(painter.fillShader.a_color);
     }
+
+    gl.enableVertexAttribArray(painter.fillShader.a_color);
 
     // Now that we have the stencil mask in the stencil buffer, we can start
     // writing to the color buffer.
@@ -104,18 +103,20 @@ function drawFill(painter, layer, posMatrix, tile) {
         elements = tile.buffers.outlineElement;
         elements.bind(gl);
 
+        gl.disableVertexAttribArray(painter.outlineShader.a_color);
+        gl.vertexAttrib4fv(painter.outlineShader.a_color, strokeColor ? strokeColor : color);
+
         for (var k = 0; k < elementGroups.groups.length; k++) {
             group = elementGroups.groups[k];
             offset = group.vertexStartIndex * vertex.itemSize;
             gl.vertexAttribPointer(painter.outlineShader.a_pos, 2, gl.SHORT, false, 4, offset + 0);
 
-            gl.disableVertexAttribArray(painter.outlineShader.a_color);
-            gl.vertexAttrib4fv(painter.outlineShader.a_color, strokeColor ? strokeColor : color);
-
             count = group.secondElementLength * 2;
             elementOffset = group.secondElementStartIndex * elements.itemSize;
             gl.drawElements(gl.LINES, count, gl.UNSIGNED_SHORT, elementOffset);
         }
+
+        gl.enableVertexAttribArray(painter.fillShader.a_color);
     }
 
     var image = layer.paint['fill-image'];
@@ -169,8 +170,9 @@ function drawFill(painter, layer, posMatrix, tile) {
     gl.stencilFunc(gl.NOTEQUAL, 0x0, 0x3F);
     gl.bindBuffer(gl.ARRAY_BUFFER, painter.tileExtentBuffer);
     gl.vertexAttribPointer(shader.a_pos, painter.tileExtentBuffer.itemSize, gl.SHORT, false, 0, 0);
-
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
+
+    if (shader.a_color !== undefined) gl.enableVertexAttribArray(shader.a_color);
 
     gl.stencilMask(0x00);
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -130,31 +130,30 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.uniformMatrix2fv(shader.u_antialiasingmatrix, false, antialiasingMatrix);
     }
 
+    if (shader.a_color !== undefined) {
+        gl.disableVertexAttribArray(shader.a_color);
+        gl.vertexAttrib4fv(shader.a_color, color);
+    }
+
+    if (shader.a_linewidth !== undefined) {
+        gl.disableVertexAttribArray(shader.a_linewidth);
+        gl.vertexAttrib2f(shader.a_linewidth, outset, inset);
+    }
+
     var vertex = tile.buffers.lineVertex;
     vertex.bind(gl);
     var element = tile.buffers.lineElement;
     element.bind(gl);
 
-    gl.withDisabledVertexAttribArrays(shader, ['a_color', 'a_linewidth'], function() {
-        for (var i = 0; i < elementGroups.groups.length; i++) {
-            var group = elementGroups.groups[i];
-            var vtxOffset = group.vertexStartIndex * vertex.itemSize;
-            gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, 8, vtxOffset + 0);
-            gl.vertexAttribPointer(shader.a_data, 4, gl.BYTE, false, 8, vtxOffset + 4);
 
-            if (shader.a_color !== undefined) {
-                gl.vertexAttrib4fv(shader.a_color, color);
-            }
+    for (var i = 0; i < elementGroups.groups.length; i++) {
+        var group = elementGroups.groups[i];
+        var vtxOffset = group.vertexStartIndex * vertex.itemSize;
+        gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, 8, vtxOffset + 0);
+        gl.vertexAttribPointer(shader.a_data, 4, gl.BYTE, false, 8, vtxOffset + 4);
 
-            if (shader.a_linewidth !== undefined) {
-                gl.vertexAttrib2f(shader.a_linewidth, outset, inset);
-            }
-
-            var count = group.elementLength * 3;
-            var elementOffset = group.elementStartIndex * element.itemSize;
-            gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
-        }
-    });
-
-
+        var count = group.elementLength * 3;
+        var elementOffset = group.elementStartIndex * element.itemSize;
+        gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
+    }
 };

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -76,7 +76,6 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.switchShader(shader, vtxMatrix, tile.exMatrix);
 
         gl.uniform1f(shader.u_ratio, ratio);
-        gl.uniform1f(shader.u_blur, blur);
 
         var posA = painter.lineAtlas.getDash(dasharray.from, layer.layout['line-cap'] === 'round');
         var posB = painter.lineAtlas.getDash(dasharray.to, layer.layout['line-cap'] === 'round');
@@ -109,7 +108,6 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.switchShader(shader, vtxMatrix, tile.exMatrix);
 
         gl.uniform1f(shader.u_ratio, ratio);
-        gl.uniform1f(shader.u_blur, blur);
 
         gl.uniform2fv(shader.u_pattern_size_a, [imagePosA.size[0] * factor * image.fromScale, imagePosB.size[1] ]);
         gl.uniform2fv(shader.u_pattern_size_b, [imagePosB.size[0] * factor * image.toScale, imagePosB.size[1] ]);
@@ -125,20 +123,21 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.switchShader(shader, vtxMatrix, tile.exMatrix);
 
         gl.uniform1f(shader.u_ratio, ratio);
-        gl.uniform1f(shader.u_blur, blur);
         gl.uniform1f(shader.u_extra, extra);
         gl.uniformMatrix2fv(shader.u_antialiasingmatrix, false, antialiasingMatrix);
     }
 
+    // linepattern does not have a color attribute
     if (shader.a_color !== undefined) {
         gl.disableVertexAttribArray(shader.a_color);
         gl.vertexAttrib4fv(shader.a_color, color);
     }
 
-    if (shader.a_linewidth !== undefined) {
-        gl.disableVertexAttribArray(shader.a_linewidth);
-        gl.vertexAttrib2f(shader.a_linewidth, outset, inset);
-    }
+    gl.disableVertexAttribArray(shader.a_linewidth);
+    gl.vertexAttrib2f(shader.a_linewidth, outset, inset);
+
+    gl.disableVertexAttribArray(shader.a_blur);
+    gl.vertexAttrib1f(shader.a_blur, blur);
 
     var vertex = tile.buffers.lineVertex;
     vertex.bind(gl);

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -144,7 +144,6 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
     var element = tile.buffers.lineElement;
     element.bind(gl);
 
-
     for (var i = 0; i < elementGroups.groups.length; i++) {
         var group = elementGroups.groups[i];
         var vtxOffset = group.vertexStartIndex * vertex.itemSize;
@@ -155,4 +154,9 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         var elementOffset = group.elementStartIndex * element.itemSize;
         gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
     }
+
+    if (shader.a_color !== undefined) gl.enableVertexAttribArray(shader.a_color);
+    if (shader.a_linewidth !== undefined) gl.enableVertexAttribArray(shader.a_linewidth);
+    if (shader.a_blur !== undefined) gl.enableVertexAttribArray(shader.a_blur);
+
 };

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -154,9 +154,4 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         var elementOffset = group.elementStartIndex * element.itemSize;
         gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
     }
-
-    if (shader.a_color !== undefined) gl.enableVertexAttribArray(shader.a_color);
-    if (shader.a_linewidth !== undefined) gl.enableVertexAttribArray(shader.a_linewidth);
-    if (shader.a_blur !== undefined) gl.enableVertexAttribArray(shader.a_blur);
-
 };

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -78,7 +78,6 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.uniform2fv(shader.u_linewidth, [ outset, inset ]);
         gl.uniform1f(shader.u_ratio, ratio);
         gl.uniform1f(shader.u_blur, blur);
-        gl.uniform4fv(shader.u_color, color);
 
         var posA = painter.lineAtlas.getDash(dasharray.from, layer.layout['line-cap'] === 'round');
         var posB = painter.lineAtlas.getDash(dasharray.to, layer.layout['line-cap'] === 'round');
@@ -132,8 +131,6 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.uniform1f(shader.u_blur, blur);
         gl.uniform1f(shader.u_extra, extra);
         gl.uniformMatrix2fv(shader.u_antialiasingmatrix, false, antialiasingMatrix);
-
-        gl.uniform4fv(shader.u_color, color);
     }
 
     var vertex = tile.buffers.lineVertex;
@@ -141,15 +138,20 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
     var element = tile.buffers.lineElement;
     element.bind(gl);
 
+    gl.disableVertexAttribArray(shader.a_color);
+
     for (var i = 0; i < elementGroups.groups.length; i++) {
         var group = elementGroups.groups[i];
         var vtxOffset = group.vertexStartIndex * vertex.itemSize;
         gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, 8, vtxOffset + 0);
         gl.vertexAttribPointer(shader.a_data, 4, gl.BYTE, false, 8, vtxOffset + 4);
+        gl.vertexAttrib4f(shader.a_color, color[0], color[1], color[2], color[3]);
 
         var count = group.elementLength * 3;
         var elementOffset = group.elementStartIndex * element.itemSize;
         gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
     }
+
+    gl.enableVertexAttribArray(shader.a_color);
 
 };

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -116,7 +116,9 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.uniform2fv(shader.u_pattern_tl_b, imagePosB.tl);
         gl.uniform2fv(shader.u_pattern_br_b, imagePosB.br);
         gl.uniform1f(shader.u_fade, image.t);
-        gl.uniform1f(shader.u_opacity, layer.paint['line-opacity']);
+
+        gl.disableVertexAttribArray(shader.a_opacity);
+        gl.vertexAttrib1f(shader.a_opacity, layer.paint['line-opacity']);
 
     } else {
         shader = painter.lineShader;

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -154,6 +154,7 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
             // Draw halo underneath the text.
             gl.uniform1f(shader.u_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
 
+            // vertex attrib arrays disabled above
             gl.vertexAttrib4fv(shader.a_color, layer.paint[prefix + '-halo-color']);
             gl.vertexAttrib1f(shader.a_buffer, (haloOffset - layer.paint[prefix + '-halo-width'] / fontScale) / sdfPx);
 
@@ -168,7 +169,9 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
             }
         }
     } else {
-        gl.uniform1f(shader.u_opacity, layer.paint['icon-opacity']);
+        gl.disableVertexAttribArray(shader.a_opacity);
+        gl.vertexAttrib1f(shader.a_opacity, layer.paint['icon-opacity']);
+
         for (var k = 0; k < elementGroups.groups.length; k++) {
             group = elementGroups.groups[k];
             offset = group.vertexStartIndex * vertex.itemSize;

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -137,7 +137,8 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
         gl.disableVertexAttribArray(shader.a_color);
         gl.vertexAttrib4fv(shader.a_color, layer.paint[prefix + '-color']);
 
-        gl.uniform1f(shader.u_buffer, (256 - 64) / 256);
+        gl.disableVertexAttribArray(shader.a_buffer);
+        gl.vertexAttrib1f(shader.a_buffer, (256 - 64) / 256);
 
         for (var i = 0; i < elementGroups.groups.length; i++) {
             group = elementGroups.groups[i];
@@ -149,6 +150,9 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
         }
 
+        gl.enableVertexAttribArray(shader.a_color);
+        gl.enableVertexAttribArray(shader.a_buffer);
+
         if (layer.paint[prefix + '-halo-color']) {
             // Draw halo underneath the text.
             gl.uniform1f(shader.u_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
@@ -156,7 +160,8 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
             gl.disableVertexAttribArray(shader.a_color);
             gl.vertexAttrib4fv(shader.a_color, layer.paint[prefix + '-halo-color']);
 
-            gl.uniform1f(shader.u_buffer, (haloOffset - layer.paint[prefix + '-halo-width'] / fontScale) / sdfPx);
+            gl.disableVertexAttribArray(shader.a_buffer);
+            gl.vertexAttrib1f(shader.a_buffer, (haloOffset - layer.paint[prefix + '-halo-width'] / fontScale) / sdfPx);
 
             for (var j = 0; j < elementGroups.groups.length; j++) {
                 group = elementGroups.groups[j];
@@ -167,6 +172,9 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
                 elementOffset = group.elementStartIndex * elements.itemSize;
                 gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
             }
+
+            gl.enableVertexAttribArray(shader.a_color);
+            gl.enableVertexAttribArray(shader.a_buffer);
         }
     } else {
         gl.uniform1f(shader.u_opacity, layer.paint['icon-opacity']);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -132,7 +132,8 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
         var haloOffset = 6;
         var gamma = 0.105 * defaultSizes[prefix] / fontSize / browser.devicePixelRatio;
 
-        gl.uniform1f(shader.u_gamma, gamma * gammaScale);
+        gl.disableVertexAttribArray(shader.a_gamma);
+        gl.vertexAttrib1f(shader.a_gamma, gamma * gammaScale);
 
         gl.disableVertexAttribArray(shader.a_color);
         gl.vertexAttrib4fv(shader.a_color, layer.paint[prefix + '-color']);
@@ -151,12 +152,11 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
         }
 
         if (layer.paint[prefix + '-halo-color']) {
-            // Draw halo underneath the text.
-            gl.uniform1f(shader.u_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
 
             // vertex attrib arrays disabled above
             gl.vertexAttrib4fv(shader.a_color, layer.paint[prefix + '-halo-color']);
             gl.vertexAttrib1f(shader.a_buffer, (haloOffset - layer.paint[prefix + '-halo-width'] / fontScale) / sdfPx);
+            gl.vertexAttrib1f(shader.a_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
 
             for (var j = 0; j < elementGroups.groups.length; j++) {
                 group = elementGroups.groups[j];

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -133,7 +133,10 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
         var gamma = 0.105 * defaultSizes[prefix] / fontSize / browser.devicePixelRatio;
 
         gl.uniform1f(shader.u_gamma, gamma * gammaScale);
-        gl.uniform4fv(shader.u_color, layer.paint[prefix + '-color']);
+
+        gl.disableVertexAttribArray(shader.a_color);
+        gl.vertexAttrib4fv(shader.a_color, layer.paint[prefix + '-color']);
+
         gl.uniform1f(shader.u_buffer, (256 - 64) / 256);
 
         for (var i = 0; i < elementGroups.groups.length; i++) {
@@ -149,7 +152,10 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
         if (layer.paint[prefix + '-halo-color']) {
             // Draw halo underneath the text.
             gl.uniform1f(shader.u_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
-            gl.uniform4fv(shader.u_color, layer.paint[prefix + '-halo-color']);
+
+            gl.disableVertexAttribArray(shader.a_color);
+            gl.vertexAttrib4fv(shader.a_color, layer.paint[prefix + '-halo-color']);
+
             gl.uniform1f(shader.u_buffer, (haloOffset - layer.paint[prefix + '-halo-width'] / fontScale) / sdfPx);
 
             for (var j = 0; j < elementGroups.groups.length; j++) {

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -150,9 +150,6 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
         }
 
-        gl.enableVertexAttribArray(shader.a_color);
-        gl.enableVertexAttribArray(shader.a_buffer);
-
         if (layer.paint[prefix + '-halo-color']) {
             // Draw halo underneath the text.
             gl.uniform1f(shader.u_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
@@ -172,9 +169,6 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
                 elementOffset = group.elementStartIndex * elements.itemSize;
                 gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, elementOffset);
             }
-
-            gl.enableVertexAttribArray(shader.a_color);
-            gl.enableVertexAttribArray(shader.a_buffer);
         }
     } else {
         gl.uniform1f(shader.u_opacity, layer.paint['icon-opacity']);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -154,10 +154,7 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
             // Draw halo underneath the text.
             gl.uniform1f(shader.u_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
 
-            gl.disableVertexAttribArray(shader.a_color);
             gl.vertexAttrib4fv(shader.a_color, layer.paint[prefix + '-halo-color']);
-
-            gl.disableVertexAttribArray(shader.a_buffer);
             gl.vertexAttrib1f(shader.a_buffer, (haloOffset - layer.paint[prefix + '-halo-width'] / fontScale) / sdfPx);
 
             for (var j = 0; j < elementGroups.groups.length; j++) {

--- a/js/render/gl_util.js
+++ b/js/render/gl_util.js
@@ -71,22 +71,17 @@ exports.extend = function(context) {
         if (this.currentShader !== shader) {
             this.useProgram(shader.program);
 
-            // Disable all attributes from the existing shader that aren't used in
-            // the new shader. Note: attribute indices are *not* program specific!
-            var enabled = this.currentShader ? this.currentShader.attributes : [];
-            var required = shader.attributes;
-
-            for (var i = 0; i < enabled.length; i++) {
-                if (required.indexOf(enabled[i]) < 0) {
-                    this.disableVertexAttribArray(enabled[i]);
-                }
+            // Disable all attribute arrays used by the previous shader and enable all the attribute
+            // arrays used by the next shader. Ideally we would do a better job diffing these to
+            // minimize operations (as we did in previously) but it is hard to keep track of state
+            // in spaghetti shader boilerplate code and hard to debug when things go wrong.
+            var previous = this.currentShader ? this.currentShader.attributes : [];
+            for (var i = 0; i < previous.length; i++) {
+                this.disableVertexAttribArray(previous[i]);
             }
-
-            // Enable all attributes for the new shader.
-            for (var j = 0; j < required.length; j++) {
-                if (enabled.indexOf(required[j]) < 0) {
-                    this.enableVertexAttribArray(required[j]);
-                }
+            var next = shader.attributes;
+            for (var j = 0; j < next.length; j++) {
+                this.enableVertexAttribArray(next[j]);
             }
 
             this.currentShader = shader;

--- a/js/render/gl_util.js
+++ b/js/render/gl_util.js
@@ -118,27 +118,5 @@ exports.extend = function(context) {
         context.vertexAttrib4f(attribute, values[0], values[1], values[2], values[3]);
     }
 
-    context.disableVertexAttribArrays = function(shader, attributes) {
-        for (var i = 0; i < attributes.length; i++) {
-            var attribute = attributes[i];
-            if (shader[attribute] === undefined) continue;
-            else context.disableVertexAttribArray(shader[attribute]);
-        }
-    }
-
-    context.enableVertexAttribArrays = function(shader, attributes) {
-        for (var i = 0; i < attributes.length; i++) {
-            var attribute = attributes[i];
-            if (shader[attribute] === undefined) continue;
-            else context.enableVertexAttribArray(shader[attribute]);
-        }
-    }
-
-    context.withDisabledVertexAttribArrays = function(shader, attributes, callback) {
-        disableVertexAttribArrays(shader, attributes);
-        callback();
-        disableVertexAttribArrays(shader, attributes);
-    }
-
     return context;
 };

--- a/js/render/gl_util.js
+++ b/js/render/gl_util.js
@@ -33,7 +33,6 @@ exports.extend = function(context) {
             vertex: this.getShader(name, this.VERTEX_SHADER),
             attributes: []
         };
-
         this.attachShader(shader.program, shader.vertex);
         this.attachShader(shader.program, shader.fragment);
 
@@ -108,15 +107,15 @@ exports.extend = function(context) {
 
     context.vertexAttrib2fv = function(attribute, values) {
         context.vertexAttrib2f(attribute, values[0], values[1]);
-    }
+    };
 
     context.vertexAttrib3fv = function(attribute, values) {
         context.vertexAttrib3f(attribute, values[0], values[1], values[2]);
-    }
+    };
 
     context.vertexAttrib4fv = function(attribute, values) {
         context.vertexAttrib4f(attribute, values[0], values[1], values[2], values[3]);
-    }
+    };
 
     return context;
 };

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -97,8 +97,8 @@ Painter.prototype.setup = function() {
     );
 
     this.fillShader = gl.initializeShader('fill',
-        ['a_pos'],
-        ['u_matrix', 'u_color']
+        ['a_pos', 'a_color'],
+        ['u_matrix']
     );
 
     this.collisionBoxShader = gl.initializeShader('collisionbox',
@@ -207,14 +207,18 @@ Painter.prototype.drawClippingMask = function(tile) {
     gl.stencilOp(gl.REPLACE, gl.KEEP, gl.KEEP);
 
     // Draw the clipping mask
+    gl.disableVertexAttribArray(this.fillShader.a_color);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.tileExtentBuffer);
     gl.vertexAttribPointer(this.fillShader.a_pos, this.tileExtentBuffer.itemSize, gl.SHORT, false, 8, 0);
+    gl.vertexAttrib4fv(this.fillShader.a_color, [0, 0, 0, 0.5]);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, this.tileExtentBuffer.itemCount);
+
 
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
     gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
     gl.stencilMask(0x00);
     gl.colorMask(true, true, true, true);
+    gl.enableVertexAttribArray(this.fillShader.a_color);
 };
 
 // Overridden by headless tests.
@@ -303,8 +307,9 @@ Painter.prototype.drawStencilBuffer = function() {
     // Drw the filling quad where the stencil buffer isn't set.
     gl.bindBuffer(gl.ARRAY_BUFFER, this.backgroundBuffer);
     gl.vertexAttribPointer(this.fillShader.a_pos, this.backgroundBuffer.itemSize, gl.SHORT, false, 0, 0);
-    gl.uniform4fv(this.fillShader.u_color, [0, 0, 0, 0.5]);
-    gl.drawArrays(gl.TRIANGLE_STRIP, 0, this.backgroundBuffer.itemCount);
+    gl.disableVertexAttribArray(this.fillShader.a_color);
+    gl.vertexAttrib4fv(this.fillShader.a_color, [0, 0, 0, 0.5]);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
 
     // Revert blending mode to blend to the back.
     gl.blendFunc(gl.ONE_MINUS_DST_ALPHA, gl.ONE);

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -87,8 +87,8 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_opacity', 'u_skewed', 'u_extra']);
 
     this.outlineShader = gl.initializeShader('outline',
-        ['a_pos'],
-        ['u_matrix', 'u_color', 'u_world']
+        ['a_pos', 'a_color'],
+        ['u_matrix', 'u_world']
     );
 
     this.patternShader = gl.initializeShader('pattern',

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -83,8 +83,8 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_gamma', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']);
 
     this.iconShader = gl.initializeShader('icon',
-        ['a_pos', 'a_offset', 'a_data1', 'a_data2'],
-        ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_opacity', 'u_skewed', 'u_extra']);
+        ['a_pos', 'a_offset', 'a_data1', 'a_data2', 'a_opacity'],
+        ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']);
 
     this.outlineShader = gl.initializeShader('outline',
         ['a_pos', 'a_color'],

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -63,16 +63,16 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_brightness_low', 'u_brightness_high', 'u_saturation_factor', 'u_spin_weights', 'u_contrast_factor', 'u_opacity0', 'u_opacity1', 'u_image0', 'u_image1', 'u_tl_parent', 'u_scale_parent', 'u_buffer_scale']);
 
     this.lineShader = gl.initializeShader('line',
-        ['a_pos', 'a_data', 'a_color', 'a_linewidth'],
-        ['u_matrix', 'u_ratio', 'u_blur', 'u_extra', 'u_antialiasingmatrix']);
+        ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur'],
+        ['u_matrix', 'u_ratio', 'u_extra', 'u_antialiasingmatrix']);
 
     this.linepatternShader = gl.initializeShader('linepattern',
-        ['a_pos', 'a_data', 'a_linewidth'],
-        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_blur', 'u_fade', 'u_opacity']);
+        ['a_pos', 'a_data', 'a_linewidth', 'a_blur'],
+        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_fade', 'u_opacity']);
 
     this.linesdfpatternShader = gl.initializeShader('linesdfpattern',
-        ['a_pos', 'a_data', 'a_color', 'a_linewidth'],
-        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_blur', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix']);
+        ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur'],
+        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix']);
 
     this.dotShader = gl.initializeShader('dot',
         ['a_pos'],

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -63,16 +63,16 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_brightness_low', 'u_brightness_high', 'u_saturation_factor', 'u_spin_weights', 'u_contrast_factor', 'u_opacity0', 'u_opacity1', 'u_image0', 'u_image1', 'u_tl_parent', 'u_scale_parent', 'u_buffer_scale']);
 
     this.lineShader = gl.initializeShader('line',
-        ['a_pos', 'a_data'],
-        ['u_matrix', 'u_linewidth', 'u_color', 'u_ratio', 'u_blur', 'u_extra', 'u_antialiasingmatrix']);
+        ['a_pos', 'a_data', 'a_color'],
+        ['u_matrix', 'u_linewidth', 'u_ratio', 'u_blur', 'u_extra', 'u_antialiasingmatrix']);
 
     this.linepatternShader = gl.initializeShader('linepattern',
-        ['a_pos', 'a_data'],
+        ['a_pos', 'a_data', 'a_color'],
         ['u_matrix', 'u_exmatrix', 'u_linewidth', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_blur', 'u_fade', 'u_opacity']);
 
     this.linesdfpatternShader = gl.initializeShader('linesdfpattern',
-        ['a_pos', 'a_data'],
-        ['u_matrix', 'u_exmatrix', 'u_linewidth', 'u_color', 'u_ratio', 'u_blur', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix']);
+        ['a_pos', 'a_data', 'a_color'],
+        ['u_matrix', 'u_exmatrix', 'u_linewidth', 'u_ratio', 'u_blur', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix']);
 
     this.dotShader = gl.initializeShader('dot',
         ['a_pos'],

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -63,16 +63,16 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_brightness_low', 'u_brightness_high', 'u_saturation_factor', 'u_spin_weights', 'u_contrast_factor', 'u_opacity0', 'u_opacity1', 'u_image0', 'u_image1', 'u_tl_parent', 'u_scale_parent', 'u_buffer_scale']);
 
     this.lineShader = gl.initializeShader('line',
-        ['a_pos', 'a_data', 'a_color'],
-        ['u_matrix', 'u_linewidth', 'u_ratio', 'u_blur', 'u_extra', 'u_antialiasingmatrix']);
+        ['a_pos', 'a_data', 'a_color', 'a_linewidth'],
+        ['u_matrix', 'u_ratio', 'u_blur', 'u_extra', 'u_antialiasingmatrix']);
 
     this.linepatternShader = gl.initializeShader('linepattern',
-        ['a_pos', 'a_data', 'a_color'],
-        ['u_matrix', 'u_exmatrix', 'u_linewidth', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_blur', 'u_fade', 'u_opacity']);
+        ['a_pos', 'a_data', 'a_linewidth'],
+        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_blur', 'u_fade', 'u_opacity']);
 
     this.linesdfpatternShader = gl.initializeShader('linesdfpattern',
-        ['a_pos', 'a_data', 'a_color'],
-        ['u_matrix', 'u_exmatrix', 'u_linewidth', 'u_ratio', 'u_blur', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix']);
+        ['a_pos', 'a_data', 'a_color', 'a_linewidth'],
+        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_blur', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix']);
 
     this.dotShader = gl.initializeShader('dot',
         ['a_pos'],

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -210,7 +210,6 @@ Painter.prototype.drawClippingMask = function(tile) {
     gl.disableVertexAttribArray(this.fillShader.a_color);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.tileExtentBuffer);
     gl.vertexAttribPointer(this.fillShader.a_pos, this.tileExtentBuffer.itemSize, gl.SHORT, false, 8, 0);
-    gl.vertexAttrib4fv(this.fillShader.a_color, [0, 0, 0, 0.5]);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, this.tileExtentBuffer.itemCount);
 
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -79,8 +79,8 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_size', 'u_color', 'u_blur']);
 
     this.sdfShader = gl.initializeShader('sdf',
-        ['a_pos', 'a_offset', 'a_data1', 'a_data2', 'a_color'],
-        ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_gamma', 'u_buffer', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']);
+        ['a_pos', 'a_offset', 'a_data1', 'a_data2', 'a_color', 'a_buffer'],
+        ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_gamma', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']);
 
     this.iconShader = gl.initializeShader('icon',
         ['a_pos', 'a_offset', 'a_data1', 'a_data2'],
@@ -213,7 +213,6 @@ Painter.prototype.drawClippingMask = function(tile) {
     gl.vertexAttrib4fv(this.fillShader.a_color, [0, 0, 0, 0.5]);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, this.tileExtentBuffer.itemCount);
 
-
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
     gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
     gl.stencilMask(0x00);
@@ -309,7 +308,7 @@ Painter.prototype.drawStencilBuffer = function() {
     gl.vertexAttribPointer(this.fillShader.a_pos, this.backgroundBuffer.itemSize, gl.SHORT, false, 0, 0);
     gl.disableVertexAttribArray(this.fillShader.a_color);
     gl.vertexAttrib4fv(this.fillShader.a_color, [0, 0, 0, 0.5]);
-    gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, this.tileExtentBuffer.itemCount);
 
     // Revert blending mode to blend to the back.
     gl.blendFunc(gl.ONE_MINUS_DST_ALPHA, gl.ONE);

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -79,8 +79,8 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_size', 'u_color', 'u_blur']);
 
     this.sdfShader = gl.initializeShader('sdf',
-        ['a_pos', 'a_offset', 'a_data1', 'a_data2', 'a_color', 'a_buffer'],
-        ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_gamma', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']);
+        ['a_pos', 'a_offset', 'a_data1', 'a_data2', 'a_color', 'a_buffer', 'a_gamma'],
+        ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']);
 
     this.iconShader = gl.initializeShader('icon',
         ['a_pos', 'a_offset', 'a_data1', 'a_data2', 'a_opacity'],

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -79,8 +79,8 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_size', 'u_color', 'u_blur']);
 
     this.sdfShader = gl.initializeShader('sdf',
-        ['a_pos', 'a_offset', 'a_data1', 'a_data2'],
-        ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_color', 'u_gamma', 'u_buffer', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']);
+        ['a_pos', 'a_offset', 'a_data1', 'a_data2', 'a_color'],
+        ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_gamma', 'u_buffer', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']);
 
     this.iconShader = gl.initializeShader('icon',
         ['a_pos', 'a_offset', 'a_data1', 'a_data2'],

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -67,8 +67,8 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_ratio', 'u_extra', 'u_antialiasingmatrix']);
 
     this.linepatternShader = gl.initializeShader('linepattern',
-        ['a_pos', 'a_data', 'a_linewidth', 'a_blur'],
-        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_fade', 'u_opacity']);
+        ['a_pos', 'a_data', 'a_linewidth', 'a_blur', 'a_opacity'],
+        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_fade']);
 
     this.linesdfpatternShader = gl.initializeShader('linesdfpattern',
         ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur'],

--- a/shaders/fill.fragment.glsl
+++ b/shaders/fill.fragment.glsl
@@ -1,5 +1,5 @@
-uniform vec4 u_color;
+varying vec4 v_color;
 
 void main() {
-    gl_FragColor = u_color;
+    gl_FragColor = v_color;
 }

--- a/shaders/fill.vertex.glsl
+++ b/shaders/fill.vertex.glsl
@@ -1,7 +1,13 @@
-attribute vec2 a_pos;
 uniform mat4 u_matrix;
+
+attribute vec2 a_pos;
+attribute vec4 a_color;
+
+varying vec4 v_color;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     gl_PointSize = 2.0;
+
+    v_color = a_color;
 }

--- a/shaders/icon.vertex.glsl
+++ b/shaders/icon.vertex.glsl
@@ -2,7 +2,7 @@ attribute vec2 a_pos;
 attribute vec2 a_offset;
 attribute vec4 a_data1;
 attribute vec4 a_data2;
-
+attribute float a_opacity;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -13,7 +13,6 @@ uniform float u_fadedist;
 uniform float u_minfadezoom;
 uniform float u_maxfadezoom;
 uniform float u_fadezoom;
-uniform float u_opacity;
 uniform bool u_skewed;
 uniform float u_extra;
 
@@ -63,5 +62,5 @@ void main() {
 
     v_tex = a_tex / u_texsize;
 
-    v_alpha *= u_opacity;
+    v_alpha *= a_opacity;
 }

--- a/shaders/line.fragment.glsl
+++ b/shaders/line.fragment.glsl
@@ -1,9 +1,9 @@
 uniform vec2 u_linewidth;
-uniform vec4 u_color;
 uniform float u_blur;
 
 uniform vec2 u_dasharray;
 
+varying vec4 v_color;
 varying vec2 v_normal;
 varying float v_linesofar;
 varying float gamma_scale;
@@ -18,5 +18,5 @@ void main() {
     float blur = u_blur * gamma_scale;
     float alpha = clamp(min(dist - (u_linewidth.t - blur), u_linewidth.s - dist) / blur, 0.0, 1.0);
 
-    gl_FragColor = u_color * alpha;
+    gl_FragColor = v_color * alpha;
 }

--- a/shaders/line.fragment.glsl
+++ b/shaders/line.fragment.glsl
@@ -1,4 +1,3 @@
-uniform vec2 u_linewidth;
 uniform float u_blur;
 
 uniform vec2 u_dasharray;
@@ -7,16 +6,17 @@ varying vec4 v_color;
 varying vec2 v_normal;
 varying float v_linesofar;
 varying float gamma_scale;
+varying vec2 v_linewidth;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * u_linewidth.s;
+    float dist = length(v_normal) * v_linewidth.s;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
     float blur = u_blur * gamma_scale;
-    float alpha = clamp(min(dist - (u_linewidth.t - blur), u_linewidth.s - dist) / blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linewidth.t - blur), v_linewidth.s - dist) / blur, 0.0, 1.0);
 
     gl_FragColor = v_color * alpha;
 }

--- a/shaders/line.fragment.glsl
+++ b/shaders/line.fragment.glsl
@@ -1,4 +1,3 @@
-uniform float u_blur;
 
 uniform vec2 u_dasharray;
 
@@ -7,6 +6,7 @@ varying vec2 v_normal;
 varying float v_linesofar;
 varying float gamma_scale;
 varying vec2 v_linewidth;
+varying float v_blur;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
@@ -15,7 +15,7 @@ void main() {
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float blur = u_blur * gamma_scale;
+    float blur = v_blur * gamma_scale;
     float alpha = clamp(min(dist - (v_linewidth.t - blur), v_linewidth.s - dist) / blur, 0.0, 1.0);
 
     gl_FragColor = v_color * alpha;

--- a/shaders/line.vertex.glsl
+++ b/shaders/line.vertex.glsl
@@ -9,6 +9,7 @@
 attribute vec2 a_pos;
 attribute vec4 a_data;
 attribute vec4 a_color;
+attribute vec2 a_linewidth;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -16,7 +17,6 @@ uniform mat4 u_matrix;
 
 // shared
 uniform float u_ratio;
-uniform vec2 u_linewidth;
 
 uniform float u_extra;
 uniform mat2 u_antialiasingmatrix;
@@ -25,6 +25,7 @@ varying vec2 v_normal;
 varying float v_linesofar;
 varying vec4 v_color;
 varying float gamma_scale;
+varying vec2 v_linewidth;
 
 void main() {
     vec2 a_extrude = a_data.xy;
@@ -39,7 +40,7 @@ void main() {
 
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
-    vec4 dist = vec4(u_linewidth.s * a_extrude * scale, 0.0, 0.0);
+    vec4 dist = vec4(a_linewidth.s * a_extrude * scale, 0.0, 0.0);
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -59,4 +60,5 @@ void main() {
     gamma_scale = perspective_scale * squish_scale;
 
     v_color = a_color;
+    v_linewidth = a_linewidth;
 }

--- a/shaders/line.vertex.glsl
+++ b/shaders/line.vertex.glsl
@@ -10,6 +10,7 @@ attribute vec2 a_pos;
 attribute vec4 a_data;
 attribute vec4 a_color;
 attribute vec2 a_linewidth;
+attribute float a_blur;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -26,6 +27,7 @@ varying float v_linesofar;
 varying vec4 v_color;
 varying float gamma_scale;
 varying vec2 v_linewidth;
+varying float v_blur;
 
 void main() {
     vec2 a_extrude = a_data.xy;
@@ -61,4 +63,5 @@ void main() {
 
     v_color = a_color;
     v_linewidth = a_linewidth;
+    v_blur = a_blur;
 }

--- a/shaders/line.vertex.glsl
+++ b/shaders/line.vertex.glsl
@@ -8,6 +8,7 @@
 
 attribute vec2 a_pos;
 attribute vec4 a_data;
+attribute vec4 a_color;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -16,13 +17,13 @@ uniform mat4 u_matrix;
 // shared
 uniform float u_ratio;
 uniform vec2 u_linewidth;
-uniform vec4 u_color;
 
 uniform float u_extra;
 uniform mat2 u_antialiasingmatrix;
 
 varying vec2 v_normal;
 varying float v_linesofar;
+varying vec4 v_color;
 varying float gamma_scale;
 
 void main() {
@@ -56,4 +57,6 @@ void main() {
     float perspective_scale = 1.0 / (1.0 - y * u_extra);
 
     gamma_scale = perspective_scale * squish_scale;
+
+    v_color = a_color;
 }

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -7,7 +7,6 @@ uniform vec2 u_pattern_br_a;
 uniform vec2 u_pattern_tl_b;
 uniform vec2 u_pattern_br_b;
 uniform float u_fade;
-uniform float u_opacity;
 
 uniform sampler2D u_image;
 
@@ -15,6 +14,7 @@ varying vec2 v_normal;
 varying float v_linesofar;
 varying vec2 v_linewidth;
 varying float v_blur;
+varying float v_opacity;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
@@ -34,7 +34,7 @@ void main() {
 
     vec4 color = mix(texture2D(u_image, pos), texture2D(u_image, pos2), u_fade);
 
-    alpha *= u_opacity;
+    alpha *= v_opacity;
 
     gl_FragColor = color * alpha;
 }

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -1,5 +1,4 @@
 uniform float u_point;
-uniform float u_blur;
 
 uniform vec2 u_pattern_size_a;
 uniform vec2 u_pattern_size_b;
@@ -15,6 +14,7 @@ uniform sampler2D u_image;
 varying vec2 v_normal;
 varying float v_linesofar;
 varying vec2 v_linewidth;
+varying float v_blur;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
@@ -23,7 +23,7 @@ void main() {
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp(min(dist - (v_linewidth.t - u_blur), v_linewidth.s - dist) / u_blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linewidth.t - v_blur), v_linewidth.s - dist) / v_blur, 0.0, 1.0);
 
     float x_a = mod(v_linesofar / u_pattern_size_a.x, 1.0);
     float x_b = mod(v_linesofar / u_pattern_size_b.x, 1.0);

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -1,4 +1,3 @@
-uniform vec2 u_linewidth;
 uniform float u_point;
 uniform float u_blur;
 
@@ -15,20 +14,21 @@ uniform sampler2D u_image;
 
 varying vec2 v_normal;
 varying float v_linesofar;
+varying vec2 v_linewidth;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * u_linewidth.s;
+    float dist = length(v_normal) * v_linewidth.s;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp(min(dist - (u_linewidth.t - u_blur), u_linewidth.s - dist) / u_blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linewidth.t - u_blur), v_linewidth.s - dist) / u_blur, 0.0, 1.0);
 
     float x_a = mod(v_linesofar / u_pattern_size_a.x, 1.0);
     float x_b = mod(v_linesofar / u_pattern_size_b.x, 1.0);
-    float y_a = 0.5 + (v_normal.y * u_linewidth.s / u_pattern_size_a.y);
-    float y_b = 0.5 + (v_normal.y * u_linewidth.s / u_pattern_size_b.y);
+    float y_a = 0.5 + (v_normal.y * v_linewidth.s / u_pattern_size_a.y);
+    float y_b = 0.5 + (v_normal.y * v_linewidth.s / u_pattern_size_b.y);
     vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, vec2(x_a, y_a));
     vec2 pos2 = mix(u_pattern_tl_b, u_pattern_br_b, vec2(x_b, y_b));
 

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -8,6 +8,7 @@
 
 attribute vec2 a_pos;
 attribute vec4 a_data;
+attribute vec2 a_linewidth;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -16,10 +17,10 @@ uniform mat4 u_exmatrix;
 
 // shared
 uniform float u_ratio;
-uniform vec2 u_linewidth;
 
 varying vec2 v_normal;
 varying float v_linesofar;
+varying vec2 v_linewidth;
 
 void main() {
     vec2 a_extrude = a_data.xy;
@@ -36,7 +37,7 @@ void main() {
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
     vec2 extrude = a_extrude * scale;
-    vec2 dist = u_linewidth.s * extrude;
+    vec2 dist = a_linewidth.s * extrude;
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -44,4 +45,6 @@ void main() {
     // tile's zoom level.
     gl_Position = u_matrix * vec4(floor(a_pos * 0.5) + dist.xy / u_ratio, 0.0, 1.0);
     v_linesofar = a_linesofar;// * u_ratio;
+
+    v_linewidth = a_linewidth;
 }

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -17,7 +17,6 @@ uniform mat4 u_exmatrix;
 // shared
 uniform float u_ratio;
 uniform vec2 u_linewidth;
-uniform vec4 u_color;
 
 varying vec2 v_normal;
 varying float v_linesofar;
@@ -45,5 +44,4 @@ void main() {
     // tile's zoom level.
     gl_Position = u_matrix * vec4(floor(a_pos * 0.5) + dist.xy / u_ratio, 0.0, 1.0);
     v_linesofar = a_linesofar;// * u_ratio;
-
 }

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -9,6 +9,7 @@
 attribute vec2 a_pos;
 attribute vec4 a_data;
 attribute vec2 a_linewidth;
+attribute float a_blur;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -21,6 +22,7 @@ uniform float u_ratio;
 varying vec2 v_normal;
 varying float v_linesofar;
 varying vec2 v_linewidth;
+varying float v_blur;
 
 void main() {
     vec2 a_extrude = a_data.xy;
@@ -47,4 +49,5 @@ void main() {
     v_linesofar = a_linesofar;// * u_ratio;
 
     v_linewidth = a_linewidth;
+    v_blur = a_blur;
 }

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -10,6 +10,7 @@ attribute vec2 a_pos;
 attribute vec4 a_data;
 attribute vec2 a_linewidth;
 attribute float a_blur;
+attribute float a_opacity;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -23,6 +24,7 @@ varying vec2 v_normal;
 varying float v_linesofar;
 varying vec2 v_linewidth;
 varying float v_blur;
+varying float v_opacity;
 
 void main() {
     vec2 a_extrude = a_data.xy;
@@ -50,4 +52,5 @@ void main() {
 
     v_linewidth = a_linewidth;
     v_blur = a_blur;
+    v_opacity = a_opacity;
 }

--- a/shaders/linesdfpattern.fragment.glsl
+++ b/shaders/linesdfpattern.fragment.glsl
@@ -1,14 +1,13 @@
 uniform vec2 u_linewidth;
-uniform vec4 u_color;
 uniform float u_blur;
 uniform sampler2D u_image;
 uniform float u_sdfgamma;
 uniform float u_mix;
 
-
 varying vec2 v_normal;
 varying vec2 v_tex_a;
 varying vec2 v_tex_b;
+varying vec4 v_color;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
@@ -24,5 +23,5 @@ void main() {
     float sdfdist = mix(sdfdist_a, sdfdist_b, u_mix);
     alpha *= smoothstep(0.5 - u_sdfgamma, 0.5 + u_sdfgamma, sdfdist);
 
-    gl_FragColor = u_color * alpha;
+    gl_FragColor = v_color * alpha;
 }

--- a/shaders/linesdfpattern.fragment.glsl
+++ b/shaders/linesdfpattern.fragment.glsl
@@ -1,4 +1,3 @@
-uniform float u_blur;
 uniform sampler2D u_image;
 uniform float u_sdfgamma;
 uniform float u_mix;
@@ -8,6 +7,7 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying vec4 v_color;
 varying vec2 v_linewidth;
+varying float v_blur;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
@@ -16,7 +16,7 @@ void main() {
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp(min(dist - (v_linewidth.t - u_blur), v_linewidth.s - dist) / u_blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linewidth.t - v_blur), v_linewidth.s - dist) / v_blur, 0.0, 1.0);
 
     float sdfdist_a = texture2D(u_image, v_tex_a).a;
     float sdfdist_b = texture2D(u_image, v_tex_b).a;

--- a/shaders/linesdfpattern.fragment.glsl
+++ b/shaders/linesdfpattern.fragment.glsl
@@ -1,4 +1,3 @@
-uniform vec2 u_linewidth;
 uniform float u_blur;
 uniform sampler2D u_image;
 uniform float u_sdfgamma;
@@ -8,15 +7,16 @@ varying vec2 v_normal;
 varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying vec4 v_color;
+varying vec2 v_linewidth;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * u_linewidth.s;
+    float dist = length(v_normal) * v_linewidth.s;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp(min(dist - (u_linewidth.t - u_blur), u_linewidth.s - dist) / u_blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linewidth.t - u_blur), v_linewidth.s - dist) / u_blur, 0.0, 1.0);
 
     float sdfdist_a = texture2D(u_image, v_tex_a).a;
     float sdfdist_b = texture2D(u_image, v_tex_b).a;

--- a/shaders/linesdfpattern.vertex.glsl
+++ b/shaders/linesdfpattern.vertex.glsl
@@ -10,6 +10,7 @@ attribute vec2 a_pos;
 attribute vec4 a_data;
 attribute vec4 a_color;
 attribute vec2 a_linewidth;
+attribute float a_blur;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -27,6 +28,7 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying vec4 v_color;
 varying vec2 v_linewidth;
+varying float v_blur;
 
 void main() {
     vec2 a_extrude = a_data.xy;
@@ -55,4 +57,5 @@ void main() {
 
     v_color = a_color;
     v_linewidth = a_linewidth;
+    v_blur = a_blur;
 }

--- a/shaders/linesdfpattern.vertex.glsl
+++ b/shaders/linesdfpattern.vertex.glsl
@@ -8,6 +8,7 @@
 
 attribute vec2 a_pos;
 attribute vec4 a_data;
+attribute vec4 a_color;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -24,6 +25,7 @@ uniform float u_tex_y_b;
 varying vec2 v_normal;
 varying vec2 v_tex_a;
 varying vec2 v_tex_b;
+varying vec4 v_color;
 
 void main() {
     vec2 a_extrude = a_data.xy;
@@ -49,4 +51,6 @@ void main() {
 
     v_tex_a = vec2(a_linesofar * u_patternscale_a.x, normal.y * u_patternscale_a.y + u_tex_y_a);
     v_tex_b = vec2(a_linesofar * u_patternscale_b.x, normal.y * u_patternscale_b.y + u_tex_y_b);
+
+    v_color = a_color;
 }

--- a/shaders/linesdfpattern.vertex.glsl
+++ b/shaders/linesdfpattern.vertex.glsl
@@ -9,13 +9,13 @@
 attribute vec2 a_pos;
 attribute vec4 a_data;
 attribute vec4 a_color;
+attribute vec2 a_linewidth;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
 uniform mat4 u_matrix;
 uniform mat4 u_exmatrix;
 
-uniform vec2 u_linewidth;
 uniform float u_ratio;
 uniform vec2 u_patternscale_a;
 uniform float u_tex_y_a;
@@ -26,6 +26,7 @@ varying vec2 v_normal;
 varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying vec4 v_color;
+varying vec2 v_linewidth;
 
 void main() {
     vec2 a_extrude = a_data.xy;
@@ -41,7 +42,7 @@ void main() {
 
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
-    vec4 dist = vec4(u_linewidth.s * a_extrude * scale, 0.0, 0.0);
+    vec4 dist = vec4(a_linewidth.s * a_extrude * scale, 0.0, 0.0);
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -53,4 +54,5 @@ void main() {
     v_tex_b = vec2(a_linesofar * u_patternscale_b.x, normal.y * u_patternscale_b.y + u_tex_y_b);
 
     v_color = a_color;
+    v_linewidth = a_linewidth;
 }

--- a/shaders/outline.fragment.glsl
+++ b/shaders/outline.fragment.glsl
@@ -1,9 +1,8 @@
-uniform vec4 u_color;
-
+varying vec4 v_color;
 varying vec2 v_pos;
 
 void main() {
     float dist = length(v_pos - gl_FragCoord.xy);
     float alpha = smoothstep(1.0, 0.0, dist);
-    gl_FragColor = u_color * alpha;
+    gl_FragColor = v_color * alpha;
 }

--- a/shaders/outline.vertex.glsl
+++ b/shaders/outline.vertex.glsl
@@ -3,6 +3,7 @@ attribute vec4 a_color;
 
 uniform mat4 u_matrix;
 uniform vec2 u_world;
+
 varying vec4 v_color;
 varying vec2 v_pos;
 

--- a/shaders/outline.vertex.glsl
+++ b/shaders/outline.vertex.glsl
@@ -1,10 +1,13 @@
 attribute vec2 a_pos;
+attribute vec4 a_color;
+
 uniform mat4 u_matrix;
 uniform vec2 u_world;
-
+varying vec4 v_color;
 varying vec2 v_pos;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = (gl_Position.xy/gl_Position.w + 1.0) / 2.0 * u_world;
+    v_color = a_color;
 }

--- a/shaders/sdf.fragment.glsl
+++ b/shaders/sdf.fragment.glsl
@@ -1,15 +1,15 @@
 uniform sampler2D u_texture;
-uniform float u_buffer;
 uniform float u_gamma;
 
 varying vec2 v_tex;
 varying float v_alpha;
 varying float v_gamma_scale;
 varying vec4 v_color;
+varying float v_buffer;
 
 void main() {
     float gamma = u_gamma * v_gamma_scale;
     float dist = texture2D(u_texture, v_tex).a;
-    float alpha = smoothstep(u_buffer - gamma, u_buffer + gamma, dist) * v_alpha;
+    float alpha = smoothstep(v_buffer - gamma, v_buffer + gamma, dist) * v_alpha;
     gl_FragColor = v_color * alpha;
 }

--- a/shaders/sdf.fragment.glsl
+++ b/shaders/sdf.fragment.glsl
@@ -1,15 +1,15 @@
 uniform sampler2D u_texture;
-uniform vec4 u_color;
 uniform float u_buffer;
 uniform float u_gamma;
 
 varying vec2 v_tex;
 varying float v_alpha;
 varying float v_gamma_scale;
+varying vec4 v_color;
 
 void main() {
     float gamma = u_gamma * v_gamma_scale;
     float dist = texture2D(u_texture, v_tex).a;
     float alpha = smoothstep(u_buffer - gamma, u_buffer + gamma, dist) * v_alpha;
-    gl_FragColor = u_color * alpha;
+    gl_FragColor = v_color * alpha;
 }

--- a/shaders/sdf.fragment.glsl
+++ b/shaders/sdf.fragment.glsl
@@ -1,14 +1,14 @@
 uniform sampler2D u_texture;
-uniform float u_gamma;
 
 varying vec2 v_tex;
 varying float v_alpha;
 varying float v_gamma_scale;
 varying vec4 v_color;
 varying float v_buffer;
+varying float v_gamma;
 
 void main() {
-    float gamma = u_gamma * v_gamma_scale;
+    float gamma = v_gamma * v_gamma_scale;
     float dist = texture2D(u_texture, v_tex).a;
     float alpha = smoothstep(v_buffer - gamma, v_buffer + gamma, dist) * v_alpha;
     gl_FragColor = v_color * alpha;

--- a/shaders/sdf.vertex.glsl
+++ b/shaders/sdf.vertex.glsl
@@ -2,7 +2,7 @@ attribute vec2 a_pos;
 attribute vec2 a_offset;
 attribute vec4 a_data1;
 attribute vec4 a_data2;
-
+attribute vec4 a_color;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -22,6 +22,7 @@ uniform vec2 u_texsize;
 varying vec2 v_tex;
 varying float v_alpha;
 varying float v_gamma_scale;
+varying vec4 v_color;
 
 void main() {
     vec2 a_tex = a_data1.xy;
@@ -67,4 +68,5 @@ void main() {
     v_gamma_scale = perspective_scale;
 
     v_tex = a_tex / u_texsize;
+    v_color = a_color;
 }

--- a/shaders/sdf.vertex.glsl
+++ b/shaders/sdf.vertex.glsl
@@ -3,6 +3,7 @@ attribute vec2 a_offset;
 attribute vec4 a_data1;
 attribute vec4 a_data2;
 attribute vec4 a_color;
+attribute float a_buffer;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -23,6 +24,7 @@ varying vec2 v_tex;
 varying float v_alpha;
 varying float v_gamma_scale;
 varying vec4 v_color;
+varying float v_buffer;
 
 void main() {
     vec2 a_tex = a_data1.xy;
@@ -69,4 +71,5 @@ void main() {
 
     v_tex = a_tex / u_texsize;
     v_color = a_color;
+    v_buffer = a_buffer;
 }

--- a/shaders/sdf.vertex.glsl
+++ b/shaders/sdf.vertex.glsl
@@ -4,6 +4,7 @@ attribute vec4 a_data1;
 attribute vec4 a_data2;
 attribute vec4 a_color;
 attribute float a_buffer;
+attribute float a_gamma;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
@@ -25,6 +26,7 @@ varying float v_alpha;
 varying float v_gamma_scale;
 varying vec4 v_color;
 varying float v_buffer;
+varying float v_gamma;
 
 void main() {
     vec2 a_tex = a_data1.xy;
@@ -72,4 +74,5 @@ void main() {
     v_tex = a_tex / u_texsize;
     v_color = a_color;
     v_buffer = a_buffer;
+    v_gamma = a_gamma;
 }


### PR DESCRIPTION
The first step to data driven styling is refactoring the shaders to allow per-feature colors. This pull request makes all three line shaders compatible with this functionality. It does not seem to degrade performance measurably -- all benchmarks still run at 60fps. 

cc @jfirebaugh @ansis 