### PR TITLE
Remove try/catch in actor.postMessage

### DIFF
--- a/js/util/actor.js
+++ b/js/util/actor.js
@@ -59,9 +59,5 @@ Actor.prototype.send = function(type, data, callback, buffers) {
  * @private
  */
 Actor.prototype.postMessage = function(message, transferList) {
-    try {
-        this.target.postMessage(message, transferList);
-    } catch (e) {
-        this.target.postMessage(message); // No support for transferList on IE
-    }
+    this.target.postMessage(message, transferList);
 };


### PR DESCRIPTION
Makes actor.postMessage optimizable by V8 and also makes sure we see any errors thrown on postMessage. Not tested in IE yet.

- [x] actually test on IE!