### PR TITLE
Fixed test failures due to stricter style spec validation

### DIFF
--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -123,11 +123,14 @@ test('Style#_resolve', function(t) {
                 }
             },
             "layers": [{
-                id: "fill",
-                source: "foo",
-                type: "fill"
+                "id": "fill",
+                "source": "foo",
+                "source-layer": "source-layer",
+                "type": "fill"
             }]
         });
+
+        style.on('error', function(error) { t.error(error); });
 
         style.on('load', function() {
             t.ok(style.getLayer('fill') instanceof StyleLayer);
@@ -144,14 +147,17 @@ test('Style#_resolve', function(t) {
                 }
             },
             "layers": [{
-                id: "ref",
-                ref: "referent"
+                "id": "ref",
+                "ref": "referent"
             }, {
-                id: "referent",
-                source: "foo",
-                type: "fill"
+                "id": "referent",
+                "source": "foo",
+                "source-layer": "source-layer",
+                "type": "fill"
             }]
         });
+
+        style.on('error', function(event) { t.error(event.error); });
 
         style.on('load', function() {
             var ref = style.getLayer('ref'),


### PR DESCRIPTION
The CI failures _were_ being caused by a package update

... and our very own @lucaswoj was the source of the update. :grimacing: 

The stricter `mapbox-gl-style-spec` validations introduced in https://github.com/mapbox/mapbox-gl-style-spec/pull/381 caused an error to be thrown during the construction of the `Style` object in one of the tests. Because the error was never caught, the test timed out. 

ref #1767 

cc @jfirebaugh 