### PR TITLE
calculate layout properties per-feature

### DIFF
--- a/js/data/buffer/buffer.js
+++ b/js/data/buffer/buffer.js
@@ -74,5 +74,9 @@ Buffer.prototype = {
 
             this.setupViews();
         }
+    },
+
+    alignInitialPos: function() {
+        this.pos += Math.ceil(this.pos / this.itemSize) * this.itemSize;
     }
 };

--- a/js/data/buffer/buffer.js
+++ b/js/data/buffer/buffer.js
@@ -77,6 +77,6 @@ Buffer.prototype = {
     },
 
     alignInitialPos: function() {
-        this.pos += Math.ceil(this.pos / this.itemSize) * this.itemSize;
+        this.pos = Math.ceil(this.pos / this.itemSize) * this.itemSize;
     }
 };

--- a/js/data/buffer/glyph_vertex_buffer.js
+++ b/js/data/buffer/glyph_vertex_buffer.js
@@ -37,15 +37,21 @@ GlyphVertexBuffer.prototype = util.inherit(Buffer, {
         this.pos += this.itemSize;
     },
 
-    bind: function(gl, shader, offset) {
+    bind: function(gl, shader, offset, stride) {
         Buffer.prototype.bind.call(this, gl);
-
-        var stride = this.itemSize;
 
         gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, stride, offset + 0);
         gl.vertexAttribPointer(shader.a_offset, 2, gl.SHORT, false, stride, offset + 4);
 
         gl.vertexAttribPointer(shader.a_data1, 4, gl.UNSIGNED_BYTE, false, stride, offset + 8);
         gl.vertexAttribPointer(shader.a_data2, 2, gl.UNSIGNED_BYTE, false, stride, offset + 12);
+    },
+
+    addColor: function(index, offset, color) {
+        var pos = index * this.itemSize + offset;
+        this.ubytes[pos + 0] = color[0];
+        this.ubytes[pos + 1] = color[1];
+        this.ubytes[pos + 2] = color[2];
+        this.ubytes[pos + 3] = color[3];
     }
 });

--- a/js/data/buffer/icon_vertex_buffer.js
+++ b/js/data/buffer/icon_vertex_buffer.js
@@ -36,14 +36,25 @@ GlyphVertexBuffer.prototype = util.inherit(Buffer, {
         this.pos += this.itemSize;
     },
 
-    bind: function(gl, shader, offset) {
+    bind: function(gl, shader, offset, stride) {
         Buffer.prototype.bind.call(this, gl);
-
-        var stride = this.itemSize;
 
         gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, stride, offset + 0);
         gl.vertexAttribPointer(shader.a_offset, 2, gl.SHORT, false, stride, offset + 4);
         gl.vertexAttribPointer(shader.a_data1, 4, gl.UNSIGNED_BYTE, false, stride, offset + 8);
         gl.vertexAttribPointer(shader.a_data2, 2, gl.UNSIGNED_BYTE, false, stride, offset + 12);
+    },
+
+    addColor: function(index, offset, color) {
+        var pos = index * this.itemSize + offset;
+        this.ubytes[pos + 0] = color[0];
+        this.ubytes[pos + 1] = color[1];
+        this.ubytes[pos + 2] = color[2];
+        this.ubytes[pos + 3] = color[3];
+    },
+
+    addOpacity: function(index, offset, opacity) {
+        var pos = index * this.itemSize + offset;
+        this.ubytes[pos + 0] = Math.round(opacity * 255);
     }
 });

--- a/js/data/buffer/line_vertex_buffer.js
+++ b/js/data/buffer/line_vertex_buffer.js
@@ -38,9 +38,31 @@ LineVertexBuffer.prototype = util.inherit(Buffer, {
         this.bytes[pos + 4] = Math.round(extrudeScale * extrude.x);
         this.bytes[pos + 5] = Math.round(extrudeScale * extrude.y);
         this.bytes[pos + 6] = (linesofar || 0) / 128;
-        this.bytes[pos + 7] = (linesofar || 0) % 128;
 
         this.pos += this.itemSize;
         return index;
+    },
+
+    addColor: function(index, offset, color) {
+        var pos = index * this.itemSize + offset;
+        this.ubytes[pos + 0] = color[0];
+        this.ubytes[pos + 1] = color[1];
+        this.ubytes[pos + 2] = color[2];
+        this.ubytes[pos + 3] = color[3];
+    },
+
+    addWidth: function(index, offset, width) {
+        var pos = index * this.itemSize + offset;
+        this.ubytes[pos + 0] = width;
+    },
+
+    addBlur: function(index, offset, blur) {
+        var pos = index * this.itemSize + offset;
+        this.ubytes[pos + 0] = blur;
+    },
+
+    addOpacity: function(index, offset, opacity) {
+        var pos = index * this.itemSize + offset;
+        this.ubytes[pos + 0] = Math.round(opacity * 255);
     }
 });

--- a/js/data/create_bucket.js
+++ b/js/data/create_bucket.js
@@ -5,25 +5,18 @@ module.exports = createBucket;
 var LineBucket = require('./line_bucket');
 var FillBucket = require('./fill_bucket');
 var SymbolBucket = require('./symbol_bucket');
-var LayoutProperties = require('../style/layout_properties');
 var featureFilter = require('feature-filter');
 var StyleDeclarationSet = require('../style/style_declaration_set');
 
 function createBucket(layer, buffers, z, overscaling, collisionDebug) {
-    var values = new StyleDeclarationSet('layout', layer.type, layer.layout, {}).values(),
-        fakeZoomHistory = { lastIntegerZoom: Infinity, lastIntegerZoomTime: 0, lastZoom: 0 },
-        layout = {};
-
-    for (var k in values) {
-        layout[k] = values[k].calculate(z, fakeZoomHistory);
-    }
+    var values = new StyleDeclarationSet('layout', layer.type, layer.layout, {}).values();
 
     var BucketClass =
         layer.type === 'line' ? LineBucket :
         layer.type === 'fill' ? FillBucket :
         layer.type === 'symbol' ? SymbolBucket : null;
 
-    var bucket = new BucketClass(buffers, new LayoutProperties[layer.type](layout), overscaling, z, collisionDebug);
+    var bucket = new BucketClass(buffers, values, overscaling, z, collisionDebug);
 
     bucket.id = layer.id;
     bucket.type = layer.type;

--- a/js/data/create_bucket.js
+++ b/js/data/create_bucket.js
@@ -10,14 +10,13 @@ var StyleDeclarationSet = require('../style/style_declaration_set');
 
 function createBucket(layer, buffers, constants, z, overscaling, collisionDebug) {
     var layoutDeclarations = new StyleDeclarationSet('layout', layer.type, layer.layout, {}).values();
-    var paintDeclarations = new StyleDeclarationSet('paint', layer.type, layer.paint, constants).values();
 
     var BucketClass =
         layer.type === 'line' ? LineBucket :
         layer.type === 'fill' ? FillBucket :
         layer.type === 'symbol' ? SymbolBucket : null;
 
-    var bucket = new BucketClass(buffers, layoutDeclarations, paintDeclarations, overscaling, z, collisionDebug);
+    var bucket = new BucketClass(buffers, layoutDeclarations, overscaling, z, collisionDebug);
 
     bucket.id = layer.id;
     bucket.type = layer.type;
@@ -27,6 +26,7 @@ function createBucket(layer, buffers, constants, z, overscaling, collisionDebug)
     bucket.maxZoom = layer.maxzoom;
     bucket.filter = featureFilter(layer.filter);
     bucket.features = [];
+    bucket.layerPaintDeclarations = {};
 
     return bucket;
 }

--- a/js/data/create_bucket.js
+++ b/js/data/create_bucket.js
@@ -8,15 +8,16 @@ var SymbolBucket = require('./symbol_bucket');
 var featureFilter = require('feature-filter');
 var StyleDeclarationSet = require('../style/style_declaration_set');
 
-function createBucket(layer, buffers, z, overscaling, collisionDebug) {
-    var values = new StyleDeclarationSet('layout', layer.type, layer.layout, {}).values();
+function createBucket(layer, buffers, constants, z, overscaling, collisionDebug) {
+    var layoutDeclarations = new StyleDeclarationSet('layout', layer.type, layer.layout, {}).values();
+    var paintDeclarations = new StyleDeclarationSet('paint', layer.type, layer.paint, constants).values();
 
     var BucketClass =
         layer.type === 'line' ? LineBucket :
         layer.type === 'fill' ? FillBucket :
         layer.type === 'symbol' ? SymbolBucket : null;
 
-    var bucket = new BucketClass(buffers, values, overscaling, z, collisionDebug);
+    var bucket = new BucketClass(buffers, layoutDeclarations, paintDeclarations, overscaling, z, collisionDebug);
 
     bucket.id = layer.id;
     bucket.type = layer.type;

--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var ElementGroups = require('./element_groups');
+var LineLayoutProperties = require('../style/layout_properties').line;
 
 module.exports = LineBucket;
 
@@ -8,10 +9,10 @@ module.exports = LineBucket;
  * @class LineBucket
  * @private
  */
-function LineBucket(buffers, layoutProperties) {
+function LineBucket(buffers, declarationSet) {
     this.buffers = buffers;
     this.elementGroups = new ElementGroups(buffers.lineVertex, buffers.lineElement);
-    this.layoutProperties = layoutProperties;
+    this.declarationSet = declarationSet;
 }
 
 LineBucket.prototype.addFeatures = function() {
@@ -23,7 +24,13 @@ LineBucket.prototype.addFeatures = function() {
 };
 
 LineBucket.prototype.addFeature = function(lines) {
-    var layoutProperties = this.layoutProperties;
+    var declarationSet = this.declarationSet;
+    var calculatedLayout = {};
+    for (var k in declarationSet) {
+        calculatedLayout[k] = declarationSet[k].calculate(this.zoom);
+    }
+    var layoutProperties = new LineLayoutProperties(calculatedLayout);
+
     for (var i = 0; i < lines.length; i++) {
         this.addLine(lines[i],
             layoutProperties['line-join'],

--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -11,42 +11,43 @@ module.exports = LineBucket;
  */
 function LineBucket(buffers, layoutDeclarations, paintDeclarations, _, zoom) {
 
-    // TODO figure this out using layoutDeclarations
-    var isColorPerFeature = false;
-    var isWidthPerFeature = true && paintDeclarations['line-width'];
-    var isGapWidthPerFeature = false;
-    var isBlurPerFeature = false;
-    var isOpacityPerFeature = false;
-
     this.partiallyEvaluatedScales = {};
     var itemSize = 8;
     var offsets = {};
 
-    if (isColorPerFeature) {
+    var lineColor = paintDeclarations['line-color'];
+    if (lineColor && !lineColor.calculate.isFeatureConstant) {
         offsets.color = itemSize;
         itemSize += 4;
-        this.partiallyEvaluatedScales.color = paintDeclarations['line-color'].calculate(zoom);
+        this.partiallyEvaluatedScales.color = lineColor.calculate(zoom);
     }
 
-    if (isWidthPerFeature) {
+    var lineWidth = paintDeclarations['line-width'];
+    if (lineWidth && !lineWidth.calculate.isFeatureConstant) {
         offsets.width = itemSize;
-        this.partiallyEvaluatedScales.width = paintDeclarations['line-width'].calculate(zoom);
         itemSize += 4;
+        this.partiallyEvaluatedScales.width = lineWidth.calculate(zoom);
     }
 
-    if (isGapWidthPerFeature) {
+    var lineGapWidth = paintDeclarations['line-gap-width'];
+    if (lineGapWidth && !lineGapWidth.calculate.isFeatureConstant) {
         offsets.gapWidth = itemSize;
         itemSize += 4;
+        this.partiallyEvaluatedScales.gapWidth = lineGapWidth.calculate(zoom);
     }
 
-    if (isBlurPerFeature) {
+    var lineBlur = paintDeclarations['line-blur'];
+    if (lineBlur && !lineBlur.calculate.isFeatureConstant) {
         offsets.blur = itemSize;
         itemSize += 4;
+        this.partiallyEvaluatedScales.blur = lineBlur.calculate(zoom);
     }
 
-    if (isOpacityPerFeature) {
+    var lineOpacity = paintDeclarations['line-opacity'];
+    if (lineOpacity && !lineOpacity.calculate.isFeatureConstant) {
         offsets.opacity = itemSize;
         itemSize += 4;
+        this.partiallyEvaluatedScales.opacity = lineOpacity.calculate(zoom);
     }
 
     this.buffers = buffers;
@@ -116,21 +117,21 @@ LineBucket.prototype.addFeature = function(feature) {
     }
 
     if (gapWidthOffset !== undefined) {
-        var gapWidth = 5;
+        var gapWidth = this.partiallyEvaluatedScales.gapWidth(feature.properties);
         for (index = featureStartIndex; index < featureEndIndex; index++) {
             lineVertex.addWidth(index, gapWidthOffset, gapWidth);
         }
     }
 
     if (blurOffset !== undefined) {
-        var blur = 2;
+        var blur = this.partiallyEvaluatedScales.blur(feature.properties);
         for (index = featureStartIndex; index < featureEndIndex; index++) {
             lineVertex.addBlur(index, blurOffset, blur);
         }
     }
 
     if (blurOffset !== undefined) {
-        var opacity = 0.5;
+        var opacity = this.partiallyEvaluatedScales.opacity(feature.properties);
         for (index = featureStartIndex; index < featureEndIndex; index++) {
             lineVertex.addOpacity(index, opacityOffset, opacity);
         }

--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -10,9 +10,51 @@ module.exports = LineBucket;
  * @private
  */
 function LineBucket(buffers, declarationSet) {
+
+    // TODO figure this out using declarationSet
+    var isColorPerFeature = true;
+    var isWidthPerFeature = true;
+    var isGapWidthPerFeature = true;
+    var isBlurPerFeature = true;
+    var isOpacityPerFeature = true;
+
+    var itemSize = 8;
+    var offsets = {};
+
+    if (isColorPerFeature) {
+        offsets.color = itemSize;
+        itemSize += 4;
+    }
+
+    if (isWidthPerFeature) {
+        offsets.width = itemSize;
+        itemSize += 4;
+    }
+
+    if (isGapWidthPerFeature) {
+        offsets.gapWidth = itemSize;
+        itemSize += 4;
+    }
+
+    if (isBlurPerFeature) {
+        offsets.blur = itemSize;
+        itemSize += 4;
+    }
+
+    if (isOpacityPerFeature) {
+        offsets.opacity = itemSize;
+        itemSize += 4;
+    }
+
+    buffers.lineVertex.itemSize = itemSize;
+    buffers.lineVertex.alignInitialPos();
+
     this.buffers = buffers;
     this.elementGroups = new ElementGroups(buffers.lineVertex, buffers.lineElement);
     this.declarationSet = declarationSet;
+
+    this.elementGroups.itemSize = itemSize;
+    this.elementGroups.offsets = offsets;
 }
 
 LineBucket.prototype.addFeatures = function() {
@@ -31,12 +73,60 @@ LineBucket.prototype.addFeature = function(lines) {
     }
     var layoutProperties = new LineLayoutProperties(calculatedLayout);
 
+    var lineVertex = this.buffers.lineVertex;
+    var featureStartIndex = lineVertex.index;
+
     for (var i = 0; i < lines.length; i++) {
         this.addLine(lines[i],
             layoutProperties['line-join'],
             layoutProperties['line-cap'],
             layoutProperties['line-miter-limit'],
             layoutProperties['line-round-limit']);
+    }
+
+    var featureEndIndex = lineVertex.index;
+    var offsets = this.elementGroups.offsets;
+    var index;
+
+    var colorOffset = offsets.color;
+    var widthOffset = offsets.width;
+    var gapWidthOffset = offsets.gapWidth;
+    var blurOffset = offsets.blur;
+    var opacityOffset = offsets.opacity;
+
+    if (colorOffset !== undefined) {
+        var color = [255, 0, 0, 255];
+        for (index = featureStartIndex; index < featureEndIndex; index++) {
+            lineVertex.addColor(index, colorOffset, color);
+        }
+    }
+
+    if (widthOffset !== undefined) {
+        var width = 10;
+        for (index = featureStartIndex; index < featureEndIndex; index++) {
+            lineVertex.addWidth(index, widthOffset, width);
+        }
+    }
+
+    if (gapWidthOffset !== undefined) {
+        var gapWidth = 5;
+        for (index = featureStartIndex; index < featureEndIndex; index++) {
+            lineVertex.addWidth(index, gapWidthOffset, gapWidth);
+        }
+    }
+
+    if (blurOffset !== undefined) {
+        var blur = 2;
+        for (index = featureStartIndex; index < featureEndIndex; index++) {
+            lineVertex.addBlur(index, blurOffset, blur);
+        }
+    }
+
+    if (blurOffset !== undefined) {
+        var opacity = 0.5;
+        for (index = featureStartIndex; index < featureEndIndex; index++) {
+            lineVertex.addOpacity(index, opacityOffset, opacity);
+        }
     }
 };
 

--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -12,11 +12,11 @@ module.exports = LineBucket;
 function LineBucket(buffers, declarationSet) {
 
     // TODO figure this out using declarationSet
-    var isColorPerFeature = true;
-    var isWidthPerFeature = true;
-    var isGapWidthPerFeature = true;
-    var isBlurPerFeature = true;
-    var isOpacityPerFeature = true;
+    var isColorPerFeature = false;
+    var isWidthPerFeature = false;
+    var isGapWidthPerFeature = false;
+    var isBlurPerFeature = false;
+    var isOpacityPerFeature = false;
 
     var itemSize = 8;
     var offsets = {};
@@ -61,15 +61,16 @@ LineBucket.prototype.addFeatures = function() {
     var features = this.features;
     for (var i = 0; i < features.length; i++) {
         var feature = features[i];
-        this.addFeature(feature.loadGeometry());
+        this.addFeature(feature);
     }
 };
 
-LineBucket.prototype.addFeature = function(lines) {
+LineBucket.prototype.addFeature = function(feature) {
+    var lines = feature.loadGeometry();
     var declarationSet = this.declarationSet;
     var calculatedLayout = {};
     for (var k in declarationSet) {
-        calculatedLayout[k] = declarationSet[k].calculate(this.zoom);
+        calculatedLayout[k] = declarationSet[k].calculate(this.zoom)(feature.properties);
     }
     var layoutProperties = new LineLayoutProperties(calculatedLayout);
 

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -448,10 +448,12 @@ SymbolBucket.prototype.addSymbols = function(vertex, element, elementGroups, qua
 SymbolBucket.prototype.calculateLayoutProperties = function() {
     var declarationSet = this.declarationSet;
     var featureLayoutProperties = this.featureLayoutProperties = [];
-    for (var i = 0; i < this.features.length; i++) {
+    var features = this.features;
+    for (var i = 0; i < features.length; i++) {
+        var feature = features[i];
         var layout = {};
         for (var k in declarationSet) {
-            layout[k] = declarationSet[k].calculate(this.zoom);
+            layout[k] = declarationSet[k].calculate(this.zoom)(feature.properties);
         }
         featureLayoutProperties.push(new SymbolLayoutProperties(layout));
     }

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -21,9 +21,9 @@ var CollisionFeature = require('../symbol/collision_feature');
 
 module.exports = SymbolBucket;
 
-function SymbolBucket(buffers, declarationSet, overscaling, zoom, collisionDebug) {
+function SymbolBucket(buffers, layoutDeclarations, paintDeclarations, overscaling, zoom, collisionDebug) {
 
-    // TODO figure this out using declarationSet
+    // TODO figure this out using layoutDeclarations
     var isTextColorPerFeature = false;
     var isTextHaloColorPerFeature = false;
     var isIconColorPerFeature = false;
@@ -66,7 +66,7 @@ function SymbolBucket(buffers, declarationSet, overscaling, zoom, collisionDebug
     offsets.iconItemSize = iconItemSize;
 
     this.buffers = buffers;
-    this.declarationSet = declarationSet;
+    this.layoutDeclarations = layoutDeclarations;
     this.overscaling = overscaling;
     this.zoom = zoom;
     this.collisionDebug = collisionDebug;
@@ -242,6 +242,12 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, buffers, collisio
     this.buffers = buffers;
 
     var offsets = this.offsets;
+
+    buffers.glyphVertex.itemSize = offsets.textItemSize;
+    buffers.iconVertex.itemSize = offsets.iconItemSize;
+    buffers.glyphVertex.alignInitialPos();
+    buffers.iconVertex.alignInitialPos();
+
     var elementGroups = this.elementGroups = {
         text: new ElementGroups(buffers.glyphVertex, buffers.glyphElement),
         icon: new ElementGroups(buffers.iconVertex, buffers.iconElement),
@@ -253,10 +259,6 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, buffers, collisio
     elementGroups.text.itemSize = offsets.textItemSize;
     elementGroups.icon.itemSize = offsets.iconItemSize;
 
-    buffers.glyphVertex.itemSize = offsets.textItemSize;
-    buffers.iconVertex.itemSize = offsets.iconItemSize;
-    buffers.glyphVertex.alignInitialPos();
-    buffers.iconVertex.alignInitialPos();
 
     var featureLayoutProperties = this.featureLayoutProperties;
     var maxScale = collisionTile.maxScale;
@@ -446,14 +448,14 @@ SymbolBucket.prototype.addSymbols = function(vertex, element, elementGroups, qua
 };
 
 SymbolBucket.prototype.calculateLayoutProperties = function() {
-    var declarationSet = this.declarationSet;
+    var layoutDeclarations = this.layoutDeclarations;
     var featureLayoutProperties = this.featureLayoutProperties = [];
     var features = this.features;
     for (var i = 0; i < features.length; i++) {
         var feature = features[i];
         var layout = {};
-        for (var k in declarationSet) {
-            layout[k] = declarationSet[k].calculate(this.zoom)(feature.properties);
+        for (var k in layoutDeclarations) {
+            layout[k] = layoutDeclarations[k].calculate(this.zoom)(feature.properties);
         }
         featureLayoutProperties.push(new SymbolLayoutProperties(layout));
     }
@@ -472,7 +474,7 @@ SymbolBucket.prototype.getDependencies = function(tile, actor, callback) {
 };
 
 SymbolBucket.prototype.getIconDependencies = function(tile, actor, callback) {
-    if (this.declarationSet['icon-image']) {
+    if (this.layoutDeclarations['icon-image']) {
         var features = this.features;
         var icons = resolveIcons(features, this.featureLayoutProperties);
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -20,7 +20,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
     if (!elementGroups) return;
 
     var gl = painter.gl;
-    var offsets = elementGroups.offsets;
+    var offsets = elementGroups.offsets[layer.id];
 
     // don't draw zero-width lines
     if (layer.paint['line-width'] <= 0) return;

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -20,6 +20,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
     if (!elementGroups) return;
 
     var gl = painter.gl;
+    var offsets = elementGroups.offsets;
 
     // don't draw zero-width lines
     if (layer.paint['line-width'] <= 0) return;
@@ -117,8 +118,10 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.uniform2fv(shader.u_pattern_br_b, imagePosB.br);
         gl.uniform1f(shader.u_fade, image.t);
 
-        gl.disableVertexAttribArray(shader.a_opacity);
-        gl.vertexAttrib1f(shader.a_opacity, layer.paint['line-opacity']);
+        if (offsets.opacity === undefined) {
+            gl.disableVertexAttribArray(shader.a_opacity);
+            gl.vertexAttrib1f(shader.a_opacity, layer.paint['line-opacity'] * 255);
+        }
 
     } else {
         shader = painter.lineShader;
@@ -130,27 +133,58 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
     }
 
     // linepattern does not have a color attribute
-    if (shader.a_color !== undefined) {
+    if (shader.a_color !== undefined && offsets.color === undefined) {
         gl.disableVertexAttribArray(shader.a_color);
-        gl.vertexAttrib4fv(shader.a_color, color);
+        gl.vertexAttrib4fv(shader.a_color, [color[0] * 255, color[1] * 255, color[2] * 255, color[3] * 255]);
     }
 
-    gl.disableVertexAttribArray(shader.a_linewidth);
-    gl.vertexAttrib2f(shader.a_linewidth, outset, inset);
+    if (offsets.width === undefined) {
+        gl.disableVertexAttribArray(shader.a_linewidth);
+        gl.vertexAttrib1f(shader.a_linewidth, outset);
+    }
 
-    gl.disableVertexAttribArray(shader.a_blur);
-    gl.vertexAttrib1f(shader.a_blur, blur);
+    if (offsets.gapWidth === undefined) {
+        gl.disableVertexAttribArray(shader.a_linegapwidth);
+        gl.vertexAttrib1f(shader.a_linegapwidth, inset);
+    }
+
+    if (offsets.blur === undefined) {
+        gl.disableVertexAttribArray(shader.a_blur);
+        gl.vertexAttrib1f(shader.a_blur, blur);
+    }
 
     var vertex = tile.buffers.lineVertex;
     vertex.bind(gl);
     var element = tile.buffers.lineElement;
     element.bind(gl);
 
+    var stride = elementGroups.itemSize;
+
     for (var i = 0; i < elementGroups.groups.length; i++) {
         var group = elementGroups.groups[i];
-        var vtxOffset = group.vertexStartIndex * vertex.itemSize;
-        gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, 8, vtxOffset + 0);
-        gl.vertexAttribPointer(shader.a_data, 4, gl.BYTE, false, 8, vtxOffset + 4);
+        var vtxOffset = group.vertexStartIndex * stride;
+        gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, stride, vtxOffset + 0);
+        gl.vertexAttribPointer(shader.a_data, 4, gl.BYTE, false, stride, vtxOffset + 4);
+
+        if (shader.a_color !== undefined && offsets.color !== undefined) {
+            gl.vertexAttribPointer(shader.a_color, 4, gl.UNSIGNED_BYTE, false, stride, vtxOffset + offsets.color);
+        }
+
+        if (offsets.width !== undefined) {
+            gl.vertexAttribPointer(shader.a_linewidth, 1, gl.UNSIGNED_BYTE, false, stride, vtxOffset + offsets.width);
+        }
+
+        if (offsets.gapWidth !== undefined) {
+            gl.vertexAttribPointer(shader.a_linegapwidth, 1, gl.UNSIGNED_BYTE, false, stride, vtxOffset + offsets.gapWidth);
+        }
+
+        if (offsets.blur !== undefined) {
+            gl.vertexAttribPointer(shader.a_blur, 1, gl.UNSIGNED_BYTE, false, stride, vtxOffset + offsets.blur);
+        }
+
+        if (shader.opacity !== undefined && offsets.opacity !== undefined) {
+            gl.vertexAttribPointer(shader.a_opacity, 1, gl.UNSIGNED_BYTE, false, stride, vtxOffset + offsets.opacity);
+        }
 
         var count = group.elementLength * 3;
         var elementOffset = group.elementStartIndex * element.itemSize;

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -123,7 +123,7 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf)
     gl.uniform1f(shader.u_maxfadezoom, Math.floor(f.maxfadezoom * 10));
     gl.uniform1f(shader.u_fadezoom, (painter.transform.zoom + f.bump) * 10);
 
-    var offsets = elementGroups.offsets;
+    var offsets = elementGroups.offsets[layer.id];
 
     var group, offset, count, elementOffset;
 

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -63,15 +63,15 @@ Painter.prototype.setup = function() {
         ['u_matrix', 'u_brightness_low', 'u_brightness_high', 'u_saturation_factor', 'u_spin_weights', 'u_contrast_factor', 'u_opacity0', 'u_opacity1', 'u_image0', 'u_image1', 'u_tl_parent', 'u_scale_parent', 'u_buffer_scale']);
 
     this.lineShader = gl.initializeShader('line',
-        ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur'],
+        ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur', 'a_linegapwidth'],
         ['u_matrix', 'u_ratio', 'u_extra', 'u_antialiasingmatrix']);
 
     this.linepatternShader = gl.initializeShader('linepattern',
-        ['a_pos', 'a_data', 'a_linewidth', 'a_blur', 'a_opacity'],
+        ['a_pos', 'a_data', 'a_linewidth', 'a_blur', 'a_opacity', 'a_linegapwidth'],
         ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_fade']);
 
     this.linesdfpatternShader = gl.initializeShader('linesdfpattern',
-        ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur'],
+        ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur', 'a_linegapwidth'],
         ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix']);
 
     this.dotShader = gl.initializeShader('dot',

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -25,8 +25,9 @@ function Worker(self) {
 }
 
 util.extend(Worker.prototype, {
-    'set layers': function(layers) {
-        this.layers = layers;
+    'set layers and constants': function(data) {
+        this.layers = data.layers;
+        this.constants = data.constants;
     },
 
     'load tile': function(params, callback) {
@@ -47,7 +48,7 @@ util.extend(Worker.prototype, {
             if (err) return callback(err);
 
             tile.data = new vt.VectorTile(new Protobuf(new Uint8Array(data)));
-            tile.parse(tile.data, this.layers, this.actor, callback);
+            tile.parse(tile.data, this.layers, this.constants, this.actor, callback);
 
             this.loaded[source] = this.loaded[source] || {};
             this.loaded[source][uid] = tile;
@@ -59,7 +60,7 @@ util.extend(Worker.prototype, {
             uid = params.uid;
         if (loaded && loaded[uid]) {
             var tile = loaded[uid];
-            tile.parse(tile.data, this.layers, this.actor, callback);
+            tile.parse(tile.data, this.layers, this.constants, this.actor, callback);
         }
     },
 
@@ -132,7 +133,7 @@ util.extend(Worker.prototype, {
         if (!geoJSONTile) return callback(null, null); // nothing in the given tile
 
         var tile = new WorkerTile(params);
-        tile.parse(new GeoJSONWrapper(geoJSONTile.features), this.layers, this.actor, callback);
+        tile.parse(new GeoJSONWrapper(geoJSONTile.features), this.layers, this.constants, this.actor, callback);
 
         this.loaded[source] = this.loaded[source] || {};
         this.loaded[source][params.uid] = tile;

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -4,6 +4,7 @@ var FeatureTree = require('../data/feature_tree');
 var CollisionTile = require('../symbol/collision_tile');
 var BufferSet = require('../data/buffer/buffer_set');
 var createBucket = require('../data/create_bucket');
+var StyleDeclarationSet = require('../style/style_declaration_set');
 
 module.exports = WorkerTile;
 
@@ -61,7 +62,7 @@ WorkerTile.prototype.parse = function(data, layers, constants, actor, callback) 
             continue;
 
         bucket = createBucket(layer, buffers, constants, this.zoom, this.overscaling, this.collisionDebug);
-        bucket.layers = [layer.id];
+        bucket.layers = [];
 
         buckets[bucket.id] = bucket;
         bucketsInOrder.push(bucket);
@@ -85,14 +86,13 @@ WorkerTile.prototype.parse = function(data, layers, constants, actor, callback) 
         if (layer.source !== this.source)
             continue;
 
-        if (!layer.ref)
-            continue;
-
-        bucket = buckets[layer.ref];
+        bucket = buckets[layer.ref || layer.id];
         if (!bucket)
             continue;
 
         bucket.layers.push(layer.id);
+        bucket.layerPaintDeclarations[layer.id] =
+            new StyleDeclarationSet('paint', layer.type, layer.paint, constants).values();
     }
 
     var extent = 4096;

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -22,7 +22,7 @@ function WorkerTile(params) {
     this.stacks = {};
 }
 
-WorkerTile.prototype.parse = function(data, layers, actor, callback) {
+WorkerTile.prototype.parse = function(data, layers, constants, actor, callback) {
 
     this.status = 'parsing';
 
@@ -60,7 +60,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         if (visibility === 'none')
             continue;
 
-        bucket = createBucket(layer, buffers, this.zoom, this.overscaling, this.collisionDebug);
+        bucket = createBucket(layer, buffers, constants, this.zoom, this.overscaling, this.collisionDebug);
         bucket.layers = [layer.id];
 
         buckets[bucket.id] = bucket;

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -479,6 +479,6 @@ Style.prototype = util.inherit(Evented, {
     },
 
     'get glyphs': function(params, callback) {
-        this.glyphSource.getSimpleGlyphs(params.fontstack, params.codepoints, params.uid, callback);
+        this.glyphSource.getSimpleGlyphs(params.missing, params.uid, callback);
     }
 });

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -147,7 +147,10 @@ Style.prototype = util.inherit(Evented, {
             ordered.push(this._layers[id].json());
         }
 
-        this.dispatcher.broadcast('set layers', ordered);
+        this.dispatcher.broadcast('set layers and constants', {
+            layers: ordered,
+            constants: this.stylesheet.constants
+        });
     },
 
     _cascade: function(classes, options) {

--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -31,20 +31,44 @@ function StyleDeclaration(reference, value) {
     }
 }
 
+// TODO remove this
+function migrateParameters(parameters) {
+    //parameters = clone(parameters);
+    if (parameters.stops) {
+        parameters.domain = [];
+        parameters.range = [];
+
+        for (var i = 0; i < parameters.stops.length; i++) {
+            parameters.domain.push(parameters.stops[i][0]);
+            parameters.range.push(parameters.stops[i][1]);
+        }
+
+        delete parameters.stops;
+    }
+
+    return parameters;
+}
+
+// TODO remove this
 function migrate(value, interpolated) {
 
     var parameters;
     if (value.stops) {
-        parameters = mapboxGLFunction.migrate(value);
+        parameters = migrateParameters(value);
         parameters.type = interpolated ? "power" : "ordinal";
+        parameters.property = '$zoom';
     } else {
         parameters = value;
     }
 
     var fn = mapboxGLFunction(parameters);
-    return function(z) {
+
+    var wrapped = function(z) {
         return fn({ '$zoom': z });
     };
+
+    wrapped.isFeatureConstant = fn.isFeatureConstant;
+    return wrapped;
 }
 
 function transitioned(calculate) {

--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -22,13 +22,25 @@ function StyleDeclaration(reference, value) {
     }
 
     if (reference.function === 'interpolated') {
-        this.calculate = mapboxGLFunction.interpolated(this.value);
+        this.calculate = migrate(this.value, true);
     } else {
-        this.calculate = mapboxGLFunction['piecewise-constant'](this.value);
+        this.calculate = migrate(this.value, false);
         if (reference.transition) {
             this.calculate = transitioned(this.calculate);
         }
     }
+}
+
+function migrate(value, interpolated) {
+    var parameters = mapboxGLFunction.migrate(value);
+
+    if (value.stops) {
+        parameters.type = interpolated ? "power" : "ordinal";
+    }
+    var fn = mapboxGLFunction(parameters);
+    return function(z) {
+        return fn({ '$zoom': z })({});
+    };
 }
 
 function transitioned(calculate) {

--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -32,7 +32,10 @@ function StyleDeclaration(reference, value) {
 }
 
 function transitioned(calculate) {
+    var fakeZoomHistory = { lastIntegerZoom: Infinity, lastIntegerZoomTime: 0, lastZoom: 0 };
+
     return function(z, zh, duration) {
+        if (zh === undefined) zh = fakeZoomHistory;
         var fraction = z % 1;
         var t = Math.min((Date.now() - zh.lastIntegerZoomTime) / duration, 1);
         var fromScale = 1;

--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -32,14 +32,18 @@ function StyleDeclaration(reference, value) {
 }
 
 function migrate(value, interpolated) {
-    var parameters = mapboxGLFunction.migrate(value);
 
+    var parameters;
     if (value.stops) {
+        parameters = mapboxGLFunction.migrate(value);
         parameters.type = interpolated ? "power" : "ordinal";
+    } else {
+        parameters = value;
     }
+
     var fn = mapboxGLFunction(parameters);
     return function(z) {
-        return fn({ '$zoom': z })({});
+        return fn({ '$zoom': z });
     };
 }
 
@@ -57,21 +61,23 @@ function transitioned(calculate) {
         if (z > zh.lastIntegerZoom) {
             mix = fraction + (1 - fraction) * t;
             fromScale *= 2;
-            from = calculate(z - 1);
-            to = calculate(z);
+            from = calculate(z - 1)({});
+            to = calculate(z)({});
         } else {
             mix = 1 - (1 - t) * fraction;
-            to = calculate(z);
-            from = calculate(z + 1);
+            to = calculate(z)({});
+            from = calculate(z + 1)({});
             fromScale /= 2;
         }
 
-        return {
-            from: from,
-            fromScale: fromScale,
-            to: to,
-            toScale: toScale,
-            t: mix
+        return function() {
+            return {
+                from: from,
+                fromScale: fromScale,
+                to: to,
+                toScale: toScale,
+                t: mix
+            };
         };
     };
 }

--- a/js/style/style_transition.js
+++ b/js/style/style_transition.js
@@ -46,7 +46,7 @@ StyleTransition.prototype.instant = function() {
  */
 StyleTransition.prototype.at = function(z, zoomHistory, t) {
 
-    var value = this.declaration.calculate(z, zoomHistory, this.duration);
+    var value = this.declaration.calculate(z, zoomHistory, this.duration)({});
 
     if (this.instant()) return value;
 

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -22,7 +22,29 @@ function GlyphSource(url, glyphAtlas) {
     this.loading = {};
 }
 
-GlyphSource.prototype.getSimpleGlyphs = function(fontstack, glyphIDs, uid, callback) {
+GlyphSource.prototype.getSimpleGlyphs = function(missing, uid, callback) {
+    var results = {};
+    var remaining = Object.keys(missing).length;
+    var error;
+
+    if (!remaining) callback(undefined, results);
+
+    for (var fontstack in missing) {
+        var glyphIDs = missing[fontstack];
+        this.getSimpleGlyphsFromStack(fontstack, glyphIDs, uid, done(fontstack));
+    }
+
+    function done(fontstack) {
+        return function(err, result) {
+            if (err) error = err;
+            results[fontstack] = result;
+            remaining--;
+            if (!remaining) callback(error, results);
+        };
+    }
+};
+
+GlyphSource.prototype.getSimpleGlyphsFromStack = function(fontstack, glyphIDs, uid, callback) {
 
     if (this.stacks[fontstack] === undefined) this.stacks[fontstack] = {};
 

--- a/js/symbol/resolve_icons.js
+++ b/js/symbol/resolve_icons.js
@@ -5,11 +5,11 @@ var resolveTokens = require('../util/token');
 module.exports = resolveIcons;
 
 // For an array of features determine what icons need to be loaded.
-function resolveIcons(features, layoutProperties) {
+function resolveIcons(features, featureLayoutProperties) {
     var icons = [];
 
     for (var i = 0, fl = features.length; i < fl; i++) {
-        var text = resolveTokens(features[i].properties, layoutProperties['icon-image']);
+        var text = resolveTokens(features[i].properties, featureLayoutProperties[i]['icon-image']);
         if (!text) continue;
 
         if (icons.indexOf(text) < 0) {

--- a/js/symbol/resolve_text.js
+++ b/js/symbol/resolve_text.js
@@ -11,11 +11,13 @@ module.exports = resolveText;
  * feature text directly.
  * @private
  */
-function resolveText(features, layoutProperties, glyphs) {
+function resolveText(features, featureLayoutProperties, stacks) {
     var textFeatures = [];
-    var codepoints = [];
+    var fontstackCodepoints = {};
+    var fontstack;
 
     for (var i = 0, fl = features.length; i < fl; i++) {
+        var layoutProperties = featureLayoutProperties[i];
         var text = resolveTokens(features[i].properties, layoutProperties['text-field']);
         if (!text) {
             textFeatures[i] = null;
@@ -30,6 +32,13 @@ function resolveText(features, layoutProperties, glyphs) {
             text = text.toLocaleLowerCase();
         }
 
+        fontstack = layoutProperties['text-font'];
+
+        var codepoints = fontstackCodepoints[fontstack];
+        if (codepoints === undefined) {
+            codepoints = fontstackCodepoints[fontstack] = [];
+        }
+
         for (var j = 0, jl = text.length; j < jl; j++) {
             codepoints.push(text.charCodeAt(j));
         }
@@ -38,12 +47,19 @@ function resolveText(features, layoutProperties, glyphs) {
         textFeatures[i] = text;
     }
 
-    // get a list of unique codepoints we are missing
-    codepoints = uniq(codepoints, glyphs);
+    for (fontstack in fontstackCodepoints) {
+        var glyphs = stacks[fontstack];
+        if (glyphs === undefined) {
+            glyphs = stacks[fontstack] = {};
+        }
+
+        // get a list of unique codepoints we are missing
+        fontstackCodepoints[fontstack] = uniq(fontstackCodepoints[fontstack], glyphs);
+    }
 
     return {
         textFeatures: textFeatures,
-        codepoints: codepoints
+        codepoints: fontstackCodepoints
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "geojson-vt": "^1.0.1",
     "gl-matrix": "https://github.com/toji/gl-matrix/archive/v2.2.1.tar.gz",
     "glify": "0.5.0",
-    "mapbox-gl-function": "^1.0.0",
+    "mapbox-gl-function": "git+https://github.com/mapbox/mapbox-gl-function.git#c5e8650563c7ce178e5a894832b2910f9d797f98",
     "mapbox-gl-style-spec": "^7.4.0",
     "minifyify": "^6.1.0",
     "pbf": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "geojson-vt": "^1.0.1",
     "gl-matrix": "https://github.com/toji/gl-matrix/archive/v2.2.1.tar.gz",
     "glify": "0.5.0",
-    "mapbox-gl-function": "git+https://github.com/mapbox/mapbox-gl-function.git#c5e8650563c7ce178e5a894832b2910f9d797f98",
+    "mapbox-gl-function": "git+https://github.com/mapbox/mapbox-gl-function.git#c8388d193cee9e1603d0d6527d17d2840c1f6604",
     "mapbox-gl-style-spec": "^7.4.0",
     "minifyify": "^6.1.0",
     "pbf": "^1.2.0",

--- a/shaders/icon.vertex.glsl
+++ b/shaders/icon.vertex.glsl
@@ -62,5 +62,5 @@ void main() {
 
     v_tex = a_tex / u_texsize;
 
-    v_alpha *= a_opacity;
+    v_alpha *= a_opacity / 255.0;
 }

--- a/shaders/line.fragment.glsl
+++ b/shaders/line.fragment.glsl
@@ -5,18 +5,19 @@ varying vec4 v_color;
 varying vec2 v_normal;
 varying float v_linesofar;
 varying float gamma_scale;
-varying vec2 v_linewidth;
+varying float v_linewidth;
+varying float v_linegapwidth;
 varying float v_blur;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * v_linewidth.s;
+    float dist = length(v_normal) * v_linewidth;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
     float blur = v_blur * gamma_scale;
-    float alpha = clamp(min(dist - (v_linewidth.t - blur), v_linewidth.s - dist) / blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linegapwidth - blur), v_linewidth - dist) / blur, 0.0, 1.0);
 
     gl_FragColor = v_color * alpha;
 }

--- a/shaders/line.vertex.glsl
+++ b/shaders/line.vertex.glsl
@@ -9,7 +9,8 @@
 attribute vec2 a_pos;
 attribute vec4 a_data;
 attribute vec4 a_color;
-attribute vec2 a_linewidth;
+attribute float a_linewidth;
+attribute float a_linegapwidth;
 attribute float a_blur;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
@@ -26,7 +27,8 @@ varying vec2 v_normal;
 varying float v_linesofar;
 varying vec4 v_color;
 varying float gamma_scale;
-varying vec2 v_linewidth;
+varying float v_linewidth;
+varying float v_linegapwidth;
 varying float v_blur;
 
 void main() {
@@ -42,7 +44,7 @@ void main() {
 
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
-    vec4 dist = vec4(a_linewidth.s * a_extrude * scale, 0.0, 0.0);
+    vec4 dist = vec4(a_linewidth * a_extrude * scale, 0.0, 0.0);
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -61,7 +63,8 @@ void main() {
 
     gamma_scale = perspective_scale * squish_scale;
 
-    v_color = a_color;
+    v_color = a_color / 255.0;
     v_linewidth = a_linewidth;
+    v_linegapwidth = a_linegapwidth;
     v_blur = a_blur;
 }

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -12,23 +12,24 @@ uniform sampler2D u_image;
 
 varying vec2 v_normal;
 varying float v_linesofar;
-varying vec2 v_linewidth;
+varying float v_linewidth;
+varying float v_linegapwidth;
 varying float v_blur;
 varying float v_opacity;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * v_linewidth.s;
+    float dist = length(v_normal) * v_linewidth;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp(min(dist - (v_linewidth.t - v_blur), v_linewidth.s - dist) / v_blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linegapwidth - v_blur), v_linewidth - dist) / v_blur, 0.0, 1.0);
 
     float x_a = mod(v_linesofar / u_pattern_size_a.x, 1.0);
     float x_b = mod(v_linesofar / u_pattern_size_b.x, 1.0);
-    float y_a = 0.5 + (v_normal.y * v_linewidth.s / u_pattern_size_a.y);
-    float y_b = 0.5 + (v_normal.y * v_linewidth.s / u_pattern_size_b.y);
+    float y_a = 0.5 + (v_normal.y * v_linewidth / u_pattern_size_a.y);
+    float y_b = 0.5 + (v_normal.y * v_linewidth / u_pattern_size_b.y);
     vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, vec2(x_a, y_a));
     vec2 pos2 = mix(u_pattern_tl_b, u_pattern_br_b, vec2(x_b, y_b));
 

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -8,7 +8,8 @@
 
 attribute vec2 a_pos;
 attribute vec4 a_data;
-attribute vec2 a_linewidth;
+attribute float a_linewidth;
+attribute float a_linegapwidth;
 attribute float a_blur;
 attribute float a_opacity;
 
@@ -22,7 +23,8 @@ uniform float u_ratio;
 
 varying vec2 v_normal;
 varying float v_linesofar;
-varying vec2 v_linewidth;
+varying float v_linewidth;
+varying float v_linegapwidth;
 varying float v_blur;
 varying float v_opacity;
 
@@ -41,7 +43,7 @@ void main() {
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
     vec2 extrude = a_extrude * scale;
-    vec2 dist = a_linewidth.s * extrude;
+    vec2 dist = a_linewidth * extrude;
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -51,6 +53,7 @@ void main() {
     v_linesofar = a_linesofar;// * u_ratio;
 
     v_linewidth = a_linewidth;
+    v_linegapwidth = a_linegapwidth;
     v_blur = a_blur;
     v_opacity = a_opacity;
 }

--- a/shaders/linesdfpattern.fragment.glsl
+++ b/shaders/linesdfpattern.fragment.glsl
@@ -6,17 +6,18 @@ varying vec2 v_normal;
 varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying vec4 v_color;
-varying vec2 v_linewidth;
+varying float v_linewidth;
+varying float v_linegapwidth;
 varying float v_blur;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * v_linewidth.s;
+    float dist = length(v_normal) * v_linewidth;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp(min(dist - (v_linewidth.t - v_blur), v_linewidth.s - dist) / v_blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linegapwidth - v_blur), v_linewidth - dist) / v_blur, 0.0, 1.0);
 
     float sdfdist_a = texture2D(u_image, v_tex_a).a;
     float sdfdist_b = texture2D(u_image, v_tex_b).a;

--- a/shaders/linesdfpattern.vertex.glsl
+++ b/shaders/linesdfpattern.vertex.glsl
@@ -9,7 +9,8 @@
 attribute vec2 a_pos;
 attribute vec4 a_data;
 attribute vec4 a_color;
-attribute vec2 a_linewidth;
+attribute float a_linewidth;
+attribute float a_linegapwidth;
 attribute float a_blur;
 
 // matrix is for the vertex position, exmatrix is for rotating and projecting
@@ -27,7 +28,8 @@ varying vec2 v_normal;
 varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying vec4 v_color;
-varying vec2 v_linewidth;
+varying float v_linewidth;
+varying float v_linegapwidth;
 varying float v_blur;
 
 void main() {
@@ -44,7 +46,7 @@ void main() {
 
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
-    vec4 dist = vec4(a_linewidth.s * a_extrude * scale, 0.0, 0.0);
+    vec4 dist = vec4(a_linewidth * a_extrude * scale, 0.0, 0.0);
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -55,7 +57,8 @@ void main() {
     v_tex_a = vec2(a_linesofar * u_patternscale_a.x, normal.y * u_patternscale_a.y + u_tex_y_a);
     v_tex_b = vec2(a_linesofar * u_patternscale_b.x, normal.y * u_patternscale_b.y + u_tex_y_b);
 
-    v_color = a_color;
+    v_color = a_color / 255.0;
     v_linewidth = a_linewidth;
+    v_linegapwidth = a_linegapwidth;
     v_blur = a_blur;
 }

--- a/shaders/sdf.vertex.glsl
+++ b/shaders/sdf.vertex.glsl
@@ -72,7 +72,7 @@ void main() {
     v_gamma_scale = perspective_scale;
 
     v_tex = a_tex / u_texsize;
-    v_color = a_color;
+    v_color = a_color / 255.0;
     v_buffer = a_buffer;
     v_gamma = a_gamma;
 }

--- a/test/js/data/line_bucket.test.js
+++ b/test/js/data/line_bucket.test.js
@@ -21,6 +21,9 @@ test('LineBucket', function(t) {
     var pointWithScale = new Point(0, 0);
     pointWithScale.scale = 10;
 
+    bucket.layers = [];
+    bucket.calculatePaintAttributeOffsets();
+
     // should throw in the future?
     t.equal(bucket.addLine([
         new Point(0, 0)
@@ -46,7 +49,7 @@ test('LineBucket', function(t) {
         new Point(0, 0)
     ]), undefined);
 
-    t.equal(bucket.addFeature(feature.loadGeometry()), undefined);
+    t.equal(bucket.addFeature(feature), undefined);
 
     t.end();
 });

--- a/test/js/data/symbol_bucket.test.js
+++ b/test/js/data/symbol_bucket.test.js
@@ -32,6 +32,7 @@ test('SymbolBucket', function(t) {
         bucket.textFeatures = ['abcde'];
         bucket.stacks = { 'Test': glyphs };
         bucket.features = [feature];
+        bucket.layers = [];
         t.ok(bucket, 'bucketSetup');
         bucket.calculateLayoutProperties();
         return bucket;

--- a/test/js/data/symbol_bucket.test.js
+++ b/test/js/data/symbol_bucket.test.js
@@ -9,7 +9,7 @@ var SymbolBucket = require('../../../js/data/symbol_bucket');
 var BufferSet = require('../../../js/data/buffer/buffer_set');
 var Collision = require('../../../js/symbol/collision_tile');
 var GlyphAtlas = require('../../../js/symbol/glyph_atlas');
-var LayoutProperties = require('../../../js/style/layout_properties');
+var StyleDeclarationSet = require('../../../js/style/style_declaration_set');
 
 // Load a point feature from fixture tile.
 var vt = new VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
@@ -18,7 +18,7 @@ var glyphs = JSON.parse(fs.readFileSync(path.join(__dirname, '/../../fixtures/fo
 
 test('SymbolBucket', function(t) {
     /*eslint new-cap: 0*/
-    var info = new LayoutProperties.symbol({ type: 'symbol', 'text-font': 'Test' });
+    var values = new StyleDeclarationSet('layout', 'symbol', {'text-font': 'Test'}, {}).values();
     var buffers = new BufferSet();
     var collision = new Collision(0, 0);
     var atlas = new GlyphAtlas(1024, 1024);
@@ -28,11 +28,12 @@ test('SymbolBucket', function(t) {
     }
 
     function bucketSetup() {
-        var bucket = new SymbolBucket(buffers, info, 1);
+        var bucket = new SymbolBucket(buffers, values, 1);
         bucket.textFeatures = ['abcde'];
         bucket.stacks = { 'Test': glyphs };
         bucket.features = [feature];
         t.ok(bucket, 'bucketSetup');
+        bucket.calculateLayoutProperties();
         return bucket;
     }
 

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -24,7 +24,7 @@ test('basic', function(t) {
         coord: new TileCoord(1, 1, 1), overscaling: 1 });
 
     t.test('basic worker tile', function(t) {
-        tile.parse(new Wrapper(features), buckets, {}, function(err, result) {
+        tile.parse(new Wrapper(features), buckets, {}, {}, function(err, result) {
             t.equal(err, null);
             t.ok(result.buffers, 'buffers');
             t.ok(result.elementGroups, 'element groups');
@@ -40,7 +40,7 @@ test('basic', function(t) {
             layout: { visibility: 'none' },
             compare: function () { return true; }
         });
-        tile.parse(new Wrapper(features), buckets, {}, function(err, result) {
+        tile.parse(new Wrapper(features), buckets, {}, {}, function(err, result) {
             t.equal(err, null);
             t.equal(Object.keys(result.elementGroups).length, 1, 'element groups exclude hidden layer');
             t.end();

--- a/test/js/symbol/resolve_text.test.js
+++ b/test/js/symbol/resolve_text.test.js
@@ -13,6 +13,7 @@ function mockFeature(obj) {
 test('resolveText', function(t) {
     // Latin ranges.
     // Skips feature without text field.
+    var layout = { 'text-field': '{name}', 'text-font': 'Test' };
     t.deepEqual({
         textFeatures: [
             'Pennsylvania Ave NW DC',
@@ -20,17 +21,16 @@ test('resolveText', function(t) {
             null,
             '14 St NW'
         ],
-        codepoints: [ 32, 49, 52, 65, 66, 67, 68, 78, 80, 83, 87, 97, 101, 105, 107, 108, 110, 114, 115, 116, 118, 121 ]
+        codepoints: { 'Test': [ 32, 49, 52, 65, 66, 67, 68, 78, 80, 83, 87, 97, 101, 105, 107, 108, 110, 114, 115, 116, 118, 121 ] }
     }, resolveText([
         mockFeature({ 'name': 'Pennsylvania Ave NW DC' }),
         mockFeature({ 'name': 'Baker St' }),
         mockFeature({}),
         mockFeature({ 'name': '14 St NW' })
-    ], {
-        'text-field': '{name}'
-    }, {}));
+    ], [layout, layout, layout, layout], {}));
 
     // Token replacement.
+    layout = { 'text-field': '{name}-suffixed', 'text-font': 'Test' };
     t.deepEqual({
         textFeatures: [
             'Pennsylvania Ave NW DC-suffixed',
@@ -38,73 +38,67 @@ test('resolveText', function(t) {
             '-suffixed',
             '14 St NW-suffixed'
         ],
-        codepoints: [ 32, 45, 49, 52, 65, 66, 67, 68, 78, 80, 83, 87, 97, 100, 101, 102, 105, 107, 108, 110, 114, 115, 116, 117, 118, 120, 121 ]
+        codepoints: { 'Test': [ 32, 45, 49, 52, 65, 66, 67, 68, 78, 80, 83, 87, 97, 100, 101, 102, 105, 107, 108, 110, 114, 115, 116, 117, 118, 120, 121 ] }
     }, resolveText([
         mockFeature({ 'name': 'Pennsylvania Ave NW DC' }),
         mockFeature({ 'name': 'Baker St' }),
         mockFeature({}),
         mockFeature({ 'name': '14 St NW' })
-    ], {
-        'text-field': '{name}-suffixed'
-    }, {}));
+    ], [layout, layout, layout, layout], {}));
 
     // Non-latin ranges.
+    layout = { 'text-field': '{city}', 'text-font': 'Test' };
     t.deepEqual({
         textFeatures: [
             '서울특별시'
         ],
-        codepoints: [ 48324, 49436, 49884, 50872, 53945 ]
+        codepoints: { 'Test': [ 48324, 49436, 49884, 50872, 53945 ] }
     }, resolveText([
         mockFeature({ 'city': '서울특별시' })
-    ], {
-        'text-field': '{city}'
-    }, {}));
+    ], [layout], {}));
 
     // Includes unicode up to 65535.
+    layout = { 'text-field': '{text}', 'text-font': 'Test' };
     t.deepEqual({
         textFeatures: [
             '\ufff0',
             '\uffff'
         ],
-        codepoints: [ 65520, 65535 ]
+        codepoints: { 'Test': [ 65520, 65535 ] }
     }, resolveText([
         mockFeature({ 'text': '\ufff0' }),
         mockFeature({ 'text': '\uffff' })
-    ], {
-        'text-field': '{text}'
-    }, {}));
+    ], [layout, layout], {}));
 
     // Non-string values cast to strings.
+    layout = { 'text-field': '{name}', 'text-font': 'Test' };
     t.deepEqual({
         textFeatures: [
             '5000',
             '-15.5',
             'true'
         ],
-        codepoints: [ 45, 46, 48, 49, 53, 101, 114, 116, 117 ]
+        codepoints: { 'Test': [ 45, 46, 48, 49, 53, 101, 114, 116, 117 ] }
     }, resolveText([
         mockFeature({ 'name': 5000 }),
         mockFeature({ 'name': -15.5 }),
         mockFeature({ 'name': true })
-    ], {
-        'text-field': '{name}'
-    }, {}));
+    ], [layout, layout, layout], {}));
 
     // Non-string values cast to strings, with token replacement.
+    layout = { 'text-field': '{name}-suffix', 'text-font': 'Test' };
     t.deepEqual({
         textFeatures: [
             '5000-suffix',
             '-15.5-suffix',
             'true-suffix'
         ],
-        codepoints: [ 45, 46, 48, 49, 53, 101, 102, 105, 114, 115, 116, 117, 120 ]
+        codepoints: { 'Test': [ 45, 46, 48, 49, 53, 101, 102, 105, 114, 115, 116, 117, 120 ] }
     }, resolveText([
         mockFeature({ 'name': 5000 }),
         mockFeature({ 'name': -15.5 }),
         mockFeature({ 'name': true })
-    ], {
-        'text-field': '{name}-suffix'
-    }, {}));
+    ], [layout, layout, layout], {}));
 
 
     t.end();


### PR DESCRIPTION
Instead of having one layout property value for an entire layer, calculate values separately for each feature. This will eventually enable things like multiple fonts within a single layer.

Since the style functions don't make use of the feature properties yet all properties within a layer still have identical values.

This should not have any impact rendering.

@jfirebaugh want to review?