### PR TITLE
Bind [mouse|touch]move handlers to document only when necessary

### DIFF
--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -76,9 +76,6 @@ function Interaction(el) {
     document.addEventListener('mouseup', onmouseup, false);
     document.addEventListener('touchend', onmouseup, false);
 
-    document.addEventListener('mousemove', onmousemove, false);
-    document.addEventListener('touchmove', ontouchmove, false);
-
     el.addEventListener('click', onclick, false);
     scrollwheel(zoom);
     el.addEventListener('dblclick', ondoubleclick, false);
@@ -168,6 +165,9 @@ function Interaction(el) {
     }
 
     function onmousedown(ev) {
+        document.addEventListener('mousemove', onmousemove, false);
+        document.addEventListener('touchmove', ontouchmove, false);
+
         firstPos = pos = mousePos(ev);
         interaction.fire('down');
         if (ev.shiftKey || ((ev.which === 1) && (ev.button === 1))) {
@@ -240,6 +240,8 @@ function Interaction(el) {
     var tapped;
 
     function ontouchstart(e) {
+        document.addEventListener('touchmove', ontouchmove, false);
+
         if (e.touches.length === 1) {
             onmousedown(e);
 

--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -176,6 +176,9 @@ function Interaction(el) {
     }
 
     function onmouseup(ev) {
+        document.removeEventListener('mousemove', onmousemove, false);
+        document.removeEventListener('touchmove', ontouchmove, false);
+
         panned = pos && firstPos && (pos.x !== firstPos.x || pos.y !== firstPos.y);
 
         rotating = false;


### PR DESCRIPTION
Hi there - we've found what seems like a bug in 0.8 involving touch events. The mousemove/touchmove handlers are bound to the entire document (rather than the map container) whenever interactions are enabled, and because the event default is [prevented](https://github.com/mapbox/mapbox-gl-js/blob/597ffad1eaf67ef380619e20f1321a4cf334cb3f/js/ui/interaction.js#L279) that was preventing scrolling when a user interacted with the page *outside* the map container.

This PR addresses it by only binding the `onmousemove` and `ontouchmove` handlers at the start of an interaction (i.e. as soon as `onmousedown` or `ontouchstart` is called). The handlers are removed inside `onmouseup`.

Thanks for all your work on this library, it's terrific. Afraid I haven't been able to run the tests (`gl` won't install), but have confirmed it solves the scrolling issue.