### PR TITLE
Fix rendering of collision boxes

### DIFF
--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -461,7 +461,7 @@ SymbolBucket.prototype.updateFont = function(stacks) {
 
 SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
     this.elementGroups.collisionBox = new ElementGroups(this.buffers.collisionBoxVertex);
-    this.makeRoomFor('collisionBox', 0);
+    var group = this.makeRoomFor('collisionBox', 8);
     var angle = -collisionTile.angle;
     var yStretch = collisionTile.yStretch;
 
@@ -491,6 +491,7 @@ SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
                 this.addCollisionBoxVertex(anchorPoint, bl, maxZoom, placementZoom);
                 this.addCollisionBoxVertex(anchorPoint, bl, maxZoom, placementZoom);
                 this.addCollisionBoxVertex(anchorPoint, tl, maxZoom, placementZoom);
+                group.vertexLength++;
             }
         }
     }


### PR DESCRIPTION
`SymbolBucket#addToDebugBuffers` was not updated in #1686

fixes #1706

cc @edenh @bhousel 