### PR TITLE
Fixed license according to SPDX expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A WebGL interactive maps library",
   "version": "0.8.0",
   "main": "js/mapbox-gl.js",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.com/mapbox/mapbox-gl-js.git"


### PR DESCRIPTION
I got this warning while issuing `npm install`:

```npm WARN package.json mapbox-gl@0.8.0 license should be a valid SPDX
license expression```

See http://spdx.org/licenses/BSD-3-Clause for details.