### PR TITLE
Reverse line-offset

### DIFF
--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -100,7 +100,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.uniform1f(shader.u_mix, dasharray.t);
 
         gl.uniform1f(shader.u_extra, extra);
-        gl.uniform1f(shader.u_offset, layer.paint['line-offset']);
+        gl.uniform1f(shader.u_offset, -layer.paint['line-offset']);
         gl.uniformMatrix2fv(shader.u_antialiasingmatrix, false, antialiasingMatrix);
 
     } else if (image) {
@@ -128,7 +128,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.uniform1f(shader.u_opacity, layer.paint['line-opacity']);
 
         gl.uniform1f(shader.u_extra, extra);
-        gl.uniform1f(shader.u_offset, layer.paint['line-offset']);
+        gl.uniform1f(shader.u_offset, -layer.paint['line-offset']);
         gl.uniformMatrix2fv(shader.u_antialiasingmatrix, false, antialiasingMatrix);
 
     } else {
@@ -139,7 +139,7 @@ module.exports = function drawLine(painter, layer, posMatrix, tile) {
         gl.uniform1f(shader.u_ratio, ratio);
         gl.uniform1f(shader.u_blur, blur);
         gl.uniform1f(shader.u_extra, extra);
-        gl.uniform1f(shader.u_offset, layer.paint['line-offset']);
+        gl.uniform1f(shader.u_offset, -layer.paint['line-offset']);
         gl.uniformMatrix2fv(shader.u_antialiasingmatrix, false, antialiasingMatrix);
 
         gl.uniform4fv(shader.u_color, color);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#96a784f76653f0476f2ce4858bb1fbde3e1e7bf5",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#117067ee1789203c46d7648eef8dd49659e62090",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
As per https://github.com/mapbox/mapbox-gl-style-spec/issues/386, we're reversing the direction of line-offset.

Master ticket: https://github.com/mapbox/mapbox-gl/issues/3#issuecomment-162607343