### PR TITLE
Document Camera zoom around, correct typo in easeTo options, better LngLat docs

### DIFF
--- a/js/geo/lng_lat.js
+++ b/js/geo/lng_lat.js
@@ -6,6 +6,14 @@ var wrap = require('../util/util').wrap;
 
 /**
  * Create a longitude, latitude object from a given longitude and latitude pair in degrees.
+ * Mapbox GL uses Longitude, Latitude coordinate order to match GeoJSON.
+ *
+ * Note that any Mapbox GL method that accepts a `LngLat` object can also accept an
+ * `Array` and will perform an implicit conversion.  The following lines are equivalent:
+ ```
+ map.setCenter([-79.469, 39.261]);
+ map.setCenter( new mapboxgl.LngLat(-79.469, 39.261) );
+ ```
  *
  * @class LngLat
  * @classdesc A representation of a longitude, latitude point, in degrees.

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -201,10 +201,12 @@ Transform.prototype = {
      * @private
      */
     locationCoordinate: function(lnglat) {
-        var k = this.zoomScale(this.tileZoom) / this.worldSize;
+        var k = this.zoomScale(this.tileZoom) / this.worldSize,
+            ll = LngLat.convert(lnglat);
+
         return new Coordinate(
-            this.lngX(lnglat.lng) * k,
-            this.latY(lnglat.lat) * k,
+            this.lngX(ll.lng) * k,
+            this.latY(ll.lat) * k,
             this.tileZoom);
     },
 

--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -13,11 +13,11 @@ var Point = require('point-geometry');
  * options will default to the current value for that property.
  *
  * @typedef {Object} CameraOptions
- * @property {LngLat|Array<number>} center Map center
+ * @property {LngLat} center Map center
  * @property {number} zoom Map zoom level
  * @property {number} bearing Map rotation bearing in degrees counter-clockwise from north
  * @property {number} pitch Map angle in degrees at which the camera is looking at the ground
- * @property {LngLat|Array<number>} around If zooming, the zoom center (defaults to map center)
+ * @property {LngLat} around If zooming, the zoom center (defaults to map center)
  */
 
 /**
@@ -44,7 +44,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
     /**
      * Sets a map location. Equivalent to `jumpTo({center: center})`.
      *
-     * @param {LngLat|Array<number>} center Map center to jump to
+     * @param {LngLat} center Map center to jump to
      * @fires movestart
      * @fires moveend
      * @returns {Map} `this`
@@ -73,7 +73,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
     /**
      * Pan to a certain location with easing
      *
-     * @param {LngLat|Array<number>} lnglat Location to pan to
+     * @param {LngLat} lnglat Location to pan to
      * @param {AnimationOptions} [options]
      * @fires movestart
      * @fires moveend

--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -16,7 +16,8 @@ var Point = require('point-geometry');
  * @property {Array} center Longitude and latitude (passed as `[lng, lat]`)
  * @property {number} zoom Map zoom level
  * @property {number} bearing Map rotation bearing in degrees counter-clockwise from north
- * @property {number} pitch The angle at which the camera is looking at the ground
+ * @property {number} pitch The angle in degrees at which the camera is looking at the ground
+ * @property {Array} around If zooming, the zoom center (defaults to map center, passed as `[lng, lat]`)
  */
 
 /**
@@ -427,7 +428,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
     /**
      * Easing animation to a specified location/zoom/bearing
      *
-     * @param {CameraOptions~AnimationOptions} options map view and animation options
+     * @param {CameraOptions|AnimationOptions} options map view and animation options
      * @fires movestart
      * @fires moveend
      * @returns {Map} `this`

--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -13,11 +13,11 @@ var Point = require('point-geometry');
  * options will default to the current value for that property.
  *
  * @typedef {Object} CameraOptions
- * @property {Array} center Longitude and latitude (passed as `[lng, lat]`)
+ * @property {LngLat|Array<number>} center Map center
  * @property {number} zoom Map zoom level
  * @property {number} bearing Map rotation bearing in degrees counter-clockwise from north
- * @property {number} pitch The angle in degrees at which the camera is looking at the ground
- * @property {Array} around If zooming, the zoom center (defaults to map center, passed as `[lng, lat]`)
+ * @property {number} pitch Map angle in degrees at which the camera is looking at the ground
+ * @property {LngLat|Array<number>} around If zooming, the zoom center (defaults to map center)
  */
 
 /**
@@ -44,7 +44,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
     /**
      * Sets a map location. Equivalent to `jumpTo({center: center})`.
      *
-     * @param {Array} center Longitude and latitude (passed as `[lng, lat]`)
+     * @param {LngLat|Array<number>} center Map center to jump to
      * @fires movestart
      * @fires moveend
      * @returns {Map} `this`
@@ -59,7 +59,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
     /**
      * Pan by a certain number of pixels
      *
-     * @param {Array} offset [x, y]
+     * @param {Array<number>} offset [x, y]
      * @param {AnimationOptions} [options]
      * @fires movestart
      * @fires moveend
@@ -73,7 +73,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
     /**
      * Pan to a certain location with easing
      *
-     * @param {LngLat|Array<number>} lnglat
+     * @param {LngLat|Array<number>} lnglat Location to pan to
      * @param {AnimationOptions} [options]
      * @fires movestart
      * @fires moveend


### PR DESCRIPTION
This just 
* Adds documentation for the `around` parameter in `CameraOptions` (#1432)
* Replaces `~` with `|` in `easeTo` documentation
* Improves LngLat documentation with examples (#739)