### PR TITLE
implement symbol-avoid-edges

### DIFF
--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -354,12 +354,14 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, buffers, collisio
 
         // Calculate the scales at which the text and icon can be placed without collision.
 
-        var glyphScale = hasText && !layout['text-allow-overlap'] ?
-            collisionTile.placeCollisionFeature(symbolInstance.textCollisionFeature) :
+        var glyphScale = hasText ?
+            collisionTile.placeCollisionFeature(symbolInstance.textCollisionFeature,
+                    layout['text-allow-overlap'], layout['symbol-avoid-edges']) :
             collisionTile.minScale;
 
-        var iconScale = hasIcon && !layout['icon-allow-overlap'] ?
-            collisionTile.placeCollisionFeature(symbolInstance.iconCollisionFeature) :
+        var iconScale = hasIcon ?
+            collisionTile.placeCollisionFeature(symbolInstance.iconCollisionFeature,
+                    layout['icon-allow-overlap'], layout['symbol-avoid-edges']) :
             collisionTile.minScale;
 
 

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -28,7 +28,6 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
 
     var tile = this,
         buffers = {},
-        collisionTile = new CollisionTile(this.angle, this.pitch),
         bucketsById = {},
         bucketsBySourceLayer = {},
         i, layer, sourceLayerId, bucket;
@@ -96,6 +95,9 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
     var buckets = [],
         symbolBuckets = this.symbolBuckets = [],
         otherBuckets = [];
+
+    this.extent = extent;
+    var collisionTile = new CollisionTile(this.angle, this.pitch, extent);
 
     for (var id in bucketsById) {
         bucket = bucketsById[id];
@@ -209,7 +211,7 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, collisionDebug) {
     }
 
     var buffers = {},
-        collisionTile = new CollisionTile(angle, pitch);
+        collisionTile = new CollisionTile(angle, pitch, this.extent);
 
     for (var i = this.symbolBuckets.length - 1; i >= 0; i--) {
         this.symbolBuckets[i].placeFeatures(collisionTile, buffers, collisionDebug);

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -33,7 +33,6 @@ StyleLayer.prototype = {
                 if (!this.layout.hasOwnProperty('icon-rotation-alignment')) {
                     this.layout['icon-rotation-alignment'] = 'map';
                 }
-                this.layout['symbol-avoid-edges'] = true;
             }
         }
     },

--- a/js/symbol/collision_tile.js
+++ b/js/symbol/collision_tile.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var rbush = require('rbush');
+var CollisionBox = require('./collision_box');
+var Point = require('point-geometry');
 
 module.exports = CollisionTile;
 
@@ -14,13 +16,14 @@ module.exports = CollisionTile;
  * @param {number} pitch
  * @private
  */
-function CollisionTile(angle, pitch) {
+function CollisionTile(angle, pitch, extent) {
     this.tree = rbush();
     this.angle = angle;
 
     var sin = Math.sin(angle),
         cos = Math.cos(angle);
     this.rotationMatrix = [cos, -sin, sin, cos];
+    this.reverseRotationMatrix = [cos, sin, -sin, cos];
 
     // Stretch boxes in y direction to account for the map tilt.
     this.yStretch = 1 / Math.cos(pitch / 180 * Math.PI);
@@ -28,6 +31,17 @@ function CollisionTile(angle, pitch) {
     // The amount the map is squished depends on the y position.
     // Sort of account for this by making all boxes a bit bigger.
     this.yStretch = Math.pow(this.yStretch, 1.3);
+
+    this.edges = [
+        //left
+        new CollisionBox(new Point(0, 0), 0, -Infinity, 0, Infinity, Infinity),
+        // right
+        new CollisionBox(new Point(extent, 0), 0, -Infinity, 0, Infinity, Infinity),
+        // top
+        new CollisionBox(new Point(0, 0), -Infinity, 0, Infinity, 0, Infinity),
+        // bottom
+        new CollisionBox(new Point(0, extent), -Infinity, 0, Infinity, 0, Infinity)
+    ];
 }
 
 CollisionTile.prototype.minScale = 0.25;
@@ -42,7 +56,7 @@ CollisionTile.prototype.maxScale = 2;
  * @returns {number} placementScale
  * @private
  */
-CollisionTile.prototype.placeCollisionFeature = function(collisionFeature) {
+CollisionTile.prototype.placeCollisionFeature = function(collisionFeature, allowOverlap, avoidEdges) {
 
     var minPlacementScale = this.minScale;
     var rotationMatrix = this.rotationMatrix;
@@ -52,60 +66,94 @@ CollisionTile.prototype.placeCollisionFeature = function(collisionFeature) {
 
         var box = collisionFeature.boxes[b];
 
-        var anchorPoint = box.anchorPoint.matMult(rotationMatrix);
-        var x = anchorPoint.x;
-        var y = anchorPoint.y;
+        if (!allowOverlap) {
+            var anchorPoint = box.anchorPoint.matMult(rotationMatrix);
+            var x = anchorPoint.x;
+            var y = anchorPoint.y;
 
-        box[0] = x + box.x1;
-        box[1] = y + box.y1 * yStretch;
-        box[2] = x + box.x2;
-        box[3] = y + box.y2 * yStretch;
+            box[0] = x + box.x1;
+            box[1] = y + box.y1 * yStretch;
+            box[2] = x + box.x2;
+            box[3] = y + box.y2 * yStretch;
 
-        var blockingBoxes = this.tree.search(box);
+            var blockingBoxes = this.tree.search(box);
 
-        for (var i = 0; i < blockingBoxes.length; i++) {
-            var blocking = blockingBoxes[i];
-            var blockingAnchorPoint = blocking.anchorPoint.matMult(rotationMatrix);
+            for (var i = 0; i < blockingBoxes.length; i++) {
+                var blocking = blockingBoxes[i];
+                var blockingAnchorPoint = blocking.anchorPoint.matMult(rotationMatrix);
 
-            // Find the lowest scale at which the two boxes can fit side by side without overlapping.
-            // Original algorithm:
-            var s1 = (blocking.x1 - box.x2) / (x - blockingAnchorPoint.x); // scale at which new box is to the left of old box
-            var s2 = (blocking.x2 - box.x1) / (x - blockingAnchorPoint.x); // scale at which new box is to the right of old box
-            var s3 = (blocking.y1 - box.y2) * yStretch / (y - blockingAnchorPoint.y); // scale at which new box is to the top of old box
-            var s4 = (blocking.y2 - box.y1) * yStretch / (y - blockingAnchorPoint.y); // scale at which new box is to the bottom of old box
-
-            if (isNaN(s1) || isNaN(s2)) s1 = s2 = 1;
-            if (isNaN(s3) || isNaN(s4)) s3 = s4 = 1;
-
-            var collisionFreeScale = Math.min(Math.max(s1, s2), Math.max(s3, s4));
-
-            if (collisionFreeScale > blocking.maxScale) {
-                // After a box's maxScale the label has shrunk enough that the box is no longer needed to cover it,
-                // so unblock the new box at the scale that the old box disappears.
-                collisionFreeScale = blocking.maxScale;
+                minPlacementScale = this.getPlacementScale(minPlacementScale, anchorPoint, box, blockingAnchorPoint, blocking);
+                if (minPlacementScale >= this.maxScale) {
+                    return minPlacementScale;
+                }
             }
+        }
 
-            if (collisionFreeScale > box.maxScale) {
-                // If the box can only be shown after it is visible, then the box can never be shown.
-                // But the label can be shown after this box is not visible.
-                collisionFreeScale = box.maxScale;
+        if (avoidEdges) {
+            var reverseRotationMatrix = this.reverseRotationMatrix;
+            var tl = new Point(box.x1, box.y1).matMult(reverseRotationMatrix);
+            var tr = new Point(box.x2, box.y1).matMult(reverseRotationMatrix);
+            var bl = new Point(box.x1, box.y2).matMult(reverseRotationMatrix);
+            var br = new Point(box.x2, box.y2).matMult(reverseRotationMatrix);
+            var rotatedCollisionBox = new CollisionBox(box.anchorPoint,
+                    Math.min(tl.x, tr.x, bl.x, br.x),
+                    Math.min(tl.y, tr.x, bl.x, br.x),
+                    Math.max(tl.x, tr.x, bl.x, br.x),
+                    Math.max(tl.y, tr.x, bl.x, br.x),
+                    box.maxScale);
+
+            for (var k = 0; k < this.edges.length; k++) {
+                var edgeBox = this.edges[k];
+                minPlacementScale = this.getPlacementScale(minPlacementScale, box.anchorPoint, rotatedCollisionBox, edgeBox.anchorPoint, edgeBox);
+                if (minPlacementScale >= this.maxScale) {
+                    return minPlacementScale;
+                }
             }
-
-            if (collisionFreeScale > minPlacementScale &&
-                    collisionFreeScale >= blocking.placementScale) {
-                // If this collision occurs at a lower scale than previously found collisions
-                // and the collision occurs while the other label is visible
-
-                // this this is the lowest scale at which the label won't collide with anything
-                minPlacementScale = collisionFreeScale;
-            }
-
-            if (minPlacementScale >= this.maxScale) return minPlacementScale;
         }
     }
 
     return minPlacementScale;
 };
+
+
+CollisionTile.prototype.getPlacementScale = function(minPlacementScale, anchorPoint, box, blockingAnchorPoint, blocking) {
+
+    // Find the lowest scale at which the two boxes can fit side by side without overlapping.
+    // Original algorithm:
+    var s1 = (blocking.x1 - box.x2) / (anchorPoint.x - blockingAnchorPoint.x); // scale at which new box is to the left of old box
+    var s2 = (blocking.x2 - box.x1) / (anchorPoint.x - blockingAnchorPoint.x); // scale at which new box is to the right of old box
+    var s3 = (blocking.y1 - box.y2) * this.yStretch / (anchorPoint.y - blockingAnchorPoint.y); // scale at which new box is to the top of old box
+    var s4 = (blocking.y2 - box.y1) * this.yStretch / (anchorPoint.y - blockingAnchorPoint.y); // scale at which new box is to the bottom of old box
+
+    if (isNaN(s1) || isNaN(s2)) s1 = s2 = 1;
+    if (isNaN(s3) || isNaN(s4)) s3 = s4 = 1;
+
+    var collisionFreeScale = Math.min(Math.max(s1, s2), Math.max(s3, s4));
+
+    if (collisionFreeScale > blocking.maxScale) {
+        // After a box's maxScale the label has shrunk enough that the box is no longer needed to cover it,
+        // so unblock the new box at the scale that the old box disappears.
+        collisionFreeScale = blocking.maxScale;
+    }
+
+    if (collisionFreeScale > box.maxScale) {
+        // If the box can only be shown after it is visible, then the box can never be shown.
+        // But the label can be shown after this box is not visible.
+        collisionFreeScale = box.maxScale;
+    }
+
+    if (collisionFreeScale > minPlacementScale &&
+            collisionFreeScale >= blocking.placementScale) {
+        // If this collision occurs at a lower scale than previously found collisions
+        // and the collision occurs while the other label is visible
+
+        // this this is the lowest scale at which the label won't collide with anything
+        minPlacementScale = collisionFreeScale;
+    }
+
+    return minPlacementScale;
+};
+
 
 /**
  * Remember this collisionFeature and what scale it was placed at to block

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#a6fe23c8cccda72a0afde9a87f8c6aabd4dcccba",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#bc0272cdde41d027a5df1ca8fb3aa1bc49aa8149",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
Prevent symbols from colliding with tile edges when `symbol-avoid-edges` is true.

ref https://github.com/mapbox/mapbox-gl-native/issues/3582

render tests: https://github.com/mapbox/mapbox-gl-test-suite/commit/bc0272cdde41d027a5df1ca8fb3aa1bc49aa8149