### PR TITLE
Snap bearing to north

### DIFF
--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -293,6 +293,20 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
         return this;
     },
 
+    /**
+     * Animates map bearing to 0 (north) if it's already close to it.
+     *
+     * @param {AnimationOptions} [options]
+     * @fires movestart
+     * @fires moveend
+     * @returns {Map} `this`
+     */
+    snapToNorth: function(options) {
+        if (Math.abs(this.getBearing()) < this.options.bearingSnap) {
+            return this.resetNorth(options);
+        }
+        return this;
+    },
 
     /**
      * Get the current angle in degrees

--- a/js/ui/control/navigation.js
+++ b/js/ui/control/navigation.js
@@ -81,6 +81,8 @@ Navigation.prototype = util.inherit(Control, {
             this._moved = false;
             DOM.suppressClick();
         }
+
+        this._map.snapToNorth();
     },
 
     _createButton: function(className, fn) {

--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -24,8 +24,9 @@ DragRotate.prototype = {
     },
 
     _onContextMenu: function (e) {
-        this._startPos = this._pos = DOM.mousePos(this._el, e);
+        this._map.stop();
         this.active = true;
+        this._startPos = this._pos = DOM.mousePos(this._el, e);
 
         document.addEventListener('mousemove', this._onMouseMove, false);
         document.addEventListener('mouseup', this._onMouseUp, false);
@@ -67,9 +68,15 @@ DragRotate.prototype = {
     },
 
     _onTimeout: function () {
-        this._map.rotating = false;
-        this._map._rerender();
-        this._map.fire('moveend');
+        var map = this._map;
+
+        map.rotating = false;
+        map.snapToNorth();
+
+        if (!map.rotating) {
+            map._rerender();
+            map.fire('moveend');
+        }
     },
 
     _onMouseUp: function () {

--- a/js/ui/handler/pinch.js
+++ b/js/ui/handler/pinch.js
@@ -58,6 +58,8 @@ Pinch.prototype = {
     },
 
     _onEnd: function () {
+        this._map.snapToNorth();
+
         document.removeEventListener('touchmove', this._onMove);
         document.removeEventListener('touchend', this._onEnd);
     }

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -39,6 +39,7 @@ var Attribution = require('./control/attribution');
  * @param {Object} options.style Map style and data source definition (either a JSON object or a JSON URL), described in the [style reference](https://mapbox.com/mapbox-gl-style-spec/)
  * @param {boolean} [options.hash=false] If `true`, the map will track and update the page URL according to map position
  * @param {boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners are attached to the map, so it will not respond to input
+ * @param {number} [options.bearingSnap=7] Snap to north threshold in degrees.
  * @param {Array} options.classes Style class names with which to initialize the map
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than expected.
  * @param {boolean} [options.preserveDrawingBuffer=false] If `true`, The maps canvas can be exported to a PNG using `map.getCanvas().toDataURL();`. This is false by default as a performance optimization.
@@ -139,6 +140,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         keyboard: true,
         doubleClickZoom: true,
         pinch: true,
+
+        bearingSnap: 7,
 
         hash: false,
 


### PR DESCRIPTION
Closes #1059. Adds `map.snapToNorth()` and uses it when doing drag rotate and pinch zoom.
Not sure `bearingSnap` is the best option name but can't think of a better one.

cc @jfirebaugh @friedbunny 