### PR TITLE
Apply raster-opacity to non-tile sources

### DIFF
--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -79,26 +79,27 @@ function saturationFactor(saturation) {
 }
 
 function getOpacities(tile, parentTile, layer, transform) {
-    if (!tile.source) return [1, 0];
+    var opacity = [1, 0];
 
-    var now = new Date().getTime();
+    if (tile.source) {
+        var now = new Date().getTime();
 
-    var fadeDuration = layer.paint['raster-fade-duration'];
-    var sinceTile = (now - tile.timeAdded) / fadeDuration;
-    var sinceParent = parentTile ? (now - parentTile.timeAdded) / fadeDuration : -1;
+        var fadeDuration = layer.paint['raster-fade-duration'];
+        var sinceTile = (now - tile.timeAdded) / fadeDuration;
+        var sinceParent = parentTile ? (now - parentTile.timeAdded) / fadeDuration : -1;
 
-    var idealZ = tile.source._pyramid.coveringZoomLevel(transform);
-    var parentFurther = parentTile ? Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ) : false;
+        var idealZ = tile.source._pyramid.coveringZoomLevel(transform);
+        var parentFurther = parentTile ? Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ) : false;
 
-    var opacity = [];
-    if (!parentTile || parentFurther) {
-        // if no parent or parent is older
-        opacity[0] = util.clamp(sinceTile, 0, 1);
-        opacity[1] = 1 - opacity[0];
-    } else {
-        // parent is younger, zooming out
-        opacity[0] = util.clamp(1 - sinceParent, 0, 1);
-        opacity[1] = 1 - opacity[0];
+        if (!parentTile || parentFurther) {
+            // if no parent or parent is older
+            opacity[0] = util.clamp(sinceTile, 0, 1);
+            opacity[1] = 1 - opacity[0];
+        } else {
+            // parent is younger, zooming out
+            opacity[0] = util.clamp(1 - sinceParent, 0, 1);
+            opacity[1] = 1 - opacity[0];
+        }
     }
 
     var op = layer.paint['raster-opacity'];

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.3.15",
-    "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#ac11a6694eac8e18081e3f636a49ae160f0e7ae4",
+    "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#b5445f61127921ec825bf2f71f1b91f82af7c9fc",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^0.5.5",


### PR DESCRIPTION
Non-tile sources (e.g. image/video) should be able to have `raster-opacity` applied to them.

(related #1270)