### PR TITLE
#1844 Improve touch handler perceived performance

### DIFF
--- a/js/ui/handler/drag_pan.js
+++ b/js/ui/handler/drag_pan.js
@@ -5,10 +5,10 @@ var DOM = require('../../util/dom'),
 
 module.exports = DragPan;
 
-var inertiaLinearity = 0.25,
+var inertiaLinearity = 0.3,
     inertiaEasing = util.bezier(0, 0, inertiaLinearity, 1),
-    inertiaMaxSpeed = 3000, // px/s
-    inertiaDeceleration = 4000; // px/s^2
+    inertiaMaxSpeed = 1400, // px/s
+    inertiaDeceleration = 2500; // px/s^2
 
 
 function DragPan(map) {
@@ -154,10 +154,9 @@ DragPan.prototype = {
     _drainInertiaBuffer: function () {
         var inertia = this._inertia,
             now = Date.now(),
-            cutoff = 50;   // msec
+            cutoff = 160;   // msec
 
-        while (inertia.length > 0 && now - inertia[0][0] > cutoff)
-            inertia.shift();
+        while (inertia.length > 0 && now - inertia[0][0] > cutoff) inertia.shift();
     }
 };
 

--- a/js/ui/handler/touch_zoom_rotate.js
+++ b/js/ui/handler/touch_zoom_rotate.js
@@ -163,7 +163,7 @@ TouchZoomRotate.prototype = {
             now = Date.now(),
             cutoff = 160; // msec
 
-        while (inertia.length > 2 && now - inertia[0][0] > cutoff) 
+        while (inertia.length > 2 && now - inertia[0][0] > cutoff)
             inertia.shift();
     }
 };

--- a/js/ui/handler/touch_zoom_rotate.js
+++ b/js/ui/handler/touch_zoom_rotate.js
@@ -5,6 +5,12 @@ var DOM = require('../../util/dom'),
 
 module.exports = TouchZoomRotate;
 
+var inertiaLinearity = 0.15,
+    inertiaEasing = util.bezier(0, 0, inertiaLinearity, 1),
+    inertiaDeceleration = 12, // scale / s^2
+    inertiaMaxSpeed = 2.5, // scale / s
+    significantScaleThreshold = 0.1, // scale
+    significantRotateThreshold = 5; // bearing
 
 function TouchZoomRotate(map) {
     this._map = map;
@@ -39,6 +45,10 @@ TouchZoomRotate.prototype = {
         this._startVec = p0.sub(p1);
         this._startScale = this._map.transform.scale;
         this._startBearing = this._map.transform.bearing;
+        this._scalingSignificantly = false;
+        this._rotatingSignificantly = false;
+        this._blockRotation = undefined,
+        this._inertia = [];
 
         document.addEventListener('touchmove', this._onMove, false);
         document.addEventListener('touchend', this._onEnd, false);
@@ -53,11 +63,40 @@ TouchZoomRotate.prototype = {
             vec = p0.sub(p1),
             scale = vec.mag() / this._startVec.mag(),
             bearing = this._rotationDisabled ? 0 : vec.angleWith(this._startVec) * 180 / Math.PI,
-            map = this._map;
+            map = this._map,
+            now = Date.now(),
+            inertia = this._inertia;
+
+        this._scalingSignificantly =
+            this._scalingSignificantly || (Math.abs(1 - scale) > significantScaleThreshold);
+
+        this._rotatingSignificantly =
+            this._rotatingSignificantly || (Math.abs(bearing) > significantRotateThreshold);
+
+        // Similar to google maps: if the user's intent is pinch zooming, rotate
+        // will be disabled. If their intent is rotating, then both rotate and
+        // zoom will be supported. We determine 'intent' by whichever threshold is
+        // surpassed first. Once determined, we keep that state for the duration
+        // of this gesture.
+        if (this._blockRotation === undefined) {
+            if (this._scalingSignificantly) {
+                this._blockRotation = true;
+            } else if (this._rotatingSignificantly) {
+                this._blockRotation = false;
+            }
+        }
+
+        map.stop();
+        this._drainInertiaBuffer();
+        inertia.push([now, scale, bearing, p, this._blockRotation]);
+        
+        // Only set the bearing if rotation is allowed AND we are rotating more than our threshold
+        var updateBearing = ((this._blockRotation === false) && this._rotatingSignificantly);
+        
 
         map.easeTo({
             zoom: map.transform.scaleZoom(this._startScale * scale),
-            bearing: this._startBearing + bearing,
+            bearing: updateBearing ? (this._startBearing + bearing) : this._startBearing,
             duration: 0,
             around: map.unproject(p)
         });
@@ -66,9 +105,65 @@ TouchZoomRotate.prototype = {
     },
 
     _onEnd: function () {
-        this._map.snapToNorth();
+        var inertia = this._inertia,
+            map = this._map;
+
+        if (inertia.length < 2) {
+            map.snapToNorth();
+            return;
+        }
+
+        var last = inertia[inertia.length - 1],
+            first = inertia[0],
+            bearing = last[2],
+            p = last[3],
+            blockRotation = last[4],
+            lastScale = map.transform.scaleZoom(this._startScale * last[1]),
+            firstScale = map.transform.scaleZoom(this._startScale * first[1]),
+            scaleOffset = lastScale - firstScale,
+            scaleDuration = (last[0] - first[0]) / 1000;
+
+        if (scaleDuration === 0 || lastScale === firstScale) {
+            map.snapToNorth();
+            return;
+        }
+
+        // calculate scale/s speed and ajust for increased initial animation speed when easing
+        var speed = scaleOffset * inertiaLinearity / scaleDuration; // scale/s
+        
+        if (Math.abs(speed) > inertiaMaxSpeed) {
+            if (speed > 0) {
+                speed = inertiaMaxSpeed;
+            } else {
+                speed = -inertiaMaxSpeed;
+            }
+        }
+
+        var duration = Math.abs(speed / (inertiaDeceleration * inertiaLinearity)) * 1000,
+            targetScale = lastScale + speed * duration / 2000;
+
+        if (targetScale < 0) {
+            targetScale = 0;
+        }
+      
+        var updateBearing = ((blockRotation === false) && this._rotatingSignificantly);
+
+        map.easeTo({
+            zoom: targetScale,
+            bearing: updateBearing ? (this._startBearing + bearing) : this._startBearing,
+            duration: duration,
+            around: map.unproject(p)
+        });
 
         document.removeEventListener('touchmove', this._onMove);
         document.removeEventListener('touchend', this._onEnd);
+    },
+
+    _drainInertiaBuffer: function() {
+        var inertia = this._inertia,
+            now = Date.now(),
+            cutoff = 160; // msec
+
+            while (inertia.length > 2 && now - inertia[0][0] > cutoff) inertia.shift();
     }
 };

--- a/js/ui/handler/touch_zoom_rotate.js
+++ b/js/ui/handler/touch_zoom_rotate.js
@@ -91,7 +91,7 @@ TouchZoomRotate.prototype = {
         inertia.push([now, scale, bearing, p, this._blockRotation]);
         // Only set the bearing if rotation is allowed AND we are rotating more than our threshold
         var updateBearing = ((this._blockRotation === false) && this._rotatingSignificantly);
-        
+
         map.easeTo({
             zoom: map.transform.scaleZoom(this._startScale * scale),
             bearing: updateBearing ? (this._startBearing + bearing) : this._startBearing,
@@ -128,7 +128,7 @@ TouchZoomRotate.prototype = {
 
         // calculate scale/s speed and ajust for increased initial animation speed when easing
         var speed = scaleOffset * inertiaLinearity / scaleDuration; // scale/s
-        
+
         if (Math.abs(speed) > inertiaMaxSpeed) {
             if (speed > 0) {
                 speed = inertiaMaxSpeed;
@@ -143,7 +143,7 @@ TouchZoomRotate.prototype = {
         if (targetScale < 0) {
             targetScale = 0;
         }
-      
+
         var updateBearing = ((blockRotation === false) && this._rotatingSignificantly);
 
         map.easeTo({

--- a/js/ui/handler/touch_zoom_rotate.js
+++ b/js/ui/handler/touch_zoom_rotate.js
@@ -47,7 +47,7 @@ TouchZoomRotate.prototype = {
         this._startBearing = this._map.transform.bearing;
         this._scalingSignificantly = false;
         this._rotatingSignificantly = false;
-        this._blockRotation = undefined,
+        this._blockRotation = undefined;
         this._inertia = [];
 
         document.addEventListener('touchmove', this._onMove, false);
@@ -89,11 +89,9 @@ TouchZoomRotate.prototype = {
         map.stop();
         this._drainInertiaBuffer();
         inertia.push([now, scale, bearing, p, this._blockRotation]);
-        
         // Only set the bearing if rotation is allowed AND we are rotating more than our threshold
         var updateBearing = ((this._blockRotation === false) && this._rotatingSignificantly);
         
-
         map.easeTo({
             zoom: map.transform.scaleZoom(this._startScale * scale),
             bearing: updateBearing ? (this._startBearing + bearing) : this._startBearing,
@@ -152,6 +150,7 @@ TouchZoomRotate.prototype = {
             zoom: targetScale,
             bearing: updateBearing ? (this._startBearing + bearing) : this._startBearing,
             duration: duration,
+            easing: inertiaEasing,
             around: map.unproject(p)
         });
 
@@ -164,6 +163,7 @@ TouchZoomRotate.prototype = {
             now = Date.now(),
             cutoff = 160; // msec
 
-            while (inertia.length > 2 && now - inertia[0][0] > cutoff) inertia.shift();
+        while (inertia.length > 2 && now - inertia[0][0] > cutoff) 
+            inertia.shift();
     }
 };


### PR DESCRIPTION
FYI: Included PR #1917. That code should probably be discussed separately and then merged.

Changes:
– Reduced dragPan inertia max speed and increased inertiaArray length to reduce unintended map flings due to JS garbage collection ticks / general slowness.
– Included @liebrand touchZoomRotate rotation lock.
– Mirrored dragPan easing to touchZoomRotate.
– General tweaks to inertiaLinearity and inertiaDeceleration to be comparable to mapbox-gl-native