### PR TITLE
Expose geojson-vt options in GeoJSONSource

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -14,6 +14,8 @@ module.exports = GeoJSONSource;
  * @param {Object} [options]
  * @param {Object|string} options.data A GeoJSON data object or URL to it. The latter is preferable in case of large GeoJSON files.
  * @param {number} [options.maxzoom=14] Maximum zoom to preserve detail at.
+ * @param {number} [options.buffer] Tile buffer on each side.
+ * @param {number} [options.tolerance] Simplification tolerance (higher means simpler).
  * @example
  * var sourceObj = new mapboxgl.GeoJSONSource({
  *    data: {
@@ -39,6 +41,10 @@ function GeoJSONSource(options) {
     this._data = options.data;
 
     if (options.maxzoom !== undefined) this.maxzoom = options.maxzoom;
+
+    this.geojsonVtOptions = { maxZoom: this.maxzoom };
+    if (options.buffer !== undefined) this.geojsonVtOptions.buffer = options.buffer;
+    if (options.tolerance !== undefined) this.geojsonVtOptions.tolerance = options.tolerance;
 
     this._pyramid = new TilePyramid({
         tileSize: 512,
@@ -111,7 +117,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             data: data,
             tileSize: 512,
             source: this.id,
-            maxZoom: this.maxzoom
+            geojsonVtOptions: this.geojsonVtOptions
         }, function(err) {
 
             if (err) {

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -101,7 +101,7 @@ util.extend(Worker.prototype, {
     'parse geojson': function(params, callback) {
         var indexData = function(err, data) {
             if (err) return callback(err);
-            this.geoJSONIndexes[params.source] = geojsonvt(data, {maxZoom: params.maxZoom});
+            this.geoJSONIndexes[params.source] = geojsonvt(data, params.geojsonVtOptions);
             callback(null);
         }.bind(this);
 

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -75,6 +75,29 @@ test('GeoJSONSource#update', function(t) {
         source.update(transform);
     });
 
+    t.test('forwards geojson-vt options with worker request', function(t) {
+        var source = new GeoJSONSource({
+          data: {},
+          maxzoom: 10,
+          tolerance: 2,
+          buffer: 128
+        });
+
+        source.dispatcher = {
+            send: function(message, params) {
+                t.equal(message, 'parse geojson');
+                t.deepEqual(params.geojsonVtOptions, {
+                  maxZoom: 10,
+                  tolerance: 2,
+                  buffer: 128
+                });
+                t.end();
+            }
+        };
+
+        source.update(transform);
+    });
+
     t.test('emits change on success', function(t) {
         var source = new GeoJSONSource({data: {}});
 


### PR DESCRIPTION
Specifically, this exposes `buffer` and `tolerance` options.

See #1271 for some background.