### PR TITLE
Add some differentiation between source and source-layer names

### DIFF
--- a/docs/_posts/examples/3400-01-01-vector-source.html
+++ b/docs/_posts/examples/3400-01-01-vector-source.html
@@ -14,14 +14,14 @@ var map = new mapboxgl.Map({
 });
 
 map.on('style.load', function () {
-    map.addSource('contours', {
+    map.addSource('terrain-data', {
         type: 'vector',
         url: 'mapbox://mapbox.mapbox-terrain-v2'
     });
     map.addLayer({
-        "id": "contours",
+        "id": "terrain-data",
         "type": "line",
-        "source": "contours",
+        "source": "terrain-data",
         "source-layer": "contour",
         "layout": {
             "line-join": "round",


### PR DESCRIPTION
Contour and contours look quite similar. Changing `contours` to `terrain-data` adds a bit of differentiation.

cc: @lyzidiamond 