### PR TITLE
Assert valid TileCoord, fix wrap in TileCoord#cover

### DIFF
--- a/js/source/tile_coord.js
+++ b/js/source/tile_coord.js
@@ -3,11 +3,16 @@
 module.exports = TileCoord;
 
 function TileCoord(z, x, y, w) {
-    if (w === undefined) w = 0;
-    this.z = z;
-    this.x = x;
-    this.y = y;
-    this.w = w;
+    if (isNaN(w)) w = 0;
+
+    if (isNaN(z) || isNaN(x) || isNaN(y) || z < 0 || x < 0 || y < 0) {
+        throw new Error('Invalid TileCoord object: (' + z + ', ' + x + ', ' + y + ', ' + w + ')');
+    }
+
+    this.z = +z;
+    this.x = +x;
+    this.y = +y;
+    this.w = +w;
 
     // calculate id
     w *= 2;
@@ -135,11 +140,11 @@ TileCoord.cover = function(z, bounds, actualZ) {
     var t = {};
 
     function scanLine(x0, x1, y) {
-        var x, wx;
+        var x, wx, coord;
         if (y >= 0 && y <= tiles) {
             for (x = x0; x < x1; x++) {
-                wx = (x + tiles) % tiles;
-                var coord = new TileCoord(actualZ, wx, y, Math.floor(x / tiles));
+                wx = (x % tiles + tiles) % tiles;
+                coord = new TileCoord(actualZ, wx, y, Math.floor(x / tiles));
                 t[coord.id] = coord;
             }
         }

--- a/test/js/source/tile_coord.test.js
+++ b/test/js/source/tile_coord.test.js
@@ -4,6 +4,16 @@ var test = require('prova');
 var TileCoord = require('../../../js/source/tile_coord');
 
 test('TileCoord', function(t) {
+    t.test('#constructor', function(t) {
+        t.ok(new TileCoord(0, 0, 0, 0) instanceof TileCoord, 'creates an object with w');
+        t.ok(new TileCoord(0, 0, 0) instanceof TileCoord, 'creates an object without w');
+        t.throws(function() {
+            /*eslint no-new: 0*/
+            new TileCoord(-1, 0, 0, 0);
+        }, "Invalid TileCoord object: (-1, 0, 0, 0)", 'detects and throws on invalid input');
+        t.end();
+    });
+
     t.test('.id', function(t) {
         t.deepEqual(new TileCoord(0, 0, 0).id, 0);
         t.deepEqual(new TileCoord(1, 0, 0).id, 1);
@@ -50,6 +60,74 @@ test('TileCoord', function(t) {
             t.equal(TileCoord.fromID(32).parent(), null);
             t.end();
         });
+    });
+
+    t.test('.cover', function(t) {
+        t.test('calculates tile coverage at w = 0', function(t) {
+            var z = 2,
+                coords = [
+                    {column: 0, row: 1, zoom: 2},
+                    {column: 1, row: 1, zoom: 2},
+                    {column: 1, row: 2, zoom: 2},
+                    {column: 0, row: 2, zoom: 2}
+                ],
+                res = TileCoord.cover(z, coords, z);
+            t.deepEqual(res, [{id: 130, w: 0, x: 0, y: 1, z: 2}]);
+            t.end();
+        });
+
+        t.test('calculates tile coverage at w > 0', function(t) {
+            var z = 2,
+                coords = [
+                    {column: 12, row: 1, zoom: 2},
+                    {column: 13, row: 1, zoom: 2},
+                    {column: 13, row: 2, zoom: 2},
+                    {column: 12, row: 2, zoom: 2}
+                ],
+                res = TileCoord.cover(z, coords, z);
+            t.deepEqual(res, [{id: 3202, w: 3, x: 0, y: 1, z: 2}]);
+            t.end();
+        });
+
+        t.test('calculates tile coverage at w = -1', function(t) {
+            var z = 2,
+                coords = [
+                    {column: -1, row: 1, zoom: 2},
+                    {column:  0, row: 1, zoom: 2},
+                    {column:  0, row: 2, zoom: 2},
+                    {column: -1, row: 2, zoom: 2}
+                ],
+                res = TileCoord.cover(z, coords, z);
+            t.deepEqual(res, [{id: 738, w: -1, x: 3, y: 1, z: 2}]);
+            t.end();
+        });
+
+        t.test('calculates tile coverage at w < -1', function(t) {
+            var z = 2,
+                coords = [
+                    {column: -13, row: 1, zoom: 2},
+                    {column: -12, row: 1, zoom: 2},
+                    {column: -12, row: 2, zoom: 2},
+                    {column: -13, row: 2, zoom: 2}
+                ],
+                res = TileCoord.cover(z, coords, z);
+            t.deepEqual(res, [{id: 3810, w: -4, x: 3, y: 1, z: 2}]);
+            t.end();
+        });
+
+        t.test('calculates tile coverage across meridian', function(t) {
+            var z = 2,
+                coords = [
+                    {column: -0.5, row: 1, zoom: 2},
+                    {column:  0.5, row: 1, zoom: 2},
+                    {column:  0.5, row: 2, zoom: 2},
+                    {column: -0.5, row: 2, zoom: 2}
+                ],
+                res = TileCoord.cover(z, coords, z);
+            t.deepEqual(res, [{id: 130, w: 0, x: 0, y: 1, z: 2}, {id: 738, w: -1, x: 3, y: 1, z: 2}]);
+            t.end();
+        });
+
     });
 
 });


### PR DESCRIPTION
This fixes the crash caused by bad wrap code in TileCoord#cover.
Also adds assertion code to throw if TileCoord constructed from bad parameters.
(and tests for those things)

closes #1483