### PR TITLE
[DNM] Support Webp for mapbox:// urls

### DIFF
--- a/js/util/browser.js
+++ b/js/util/browser.js
@@ -40,3 +40,4 @@ exports.supported = function () {
 
 exports.devicePixelRatio = 1;
 exports.hardwareConcurrency = 8;
+exports.supportsWebp = false;

--- a/js/util/browser/browser.js
+++ b/js/util/browser/browser.js
@@ -115,3 +115,11 @@ exports.hardwareConcurrency = navigator.hardwareConcurrency || 8;
 Object.defineProperty(exports, 'devicePixelRatio', {
     get: function() { return window.devicePixelRatio; }
 });
+
+exports.supportsWebp = false;
+
+var webpImgTest = document.createElement('img');
+webpImgTest.onload = function() {
+    exports.supportsWebp = true;
+};
+webpImgTest.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -66,7 +66,8 @@ module.exports.normalizeSpriteURL = function(url, format, ext, accessToken) {
 };
 
 module.exports.normalizeTileURL = function(url, sourceUrl) {
+    var extension = browser.supportsWebp ? 'webp' : '$1';
     if (!sourceUrl || !sourceUrl.match(/^mapbox:\/\//))
         return url;
-    return url.replace(/\.((?:png|jpg)\d*)(?=$|\?)/, browser.devicePixelRatio >= 2 ? '@2x.$1' : '.$1');
+    return url.replace(/\.((?:png|jpg)\d*)(?=$|\?)/, browser.devicePixelRatio >= 2 ? '@2x.' + extension : '.' + extension);
 };

--- a/test/js/util/mapbox.test.js
+++ b/test/js/util/mapbox.test.js
@@ -117,6 +117,16 @@ test("mapbox", function(t) {
             t.end();
         });
 
+        t.test('replaces img extension with webp on supporting devices', function(t) {
+            browser.supportsWebp = true;
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', 'mapbox://user.map'), 'http://path.png/tile.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', 'mapbox://user.map'), 'http://path.png/tile.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', 'mapbox://user.map'), 'http://path.png/tile.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', 'mapbox://user.map'), 'http://path.png/tile.webp?access_token=foo');
+            browser.supportsWebp = false;
+            t.end();
+        });
+
         t.test('ignores non-mapbox:// sources', function(t) {
             t.equal(mapbox.normalizeTileURL('http://path.png', 'http://path'), 'http://path.png');
             t.end();


### PR DESCRIPTION
Mapbox recently started to support webp tiles. Webp images solve the "raster titles have black border" problems by provided an alpha channel without increasing the tile load size. Sadly they are only support by Chrome at the moment. 

Closes #1725