### PR TITLE
Fix image source testing harness and switch to lnglat coordinates

### DIFF
--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -66,8 +66,8 @@ ImageSource.prototype = util.inherit(Evented, {
      */
     createTile: function() {
         var map = this.map;
-        var coords = this.coordinates.map(function(latlng) {
-            var loc = LatLng.convert(latlng);
+        var coords = this.coordinates.map(function(lnglat) {
+            var loc = LatLng.convert([lnglat[1], lnglat[0]]);
             return map.transform.locationCoordinate(loc).zoomTo(0);
         });
 

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -59,6 +59,8 @@ exports.getImage = function(url, callback) {
                     width: png.width,
                     height: png.height,
                     data: png.data,
+                    complete: true,
+                    addEventListener: function() {},
                     getData: function() { return this.data; }
                 });
             });


### PR DESCRIPTION
I came across two issues while writing `gl-test-suite` tests for the image source per https://github.com/mapbox/mapbox-gl-test-suite/issues/27

 - incomplete mocks of image objects in the ajax module
 - inconsistent use of latlng vs lnglat between image source and video source (standardized on lnglat)

:eyes: @jfirebaugh @ansis