### PR TITLE
Adding an example showing how to reference a custom hosted style

### DIFF
--- a/docs/_posts/examples/3400-01-01-custom-style-id.html
+++ b/docs/_posts/examples/3400-01-01-custom-style-id.html
@@ -1,0 +1,16 @@
+---
+layout: example
+category: example
+title: Custom style
+description: Using a custom Mapbox-hosted style.
+---
+
+<div id='map'></div>
+<script>
+var map = new mapboxgl.Map({
+  container: 'map', // container id
+  style: 'mapbox://mapbox.dark-v7', //hosted style id
+  center: [39, -77.38], // starting position
+  zoom: 3 // starting zoom
+});
+</script>


### PR DESCRIPTION
Bringing attention to the `style: mapbox://username.mapid` format 

Fixes #1388 