### PR TITLE
Add a vector source example

### DIFF
--- a/docs/_posts/examples/3400-01-01-vector-source.html
+++ b/docs/_posts/examples/3400-01-01-vector-source.html
@@ -1,0 +1,36 @@
+---
+layout: example
+category: example
+title: Add vector source
+description: Add a vector source to a map.
+---
+<div id='map'></div>
+<script>
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/light-v8',
+    zoom: 13,
+    center: [-122.447303, 37.753574]
+});
+
+map.on('style.load', function () {
+    map.addSource('contours', {
+        type: 'vector',
+        url: 'mapbox://mapbox.mapbox-terrain-v2'
+    });
+    map.addLayer({
+        "id": "contours",
+        "type": "line",
+        "source": "contours",
+        "source-layer": "contour",
+        "layout": {
+            "line-join": "round",
+            "line-cap": "round"
+        },
+        "paint": {
+            "line-color": "#ff69b4",
+            "line-width": 1
+        }
+    });
+});
+</script>


### PR DESCRIPTION
An example showing how to add a Mapbox-hosted vector source. /cc @lucaswoj @jfirebaugh 