### PR TITLE
Ignore boxzoom on shift-click

### DIFF
--- a/debug/site.js
+++ b/debug/site.js
@@ -75,6 +75,7 @@ map.on('style.load', function() {
 });
 
 map.on('click', function(e) {
+    if (e.originalEvent.shiftKey) return;
     (new mapboxgl.Popup())
         .setLngLat(map.unproject(e.point))
         .setHTML("<h1>Hello World!</h1>")

--- a/js/ui/handler/box_zoom.js
+++ b/js/ui/handler/box_zoom.js
@@ -66,6 +66,8 @@ BoxZoom.prototype = {
 
         this._finish();
 
+        if (p0.x === p1.x && p0.y === p1.y) return;
+
         this._map
             .fitBounds(bounds, {linear: true})
             .fire('boxzoomend', {boxZoomBounds: bounds});
@@ -79,8 +81,6 @@ BoxZoom.prototype = {
     },
 
     _finish: function () {
-        if (!this._box) return;
-
         this.active = false;
 
         document.removeEventListener('mousemove', this._onMouseMove, false);
@@ -89,8 +89,10 @@ BoxZoom.prototype = {
 
         this._container.classList.remove('mapboxgl-crosshair');
 
-        this._box.parentNode.removeChild(this._box);
-        this._box = null;
+        if (this._box) {
+            this._box.parentNode.removeChild(this._box);
+            this._box = null;
+        }
 
         DOM.enableDrag();
     }


### PR DESCRIPTION
This avoids calling fitBounds and properly exits out of box zoom mode when the box zoom bounds are identical (shift-click without dragging).

Closes #1655 
cc @jfirebaugh 