### PR TITLE
Replace temp tokens for Mapbox tiles with latest token

### DIFF
--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -3,6 +3,7 @@
 var util = require('../util/util');
 var Evented = require('../util/evented');
 var Source = require('./source');
+var normalizeURL = require('../util/mapbox').normalizeTileURL;
 
 module.exports = VectorTileSource;
 
@@ -50,7 +51,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
     _loadTile: function(tile) {
         var overscaling = tile.coord.z > this.maxzoom ? Math.pow(2, tile.coord.z - this.maxzoom) : 1;
         var params = {
-            url: tile.coord.url(this.tiles, this.maxzoom),
+            url: normalizeURL(tile.coord.url(this.tiles, this.maxzoom), this.url),
             uid: tile.uid,
             coord: tile.coord,
             zoom: tile.coord.z,

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -66,8 +66,10 @@ module.exports.normalizeSpriteURL = function(url, format, ext, accessToken) {
 };
 
 module.exports.normalizeTileURL = function(url, sourceUrl) {
-    var extension = browser.supportsWebp ? 'webp' : '$1';
     if (!sourceUrl || !sourceUrl.match(/^mapbox:\/\//))
         return url;
+
+    url = url.replace(/([?&]access_token=)tk\.[^&]+/, '$1' + config.ACCESS_TOKEN);
+    var extension = browser.supportsWebp ? 'webp' : '$1';
     return url.replace(/\.((?:png|jpg)\d*)(?=$|\?)/, browser.devicePixelRatio >= 2 ? '@2x.' + extension : '.' + extension);
 };

--- a/test/js/util/mapbox.test.js
+++ b/test/js/util/mapbox.test.js
@@ -6,6 +6,8 @@ var config = require('../../../js/util/config');
 var browser = require('../../../js/util/browser');
 
 test("mapbox", function(t) {
+    var mapboxSource = 'mapbox://user.map';
+    var nonMapboxSource = 'http://www.example.com/tiles.json';
     config.ACCESS_TOKEN = 'key';
 
     t.test('.normalizeStyleURL', function(t) {
@@ -25,25 +27,25 @@ test("mapbox", function(t) {
 
     t.test('.normalizeSourceURL', function(t) {
         t.test('returns a v4 URL with access_token parameter', function(t) {
-            t.equal(mapbox.normalizeSourceURL('mapbox://user.map'), 'https://api.mapbox.com/v4/user.map.json?access_token=key&secure');
+            t.equal(mapbox.normalizeSourceURL(mapboxSource), 'https://api.mapbox.com/v4/user.map.json?access_token=key&secure');
             t.end();
         });
 
         t.test('uses provided access token', function(t) {
-            t.equal(mapbox.normalizeSourceURL('mapbox://user.map', 'token'), 'https://api.mapbox.com/v4/user.map.json?access_token=token&secure');
+            t.equal(mapbox.normalizeSourceURL(mapboxSource, 'token'), 'https://api.mapbox.com/v4/user.map.json?access_token=token&secure');
             t.end();
         });
 
         t.test('throws an error if no access token is provided', function(t) {
             config.ACCESS_TOKEN = null;
-            t.throws(function() { mapbox.normalizeSourceURL('mapbox://user.map'); }, 'An API access token is required to use Mapbox GL.');
+            t.throws(function() { mapbox.normalizeSourceURL(mapboxSource); }, 'An API access token is required to use Mapbox GL.');
             config.ACCESS_TOKEN = 'key';
             t.end();
         });
 
         t.test('throws an error if a secret access token is provided', function(t) {
             config.ACCESS_TOKEN = 'sk.abc.123';
-            t.throws(function() { mapbox.normalizeSourceURL('mapbox://user.map'); }, 'Use a public access token (pk.*) with Mapbox GL JS.');
+            t.throws(function() { mapbox.normalizeSourceURL(mapboxSource); }, 'Use a public access token (pk.*) with Mapbox GL JS.');
             config.ACCESS_TOKEN = 'key';
             t.end();
         });
@@ -101,39 +103,57 @@ test("mapbox", function(t) {
 
     t.test('.normalizeTileURL', function(t) {
         t.test('does nothing on 1x devices', function(t) {
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', 'mapbox://user.map'), 'http://path.png/tile.png');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', 'mapbox://user.map'), 'http://path.png/tile.png32');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', 'mapbox://user.map'), 'http://path.png/tile.jpg70');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile.png');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile.png32');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile.jpg70');
             t.end();
         });
 
         t.test('inserts @2x on 2x devices', function(t) {
             browser.devicePixelRatio = 2;
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', 'mapbox://user.map'), 'http://path.png/tile@2x.png');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', 'mapbox://user.map'), 'http://path.png/tile@2x.png32');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', 'mapbox://user.map'), 'http://path.png/tile@2x.jpg70');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', 'mapbox://user.map'), 'http://path.png/tile@2x.png?access_token=foo');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile@2x.png');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile@2x.png32');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile@2x.jpg70');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource), 'http://path.png/tile@2x.png?access_token=foo');
             browser.devicePixelRatio = 1;
             t.end();
         });
 
         t.test('replaces img extension with webp on supporting devices', function(t) {
             browser.supportsWebp = true;
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', 'mapbox://user.map'), 'http://path.png/tile.webp');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', 'mapbox://user.map'), 'http://path.png/tile.webp');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', 'mapbox://user.map'), 'http://path.png/tile.webp');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', 'mapbox://user.map'), 'http://path.png/tile.webp?access_token=foo');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource), 'http://path.png/tile.webp?access_token=foo');
             browser.supportsWebp = false;
             t.end();
         });
 
         t.test('ignores non-mapbox:// sources', function(t) {
-            t.equal(mapbox.normalizeTileURL('http://path.png', 'http://path'), 'http://path.png');
+            t.equal(mapbox.normalizeTileURL('http://path.png', nonMapboxSource), 'http://path.png');
             t.end();
         });
 
         t.test('ignores undefined sources', function(t) {
             t.equal(mapbox.normalizeTileURL('http://path.png'), 'http://path.png');
+            t.end();
+        });
+
+        t.test('replace temp access tokens with the latest token', function(t) {
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tk.abc.123', mapboxSource), 'http://example.com/tile.png?access_token=key');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?foo=bar&access_token=tk.abc.123', mapboxSource), 'http://example.com/tile.png?foo=bar&access_token=key');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tk.abc.123&foo=bar', 'mapbox://user.map'), 'http://example.com/tile.png?access_token=key&foo=bar');
+            t.end();
+        });
+
+        t.test('does not modify the access token for non-mapbox sources', function(t) {
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tk.abc.123', nonMapboxSource), 'http://example.com/tile.png?access_token=tk.abc.123');
+            t.end();
+        });
+
+        t.test('does not modify the access token for non temp tokens', function(t) {
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=pk.abc.123', mapboxSource), 'http://example.com/tile.png?access_token=pk.abc.123');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tkk.abc.123', mapboxSource), 'http://example.com/tile.png?access_token=tkk.abc.123');
             t.end();
         });
 


### PR DESCRIPTION
For raster and vector tiles, the URLs defined in the TileJSON include the
access token the json was loaded with. For temporary tokens, tiles could
be requested with a stale token that had since been refreshed, but pinned
by the TileJSON.

Now, we replace a temp token in a tile url for mapbox sources with the
most current access token. Non-mapbox sources and non-temp token are
ignored.