### PR TITLE
add icon image setLayoutProperty example

### DIFF
--- a/docs/_posts/examples/3400-01-01-set-icon-image.html
+++ b/docs/_posts/examples/3400-01-01-set-icon-image.html
@@ -14,7 +14,7 @@ var map = new mapboxgl.Map({
 });
 
 map.on('style.load', function () {
-    // Specify in icon image from your style's sprite using 
+    // Specify an icon image from your style's sprite using 
     // setLayoutProperty (layer, name, value)
     map.setLayoutProperty('place-city-sm', 'icon-image', 'rocket-11');
 });

--- a/docs/_posts/examples/3400-01-01-set-icon-image.html
+++ b/docs/_posts/examples/3400-01-01-set-icon-image.html
@@ -1,0 +1,22 @@
+---
+layout: example
+category: example
+title: Change a layer's icon image
+description: Use setLayoutProperty to change a layer's icon. 
+---
+<div id='map'></div>
+<script>
+var map = new mapboxgl.Map({
+    container: 'map', 
+    style: 'mapbox://styles/mapbox/streets-v8', 
+    center: [-91.93, 43.9], 
+    zoom: 7.9 
+});
+
+map.on('style.load', function () {
+    // Specify in icon image from your style's sprite using 
+    // setLayoutProperty (layer, name, value)
+    map.setLayoutProperty('place-city-sm', 'icon-image', 'rocket-11');
+});
+
+</script>

--- a/docs/_posts/examples/3400-01-01-set-icon-image.html
+++ b/docs/_posts/examples/3400-01-01-set-icon-image.html
@@ -9,14 +9,14 @@ description: Use setLayoutProperty to change a layer's icon.
 var map = new mapboxgl.Map({
     container: 'map', 
     style: 'mapbox://styles/mapbox/streets-v8', 
-    center: [-91.93, 43.9], 
-    zoom: 7.9 
+    center: [2.34, 48.875], 
+    zoom: 14
 });
 
 map.on('style.load', function () {
     // Specify an icon image from your style's sprite using 
     // setLayoutProperty (layer, name, value)
-    map.setLayoutProperty('place-city-sm', 'icon-image', 'rocket-11');
+    map.setLayoutProperty('rail-label', 'icon-image', 'rail-11');
 });
 
 </script>


### PR DESCRIPTION
We get a lot of questions about markers/icons. This basic example uses `setLayoutProperty` to change a layer's `icon-image` property. 

![image](https://cloud.githubusercontent.com/assets/2365503/11966658/b94698ce-a8c2-11e5-9c34-b6f974e355e0.png)

cc: @lyzidiamond 