### PR TITLE
Adding special case for non-fontstack "glyph" resource URLs

### DIFF
--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -55,7 +55,10 @@ module.exports.normalizeGlyphsURL = function(url, accessToken) {
     if (!url.match(/^mapbox:\/\//))
         return url;
 
-    return normalizeURL(url, '/v4/', accessToken);
+    if (url.match(/^mapbox:\/\/fontstack/))
+        return normalizeURL(url, '/v4/', accessToken);
+
+    return normalizeURL(url, '/', accessToken);
 };
 
 module.exports.normalizeTileURL = function(url, sourceUrl) {

--- a/test/js/util/mapbox.test.js
+++ b/test/js/util/mapbox.test.js
@@ -49,8 +49,13 @@ test("mapbox", function(t) {
     });
 
     t.test('.normalizeGlyphsURL', function(t) {
-        t.test('returns a v4 URL with access_token parameter', function(t) {
+        t.test('returns a v4 URL with access_token parameter for fontstack endpoint', function(t) {
             t.equal(mapbox.normalizeGlyphsURL('mapbox://fontstack/{fontstack}/{range}.pbf'), 'https://a.tiles.mapbox.com/v4/fontstack/{fontstack}/{range}.pbf?access_token=key');
+            t.end();
+        });
+
+        t.test('returns a /fonts/v1 URL with access_token parameter for fonts endpoint', function(t) {
+            t.equal(mapbox.normalizeGlyphsURL('mapbox://fonts/v1/user/{fontstack}/{range}.pbf'), 'https://a.tiles.mapbox.com/fonts/v1/user/{fontstack}/{range}.pbf?access_token=key');
             t.end();
         });
 


### PR DESCRIPTION
- does not prepend /v4/ to api endpoints like /fonts/v1/
- only prepends it to things starting with /fontstack
- solves the problem in #1385
- refs mapbox/mapbox-gl-style-spec#309

cc/ @samanpwbb @mikemorris @mourner @tmcw 