### PR TITLE
Make example names more consistent

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Examples are written as Jekyll posts in `docs/_posts/examples`. The Jekyll front
 
 * `layout`: `example`
 * `category`: `example`
-* `title`: A short title for the example, in **sentence case**
+* `title`: A short title for the example in **sentence case** as a **verb phrase**
 * `description`: A one sentence description of the example
 
 In the post body, write the HTML and JavaScript constituting the example.

--- a/docs/_posts/examples/3400-01-01-custom-style-id.html
+++ b/docs/_posts/examples/3400-01-01-custom-style-id.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Custom style
+title: Display a map with a custom style
 description: Using a custom Mapbox-hosted style.
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-01-setstyle.html
+++ b/docs/_posts/examples/3400-01-01-setstyle.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Switch style
+title: Change a map's style
 description: Switch to another map style.
 ---
 <style>

--- a/docs/_posts/examples/3400-01-01-simple-map.html
+++ b/docs/_posts/examples/3400-01-01-simple-map.html
@@ -2,7 +2,7 @@
 layout: example
 category: example
 date: 1000-01-01
-title: A simple map
+title: Display a map
 description: Initialize a map in an HTML element with Mapbox GL JS.
 permalink: /examples
 ---

--- a/docs/_posts/examples/3400-01-01-toggle-layers.html
+++ b/docs/_posts/examples/3400-01-01-toggle-layers.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Toggling layers
+title: Show and hide layers
 description: Create a custom layer switcher to display different datasets.
 ---
 <style>

--- a/docs/_posts/examples/3400-01-01-vector-source.html
+++ b/docs/_posts/examples/3400-01-01-vector-source.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Add vector source
+title: Add a vector tile source
 description: Add a vector source to a map.
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-02-check-for-support.html
+++ b/docs/_posts/examples/3400-01-02-check-for-support.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Check for support
+title: Check for browser support
 description: Check for Mapbox GL browser support
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-02-interactive-false.html
+++ b/docs/_posts/examples/3400-01-02-interactive-false.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Non-interactive map
+title: Display a non-interactive map
 description: "Setting interactive: false to create a static map"
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-02-map-tiles.html
+++ b/docs/_posts/examples/3400-01-02-map-tiles.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Raster tile source
+title: Add a raster tile source
 description: Using a Mapbox raster tile source in a map
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-03-fitbounds.html
+++ b/docs/_posts/examples/3400-01-03-fitbounds.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: fitBounds
+title: Fit a map to a bounding box
 description: Use fitBounds to show a specific area of the map in view, regardless of the pixel size of the map.
 ---
 <style>

--- a/docs/_posts/examples/3400-01-03-flyto-options.html
+++ b/docs/_posts/examples/3400-01-03-flyto-options.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Slowly fly to location
+title: Slowly fly to a location
 description: Using .flyTo with flyOptions
 ---
 <style>

--- a/docs/_posts/examples/3400-01-03-flyto.html
+++ b/docs/_posts/examples/3400-01-03-flyto.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Fly to locations
+title: Fly to a location
 description: Using .flyTo to smoothly interpolate between locations
 ---
 <style>

--- a/docs/_posts/examples/3400-01-03-language-switch.html
+++ b/docs/_posts/examples/3400-01-03-language-switch.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Switch languages
+title: Change a map's language
 description: Using .setLayoutProperty to switch languages dynamically.
 ---
 <style>

--- a/docs/_posts/examples/3400-01-03-marker-popup.html
+++ b/docs/_posts/examples/3400-01-03-marker-popup.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Markers with a popup
+title: Display markers with popups
 description: Show a popup with information about a marker when it is clicked
 ---
 <style>

--- a/docs/_posts/examples/3400-01-03-scroll-fly-to.html
+++ b/docs/_posts/examples/3400-01-03-scroll-fly-to.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Scroll-driven navigation
+title: Fly to a location based on scroll position
 description: Scroll down through the story and the map will fly to the chapter's location.
 ---
 

--- a/docs/_posts/examples/3400-01-03-set-perspective.html
+++ b/docs/_posts/examples/3400-01-03-set-perspective.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Set initial pitch and bearing
+title: Set pitch and bearing
 description: Map options extend CameraOptions, so you can set more than just center and zoom
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-04-center-on-symbol.html
+++ b/docs/_posts/examples/3400-01-04-center-on-symbol.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Center on symbol
+title: Center the map on a clicked marker
 description: Using featuresAt and flyTo to center the map on a symbol
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-04-color-switcher.html
+++ b/docs/_posts/examples/3400-01-04-color-switcher.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Change layer fill
+title: Change a layer's color with buttons
 description: Using setPaintProperty to change a layer's fill color
 ---
 <style>

--- a/docs/_posts/examples/3400-01-04-geojson-layer-in-stack.html
+++ b/docs/_posts/examples/3400-01-04-geojson-layer-in-stack.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Adding a layer below streets and other features
+title: Add a new layer below labels
 description: Using the second argument of addLayer, you can be more precise
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-04-geojson-line.html
+++ b/docs/_posts/examples/3400-01-04-geojson-line.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Add GeoJSON line
+title: Add a GeoJSON line
 description: Add a GeoJSON line to a map.
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-04-geojson-polygon.html
+++ b/docs/_posts/examples/3400-01-04-geojson-polygon.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Add GeoJSON polygon
+title: Add a GeoJSON polygon
 description: Style a polygon with the fill layer type
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-04-hover-styles.html
+++ b/docs/_posts/examples/3400-01-04-hover-styles.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Hover styles
+title: Highlight features under the mouse pointer
 description: Using featuresAt and a filter to change hover styles
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-04-navigation.html
+++ b/docs/_posts/examples/3400-01-04-navigation.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Navigation controls
+title: Display map navigation controls
 description: Zoom and rotation controls to make map navigation more obvious
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-05-featuresat.html
+++ b/docs/_posts/examples/3400-01-05-featuresat.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: featuresAt for selection
+title: Get features under the mouse pointer
 description: Using the featuresAt API to show properties of hovered-over map elements.
 ---
 <style>

--- a/docs/_posts/examples/3400-01-05-geojson-markers.html
+++ b/docs/_posts/examples/3400-01-05-geojson-markers.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: GeoJSON markers
+title: Add GeoJSON markers
 description: Add markers from a GeoJSON collection to a map.
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-05-mouse-position.html
+++ b/docs/_posts/examples/3400-01-05-mouse-position.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Mouse position
+title: Get coordinates of the mouse pointer
 description: Showing mouse position on hover with pixel and latitude and longitude coordinates
 ---
 <style type='text/css'>

--- a/docs/_posts/examples/3400-01-05-popup-on-click.html
+++ b/docs/_posts/examples/3400-01-05-popup-on-click.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Popup on click
+title: Display a popup on click
 description: Add a popup to a clicked point on the map
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-05-popup.html
+++ b/docs/_posts/examples/3400-01-05-popup.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Popup
+title: Display a popup
 description: Add a popup to the map
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-06-satellite-map.html
+++ b/docs/_posts/examples/3400-01-06-satellite-map.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Satellite map
+title: Display a satellite map
 description: Satellite raster baselayer.
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-07-image-on-a-map.html
+++ b/docs/_posts/examples/3400-01-07-image-on-a-map.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Image on a map
+title: Add an image
 description: Dark vector baselayer with radar weather image overlay
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-07-video-on-a-map.html
+++ b/docs/_posts/examples/3400-01-07-video-on-a-map.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Video on a map
+title: Add a video
 description: Satellite raster baselayer with video on top
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-08-third-party.html
+++ b/docs/_posts/examples/3400-01-08-third-party.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Third party source
+title: Add a third party vector tile source
 description: Render a map using an external vector source of OpenStreetMap data provided by <a href='http://mapzen.com/vector/'>Mapzen</a>.
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-10-live-geojson.html
+++ b/docs/_posts/examples/3400-01-10-live-geojson.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: GeoJSON from live realtime data
+title: Add live realtime data
 description: Use realtime GeoJSON data streams to move a marker on your map with Mapbox GL JS.
 ---
 <div id='map'></div>

--- a/docs/_posts/examples/3400-01-10-rotating-controllable-marker.html
+++ b/docs/_posts/examples/3400-01-10-rotating-controllable-marker.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Rotating and controllable marker
+title: Move marker with the keyboard
 description: Control a marker with keybindings and rotate it
 ---
 <div id='map'></div>
@@ -42,7 +42,7 @@ function setPosition() {
 
 map.on('style.load', function () {
     map.addSource('drone', source);
-    
+
     map.addLayer({
         "id": "drone-glow-strong",
         "type": "circle",
@@ -64,7 +64,7 @@ map.on('style.load', function () {
             "circle-opacity": 0.1
         }
     });
-    
+
     map.addLayer({
         "id": "drone",
         "type": "symbol",
@@ -73,7 +73,7 @@ map.on('style.load', function () {
             "icon-image": "airport-24",
         }
     });
-    
+
     window.setInterval(setPosition, 10);
 });
 

--- a/docs/_posts/examples/3400-01-11-mapbox-gl-directions.html
+++ b/docs/_posts/examples/3400-01-11-mapbox-gl-directions.html
@@ -1,7 +1,7 @@
 ---
 layout: example
 category: example
-title: Driving directions
+title: Display driving directions
 description: Use the <a target='_blank' href='https://github.com/mapbox/mapbox-gl-directions'>mapbox-gl-directions</a> plugin to show results from the Mapbox Directions API.
 ---
 <script src='https://api.tiles.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v1.0.0/mapbox-gl-directions.js'></script>


### PR DESCRIPTION
There doesn't seem to be an convention around the naming of examples: some are named after the API used, some are named after functionality they add; some are noun phrases, some are verb phrases.

This PR standardizes all example names as verb phrases focused on the functionality they add. 

![screen shot 2015-12-14 at 12 55 39 pm](https://cloud.githubusercontent.com/assets/281306/11793941/681aa37e-a263-11e5-91e4-d29cb587c61e.png)

cc @jfirebaugh @lyzidiamond @danswick @mourner 