### PR TITLE
Do not do glyph request if there is no text

### DIFF
--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -396,17 +396,18 @@ SymbolBucket.prototype.getIconDependencies = function(tile, actor, callback) {
 };
 
 SymbolBucket.prototype.getTextDependencies = function(tile, actor, callback) {
-    var features = this.features;
-    var fontstack = this.layoutProperties['text-font'];
+    var fontstack = this.layoutProperties['text-font'],
+        stacks = this.stacks = tile.stacks,
+        stack = stacks[fontstack] = stacks[fontstack] || {};
 
-    var stacks = this.stacks = tile.stacks;
-    if (stacks[fontstack] === undefined) {
-        stacks[fontstack] = {};
-    }
-    var stack = stacks[fontstack];
+    var data = resolveText(this.features, this.layoutProperties, stack);
 
-    var data = resolveText(features, this.layoutProperties, stack);
     this.textFeatures = data.textFeatures;
+
+    if (!data.codepoints.length) {
+        setTimeout(callback, 0);
+        return;
+    }
 
     actor.send('get glyphs', {
         uid: tile.uid,


### PR DESCRIPTION
Makes the worker do 3 times less glyph requests (on a sample DC view,
down from 234 “get glyphs” requests to 77, which leads to less stutter on tile loads
(due to dropped main thread frames that take too much time handling all that communcation).

Generally I think we need to refactor worker communications so that mass requests like this are batched.