### PR TITLE
Support bubbling of events for custom overlays.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /node_modules
 *.sublime-*
 coverage
+.DS_Store

--- a/js/ui/handler/box_zoom.js
+++ b/js/ui/handler/box_zoom.js
@@ -9,7 +9,7 @@ module.exports = BoxZoom;
 
 function BoxZoom(map) {
     this._map = map;
-    this._el = map.getCanvas();
+    this._el = map.getCanvasContainer();
     this._container = map.getContainer();
 
     util.bindHandlers(this);

--- a/js/ui/handler/drag_pan.js
+++ b/js/ui/handler/drag_pan.js
@@ -14,7 +14,7 @@ var inertiaLinearity = 0.2,
 
 function DragPan(map) {
     this._map = map;
-    this._el = map.getCanvas();
+    this._el = map.getCanvasContainer();
 
     util.bindHandlers(this);
 }

--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -9,7 +9,7 @@ module.exports = DragRotate;
 
 function DragRotate(map) {
     this._map = map;
-    this._el = map.getCanvas();
+    this._el = map.getCanvasContainer();
 
     util.bindHandlers(this);
 }

--- a/js/ui/handler/keyboard.js
+++ b/js/ui/handler/keyboard.js
@@ -9,7 +9,7 @@ var panDelta = 80,
 
 function Keyboard(map) {
     this._map = map;
-    this._el = map.getCanvas();
+    this._el = map.getCanvasContainer();
 
     this._onKeyDown = this._onKeyDown.bind(this);
 }

--- a/js/ui/handler/pinch.js
+++ b/js/ui/handler/pinch.js
@@ -8,7 +8,7 @@ module.exports = Pinch;
 
 function Pinch(map) {
     this._map = map;
-    this._el = map.getCanvas();
+    this._el = map.getCanvasContainer();
 
     util.bindHandlers(this);
 }

--- a/js/ui/handler/scroll_zoom.js
+++ b/js/ui/handler/scroll_zoom.js
@@ -14,7 +14,7 @@ var ua = typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : 
 
 function ScrollZoom(map) {
     this._map = map;
-    this._el = map.getCanvas();
+    this._el = map.getCanvasContainer();
 
     util.bindHandlers(this);
 }

--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -50,7 +50,7 @@ module.exports = Interaction;
 
 function Interaction(map) {
     this._map = map;
-    this._el = map.getCanvas();
+    this._el = map.getCanvasContainer();
 
     for (var name in handlers) {
         map[name] = new handlers[name](map);


### PR DESCRIPTION
This makes it so overlays placed in the canvas container can capture some events like "click" and bubble up others (like scrolling) to the canvas container. This wont change the behavior of controls since they're not children of the canvas container. 