### PR TITLE
Adjust semantics for mapbox:// style and sprite URL schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,13 @@ An in-progress version being developed in the `master` branch.
   now expected to be version 8. You can use the [gl-style-migrate](https://github.com/mapbox/mapbox-gl-style-lint#migrations)
   utility to update existing styles.
 
+* The format for `mapbox://` style and glyphs URLs has changed. For style URLs, you should now use the format
+  `mapbox://styles/:username/:style`. The `:style` portion of the URL no longer contains a username. For font URLs, you
+  should now use the format `mapbox://fonts/:username/{fontstack}/{range}.pbf`.
 * Mapbox default styles are now hosted via the Styles API rather than www.mapbox.com. You can make use of the Styles API
-  with a `mapbox://` style URL pointing to a v8 style, e.g. `mapbox://mapbox.streets-v8`.
-* The v8 satellite style (`mapbox://mapbox.satellite-v8`) is now a plain satellite style, and not longer supports labels
-  or countour lines via classes. For a labeled satellite style, use `mapbox://mapbox.satellite-hybrid`.
+  with a `mapbox://` style URL pointing to a v8 style, e.g. `mapbox://styles/mapbox/streets-v8`.
+* The v8 satellite style (`mapbox://styles/mapbox/satellite-v8`) is now a plain satellite style, and not longer supports labels
+  or countour lines via classes. For a labeled satellite style, use `mapbox://styles/mapbox/satellite-hybrid`.
 
 * Removed `mbgl.config.HTTP_URL` and `mbgl.config.FORCE_HTTPS`; https is always used when connecting to the Mapbox API.
 * Renamed `mbgl.config.HTTPS_URL` to `mbgl.config.API_URL`.

--- a/debug/site.js
+++ b/debug/site.js
@@ -5,7 +5,7 @@ var map = new mapboxgl.Map({
     container: 'map',
     zoom: 12.5,
     center: [-77.01866, 38.888],
-    style: 'mapbox://mapbox.streets-v8',
+    style: 'mapbox://styles/mapbox/streets-v8',
     hash: true
 });
 

--- a/docs/_posts/examples/3400-01-01-custom-style-id.html
+++ b/docs/_posts/examples/3400-01-01-custom-style-id.html
@@ -9,7 +9,7 @@ description: Using a custom Mapbox-hosted style.
 <script>
 var map = new mapboxgl.Map({
   container: 'map', // container id
-  style: 'mapbox://mapbox.dark-v8', //hosted style id
+  style: 'mapbox://styles/mapbox/dark-v8', //hosted style id
   center: [-77.38, 39], // starting position
   zoom: 3 // starting zoom
 });

--- a/docs/_posts/examples/3400-01-01-simple-map.html
+++ b/docs/_posts/examples/3400-01-01-simple-map.html
@@ -10,7 +10,7 @@ permalink: /examples
 <script>
 var map = new mapboxgl.Map({
   container: 'map', // container id
-  style: 'mapbox://mapbox.streets-v8', //stylesheet location
+  style: 'mapbox://styles/mapbox/streets-v8', //stylesheet location
   center: [-74.50, 40], // starting position
   zoom: 9 // starting zoom
 });

--- a/docs/_posts/examples/3400-01-02-check-for-support.html
+++ b/docs/_posts/examples/3400-01-02-check-for-support.html
@@ -12,7 +12,7 @@ if (!mapboxgl.supported()) {
 } else {
   var map = new mapboxgl.Map({
     container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+    style: 'mapbox://styles/mapbox/streets-v8',
     center: [-74.50, 40],
     zoom: 9
   });

--- a/docs/_posts/examples/3400-01-02-interactive-false.html
+++ b/docs/_posts/examples/3400-01-02-interactive-false.html
@@ -9,7 +9,7 @@ description: "Setting interactive: false to create a static map"
 <script>
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-74.50, 40],
   zoom: 9,
   // causes pan & zoom handlers not to be applied, similar to

--- a/docs/_posts/examples/3400-01-03-fitbounds.html
+++ b/docs/_posts/examples/3400-01-03-fitbounds.html
@@ -27,7 +27,7 @@ description: Use fitBounds to show a specific area of the map in view, regardles
 <script>
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-74.50, 40],
   zoom: 9
 });

--- a/docs/_posts/examples/3400-01-03-flyto-options.html
+++ b/docs/_posts/examples/3400-01-03-flyto-options.html
@@ -29,7 +29,7 @@ var start = [-74.50, 40];
 var end = [74.50, 40];
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: start,
   zoom: 9
 });

--- a/docs/_posts/examples/3400-01-03-flyto.html
+++ b/docs/_posts/examples/3400-01-03-flyto.html
@@ -27,7 +27,7 @@ description: Using .flyTo to smoothly interpolate between locations
 <script>
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-74.50, 40],
   zoom: 9
 });

--- a/docs/_posts/examples/3400-01-04-geojson-line.html
+++ b/docs/_posts/examples/3400-01-04-geojson-line.html
@@ -9,7 +9,7 @@ description: Add a GeoJSON line to a map.
 <script>
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-122.486052, 37.830348],
   zoom: 15
 });

--- a/docs/_posts/examples/3400-01-04-navigation.html
+++ b/docs/_posts/examples/3400-01-04-navigation.html
@@ -9,7 +9,7 @@ description: Zoom and rotation controls to make map navigation more obvious
 <script>
 var map = new mapboxgl.Map({
   container: 'map', // container id
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-74.50, 40], // starting position
   zoom: 9 // starting zoom
 });

--- a/docs/_posts/examples/3400-01-05-geojson-markers.html
+++ b/docs/_posts/examples/3400-01-05-geojson-markers.html
@@ -9,7 +9,7 @@ description: Add markers from a GeoJSON collection to a map.
 <script>
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-96, 37.8],
   zoom: 3
 });

--- a/docs/_posts/examples/3400-01-05-mouse-position.html
+++ b/docs/_posts/examples/3400-01-05-mouse-position.html
@@ -25,7 +25,7 @@ description: Showing mouse position on hover with pixel and latitude and longitu
 <script>
 var map = new mapboxgl.Map({
   container: 'map', // container id
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-74.50, 40], // starting position
   zoom: 9 // starting zoom
 });

--- a/docs/_posts/examples/3400-01-05-popup-on-click.html
+++ b/docs/_posts/examples/3400-01-05-popup-on-click.html
@@ -9,7 +9,7 @@ description: Add a popup to a clicked point on the map
 <script>
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-96, 37.8],
   zoom: 3
 });

--- a/docs/_posts/examples/3400-01-05-popup.html
+++ b/docs/_posts/examples/3400-01-05-popup.html
@@ -9,7 +9,7 @@ description: Add a popup to the map
 <script>
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://mapbox.streets-v8',
+  style: 'mapbox://styles/mapbox/streets-v8',
   center: [-96, 37.8],
   zoom: 3
 });

--- a/docs/_posts/examples/3400-01-06-satellite-map.html
+++ b/docs/_posts/examples/3400-01-06-satellite-map.html
@@ -11,7 +11,7 @@ var map = new mapboxgl.Map({
   container: 'map',
   zoom: 9,
   center: [137.9150899566626, 36.25956997955441],
-  style: 'mapbox://mapbox.satellite-v8',
+  style: 'mapbox://styles/mapbox/satellite-v8',
   hash: false
 });
 </script>

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -27,11 +27,14 @@ function normalizeURL(url, pathPrefix, accessToken) {
 }
 
 module.exports.normalizeStyleURL = function(url, accessToken) {
-    var user = url.match(/^mapbox:\/\/([^.]+)/);
-    if (!user)
+    if (!url.match(/^mapbox:\/\/styles\//))
         return url;
 
-    return normalizeURL(url, '/styles/v1/' + user[1] + '/', accessToken);
+    var split = url.split('/');
+    var user = split[3];
+    var style = split[4];
+    var draft = split[5] ? '/draft' : '';
+    return normalizeURL('mapbox://' + user + '/' + style + draft, '/styles/v1/', accessToken);
 };
 
 module.exports.normalizeSourceURL = function(url, accessToken) {
@@ -55,11 +58,11 @@ module.exports.normalizeSpriteURL = function(url, format, ext, accessToken) {
     if (!url.match(/^mapbox:\/\/sprites\//))
         return url + format + ext;
 
-    var draft = url.split('/')[4];
-    var styleId = url.split('/')[3];
-    var user = styleId.split('.')[0];
-    var newUrl = user + '/' + styleId + (draft ? '/draft/' : '/') + 'sprite' + format + ext;
-    return normalizeURL('mapbox://' + newUrl, '/styles/v1/', accessToken);
+    var split = url.split('/');
+    var user = split[3];
+    var style = split[4];
+    var draft = split[5] ? '/draft' : '';
+    return normalizeURL('mapbox://' + user + '/' + style + draft + '/sprite' + format + ext, '/styles/v1/', accessToken);
 };
 
 module.exports.normalizeTileURL = function(url, sourceUrl) {

--- a/test/js/util/mapbox.test.js
+++ b/test/js/util/mapbox.test.js
@@ -8,6 +8,21 @@ var browser = require('../../../js/util/browser');
 test("mapbox", function(t) {
     config.ACCESS_TOKEN = 'key';
 
+    t.test('.normalizeStyleURL', function(t) {
+        t.test('returns an API URL with access_token parameter', function(t) {
+            t.equal(mapbox.normalizeStyleURL('mapbox://styles/user/style'), 'https://api.mapbox.com/styles/v1/user/style?access_token=key');
+            t.equal(mapbox.normalizeStyleURL('mapbox://styles/user/style/draft'), 'https://api.mapbox.com/styles/v1/user/style/draft?access_token=key');
+            t.end();
+        });
+
+        t.test('ignores non-mapbox:// scheme', function(t) {
+            t.equal(mapbox.normalizeStyleURL('http://path'), 'http://path');
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.test('.normalizeSourceURL', function(t) {
         t.test('returns a v4 URL with access_token parameter', function(t) {
             t.equal(mapbox.normalizeSourceURL('mapbox://user.map'), 'https://api.mapbox.com/v4/user.map.json?access_token=key&secure');
@@ -61,18 +76,18 @@ test("mapbox", function(t) {
     t.test('.normalizeSpriteURL', function(t) {
         t.test('normalizes mapbox:// URLs', function(t) {
             t.equal(
-                mapbox.normalizeSpriteURL('mapbox://sprites/mapbox.streets-v8', '', '.json'),
-                'https://api.mapbox.com/styles/v1/mapbox/mapbox.streets-v8/sprite.json?access_token=key'
+                mapbox.normalizeSpriteURL('mapbox://sprites/mapbox/streets-v8', '', '.json'),
+                'https://api.mapbox.com/styles/v1/mapbox/streets-v8/sprite.json?access_token=key'
             );
 
             t.equal(
-                mapbox.normalizeSpriteURL('mapbox://sprites/mapbox.streets-v8', '@2x', '.png'),
-                'https://api.mapbox.com/styles/v1/mapbox/mapbox.streets-v8/sprite@2x.png?access_token=key'
+                mapbox.normalizeSpriteURL('mapbox://sprites/mapbox/streets-v8', '@2x', '.png'),
+                'https://api.mapbox.com/styles/v1/mapbox/streets-v8/sprite@2x.png?access_token=key'
             );
 
             t.equal(
-                mapbox.normalizeSpriteURL('mapbox://sprites/mapbox.streets-v8/draft', '@2x', '.png'),
-                'https://api.mapbox.com/styles/v1/mapbox/mapbox.streets-v8/draft/sprite@2x.png?access_token=key'
+                mapbox.normalizeSpriteURL('mapbox://sprites/mapbox/streets-v8/draft', '@2x', '.png'),
+                'https://api.mapbox.com/styles/v1/mapbox/streets-v8/draft/sprite@2x.png?access_token=key'
             );
 
             t.end();
@@ -82,20 +97,6 @@ test("mapbox", function(t) {
             t.equal(mapbox.normalizeSpriteURL('http://www.foo.com/bar', '@2x', '.png'), 'http://www.foo.com/bar@2x.png');
             t.end();
         });
-    });
-
-    t.test('.normalizeStyleURL', function(t) {
-        t.test('returns an API URL with access_token parameter', function(t) {
-            t.equal(mapbox.normalizeStyleURL('mapbox://user.style'), 'https://api.mapbox.com/styles/v1/user/user.style?access_token=key');
-            t.end();
-        });
-
-        t.test('ignores non-mapbox:// scheme', function(t) {
-            t.equal(mapbox.normalizeStyleURL('http://path'), 'http://path');
-            t.end();
-        });
-
-        t.end();
     });
 
     t.test('.normalizeTileURL', function(t) {

--- a/test/manual/popup.html
+++ b/test/manual/popup.html
@@ -20,7 +20,7 @@
 
     var map = new mapboxgl.Map({
         container: 'map',
-        style: 'mapbox://mapbox.bright-v8'
+        style: 'mapbox://styles/mapbox/bright-v8'
     });
 
     var width = map.getContainer().offsetWidth,


### PR DESCRIPTION
We are dropping usernames from style IDs, and we'll use this opportunity
to add a type prefix to the mapbox:// style URL as well.

Therefore:

* Format of mapbox:// style URLs is now mapbox://styles/:user/:style
* Format of mapbox:// sprite URLs is now mapbox://sprites/:user/:style