### PR TITLE
add reload noop method to image source

### DIFF
--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -107,6 +107,10 @@ ImageSource.prototype = util.inherit(Evented, {
         // noop
     },
 
+    reload: function() {
+        // noop
+    },
+
     render: function(layers, painter) {
         if (!this._loaded || !this.loaded()) return;
 


### PR DESCRIPTION

If we don't, updating the style with an image source throws the following error:

    Uncaught TypeError: this.sources[id].reload is not a function

from: https://github.com/mapbox/mapbox-gl-js/blob/master/js/style/style.js#L423