### PR TITLE
map.featuresAt() finds nothing for overflowing longitude

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -300,7 +300,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * });
      */
     featuresAt: function(point, params, callback) {
-        var coord = this.transform.pointCoordinate(Point.convert(point));
+        var location = this.unproject(point).wrap();
+        var coord = this.transform.locationCoordinate(location);
         this.style.featuresAt(coord, params, callback);
         return this;
     },

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -3,6 +3,7 @@
 var test = require('prova');
 var Map = require('../../../js/ui/map');
 var Style = require('../../../js/style/style');
+var LatLng = require('../../../js/geo/lat_lng');
 
 test('Map', function(t) {
     function createMap() {
@@ -204,6 +205,51 @@ test('Map', function(t) {
                 batch.addLayer({ id: 'background', type: 'background' });
             });
             t.ok(map.style.getLayer('background'), 'has background');
+
+            t.end();
+        });
+    });
+
+
+    t.test('#featuresAt', function(t) {
+        var map = createMap();
+        map.setStyle({
+            "version": 7,
+            "sources": {},
+            "layers": []
+        });
+
+        map.on('style.load', function() {
+            var callback = function () {};
+            var opts = {};
+
+            t.test('normal coords', function(t) {
+                map.style.featuresAt = function (coords, o, cb) {
+                    t.deepEqual(coords, { column: 0.5, row: 0.5, zoom: 0 });
+                    t.equal(o, opts);
+                    t.equal(cb, callback);
+
+                    t.end();
+                };
+
+                map.featuresAt(map.project(new LatLng(0, 0)), opts, callback);
+            });
+
+            t.test('wraps coords', function(t) {
+                map.style.featuresAt = function (coords, o, cb) {
+                    // avoid floating point issues
+                    t.equal(parseFloat(coords.column.toFixed(4)), 0.5);
+                    t.equal(coords.row, 0.5);
+                    t.equal(coords.zoom, 0);
+
+                    t.equal(o, opts);
+                    t.equal(cb, callback);
+
+                    t.end();
+                };
+
+                map.featuresAt(map.project(new LatLng(0, 360)), opts, callback);
+            });
 
             t.end();
         });


### PR DESCRIPTION
Querying for features past the dateline, or pan the map past the
dateline, map.featuresAt() no longer returns features.

This change will normalize the longitude to be between -180 and 180.