### PR TITLE
 	allow file URI scheme for style, sprite & png files

### DIFF
--- a/js/util/browser/ajax.js
+++ b/js/util/browser/ajax.js
@@ -1,5 +1,18 @@
 'use strict';
 
+exports.isOK = function (xhr)
+{
+    var file;
+    var ret;
+
+    file = 0 == xhr.responseURL.indexOf ("file:");
+    ret = !!xhr.response;
+    if (!file)
+        ret = ret && ((xhr.status >= 200) && (xhr.status < 300));
+
+    return (ret);
+};
+
 exports.getJSON = function(url, callback) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', url, true);
@@ -8,7 +21,7 @@ exports.getJSON = function(url, callback) {
         callback(e);
     };
     xhr.onload = function() {
-        if (xhr.status >= 200 && xhr.status < 300 && xhr.response) {
+        if (exports.isOK (xhr)) {
             var data;
             try {
                 data = JSON.parse(xhr.response);
@@ -32,7 +45,7 @@ exports.getArrayBuffer = function(url, callback) {
         callback(e);
     };
     xhr.onload = function() {
-        if (xhr.status >= 200 && xhr.status < 300 && xhr.response) {
+        if (exports.isOK (xhr)) {
             callback(null, xhr.response);
         } else {
             callback(new Error(xhr.statusText));


### PR DESCRIPTION
For development it is often easier to browse files from a local filesystem rather than set up a webserver and ensure fidelity between served files and the development environment. So for example one could open the local index.html file (CTRL-O in most browsers) to browse the application using the file URI scheme (file://xxx).

In Chrome and Chromium this requires enabling the browser to allow file URI by appending the --allow-file-access-from-files flag, e.g.:
"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --allow-file-access-from-files

Out of the box mapbox-gl-js works well with this scheme in simple use-cases in both Firefox and Chrome/Chromium. But if you use locally hosted styles, sprites and png files the program fails in Chrome/Chromium because it tests for a XMLHttpRequest response code in the range 200 to 300 while the response code from the file URI from Chrome/Chromium is zero. Firefox helpfully returns a 200 status code.

This patch enables hosting mapbox artifacts from the file URI scheme on Chrome/Chromium by only testing for a valid response code if it's not a file URI.