### PR TITLE
Don't fire mousemove when panning.

### DIFF
--- a/js/ui/handler/drag_pan.js
+++ b/js/ui/handler/drag_pan.js
@@ -49,6 +49,8 @@ DragPan.prototype = {
         var map = this._map;
         if (map.boxZoom.active || map.dragRotate.active || (e.touches && e.touches.length > 1)) return;
 
+        this.active = true;
+
         var pos = DOM.mousePos(this._el, e),
             inertia = this._inertia,
             now = Date.now();
@@ -95,6 +97,8 @@ DragPan.prototype = {
             easing: inertiaEasing,
             noMoveStart: true
         });
+
+        this.active = false;
     },
 
     _onMouseUp: function () {

--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -25,7 +25,6 @@ DragRotate.prototype = {
 
     _onContextMenu: function (e) {
         this._map.stop();
-        this.active = true;
         this._startPos = this._pos = DOM.mousePos(this._el, e);
 
         document.addEventListener('mousemove', this._onMouseMove, false);
@@ -44,6 +43,8 @@ DragRotate.prototype = {
             center = map.transform.centerPoint, // Center of rotation
             startToCenter = p0.sub(center),
             startToCenterDist = startToCenter.mag();
+
+        this.active = true;
 
         if (!map.rotating) {
             map.fire('movestart');

--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -119,7 +119,7 @@ Interaction.prototype = {
     },
 
     _onMouseUp: function (e) {
-        if (this._contextMenuFired && DOM.mousePos(this._el, e).equals(this._startPos))
+        if (this._contextMenuFired && !this._map.dragRotate.active && !this._map.dragPan.active)
             this._fireEvent('contextmenu', e);
 
         this._contextMenuFired = null;


### PR DESCRIPTION
cc @jfirebaugh. Previously dragPan handler didn’t actually have an `active` property to track its state. 

Also, dragRotate now becomes active when user actually starts dragging, not on mousedown.