### PR TITLE
Made Bucket#add* methods "less magic"

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -78,17 +78,15 @@ function Bucket(options) {
 
         if (shader.elementBuffer) {
             this[this.getAddMethodName(shaderName, 'element')] = createElementAddMethod(
-                shaderName,
-                this.getBufferName(shaderName, 'element'),
-                'elementLength'
+                this.buffers,
+                this.getBufferName(shaderName, 'element')
             );
         }
 
         if (shader.secondElementBuffer) {
             this[this.getAddMethodName(shaderName, 'secondElement')] = createElementAddMethod(
-                shaderName,
-                this.getBufferName(shaderName, 'secondElement'),
-                'secondElementLength'
+                this.buffers,
+                this.getBufferName(shaderName, 'secondElement')
             );
         }
     }
@@ -113,7 +111,7 @@ Bucket.prototype.addFeatures = function() {
  * @param {number} vertexLength The number of vertices that will be inserted to the buffer.
  */
 Bucket.prototype.makeRoomFor = function(shaderName, vertexLength) {
-    this.elementGroups[shaderName].makeRoomFor(vertexLength);
+    return this.elementGroups[shaderName].makeRoomFor(vertexLength);
 };
 
 /**
@@ -209,10 +207,7 @@ function createVertexAddMethod(shaderName, shader, bufferName) {
         pushArgs = pushArgs.concat(shader.attributes[i].value);
     }
 
-    var body = '';
-    body += 'var e = this.elementGroups.' + shaderName + '.current;\n';
-    body += 'e.vertexLength++;\n';
-    body += 'return this.buffers.' + bufferName + '.push(\n    ' + pushArgs.join(',\n    ') + '\n) - e.vertexStartIndex;';
+    var body = 'return this.buffers.' + bufferName + '.push(' + pushArgs.join(', ') + ');';
 
     if (!createVertexAddMethodCache[body]) {
         createVertexAddMethodCache[body] = new Function(shader.attributeArgs, body);
@@ -221,10 +216,10 @@ function createVertexAddMethod(shaderName, shader, bufferName) {
     return createVertexAddMethodCache[body];
 }
 
-function createElementAddMethod(shaderName, bufferName, lengthName) {
+function createElementAddMethod(buffers, bufferName) {
+    var buffer = buffers[bufferName];
     return function(one, two, three) {
-        this.elementGroups[shaderName].current[lengthName]++;
-        return this.buffers[bufferName].push(one, two, three);
+        return buffer.push(one, two, three);
     };
 }
 

--- a/js/data/circle_bucket.js
+++ b/js/data/circle_bucket.js
@@ -43,7 +43,7 @@ CircleBucket.prototype.addFeature = function(feature) {
 
     var geometries = feature.loadGeometry()[0];
     for (var j = 0; j < geometries.length; j++) {
-        this.makeRoomFor('circle', 6);
+        var group = this.makeRoomFor('circle', 4);
 
         var x = geometries[j].x;
         var y = geometries[j].y;
@@ -60,13 +60,15 @@ CircleBucket.prototype.addFeature = function(feature) {
         // │ 0     1 │
         // └─────────┘
 
-        var vertex0 = this.addCircleVertex(x, y, -1, -1);
-        var vertex1 = this.addCircleVertex(x, y, 1, -1);
-        var vertex2 = this.addCircleVertex(x, y, 1, 1);
-        var vertex3 = this.addCircleVertex(x, y, -1, 1);
+        var index = this.addCircleVertex(x, y, -1, -1) - group.vertexStartIndex;
+        this.addCircleVertex(x, y, 1, -1);
+        this.addCircleVertex(x, y, 1, 1);
+        this.addCircleVertex(x, y, -1, 1);
+        group.vertexLength += 4;
 
-        this.addCircleElement(vertex0, vertex1, vertex2);
-        this.addCircleElement(vertex0, vertex3, vertex2);
+        this.addCircleElement(index, index + 1, index + 2);
+        this.addCircleElement(index, index + 3, index + 2);
+        group.elementLength += 2;
     }
 
 };

--- a/js/data/element_groups.js
+++ b/js/data/element_groups.js
@@ -17,6 +17,7 @@ ElementGroups.prototype.makeRoomFor = function(numVertices) {
                 this.secondElementBuffer && this.secondElementBuffer.length);
         this.groups.push(this.current);
     }
+    return this.current;
 };
 
 function ElementGroup(vertexStartIndex, elementStartIndex, secondElementStartIndex) {

--- a/js/data/fill_bucket.js
+++ b/js/data/fill_bucket.js
@@ -52,23 +52,26 @@ FillBucket.prototype.addFill = function(vertices) {
     var len = vertices.length;
 
     // Expand this geometry buffer to hold all the required vertices.
-    this.makeRoomFor('fill', len + 1);
+    var group = this.makeRoomFor('fill', len + 1);
 
     // We're generating triangle fans, so we always start with the first coordinate in this polygon.
     var firstIndex, prevIndex;
     for (var i = 0; i < vertices.length; i++) {
         var currentVertex = vertices[i];
 
-        var currentIndex = this.addFillVertex(currentVertex.x, currentVertex.y);
+        var currentIndex = this.addFillVertex(currentVertex.x, currentVertex.y) - group.vertexStartIndex;
+        group.vertexLength++;
         if (i === 0) firstIndex = currentIndex;
 
         // Only add triangles that have distinct vertices.
         if (i >= 2 && (currentVertex.x !== vertices[0].x || currentVertex.y !== vertices[0].y)) {
             this.addFillElement(firstIndex, prevIndex, currentIndex);
+            group.elementLength++;
         }
 
         if (i >= 1) {
             this.addFillSecondElement(prevIndex, currentIndex);
+            group.secondElementLength++;
         }
 
         prevIndex = currentIndex;

--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -311,25 +311,28 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
 LineBucket.prototype.addCurrentVertex = function(currentVertex, flip, distance, normal, endLeft, endRight, round) {
     var tx = round ? 1 : 0;
     var extrude;
+    var group = this.elementGroups.line.current;
+    group.vertexLength += 2;
 
     extrude = normal.mult(flip);
     if (endLeft) extrude._sub(normal.perp()._mult(endLeft));
-    this.e3 = this.addLineVertex(currentVertex, extrude, tx, 0, distance);
+    this.e3 = this.addLineVertex(currentVertex, extrude, tx, 0, distance) - group.vertexStartIndex;
     if (this.e1 >= 0 && this.e2 >= 0) {
         this.addLineElement(this.e1, this.e2, this.e3);
+        group.elementLength++;
     }
     this.e1 = this.e2;
     this.e2 = this.e3;
 
     extrude = normal.mult(-flip);
     if (endRight) extrude._sub(normal.perp()._mult(endRight));
-    this.e3 = this.addLineVertex(currentVertex, extrude, tx, 1, distance);
+    this.e3 = this.addLineVertex(currentVertex, extrude, tx, 1, distance) - group.vertexStartIndex;
     if (this.e1 >= 0 && this.e2 >= 0) {
         this.addLineElement(this.e1, this.e2, this.e3);
+        group.elementLength++;
     }
     this.e1 = this.e2;
     this.e2 = this.e3;
-
 };
 
 /**
@@ -346,11 +349,14 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, flip, distance, 
 LineBucket.prototype.addPieSliceVertex = function(currentVertex, flip, distance, extrude, lineTurnsLeft) {
     var ty = lineTurnsLeft ? 1 : 0;
     extrude = extrude.mult(flip * (lineTurnsLeft ? -1 : 1));
+    var group = this.elementGroups.line.current;
 
-    this.e3 = this.addLineVertex(currentVertex, extrude, 0, ty, distance);
+    this.e3 = this.addLineVertex(currentVertex, extrude, 0, ty, distance) - group.vertexStartIndex;
+    group.vertexLength++;
 
     if (this.e1 >= 0 && this.e2 >= 0) {
         this.addLineElement(this.e1, this.e2, this.e3);
+        group.elementLength++;
     }
 
     if (lineTurnsLeft) {

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -395,8 +395,9 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, buffers, collisio
 
 SymbolBucket.prototype.addSymbols = function(shaderName, quads, scale, keepUpright, alongLine, placementAngle) {
 
-    this.makeRoomFor(shaderName, 4 * quads.length);
+    var group = this.makeRoomFor(shaderName, 4 * quads.length);
 
+    // TODO manual curry
     var addElement = this[this.getAddMethodName(shaderName, 'element')].bind(this);
     var addVertex = this[this.getAddMethodName(shaderName, 'vertex')].bind(this);
 
@@ -427,13 +428,15 @@ SymbolBucket.prototype.addSymbols = function(shaderName, quads, scale, keepUprig
         // Lower min zoom so that while fading out the label it can be shown outside of collision-free zoom levels
         if (minZoom === placementZoom) minZoom = 0;
 
-        var index0 = addVertex(anchorPoint.x, anchorPoint.y, tl.x, tl.y, tex.x, tex.y, minZoom, maxZoom, placementZoom);
-        var index1 = addVertex(anchorPoint.x, anchorPoint.y, tr.x, tr.y, tex.x + tex.w, tex.y, minZoom, maxZoom, placementZoom);
-        var index2 = addVertex(anchorPoint.x, anchorPoint.y, bl.x, bl.y, tex.x, tex.y + tex.h, minZoom, maxZoom, placementZoom);
-        var index3 = addVertex(anchorPoint.x, anchorPoint.y, br.x, br.y, tex.x + tex.w, tex.y + tex.h, minZoom, maxZoom, placementZoom);
+        var index = addVertex(anchorPoint.x, anchorPoint.y, tl.x, tl.y, tex.x, tex.y, minZoom, maxZoom, placementZoom) - group.vertexStartIndex;
+        addVertex(anchorPoint.x, anchorPoint.y, tr.x, tr.y, tex.x + tex.w, tex.y, minZoom, maxZoom, placementZoom);
+        addVertex(anchorPoint.x, anchorPoint.y, bl.x, bl.y, tex.x, tex.y + tex.h, minZoom, maxZoom, placementZoom);
+        addVertex(anchorPoint.x, anchorPoint.y, br.x, br.y, tex.x + tex.w, tex.y + tex.h, minZoom, maxZoom, placementZoom);
+        group.vertexLength += 4;
 
-        addElement(index0, index1, index2);
-        addElement(index1, index2, index3);
+        addElement(index, index + 1, index + 2);
+        addElement(index + 1, index + 2, index + 3);
+        group.elementLength += 2;
     }
 
 };

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -83,12 +83,6 @@ test('Bucket', function(t) {
         t.equal(testSecondElement.length, 1);
         t.deepEqual(testSecondElement.get(0), { vertices: [17, 42] });
 
-        var elementGroups = builder.elementGroups.test;
-        t.equal(elementGroups.groups.length, 1);
-        t.equal(elementGroups.current.vertexLength, 1);
-        t.equal(elementGroups.current.elementLength, 1);
-        t.equal(elementGroups.current.secondElementLength, 1);
-
         t.end();
     });
 


### PR DESCRIPTION
Namely, I removed the following behaviors:

 - auto incrementing element group lengths
 - auto subtracting element group vertex start index

This commit brings the buffer benchmark time down from **941 ms** to **752 ms**.