### PR TITLE
fix data driven line width and gap

### DIFF
--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -132,7 +132,7 @@ LineBucket.prototype.addFeature = function(feature) {
 
         var gapWidthOffset = offsets.gapWidth;
         if (gapWidthOffset !== undefined) {
-            var gapWidth = partiallyEvaluated.gapWidth(feature.properties);
+            var gapWidth = partiallyEvaluated.gapWidth(feature.properties) / 2;
             for (index = featureStartIndex; index < featureEndIndex; index++) {
                 lineVertex.addWidth(index, gapWidthOffset, gapWidth);
             }

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -30,20 +30,8 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
     var antialiasing = 1 / browser.devicePixelRatio;
 
     var blur = layer.paint['line-blur'] + antialiasing;
-    var edgeWidth = layer.paint['line-width'] / 2;
-    var inset = -1;
-    var offset = 0;
-    var shift = 0;
-
-    if (layer.paint['line-gap-width'] > 0) {
-        inset = layer.paint['line-gap-width'] / 2 + antialiasing * 0.5;
-        edgeWidth = layer.paint['line-width'];
-
-        // shift outer lines half a pixel towards the middle to eliminate the crack
-        offset = inset - antialiasing / 2;
-    }
-
-    var outset = offset + edgeWidth + antialiasing / 2 + shift;
+    var inset = layer.paint['line-gap-width'] / 2;
+    var outset = layer.paint['line-width'] / 2;
 
     var color = layer.paint['line-color'];
     var ratio = painter.transform.scale / (1 << tile.coord.z) / (tile.tileExtent / tile.tileSize);
@@ -77,6 +65,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.switchShader(shader, vtxMatrix, tile.exMatrix);
 
         gl.uniform1f(shader.u_ratio, ratio);
+        gl.uniform1f(shader.u_antialiasing, antialiasing / 2);
 
         var posA = painter.lineAtlas.getDash(dasharray.from, layer.layout['line-cap'] === 'round');
         var posB = painter.lineAtlas.getDash(dasharray.to, layer.layout['line-cap'] === 'round');
@@ -109,6 +98,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.switchShader(shader, vtxMatrix, tile.exMatrix);
 
         gl.uniform1f(shader.u_ratio, ratio);
+        gl.uniform1f(shader.u_antialiasing, antialiasing / 2);
 
         gl.uniform2fv(shader.u_pattern_size_a, [imagePosA.size[0] * factor * image.fromScale, imagePosB.size[1] ]);
         gl.uniform2fv(shader.u_pattern_size_b, [imagePosB.size[0] * factor * image.toScale, imagePosB.size[1] ]);
@@ -128,6 +118,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.switchShader(shader, vtxMatrix, tile.exMatrix);
 
         gl.uniform1f(shader.u_ratio, ratio);
+        gl.uniform1f(shader.u_antialiasing, antialiasing / 2);
         gl.uniform1f(shader.u_extra, extra);
         gl.uniformMatrix2fv(shader.u_antialiasingmatrix, false, antialiasingMatrix);
     }

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -68,15 +68,15 @@ Painter.prototype.setup = function() {
 
     this.lineShader = gl.initializeShader('line',
         ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur', 'a_linegapwidth'],
-        ['u_matrix', 'u_ratio', 'u_extra', 'u_antialiasingmatrix']);
+        ['u_matrix', 'u_ratio', 'u_extra', 'u_antialiasingmatrix', 'u_antialiasing']);
 
     this.linepatternShader = gl.initializeShader('linepattern',
         ['a_pos', 'a_data', 'a_linewidth', 'a_blur', 'a_opacity', 'a_linegapwidth'],
-        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_fade']);
+        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_pattern_size_a', 'u_pattern_size_b', 'u_pattern_tl_a', 'u_pattern_br_a', 'u_pattern_tl_b', 'u_pattern_br_b', 'u_fade', 'u_antialiasing']);
 
     this.linesdfpatternShader = gl.initializeShader('linesdfpattern',
         ['a_pos', 'a_data', 'a_color', 'a_linewidth', 'a_blur', 'a_linegapwidth'],
-        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix']);
+        ['u_matrix', 'u_exmatrix', 'u_ratio', 'u_patternscale_a', 'u_tex_y_a', 'u_patternscale_b', 'u_tex_y_b', 'u_image', 'u_sdfgamma', 'u_mix', 'u_antialiasing']);
 
     this.dotShader = gl.initializeShader('dot',
         ['a_pos'],

--- a/shaders/line.vertex.glsl
+++ b/shaders/line.vertex.glsl
@@ -19,6 +19,7 @@ uniform highp mat4 u_matrix;
 
 // shared
 uniform float u_ratio;
+uniform float u_antialiasing;
 
 uniform float u_extra;
 uniform mat2 u_antialiasingmatrix;
@@ -42,9 +43,13 @@ void main() {
     normal.y = sign(normal.y - 0.5);
     v_normal = normal;
 
+    float linegapIsNonzero = step(0.01, a_linegapwidth);
+    v_linewidth = a_linewidth + u_antialiasing + (a_linegapwidth + a_linewidth) * linegapIsNonzero;
+    v_linegapwidth = (a_linegapwidth + u_antialiasing) * linegapIsNonzero;
+
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
-    vec4 dist = vec4(a_linewidth * a_extrude * scale, 0.0, 0.0);
+    vec4 dist = vec4(v_linewidth * a_extrude * scale, 0.0, 0.0);
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -64,7 +69,5 @@ void main() {
     gamma_scale = perspective_scale * squish_scale;
 
     v_color = a_color / 255.0;
-    v_linewidth = a_linewidth;
-    v_linegapwidth = a_linegapwidth;
     v_blur = a_blur;
 }

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -20,6 +20,7 @@ uniform mat4 u_exmatrix;
 
 // shared
 uniform float u_ratio;
+uniform float u_antialiasing;
 
 varying vec2 v_normal;
 varying float v_linesofar;
@@ -40,10 +41,14 @@ void main() {
     normal.y = sign(normal.y - 0.5);
     v_normal = normal;
 
+    float linegapIsNonzero = step(0.01, a_linegapwidth);
+    v_linewidth = a_linewidth + u_antialiasing + (a_linegapwidth + a_linewidth) * linegapIsNonzero;
+    v_linegapwidth = a_linegapwidth + u_antialiasing * linegapIsNonzero;
+
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
     vec2 extrude = a_extrude * scale;
-    vec2 dist = a_linewidth * extrude;
+    vec2 dist = v_linewidth * extrude;
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -52,8 +57,6 @@ void main() {
     gl_Position = u_matrix * vec4(floor(a_pos * 0.5) + dist.xy / u_ratio, 0.0, 1.0);
     v_linesofar = a_linesofar;// * u_ratio;
 
-    v_linewidth = a_linewidth;
-    v_linegapwidth = a_linegapwidth;
     v_blur = a_blur;
     v_opacity = a_opacity;
 }

--- a/shaders/linesdfpattern.vertex.glsl
+++ b/shaders/linesdfpattern.vertex.glsl
@@ -23,6 +23,7 @@ uniform vec2 u_patternscale_a;
 uniform float u_tex_y_a;
 uniform vec2 u_patternscale_b;
 uniform float u_tex_y_b;
+uniform float u_antialiasing;
 
 varying vec2 v_normal;
 varying vec2 v_tex_a;
@@ -44,9 +45,13 @@ void main() {
     normal.y = sign(normal.y - 0.5);
     v_normal = normal;
 
+    float linegapIsNonzero = step(0.01, a_linegapwidth);
+    v_linewidth = a_linewidth + u_antialiasing + (a_linegapwidth + a_linewidth) * linegapIsNonzero;
+    v_linegapwidth = a_linegapwidth + u_antialiasing * linegapIsNonzero;
+
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
-    vec4 dist = vec4(a_linewidth * a_extrude * scale, 0.0, 0.0);
+    vec4 dist = vec4(v_linewidth * a_extrude * scale, 0.0, 0.0);
 
     // Remove the texture normal bit of the position before scaling it with the
     // model/view matrix. Add the extrusion vector *after* the model/view matrix
@@ -58,7 +63,5 @@ void main() {
     v_tex_b = vec2(a_linesofar * u_patternscale_b.x, normal.y * u_patternscale_b.y + u_tex_y_b);
 
     v_color = a_color / 255.0;
-    v_linewidth = a_linewidth;
-    v_linegapwidth = a_linegapwidth;
     v_blur = a_blur;
 }


### PR DESCRIPTION
Lines weren't getting drawn correctly if they had
- a data driven line-gap-width
- a data driven line-width with a nonzero line-gap-width

This fixes those cases.

@lucaswoj 