### PR TITLE
Fix maxBounds constrains

### DIFF
--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -113,14 +113,26 @@ test('transform', function(t) {
         t.end();
     });
 
-    t.test('lngRange', function(t) {
+    t.test('lngRange & latRange constrain zoom and center', function(t) {
         var transform = new Transform();
+        transform.center = new LngLat(0, 0);
+        transform.zoom = 10;
         transform.width = 500;
         transform.height = 500;
-        transform.lngRange = [-10, 10];
-        t.equal(transform.tileZoom, 0);
-        t.equal(transform.tileZoom, transform.zoom);
-        t.equal(transform.zoom, 0);
+
+        transform.lngRange = [-5, 5];
+        transform.latRange = [-5, 5];
+
+        transform.zoom = 0;
+        t.equal(transform.zoom, 5.135709286104402);
+
+        transform.center = new LngLat(-50, -30);
+        t.same(transform.center, new LngLat(0, -0.006358305286099153));
+
+        transform.zoom = 10;
+        transform.center = new LngLat(-50, -30);
+        t.same(transform.center, new LngLat(-4.828338623046875, -4.828969771321582));
+
         t.end();
     });
 });

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -26,7 +26,8 @@ test('camera', function(t) {
     }
 
     t.test('#jumpTo', function(t) {
-        var camera = createCamera();
+        // Choose initial zoom to avoid center being constrained by mercator latitude limits.
+        var camera = createCamera({zoom: 1});
 
         t.test('sets center', function(t) {
             camera.jumpTo({center: [1, 2]});
@@ -112,7 +113,8 @@ test('camera', function(t) {
     });
 
     t.test('#setCenter', function(t) {
-        var camera = createCamera();
+        // Choose initial zoom to avoid center being constrained by mercator latitude limits.
+        var camera = createCamera({zoom: 1});
 
         t.test('sets center', function(t) {
             camera.setCenter([1, 2]);


### PR DESCRIPTION
Closes #1539, and also deals with infinite loops differently than https://github.com/mapbox/mapbox-gl-js/commit/1be67c82b2b0e39417911042025dd38c5b66b726 because of: 

- floating point precision when changing center
- the previous approach failing when you set the same zoom that the transform had after changing lat/lngRange

@tmcw or @jfirebaugh to review.