### PR TITLE
Properly remove event listener that caused memory leak

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -90,9 +90,11 @@ var Map = module.exports = function(options) {
     }.bind(this));
 
     if (typeof window !== 'undefined') {
-        window.addEventListener('resize', function () {
+        this.boundOnResizeCallback = function () {
             this.stop().resize().update();
-        }.bind(this), false);
+        }.bind(this);
+
+        window.addEventListener('resize', this.boundOnResizeCallback, false);
     }
 
     this.interaction = new Interaction(this);
@@ -701,6 +703,10 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         browser.cancelFrame(this._frameId);
         clearTimeout(this._sourcesDirtyTimeout);
         this.setStyle(null);
+        if (typeof window !== 'undefined') {
+            window.removeEventListener('resize', this.boundOnResizeCallback, false);
+            this.boundOnResizeCallback = null;
+        }
         return this;
     },
 


### PR DESCRIPTION
There is an event listener in map.js on window's resize event that was never removed. Since the callback has `this` bound to it, and `this` reference dom elements, it caused a huge memory leak on an SPA where the view that contained the map was recreated when visited each time.