### PR TITLE
Run npm update and npm install on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ dependencies:
   pre:
     - sudo apt-get update; sudo apt-get -y install python-pip libglew-dev gdb
     - sudo pip install awscli
+  override:
+    - npm run preinstall && npm update && npm run postinstall && npm run prepublish
 test:
   override:
     - ./ci.sh


### PR DESCRIPTION
Because CircleCI uses a cached `node_modules` folder and never runs `npm update`, it doesn't grab the latest versions of dependencies. This PR causes CircleCI to run `npm update` alongside `npm install` on every build. 

Is this approach preferable to using shrinkwrap #1607?  

fixes #1600 

cc @jfirebaugh @tmcw @mourner 