### PR TITLE
[wrap)

### DIFF
--- a/js/util/util.js
+++ b/js/util/util.js
@@ -79,16 +79,17 @@ exports.clamp = function (n, min, max) {
 };
 
 /*
- * constrain n to the given range via modular arithmetic
- * @param {number} n
- * @param {number} min
- * @param {number} max
+ * constrain n to the given range, excluding the minimum, via modular arithmetic
+ * @param {number} n value
+ * @param {number} min the minimum value to be returned, exclusive
+ * @param {number} max the maximum value to be returned, inclusive
  * @returns {number} constrained number
  * @private
  */
 exports.wrap = function (n, min, max) {
     var d = max - min;
-    return n === max ? n : ((n - min) % d + d) % d + min;
+    var w = ((n - min) % d + d) % d + min;
+    return (w === min) ? max : w;
 };
 
 /*

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -162,7 +162,7 @@ test('util', function(t) {
     });
 
     t.test('wrap', function(t) {
-        t.equal(util.wrap(0, 0, 1), 0);
+        t.equal(util.wrap(0, 0, 1), 1);
         t.equal(util.wrap(1, 0, 1), 1);
         t.equal(util.wrap(200, 0, 180), 20);
         t.equal(util.wrap(-200, 0, 180), 160);


### PR DESCRIPTION
wrap() now excludes the maximum value, returning a value in the range [min, max). wrap(max, min, max) now returns the same thing as wrap(max * 2, min, max).

If (wrap] is desired, it is the responsibility of the caller to handle the case in which min is returned.

Backported from mapbox/mapbox-gl-native#1829. No expected changes in behavior.

/cc @mourner