### PR TITLE
Add scroll fly to example

### DIFF
--- a/docs/_posts/examples/3400-01-03-scroll-fly-to.html
+++ b/docs/_posts/examples/3400-01-03-scroll-fly-to.html
@@ -1,0 +1,168 @@
+---
+layout: example
+category: example
+title: Scroll fly to
+description: Fly to places on scroll events
+---
+
+<style>
+#map {
+    position: fixed;
+    width:50%;
+}
+#features {
+    width: 50%;
+    margin-left: 50%;
+    font-family: sans-serif;
+    overflow-y: scroll;
+}
+section {
+    padding:  10px 50px;
+    line-height: 35px;
+    border-bottom: 1px solid #ddd;
+}
+</style>
+
+<div id='map'></div>
+<div id='features'>
+    <section id='baker'>
+        <h3>221b Baker St.</h3>
+        <p>November 1895. London is shrouded in fog and Sherlock Holmes and Watson pass time restlessly awaiting a new case. "The London criminal is certainly a dull fellow," Sherlock bemoans. "There have been numerous petty thefts," Watson offers in response. Just then a telegram arrives from Sherlock's brother Mycroft with a mysterious case.</p>
+    </section>
+    <section id='aldgate'>
+        <h3>Aldgate Station</h3>
+        <p>Arthur Cadogan West was found dead, head crushed in on train tracks at Aldgate Station at 6AM Tuesday morning. West worked at Woolwich Arsenal on the Bruce-Partington submarine, a secret military project. Plans for the submarine had been stolen and seven of the ten missing papers were found in West's possession. Mycroft implores Sherlock to take the case and recover the three missing papers.</p>
+    </section>
+    <section id='london-bridge'>
+        <h3>London Bridge</h3>
+        <p>Holmes and Watson's investigations take them across London. Sherlock deduces that West was murdered elsewhere, then moved to Aldgate Station to create the illusion that he was crushed on the tracks by a train. On their way to Woolwich Sherlock dispatches a telegram to Mycroft at London Bridge: "Send list of all foreign spies known to be in England, with full address."</p>
+    </section>
+    <section id='woolwich'>
+        <h3>Woolwich Arsenal</h3>
+        <p>While investigating at Woolwich Arsenal Sherlock learns that West did not have the three keys&mdash;door, office, and safe&mdash;necessary to steal the papers. The train station clerk mentions seeing an agitated West boarding the 8:15 train to London Bridge. Sherlock suspects West of following someone who had access to the Woolwich chief's keyring with all three keys.</p>
+    </section>
+    <section id='gloucester'>
+        <h3>Gloucester Road</h3>
+        <p>Mycroft responds to Sherlock's telegram and mentions several spies. Hugo Oberstein of 13 Caulfield Gardens catches Sherlock's eye. He heads to the nearby Gloucester Road station to investigate and learns that the windows of Caulfield Gardens open over rail tracks where trains stop frequently.</p>
+    </section>
+    <section id='caulfield-gardens'>
+        <h3>13 Caulfield Gardens</h3>
+        <p>Holmes deduces that the murderer placed West atop a stopped train at Caulfield Gardens. The train traveled to Aldgate Station before West's body finally toppled off. Backtracking to the criminal's apartment, Holmes finds a series of classified ads from <em>The Daily Telegraph</em> stashed away. All are under the name Pierrot: "Monday night after nine. Two taps. Only ourselves. Do not be so suspicious. Payment in hard cash when goods delivered."</p>
+    </section>
+    <section id='telegraph'>
+        <h3>The Daily Telegraph</h3>
+        <p>Holmes and Watson head to The Daily Telegraph and place an ad to draw out the criminal. It reads: "To-night. Same hour. Same place. Two taps. Most vitally important. Your own safety at stake. Pierrot." The trap works and Holmes catches the criminal: Colonel Valentine Walter, the brother of Woolwich Arsenal's chief. He confesses to working for Hugo Oberstein to obtain the submarine plans in order to pay off his debts.</p>
+    </section>
+    <section id='charing-cross'>
+        <h3>Charing Cross Hotel</h3>
+        <p>Walter writes to Oberstein and convinces him to meet in the smoking room of the Charing Cross Hotel where he promises additional plans for the submarine in exchange for money. The plan works and Holmes and Watson catch both criminals.</p>
+        <small class='colophon'>
+            Adapted from <a href='http://www.gutenberg.org/files/2346/2346-h/2346-h.htm'>Project Gutenberg</a>
+        </small>
+    </section>
+</div>
+<script>
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v8',
+    center: [-0.12960000, 51.50110000],
+    zoom: 9
+});
+
+var activeSection = '';
+
+function isOnScreen (element) {
+    var bounds = element.getBoundingClientRect();
+    return bounds.top < window.innerHeight && bounds.bottom > 0;
+}
+
+function updateMap(newSection) {
+    // Don't update position if activeSection and passed in section are the same
+    if (activeSection === newSection) return;
+    switch (newSection) {
+        case 'baker':
+            map.flyTo({
+                bearing: 27,
+                center: [-0.12960000, 51.50110000],
+                zoom: 15.5
+            });
+            break;
+        case 'aldgate':
+            map.easeTo({
+                duration: 6000,
+                around: [-0.15591514, 51.51830379],
+                pitch: 55,
+                bearing: 150,
+                zoom: 15
+            });
+            break;
+        case 'london-bridge':
+            map.flyTo({
+                bearing: 90,
+                center: [-0.07571203, 51.51424049],
+                zoom: 13,
+                speed: 0.6
+            });
+            break;
+        case 'woolwich':
+            map.easeTo({
+                bearing: 90,
+                center: [-0.08533793, 51.50438536],
+                zoom: 12.3,
+                duration: 2000
+            });
+            break;
+        case 'gloucester':
+            map.easeTo({
+                bearing: 45,
+                center: [0.05991101, 51.48752939],
+                zoom: 15.3,
+                duration: 2000
+            });
+            break;
+        case 'caulfield-gardens':
+            map.easeTo({
+                bearing: 180,
+                center: [-0.18335806, 51.49439521],
+                zoom: 12.3,
+                pitch: 0,
+                duration: 2000
+            });
+            break;
+        case 'telegraph':
+            map.easeTo({
+                bearing: 90,
+                center: [-0.19684993, 51.5033856],
+                zoom: 17.3,
+                pitch: 20,
+                duration: 2000
+            });
+            break;
+        case 'charing-cross':
+            map.easeTo({
+                bearing: 90,
+                center: [-0.10669358, 51.51433123],
+                zoom: 12.3,
+                duration: 2000
+            });
+            break;
+    }
+    activeSection = newSection;
+}
+
+// On every scroll event, check which element is on screen
+window.onscroll = function() {
+    var newSection =
+        isOnScreen(document.getElementById('baker')) ? 'baker' :
+        isOnScreen(document.getElementById('aldgate')) ? 'aldgate' :
+        isOnScreen(document.getElementById('london-bridge')) ? 'london-bridge' :
+        isOnScreen(document.getElementById('woolwich')) ? 'woolwich' :
+        isOnScreen(document.getElementById('gloucester')) ? 'gloucester' :
+        isOnScreen(document.getElementById('caulfield-gardens')) ? 'caulfield-gardens' :
+        isOnScreen(document.getElementById('telegraph')) ? 'telegraph' :
+        isOnScreen(document.getElementById('charing-cross')) ? 'charing-cross' : '';
+
+    updateMap(newSection);
+};
+
+</script>


### PR DESCRIPTION
Drawing inspiration from https://www.mapbox.com/maps/, an example that zooms to different places on scroll events.

![tile](https://cloud.githubusercontent.com/assets/1058624/11288128/f93267e4-8ed5-11e5-9801-988161e37d71.gif)

/cc @jfirebaugh for review
