### PR TITLE
add TileJSON bounds to VectorTileSource

### DIFF
--- a/js/mapbox-gl.js
+++ b/js/mapbox-gl.js
@@ -17,6 +17,7 @@ mapboxgl.Navigation = require('./ui/control/navigation');
 mapboxgl.Attribution = require('./ui/control/attribution');
 mapboxgl.Popup = require('./ui/popup');
 
+mapboxgl.VectorTileSource = require('./source/vector_tile_source');
 mapboxgl.GeoJSONSource = require('./source/geojson_source');
 mapboxgl.VideoSource = require('./source/video_source');
 mapboxgl.ImageSource = require('./source/image_source');

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -15,7 +15,7 @@ exports._loadTileJSON = function(options) {
         }
 
         util.extend(this, util.pick(tileJSON,
-            ['tiles', 'minzoom', 'maxzoom', 'attribution']));
+            ['tiles', 'minzoom', 'maxzoom', 'attribution', 'bounds', 'center']));
 
         if (tileJSON.vector_layers) {
             this.vectorLayers = tileJSON.vector_layers;


### PR DESCRIPTION
I need to dynamically add overlays from TileJSON sources and zoom to them. This change lets me do this:
```javascript
var source = new mapboxgl.VectorTileSource({
  url: 'http://localhost:8080/index.json'
});
map.addSource(key, source);
source.on('load', function() {
  if(source.bounds){
    var llb = new mapboxgl.LngLatBounds([source.bounds[0],source.bounds[1]],[source.bounds[2],source.bounds[3]]);
    map.fitBounds(llb);
  }
});
```