### PR TITLE
Fix util asyncAll edge case

### DIFF
--- a/js/util/util.js
+++ b/js/util/util.js
@@ -135,6 +135,7 @@ exports.asyncEach = function (array, fn, callback) {
  * @private
  */
 exports.asyncAll = function (array, fn, callback) {
+    if (!array.length) { return callback(null, []); }
     var remaining = array.length;
     var results = new Array(array.length);
     var error = null;

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -145,6 +145,16 @@ test('util', function(t) {
         }));
     });
 
+    t.test('asyncAll - empty', function(t) {
+        t.equal(util.asyncAll([], function(data, callback) {
+            callback(null, 'foo');
+        }, function(err, results) {
+            t.ifError(err);
+            t.deepEqual(results, []);
+            t.end();
+        }));
+    });
+
     t.test('coalesce', function(t) {
         t.equal(util.coalesce(undefined, 1), 1);
         t.equal(util.coalesce(2, 1), 2);


### PR DESCRIPTION
`util.asyncAll` fails to call the callback if the passed array is empty.

Causes a bug in `featuresIn` when there are sources with missing tiles in the queried range, because of [this line](https://github.com/mapbox/mapbox-gl-js/blob/master/js/source/source.js#L116)