### PR TITLE
Consolidate common code in featuresAt, featuresIn

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -388,6 +388,14 @@ Style.prototype = util.inherit(Evented, {
     },
 
     featuresAt: function(coord, params, callback) {
+        this._queryFeatures('featuresAt', coord, params, callback);
+    },
+
+    featuresIn: function(bbox, params, callback) {
+        this._queryFeatures('featuresIn', bbox, params, callback);
+    },
+
+    _queryFeatures: function(queryType, bboxOrCoords, params, callback) {
         var features = [];
         var error = null;
 
@@ -397,36 +405,7 @@ Style.prototype = util.inherit(Evented, {
 
         util.asyncEach(Object.keys(this.sources), function(id, callback) {
             var source = this.sources[id];
-            source.featuresAt(coord, params, function(err, result) {
-                if (result) features = features.concat(result);
-                if (err) error = err;
-                callback();
-            });
-        }.bind(this), function() {
-            if (error) return callback(error);
-
-            callback(null, features
-                .filter(function(feature) {
-                    return this._layers[feature.layer] !== undefined;
-                }.bind(this))
-                .map(function(feature) {
-                    feature.layer = this._layers[feature.layer].json();
-                    return feature;
-                }.bind(this)));
-        }.bind(this));
-    },
-
-    featuresIn: function(bbox, params, callback) {
-        var features = [];
-        var error = null;
-
-        if (params.layer) {
-            params.layer = { id: params.layer };
-        }
-
-        util.asyncEach(Object.keys(this.sources), function(id, callback) {
-            var source = this.sources[id];
-            source.featuresIn(bbox, params, function(err, result) {
+            source[queryType](bboxOrCoords, params, function(err, result) {
                 if (result) features = features.concat(result);
                 if (err) error = err;
                 callback();

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -292,7 +292,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @param {Object} params
      * @param {number} [params.radius=0] Radius in pixels to search in
      * @param {string|Array<string>} [params.layer] Only return features from a given layer or layers
-     * @param {string} params.type Optional. Either `raster` or `vector`
+     * @param {string} [params.type] Either `raster` or `vector`
      * @param {boolean} [params.includeGeometry=false] Optional. If `true`, geometry of features will be included in the results at the expense of a much slower query time.
      * @param {featuresAtCallback} callback function that receives the results
      *
@@ -322,8 +322,9 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      *
      * @param {Array<Point>|Array<Array<number>>} [bounds] Coordinates of opposite corners of bounding rectangle, in pixel coordinates. Optional: use entire viewport if omitted.
      * @param {Object} params
-     * @param {string} params.layer Optional. Only return features from a given layer
-     * @param {string} params.type Optional. Either `raster` or `vector`
+     * @param {string} [params.layer] Only return features from a given layer or layers.
+     * @param {string} [params.type] Either `raster` or `vector`
+     * @param {boolean} [params.includeGeometry=false] Optional. If `true`, geometry of features will be included in the results at the expense of a much slower query time.
      * @param {featuresInCallback} callback function that receives the results
      *
      * @returns {Map} `this`

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -744,7 +744,7 @@ test('Style#featuresAt', function(t) {
         style._cascade([]);
         style._recalculate(0);
 
-        style.sources.mapbox.featuresAt = function(position, params, callback) {
+        style.sources.mapbox.featuresAt = style.sources.mapbox.featuresIn = function(position, params, callback) {
             var features = [{
                 type: 'Feature',
                 layer: 'land',
@@ -776,83 +776,90 @@ test('Style#featuresAt', function(t) {
             }, 10);
         };
 
-        t.test('returns feature type', function(t) {
-            style.featuresAt([256, 256], {}, function(err, results) {
-                t.error(err);
-                t.equal(results[0].geometry.type, 'Polygon');
-                t.end();
+        [
+            style.featuresAt.bind(style, [256, 256]),
+            style.featuresIn.bind(style, [256, 256, 512, 512])
+        ].forEach(function (featuresInOrAt) {
+            t.test('returns feature type', function(t) {
+                featuresInOrAt({}, function(err, results) {
+                    t.error(err);
+                    t.equal(results[0].geometry.type, 'Polygon');
+                    t.end();
+                });
             });
+
+            t.test('filters by `layer` option', function(t) {
+                featuresInOrAt({layer: 'land'}, function(err, results) {
+                    t.error(err);
+                    t.equal(results.length, 2);
+                    t.end();
+                });
+            });
+
+            t.test('includes layout properties', function(t) {
+                featuresInOrAt({}, function(err, results) {
+                    t.error(err);
+
+                    var layout = results[0].layer.layout;
+                    t.deepEqual(layout, {'line-cap': 'round'});
+                    t.deepEqual(
+                        Object.getPrototypeOf(layout),
+                        LayoutProperties.line.prototype);
+
+                    t.end();
+                });
+            });
+
+            t.test('includes paint properties', function(t) {
+                featuresInOrAt({}, function(err, results) {
+                    t.error(err);
+
+                    var paint = results[0].layer.paint;
+                    t.deepEqual(paint, {'line-color': [ 1, 0, 0, 1 ]});
+                    t.deepEqual(
+                        Object.getPrototypeOf(paint),
+                        PaintProperties.line.prototype);
+
+                    t.end();
+                });
+            });
+
+            t.test('ref layer inherits properties', function(t) {
+                featuresInOrAt({}, function(err, results) {
+                    t.error(err);
+
+                    var layer = results[1].layer;
+                    var refLayer = results[2].layer;
+                    t.deepEqual(layer.layout, refLayer.layout);
+                    t.deepEqual(layer.type, refLayer.type);
+                    t.deepEqual(layer.id, refLayer.ref);
+                    t.notEqual(layer.paint, refLayer.paint);
+
+                    t.end();
+                });
+            });
+
+            t.test('includes arbitrary keys', function(t) {
+                featuresInOrAt({}, function(err, results) {
+                    t.error(err);
+
+                    var layer = results[0].layer;
+                    t.equal(layer.something, 'else');
+
+                    t.end();
+                });
+            });
+
+            t.test('include multiple layers', function(t) {
+                featuresInOrAt({layer: ['land', 'landref']}, function(err, results) {
+                    t.error(err);
+                    t.equals(results.length, 3);
+                    t.end();
+                });
+            });
+
         });
 
-        t.test('filters by `layer` option', function(t) {
-            style.featuresAt([256, 256], {layer: 'land'}, function(err, results) {
-                t.error(err);
-                t.equal(results.length, 2);
-                t.end();
-            });
-        });
-
-        t.test('includes layout properties', function(t) {
-            style.featuresAt([256, 256], {}, function(err, results) {
-                t.error(err);
-
-                var layout = results[0].layer.layout;
-                t.deepEqual(layout, {'line-cap': 'round'});
-                t.deepEqual(
-                    Object.getPrototypeOf(layout),
-                    LayoutProperties.line.prototype);
-
-                t.end();
-            });
-        });
-
-        t.test('includes paint properties', function(t) {
-            style.featuresAt([256, 256], {}, function(err, results) {
-                t.error(err);
-
-                var paint = results[0].layer.paint;
-                t.deepEqual(paint, {'line-color': [ 1, 0, 0, 1 ]});
-                t.deepEqual(
-                    Object.getPrototypeOf(paint),
-                    PaintProperties.line.prototype);
-
-                t.end();
-            });
-        });
-
-        t.test('ref layer inherits properties', function(t) {
-            style.featuresAt([256, 256], {}, function(err, results) {
-                t.error(err);
-
-                var layer = results[1].layer;
-                var refLayer = results[2].layer;
-                t.deepEqual(layer.layout, refLayer.layout);
-                t.deepEqual(layer.type, refLayer.type);
-                t.deepEqual(layer.id, refLayer.ref);
-                t.notEqual(layer.paint, refLayer.paint);
-
-                t.end();
-            });
-        });
-
-        t.test('includes arbitrary keys', function(t) {
-            style.featuresAt([256, 256], {}, function(err, results) {
-                t.error(err);
-
-                var layer = results[0].layer;
-                t.equal(layer.something, 'else');
-
-                t.end();
-            });
-        });
-
-        t.test('include multiple layers', function(t) {
-            style.featuresAt([256, 256], {layer: ['land', 'landref']}, function(err, results) {
-                t.error(err);
-                t.equals(results.length, 3);
-                t.end();
-            });
-        });
 
         t.end();
     });


### PR DESCRIPTION
Fixes #1747

@jfirebaugh: :eyes: Something like this seems the least invasive way to do this refactor, but it would also be possible to do it in `Source` (removing `featuresIn` and `featuresAt` in favor of a single `queryFeatures`).  Preference?