### PR TITLE
fix overscaled line patterns

### DIFF
--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -141,10 +141,11 @@ module.exports = function drawLine(painter, source, layer, coords) {
         gl.setExMatrix(painter.transform.exMatrix);
         var ratio = painter.transform.scale / (1 << coord.z) / (4096 / tile.tileSize);
 
-        // how much the tile is overscaled by
-        var overscaling = tile.tileSize / painter.transform.tileSize;
 
         if (dasharray) {
+            // how much the tile is overscaled by
+            var overscaling = tile.tileSize / painter.transform.tileSize;
+
             var patternratio = Math.pow(2, Math.floor(Math.log(painter.transform.scale) / Math.LN2) - coord.z) / 8 * overscaling;
             var scaleA = [patternratio / posA.width / dasharray.fromScale, -posA.height / 2];
             var gammaA = painter.lineAtlas.width / (dasharray.fromScale * posA.width * 256 * browser.devicePixelRatio) / 2;
@@ -156,7 +157,7 @@ module.exports = function drawLine(painter, source, layer, coords) {
             gl.uniform1f(shader.u_sdfgamma, Math.max(gammaA, gammaB));
 
         } else if (image) {
-            var factor = 4096 / tile.tileSize / Math.pow(2, painter.transform.tileZoom - coord.z) * overscaling;
+            var factor = 4096 / tile.tileSize / Math.pow(2, painter.transform.tileZoom - coord.z);
             gl.uniform1f(shader.u_ratio, ratio);
             gl.uniform2fv(shader.u_pattern_size_a, [imagePosA.size[0] * factor * image.fromScale, imagePosB.size[1] ]);
             gl.uniform2fv(shader.u_pattern_size_b, [imagePosB.size[0] * factor * image.toScale, imagePosB.size[1] ]);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#35a6fc56d7eb023b123a432d51ff8a9dbfeaa002",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#46c907f48d2b3b8ae6531963cdc40cb07958fd01",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
fix #1856

render test in https://github.com/mapbox/mapbox-gl-test-suite/tree/line-pattern-overscaled

before:
![expected](https://cloud.githubusercontent.com/assets/1421652/12210207/2adac9c2-b60d-11e5-8554-23552b8b34ed.png)
after:
![actual](https://cloud.githubusercontent.com/assets/1421652/12210206/2ada4290-b60d-11e5-9653-5359b0bf0679.png)