### PR TITLE
improve round line joins for semi-transparent lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "documentation": "git+https://github.com/documentationjs/documentation#d341019b32a8a257a93bd55586e7f09f42e29341",
     "eslint": "^0.22.1",
     "istanbul": "^0.3.15",
-    "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#632163906f90883c611d09f57a5c5b988d1e923f",
+    "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#1a9e469587faaefa5cd8dcfd59574ffbadb25f94",
     "mkdirp": "^0.5.1",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",


### PR DESCRIPTION
Round line joins used to be drawn by adding a semicircle cap to the end of each segment. This looked fine for opaque lines not for semi-transparent lines.

This changes the triangulation so that round line joins don't overlap with segments. The gap between segments is filled with small triangles that look like pie slices. The edge of the round linejoin is made up of many short straight lines that look round at the sizes we draw lines.

Since sharp angles are infrequent, this does not significantly affect the total number of triangles created.

Joins for angles that are really sharp are still drawn with overlap.

<img width="696" alt="screen shot 2015-07-06 at 2 03 56 pm" src="https://cloud.githubusercontent.com/assets/1421652/8522626/30e93204-23f0-11e5-9a8a-678016a4e40c.png">

@kkaefer want to review?