### PR TITLE
fix flickering with overscaled tiles

### DIFF
--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -211,8 +211,8 @@ TilePyramid.prototype = {
 
         // Determine the overzooming/underzooming amounts.
         var zoom = (this.roundZoom ? Math.round : Math.floor)(this.getZoom(transform));
-        var minCoveringZoom = util.clamp(zoom - 10, this.minzoom, this.maxzoom);
-        var maxCoveringZoom = util.clamp(zoom + 3,  this.minzoom, this.maxzoom);
+        var minCoveringZoom = Math.max(zoom - 10, this.minzoom);
+        var maxCoveringZoom = Math.max(zoom + 3,  this.minzoom);
 
         // Retain is a list of tiles that we shouldn't delete, even if they are not
         // the most ideal tile for the current viewport. This may include tiles like


### PR DESCRIPTION
fix #1921

Maxzoom refers the maximum zoom of source tiles, not the maximum zoom over overscaled tiles. `minCoveringZoom` and `maxCoveringZoom` are used only for looking up loaded parent and child tiles, some of which many be overscaled tiles with z > maxzoom.

@mourner can you review and confirm this fixes #1921?