### PR TITLE
Fly across the antimeridan if shorter

### DIFF
--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -573,7 +573,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
 
         var scale = tr.zoomScale(zoom - startZoom),
             from = tr.point,
-            to = tr.project(center).sub(offset.div(scale));
+            to = 'center' in options ? tr.project(center).sub(offset.div(scale)) : from;
 
         var startWorldSize = tr.worldSize,
             rho = options.curve,
@@ -599,7 +599,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
             S = (r(1) - r0) / rho;
 
         if (Math.abs(u1) < 0.000001) {
-            if (Math.abs(w0 - w1) < 0.000001) return this;
+            if (Math.abs(w0 - w1) < 0.000001) return this.easeTo(options);
 
             var k = w1 < w0 ? -1 : 1;
             S = Math.abs(Math.log(w1 / w0)) / rho;

--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -560,6 +560,17 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
         var bearing = 'bearing' in options ? this._normalizeBearing(options.bearing, startBearing) : startBearing;
         var pitch = 'pitch' in options ? +options.pitch : startPitch;
 
+        // If a path crossing the antimeridian would be shorter, extend the
+        // final coordinate so that interpolating between the two endpoints will
+        // cross it.
+        if (Math.abs(tr.center.lng) + Math.abs(center.lng) > 180) {
+            if (tr.center.lng > 0 && center.lng < 0) {
+                center.lng += 360;
+            } else if (tr.center.lng < 0 && center.lng > 0) {
+                center.lng -= 360;
+            }
+        }
+
         var scale = tr.zoomScale(zoom - startZoom),
             from = tr.point,
             to = tr.project(center).sub(offset.div(scale));

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -708,7 +708,7 @@ test('camera', function(t) {
         t.test('pans with specified offset', function(t) {
             var camera = createCamera();
             camera.flyTo({ center: [100, 0], offset: [100, 0], animate: false });
-            t.deepEqual(camera.getCenter(), { lng: 29.6875, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 29.6875, lat: 0 });
             t.end();
         });
 

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -7,6 +7,7 @@ var Transform = require('../../../js/geo/transform');
 var util = require('../../../js/util/util');
 var fixed = require('../../testutil/fixed');
 var fixedLngLat = fixed.LngLat;
+var fixedNum = fixed.Num;
 
 test('camera', function(t) {
     function createCamera(options) {
@@ -553,7 +554,7 @@ test('camera', function(t) {
         });
 
         t.test('pans with specified offset relative to viewport on a rotated camera', function(t) {
-            var camera = createCamera({bearing: 180});
+            var camera = createCamera({ bearing: 180 });
             camera.easeTo({ center: [100, 0], offset: [100, 0], duration: 0 });
             t.deepEqual(camera.getCenter(), { lng: 170.3125, lat: 0 });
             t.end();
@@ -619,6 +620,260 @@ test('camera', function(t) {
                     });
                 });
             });
+        });
+
+        t.end();
+    });
+
+    t.test('#flyTo', function(t) {
+        t.test('pans to specified location', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ center: [100, 0], animate: false });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 100, lat: 0 });
+            t.end();
+        });
+
+        t.test('zooms to specified level', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ zoom: 3.2, animate: false });
+            t.equal(fixedNum(camera.getZoom()), 3.2);
+            t.end();
+        });
+
+        t.test('rotates to specified bearing', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ bearing: 90, animate: false });
+            t.equal(camera.getBearing(), 90);
+            t.end();
+        });
+
+        t.test('tilts to specified pitch', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ pitch: 45, animate: false });
+            t.equal(camera.getPitch(), 45);
+            t.end();
+        });
+
+        t.test('pans and zooms', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ center: [100, 0], zoom: 3.2, animate: false });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 100, lat: 0 });
+            t.equal(fixedNum(camera.getZoom()), 3.2);
+            t.end();
+        });
+
+        t.test('pans and rotates', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ center: [100, 0], bearing: 90, animate: false });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 100, lat: 0 });
+            t.equal(camera.getBearing(), 90);
+            t.end();
+        });
+
+        t.test('zooms and rotates', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ zoom: 3.2, bearing: 90, animate: false });
+            t.equal(fixedNum(camera.getZoom()), 3.2);
+            t.equal(camera.getBearing(), 90);
+            t.end();
+        });
+
+        t.test('pans, zooms, and rotates', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, animate: false });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 100, lat: 0 });
+            t.equal(fixedNum(camera.getZoom()), 3.2);
+            t.equal(camera.getBearing(), 90);
+            t.end();
+        });
+
+        t.test('noop', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ animate: false });
+            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.equal(camera.getZoom(), 0);
+            t.equal(camera.getBearing(), 0);
+            t.end();
+        });
+
+        t.test('noop with offset', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ offset: [100, 0], animate: false });
+            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.equal(camera.getZoom(), 0);
+            t.equal(camera.getBearing(), 0);
+            t.end();
+        });
+
+        t.test('pans with specified offset', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ center: [100, 0], offset: [100, 0], animate: false });
+            t.deepEqual(camera.getCenter(), { lng: 29.6875, lat: 0 });
+            t.end();
+        });
+
+        t.test('pans with specified offset relative to viewport on a rotated camera', function(t) {
+            var camera = createCamera({ bearing: 180 });
+            camera.easeTo({ center: [100, 0], offset: [100, 0], animate: false });
+            t.deepEqual(camera.getCenter(), { lng: 170.3125, lat: 0 });
+            t.end();
+        });
+
+        t.test('emits move, zoom, rotate, and pitch events', function(t) {
+            var camera = createCamera();
+            var started;
+            var moved;
+            var zoomed;
+            var rotated;
+            var pitched;
+
+            camera.on('movestart', function() {
+                started = true;
+            });
+
+            camera.on('move', function() {
+                moved = true;
+            });
+
+            camera.on('zoom', function() {
+                zoomed = true;
+            });
+
+            camera.on('rotate', function() {
+                rotated = true;
+            });
+
+            camera.on('pitch', function() {
+                pitched = true;
+            });
+
+            camera.on('moveend', function() {
+                t.ok(started);
+                t.ok(moved);
+                t.ok(zoomed);
+                t.ok(rotated);
+                t.ok(pitched);
+                t.end();
+            });
+
+            camera.flyTo({ center: [100, 0], zoom: 3.2, bearing: 90, pitch: 45, animate: false });
+        });
+
+        t.test('stops existing ease', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ center: [200, 0] });
+            camera.flyTo({ center: [100, 0], animate: false });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 100, lat: 0 });
+            t.end();
+        });
+
+        t.test('can be called from within a moveend event handler', function(t) {
+            var camera = createCamera();
+            camera.flyTo({ center: [100, 0] });
+            camera.once('moveend', function() {
+                camera.flyTo({ center: [200, 0] });
+                camera.once('moveend', function() {
+                    camera.flyTo({ center: [300, 0] });
+                    camera.once('moveend', function() {
+                        t.end();
+                    });
+                });
+            });
+        });
+
+        t.test('ascends', function(t) {
+            var camera = createCamera();
+            camera.setZoom(18);
+            var ascended;
+
+            camera.on('zoom', function() {
+                if (camera.getZoom() < 1.9) {
+                    ascended = true;
+                }
+            });
+
+            camera.on('moveend', function() {
+                t.ok(ascended);
+                t.end();
+            });
+
+            camera.flyTo({ center: [100, 0], zoom: 18 });
+        });
+
+        t.test('pans eastward across the prime meridian', function(t) {
+            var camera = createCamera();
+            camera.setCenter([-10, 0]);
+            var crossedPrimeMeridian;
+
+            camera.on('move', function() {
+                if (Math.abs(camera.getCenter().lng) < 10) {
+                    crossedPrimeMeridian = true;
+                }
+            });
+
+            camera.on('moveend', function() {
+                t.ok(crossedPrimeMeridian);
+                t.end();
+            });
+
+            camera.flyTo({ center: [10, 0] });
+        });
+
+        t.test('pans westward across the prime meridian', function(t) {
+            var camera = createCamera();
+            camera.setCenter([10, 0]);
+            var crossedPrimeMeridian;
+
+            camera.on('move', function() {
+                if (Math.abs(camera.getCenter().lng) < 10) {
+                    crossedPrimeMeridian = true;
+                }
+            });
+
+            camera.on('moveend', function() {
+                t.ok(crossedPrimeMeridian);
+                t.end();
+            });
+
+            camera.flyTo({ center: [-10, 0] });
+        });
+
+        t.test('pans eastward across the antimeridian', function(t) {
+            var camera = createCamera();
+            camera.setCenter([170, 0]);
+            var crossedAntimeridian;
+
+            camera.on('move', function() {
+                if (camera.getCenter().lng > 170) {
+                    crossedAntimeridian = true;
+                }
+            });
+
+            camera.on('moveend', function() {
+                t.ok(crossedAntimeridian);
+                t.end();
+            });
+
+            camera.flyTo({ center: [-170, 0] });
+        });
+
+        t.test('pans westward across the antimeridian', function(t) {
+            var camera = createCamera();
+            camera.setCenter([-170, 0]);
+            var crossedAntimeridian;
+
+            camera.on('move', function() {
+                if (camera.getCenter().lng < -170) {
+                    crossedAntimeridian = true;
+                }
+            });
+
+            camera.on('moveend', function() {
+                t.ok(crossedAntimeridian);
+                t.end();
+            });
+
+            camera.flyTo({ center: [170, 0] });
         });
 
         t.end();


### PR DESCRIPTION
If flying across the antimeridian yields a shorter flight path than flying across the Prime Meridian, cross the antimeridian. This PR also adds a full complement of unit tests based on the `easeTo()` unit tests and fixes a couple corner cases that differ between `easeTo()` and `flyTo()`: now, if you fly to the current location but with a different zoom level, bearing, or pitch, we ease to the new camera instead of bailing. We also avoid offsetting if the `options` don’t call for a new center point.

Fixes #1853. Ported from mapbox/mapbox-gl-native@97c143a3388647e74a9f74a4994ab9d6aafe26a9 for mapbox/mapbox-gl-native#3355.

/cc @mourner @lucaswoj