### PR TITLE
Make gl a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,8 @@
     "sinon": "^1.15.4",
     "st": "^1.0.0",
     "through": "^2.3.7",
+    "gl": "^2.1.5",
     "watchify": "^3.2.2"
-  },
-  "optionalDependencies": {
-    "gl": "^2.1.5"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Fixes #1845 by making the `gl` dependency a devDependency instead of an optionalDependency.