### PR TITLE
Standardize on a 1024x768 map for FPS benchmarking

### DIFF
--- a/bench/fps/index.html
+++ b/bench/fps/index.html
@@ -9,7 +9,8 @@
 
     <style>
         body { margin: 0; padding: 0; }
-        html, body, #map { height: 100%; }
+        html, body { height: 100%; }
+        #map { width: 1024px; height: 768px; }
     </style>
 </head>
 <body>

--- a/bench/fps/site.js
+++ b/bench/fps/site.js
@@ -1,8 +1,8 @@
 var urls = [
     'https://api.tiles.mapbox.com/mapbox-gl-js/v0.7.0/mapbox-gl.js',
-    '/dist/mapbox-gl.js',
+    '/debug/mapbox-gl.js',
     'https://api.tiles.mapbox.com/mapbox-gl-js/v0.7.0/mapbox-gl.js',
-    '/dist/mapbox-gl.js'
+    '/debug/mapbox-gl.js'
 ];
 
 var duration = 3000;


### PR DESCRIPTION
The previous benchmarking page was rendering a 0x0 map and pretty much always produced 60 FPS. Unless I'm missing something, we should aim for a reasonable map size, like 1024x768. This results in about 10 FPS on my machine, which is generally consistent with my experience using GL JS in the wild. 

cc @jfirebaugh @kkaefer @ansis 