### PR TITLE
Simplify Circle config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,9 @@
 machine:
   node:
-    version: '0.10'
+    version: '0.12'
 dependencies:
-  pre:
-    - sudo apt-get update; sudo apt-get -y install python-pip libglew-dev gdb
-    - sudo pip install awscli
   override:
-    - npm run preinstall && npm update && npm run postinstall && npm run prepublish
+    - npm update && npm run prepublish
 test:
   override:
     - ./ci.sh
@@ -14,6 +11,7 @@ deployment:
   release:
     tag: /v[0-9]+\.[0-9]+\.[0-9]+/
     commands:
+      - pip install awscli
       - ./deploy.sh
 general:
   artifacts:


### PR DESCRIPTION
- upgrade Node to 0.12
- remove apt updates/installs which are no longer necessary

Makes the build take 4:40 instead of 6:40: https://circleci.com/gh/mapbox/mapbox-gl-js/1391

cc @jfirebaugh 