### PR TITLE
Glyph Atlas improvements

### DIFF
--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -302,7 +302,6 @@ SymbolBucket.prototype.anchorIsTooClose = function(text, repeatDistance, anchor)
 };
 
 SymbolBucket.prototype.placeFeatures = function(collisionTile, buffers, collisionDebug) {
-
     // Calculate which labels can be shown and when they can be shown and
     // create the bufers used for rendering.
 
@@ -319,6 +318,7 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, buffers, collisio
     var maxScale = collisionTile.maxScale;
 
     elementGroups.glyph['text-size'] = layout['text-size'];
+    elementGroups.glyph['text-font'] = layout['text-font'];
     elementGroups.icon['icon-size'] = layout['icon-size'];
 
     var textAlongLine = layout['text-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -119,10 +119,15 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf,
     }
 
     if (text) {
-        painter.glyphAtlas.updateTexture(gl);
+        var textfont = elementGroups['text-font'];
+        var fontstack = textfont && textfont.join(',');
+        var glyphAtlas = fontstack && painter.glyphSource.getGlyphAtlas(fontstack);
+        if (!glyphAtlas) return;
+
+        glyphAtlas.updateTexture(gl);
         vertex = tile.buffers.glyphVertex;
         elements = tile.buffers.glyphElement;
-        texsize = [painter.glyphAtlas.width / 4, painter.glyphAtlas.height / 4];
+        texsize = [glyphAtlas.width / 4, glyphAtlas.height / 4];
     } else {
         var mapMoving = painter.options.rotating || painter.options.zooming;
         var iconScaled = fontScale !== 1 || browser.devicePixelRatio !== painter.spriteAtlas.pixelRatio || iconsNeedLinear;

--- a/js/render/line_atlas.js
+++ b/js/render/line_atlas.js
@@ -3,7 +3,7 @@
 module.exports = LineAtlas;
 
 /**
- * Much like a GlyphAtlas, a LineAtlas lets us reuse rendered dashed lines
+ * A LineAtlas lets us reuse rendered dashed lines
  * by writing many of them to a texture and then fetching their positions
  * using .getDash.
  *

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -269,8 +269,7 @@ Painter.prototype.render = function(style, options) {
     this.spriteAtlas = style.spriteAtlas;
     this.spriteAtlas.setSprite(style.sprite);
 
-    this.glyphAtlas = style.glyphAtlas;
-    this.glyphAtlas.bind(this.gl);
+    this.glyphSource = style.glyphSource;
 
     this.frameHistory.record(this.transform.zoom);
 

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -190,7 +190,6 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
 
     _unloadTile: function(tile) {
         tile.unloadVectorData(this.map.painter);
-        // this.glyphAtlas.removeGlyphs(tile.uid);
         this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, null, tile.workerID);
     },
 

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -190,7 +190,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
 
     _unloadTile: function(tile) {
         tile.unloadVectorData(this.map.painter);
-        this.glyphAtlas.removeGlyphs(tile.uid);
+        // this.glyphAtlas.removeGlyphs(tile.uid);
         this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, null, tile.workerID);
     },
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -108,7 +108,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
 
     _unloadTile: function(tile) {
         tile.unloadVectorData(this.map.painter);
-        this.glyphAtlas.removeGlyphs(tile.uid);
+        // this.glyphAtlas.removeGlyphs(tile.uid);
         this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, null, tile.workerID);
     },
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -108,7 +108,6 @@ VectorTileSource.prototype = util.inherit(Evented, {
 
     _unloadTile: function(tile) {
         tile.unloadVectorData(this.map.painter);
-        // this.glyphAtlas.removeGlyphs(tile.uid);
         this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, null, tile.workerID);
     },
 

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -5,7 +5,6 @@ var styleBatch = require('./style_batch');
 var StyleLayer = require('./style_layer');
 var ImageSprite = require('./image_sprite');
 var GlyphSource = require('../symbol/glyph_source');
-var GlyphAtlas = require('../symbol/glyph_atlas');
 var SpriteAtlas = require('../symbol/sprite_atlas');
 var LineAtlas = require('../render/line_atlas');
 var util = require('../util/util');
@@ -21,7 +20,6 @@ module.exports = Style;
 function Style(stylesheet, animationLoop) {
     this.animationLoop = animationLoop || new AnimationLoop();
     this.dispatcher = new Dispatcher(Math.max(browser.hardwareConcurrency - 1, 1), this);
-    this.glyphAtlas = new GlyphAtlas(1024, 1024);
     this.spriteAtlas = new SpriteAtlas(512, 512);
     this.lineAtlas = new LineAtlas(256, 512);
 
@@ -65,7 +63,7 @@ function Style(stylesheet, animationLoop) {
             this.sprite.on('load', this.fire.bind(this, 'change'));
         }
 
-        this.glyphSource = new GlyphSource(stylesheet.glyphs, this.glyphAtlas);
+        this.glyphSource = new GlyphSource(stylesheet.glyphs);
         this._resolve();
         this.fire('load');
     }.bind(this);

--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -151,7 +151,6 @@ styleBatch.prototype = {
         source.id = id;
         source.style = this._style;
         source.dispatcher = this._style.dispatcher;
-        // source.glyphAtlas = this._style.glyphAtlas;
         source
             .on('load', this._style._forwardSourceEvent)
             .on('error', this._style._forwardSourceEvent)

--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -151,7 +151,7 @@ styleBatch.prototype = {
         source.id = id;
         source.style = this._style;
         source.dispatcher = this._style.dispatcher;
-        source.glyphAtlas = this._style.glyphAtlas;
+        // source.glyphAtlas = this._style.glyphAtlas;
         source
             .on('load', this._style._forwardSourceEvent)
             .on('error', this._style._forwardSourceEvent)

--- a/js/symbol/bin_pack.js
+++ b/js/symbol/bin_pack.js
@@ -1,84 +1,105 @@
 'use strict';
 
 module.exports = BinPack;
+
+/**
+ * Simple Bin Packing
+ * Uses the Shelf Best Height Fit algorithm from
+ * http://clb.demon.fi/files/RectangleBinPack.pdf
+ * @private
+ */
 function BinPack(width, height) {
     this.width = width;
     this.height = height;
-    this.free = [{ x: 0, y: 0, w: width, h: height }];
+    this.shelves = [];
+    this.stats = {};
+    this.count = function(h) {
+        this.stats[h] = (this.stats[h] | 0) + 1;
+    };
 }
 
-/**
- * Simple algorithm to recursively merge the newly released cell with its
- * neighbor. This doesn't merge more than two cells at a time, and fails
- * for complicated merges.
- * @private
- */
-BinPack.prototype.release = function(rect) {
-    for (var i = 0; i < this.free.length; i++) {
-        var free = this.free[i];
+BinPack.prototype.allocate = function(reqWidth, reqHeight) {
+    var y = 0,
+        best = { shelf: -1, waste: Infinity },
+        shelf, waste;
 
-        if (free.y === rect.y && free.h === rect.h && free.x + free.w === rect.x) {
-            free.w += rect.w;
+    // find shelf
+    for (var i = 0; i < this.shelves.length; i++) {
+        shelf = this.shelves[i];
+        y += shelf.height;
 
-        } else if (free.x === rect.x && free.w === rect.w && free.y + free.h === rect.y) {
-            free.h += rect.h;
-
-        } else if (rect.y === free.y && rect.h === free.h && rect.x + rect.w === free.x) {
-            free.x = rect.x;
-            free.w += rect.w;
-
-        } else if (rect.x === free.x && rect.w === free.w && rect.y + rect.h === free.y) {
-            free.y = rect.y;
-            free.h += rect.h;
-
-        } else continue;
-
-        this.free.splice(i, 1);
-        this.release(free);
-        return;
-
-    }
-    this.free.push(rect);
-};
-
-BinPack.prototype.allocate = function(width, height) {
-    // Find the smallest free rect angle
-    var rect = { x: Infinity, y: Infinity, w: Infinity, h: Infinity };
-    var smallest = -1;
-    for (var i = 0; i < this.free.length; i++) {
-        var ref = this.free[i];
-        if (width <= ref.w && height <= ref.h && ref.y <= rect.y && ref.x <= rect.x) {
-            rect = ref;
-            smallest = i;
+        // exactly the right height with width to spare, pack it..
+        if (reqHeight === shelf.height && reqWidth <= shelf.free) {
+            this.count(reqHeight);
+            return shelf.alloc(reqWidth, reqHeight);
+        }
+        // not enough height or width, skip it..
+        if (reqHeight > shelf.height || reqWidth > shelf.free) {
+            continue;
+        }
+        // maybe enough height or width, minimize waste..
+        if (reqHeight < shelf.height && reqWidth <= shelf.free) {
+            waste = shelf.height - reqHeight;
+            if (waste < best.waste) {
+                best.waste = waste;
+                best.shelf = i;
+            }
         }
     }
 
-    if (smallest < 0) {
-        // There's no space left for this char.
-        return { x: -1, y: -1 };
+    if (best.shelf !== -1) {
+        shelf = this.shelves[best.shelf];
+        this.count(reqHeight);
+        return shelf.alloc(reqWidth, reqHeight);
     }
 
-    this.free.splice(smallest, 1);
-
-    // Shorter/Longer Axis Split Rule (SAS)
-    // http://clb.demon.fi/files/RectangleBinPack.pdf p. 15
-    // Ignore the dimension of R and just split long the shorter dimension
-    // See Also: http://www.cs.princeton.edu/~chazelle/pubs/blbinpacking.pdf
-    if (rect.w < rect.h) {
-        // split horizontally
-        // +--+---+
-        // |__|___|  <-- b1
-        // +------+  <-- b2
-        if (rect.w > width) this.free.push({ x: rect.x + width, y: rect.y, w: rect.w - width, h: height });
-        if (rect.h > height) this.free.push({ x: rect.x, y: rect.y + height, w: rect.w, h: rect.h - height });
-    } else {
-        // split vertically
-        // +--+---+
-        // |__|   | <-- b1
-        // +--|---+ <-- b2
-        if (rect.w > width) this.free.push({ x: rect.x + width, y: rect.y, w: rect.w - width, h: rect.h });
-        if (rect.h > height) this.free.push({ x: rect.x, y: rect.y + height, w: width, h: rect.h - height });
+    // add shelf
+    if (reqHeight <= (this.height - y) && reqWidth <= this.width) {
+        shelf = new Shelf(y, this.width, reqHeight);
+        this.shelves.push(shelf);
+        this.count(reqHeight);
+        return shelf.alloc(reqWidth, reqHeight);
     }
 
-    return { x: rect.x, y: rect.y, w: width, h: height };
+    // no more space
+    return {x: -1, y: -1};
 };
+
+
+BinPack.prototype.resize = function(reqWidth, reqHeight) {
+    if (reqWidth < this.width || reqHeight < this.height) { return false; }
+    this.height = reqHeight;
+    this.width = reqWidth;
+    for (var i = 0; i < this.shelves.length; i++) {
+        this.shelves[i].resize(reqWidth);
+    }
+    return true;
+};
+
+
+function Shelf(y, width, height) {
+    this.y = y;
+    this.x = 0;
+    this.width = this.free = width;
+    this.height = height;
+}
+
+Shelf.prototype = {
+    alloc: function(reqWidth, reqHeight) {
+        if (reqWidth > this.free || reqHeight > this.height) {
+            return {x: -1, y: -1};
+        }
+        var x = this.x;
+        this.x += reqWidth;
+        this.free -= reqWidth;
+        return {x: x, y: this.y, w: reqWidth, h: reqHeight};
+    },
+
+    resize: function(reqWidth) {
+        if (reqWidth < this.width) { return false; }
+        this.free += (reqWidth - this.width);
+        this.width = reqWidth;
+        return true;
+    }
+};
+

--- a/js/symbol/glyph_atlas.js
+++ b/js/symbol/glyph_atlas.js
@@ -68,38 +68,6 @@ GlyphAtlas.prototype.getRects = function() {
     return rects;
 };
 
-GlyphAtlas.prototype.removeGlyphs = function(id) {
-    for (var key in this.ids) {
-
-        var ids = this.ids[key];
-
-        var pos = ids.indexOf(id);
-        if (pos >= 0) ids.splice(pos, 1);
-        this.ids[key] = ids;
-
-        if (!ids.length) {
-            var rect = this.index[key];
-
-            var target = this.data;
-            for (var y = 0; y < rect.h; y++) {
-                var y1 = this.width * (rect.y + y) + rect.x;
-                for (var x = 0; x < rect.w; x++) {
-                    target[y1 + x] = 0;
-                }
-            }
-
-            this.dirty = true;
-
-            this.bin.release(rect);
-
-            delete this.index[key];
-            delete this.ids[key];
-        }
-    }
-
-
-    this.updateTexture(this.gl);
-};
 
 GlyphAtlas.prototype.addGlyph = function(id, name, glyph, buffer) {
     if (!glyph) {
@@ -137,6 +105,10 @@ GlyphAtlas.prototype.addGlyph = function(id, name, glyph, buffer) {
 
     var rect = this.bin.allocate(packWidth, packHeight);
     if (rect.x < 0) {
+        this.resize();
+        rect = this.bin.allocate(packWidth, packHeight);
+    }
+    if (rect.x < 0) {
         console.warn('glyph bitmap overflow');
         return { glyph: glyph, rect: null };
     }
@@ -157,6 +129,31 @@ GlyphAtlas.prototype.addGlyph = function(id, name, glyph, buffer) {
     this.dirty = true;
 
     return rect;
+};
+
+GlyphAtlas.prototype.resize = function() {
+    var origw = this.width,
+        origh = this.height;
+
+    if (this.texture) {
+        if (this.gl) {
+            this.gl.deleteTexture(this.texture);
+        }
+        this.texture = null;
+    }
+
+    this.width *= 2;
+    this.height *= 2;
+    this.bin.resize(this.width, this.height);
+
+    var buf = new ArrayBuffer(this.width * this.height),
+        src, dst;
+    for (var i = 0; i < origh; i++) {
+        src = new Uint8Array(this.data.buffer, origh * i, origw);
+        dst = new Uint8Array(buf, origh * i * 2, origw);
+        dst.set(src);
+    }
+    this.data = new Uint8Array(buf);
 };
 
 GlyphAtlas.prototype.bind = function(gl) {

--- a/js/symbol/glyph_atlas.js
+++ b/js/symbol/glyph_atlas.js
@@ -135,6 +135,10 @@ GlyphAtlas.prototype.resize = function() {
     var origw = this.width,
         origh = this.height;
 
+    // For now, don't grow the atlas beyond 1024x1024 because of how
+    // texture coords pack into unsigned byte in symbol bucket.
+    if (origw > 512 || origh > 512) return;
+
     if (this.texture) {
         if (this.gl) {
             this.gl.deleteTexture(this.texture);

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -28,7 +28,7 @@ GlyphSource.prototype.getSimpleGlyphs = function(fontstack, glyphIDs, uid, callb
         this.stacks[fontstack] = {};
     }
     if (this.atlases[fontstack] === undefined) {
-        this.atlases[fontstack] = new GlyphAtlas(2048, 2048);
+        this.atlases[fontstack] = new GlyphAtlas(128, 128);
     }
 
     var glyphs = {};

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -3,33 +3,37 @@
 var normalizeURL = require('../util/mapbox').normalizeGlyphsURL;
 var getArrayBuffer = require('../util/ajax').getArrayBuffer;
 var Glyphs = require('../util/glyphs');
+var GlyphAtlas = require('../symbol/glyph_atlas');
 var Protobuf = require('pbf');
 
 module.exports = GlyphSource;
 
 /**
- * A glyph source has a URL from which to load new glyphs and owns a GlyphAtlas
- * that stores currently-loaded glyphs.
+ * A glyph source has a URL from which to load new glyphs and manages
+ * GlyphAtlases in which to store glyphs used by the requested fontstacks
+ * and ranges.
  *
  * @param {string} url glyph template url
- * @param {Object} glyphAtlas glyph atlas object
  * @private
  */
-function GlyphSource(url, glyphAtlas) {
+function GlyphSource(url) {
     this.url = url && normalizeURL(url);
-    this.glyphAtlas = glyphAtlas;
-    this.stacks = [];
+    this.atlases = {};
+    this.stacks = {};
     this.loading = {};
 }
 
 GlyphSource.prototype.getSimpleGlyphs = function(fontstack, glyphIDs, uid, callback) {
-
-    if (this.stacks[fontstack] === undefined) this.stacks[fontstack] = {};
+    if (this.stacks[fontstack] === undefined) {
+        this.stacks[fontstack] = {};
+    }
+    if (this.atlases[fontstack] === undefined) {
+        this.atlases[fontstack] = new GlyphAtlas(2048, 2048);
+    }
 
     var glyphs = {};
-
     var stack = this.stacks[fontstack];
-    var glyphAtlas = this.glyphAtlas;
+    var atlas = this.atlases[fontstack];
 
     // the number of pixels the sdf bitmaps are padded by
     var buffer = 3;
@@ -44,7 +48,7 @@ GlyphSource.prototype.getSimpleGlyphs = function(fontstack, glyphIDs, uid, callb
 
         if (stack[range]) {
             var glyph = stack[range].glyphs[glyphID];
-            var rect  = glyphAtlas.addGlyph(uid, fontstack, glyph, buffer);
+            var rect  = atlas.addGlyph(uid, fontstack, glyph, buffer);
             if (glyph) glyphs[glyphID] = new SimpleGlyph(glyph, rect, buffer);
         } else {
             if (missing[range] === undefined) {
@@ -64,7 +68,7 @@ GlyphSource.prototype.getSimpleGlyphs = function(fontstack, glyphIDs, uid, callb
             for (var i = 0; i < missing[range].length; i++) {
                 var glyphID = missing[range][i];
                 var glyph = stack.glyphs[glyphID];
-                var rect  = glyphAtlas.addGlyph(uid, fontstack, glyph, buffer);
+                var rect  = atlas.addGlyph(uid, fontstack, glyph, buffer);
                 if (glyph) glyphs[glyphID] = new SimpleGlyph(glyph, rect, buffer);
             }
         }
@@ -87,10 +91,11 @@ function SimpleGlyph(glyph, rect, buffer) {
 }
 
 GlyphSource.prototype.loadRange = function(fontstack, range, callback) {
-
     if (range * 256 > 65535) return callback('glyphs > 65535 not supported');
 
-    if (this.loading[fontstack] === undefined) this.loading[fontstack] = {};
+    if (this.loading[fontstack] === undefined) {
+        this.loading[fontstack] = {};
+    }
     var loading = this.loading[fontstack];
 
     if (loading[range]) {
@@ -109,6 +114,10 @@ GlyphSource.prototype.loadRange = function(fontstack, range, callback) {
             delete loading[range];
         });
     }
+};
+
+GlyphSource.prototype.getGlyphAtlas = function(fontstack) {
+    return this.atlases[fontstack];
 };
 
 /**

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -163,9 +163,6 @@ test('GeoJSONSource#update', function(t) {
         source.map.transform.resize(512, 512);
 
         source.style = {};
-        // source.glyphAtlas = {
-        //     removeGlyphs: function() {}
-        // };
 
         source.update(transform);
 

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -163,9 +163,9 @@ test('GeoJSONSource#update', function(t) {
         source.map.transform.resize(512, 512);
 
         source.style = {};
-        source.glyphAtlas = {
-            removeGlyphs: function() {}
-        };
+        // source.glyphAtlas = {
+        //     removeGlyphs: function() {}
+        // };
 
         source.update(transform);
 

--- a/test/js/symbol/binpack.test.js
+++ b/test/js/symbol/binpack.test.js
@@ -4,97 +4,51 @@ var test = require('prova');
 var BinPack = require('../../../js/symbol/bin_pack');
 
 test('binpack', function(t) {
-    t.test('large square', function(t) {
-        var bp = new BinPack(800, 800);
-        t.deepEqual(bp.allocate(10, 10), {
-            x: 0,
-            y: 0,
-            w: 10,
-            h: 10
-        }, 'packs a 10x10 square');
-        t.deepEqual(bp.allocate(10, 10), {
-            x: 10,
-            y: 0,
-            w: 10,
-            h: 10
-        }, 'packs a 10x10 square');
-        t.deepEqual(bp.allocate(10, 10), {
-            x: 0,
-            y: 10,
-            w: 10,
-            h: 10
-        }, 'packs a 10x10 square');
+    t.test('packs same height bins on existing shelf', function(t) {
+        var bp = new BinPack(64, 64);
+        t.deepEqual(bp.allocate(10, 10), {x: 0, y: 0, w: 10, h: 10 }, 'first 10x10 bin');
+        t.deepEqual(bp.allocate(10, 10), {x: 10, y: 0, w: 10, h: 10 }, 'second 10x10 bin');
+        t.deepEqual(bp.allocate(10, 10), {x: 20, y: 0, w: 10, h: 10 }, 'third 10x10 bin');
         t.end();
     });
-    t.test('release single', function(t) {
-        var bp = new BinPack(10, 10);
-        var allocated = bp.allocate(10, 10);
-        var expected = {
-            x: 0,
-            y: 0,
-            w: 10,
-            h: 10
-        };
-        t.deepEqual(allocated, expected, 'packs a 10x10 square');
-        t.deepEqual(bp.allocate(10, 10), {
-            x: -1,
-            y: -1
-        }, 'cannot pack another');
-        var freed = bp.release(allocated);
-        t.deepEqual(freed, undefined, 'releases a 10x10 square');
+
+    t.test('packs larger bins on new shelf', function(t) {
+        var bp = new BinPack(64, 64);
+        t.deepEqual(bp.allocate(10, 10), {x: 0, y: 0, w: 10, h: 10 }, 'shelf 1, 10x10 bin');
+        t.deepEqual(bp.allocate(10, 15), {x: 0, y: 10, w: 10, h: 15 }, 'shelf 2, 10x15 bin');
+        t.deepEqual(bp.allocate(10, 20), {x: 0, y: 25, w: 10, h: 20 }, 'shelf 3, 10x20 bin');
         t.end();
     });
-    t.test('release many in same order', function(t) {
-        var bp = new BinPack(100, 100);
-        var allocated = [];
-        for (var i = 0; i < 20; i++) {
-            allocated.push(bp.allocate(10, 10));
-        }
-        for (i = 19; i >= 0; i--) {
-            bp.release(allocated[i]);
-        }
-        allocated = bp.allocate(10, 10);
-        var expected = {
-            x: 0,
-            y: 0,
-            w: 10,
-            h: 10
-        };
-        t.deepEqual(allocated, expected, 'packs a 10x10 square');
+
+    t.test('packs shorter bins on existing shelf, minimizing waste', function(t) {
+        var bp = new BinPack(64, 64);
+        t.deepEqual(bp.allocate(10, 10), {x: 0, y: 0, w: 10, h: 10 }, 'shelf 1, 10x10 bin');
+        t.deepEqual(bp.allocate(10, 15), {x: 0, y: 10, w: 10, h: 15 }, 'shelf 2, 10x15 bin');
+        t.deepEqual(bp.allocate(10, 20), {x: 0, y: 25, w: 10, h: 20 }, 'shelf 3, 10x20 bin');
+        t.deepEqual(bp.allocate(10, 9),  {x: 10, y: 0, w: 10, h: 9 }, 'shelf 1, 10x9 bin');
         t.end();
     });
-    t.test('release many in reverse order', function(t) {
-        var bp = new BinPack(100, 100);
-        var allocated = [];
-        for (var i = 0; i < 20; i++) {
-            allocated.push(bp.allocate(10, 10));
-        }
-        for (i = 0; i < 20; i++) {
-            bp.release(allocated[i]);
-        }
-        allocated = bp.allocate(10, 10);
-        var expected = {
-            x: 0,
-            y: 0,
-            w: 10,
-            h: 10
-        };
-        t.deepEqual(allocated, expected, 'packs a 10x10 square');
-        t.end();
-    });
+
     t.test('not enough room', function(t) {
         var bp = new BinPack(10, 10);
-        t.deepEqual(bp.allocate(10, 10), {
-            x: 0,
-            y: 0,
-            w: 10,
-            h: 10
-        }, 'packs a 10x10 square');
-        t.deepEqual(bp.allocate(10, 10), {
-            x: -1,
-            y: -1
-        }, 'not enough room');
+        t.deepEqual(bp.allocate(10, 10), {x: 0, y: 0, w: 10, h: 10 }, 'first 10x10 bin');
+        t.deepEqual(bp.allocate(10, 10), {x: -1, y: -1 }, 'not enough room');
         t.end();
     });
+
+    t.test('resize larger succeeds', function(t) {
+        var bp = new BinPack(10, 10);
+        t.ok(bp.resize(10, 20));
+        t.ok(bp.resize(20, 20));
+        t.end();
+    });
+
+    t.test('resize smaller fails', function(t) {
+        var bp = new BinPack(10, 10);
+        t.notOk(bp.resize(10, 9));
+        t.notOk(bp.resize(9, 10));
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
Improves but does not completely eliminate issues with glyph atlas overflow (#141)

* `GlyphSource` now manages multiple `GlyphAtlases`, 1 per fontstack.
* `GlyphAtlas` GL textures start out 128x128 and grow by power of 2 up to 1024x1024
* `BinPack` now uses shelf best height fit algorithm, more efficient packing for things with similar heights
* Doesn't attempt to remove glyphs when removing tiles (performance boost)
