### PR TITLE
Propagate WebGL context events

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -678,6 +678,14 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         this.painter = new Painter(gl, this.transform);
     },
 
+    /**
+     * WebGL Context Lost event.
+     *
+     * @event webglcontextlost
+     * @memberof Map
+     * @type {Object}
+     * @property {Event} originalEvent the original DOM event
+     */
     _contextLost: function(event) {
         event.preventDefault();
         if (this._frameId) {
@@ -685,7 +693,14 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         }
         this.fire("webglcontextlost", event);
     },
-
+    
+    /**
+     * WebGL Context Restored event.
+     *
+     * @event webglcontextrestored
+     * @memberof Map
+     * @type {Object}
+     */
     _contextRestored: function() {
         this._setupPainter();
         this.resize();

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -683,12 +683,14 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         if (this._frameId) {
             browser.cancelFrame(this._frameId);
         }
+        this.fire("webglcontextlost", event);
     },
 
     _contextRestored: function() {
         this._setupPainter();
         this.resize();
         this.update();
+        this.fire("webglcontextrestored");
     },
 
     /**


### PR DESCRIPTION
Right now, mapbox-gl swallow the errors and doesn't allow the developper to use those event. For instance, listen to webglcontextlost and tell the user to refresh his page.
Errors could even be caught via event.target.painter.gl.getError()