### PR TITLE
Disable eslint "no-else-return" rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       "space-after-keywords": 2,
       "comma-style": 2,
       "no-lonely-if": 2,
-      "no-else-return": 2,
+      "no-else-return": 0,
       "new-cap": 0,
       "no-empty": 2,
       "no-new": 2,


### PR DESCRIPTION
cc @mourner @tmcw 

It sounds like there are some differing opinions on this rule. Personally, I have an easier time reading code written *with* an "else return." I propose we disable the rule and leave it up to personal preference. 
