### PR TITLE
Fix unstable symbol rendering order

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -172,13 +172,9 @@ Style.prototype = util.inherit(Evented, {
     },
 
     _broadcastLayers: function() {
-        var ordered = [];
-
-        for (var id in this._layers) {
-            ordered.push(this._layers[id].json());
-        }
-
-        this.dispatcher.broadcast('set layers', ordered);
+        this.dispatcher.broadcast('set layers', this._order.map(function(id) {
+            return this._layers[id].json();
+        }, this));
     },
 
     _cascade: function(classes, options) {

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -113,6 +113,38 @@ test('Style', function(t) {
     });
 });
 
+test('Style#_broadcastLayers', function(t) {
+    var style = new Style({
+        'version': 8,
+        'sources': {
+            'source': {
+                'type': 'vector'
+            }
+        },
+        'layers': [{
+            'id': 'second',
+            'source': 'source',
+            'source-layer': 'source-layer',
+            'type': 'fill'
+        }]
+    });
+
+    style.on('error', function(error) { t.error(error); });
+
+    style.on('load', function() {
+        style.addLayer({id: 'first', source: 'source', type: 'fill' }, 'second');
+        style.addLayer({id: 'third', source: 'source', type: 'fill' });
+
+        style.dispatcher.broadcast = function(key, value) {
+            t.equal(key, 'set layers');
+            t.deepEqual(value.map(function(layer) { return layer.id; }), ['first', 'second', 'third']);
+            t.end();
+        };
+
+        style._broadcastLayers();
+    });
+});
+
 test('Style#_resolve', function(t) {
     t.test('creates StyleLayers', function(t) {
         var style = new Style({


### PR DESCRIPTION
The order of the layers we pass to `WorkerTile` is related to the order that they were added to the stylesheet, not their logical order. 

fixes #1558

cc @scothis @samanpwbb 