### PR TITLE
Guard Source#reload() if source is not loaded

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -101,7 +101,9 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     },
 
     reload: function() {
-        this._pyramid.reload();
+        if (this._loaded) {
+            this._pyramid.reload();
+        }
     },
 
     render: Source._renderTiles,

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -38,7 +38,9 @@ VectorTileSource.prototype = util.inherit(Evented, {
     },
 
     reload: function() {
-        this._pyramid.reload();
+        if (this._pyramid) {
+            this._pyramid.reload();
+        }
     },
 
     redoPlacement: function() {

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -55,6 +55,20 @@ test('GeoJSONSource#setData', function(t) {
     });
 });
 
+test('GeoJSONSource#reload', function(t) {
+    t.test('before loaded', function(t) {
+        var source = new GeoJSONSource({data: {}});
+
+        t.doesNotThrow(function() {
+            source.reload();
+        }, null, 'reload ignored gracefully');
+
+        t.end();
+    });
+
+    t.end();
+});
+
 test('GeoJSONSource#update', function(t) {
     var transform = new Transform();
 

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -56,6 +56,20 @@ test('VectorTileSource', function(t) {
         });
     });
 
+    t.test('ignores reload before loaded', function(t) {
+        var source = new VectorTileSource({
+            url: "http://localhost:2900/source.json"
+        });
+
+        t.doesNotThrow(function() {
+            source.reload();
+        }, null, 'reload ignored gracefully');
+
+        source.on('load', function() {
+            t.end();
+        });
+    });
+
     t.test('after', function(t) {
         server.close(t.end);
     });


### PR DESCRIPTION
Source#reload() currently assumes the source is loaded calling reload on
the TilePyramid. If the source has not finished loading, calls to reload
should be ignored.

The new behavior mirrors Source#update().