### PR TITLE
Language example

### DIFF
--- a/docs/_posts/examples/3400-01-03-language-switch.html
+++ b/docs/_posts/examples/3400-01-03-language-switch.html
@@ -1,0 +1,50 @@
+---
+layout: example
+category: example
+title: Switch Languages
+description: Using .setLayoutProperty to switch languages dynamically. 
+---
+
+<style>
+    #languageButtons {
+        width: 90%;
+        margin: 0 auto;
+    }
+    .language-switch-button {
+        display: inline-block;
+        position: relative;
+        cursor: pointer;
+        width: 20%;
+        padding: 8px;
+        border-radius: 3px;
+        font-size: 12px;
+        text-align: center;
+        color: #fff;
+        background: #ee8a65;
+        font-family: sans-serif;
+        font-weight: bold;
+    }
+</style>
+<div id='map'></div>
+<br />
+<ul id="languageButtons">
+    <li onclick='languageSwitcher("fr");' class='language-switch-button'>French</li>
+    <li onclick='languageSwitcher("ru");' class='language-switch-button'>Russian</li>
+    <li onclick='languageSwitcher("de");' class='language-switch-button'>German</li>
+    <li onclick='languageSwitcher("es");' class='language-switch-button'>Spanish</li>
+</ul>
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoiZGFuc3dpY2siLCJhIjoieUZiWmwtVSJ9.0cPQywdbPVmvHiHJ6NwdXA';
+
+var map = new mapboxgl.Map({
+  container: 'map',
+  style: 'mapbox://styles/danswick/cieukjnf80io2rxm2or8mu2wz',
+  center: [16.05, 48],
+  zoom: 3
+});
+
+function languageSwitcher(language) {
+    var lang = language;
+    map.setLayoutProperty('country_label', 'text-field', "{name_" + lang + "}");
+}
+</script>

--- a/docs/_posts/examples/3400-01-03-language-switch.html
+++ b/docs/_posts/examples/3400-01-03-language-switch.html
@@ -44,7 +44,9 @@ var map = new mapboxgl.Map({
 });
 
 function languageSwitcher(language) {
-    var lang = language;
-    map.setLayoutProperty('country_label', 'text-field', "{name_" + lang + "}");
+    // use setLayoutProperty to set the value of a layout property 
+    // in a given style layer. This should look like
+    // setLayoutProperty(layer, name, value). 
+    map.setLayoutProperty('country_label', 'text-field', "{name_" + language + "}");
 }
 </script>

--- a/docs/_posts/examples/3400-01-03-language-switch.html
+++ b/docs/_posts/examples/3400-01-03-language-switch.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Switch Languages
+title: Switch languages
 description: Using .setLayoutProperty to switch languages dynamically. 
 ---
 
@@ -34,19 +34,17 @@ description: Using .setLayoutProperty to switch languages dynamically.
     <li onclick='languageSwitcher("es");' class='language-switch-button'>Spanish</li>
 </ul>
 <script>
-mapboxgl.accessToken = 'pk.eyJ1IjoiZGFuc3dpY2siLCJhIjoieUZiWmwtVSJ9.0cPQywdbPVmvHiHJ6NwdXA';
-
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://styles/danswick/cieukjnf80io2rxm2or8mu2wz',
+  style: 'mapbox://styles/mapbox/light-v8',
   center: [16.05, 48],
-  zoom: 3
+  zoom: 2.9
 });
 
 function languageSwitcher(language) {
     // use setLayoutProperty to set the value of a layout property 
     // in a given style layer. This should look like
     // setLayoutProperty(layer, name, value). 
-    map.setLayoutProperty('country_label', 'text-field', "{name_" + language + "}");
+    map.setLayoutProperty('country-label-lg', 'text-field', "{name_" + language + "}");
 }
 </script>


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-gl-js/issues/1502: Adds new example showing how to switch a map's language by using setLayoutProperty with the text-field property.

![language-switcher](https://cloud.githubusercontent.com/assets/2365503/10008494/005c7ed6-6084-11e5-8848-9eb6a6920d9b.gif)

**Note**: I tested this out with a Chinese option, but loading glyphs took long enough that it felt like the example wasn't working correctly. 

cc: @lyzidiamond, @tmcw 