### PR TITLE
Unset layout and paint properties

### DIFF
--- a/js/style/style_constant.js
+++ b/js/style/style_constant.js
@@ -21,7 +21,7 @@ exports.resolve = function(value, constants) {
         }
     }
 
-    if (value.stops) {
+    if (value && value.stops) {
         value = util.extend({}, value);
         value.stops = value.stops.slice();
 

--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -10,6 +10,10 @@ function StyleDeclaration(reference, value) {
     this.type = reference.type;
     this.transitionable = reference.transition;
 
+    if (value == null) {
+        value = reference.default;
+    }
+
     // immutable representation of value. used for comparison
     this.json = JSON.stringify(value);
 

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -42,7 +42,11 @@ StyleLayer.prototype = {
     },
 
     setLayoutProperty: function(name, value) {
-        this.layout[name] = StyleConstant.resolve(value, this._constants);
+        if (value == null) {
+            delete this.layout[name];
+        } else {
+            this.layout[name] = StyleConstant.resolve(value, this._constants);
+        }
     },
 
     getLayoutProperty: function(name) {

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -111,6 +111,22 @@ test('StyleLayer#setPaintProperty', function(t) {
         t.end();
     });
 
+    t.test('unsets property value', function(t) {
+        var layer = new StyleLayer({
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "red"
+            }
+        });
+
+        layer.resolvePaint({});
+        layer.setPaintProperty('background-color', null);
+
+        t.deepEqual(layer.getPaintProperty('background-color'), [0, 0, 0, 1]);
+        t.end();
+    });
+
     t.test('sets classed paint value', function(t) {
         var layer = new StyleLayer({
             "id": "background",
@@ -124,6 +140,22 @@ test('StyleLayer#setPaintProperty', function(t) {
         layer.setPaintProperty('background-color', 'blue', 'night');
 
         t.deepEqual(layer.getPaintProperty('background-color', 'night'), [0, 0, 1, 1]);
+        t.end();
+    });
+
+    t.test('unsets classed paint value', function(t) {
+        var layer = new StyleLayer({
+            "id": "background",
+            "type": "background",
+            "paint.night": {
+                "background-color": "red"
+            }
+        });
+
+        layer.resolvePaint({});
+        layer.setPaintProperty('background-color', null, 'night');
+
+        t.deepEqual(layer.getPaintProperty('background-color', 'night'), [0, 0, 0, 1]);
         t.end();
     });
 
@@ -223,6 +255,22 @@ test('StyleLayer#setLayoutProperty', function(t) {
         layer.setLayoutProperty('text-transform', 'lowercase');
 
         t.deepEqual(layer.getLayoutProperty('text-transform'), 'lowercase');
+        t.end();
+    });
+
+    t.test('unsets property value', function(t) {
+        var layer = new StyleLayer({
+            "id": "symbol",
+            "type": "symbol",
+            "layout": {
+                "text-transform": "uppercase"
+            }
+        });
+
+        layer.resolveLayout();
+        layer.setLayoutProperty('text-transform', null);
+
+        t.deepEqual(layer.getLayoutProperty('text-transform'), 'none');
         t.end();
     });
 


### PR DESCRIPTION
Previously, there was no way to remove a layout or paint property,
restoring to the default value. You would have to explicitly set the
property to the default.

Now, calling `map.setLayoutProperty('prop', null)` or
`map.setPaintProperty('prop', null)` will reset the value of 'prop' to
the default value.