### PR TITLE
improve text-max-angle check

### DIFF
--- a/js/symbol/check_max_angle.js
+++ b/js/symbol/check_max_angle.js
@@ -53,7 +53,7 @@ function checkMaxAngle(line, anchor, labelLength, windowSize, maxAngle) {
 
         var angleDelta = prev.angleTo(current) - current.angleTo(next);
         // restrict angle to -pi..pi range
-        angleDelta = ((angleDelta + 3 * Math.PI) % (Math.PI * 2)) - Math.PI;
+        angleDelta = Math.abs(((angleDelta + 3 * Math.PI) % (Math.PI * 2)) - Math.PI);
 
         recentCorners.push({
             distance: anchorDistance,
@@ -67,7 +67,7 @@ function checkMaxAngle(line, anchor, labelLength, windowSize, maxAngle) {
         }
 
         // the sum of angles within the window area exceeds the maximum allowed value. check fails.
-        if (Math.abs(recentAngleDelta) > maxAngle) return false;
+        if (recentAngleDelta > maxAngle) return false;
 
         index++;
         anchorDistance += current.dist(next);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#059d488e07faf339b17f4e7df6936650cd1f8608",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2f4d8ed044a3c962a43d62de0608b752eb68052c",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
Instead of using the absolute value of the sum of angles, use the sum of the absolute values of angles.

This helps avoid labels on lines with sharp zig zags.

for example, the "Central Campus Mall" label here:
https://github.com/mapbox/mapbox-gl-native/issues/2998

test-suite update: https://github.com/mapbox/mapbox-gl-test-suite/tree/max-angle-fix

@lucaswoj can you review?