### PR TITLE
Batch mode for efficiently mutating Style instances

### DIFF
--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -1,0 +1,178 @@
+'use strict';
+
+var Source = require('../source/source');
+var StyleLayer = require('./style_layer');
+
+function styleBatch(style, work) {
+    if (!style._loaded) {
+        throw new Error('Style is not done loading');
+    }
+
+    var batch = Object.create(styleBatch.prototype);
+
+    batch._style = style;
+    batch._defer = {
+        groupLayers: false,
+        broadcastLayers: false,
+        sources: {},
+        events: [],
+        change: false
+    };
+
+    work(batch);
+
+    // call once if called
+    if (batch._defer.groupLayers) batch._style._groupLayers();
+    if (batch._defer.broadcastLayers) batch._style._broadcastLayers();
+
+    // reload sources
+    Object.keys(batch._defer.sources).forEach(function(sourceId) {
+        batch._style._reloadSource(sourceId);
+    });
+
+    // re-fire events
+    batch._defer.events.forEach(function(args) {
+        batch._style.fire.apply(batch._style, args);
+    });
+    if (batch._defer.change) {
+        batch._style.fire('change');
+    }
+}
+
+styleBatch.prototype = {
+
+    addLayer: function(layer, before) {
+        if (this._style._layers[layer.id] !== undefined) {
+            throw new Error('There is already a layer with this ID');
+        }
+        if (!(layer instanceof StyleLayer)) {
+            layer = new StyleLayer(layer, this._style.stylesheet.constants || {});
+        }
+        this._style._layers[layer.id] = layer;
+        this._style._order.splice(before ? this._style._order.indexOf(before) : Infinity, 0, layer.id);
+        layer.resolveLayout();
+        layer.resolveReference(this._style._layers);
+        layer.resolvePaint();
+        this._groupLayers();
+        this._broadcastLayers();
+        if (layer.source) {
+            this._reloadSource(layer.source);
+        }
+        this.fire('layer.add', {layer: layer});
+
+        return this;
+    },
+
+    removeLayer: function(id) {
+        var layer = this._style._layers[id];
+        if (layer === undefined) {
+            throw new Error('There is no layer with this ID');
+        }
+        for (var i in this._style._layers) {
+            if (this._style._layers[i].ref === id) {
+                this.removeLayer(i);
+            }
+        }
+        delete this._style._layers[id];
+        this._style._order.splice(this._style._order.indexOf(id), 1);
+        this._groupLayers();
+        this._broadcastLayers();
+        this.fire('layer.remove', {layer: layer});
+
+        return this;
+    },
+
+    setPaintProperty: function(layer, name, value, klass) {
+        this._style.getLayer(layer).setPaintProperty(name, value, klass);
+        this.fire('change');
+
+        return this;
+    },
+
+    setLayoutProperty: function(layer, name, value) {
+        layer = this._style.getReferentLayer(layer);
+        layer.setLayoutProperty(name, value);
+        this._broadcastLayers();
+        if (layer.source) {
+            this._reloadSource(layer.source);
+        }
+        this.fire('change');
+
+        return this;
+    },
+
+    setFilter: function(layer, filter) {
+        layer = this._style.getReferentLayer(layer);
+        layer.filter = filter;
+        this._broadcastLayers();
+        this._reloadSource(layer.source);
+        this.fire('change');
+
+        return this;
+    },
+
+    addSource: function(id, source) {
+        if (!this._style._loaded) {
+            throw new Error('Style is not done loading');
+        }
+        if (this._style.sources[id] !== undefined) {
+            throw new Error('There is already a source with this ID');
+        }
+        source = Source.create(source);
+        this._style.sources[id] = source;
+        source.id = id;
+        source.style = this._style;
+        source.dispatcher = this._style.dispatcher;
+        source.glyphAtlas = this._style.glyphAtlas;
+        source
+            .on('load', this._style._forwardSourceEvent)
+            .on('error', this._style._forwardSourceEvent)
+            .on('change', this._style._forwardSourceEvent)
+            .on('tile.add', this._style._forwardTileEvent)
+            .on('tile.load', this._style._forwardTileEvent)
+            .on('tile.error', this._style._forwardTileEvent)
+            .on('tile.remove', this._style._forwardTileEvent);
+        this.fire('source.add', {source: source});
+
+        return this;
+    },
+
+    removeSource: function(id) {
+        if (this._style.sources[id] === undefined) {
+            throw new Error('There is no source with this ID');
+        }
+        var source = this._style.sources[id];
+        delete this._style.sources[id];
+        source
+            .off('load', this._style._forwardSourceEvent)
+            .off('error', this._style._forwardSourceEvent)
+            .off('change', this._style._forwardSourceEvent)
+            .off('tile.add', this._style._forwardTileEvent)
+            .off('tile.load', this._style._forwardTileEvent)
+            .off('tile.error', this._style._forwardTileEvent)
+            .off('tile.remove', this._style._forwardTileEvent);
+        this.fire('source.remove', {source: source});
+
+        return this;
+    },
+
+    _groupLayers: function() {
+        this._defer.groupLayers = true;
+    },
+    _broadcastLayers: function() {
+        this._defer.broadcastLayers = true;
+    },
+    _reloadSource: function(sourceId) {
+        this._defer.sources[sourceId] = true;
+    },
+    fire: function(type) {
+        if (type === 'change') {
+            this._defer.change = true;
+        } else {
+            this._defer.events.push(arguments);
+        }
+    }
+
+};
+
+module.exports = styleBatch;

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -306,6 +306,25 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     /**
+     * Apply multiple style mutations in a batch
+     *
+     * map.batch(function (batch) {
+     *     batch.addLayer(layer1);
+     *     batch.addLayer(layer2);
+     *     ...
+     *     batch.addLayer(layerN);
+     * });
+     *
+     * @param {function} work Function which accepts the StyleBatch interface
+     */
+    batch: function(work) {
+        this.style.batch(work);
+
+        this.style._cascade(this._classes);
+        this.update(true);
+    },
+
+    /**
      * Replaces the map's style object
      *
      * @param {Object} style A style object formatted as JSON

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#632163906f90883c611d09f57a5c5b988d1e923f",
     "mkdirp": "^0.5.1",
     "prova": "^2.1.2",
+    "sinon": "^1.15.4",
     "st": "^0.5.4",
     "through": "^2.3.7",
     "watchify": "^3.2.2"

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -4,6 +4,7 @@ var test = require('prova');
 var st = require('st');
 var http = require('http');
 var path = require('path');
+var sinon = require('sinon');
 var Style = require('../../../js/style/style');
 var VectorTileSource = require('../../../js/source/vector_tile_source');
 var LayoutProperties = require('../../../js/style/layout_properties');
@@ -27,6 +28,16 @@ function createSource() {
         attribution: 'Mapbox',
         tiles: ['http://example.com/{z}/{x}/{y}.png']
     });
+}
+
+function createGeoJSONSourceJSON() {
+    return {
+        "type": "geojson",
+        "data": {
+            "type": "FeatureCollection",
+            "features": []
+        }
+    };
 }
 
 test('Style', function(t) {
@@ -917,5 +928,66 @@ test('Style#featuresAt', function(t) {
         });
 
         t.end();
+    });
+});
+
+test('Style#batch', function(t) {
+    t.test('defers expensive methods', function(t) {
+        var style = new Style(createStyleJSON({
+            "sources": {
+                "streets": createGeoJSONSourceJSON(),
+                "terrain": createGeoJSONSourceJSON()
+            }
+        }));
+
+        style.on('load', function() {
+            // spies to track defered methods
+            sinon.spy(style, 'fire');
+            sinon.spy(style, '_reloadSource');
+            sinon.spy(style, '_broadcastLayers');
+            sinon.spy(style, '_groupLayers');
+
+            style.batch(function(s) {
+                s.addLayer({ id: 'first', type: 'symbol', source: 'streets' });
+                s.addLayer({ id: 'second', type: 'symbol', source: 'streets' });
+                s.addLayer({ id: 'third', type: 'symbol', source: 'terrain' });
+
+                s.setPaintProperty('first', 'text-color', 'black');
+                s.setPaintProperty('first', 'text-halo-color', 'white');
+
+                t.notOk(style.fire.called, 'fire is deferred');
+                t.notOk(style._reloadSource.called, '_reloadSource is deferred');
+                t.notOk(style._broadcastLayers.called, '_broadcastLayers is deferred');
+                t.notOk(style._groupLayers.called, '_groupLayers is deferred');
+            });
+
+            // called per added layer, conflating 'change' events
+            t.equal(style.fire.callCount, 4, 'fire is called per action');
+            t.equal(style.fire.args[0][0], 'layer.add', 'fire was called with layer.add');
+            t.equal(style.fire.args[1][0], 'layer.add', 'fire was called with layer.add');
+            t.equal(style.fire.args[2][0], 'layer.add', 'fire was called with layer.add');
+            t.equal(style.fire.args[3][0], 'change', 'fire was called with change');
+
+            // called per source
+            t.ok(style._reloadSource.calledTwice, '_reloadSource is called per source');
+            t.ok(style._reloadSource.calledWith('streets'), '_reloadSource is called for streets');
+            t.ok(style._reloadSource.calledWith('terrain'), '_reloadSource is called for terrain');
+
+            // called once
+            t.ok(style._broadcastLayers.calledOnce, '_broadcastLayers is called once');
+            t.ok(style._groupLayers.calledOnce, '_groupLayers is called once');
+
+            t.end();
+        });
+    });
+
+    t.test('throw before loaded', function(t) {
+        var style = new Style(createStyleJSON());
+        t.throws(function() {
+            style.batch(function() {});
+        }, Error, /load/i);
+        style.on('load', function() {
+            t.end();
+        });
     });
 });

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -192,5 +192,22 @@ test('Map', function(t) {
         t.end();
     });
 
+    t.test('#batch', function(t) {
+        var map = createMap();
+        map.setStyle({
+            version: 7,
+            sources: {},
+            layers: []
+        });
+        map.on('style.load', function() {
+            map.batch(function(batch) {
+                batch.addLayer({ id: 'background', type: 'background' });
+            });
+            t.ok(map.style.getLayer('background'), 'has background');
+
+            t.end();
+        });
+    });
+
     t.end();
 });


### PR DESCRIPTION
Mutation operations on a Style instance are designed to be atomic.
Depending on the operation, there is a significant amount of work that
must be preformed to flush and recreate state. This work is wasted when
multiple mutation methods are invokes sequentially.

Batching these mutations allows deferring this work until the batch is
complete and deduping the work.

    map.batch(function(batch) {
        batch.addLayer(layer1);
        batch.addLayer(layer2);
        ...
        batch.addLayer(layerN);
    });

Methods on the batch object provided to the work function mirror methods
on Map and Style, and include:
- addLayer
- removeLayer
- setPaintProperty
- setLayoutProperty
- setFilter
- addSource
- removeSource

Internally, calls to four methods are deferred:
- style._groupLayers (will only fire once)
- style._broadcastLayers (will only fire once)
- style._reloadSource (will fire once per source)
- style.fire (each call will fire)

A casual benchmark shows the time to add 80 layers dropping from ~800 ms
to ~20 ms when run as a batch.

Issue: #1341