### PR TITLE
Add featuresAt includeGeometry option

### DIFF
--- a/js/data/feature_tree.js
+++ b/js/data/feature_tree.js
@@ -49,6 +49,11 @@ FeatureTree.prototype.query = function(args, callback) {
             continue;
 
         var geoJSON = feature.toGeoJSON(this.x, this.y, this.z);
+
+        if (!params.includeGeometry) {
+            geoJSON.geometry = null;
+        }
+
         for (var l = 0; l < layers.length; l++) {
             var layer = layers[l];
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -286,6 +286,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @param {number} [params.radius=0] Optional. Radius in pixels to search in
      * @param {string} params.layer Optional. Only return features from a given layer
      * @param {string} params.type Optional. Either `raster` or `vector`
+     * @param {boolean} [params.includeGeometry=false] Optional. If `true`, geometry of features will be included in the results at the expense of a much slower query time.
      * @param {featuresAtCallback} callback function that returns the response
      *
      * @callback featuresAtCallback

--- a/test/js/data/feature_tree.test.js
+++ b/test/js/data/feature_tree.test.js
@@ -76,7 +76,8 @@ test('featuretree query', function(t) {
         source: "mapbox.mapbox-streets-v5",
         scale: 724.0773439350247,
         params: {
-            radius: 30
+            radius: 30,
+            includeGeometry: true
         },
         x: 1842,
         y: 2014


### PR DESCRIPTION
Closes #1191. I suggest not returning geometry by default, since it seems uncommon to use it, and it hinders performance significantly. @tmcw to review.