### PR TITLE
Add buffer benchmark warmup & cooldown

### DIFF
--- a/bench/buffer/site.js
+++ b/bench/buffer/site.js
@@ -2,12 +2,15 @@ var urls = [
     '/dist/mapbox-gl.js',
     'https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.2/mapbox-gl.js',
     '/dist/mapbox-gl.js',
+    'https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.2/mapbox-gl.js',
+    '/dist/mapbox-gl.js',
     'https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.2/mapbox-gl.js'
 ];
 
-var duration = 30 * 1000;
+var TEST_DURATION = 35 * 1000;
+var WARMUP_DURATION = 5 * 1000;
 
-Benchmark(urls, duration, setup, teardown);
+Benchmark(urls, TEST_DURATION, setup, teardown);
 
 function setup(state, callback) {
 
@@ -29,12 +32,14 @@ function setup(state, callback) {
     state.map = map;
 
     map.on('load', function() {
-        callback();
+        setTimeout(function() {
+            callback();
+        }, WARMUP_DURATION);
     });
 }
 
 function teardown(state, callback) {
-    state.map.repaint = false;
+    state.map.style._remove();
     callback();
 }
 


### PR DESCRIPTION
Looks like we can get more reliable bench results by adding a warmup & cooldown period to each run. The longer the warmup & cooldown, the better, but with diminishing returns. 5s seems like a good value for now.

These results indicate no major changes in the 95% percentile benchmark before / after #1526. 

These results also indicate that average buffer time tends to be a more consistent # and provides as much separation as 95%, while being easier to reason about. We might want to rethink the inclusion of 95% as a statistic. 

cc @mourner @jfirebaugh 

-----

# 0 Sec Warmup & Cooldown

<table><tr><th>url</th><th>95% time</th><th>average time</th><th># samples</th></tr><tr><td>http://localhost:9000/master.js</td><td>2450ms </td><td>1658ms </td><td>126</td></tr><tr><td>http://localhost:9000/after-buffer2.js</td><td>3310ms </td><td>2312ms </td><td>116</td></tr><tr><td>http://localhost:9000/before-buffer2.js</td><td>2789ms </td><td>2046ms </td><td>119</td></tr><tr><td>http://localhost:9000/bucket2.js</td><td>4132ms </td><td>2442ms </td><td>118</td></tr><tr><td>https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js</td><td>2562ms </td><td>1727ms </td><td>128</td></tr><tr><td>https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js</td><td>2567ms </td><td>1749ms </td><td>126</td></tr><tr><td>http://localhost:9000/bucket2.js</td><td>3805ms </td><td>2342ms </td><td>121</td></tr><tr><td>http://localhost:9000/before-buffer2.js</td><td>2187ms </td><td>1541ms </td><td>127</td></tr><tr><td>http://localhost:9000/after-buffer2.js</td><td>2690ms </td><td>1901ms </td><td>124</td></tr></table>

|                                                                |              |                 | 
|----------------------------------------------------------------|--------------|-----------------| 
| url                                                            | 95% std dev  | average std dev | 
| http://localhost:9000/after-buffer2.js                         | 620ms        | 411ms           | 
| http://localhost:9000/before-buffer2.js                        | 602ms        | 505ms           | 
| http://localhost:9000/bucket2.js                               | 327ms        | 100ms           | 
| http://localhost:9000/master.js                                | 34ms         | 12ms            | 
| https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js | 5ms          | 22ms            | 
| **average**                                                        | 318ms        | 210ms           | 



# 1 Sec Warmup & Cooldown

<table><tr><th>url</th><th>95% time</th><th>average time</th><th># samples</th></tr><tr><td>http://localhost:9000/master.js</td><td>2225ms </td><td>1449ms </td><td>128</td></tr><tr><td>http://localhost:9000/after-buffer2.js</td><td>2798ms </td><td>1798ms </td><td>122</td></tr><tr><td>http://localhost:9000/before-buffer2.js</td><td>2772ms </td><td>1948ms </td><td>125</td></tr><tr><td>http://localhost:9000/bucket2.js</td><td>3866ms </td><td>2462ms </td><td>121</td></tr><tr><td>https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js</td><td>2453ms </td><td>1710ms </td><td>129</td></tr><tr><td>https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js</td><td>2268ms </td><td>1669ms </td><td>126</td></tr><tr><td>http://localhost:9000/bucket2.js</td><td>3308ms </td><td>2059ms </td><td>124</td></tr><tr><td>http://localhost:9000/before-buffer2.js</td><td>2421ms </td><td>1797ms </td><td>121</td></tr><tr><td>http://localhost:9000/after-buffer2.js</td><td>2715ms </td><td>1853ms </td><td>125</td></tr><tr><td>http://localhost:9000/master.js</td><td>2299ms </td><td>1461ms </td><td>121</td></tr></table>

| url                                                            | 95% std dev  | average std dev | 
|----------------------------------------------------------------|--------------|-----------------| 
| http://localhost:9000/after-buffer2.js                         | 83           | 55              | 
| http://localhost:9000/before-buffer2.js                        | 351          | 151             | 
| http://localhost:9000/bucket2.js                               | 558          | 403             | 
| http://localhost:9000/master.js                                | 37           | 6               | 
| https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js | 185          | 41              | 
| **average**                                                        | 243          | 131             | 



# 5 Sec Warmup & Cooldown

<table><tr><th>url</th><th>95% time</th><th>average time</th><th># samples</th></tr><tr><td>http://localhost:9000/master.js</td><td>2402ms </td><td>1590ms </td><td>124</td></tr><tr><td>http://localhost:9000/after-buffer2.js</td><td>2873ms </td><td>1824ms </td><td>123</td></tr><tr><td>http://localhost:9000/before-buffer2.js</td><td>2462ms </td><td>1819ms </td><td>126</td></tr><tr><td>http://localhost:9000/bucket2.js</td><td>3779ms </td><td>2462ms </td><td>120</td></tr><tr><td>https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js</td><td>2277ms </td><td>1643ms </td><td>128</td></tr><tr><td>https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js</td><td>2666ms </td><td>1923ms </td><td>122</td></tr><tr><td>http://localhost:9000/bucket2.js</td><td>3750ms </td><td>2268ms </td><td>122</td></tr><tr><td>http://localhost:9000/before-buffer2.js</td><td>2509ms </td><td>1785ms </td><td>122</td></tr><tr><td>http://localhost:9000/after-buffer2.js</td><td>2505ms </td><td>1691ms </td><td>124</td></tr><tr><td>http://localhost:9000/master.js</td><td>2412ms </td><td>1588ms </td><td>128</td></tr></table>

| url                                                            | 95% std dev  | average std dev | 
|----------------------------------------------------------------|--------------|-----------------| 
| http://localhost:9000/after-buffer2.js                         | 368          | 133             | 
| http://localhost:9000/before-buffer2.js                        | 47           | 34              | 
| http://localhost:9000/bucket2.js                               | 29           | 194             | 
| http://localhost:9000/master.js                                | 5            | 1               | 
| https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js | 389          | 280             | 
| **average**                                                        | 168          | 128             | 

# 10 Sec Warmup & Cooldown

<table><tr><th>url</th><th>95% time</th><th>average time</th><th># samples</th></tr><tr><td>http://localhost:9000/master.js</td><td>2441ms </td><td>1616ms </td><td>125</td></tr><tr><td>http://localhost:9000/after-buffer2.js</td><td>2956ms </td><td>1951ms </td><td>125</td></tr><tr><td>http://localhost:9000/before-buffer2.js</td><td>2662ms </td><td>1861ms </td><td>120</td></tr><tr><td>http://localhost:9000/bucket2.js</td><td>3622ms </td><td>2385ms </td><td>120</td></tr><tr><td>https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js</td><td>2470ms </td><td>1824ms </td><td>125</td></tr><tr><td>https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js</td><td>2487ms </td><td>1780ms </td><td>124</td></tr><tr><td>http://localhost:9000/bucket2.js</td><td>3767ms </td><td>2362ms </td><td>121</td></tr><tr><td>http://localhost:9000/before-buffer2.js</td><td>2223ms </td><td>1578ms </td><td>126</td></tr><tr><td>http://localhost:9000/after-buffer2.js</td><td>2655ms </td><td>1802ms </td><td>124</td></tr><tr><td>http://localhost:9000/master.js</td><td>2548ms </td><td>1739ms </td><td>122</td></tr></table>

|                                                                |              |                 | 
|----------------------------------------------------------------|--------------|-----------------| 
| url                                                            | 95% std dev  | average std dev | 
| http://localhost:9000/after-buffer2.js                         | 301ms        | 149ms           | 
| http://localhost:9000/before-buffer2.js                        | 439ms        | 283ms           | 
| http://localhost:9000/bucket2.js                               | 145ms        | 23ms            | 
| http://localhost:9000/master.js                                | 54ms         | 61ms            | 
| https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.1/mapbox-gl.js | 17ms         | 44ms            | 
| **average**                                                        | 191ms        | 112ms           | 
