### PR TITLE
Allow layer zoom extent mutation

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -323,6 +323,14 @@ Style.prototype = util.inherit(Evented, {
         return this;
     },
 
+    setLayerZoomRange: function(layerId, minzoom, maxzoom) {
+        this.batch(function(batch) {
+            batch.setLayerZoomRange(layerId, minzoom, maxzoom);
+        });
+
+        return this;
+    },
+
     /**
      * Get a layer's filter object
      * @param {string} layer the layer to inspect

--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -120,6 +120,24 @@ styleBatch.prototype = {
         return this;
     },
 
+    setLayerZoomRange: function(layerId, minzoom, maxzoom) {
+        var layer = this._style.getReferentLayer(layerId);
+        if (minzoom != null) {
+          layer.minzoom = minzoom;
+        }
+        if (maxzoom != null) {
+          layer.maxzoom = maxzoom;
+        }
+
+        this._broadcastLayers = true;
+        if (layer.source) {
+            this._reloadSources[layer.source] = true;
+        }
+        this._change = true;
+
+        return this;
+    },
+
     addSource: function(id, source) {
         if (!this._style._loaded) {
             throw new Error('Style is not done loading');

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -461,6 +461,19 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     /**
+     * Set the zoom extent for a given style layer.
+     *
+     * @param {string} layerId ID of a layer
+     * @param {number} minzoom minimum zoom extent
+     * @param {number} maxzoom maximum zoom extent
+     * @returns {Map} `this`
+     */
+    setLayerZoomRange: function(layerId, minzoom, maxzoom) {
+        this.style.setLayerZoomRange(layerId, minzoom, maxzoom);
+        return this;
+    },
+
+    /**
      * Get the filter for a given style layer.
      *
      * @param {string} layer ID of a layer

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -740,6 +740,49 @@ test('Style#setPaintProperty', function(t) {
     });
 });
 
+test('Style#setLayerZoomRange', function(t) {
+    t.test('sets zoom range', function(t) {
+        var style = new Style({
+            "version": 7,
+            "sources": {
+                "geojson": createGeoJSONSourceJSON()
+            },
+            "layers": [{
+                "id": "symbol",
+                "type": "symbol",
+                "source": "geojson"
+            }]
+        });
+
+        style.on('load', function() {
+            style.setLayerZoomRange('symbol', 5, 12);
+            t.equal(style.getLayer('symbol').minzoom, 5, 'set minzoom');
+            t.equal(style.getLayer('symbol').maxzoom, 12, 'set maxzoom');
+            t.end();
+        });
+    });
+
+    t.test('throw before loaded', function(t) {
+        var style = new Style(createStyleJSON({
+            "version": 7,
+            "sources": {
+                "geojson": createGeoJSONSourceJSON()
+            },
+            "layers": [{
+                "id": "symbol",
+                "type": "symbol",
+                "source": "geojson"
+            }]
+        }));
+        t.throws(function () {
+            style.setLayerZoomRange('symbol', 5, 12);
+        }, Error, /load/i);
+        style.on('load', function() {
+            t.end();
+        });
+    });
+});
+
 test('Style#featuresAt - race condition', function(t) {
     var style = new Style({
         "version": 7,


### PR DESCRIPTION
It's not currently possible to alter the zoom extent via a public API
without removing and adding a layer. Now you can directly mutate the
minzoom and maxzoom layer properties.

    map.setLayerZoomExtent(layerId, minzoom, maxzoom)

The mutation is implemented on the style object as a batch mutation.