### PR TITLE
Use latest access token fetching vector and raster tiles

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -39,6 +39,10 @@ RasterTileSource.prototype = util.inherit(Evented, {
         // noop
     },
 
+    remove: function() {
+        this.fire('remove');
+    },
+
     render: Source._renderTiles,
 
     _loadTile: function(tile) {

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -43,6 +43,10 @@ VectorTileSource.prototype = util.inherit(Evented, {
         }
     },
 
+    remove: function() {
+        this.fire('remove');
+    },
+
     render: Source._renderTiles,
     featuresAt: Source._vectorFeaturesAt,
     featuresIn: Source._vectorFeaturesIn,

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -426,6 +426,12 @@ Style.prototype = util.inherit(Evented, {
 
     _remove: function() {
         this.dispatcher.remove();
+
+        for (var id in this.sources) {
+            if (this.sources[id] && this.sources[id].remove) {
+                this.sources[id].remove();
+            }
+        }
     },
 
     _reloadSource: function(id) {

--- a/js/util/config.js
+++ b/js/util/config.js
@@ -1,6 +1,20 @@
 'use strict';
 
-module.exports = {
+var Evented = require('./evented');
+var util = require('./util');
+
+var config = util.extend({
     API_URL: 'https://api.mapbox.com',
     REQUIRE_ACCESS_TOKEN: true
-};
+}, Evented);
+
+var accessToken;
+Object.defineProperty(config, 'ACCESS_TOKEN', {
+    get: function() { return accessToken; },
+    set: function(token) {
+        accessToken = token;
+        this.fire('token.change', { token: token });
+    }
+});
+
+module.exports = config;

--- a/test/fixtures/source_secure.json
+++ b/test/fixtures/source_secure.json
@@ -1,0 +1,6 @@
+{
+    "tiles": ["https://example.com/{z}/{x}/{y}.png"],
+    "minzoom": 1,
+    "maxzoom": 10,
+    "attribution": "Mapbox"
+}

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -5,6 +5,7 @@ var st = require('st');
 var http = require('http');
 var path = require('path');
 var VectorTileSource = require('../../../js/source/vector_tile_source');
+var config = require('../../../js/util/config');
 
 var server = http.createServer(st({path: path.join(__dirname, '/../../fixtures')}));
 
@@ -23,6 +24,7 @@ test('VectorTileSource', function(t) {
 
         source.on('error', function(e) {
             t.fail(e.error);
+            source.remove();
             t.end();
         });
 
@@ -32,6 +34,7 @@ test('VectorTileSource', function(t) {
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
             t.deepEqual(source.attribution, "Mapbox");
+            source.remove();
             t.end();
         });
     });
@@ -43,6 +46,7 @@ test('VectorTileSource', function(t) {
 
         source.on('error', function(e) {
             t.fail(e.error);
+            source.remove();
             t.end();
         });
 
@@ -52,7 +56,40 @@ test('VectorTileSource', function(t) {
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
             t.deepEqual(source.attribution, "Mapbox");
+            source.remove();
             t.end();
+        });
+    });
+
+    t.test('can be refreshed from a TileJSON URL after token change', function(t) {
+        var source = new VectorTileSource({
+            url: "http://localhost:2900/source.json"
+        });
+
+        source.on('error', function(e) {
+            t.fail(e.error);
+            source.remove();
+            t.end();
+        });
+
+        source.once('load', function() {
+            t.ok(source.loaded());
+            t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
+
+            var tilePyramid = source._pyramid;
+            source.once('load', function() {
+                t.ok(source.loaded());
+                t.deepEqual(source.tiles, ["https://example.com/{z}/{x}/{y}.png"]);
+                t.equal(tilePyramid, source._pyramid);
+
+                source.remove();
+                t.end();
+            });
+
+            // since the fixtures are static change the TileJSON URL
+            // so we know the source has updated
+            source.url = "http://localhost:2900/source_secure.json";
+            config.fire('token.change');
         });
     });
 
@@ -66,6 +103,7 @@ test('VectorTileSource', function(t) {
         }, null, 'reload ignored gracefully');
 
         source.on('load', function() {
+            source.remove();
             t.end();
         });
     });

--- a/test/js/util/config.test.js
+++ b/test/js/util/config.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var test = require('prova');
+var config = require('../../../js/util/config');
+
+test('config', function(t) {
+    t.test('ACCESS_TOKEN', function(t) {
+        config.once('token.change', function (e) {
+            t.equal('tk.abc.xyz', e.token);
+            t.equal('tk.abc.xyz', config.ACCESS_TOKEN);
+
+            t.end();
+        });
+
+        config.ACCESS_TOKEN = 'tk.abc.xyz';
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Most requests use the current access token, however, for sources that use
a tile.json, the access token used to fetch the descriptor is embedded
into the tile URLs used to fetch tiles for the source. If the access
token is changed, requests for new tiles within that source will continue
to use the access token active when the source was created.

Now, changes to the `config.ACCESS_TOKEN` property are intercepted and
broadcast as a global `token.changed` event. Vector and raster sources
listen for this event and refresh the tile.json if needed. The source's
tile pyramid is preserved as previously fetched tiles are still valid,
only new requests need the new access token.