### PR TITLE
Fix disappearing icons when browser reports a non-integer pixel ratio

### DIFF
--- a/js/symbol/sprite_atlas.js
+++ b/js/symbol/sprite_atlas.js
@@ -38,6 +38,8 @@ SpriteAtlas.prototype = {
 };
 
 SpriteAtlas.prototype.resize = function(newRatio) {
+    newRatio = newRatio > 1 ? 2 : 1;
+
     if (this.pixelRatio === newRatio) return false;
 
     var oldRatio = this.pixelRatio;


### PR DESCRIPTION
resolves #1029 #1475 #1476

replaces #1481 

cc @jfirebaugh @fnicollet @kkaefer 