### PR TITLE
Break lines on com­mon­ly un­spaced punc­tu­a­tion

### DIFF
--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -52,7 +52,23 @@ function shapeText(text, glyphs, maxWidth, lineHeight, horizontalAlign, vertical
     return shaping;
 }
 
-var breakable = { 32: true }; // Currently only breaks at regular spaces
+var invisible = {
+    0x20:   true, // space
+    0x200b: true  // zero-width space
+};
+
+var breakable = {
+    0x20:   true, // space
+    0x26:   true, // ampersand
+    0x2b:   true, // plus sign
+    0x2d:   true, // hyphen-minus
+    0x2f:   true, // solidus
+    0xad:   true, // soft hyphen
+    0xb7:   true, // middle dot
+    0x200b: true, // zero-width space
+    0x2010: true, // hyphen
+    0x2013: true  // en dash
+};
 
 function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify) {
     var lastSafeBreak = null;
@@ -83,7 +99,13 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
                 }
 
                 if (justify) {
-                    justifyLine(positionedGlyphs, glyphs, lineStartIndex, lastSafeBreak - 1, justify);
+                    // Collapse invisible characters.
+                    var lineEnd = lastSafeBreak;
+                    if (invisible[positionedGlyphs[lastSafeBreak].codePoint]) {
+                        lineEnd--;
+                    }
+
+                    justifyLine(positionedGlyphs, glyphs, lineStartIndex, lineEnd, justify);
                 }
 
                 lineStartIndex = lastSafeBreak + 1;


### PR DESCRIPTION
This PR breaks lines in labels on commonly unspaced punctuation, par­ti­cu­lar­ly hy­phens (important in French-speaking regions) and soft hy­phens (important in Welsh, Thai, and Māori-speaking regions). The improved wrapping also seems to fix quite a few label collisions.

_Before:_  
![before](https://cloud.githubusercontent.com/assets/1231218/10463860/bc5a106c-719b-11e5-8638-ca8ac55a98de.png)

_After:_
![after](https://cloud.githubusercontent.com/assets/1231218/10463866/c9ee4874-719b-11e5-9295-1372c90b9e24.png)

This is a port of mapbox/mapbox-gl-native#2598 that fixes #1115.

/cc @peterqliu