### PR TITLE
Fix memory leak in worker

### DIFF
--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -184,6 +184,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
                 self.bucketStats._total += time;
                 self.bucketStats[bucket.id] = (self.bucketStats[bucket.id] || 0) + time;
             }
+            bucket.features = null;
         }
 
         remaining--;


### PR DESCRIPTION
Makes the worker consume 30% less memory (without interactive layers) by not retaining data that's no longer needed after it was parsed or processed.

Snapshot sizes when loading the same DC z11 view `/#11.06/38.9049/-77.0460` (no panning/zooming):

```
32.0 MB — no patch, not interactive
23.1 MB — with patch, not interactive
44.2 MB — no patch, all layers interactive
43.4 MB — with patch, all layers interactive
```

@jfirebaugh for review