### PR TITLE
add color switcher example.

### DIFF
--- a/docs/_posts/examples/3400-01-04-color-switcher.html
+++ b/docs/_posts/examples/3400-01-04-color-switcher.html
@@ -12,7 +12,7 @@ description: Using setPaintProperty to change a layer's fill color
       top: 0;
       right: 0;
       width: 70px;
-      height: 100%;
+      height: 95%;
       list-style-type: none;
     }
 
@@ -51,7 +51,6 @@ description: Using setPaintProperty to change a layer's fill color
    <li class="color-swatch" onclick="paintIt('#bd0026', 'building')" style="background-color: #bd0026"></li> 
 </ul>
 <script>
-mapboxgl.accessToken = 'pk.eyJ1IjoiZGFuc3dpY2siLCJhIjoieUZiWmwtVSJ9.0cPQywdbPVmvHiHJ6NwdXA';
 var map = new mapboxgl.Map({
     container: 'map',
     style: 'mapbox://styles/mapbox/light-v8',

--- a/docs/_posts/examples/3400-01-04-color-switcher.html
+++ b/docs/_posts/examples/3400-01-04-color-switcher.html
@@ -1,0 +1,65 @@
+---
+layout: example
+category: example
+title: Change layer fill
+description: Using setPaintProperty to change a layer's fill color
+---
+<style>
+    #colorSwitcherWater {
+      margin: 0;
+      padding: 0;
+      position: fixed;
+      top: 0;
+      right: 0;
+      width: 70px;
+      height: 100%;
+      list-style-type: none;
+    }
+
+    #colorSwitcherBuilding {
+      margin: 0;
+      padding: 0;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 70px;
+      height: 100%;
+      list-style-type: none;
+    }
+
+    .color-swatch {
+      height: 20%;
+      width: 100%;
+      cursor: pointer;
+    }
+
+</style>
+<div id='map'></div>
+<ul id='colorSwitcherWater'>
+   <li class="color-swatch" onclick="paintIt('#ffffcc', 'water')" style="background-color: #ffffcc"></li>
+   <li class="color-swatch" onclick="paintIt('#a1dab4', 'water')" style="background-color: #a1dab4"></li>
+   <li class="color-swatch" onclick="paintIt('#41b6c4', 'water')" style="background-color: #41b6c4"></li>
+   <li class="color-swatch" onclick="paintIt('#2c7fb8', 'water')" style="background-color: #2c7fb8"></li>
+   <li class="color-swatch" onclick="paintIt('#253494', 'water')" style="background-color: #253494"></li> 
+</ul>
+
+<ul id='colorSwitcherBuilding'>
+   <li class="color-swatch" onclick="paintIt('#fed976', 'building')" style="background-color: #fed976"></li>
+   <li class="color-swatch" onclick="paintIt('#feb24c', 'building')" style="background-color: #feb24c"></li>
+   <li class="color-swatch" onclick="paintIt('#fd8d3c', 'building')" style="background-color: #fd8d3c"></li>
+   <li class="color-swatch" onclick="paintIt('#f03b20', 'building')" style="background-color: #f03b20"></li>
+   <li class="color-swatch" onclick="paintIt('#bd0026', 'building')" style="background-color: #bd0026"></li> 
+</ul>
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoiZGFuc3dpY2siLCJhIjoieUZiWmwtVSJ9.0cPQywdbPVmvHiHJ6NwdXA';
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/light-v8',
+    center: [12.338, 45.4385],
+    zoom: 17.4
+});
+
+function paintIt(myColor, layer) {    
+  map.setPaintProperty(layer, 'fill-color', myColor);
+}
+</script>


### PR DESCRIPTION
Simple example to demonstrate how to style layers interactively using Mapbox GL JS. Gives a few choices each for styling buildings and water. 

![color-switcher](https://cloud.githubusercontent.com/assets/2365503/10112466/4ce53c2a-6390-11e5-9363-18e5f78f8bbe.gif)