### PR TITLE
reverse symbol placement priority order

### DIFF
--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -135,7 +135,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
      *  Buckets that don't need to be parsed in order, aren't to save time.
      */
 
-    for (i = 0; i < bucketsInOrder.length; i++) {
+    for (i = bucketsInOrder.length - 1; i >= 0; i--) {
         bucket = bucketsInOrder[i];
 
         // Link buckets that need to be parsed in order
@@ -244,7 +244,7 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, collisionDebug) {
     var collisionTile = new CollisionTile(angle, pitch);
 
     var bucketsInOrder = this.bucketsInOrder;
-    for (var i = 0; i < bucketsInOrder.length; i++) {
+    for (var i = bucketsInOrder.length - 1; i >= 0; i--) {
         var bucket = bucketsInOrder[i];
 
         if (bucket.type === 'symbol') {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "documentation": "git+https://github.com/documentationjs/documentation#d341019b32a8a257a93bd55586e7f09f42e29341",
     "eslint": "^0.14.1",
     "istanbul": "^0.3.0",
-    "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#af7481f223acec41421bcf9ec944651216c1358c",
+    "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#a3ef92f17efb651d65176337daf51f4690794093",
     "marked": "0.3.x",
     "mkdirp": "^0.5.0",
     "prova": "^2.1.2",


### PR DESCRIPTION
Labels later in the layer list now have priority over those that are earlier in the layer list.

implements https://github.com/mapbox/mapbox-gl-style-spec/issues/256

spec pr: https://github.com/mapbox/mapbox-gl-style-spec/pull/337
test-suite pr: https://github.com/mapbox/mapbox-gl-test-suite/pull/41