### PR TITLE
Faster transform

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -248,16 +248,19 @@ Transform.prototype = {
         if (targetZ === undefined) targetZ = 0;
 
         var matrix = this.coordinatePointMatrix(this.tileZoom);
-        var inverted = mat4.invert(new Float64Array(16), matrix);
+        mat4.invert(matrix, matrix);
 
-        if (!inverted) throw new Error("failed to invert matrix");
+        if (!matrix) throw new Error("failed to invert matrix");
 
         // since we don't know the correct projected z value for the point,
         // unproject two points to get a line and then find the point on that
         // line with z=0
 
-        var coord0 = vec4.transformMat4([], [p.x, p.y, 0, 1], inverted);
-        var coord1 = vec4.transformMat4([], [p.x, p.y, 1, 1], inverted);
+        var coord0 = [p.x, p.y, 0, 1];
+        var coord1 = [p.x, p.y, 1, 1];
+
+        vec4.transformMat4(coord0, coord0, matrix);
+        vec4.transformMat4(coord1, coord1, matrix);
 
         var w0 = coord0[3];
         var w1 = coord1[3];
@@ -285,7 +288,8 @@ Transform.prototype = {
      */
     coordinatePoint: function(coord) {
         var matrix = this.coordinatePointMatrix(coord.zoom);
-        var p = vec4.transformMat4([], [coord.column, coord.row, 0, 1], matrix);
+        var p = [coord.column, coord.row, 0, 1];
+        vec4.transformMat4(p, p, matrix);
         return new Point(p[0] / p[3], p[1] / p[3]);
     },
 

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -97,6 +97,12 @@ Transform.prototype = {
         this._constrain();
     },
 
+    resize: function(width, height) {
+        this.width = width;
+        this.height = height;
+        this._constrain();
+    },
+
     zoomScale: function(zoom) { return Math.pow(2, zoom); },
     scaleZoom: function(scale) { return Math.log(scale) / Math.LN2; },
 

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -5,8 +5,11 @@ var LngLat = require('./lng_lat'),
     Coordinate = require('./coordinate'),
     wrap = require('../util/util').wrap,
     interp = require('../util/interpolate'),
-    vec4 = require('gl-matrix').vec4,
-    mat4 = require('gl-matrix').mat4;
+    glmatrix = require('gl-matrix');
+
+var vec4 = glmatrix.vec4,
+    mat4 = glmatrix.mat4,
+    mat2 = glmatrix.mat2;
 
 module.exports = Transform;
 
@@ -65,6 +68,10 @@ Transform.prototype = {
     },
     set bearing(bearing) {
         this.angle = -wrap(bearing, -180, 180) * Math.PI / 180;
+
+        // 2x2 matrix for rotating points
+        this.rotationMatrix = mat2.create();
+        mat2.rotate(this.rotationMatrix, this.rotationMatrix, this.angle);
     },
 
     get pitch() {
@@ -100,6 +107,10 @@ Transform.prototype = {
     resize: function(width, height) {
         this.width = width;
         this.height = height;
+
+        // The extrusion matrix
+        this.exMatrix = mat4.create();
+        mat4.ortho(this.exMatrix, 0, width, height, 0, 0, -1);
         this._constrain();
     },
 

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -1,8 +1,6 @@
 'use strict';
 
-var glmatrix = require('gl-matrix');
-var mat2 = glmatrix.mat2;
-var mat4 = glmatrix.mat4;
+var mat4 = require('gl-matrix').mat4;
 var util = require('../util/util');
 var BufferSet = require('../data/buffer_set');
 
@@ -49,22 +47,16 @@ Tile.prototype = {
 
         // The position matrix
         this.posMatrix = new Float64Array(16);
+
         mat4.identity(this.posMatrix);
         mat4.translate(this.posMatrix, this.posMatrix, [x * scale, y * scale, 0]);
-
         mat4.scale(this.posMatrix, this.posMatrix, [ scale / this.tileExtent, scale / this.tileExtent, 1 ]);
         mat4.multiply(this.posMatrix, transform.getProjMatrix(), this.posMatrix);
 
-        // The extrusion matrix.
-        this.exMatrix = mat4.create();
-        mat4.ortho(this.exMatrix, 0, transform.width, transform.height, 0, 0, -1);
-        //mat4.rotateZ(this.exMatrix, this.exMatrix, -transform.angle);
-
-        // 2x2 matrix for rotating points
-        this.rotationMatrix = mat2.create();
-        mat2.rotate(this.rotationMatrix, this.rotationMatrix, transform.angle);
-
         this.posMatrix = new Float32Array(this.posMatrix);
+
+        this.exMatrix = transform.exMatrix;
+        this.rotationMatrix = transform.rotationMatrix;
     },
 
     /**

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -51,7 +51,7 @@ Tile.prototype = {
         mat4.identity(this.posMatrix);
         mat4.translate(this.posMatrix, this.posMatrix, [x * scale, y * scale, 0]);
         mat4.scale(this.posMatrix, this.posMatrix, [ scale / this.tileExtent, scale / this.tileExtent, 1 ]);
-        mat4.multiply(this.posMatrix, transform.getProjMatrix(), this.posMatrix);
+        mat4.multiply(this.posMatrix, transform.projMatrix, this.posMatrix);
 
         this.posMatrix = new Float32Array(this.posMatrix);
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -243,11 +243,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         }
 
         this._canvas.resize(width, height);
-
-        this.transform.width = width;
-        this.transform.height = height;
-        this.transform._constrain();
-
+        this.transform.resize(width, height);
         this.painter.resize(width, height);
 
         return this

--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -13,8 +13,7 @@ test('transform', function(t) {
 
     t.test('creates a transform', function(t) {
         var transform = new Transform();
-        transform.width = 500;
-        transform.height = 500;
+        transform.resize(500, 500);
         t.equal(transform.tileSize, 512, 'tileSize');
         t.equal(transform.worldSize, 512, 'worldSize');
         t.equal(transform.width, 500, 'width');
@@ -45,8 +44,7 @@ test('transform', function(t) {
 
     t.test('panBy', function(t) {
         var transform = new Transform();
-        transform.width = 500;
-        transform.height = 500;
+        transform.resize(500, 500);
         transform.latRange = undefined;
         t.deepEqual(transform.center, { lng: 0, lat: 0 });
         t.equal(transform.panBy(new Point(10, 10)), undefined);
@@ -56,8 +54,7 @@ test('transform', function(t) {
 
     t.test('setZoomAround', function(t) {
         var transform = new Transform();
-        transform.width = 500;
-        transform.height = 500;
+        transform.resize(500, 500);
         t.deepEqual(transform.center, { lng: 0, lat: 0 });
         t.equal(transform.zoom, 0);
         t.equal(transform.setZoomAround(10, transform.pointLocation(new Point(10, 10))), undefined);
@@ -68,8 +65,7 @@ test('transform', function(t) {
 
     t.test('setZoomAround tilted', function(t) {
         var transform = new Transform();
-        transform.width = 500;
-        transform.height = 500;
+        transform.resize(500, 500);
         transform.pitch = 50;
         transform.zoom = 4;
         t.deepEqual(transform.center, { lng: 0, lat: 0 });
@@ -82,8 +78,7 @@ test('transform', function(t) {
 
     t.test('setLocationAt', function(t) {
         var transform = new Transform();
-        transform.width = 500;
-        transform.height = 500;
+        transform.resize(500, 500);
         transform.zoom = 4;
         t.deepEqual(transform.center, { lng: 0, lat: 0 });
         transform.setLocationAtPoint({ lng: 13, lat: 10 }, new Point(15, 45));
@@ -93,8 +88,7 @@ test('transform', function(t) {
 
     t.test('setLocationAt tilted', function(t) {
         var transform = new Transform();
-        transform.width = 500;
-        transform.height = 500;
+        transform.resize(500, 500);
         transform.zoom = 4;
         transform.pitch = 50;
         t.deepEqual(transform.center, { lng: 0, lat: 0 });
@@ -105,8 +99,7 @@ test('transform', function(t) {
 
     t.test('has a default zoom', function(t) {
         var transform = new Transform();
-        transform.width = 500;
-        transform.height = 500;
+        transform.resize(500, 500);
         t.equal(transform.tileZoom, 0);
         t.equal(transform.tileZoom, transform.zoom);
         t.end();
@@ -116,8 +109,7 @@ test('transform', function(t) {
         var transform = new Transform();
         transform.center = new LngLat(0, 0);
         transform.zoom = 10;
-        transform.width = 500;
-        transform.height = 500;
+        transform.resize(500, 500);
 
         transform.lngRange = [-5, 5];
         transform.latRange = [-5, 5];

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -71,9 +71,7 @@ test('GeoJSONSource#reload', function(t) {
 
 test('GeoJSONSource#update', function(t) {
     var transform = new Transform();
-
-    transform.width = 200;
-    transform.height = 200;
+    transform.resize(200, 200);
     transform.setZoomAround(15, LngLat.convert([-122.486052, 37.830348]));
 
     t.test('sends parse request to dispatcher', function(t) {
@@ -162,12 +160,9 @@ test('GeoJSONSource#update', function(t) {
             transform: new Transform()
         };
 
-        source.map.transform.width = 512;
-        source.map.transform.height = 512;
+        source.map.transform.resize(512, 512);
 
-        source.style = {
-
-        };
+        source.style = {};
         source.glyphAtlas = {
             removeGlyphs: function() {}
         };

--- a/test/js/source/tile_pyramid.test.js
+++ b/test/js/source/tile_pyramid.test.js
@@ -16,9 +16,7 @@ test('TilePyramid#coveringTiles', function(t) {
     });
 
     var transform = new Transform();
-
-    transform.width = 200;
-    transform.height = 200;
+    transform.resize(200, 200);
 
     transform.zoom = 0;
     t.deepEqual(pyramid.coveringTiles(transform), []);
@@ -237,8 +235,7 @@ test('TilePyramid#removeTile', function(t) {
 test('TilePyramid#update', function(t) {
     t.test('loads no tiles if used is false', function(t) {
         var transform = new Transform();
-        transform.width = 512;
-        transform.height = 512;
+        transform.resize(512, 512);
         transform.zoom = 0;
 
         var pyramid = createPyramid({});
@@ -250,8 +247,7 @@ test('TilePyramid#update', function(t) {
 
     t.test('loads covering tiles', function(t) {
         var transform = new Transform();
-        transform.width = 511;
-        transform.height = 511;
+        transform.resize(511, 511);
         transform.zoom = 0;
 
         var pyramid = createPyramid({});
@@ -263,8 +259,7 @@ test('TilePyramid#update', function(t) {
 
     t.test('removes unused tiles', function(t) {
         var transform = new Transform();
-        transform.width = 511;
-        transform.height = 511;
+        transform.resize(511, 511);
         transform.zoom = 0;
 
         var pyramid = createPyramid({
@@ -290,8 +285,7 @@ test('TilePyramid#update', function(t) {
 
     t.test('retains parent tiles for pending children', function(t) {
         var transform = new Transform();
-        transform.width = 511;
-        transform.height = 511;
+        transform.resize(511, 511);
         transform.zoom = 0;
 
         var pyramid = createPyramid({
@@ -318,8 +312,7 @@ test('TilePyramid#update', function(t) {
 
     t.test('retains parent tiles for pending children (wrapped)', function(t) {
         var transform = new Transform();
-        transform.width = 511;
-        transform.height = 511;
+        transform.resize(511, 511);
         transform.zoom = 0;
         transform.center = new LngLat(360, 0);
 
@@ -375,8 +368,7 @@ test('TilePyramid#clearTiles', function(t) {
 
 test('TilePyramid#tilesIn', function (t) {
     var transform = new Transform();
-    transform.width = 511;
-    transform.height = 511;
+    transform.resize(511, 511);
     transform.zoom = 1;
 
     var pyramid = createPyramid({

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -13,8 +13,7 @@ test('camera', function(t) {
         var camera = new Camera();
 
         var transform = camera.transform = new Transform(0, 20);
-        transform.width = 512;
-        transform.height = 512;
+        transform.resize(512, 512);
 
         util.extend(camera, Evented);
 


### PR DESCRIPTION
Makes rendering faster by caching expensive transform matrix calculations wherever possible.

With this PR, a test zoomTo consistently takes 1500ms vs 1600ms CPU time in main thread.