### PR TITLE
Ensure vector tile error messages get passed all the way up

### DIFF
--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -75,7 +75,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
             return;
 
         if (err) {
-            this.fire('tile.error', {tile: tile});
+            this.fire('tile.error', {tile: tile, error: err});
             return;
         }
 


### PR DESCRIPTION
I fixed this for raster tiles in https://github.com/mapbox/mapbox-gl-js/pull/1772 but missed the equivalent vector tile fix.

cc @jfirebaugh @mourner @lyzidiamond 