### PR TITLE
Remove examples map ID

### DIFF
--- a/docs/_posts/examples/3400-01-02-map-tiles.html
+++ b/docs/_posts/examples/3400-01-02-map-tiles.html
@@ -7,7 +7,7 @@ description: Using a tiled raster map
 
 <div id='map'></div>
 <script>
-var tileset = 'examples.map-i86nkdio';
+var tileset = 'mapbox.streets';
 var map = new mapboxgl.Map({
   container: 'map', // container id
   style: {


### PR DESCRIPTION
Removes examples map ID from map-tiles example. /cc @jfirebaugh @tmcw 