### PR TITLE
Efficiently apply style changes

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -216,6 +216,9 @@ Style.prototype = util.inherit(Evented, {
     },
 
     addSource: function(id, source) {
+        if (!this._loaded) {
+            throw new Error('Style is not done loading');
+        }
         if (this.sources[id] !== undefined) {
             throw new Error('There is already a source with this ID');
         }
@@ -245,6 +248,9 @@ Style.prototype = util.inherit(Evented, {
      * @private
      */
     removeSource: function(id) {
+        if (!this._loaded) {
+            throw new Error('Style is not done loading');
+        }
         if (this.sources[id] === undefined) {
             throw new Error('There is no source with this ID');
         }
@@ -282,6 +288,9 @@ Style.prototype = util.inherit(Evented, {
      * @private
      */
     addLayer: function(layer, before) {
+        if (!this._loaded) {
+            throw new Error('Style is not done loading');
+        }
         if (this._layers[layer.id] !== undefined) {
             throw new Error('There is already a layer with this ID');
         }
@@ -310,6 +319,9 @@ Style.prototype = util.inherit(Evented, {
      * @private
      */
     removeLayer: function(id) {
+        if (!this._loaded) {
+            throw new Error('Style is not done loading');
+        }
         var layer = this._layers[id];
         if (layer === undefined) {
             throw new Error('There is no layer with this ID');
@@ -354,6 +366,9 @@ Style.prototype = util.inherit(Evented, {
     },
 
     setFilter: function(layer, filter) {
+        if (!this._loaded) {
+            throw new Error('Style is not done loading');
+        }
         layer = this.getReferentLayer(layer);
         layer.filter = filter;
         this._broadcastLayers();
@@ -372,6 +387,9 @@ Style.prototype = util.inherit(Evented, {
     },
 
     setLayoutProperty: function(layer, name, value) {
+        if (!this._loaded) {
+            throw new Error('Style is not done loading');
+        }
         layer = this.getReferentLayer(layer);
         layer.setLayoutProperty(name, value);
         this._broadcastLayers();
@@ -393,6 +411,9 @@ Style.prototype = util.inherit(Evented, {
     },
 
     setPaintProperty: function(layer, name, value, klass) {
+        if (!this._loaded) {
+            throw new Error('Style is not done loading');
+        }
         this.getLayer(layer).setPaintProperty(name, value, klass);
         this.fire('change');
     },

--- a/js/style/style_diff.js
+++ b/js/style/style_diff.js
@@ -1,0 +1,255 @@
+'use strict';
+
+var isEqual = require('lodash.isequal');
+
+var operations = {
+    addLayer: 'addLayer',
+    removeLayer: 'removeLayer',
+    setPaintProperty: 'setPaintProperty',
+    setLayoutProperty: 'setLayoutProperty',
+    setFilter: 'setFilter',
+    addSource: 'addSource',
+    removeSource: 'removeSource',
+
+    // prospective operations
+    setStyle: 'setStyle',
+    setConstant: 'setConstant',
+    setSprite: 'setSprite',
+    setGlyphs: 'setGlyphs',
+    setTransition: 'setTransition',
+    setLayerProperty: 'setLayerProperty'
+};
+
+function pluckId(layer) {
+    return layer.id;
+}
+function mapById(group, layer) {
+    group[layer.id] = layer;
+    return group;
+}
+
+function computeConstantChanges(before, after, commands) {
+    before = before || {};
+    after = after || {};
+    var prop;
+    for (prop in before) {
+        if (!before.hasOwnProperty(prop)) continue;
+        if (!isEqual(before[prop], after[prop])) {
+            commands.push({ command: operations.setConstant, args: [prop, after[prop]] });
+        }
+    }
+    for (prop in after) {
+        if (!after.hasOwnProperty(prop) || before.hasOwnProperty(prop)) continue;
+        if (!isEqual(before[prop], after[prop])) {
+            commands.push({ command: operations.setConstant, args: [prop, after[prop]] });
+        }
+    }
+}
+
+function computeSourceChanges(before, after, commands) {
+    before = before || {};
+    after = after || {};
+
+    var sourceId;
+
+    // look for sources to remove
+    for (sourceId in before) {
+        if (!before.hasOwnProperty(sourceId)) continue;
+        if (!after.hasOwnProperty(sourceId)) {
+            commands.push({ command: operations.removeSource, args: [sourceId] });
+        }
+    }
+
+    // look for sources to add/update
+    for (sourceId in after) {
+        if (!after.hasOwnProperty(sourceId)) continue;
+        if (!before.hasOwnProperty(sourceId)) {
+            commands.push({ command: operations.addSource, args: [sourceId, after[sourceId]] });
+        }
+        else if (!isEqual(before[sourceId], after[sourceId])) {
+            // no update command, must remove then add
+            commands.push({ command: operations.removeSource, args: [sourceId] });
+            commands.push({ command: operations.addSource, args: [sourceId, after[sourceId]] });
+        }
+    }
+}
+
+function computeLayerPropertyChanges(before, after, commands, layerId, klass, command) {
+    before = before || {};
+    after = after || {};
+
+    var prop;
+
+    for (prop in before) {
+        if (!before.hasOwnProperty(prop)) continue;
+        if (!isEqual(before[prop], after[prop])) {
+            commands.push({ command: command, args: [layerId, prop, after[prop], klass] });
+        }
+    }
+    for (prop in after) {
+        if (!after.hasOwnProperty(prop) || before.hasOwnProperty(prop)) continue;
+        if (!isEqual(before[prop], after[prop])) {
+            commands.push({ command: command, args: [layerId, prop, after[prop], klass] });
+        }
+    }
+}
+
+function computeLayerChanges(before, after, commands) {
+    before = before || [];
+    after = after || [];
+
+    // order of layers by id
+    var beforeOrder = before.map(pluckId);
+    var afterOrder = after.map(pluckId);
+
+    // index of layer by id
+    var beforeIndex = before.reduce(mapById, {});
+    var afterIndex = after.reduce(mapById, {});
+
+    // track order of layers as if they have been mutated
+    var tracker = beforeOrder.slice();
+
+    // layers that have been added do not need to be diffed
+    var clean = Object.create(null);
+
+    var i, d, layerId, insertBeforeLayerId, beforeLayer, afterLayer, prop;
+
+    // remove layers
+    for (i = 0, d = 0; i < beforeOrder.length; i++) {
+        layerId = beforeOrder[i];
+        if (!afterIndex.hasOwnProperty(layerId)) {
+            commands.push({ command: operations.removeLayer, args: [layerId] });
+            tracker.splice(tracker.indexOf(layerId, d), 1);
+        } else {
+            // limit where in tracker we need to look for a match
+            d++;
+        }
+    }
+
+    // add/reorder layers
+    for (i = 0, d = 0; i < afterOrder.length; i++) {
+        // work backwards as insert is before an existing layer
+        layerId = afterOrder[afterOrder.length - 1 - i];
+
+        if (tracker[tracker.length - 1 - i] === layerId) continue;
+
+        if (beforeIndex.hasOwnProperty(layerId)) {
+            // remove the layer before we insert at the correct position
+            commands.push({ command: operations.removeLayer, args: [layerId] });
+            tracker.splice(tracker.lastIndexOf(layerId, tracker.length - d), 1);
+        } else {
+            // limit where in tracker we need to look for a match
+            d++;
+        }
+
+        // add layer at correct position
+        insertBeforeLayerId = tracker[tracker.length - i];
+        commands.push({ command: operations.addLayer, args: [afterIndex[layerId], insertBeforeLayerId] });
+        tracker.splice(tracker.length - i, 0, layerId);
+        clean[layerId] = true;
+    }
+
+    // update layers
+    for (i = 0; i < afterOrder.length; i++) {
+        layerId = afterOrder[i];
+        beforeLayer = beforeIndex[layerId];
+        afterLayer = afterIndex[layerId];
+
+        // no need to update if previously added (new or moved)
+        if (clean[layerId] || isEqual(beforeLayer, afterLayer)) continue;
+
+        // layout, paint, filter
+        computeLayerPropertyChanges(beforeLayer.layout, afterLayer.layout, commands, layerId, null, operations.setLayoutProperty);
+        computeLayerPropertyChanges(beforeLayer.paint, afterLayer.paint, commands, layerId, null, operations.setPaintProperty);
+        if (!isEqual(beforeLayer.filter, afterLayer.filter)) {
+            commands.push({ command: operations.setFilter, args: [layerId, afterLayer.filter] });
+        }
+
+        // handle all other layer props, including paint.*
+        for (prop in beforeLayer) {
+            if (!beforeLayer.hasOwnProperty(prop)) continue;
+            if (prop === 'layout' || prop === 'paint' || prop === 'filter') continue;
+            if (prop.indexOf('paint.') === 0) {
+                computeLayerPropertyChanges(beforeLayer[prop], afterLayer[prop], commands, layerId, prop.slice(6), operations.setPaintProperty);
+            } else if (!isEqual(beforeLayer[prop], afterLayer[prop])) {
+                commands.push({ command: operations.setLayerProperty, args: [layerId, prop, afterLayer[prop]] });
+            }
+        }
+        for (prop in afterLayer) {
+            if (!afterLayer.hasOwnProperty(prop) || beforeLayer.hasOwnProperty(prop)) continue;
+            if (prop === 'layout' || prop === 'paint' || prop === 'filter') continue;
+            if (prop.indexOf('paint.') === 0) {
+                computeLayerPropertyChanges(beforeLayer[prop], afterLayer[prop], commands, layerId, prop.slice(6), operations.setPaintProperty);
+            } else if (!isEqual(beforeLayer[prop], afterLayer[prop])) {
+                commands.push({ command: operations.setLayerProperty, args: [layerId, prop, afterLayer[prop]] });
+            }
+        }
+    }
+}
+
+function computeStyleChanges(before, after) {
+    after = after || {};
+    if (!before) return [{ command: operations.setStyle, args: [after] }];
+
+    var commands = [];
+
+    try {
+        if (!isEqual(before.sprite, after.sprite)) {
+            commands.push({ command: operations.setSprite, args: [after.sprite] });
+        }
+        if (!isEqual(before.glyphs, after.glyphs)) {
+            commands.push({ command: operations.setGlyphs, args: [after.glyphs] });
+        }
+        if (!isEqual(before.transition, after.transition)) {
+            commands.push({ command: operations.setTransition, args: [after.transition] });
+        }
+        computeConstantChanges(before.constants, after.constants, commands);
+        computeSourceChanges(before.sources, after.sources, commands);
+        computeLayerChanges(before.layers, after.layers, commands);
+    } catch (e) {
+        // fall back to setStyle
+        console.warn('Unable to compute style diff:', e);
+        commands = [{ command: operations.setStyle, args: [after] }];
+    }
+
+    return commands;
+}
+
+function applyStyleChanges(style, commands) {
+    style.batch(function () {
+        for (var i = 0; i < commands.length; i++) {
+            switch (commands[i].command) {
+                case operations.addLayer:
+                    style.addLayer.apply(style, commands[i].args);
+                    break;
+                case operations.removeLayer:
+                    style.removeLayer.apply(style, commands[i].args);
+                    break;
+                case operations.setPaintProperty:
+                    style.setPaintProperty.apply(style, commands[i].args);
+                    break;
+                case operations.setLayoutProperty:
+                    style.setLayoutProperty.apply(style, commands[i].args);
+                    break;
+                case operations.setFilter:
+                    style.setFilter.apply(style, commands[i].args);
+                    break;
+                case operations.addSource:
+                    style.addSource.apply(style, commands[i].args);
+                    break;
+                case operations.removeSource:
+                    style.removeSource.apply(style, commands[i].args);
+                    break;
+                default:
+                    throw new Error('Unable to apply command \'' + commands[i].command + '\' to style');
+            }
+        }
+    });
+
+    return style;
+}
+
+module.exports = computeStyleChanges;
+module.exports.diff = computeStyleChanges;
+module.exports.patch = applyStyleChanges;
+module.exports.operations = operations;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gl-matrix": "^2.3.1",
     "glify": "^0.5.0",
     "lodash.clonedeep": "^3.0.1",
+    "lodash.isequal": "^3.0.4",
     "mapbox-gl-function": "^1.0.0",
     "mapbox-gl-style-spec": "^7.4.1",
     "minifyify": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#632163906f90883c611d09f57a5c5b988d1e923f",
     "mkdirp": "^0.5.1",
     "prova": "^2.1.2",
+    "sinon": "^1.15.4",
     "st": "^0.5.4",
     "through": "^2.3.7",
     "watchify": "^3.2.2"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "geojson-vt": "^2.1.0",
     "gl-matrix": "^2.3.1",
     "glify": "^0.5.0",
+    "lodash.clonedeep": "^3.0.1",
     "mapbox-gl-function": "^1.0.0",
     "mapbox-gl-style-spec": "^7.4.1",
     "minifyify": "^7.0.1",

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -4,6 +4,7 @@ var test = require('prova');
 var st = require('st');
 var http = require('http');
 var path = require('path');
+var sinon = require('sinon');
 var Style = require('../../../js/style/style');
 var VectorTileSource = require('../../../js/source/vector_tile_source');
 var LayoutProperties = require('../../../js/style/layout_properties');
@@ -1095,5 +1096,111 @@ test('Style#featuresAt', function(t) {
         });
 
         t.end();
+    });
+});
+
+test('Style#batch', function(t) {
+    t.test('hoists and replaces methods', function(t) {
+        var style = new Style(createStyleJSON());
+        var methods = {
+            fire: style.fire,
+            _groupLayers: style._groupLayers,
+            _broadcastLayers: style._broadcastLayers,
+            _reloadSource: style._reloadSource
+        };
+        style.on('load', function() {
+            style.batch(function() {
+                t.notEqual(style.fire, methods.fire, 'surrogate method');
+                t.notEqual(style._groupLayers, methods._groupLayers, 'surrogate method');
+                t.notEqual(style._broadcastLayers, methods._broadcastLayers, 'surrogate method');
+                t.notEqual(style._reloadSource, methods._reloadSource, 'surrogate method');
+            });
+
+            t.equal(style.fire, methods.fire, 'original method');
+            t.equal(style._groupLayers, methods._groupLayers, 'original method');
+            t.equal(style._broadcastLayers, methods._broadcastLayers, 'original method');
+            t.equal(style._reloadSource, methods._reloadSource, 'original method');
+
+            t.end();
+        });
+    });
+
+    t.test('hoists and replaces methods after error', function(t) {
+        var style = new Style(createStyleJSON());
+        var methods = {
+            fire: style.fire,
+            _groupLayers: style._groupLayers,
+            _broadcastLayers: style._broadcastLayers,
+            _reloadSource: style._reloadSource
+        };
+        style.on('load', function() {
+            var error = new Error('Must recover');
+
+            t.throws(function() {
+                style.batch(function() {
+                    throw error;
+                });
+            }, error, 'same error as thrown');
+
+            t.equal(style.fire, methods.fire, 'original method');
+            t.equal(style._groupLayers, methods._groupLayers, 'original method');
+            t.equal(style._broadcastLayers, methods._broadcastLayers, 'original method');
+            t.equal(style._reloadSource, methods._reloadSource, 'original method');
+
+            t.end();
+        });
+    });
+
+    t.test('defers expensive methods', function(t) {
+        var style = new Style(createStyleJSON({
+            "sources": {
+                "streets": createGeoJSONSourceJSON(),
+                "terrain": createGeoJSONSourceJSON()
+            }
+        }));
+
+        style.on('load', function() {
+            // spies to track defered methods
+            sinon.spy(style, 'fire');
+            sinon.spy(style, '_reloadSource');
+            sinon.spy(style, '_broadcastLayers');
+            sinon.spy(style, '_groupLayers');
+
+            style.batch(function(s) {
+                s.addLayer({ id: 'first', type: 'symbol', source: 'streets' });
+                s.addLayer({ id: 'second', type: 'symbol', source: 'streets' });
+                s.addLayer({ id: 'third', type: 'symbol', source: 'terrain' });
+
+                t.notOk(style.fire.called, 'fire is deferred');
+                t.notOk(style._reloadSource.called, '_reloadSource is deferred');
+                t.notOk(style._broadcastLayers.called, '_broadcastLayers is deferred');
+                t.notOk(style._groupLayers.called, '_groupLayers is deferred');
+            });
+
+            // called per added layer
+            t.ok(style.fire.calledThrice, 'fire is called per action');
+            t.ok(style.fire.calledWith('layer.add'), 'fire was called with layer.add');
+
+            // called per source
+            t.ok(style._reloadSource.calledTwice, '_reloadSource is called per source');
+            t.ok(style._reloadSource.calledWith('streets'), '_reloadSource is called for streets');
+            t.ok(style._reloadSource.calledWith('terrain'), '_reloadSource is called for terrain');
+
+            // called once
+            t.ok(style._broadcastLayers.calledOnce, '_broadcastLayers is called once');
+            t.ok(style._groupLayers.calledOnce, '_groupLayers is called once');
+
+            t.end();
+        });
+    });
+
+    t.test('throw before loaded', function(t) {
+        var style = new Style(createStyleJSON());
+        t.throws(function() {
+            style.batch(function() {});
+        }, Error, /load/i);
+        style.on('load', function() {
+            t.end();
+        });
     });
 });

--- a/test/js/style/style_diff.test.js
+++ b/test/js/style/style_diff.test.js
@@ -1,0 +1,273 @@
+'use strict';
+
+var test = require('prova');
+var styleDiff = require('../../../js/style/style_diff');
+var Style = require('../../../js/style/style');
+var util = require('../../../js/util/util');
+
+function createStyleJSON(properties) {
+    return util.extend({
+        "version": 7,
+        "sources": {},
+        "layers": []
+    }, properties);
+}
+
+test('styleDiff#diff', function (t) {
+
+    t.deepEqual(styleDiff.diff({
+        constants: { '@a': 1 }
+    }, {
+        constants: { '@a': 1 }
+    }), [], 'no changes');
+
+    t.deepEqual(styleDiff.diff({
+        constants: { '@a': 1 }
+    }, {
+        constants: { '@b': 1 }
+    }), [
+        { command: styleDiff.operations.setConstant, args: ['@a', undefined] },
+        { command: styleDiff.operations.setConstant, args: ['@b', 1] }
+    ]);
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'a' }]
+    }, {
+        layers: [{ id: 'a' }, { id: 'b' }]
+    }), [ { command: styleDiff.operations.addLayer, args: [{ id: 'b' }, undefined] } ], 'add a layer');
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'b' }]
+    }, {
+        layers: [{ id: 'a' }, { id: 'b' }]
+    }), [ { command: styleDiff.operations.addLayer, args: [{ id: 'a' }, 'b'] } ], 'add a layer before another');
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'a' }, { id: 'b', source: 'foo', nested: [1] }]
+    }, {
+        layers: [{ id: 'a' }]
+    }), [ { command: styleDiff.operations.removeLayer, args: ['b'] } ], 'remove a layer');
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'a' }, { id: 'b' }]
+    }, {
+        layers: [{ id: 'b' }, { id: 'a' }]
+    }), [
+        { command: styleDiff.operations.removeLayer, args: ['a'] },
+        { command: styleDiff.operations.addLayer, args: [{ id: 'a' }, undefined] }
+    ], 'move a layer');
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'a', paint: { foo: 1 } }]
+    }, {
+        layers: [{ id: 'a', paint: { foo: 2 } }]
+    }), [ { command: styleDiff.operations.setPaintProperty, args: ['a', 'foo', 2, null] } ]);
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'a', 'paint.light': { foo: 1 } }]
+    }, {
+        layers: [{ id: 'a', 'paint.light': { foo: 2 } }]
+    }), [ { command: styleDiff.operations.setPaintProperty, args: ['a', 'foo', 2, 'light'] } ]);
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'a', paint: { foo: { ramp: [1, 2] } } }]
+    }, {
+        layers: [{ id: 'a', paint: { foo: { ramp: [1] } } }]
+    }), [ { command: styleDiff.operations.setPaintProperty, args: ['a', 'foo', { ramp: [1] }, null] } ], 'nested style change');
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'a', layout: { foo: 1 } }]
+    }, {
+        layers: [{ id: 'a', layout: { foo: 2 } }]
+    }), [ { command: styleDiff.operations.setLayoutProperty, args: ['a', 'foo', 2, null] } ]);
+
+    t.deepEqual(styleDiff.diff({
+        layers: [{ id: 'a', filter: ['==', 'foo', 'bar'] }]
+    }, {
+        layers: [{ id: 'a', filter: ['==', 'foo', 'baz'] }]
+    }), [ { command: styleDiff.operations.setFilter, args: ['a', [ '==', 'foo', 'baz' ] ] } ]);
+
+    t.deepEqual(styleDiff.diff({
+        sources: { foo: 1 }
+    }, {
+        sources: { }
+    }), [ { command: styleDiff.operations.removeSource, args: ['foo'] } ]);
+
+    t.deepEqual(styleDiff.diff({
+        sources: { }
+    }, {
+        sources: { foo: 1 }
+    }), [ { command: styleDiff.operations.addSource, args: ['foo', 1] } ]);
+
+    t.end();
+});
+
+test('styleDiff#patch', function (t) {
+
+    t.test('applies addLayer', function (t) {
+        var style = new Style(createStyleJSON());
+
+        style.on('load', function () {
+            t.notOk(style.getLayer('background'), 'has no background');
+            styleDiff.patch(style, [
+                {
+                    command: styleDiff.operations.addLayer,
+                    args: [{ id: 'background', type: 'background' }]
+                }
+            ]);
+            t.ok(style.getLayer('background'), 'has background');
+
+            t.end();
+        });
+    });
+
+    t.test('applies removeLayer', function (t) {
+        var style = new Style(createStyleJSON({
+            layers: [
+                { id: 'background', type: 'background' }
+            ]
+        }));
+
+        style.on('load', function () {
+            t.ok(style.getLayer('background'), 'has background');
+            styleDiff.patch(style, [
+                {
+                    command: styleDiff.operations.removeLayer,
+                    args: ['background']
+                }
+            ]);
+            t.notOk(style.getLayer('background'), 'has no background');
+
+            t.end();
+        });
+    });
+
+    t.test('applies setPaintProperty', function (t) {
+        var style = new Style(createStyleJSON({
+            layers: [
+                { id: 'background', type: 'background' }
+            ]
+        }));
+
+        style.on('load', function () {
+            t.notOk(style.getPaintProperty('background', 'background-color'), 'has no background-color');
+            styleDiff.patch(style, [
+                {
+                    command: styleDiff.operations.setPaintProperty,
+                    args: ['background', 'background-color', 'black', null]
+                }
+            ]);
+            t.ok(style.getPaintProperty('background', 'background-color'), 'has background-color');
+
+            t.end();
+        });
+    });
+
+    t.test('applies setLayoutProperty', function (t) {
+        var style = new Style(createStyleJSON({
+            layers: [
+                { id: 'background', type: 'background' }
+            ]
+        }));
+
+        style.on('load', function () {
+            t.equal(style.getLayoutProperty('background', 'visibility'), 'visible', 'has no visibility');
+            styleDiff.patch(style, [
+                {
+                    command: styleDiff.operations.setLayoutProperty,
+                    args: ['background', 'visibility', 'none', null]
+                }
+            ]);
+            t.equal(style.getLayoutProperty('background', 'visibility'), 'none', 'has visibility');
+
+            t.end();
+        });
+    });
+
+    t.test('applies setFilter', function (t) {
+        var style = new Style(createStyleJSON({
+            sources: {
+                streets: {
+                    type: 'geojson',
+                    data: {
+                        type: 'FeatureCollection',
+                        features: []
+                    }
+                }
+            },
+            layers: [
+                { id: 'streets', type: 'symbol', source: 'streets' }
+            ]
+        }));
+
+        style.on('load', function () {
+            t.notOk(style.getFilter('streets'), 'has no filter');
+            styleDiff.patch(style, [
+                {
+                    command: styleDiff.operations.setFilter,
+                    args: ['streets', ['==', 'class', 'major']]
+                }
+            ]);
+            t.ok(style.getFilter('streets'), 'has filter');
+
+            t.end();
+        });
+    });
+
+    t.test('applies addSource', function (t) {
+        var style = new Style(createStyleJSON());
+
+        style.on('load', function () {
+            t.notOk(style.getSource('streets'), 'has no source');
+            styleDiff.patch(style, [
+                {
+                    command: styleDiff.operations.addSource,
+                    args: ['streets', { type: 'vector', tiles: [] }]
+                }
+            ]);
+            t.ok(style.getSource('streets'), 'has source');
+
+            t.end();
+        });
+    });
+
+    t.test('applies removeSource', function (t) {
+        var style = new Style(createStyleJSON({
+            sources: {
+                streets: { type: 'vector', tiles: [] }
+            }
+        }));
+
+        style.on('load', function () {
+            t.ok(style.getSource('streets'), 'has source');
+            styleDiff.patch(style, [
+                {
+                    command: styleDiff.operations.removeSource,
+                    args: ['streets']
+                }
+            ]);
+            t.notOk(style.getSource('streets'), 'has no source');
+
+            t.end();
+        });
+    });
+
+    t.test('handles unsupported commands', function (t) {
+        var style = new Style(createStyleJSON());
+
+        style.on('load', function () {
+            t.throws(function () {
+                styleDiff.patch(style, [
+                    {
+                        command: styleDiff.operations.setStyle,
+                        args: [createStyleJSON()]
+                    }
+                ]);
+            }, /Unable to apply command/);
+
+            t.end();
+        });
+    });
+
+    t.end();
+});

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -85,9 +85,57 @@ test('Map', function(t) {
             var map = createMap();
 
             map.setStyle({version: 7, sources: {}, layers: []});
+            var style = map.style;
             map.setStyle({version: 7, sources: {}, layers: []});
 
+            t.notOk(map.style === style, 'style is replaced');
+
             t.end();
+        });
+
+        t.test('styles are updated', function(t) {
+            var map = createMap();
+
+            map.on('style.load', onLoad);
+            map.setStyle({version: 7, sources: {}, layers: []});
+
+            function onLoad() {
+                map.off('style.load', onLoad);
+
+                var style = map.style;
+                map.setStyle({version: 7, sources: {}, layers: []});
+                t.ok(map.style === style, 'style is updated');
+
+                t.end();
+            }
+        });
+
+        t.test('falls back to new style for incompatible changes', function(t) {
+            var map = createMap();
+
+            map.on('style.load', onLoad);
+            map.setStyle({
+                version: 7,
+                sources: {},
+                layers: []
+            });
+
+            function onLoad() {
+                map.off('style.load', onLoad);
+
+                var style = map.style;
+                map.setStyle({
+                    version: 7,
+                    sources: {},
+                    layers: [],
+                    constants: {
+                        '@water': 'blue'
+                    }
+                });
+                t.notOk(map.style === style, 'style is replaced');
+
+                t.end();
+            }
         });
     });
 


### PR DESCRIPTION
This PR contains five discreet commits:
- Throw on style mutation before load
- Track the stylesheet as a pure JSON object
- Batch mode for efficiently mutating Style instances
- Utility to diff stylesheets
- Use styleDiff to apply setStyle changes incrementally

Issue: #1341