### PR TITLE
Floor values to integer before copying pixels, fixes devicePixelRatio issues

### DIFF
--- a/js/symbol/sprite_atlas.js
+++ b/js/symbol/sprite_atlas.js
@@ -81,6 +81,10 @@ SpriteAtlas.prototype.resize = function(newRatio) {
 };
 
 function copyBitmap(src, srcStride, srcX, srcY, dst, dstStride, dstX, dstY, width, height, wrap) {
+    // floor values for non-integer pixelRatio
+    dstStride = dstStride << 0;
+    dstX = dstX << 0;
+    dstY = dstY << 0;
     var srcI = srcY * srcStride + srcX;
     var dstI = dstY * dstStride + dstX;
     var x, y;


### PR DESCRIPTION
Because of non-integer browser.devicePixelRatio values, copyBitmap would try to copy to floating pixels, which would not work and not display any icon at all.
This happens when the web browser is zoom in or out on map load, devicePixelRatio  reports a value of about 0.82 in my case on Windows 10 because or resolution down-scaling.
```
    var padding = 1;

    copyBitmap(
        /* source buffer */  srcImg,
        /* source stride */  this.sprite.img.width,
        /* source x */       src.x,
        /* source y */       src.y,
        /* dest buffer */    dstImg,
        /* dest stride */    this.width * this.pixelRatio,
        /* dest x */         (dst.x + padding) * this.pixelRatio,
        /* dest y */         (dst.y + padding) * this.pixelRatio,
        /* icon dimension */ src.width,
        /* icon dimension */ src.height,
        /* wrap */ wrap
    );
```
When a new icon comes up, it is first allocated and then copied by cropping the sprite. Because dstStride, dstX and dstY are multiplied by the pixelRatio, they can be floating values.
They are then used in copyBitmap in loops, which then makes pixel allocations on floating values here: 
```
dst[dstI + x] = src[srcI + x];
```

For integer pixel ratios, this doesn't change anything.

I used the bitwise "<< 0" to floor the values as these are positive and relatively small values (max value is about the pixel width of the PNG sprite image) so it is faster than Math.floor and won't impact performances.

I believe this PR should fix these issues:
#1029
#1475
#1476

The code works but there are some rounding artifacts for sprites where there is no padding between images, such as "streets-v8". Here is an example of these artifacts:
![image](https://cloud.githubusercontent.com/assets/1240481/9831228/56c5e826-594e-11e5-85af-e14539ed2c13.png)
There is a line on the side of some icons. I am not sure if this line comes from the copyBitmap or the BinPacking storage. There is a padding from commit https://github.com/mapbox/mapbox-gl-js/commit/212760981493460b438f1cc117001825773fad91#diff-260b88e5dab461aa35bdc43d18b7125b by @ansis but I am not sure if these artifacts can be removed by changing the padding or something.

These artifacts don't happen on most icons and only in very packed sprites, but at least icons show up :)

Fabien