### PR TITLE
Look the other way when placing icon at start of line

### DIFF
--- a/js/symbol/quads.js
+++ b/js/symbol/quads.js
@@ -68,7 +68,12 @@ function getIconQuads(anchor, shapedIcon, boxScale, line, layout, alongLine) {
     var angle = layout['icon-rotate'] * Math.PI / 180;
     if (alongLine) {
         var prev = line[anchor.segment];
-        angle += Math.atan2(anchor.y - prev.y, anchor.x - prev.x);
+        if (anchor.y === prev.y && anchor.x === prev.x && anchor.segment + 1 < line.length) {
+            var next = line[anchor.segment + 1];
+            angle += Math.atan2(anchor.y - next.y, anchor.x - next.x) + Math.PI;
+        } else {
+            angle += Math.atan2(anchor.y - prev.y, anchor.x - prev.x);
+        }
     }
 
     if (angle) {


### PR DESCRIPTION
This PR is a port of mapbox/mapbox-gl-native#2530 that fixes a bug exposed by #1283. When an anchor is at the beginning of a line, it is coincident with its segment, resulting in an angle of 0°. In that case, consider the next segment instead.

This gets us much further towards fixing #1461, but there will be no visible effect until #1575 is fixed.

/cc @nickidlugash @ansis @jfirebaugh

[![Both ways (CC BY 2.0 by Flickr user daveynin)](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2d/Which_way_should_I_go%3F_%281092932310%29.jpg/640px-Which_way_should_I_go%3F_%281092932310%29.jpg)](https://www.flickr.com/photos/daveynin/1092932310/)