### PR TITLE
Added docs for maxBounds option, restyled API docs page

### DIFF
--- a/docs/_theme/section.hbs
+++ b/docs/_theme/section.hbs
@@ -24,31 +24,31 @@
   </div>
 
   {{#if params}}
-    <table class='prose space-bottom1'>
-      <thead>
-        <th>parameter</th>
-        <th>type</th>
-        <th>description</th>
-      </thead>
+    <h3 class='space-bottom1 space-top1'>Parameters</h3>
+    <table class='prose space-bottom1 small'>
       {{#params}}
         <tr>
-          <td>{{name}}</td>
-          <td>
+          <td class="fill-light">
+            <div class="code strong">{{name}}</div>
+            <div class="quiet">
             {{{format_type type}}}
-            {{#default}}
-              (default <code>{{.}}</code>)
-            {{/default}}
+                {{#default}}
+                  (default <code>{{.}}</code>)
+                {{/default}}
+            </div>
           </td>
           <td>{{{md description}}}</td>
         </tr>
         {{#properties}}
           <tr>
-            <td>{{name}}</td>
-            <td>
-              {{{format_type type}}}
-              {{#default}}
-              (default <code>{{.}}</code>)
-              {{/default}}
+            <td class="fill-light">
+              <div class="code strong">{{name}}</div>
+              <div class="quiet">
+                {{{format_type type}}}
+                {{#default}}
+                  (default <code>{{.}}</code>)
+                {{/default}}
+              </div>
             </td>
             <td>{{{md description}}}</td>
           </tr>
@@ -58,20 +58,18 @@
   {{/if}}
 
   {{#if properties}}
-    <table class='prose space-bottom1'>
-      <thead>
-        <th>property</th>
-        <th>type</th>
-        <th>description</th>
-      </thead>
+    <h3 class='space-bottom1 space-top1'>Properties</h3>
+    <table class='prose space-bottom1 small'>
       {{#properties}}
         <tr>
-          <td>{{name}}</td>
-          <td>
-            {{{format_type type}}}
-            {{#default}}
-              (default <code>{{.}}</code>)
-            {{/default}}
+          <td class="fill-light">
+            <div class="code strong">{{name}}</div>
+            <div class="quiet">
+              {{{format_type type}}}
+              {{#default}}
+                (default <code>{{.}}</code>)
+              {{/default}}
+            </div>
           </td>
           <td>{{{md description}}}</td>
         </tr>
@@ -81,7 +79,7 @@
 
   {{#if returns}}
     {{#returns}}
-      <h4 class='space-bottom1'>Returns</h4>
+      <h3 class='space-bottom1 space-top1'>Returns</h3>
       <code>{{{format_type type}}}</code>
       {{#if description}}:{{/if}}
       <span class='inline'>
@@ -91,7 +89,7 @@
   {{/if}}
 
   {{#if throws}}
-    <h4>Throws</h4>
+    <h3>Throws</h3>
     <table class='prose space-bottom1'>
       <thead>
         <th>exception</th>
@@ -109,7 +107,7 @@
   {{/if}}
 
   {{#if examples}}
-    <h4 class='space-bottom1'>Examples</h4>
+    <h3 class='space-bottom1 space-top1'>Examples</h3>
 <div class='prose'>
 {{#each examples ~}}
 <pre>

--- a/js/geo/lng_lat_bounds.js
+++ b/js/geo/lng_lat_bounds.js
@@ -164,7 +164,7 @@ LngLatBounds.prototype = {
  * var llb = mapboxgl.LngLatBounds.convert(arr);
  * llb;   // = LngLatBounds {_sw: LngLat {lng: -73.9876, lat: 40.7661}, _ne: LngLat {lng: -73.9397, lat: 40.8002}}
  */
-LngLatBounds.convert = function (a) {
-    if (!a || a instanceof LngLatBounds) return a;
-    return new LngLatBounds(a);
+LngLatBounds.convert = function (input) {
+    if (!input || input instanceof LngLatBounds) return input;
+    return new LngLatBounds(input);
 };

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -49,6 +49,7 @@ var Attribution = require('./control/attribution');
  * @param {boolean} [options.attributionControl=true] If `true`, an attribution control will be added to the map.
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than expected.
  * @param {boolean} [options.preserveDrawingBuffer=false] If `true`, The maps canvas can be exported to a PNG using `map.getCanvas().toDataURL();`. This is false by default as a performance optimization.
+ * @param {LngLatBounds|Array<Array<number>>} [options.maxBounds] If set, the map is constrained to the given bounds.
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -362,7 +362,10 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     /**
      * Apply multiple style mutations in a batch
      *
-     * @param {function} work Function which accepts the StyleBatch interface
+     * @param {function} work Function which accepts a `StyleBatch` object,
+     *      a subset of `Map`, with `addLayer`, `removeLayer`,
+     *      `setPaintProperty`, `setLayoutProperty`, `setFilter`,
+     *      `setLayerZoomRange`, `addSource`, and `removeSource`
      *
      * @example
      * map.batch(function (batch) {


### PR DESCRIPTION
Naively adding the maxBounds option caused a width overflow on the API docs page. In order to document that option, I had to restyle the page, moving the parameter types below the parameter names. 

<img width="1680" alt="screen shot 2015-11-13 at 1 12 08 pm" src="https://cloud.githubusercontent.com/assets/281306/11157915/35b943d0-8a09-11e5-8cab-ac12b9c10669.png">

cc @jfirebaugh @tristen @peterqliu 

fixes #1712 #1707 