### PR TITLE
Reload layer source after adding

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -295,6 +295,9 @@ Style.prototype = util.inherit(Evented, {
         layer.resolvePaint();
         this._groupLayers();
         this._broadcastLayers();
+        if (layer.source) {
+            this.sources[layer.source].reload();
+        }
         this.fire('layer.add', {layer: layer});
         return this;
     },

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -243,6 +243,29 @@ test('Style#addLayer', function(t) {
         });
     });
 
+    t.test('reloads source', function(t) {
+        var style = new Style(util.extend(createStyleJSON(), {
+            "sources": {
+                "mapbox": {
+                    "type": "vector",
+                    "tiles": []
+                }
+            }
+        }));
+        var layer = {
+            "id": "symbol",
+            "type": "symbol",
+            "source": "mapbox",
+            "filter": ["==", "id", 0]
+        };
+
+        style.on('load', function() {
+            style.getSource('mapbox').reload = t.end;
+
+            style.addLayer(layer);
+        });
+    });
+
     t.test('fires layer.add', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};


### PR DESCRIPTION
When calling `map.addLayer()`, if geometry is being styled for the first
time, the new geometry does not render. However, as you zoom or pan the
map to a new tile the correct geometry renders.

New layers with sources need their sources to be refreshed in order to
pickup previously unused geometry.