### PR TITLE
Provide an API to disable pinch rotation

### DIFF
--- a/js/ui/handler/pinch.js
+++ b/js/ui/handler/pinch.js
@@ -22,6 +22,14 @@ Pinch.prototype = {
         this._el.removeEventListener('touchstart', this._onStart);
     },
 
+    disableRotation: function() {
+        this._rotationDisabled = true;
+    },
+
+    enableRotation: function() {
+        this._rotationDisabled = false;
+    },
+
     _onStart: function (e) {
         if (e.touches.length !== 2) return;
 
@@ -44,7 +52,7 @@ Pinch.prototype = {
             p = p0.add(p1).div(2),
             vec = p0.sub(p1),
             scale = vec.mag() / this._startVec.mag(),
-            bearing = vec.angleWith(this._startVec) * 180 / Math.PI,
+            bearing = this._rotationDisabled ? 0 : vec.angleWith(this._startVec) * 180 / Math.PI,
             map = this._map;
 
         map.easeTo({

--- a/js/ui/handler/touch_zoom_rotate.js
+++ b/js/ui/handler/touch_zoom_rotate.js
@@ -3,17 +3,17 @@
 var DOM = require('../../util/dom'),
     util = require('../../util/util');
 
-module.exports = Pinch;
+module.exports = TouchZoomRotate;
 
 
-function Pinch(map) {
+function TouchZoomRotate(map) {
     this._map = map;
     this._el = map.getCanvasContainer();
 
     util.bindHandlers(this);
 }
 
-Pinch.prototype = {
+TouchZoomRotate.prototype = {
     enable: function () {
         this._el.addEventListener('touchstart', this._onStart, false);
     },

--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -7,7 +7,7 @@ var handlers = {
     dragPan: require('./handler/drag_pan'),
     keyboard: require('./handler/keyboard'),
     doubleClickZoom: require('./handler/dblclick_zoom'),
-    pinch: require('./handler/pinch')
+    touchZoomRotate: require('./handler/touch_zoom_rotate')
 };
 
 var DOM = require('../util/dom'),
@@ -252,4 +252,3 @@ Interaction.prototype = {
  * @type {Object}
  * @property {Event} originalEvent the original DOM event, only present if triggered by user interaction
  */
-

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -150,7 +150,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         dragPan: true,
         keyboard: true,
         doubleClickZoom: true,
-        pinch: true,
+        touchZoomRotate: true,
 
         bearingSnap: 7,
 


### PR DESCRIPTION
fixes #1496 

Allows touch / pinch rotation to be disabled via
```js
map.pinch.disableRotation();
```

and enabled via
```js
map.pinch.enableRotation();
```

cc @jfirebaugh @mcwhittemore @bhousel @mourner 