### PR TITLE
Improve error message for invalid color ramps

### DIFF
--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -75,7 +75,7 @@ function parseColor(input) {
         return input;
 
     // GL function
-    } else if (input.stops) {
+    } else if (input && input.stops) {
         return util.extend({}, input, {
             stops: input.stops.map(function(step) {
                 return [step[0], parseColor(step[1])];

--- a/test/js/style/style_declaration.test.js
+++ b/test/js/style/style_declaration.test.js
@@ -48,6 +48,9 @@ test('StyleDeclaration', function(t) {
         t.deepEqual(new StyleDeclaration(reference, 'red').calculate(0), [ 1, 0, 0, 1 ]);
         t.deepEqual(new StyleDeclaration(reference, '#ff00ff').calculate(0), [ 1, 0, 1, 1 ]);
         t.deepEqual(new StyleDeclaration(reference, { stops: [[0, '#f00'], [1, '#0f0']] }).calculate(0), [1, 0, 0, 1]);
+        t.throws(function () {
+            t.ok(new StyleDeclaration(reference, { stops: [[0, '#f00'], [1, null]] }));
+        }, /Invalid color/);
         // cached
         t.deepEqual(new StyleDeclaration(reference, '#ff00ff').calculate(0), [ 1, 0, 1, 1 ]);
         t.deepEqual(new StyleDeclaration(reference, 'rgba(255, 51, 0, 1)').calculate(0), [ 1, 0.2, 0, 1 ]);


### PR DESCRIPTION
If there is a null value in a color ramp, a typical error message is:

    "TypeError: Cannot read property 'stops' of undefined"

By guarding the input.stops in parseColor, we can create a better error:

    "Invalid color null"

Note: null values in ramps are normally disallowed by the style validator,
however, setPaintProperty bypasses the validator.