### PR TITLE
Fix easeTo pan, zoom, and rotate when initial rotation != 0

### DIFF
--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -475,10 +475,6 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
             this.pitching = true;
         }
 
-        if (this.zooming && !around) {
-            around = tr.pointLocation(tr.centerPoint.add(to.sub(from).div(1 - 1 / scale)));
-        }
-
         this.fire('movestart');
 
         this._ease(function (k) {

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -520,7 +520,7 @@ test('camera', function(t) {
         });
 
         t.test('pans, zooms, and rotates', function(t) {
-            var camera = createCamera();
+            var camera = createCamera({bearing: -90});
             camera.easeTo({ center: [100, 0], zoom: 3.2, bearing: 90, duration: 0 });
             t.deepEqual(fixedLngLat(camera.getCenter()), fixedLngLat({ lng: 100, lat: 0 }));
             t.equal(camera.getZoom(), 3.2);


### PR DESCRIPTION
fixes #1944 

This fixes the bug but might not be the most elegant solution.

:eyes: :thought_balloon: @mourner @ansis @1ec5 

