### PR TITLE
Add UI controls for pitch

### DIFF
--- a/js/ui/control/navigation.js
+++ b/js/ui/control/navigation.js
@@ -80,6 +80,8 @@ Navigation.prototype = util.inherit(Control, {
         if (this._moved) {
             this._moved = false;
             DOM.suppressClick();
+        } else {
+            this._map.setPitch(0);
         }
 
         this._map.snapToNorth();

--- a/js/ui/handler/keyboard.js
+++ b/js/ui/handler/keyboard.js
@@ -64,7 +64,7 @@ Keyboard.prototype = {
 
         case 37:
             if (e.shiftKey) {
-                map.setBearing(map.getBearing() - rotateDelta);
+                map.easeTo({ bearing: map.getBearing() - rotateDelta });
             } else {
                 map.panBy([-panDelta, 0]);
             }
@@ -72,7 +72,7 @@ Keyboard.prototype = {
 
         case 39:
             if (e.shiftKey) {
-                map.setBearing(map.getBearing() + rotateDelta);
+                map.easeTo({ bearing: map.getBearing() + rotateDelta });
             } else {
                 map.panBy([panDelta, 0]);
             }
@@ -80,7 +80,7 @@ Keyboard.prototype = {
 
         case 38:
             if (e.shiftKey) {
-                map.setPitch(map.getPitch() + pitchDelta);
+                map.easeTo({ pitch: map.getPitch() + pitchDelta });
             } else {
                 map.panBy([0, -panDelta]);
             }
@@ -88,7 +88,7 @@ Keyboard.prototype = {
 
         case 40:
             if (e.shiftKey) {
-                map.setPitch(Math.max(map.getPitch() - pitchDelta, 0));
+                map.easeTo({ pitch: Math.max(map.getPitch() - pitchDelta, 0) });
             } else {
                 map.panBy([0, panDelta]);
             }

--- a/js/ui/handler/keyboard.js
+++ b/js/ui/handler/keyboard.js
@@ -17,6 +17,8 @@ var panDelta = 80,
  *  * Arrow keys: pan by 80 pixels
  *  * `Shift+⇢`: increase rotation by 2 degrees
  *  * `Shift+⇠`: decrease rotation by 2 degrees
+ *  * `Shift+⇡`: increase pitch by 5 degrees
+ *  * `Shift+⇣`: decrease pitch by 5 degrees
  * @class Keyboard
  * @example
  *   // Disable the keyboard handler

--- a/js/ui/handler/keyboard.js
+++ b/js/ui/handler/keyboard.js
@@ -4,7 +4,8 @@ module.exports = Keyboard;
 
 
 var panDelta = 80,
-    rotateDelta = 2;
+    rotateDelta = 2,
+    pitchDelta = 5;
 
 /**
  * The `Keyboard` handler responds to keyboard input by zooming, rotating, or panning the
@@ -76,11 +77,19 @@ Keyboard.prototype = {
             break;
 
         case 38:
-            map.panBy([0, -panDelta]);
+            if (e.shiftKey) {
+                map.setPitch(map.getPitch() + pitchDelta);
+            } else {
+                map.panBy([0, -panDelta]);
+            }
             break;
 
         case 40:
-            map.panBy([0, panDelta]);
+            if (e.shiftKey) {
+                map.setPitch(Math.max(map.getPitch() - pitchDelta, 0));
+            } else {
+                map.panBy([0, panDelta]);
+            }
             break;
         }
     }


### PR DESCRIPTION
Use shift-up-arrow and shift-down-arrow to control the pitch. Clicking on
the rotation button will reset the pitch to 0.

This change exposes pitch for power users, but leaves the current UI
unchanged. More advanced UIs can still be built on top of this behavior.

Issue: #1063