### PR TITLE
[wip] Added Buffer2 class

### DIFF
--- a/js/data/buffer2.js
+++ b/js/data/buffer2.js
@@ -86,7 +86,7 @@ Buffer.prototype.isMapboxBuffer = true;
 
 /**
  * Push an item onto the end of the buffer. Grows the buffer if necessary.
- *
+ * @private
  * @param {(BufferItem|BufferValue)} item Item to be appended. If the buffer only has one attribute,
  * can be a single value.
  * @returns {number} The index of the appended item.
@@ -100,7 +100,7 @@ Buffer.prototype.push = function(item) {
 
 /**
  * Set an item at a particular index. Grows the buffer if necessary.
- *
+ * @private
  * @param {number} index The index of the item to set
  * @param {(BufferItem|BufferValue)} item the item to set. If the buffer only has one attribute,
  * it can be a single value instead of an item.
@@ -118,7 +118,7 @@ Buffer.prototype.set = function(index, item) {
 
 /**
  * Set an attribute for an item at a particular index. Grows the buffer if necessary.
- *
+ * @private
  * @param {number} index The index of the item to set
  * @param {(string|BufferAttribute)} attribute The attribute of the item to set
  * @param {BufferValue} value
@@ -147,7 +147,7 @@ Buffer.prototype.setAttribute = function(index, attribute, value) {
 
 /**
  * Get an item from the `ArrayBuffer`.
- *
+ * @private
  * @param {number} index The index of the item to get
  * @returns {BufferItem}
  */
@@ -171,6 +171,8 @@ Buffer.prototype.get = function(index) {
  * Serialize the buffer to be transferred between threads via `postMessage`. This is a destructive
  * operation because it is assumed that the ownership of the buffer will be transferred to another
  * thread.
+ * @private
+ * @returns { serialized: Object, transferables: Array.<ArrayBuffer> }
  */
 Buffer.prototype.serialize = function() {
     var output = {
@@ -183,7 +185,7 @@ Buffer.prototype.serialize = function() {
             arrayBuffer: this.arrayBuffer,
             isSerializedMapboxBuffer: true
         },
-        transferrables: [this.arrayBuffer]
+        transferables: [this.arrayBuffer]
     };
 
     this.arrayBuffer = null;
@@ -194,7 +196,7 @@ Buffer.prototype.serialize = function() {
 
 /**
  * Get the byte offset of a particular index.
- *
+ * @private
  * @param {number} index
  */
 Buffer.prototype.getIndexOffset = function(index) {
@@ -203,6 +205,7 @@ Buffer.prototype.getIndexOffset = function(index) {
 
 /**
  * Get the byte offset of an attribute at a particular item index
+ * @private
  * @param {number} index
  * @param {string|BufferAttribute} attribute The attribute to set
  * @param {number} componentIndex
@@ -217,6 +220,7 @@ Buffer.prototype.getIndexAttributeOffset = function(index, attributeName, compon
 };
 
 /**
+ * @private
  * @param {(BufferAttribute|string)}
  * @returns {BufferAttribute}
  */
@@ -293,12 +297,14 @@ Buffer.AttributeType = {
  * These indicies are stored in the `BufferType.ELEMENT` buffer as `UNSIGNED_SHORT`s.
  *
  * @property {BufferAttributeType}
+ * @private
  * @readonly
  */
 Buffer.ELEMENT_INDEX_ATTRIBUTE_TYPE = Buffer.AttributeType.UNSIGNED_SHORT;
 
 /**
  * @property {number}
+ * @private
  * @readonly
  */
 Buffer.SIZE_DEFAULT = 8192;
@@ -306,6 +312,7 @@ Buffer.SIZE_DEFAULT = 8192;
 /**
  * WebGL performs best if buffer sizes are aligned to 2 byte boundaries.
  * @property {number}
+ * @private
  * @readonly
  */
 Buffer.SIZE_ALIGNMENT = 2;
@@ -313,6 +320,7 @@ Buffer.SIZE_ALIGNMENT = 2;
 /**
  * WebGL performs best if vertex attribute offsets are aligned to 4 byte boundaries.
  * @property {number}
+ * @private
  * @readonly
  */
 Buffer.VERTEX_ATTRIBUTE_OFFSET_ALIGNMENT = 4;

--- a/js/data/buffer2.js
+++ b/js/data/buffer2.js
@@ -1,0 +1,333 @@
+'use strict';
+
+// Note: all "sizes" are measured in bytes
+
+var util = require('../util/util');
+
+/**
+ * The `Buffer` class is responsible for managing one instance of `ArrayBuffer`. `ArrayBuffer`s
+ * provide low-level read/write access to a chunk of memory. `ArrayBuffer`s are populated with
+ * per-vertex data, uploaded to the GPU, and used in rendering.
+ *
+ * `Buffer` provides an abstraction over `ArrayBuffer`, making it behave like an array of
+ * statically typed structs. A buffer is comprised of items. An item is comprised of a set of
+ * attributes. Attributes are defined when the class is constructed.
+ *
+ * @class Buffer
+ * @private
+ * @param options
+ * @param {BufferType} options.type
+ * @param {Object.<string, BufferAttribute>} options.attributes
+ */
+function Buffer(options) {
+
+    // Create a new Buffer
+    if (!options.isSerializedMapboxBuffer) {
+
+        this.type = options.type;
+        this.size = align(Buffer.SIZE_DEFAULT, Buffer.SIZE_ALIGNMENT);
+        this.length = 0;
+        this.arrayBuffer = new ArrayBuffer(this.size);
+        this.attributes = {};
+        this.itemSize = 0;
+
+        this._refreshArrayBufferViews();
+
+        // Vertex buffer attributes must be aligned to "word" boundaries (4 bytes) but element
+        // buffer attributes do not need to be aligned.
+        var attributeAlignment;
+        if (this.type === Buffer.BufferType.VERTEX) {
+            attributeAlignment = Buffer.VERTEX_ATTRIBUTE_OFFSET_ALIGNMENT;
+        } else {
+            attributeAlignment = null;
+        }
+
+        // Normalize the attributes
+        for (var key in options.attributes) {
+            var attribute = util.extend({}, options.attributes[key]);
+
+            attribute.name = attribute.name || key;
+            attribute.components = attribute.components || 1;
+            attribute.type = attribute.type || Buffer.AttributeType.UNSIGNED_BYTE;
+            attribute.size = attribute.type.size * attribute.components;
+            attribute.offset = this.itemSize;
+
+            this.itemSize = align(attribute.offset + attribute.size, attributeAlignment);
+
+            this.attributes[attribute.name] = attribute;
+        }
+
+    // Restore a serialized buffer
+    } else {
+        var clone = options;
+
+        this.type = clone.type;
+        this.size = clone.size;
+        this.length = clone.index;
+        this.arrayBuffer = clone.arrayBuffer;
+        this.attributes = clone.attributes;
+        this.itemSize = clone.itemSize;
+
+        this._refreshArrayBufferViews();
+    }
+
+    util.assert(this.type);
+
+    // Enable some shortcuts if there is only one attribute on this buffer.
+    var attributeNames = Object.keys(this.attributes);
+    if (attributeNames.length === 1) {
+        this.singleAttribute = this.attributes[attributeNames[0]];
+    } else {
+        this.singleAttribute = null;
+    }
+}
+
+Buffer.prototype.isMapboxBuffer = true;
+
+/**
+ * Push an item onto the end of the buffer. Grows the buffer if necessary.
+ *
+ * @param {(BufferItem|BufferValue)} item Item to be appended. If the buffer only has one attribute,
+ * can be a single value.
+ * @returns {number} The index of the appended item.
+ */
+Buffer.prototype.push = function(item) {
+    var index = this.length;
+    this.length++;
+    this.set(index, item);
+    return index;
+};
+
+/**
+ * Set an item at a particular index. Grows the buffer if necessary.
+ *
+ * @param {number} index The index of the item to set
+ * @param {(BufferItem|BufferValue)} item the item to set. If the buffer only has one attribute,
+ * it can be a single value instead of an item.
+ */
+Buffer.prototype.set = function(index, item) {
+    if (typeof item === "object" && item !== null && !Array.isArray(item)) {
+        for (var attributeName in item) {
+           this.setAttribute(index, attributeName, item[attributeName]);
+        }
+    } else {
+        util.assert(this.singleAttribute);
+        this.setAttribute(index, this.singleAttribute.name, item);
+    }
+};
+
+/**
+ * Set an attribute for an item at a particular index. Grows the buffer if necessary.
+ *
+ * @param {number} index The index of the item to set
+ * @param {(string|BufferAttribute)} attribute The attribute of the item to set
+ * @param {BufferValue} value
+ */
+Buffer.prototype.setAttribute = function(index, attribute, value) {
+    attribute = this._normalizeAttributeReference(attribute);
+
+    // Resize the buffer if necessary
+    while (this.getIndexOffset(index + 1) > this.size) {
+        this._resize(this.size * 1.5);
+    }
+    this.length = Math.max(this.length, index + 1);
+    util.assert(this.getIndexOffset(index + 1) <= this.size);
+
+
+    if (!Array.isArray(value)) value = [value];
+
+    util.assert(value.length === attribute.components);
+    for (var componentIndex = 0; componentIndex < attribute.components; componentIndex++) {
+        var offset = this.getIndexAttributeOffset(index, attribute.name, componentIndex) / attribute.type.size;
+        var arrayBufferView = this.arrayBufferViews[attribute.type.name];
+        util.assert(isNumeric(value[componentIndex]));
+        arrayBufferView[offset] = value[componentIndex];
+    }
+};
+
+/**
+ * Get an item from the `ArrayBuffer`.
+ *
+ * @param {number} index The index of the item to get
+ * @returns {BufferItem}
+ */
+Buffer.prototype.get = function(index) {
+    var item = {};
+    for (var attributeName in this.attributes) {
+        var attribute = this.attributes[attributeName];
+        item[attributeName] = [];
+
+        for (var componentIndex = 0; componentIndex < attribute.components; componentIndex++) {
+            var offset = this.getIndexAttributeOffset(index, attributeName, componentIndex) / attribute.type.size;
+            var arrayBufferView = this.arrayBufferViews[attribute.type.name];
+            var value = arrayBufferView[offset];
+            item[attributeName][componentIndex] = value;
+        }
+    }
+    return item;
+};
+
+/**
+ * Serialize the buffer to be transferred between threads via `postMessage`. This is a destructive
+ * operation because it is assumed that the ownership of the buffer will be transferred to another
+ * thread.
+ */
+Buffer.prototype.serialize = function() {
+    var output = {
+        serialized: {
+            type: this.type,
+            attributes: this.attributes,
+            itemSize: this.itemSize,
+            size: this.size,
+            index: this.length,
+            arrayBuffer: this.arrayBuffer,
+            isSerializedMapboxBuffer: true
+        },
+        transferrables: [this.arrayBuffer]
+    };
+
+    this.arrayBuffer = null;
+    this.arrayBufferViews = null;
+
+    return output;
+};
+
+/**
+ * Get the byte offset of a particular index.
+ *
+ * @param {number} index
+ */
+Buffer.prototype.getIndexOffset = function(index) {
+    return index * this.itemSize;
+};
+
+/**
+ * Get the byte offset of an attribute at a particular item index
+ * @param {number} index
+ * @param {string|BufferAttribute} attribute The attribute to set
+ * @param {number} componentIndex
+ */
+Buffer.prototype.getIndexAttributeOffset = function(index, attributeName, componentIndex) {
+    var attribute = this.attributes[attributeName];
+    return (
+        this.getIndexOffset(index) +
+        attribute.offset +
+        attribute.type.size * (componentIndex || 0)
+    );
+};
+
+/**
+ * @param {(BufferAttribute|string)}
+ * @returns {BufferAttribute}
+ */
+Buffer.prototype._normalizeAttributeReference = function(attribute) {
+    if (typeof attribute === 'string') {
+        return this.attributes[attribute];
+    } else {
+        return attribute;
+    }
+};
+
+Buffer.prototype._resize = function(size) {
+    var old = this.arrayBufferViews.UNSIGNED_BYTE;
+    this.size = align(size, Buffer.SIZE_ALIGNMENT);
+    this.arrayBuffer = new ArrayBuffer(this.size);
+    this._refreshArrayBufferViews();
+    this.arrayBufferViews.UNSIGNED_BYTE.set(old);
+};
+
+Buffer.prototype._refreshArrayBufferViews = function() {
+    this.arrayBufferViews = {
+        UNSIGNED_BYTE:  new Uint8Array(this.arrayBuffer),
+        BYTE:           new Int8Array(this.arrayBuffer),
+        UNSIGNED_SHORT: new Uint16Array(this.arrayBuffer),
+        SHORT:          new Int16Array(this.arrayBuffer)
+    };
+};
+
+
+/**
+ * @typedef BufferAttribute
+ * @private
+ * @property {string} name
+ * @property {number} components
+ * @property {BufferAttributeType} type
+ * @property {number} size
+ * @property {number} offset
+ */
+
+/**
+ * @typedef {Object.<string, BufferValue>} BufferItem
+ * @private
+ */
+
+/**
+ * @typedef {(number|Array.<number>)} BufferValue
+ * @private
+ */
+
+/**
+ * @enum {string} BufferType
+ * @private
+ * @readonly
+ */
+Buffer.BufferType = {
+    VERTEX: 'ARRAY_BUFFER',
+    ELEMENT:  'ELEMENT_ARRAY_BUFFER'
+};
+
+/**
+ * @enum {{size: number, name: string}} BufferAttributeType
+ * @private
+ * @readonly
+ */
+Buffer.AttributeType = {
+    BYTE:           { size: 1, name: 'BYTE' },
+    UNSIGNED_BYTE:  { size: 1, name: 'UNSIGNED_BYTE' },
+    SHORT:          { size: 2, name: 'SHORT' },
+    UNSIGNED_SHORT: { size: 2, name: 'UNSIGNED_SHORT' }
+};
+
+/**
+ * An `BufferType.ELEMENT` buffer holds indicies of a corresponding `BufferType.VERTEX` buffer.
+ * These indicies are stored in the `BufferType.ELEMENT` buffer as `UNSIGNED_SHORT`s.
+ *
+ * @property {BufferAttributeType}
+ * @readonly
+ */
+Buffer.ELEMENT_INDEX_ATTRIBUTE_TYPE = Buffer.AttributeType.UNSIGNED_SHORT;
+
+/**
+ * @property {number}
+ * @readonly
+ */
+Buffer.SIZE_DEFAULT = 8192;
+
+/**
+ * WebGL performs best if buffer sizes are aligned to 2 byte boundaries.
+ * @property {number}
+ * @readonly
+ */
+Buffer.SIZE_ALIGNMENT = 2;
+
+/**
+ * WebGL performs best if vertex attribute offsets are aligned to 4 byte boundaries.
+ * @property {number}
+ * @readonly
+ */
+Buffer.VERTEX_ATTRIBUTE_OFFSET_ALIGNMENT = 4;
+
+function align(value, alignment) {
+    alignment = alignment || 1;
+    var remainder = value % alignment;
+    if (alignment !== 1 && remainder !== 0) {
+        value += (alignment - remainder);
+    }
+    return value;
+}
+
+function isNumeric(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+module.exports = Buffer;

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -362,3 +362,15 @@ exports.getCoordinatesCenter = function(coords) {
     return new Coordinate((minX + maxX) / 2, (minY + maxY) / 2, 0)
         .zoomTo(Math.floor(-Math.log(dMax) / Math.LN2));
 };
+
+/**
+ * Throw an error if a condition is not met
+ * @param {boolean} condition
+ * @returns {?string} message
+ * @private
+ */
+exports.assert = function(condition, message) {
+    if (!condition) {
+        throw new Error(message || 'Assertion failed');
+    }
+};

--- a/test/js/data/buffer2.test.js
+++ b/test/js/data/buffer2.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+var test = require('prova');
+var Buffer = require('../../../js/data/buffer2');
+var util = require('../../../js/util/util');
+
+test('Buffer2', function(t) {
+
+    function create(options) {
+        return new Buffer(util.extend({}, {
+            type: Buffer.BufferType.VERTEX,
+            attributes: {
+                map: { },
+                box: { components: 2, type: Buffer.AttributeType.SHORT }
+            }
+        }, options));
+    }
+
+    t.test('constructs itself', function(t) {
+        var buffer = create();
+
+        t.equal(buffer.type, Buffer.BufferType.VERTEX);
+        t.equal(buffer.size, 8192);
+        t.equal(buffer.length, 0);
+        t.equal(buffer.itemSize, 8);
+        t.ok(buffer.arrayBuffer);
+        t.notOk(buffer.singleAttribute);
+        t.ok(buffer.isMapboxBuffer);
+
+        t.equal(buffer.attributes.map.name, 'map');
+        t.equal(buffer.attributes.map.components, 1);
+        t.equal(buffer.attributes.map.type, Buffer.AttributeType.UNSIGNED_BYTE);
+        t.equal(buffer.attributes.map.size, 1);
+        t.equal(buffer.attributes.map.offset, 0);
+
+        t.equal(buffer.attributes.box.name, 'box');
+        t.equal(buffer.attributes.box.components, 2);
+        t.equal(buffer.attributes.box.type, Buffer.AttributeType.SHORT);
+        t.equal(buffer.attributes.box.size, 4);
+        t.equal(buffer.attributes.box.offset, 4);
+
+        t.end();
+    });
+
+    t.test('constructs itself with one attribute', function(t) {
+        var buffer = create({attributes: { map: {} }});
+
+        t.ok(buffer.singleAttribute);
+        t.equal(buffer.singleAttribute, buffer.attributes.map);
+
+        t.end();
+    });
+
+    t.test('serializes and unserializes', function(t) {
+        var bufferReference = create();
+        bufferReference.push({map: [1], box: [7, 3]});
+
+        var bufferInput = create();
+        bufferInput.push({map: [1], box: [7, 3]});
+        var bufferInputSerialized = bufferInput.serialize();
+
+        t.notOk(bufferInput.arrayBuffer);
+        t.notOk(bufferInput.arrayBufferViews);
+
+        var bufferOutput = new Buffer(bufferInputSerialized.serialized);
+
+        t.equal(bufferOutput.type, bufferReference.type);
+        t.equal(bufferOutput.size, bufferReference.size);
+        t.equal(bufferOutput.length, bufferReference.length);
+        t.equal(bufferOutput.itemSize, bufferReference.itemSize);
+        t.equal(bufferOutput.singleAttribute, bufferReference.singleAttribute);
+        t.deepEqual(bufferOutput.attributes, bufferReference.attributes);
+        t.deepEqual(bufferOutput.get(0), {map: [1], box: [7, 3]});
+
+        t.end();
+    });
+
+    t.test('pushes items', function(t) {
+        var buffer = create();
+
+        t.equal(0, buffer.push({map: 1, box: [7, 3]}));
+        t.equal(1, buffer.push({map: 4, box: [2, 5]}));
+
+        t.equal(buffer.length, 2);
+
+        t.deepEqual(buffer.get(0), {map: [1], box: [7, 3]});
+        t.deepEqual(buffer.get(1), {map: [4], box: [2, 5]});
+
+        t.end();
+    });
+
+    t.test('pushes items with one attribute', function(t) {
+        var buffer = create({attributes: { map: {} }});
+
+        t.equal(0, buffer.push(1));
+        t.equal(1, buffer.push(2));
+
+        t.equal(buffer.length, 2);
+
+        t.deepEqual(buffer.get(0), {map: [1]});
+        t.deepEqual(buffer.get(1), {map: [2]});
+
+        t.end();
+    });
+
+    t.test('sets items', function(t) {
+        var buffer = create();
+        buffer.set(1, {map: [1], box: [7, 3]});
+        t.deepEqual(buffer.get(1), {map: [1], box: [7, 3]});
+        t.equal(buffer.length, 2);
+        t.end();
+    });
+
+    t.test('sets item attributes', function(t) {
+        var buffer = create();
+        buffer.setAttribute(1, 'map', 1);
+        buffer.setAttribute(1, 'box', [7, 3]);
+        t.deepEqual(buffer.get(1), {map: [1], box: [7, 3]});
+        t.equal(buffer.length, 2);
+        t.end();
+    });
+
+    t.test('automatically resizes', function(t) {
+        var buffer = create();
+        var sizeInitial = buffer.size;
+        t.ok(sizeInitial);
+
+        var index = Math.ceil(sizeInitial * 1.5 / buffer.itemSize) + 1;
+        buffer.set(index, {map: 1, box: [7, 3]});
+
+        t.deepEqual(buffer.get(index), {map: [1], box: [7, 3]});
+        t.equal(buffer.length, index + 1);
+        t.equal(buffer.size, sizeInitial * 1.5 * 1.5);
+
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Up until now, GL JS has used hand-coded classes to specify buffer layouts and buffer manipulation operations. This worked well pre-data-driven-styling because there were < 10 possible buffer layouts. For example, [here is the `TriangleElementBuffer` class](https://github.com/mapbox/mapbox-gl-js/blob/master/js/data/buffer/triangle_element_buffer.js)

```js
module.exports = TriangleElementBuffer;

function TriangleElementBuffer(buffer) {
    Buffer.call(this, buffer);
}

TriangleElementBuffer.prototype = util.inherit(Buffer, {
    itemSize: 6, // bytes per triangle (3 * unsigned short == 6 bytes)
    arrayType: 'ELEMENT_ARRAY_BUFFER',

    add: function(a, b, c) {
        var pos2 = this.pos / 2;

        this.resize();

        this.ushorts[pos2 + 0] = a;
        this.ushorts[pos2 + 1] = b;
        this.ushorts[pos2 + 2] = c;

        this.pos += this.itemSize;
    }
});
```

Post-data-driven styling, however, the number of possible buffer layouts is [practically infinite](https://en.wikipedia.org/wiki/Zero_one_infinity_rule) because any subset of paint properties might be included in the buffer. 

The first step towards proper data driven styling was to create a more general and powerful framework for buffers (temporarily called `Buffer2`) which allows buffer layouts to be specified by configuration rather than code. Using `Buffer2`, We could write the same `TriangleElementBuffer` class as

```
module.exports = function() {
    Buffer2.apply(this, {
        type: Buffer2.BufferType.ELEMENT,
        attributes: {
            verticies: {
                components: 3,
                type: Buffer2.AttributeType.UNSIGNED_SHORT
            }
        }
    });
}
```

... but in practice we *wouldn't* write it that way. GL JS would choose the attributes for that buffer at runtime for the best performance. 

The `Buffer2` class will know how to construct, write to, and read from GL buffers but have no semantic understanding of their contents. 

Instances of `Buffer2` can be ([destructively](https://developers.google.com/web/updates/2011/12/Transferable-Objects-Lightning-Fast?hl=en)) serialized and transferred across threads. 

cc @tmcw @mourner @kkaefer 