### PR TITLE
Redo placement, don't reload, on collisionDebug.

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -879,10 +879,7 @@ util.extendAll(Map.prototype, /** @lends Map.prototype */{
     get collisionDebug() { return this._collisionDebug; },
     set collisionDebug(value) {
         this._collisionDebug = value;
-        for (var i in this.style.sources) {
-            this.style.sources[i].reload();
-        }
-        this.update();
+        this.style._redoPlacement();
     },
 
     /**


### PR DESCRIPTION
Well that was much simpler. Re-calculates positioning instead of reloading sources. Fixes #1537

cc @mourner for review