### PR TITLE
Recreate bucket element add methods after reseting buffers

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -68,27 +68,11 @@ function Bucket(options) {
 
     for (var shaderName in this.shaders) {
         var shader = this.shaders[shaderName];
-        if (shader.vertexBuffer) {
-            this[this.getAddMethodName(shaderName, 'vertex')] = createVertexAddMethod(
-                shaderName,
-                shader,
-                this.getBufferName(shaderName, 'vertex')
-            );
-        }
-
-        if (shader.elementBuffer) {
-            this[this.getAddMethodName(shaderName, 'element')] = createElementAddMethod(
-                this.buffers,
-                this.getBufferName(shaderName, 'element')
-            );
-        }
-
-        if (shader.secondElementBuffer) {
-            this[this.getAddMethodName(shaderName, 'secondElement')] = createElementAddMethod(
-                this.buffers,
-                this.getBufferName(shaderName, 'secondElement')
-            );
-        }
+        this[this.getAddMethodName(shaderName, 'vertex')] = createVertexAddMethod(
+            shaderName,
+            shader,
+            this.getBufferName(shaderName, 'vertex')
+        );
     }
 }
 
@@ -135,14 +119,20 @@ Bucket.prototype.resetBuffers = function(buffers) {
             });
         }
 
-        var elementBufferName = this.getBufferName(shaderName, 'element');
-        if (shader.elementBuffer && !buffers[elementBufferName]) {
-            buffers[elementBufferName] = createElementBuffer(shader.elementBufferComponents);
+        if (shader.elementBuffer) {
+            var elementBufferName = this.getBufferName(shaderName, 'element');
+            if (!buffers[elementBufferName]) {
+                buffers[elementBufferName] = createElementBuffer(shader.elementBufferComponents);
+            }
+            this[this.getAddMethodName(shaderName, 'element')] = createElementAddMethod(this.buffers[elementBufferName]);
         }
 
-        var secondElementBufferName = this.getBufferName(shaderName, 'secondElement');
-        if (shader.secondElementBuffer && !buffers[secondElementBufferName]) {
-            buffers[secondElementBufferName] = createElementBuffer(shader.secondElementBufferComponents);
+        if (shader.secondElementBuffer) {
+            var secondElementBufferName = this.getBufferName(shaderName, 'secondElement');
+            if (!buffers[secondElementBufferName]) {
+                buffers[secondElementBufferName] = createElementBuffer(shader.secondElementBufferComponents);
+            }
+            this[this.getAddMethodName(shaderName, 'secondElement')] = createElementAddMethod(this.buffers[secondElementBufferName]);
         }
 
         this.elementGroups[shaderName] = new ElementGroups(
@@ -216,8 +206,7 @@ function createVertexAddMethod(shaderName, shader, bufferName) {
     return createVertexAddMethodCache[body];
 }
 
-function createElementAddMethod(buffers, bufferName) {
-    var buffer = buffers[bufferName];
+function createElementAddMethod(buffer) {
     return function(one, two, three) {
         return buffer.push(one, two, three);
     };

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -89,7 +89,8 @@ test('Bucket', function(t) {
     t.test('reset buffers', function(t) {
         var builder = create();
 
-        builder.addFeatures([createFeature(17, 42)]);
+        builder.features = [createFeature(17, 42)];
+        builder.addFeatures();
 
         var buffers = {};
         builder.resetBuffers(buffers);
@@ -98,6 +99,30 @@ test('Bucket', function(t) {
         t.equal(buffers.testElement.length, 0);
         t.equal(buffers.testSecondElement.length, 0);
         t.equal(builder.elementGroups.test.groups.length, 0);
+
+        t.end();
+    });
+
+    t.test('add features after resetting buffers', function(t) {
+        var builder = create();
+
+        builder.features = [createFeature(1, 5)];
+        builder.addFeatures();
+        builder.resetBuffers({});
+        builder.features = [createFeature(17, 42)];
+        builder.addFeatures();
+
+        var testVertex = builder.buffers.testVertex;
+        t.equal(testVertex.length, 1);
+        t.deepEqual(testVertex.get(0), { map: [17], box: [34, 84] });
+
+        var testElement = builder.buffers.testElement;
+        t.equal(testElement.length, 1);
+        t.deepEqual(testElement.get(0), { vertices: [1, 2, 3] });
+
+        var testSecondElement = builder.buffers.testSecondElement;
+        t.equal(testSecondElement.length, 1);
+        t.deepEqual(testSecondElement.get(0), { vertices: [17, 42] });
 
         t.end();
     });


### PR DESCRIPTION
fixes #1694 

The bucket `add*Element` methods were holding references to old buffers after `resetBuffers` was called. This PR fixes that bug (and seems to be slightly faster than `master` in the buffer benchmark :+1:)

Does this warrant a new point release? 

cc @mourner @jfirebaugh @bhousel 