### PR TITLE
Add explicit Accept header when getting JSON

### DIFF
--- a/js/util/browser/ajax.js
+++ b/js/util/browser/ajax.js
@@ -3,6 +3,7 @@
 exports.getJSON = function(url, callback) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', url, true);
+    xhr.setRequestHeader('Accept', 'application/json');
     xhr.onerror = function(e) {
         callback(e);
     };


### PR DESCRIPTION
I have a server that does content type negotiation ([Django Rest Framework](http://www.django-rest-framework.org/api-guide/content-negotiation/)). This works great in Chrome, but Firefox sets a default Accept header on XHRs that causes my server to generate HTML instead of JSON. This fix sets `Accept: application/json` explicitly, which should be fine on all browsers and servers because we do actually want JSON here.

This is the `Accept` header sent by Firefox without this patch:
```
text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
```

And with this patch:
```
application/json
```