### PR TITLE
Refactor StyleLayer

### DIFF
--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -2,13 +2,14 @@
 
 var TilePyramid = require('../source/tile_pyramid');
 var pyramid = new TilePyramid({ tileSize: 512 });
+var util = require('../util/util');
 
 module.exports = drawBackground;
 
 function drawBackground(painter, source, layer) {
     var gl = painter.gl;
     var transform = painter.transform;
-    var color = layer.paint['background-color'];
+    var color = util.premultiply(layer.paint['background-color'], layer.paint['background-opacity']);
     var image = layer.paint['background-pattern'];
     var opacity = layer.paint['background-opacity'];
     var shader;

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var browser = require('../util/browser.js');
+var browser = require('../util/browser');
+var util = require('../util/util');
 
 module.exports = drawCircles;
 
@@ -25,7 +26,8 @@ function drawCircles(painter, source, layer, coords) {
     // are inversely related.
     var antialias = 1 / browser.devicePixelRatio / layer.paint['circle-radius'];
 
-    gl.uniform4fv(shader.u_color, layer.paint['circle-color']);
+    var color = util.premultiply(layer.paint['circle-color'], layer.paint['circle-opacity']);
+    gl.uniform4fv(shader.u_color, color);
     gl.uniform1f(shader.u_blur, Math.max(layer.paint['circle-blur'], antialias));
     gl.uniform1f(shader.u_size, layer.paint['circle-radius']);
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -1,15 +1,16 @@
 'use strict';
 
 var browser = require('../util/browser');
+var util = require('../util/util');
 
 module.exports = draw;
 
 function draw(painter, source, layer, coords) {
     var gl = painter.gl;
 
-    var color = layer.paint['fill-color'];
+    var color = util.premultiply(layer.paint['fill-color'], layer.paint['fill-opacity']);
     var image = layer.paint['fill-pattern'];
-    var strokeColor = layer.paint['fill-outline-color'];
+    var strokeColor = util.premultiply(layer.paint['fill-outline-color'], layer.paint['fill-opacity']);
 
     // Draw fill
     if (image ? !painter.isOpaquePass : painter.isOpaquePass === (color[3] === 1)) {
@@ -57,7 +58,7 @@ function drawFill(painter, source, layer, coord) {
 
     var gl = painter.gl;
 
-    var color = layer.paint['fill-color'];
+    var color = util.premultiply(layer.paint['fill-color'], layer.paint['fill-opacity']);
     var image = layer.paint['fill-pattern'];
     var opacity = layer.paint['fill-opacity'];
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -2,6 +2,7 @@
 
 var browser = require('../util/browser');
 var mat2 = require('gl-matrix').mat2;
+var util = require('../util/util');
 
 /**
  * Draw a line. Under the hood this will read elements from
@@ -47,7 +48,7 @@ module.exports = function drawLine(painter, source, layer, coords) {
     }
 
     var outset = offset + edgeWidth + antialiasing / 2 + shift;
-    var color = layer.paint['line-color'];
+    var color = util.premultiply(layer.paint['line-color'], layer.paint['line-opacity']);
 
     var tr = painter.transform;
 

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -4,6 +4,7 @@ var mat4 = require('gl-matrix').mat4;
 
 var browser = require('../util/browser');
 var drawCollisionDebug = require('./draw_collision_debug');
+var util = require('../util/util');
 
 module.exports = drawSymbols;
 
@@ -167,9 +168,11 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf,
         var gamma = 0.105 * defaultSizes[prefix] / fontSize / browser.devicePixelRatio;
 
         if (layer.paint[prefix + '-halo-width']) {
+            var haloColor = util.premultiply(layer.paint[prefix + '-halo-color'], layer.paint[prefix + '-opacity']);
+
             // Draw halo underneath the text.
             gl.uniform1f(shader.u_gamma, (layer.paint[prefix + '-halo-blur'] * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
-            gl.uniform4fv(shader.u_color, layer.paint[prefix + '-halo-color']);
+            gl.uniform4fv(shader.u_color, haloColor);
             gl.uniform1f(shader.u_buffer, (haloOffset - layer.paint[prefix + '-halo-width'] / fontScale) / sdfPx);
 
             for (var j = 0; j < elementGroups.groups.length; j++) {
@@ -184,8 +187,9 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf,
             }
         }
 
+        var color = util.premultiply(layer.paint[prefix + '-color'], layer.paint[prefix + '-opacity']);
         gl.uniform1f(shader.u_gamma, gamma * gammaScale);
-        gl.uniform4fv(shader.u_color, layer.paint[prefix + '-color']);
+        gl.uniform4fv(shader.u_color, color);
         gl.uniform1f(shader.u_buffer, (256 - 64) / 256);
 
         for (var i = 0; i < elementGroups.groups.length; i++) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -330,7 +330,7 @@ Painter.prototype.depthMask = function(mask) {
 };
 
 Painter.prototype.renderLayer = function(painter, source, layer, coords) {
-    if (layer.hidden) return;
+    if (layer.isHidden(this.transform.zoom)) return;
     if (layer.type !== 'background' && !coords.length) return;
     draw[layer.type](painter, source, layer, coords);
 };

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -129,7 +129,7 @@ Style.prototype = util.inherit(Evented, {
         this._order  = [];
 
         for (var i = 0; i < this.stylesheet.layers.length; i++) {
-            layer = new StyleLayer(this.stylesheet.layers[i]);
+            layer = StyleLayer.create(this.stylesheet.layers[i]);
             this._layers[layer.id] = layer;
             this._order.push(layer.id);
         }

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -205,7 +205,8 @@ Style.prototype = util.inherit(Evented, {
         for (id in this._layers) {
             var layer = this._layers[id];
 
-            if (layer.recalculate(z, this.zoomHistory) && layer.source) {
+            layer.recalculate(z, this.zoomHistory);
+            if (!layer.isHidden(z) && layer.source) {
                 this.sources[layer.source].used = true;
             }
         }

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -93,14 +93,14 @@ Style.prototype = util.inherit(Evented, {
     _validateLayer: function(layer) {
         var source = this.sources[layer.source];
 
-        if (!layer['source-layer']) return;
+        if (!layer.sourceLayer) return;
         if (!source) return;
         if (!source.vectorLayerIds) return;
 
-        if (source.vectorLayerIds.indexOf(layer['source-layer']) === -1) {
+        if (source.vectorLayerIds.indexOf(layer.sourceLayer) === -1) {
             this.fire('error', {
                 error: new Error(
-                    'Source layer "' + layer['source-layer'] + '" ' +
+                    'Source layer "' + layer.sourceLayer + '" ' +
                     'does not exist on source "' + source.id + '" ' +
                     'as specified by style layer "' + layer.id + '"'
                 )

--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -47,7 +47,7 @@ styleBatch.prototype = {
             throw new Error('There is already a layer with this ID');
         }
         if (!(layer instanceof StyleLayer)) {
-            layer = new StyleLayer(layer);
+            layer = StyleLayer.create(layer);
         }
         this._style._validateLayer(layer);
         this._style._layers[layer.id] = layer;

--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -47,13 +47,13 @@ styleBatch.prototype = {
             throw new Error('There is already a layer with this ID');
         }
         if (!(layer instanceof StyleLayer)) {
-            layer = StyleLayer.create(layer);
+            var refLayer = layer.ref && this._style.getLayer(layer.ref);
+            layer = StyleLayer.create(layer, refLayer);
         }
         this._style._validateLayer(layer);
         this._style._layers[layer.id] = layer;
         this._style._order.splice(before ? this._style._order.indexOf(before) : Infinity, 0, layer.id);
         layer.resolveLayout();
-        layer.resolveReference(this._style._layers);
         layer.resolvePaint();
 
         this._groupLayers = true;

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -120,12 +120,16 @@ StyleLayer.prototype = {
         }
     },
 
+    getPaintValue: function(name, zoom, zoomHistory) {
+        return this._transitions[name].at(zoom, zoomHistory);
+    },
+
     // update zoom
     recalculate: function(zoom, zoomHistory) {
         this.paint = new PaintProperties[this.type]();
 
-        for (var k in this._transitions) {
-            this.paint[k] = this._transitions[k].at(zoom, zoomHistory);
+        for (var name in this._transitions) {
+            this.paint[name] = this.getPaintValue(name, zoom, zoomHistory);
         }
     },
 

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -125,14 +125,11 @@ StyleLayer.prototype = {
         this.paint = new PaintProperties[this.type]();
 
         for (var k in this._transitions) {
-            this.paint[k] = this._transitions[k].at(z, zoomHistory);
+            this.paint[k] = this._transitions[k].at(zoom, zoomHistory);
         }
 
         if (!this.isHidden(zoom)) {
             StyleLayer._premultiplyLayer(this.paint, this.type);
-            return false;
-        } else {
-            return true;
         }
     },
 

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -27,7 +27,7 @@ function StyleLayer(layer, refLayer) {
     this.ref = layer.ref;
     this.type = (refLayer || layer).type;
     this.source = (refLayer || layer).source;
-    this['source-layer'] = (refLayer || layer)['source-layer'];
+    this.sourceLayer = (refLayer || layer)['source-layer'];
     this.minzoom = (refLayer || layer).minzoom;
     this.maxzoom = (refLayer || layer).maxzoom;
     this.filter = (refLayer || layer).filter;

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -129,8 +129,12 @@ StyleLayer.prototype = {
         }
 
         if (!this.isHidden(zoom)) {
-            StyleLayer._premultiplyLayer(this.paint, this.type);
+            this.premultiply();
         }
+    },
+
+    premultiply: function() {
+        this.paint[this.type + '-color'] = util.premultiply(this.paint[this.type + '-color'], this.paint[this.type + '-opacity']);
     },
 
     json: function() {
@@ -140,29 +144,5 @@ StyleLayer.prototype = {
                 ['type', 'source', 'source-layer',
                 'minzoom', 'maxzoom', 'filter',
                 'layout', 'paint']));
-    }
-};
-
-StyleLayer._premultiplyLayer = function(layer, type) {
-    var colorProp = type + '-color',
-        haloProp = type + '-halo-color',
-        outlineProp = type + '-outline-color',
-        color = layer[colorProp],
-        haloColor = layer[haloProp],
-        outlineColor = layer[outlineProp],
-        opacity = layer[type + '-opacity'];
-
-    var colorOpacity = color && (opacity * color[3]);
-    var haloOpacity = haloColor && (opacity * haloColor[3]);
-    var outlineOpacity = outlineColor && (opacity * outlineColor[3]);
-
-    if (colorOpacity !== undefined && colorOpacity < 1) {
-        layer[colorProp] = util.premultiply([color[0], color[1], color[2], colorOpacity]);
-    }
-    if (haloOpacity !== undefined && haloOpacity < 1) {
-        layer[haloProp] = util.premultiply([haloColor[0], haloColor[1], haloColor[2], haloOpacity]);
-    }
-    if (outlineOpacity !== undefined && outlineOpacity < 1) {
-        layer[outlineProp] = util.premultiply([outlineColor[0], outlineColor[1], outlineColor[2], outlineOpacity]);
     }
 };

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -8,6 +8,10 @@ var PaintProperties = require('./paint_properties');
 
 module.exports = StyleLayer;
 
+StyleLayer.create = function(layer) {
+    return new StyleLayer(layer);
+};
+
 function StyleLayer(layer) {
     this._layer = layer;
 

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -8,21 +8,26 @@ var PaintProperties = require('./paint_properties');
 
 module.exports = StyleLayer;
 
-StyleLayer.create = function(layer) {
-    return new StyleLayer(layer);
+StyleLayer.create = function(layer, refLayer) {
+    return new StyleLayer(layer, refLayer);
 };
 
-function StyleLayer(layer) {
+function StyleLayer(layer, refLayer) {
     this._layer = layer;
 
     this.id = layer.id;
     this.ref = layer.ref;
+    this.type = (refLayer || layer).type;
+    this.source = (refLayer || layer).source;
+    this['source-layer'] = (refLayer || layer)['source-layer'];
+    this.minzoom = (refLayer || layer).minzoom;
+    this.maxzoom = (refLayer || layer).maxzoom;
+    this.filter = (refLayer || layer).filter;
+    this.layout = (refLayer || layer).layout;
 
     // Resolved and cascaded paint properties.
     this._resolved = {}; // class name -> StyleDeclarationSet
     this._cascaded = {}; // property name -> StyleTransition
-
-    this.assign(layer);
 }
 
 StyleLayer.prototype = {
@@ -51,12 +56,6 @@ StyleLayer.prototype = {
 
     getLayoutProperty: function(name) {
         return this.layout[name];
-    },
-
-    resolveReference: function(layers) {
-        if (this.ref) {
-            this.assign(layers[this.ref]);
-        }
     },
 
     resolvePaint: function() {
@@ -166,13 +165,6 @@ StyleLayer.prototype = {
         }
 
         return !this.hidden;
-    },
-
-    assign: function(layer) {
-        util.extend(this, util.pick(layer,
-            ['type', 'source', 'source-layer',
-            'minzoom', 'maxzoom', 'filter',
-            'layout']));
     },
 
     json: function() {

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -57,27 +57,23 @@ StyleLayer.prototype = {
     },
 
     resolvePaint: function() {
-        for (var p in this._layer) {
-            var match = p.match(/^paint(?:\.(.*))?$/);
-            if (!match)
-                continue;
-            this._classes[match[1] || ''] =
-                new StyleDeclarationSet('paint', this.type, this._layer[p]);
+        for (var key in this._layer) {
+            var match = key.match(/^paint(?:\.(.*))?$/);
+            if (!match) continue;
+            this._classes[match[1] || ''] = new StyleDeclarationSet('paint', this.type, this._layer[key]);
         }
     },
 
     setPaintProperty: function(name, value, klass) {
         var declarations = this._classes[klass || ''];
         if (!declarations) {
-            declarations = this._classes[klass || ''] =
-                new StyleDeclarationSet('paint', this.type, {});
+            declarations = this._classes[klass || ''] = new StyleDeclarationSet('paint', this.type, {});
         }
         declarations[name] = value;
     },
 
     getPaintProperty: function(name, klass) {
-        var declarations = this._classes[klass || ''];
-        return declarations && declarations[name];
+        return this._classes[klass || ''] && this._classes[klass || ''][name];
     },
 
     isHidden: function(zoom) {
@@ -91,11 +87,10 @@ StyleLayer.prototype = {
     // update classes
     cascade: function(classes, options, globalTrans, animationLoop) {
         for (var klass in this._classes) {
-            if (klass !== "" && !classes[klass])
-                continue;
+            if (klass !== "" && !classes[klass]) continue;
 
-            var declarations = this._classes[klass],
-                values = declarations.values();
+            var declarations = this._classes[klass];
+            var values = declarations.values();
 
             for (var k in values) {
                 var newDeclaration = values[k];
@@ -104,8 +99,7 @@ StyleLayer.prototype = {
                 // Only create a new transition if the declaration changed
                 if (!oldTransition || oldTransition.declaration.json !== newDeclaration.json) {
                     var newStyleTrans = declarations.transition(k, globalTrans);
-                    var newTransition = this._transitions[k] =
-                        new StyleTransition(newDeclaration, oldTransition, newStyleTrans);
+                    var newTransition = this._transitions[k] = new StyleTransition(newDeclaration, oldTransition, newStyleTrans);
 
                     // Run the animation loop until the end of the transition
                     if (!newTransition.instant()) {
@@ -134,11 +128,13 @@ StyleLayer.prototype = {
     },
 
     json: function() {
-        return util.extend({},
+        return util.extend(
+            {},
             this._layer,
-            util.pick(this,
-                ['type', 'source', 'source-layer',
-                'minzoom', 'maxzoom', 'filter',
-                'layout', 'paint']));
+            util.pick(this, [
+                'type', 'source', 'source-layer', 'minzoom', 'maxzoom',
+                'filter', 'layout', 'paint'
+            ])
+        );
     }
 };

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -9,7 +9,15 @@ var PaintProperties = require('./paint_properties');
 module.exports = StyleLayer;
 
 StyleLayer.create = function(layer, refLayer) {
-    return new StyleLayer(layer, refLayer);
+    var Classes = {
+        background: require('./style_layer/background_style_layer'),
+        circle: require('./style_layer/circle_style_layer'),
+        fill: require('./style_layer/fill_style_layer'),
+        line: require('./style_layer/line_style_layer'),
+        raster: require('./style_layer/raster_style_layer'),
+        symbol: require('./style_layer/symbol_style_layer')
+    };
+    return new Classes[(refLayer || layer).type](layer, refLayer);
 };
 
 function StyleLayer(layer, refLayer) {

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -86,9 +86,7 @@ StyleLayer.prototype = {
 
     getPaintProperty: function(name, klass) {
         var declarations = this._classes[klass || ''];
-        if (!declarations)
-            return undefined;
-        return declarations[name];
+        return declarations && declarations[name];
     },
 
     // update classes

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -80,6 +80,14 @@ StyleLayer.prototype = {
         return declarations && declarations[name];
     },
 
+    isHidden: function(zoom) {
+        if (this.minzoom && zoom < this.minzoom) return true;
+        if (this.maxzoom && zoom >= this.maxzoom) return true;
+        if (this.layout.visibility === 'none') return true;
+        if (this.paint[this.type + '-opacity'] === 0) return true;
+        return false;
+    },
+
     // update classes
     cascade: function(classes, options, globalTrans, animationLoop) {
         for (var klass in this._classes) {
@@ -113,26 +121,19 @@ StyleLayer.prototype = {
     },
 
     // update zoom
-    recalculate: function(z, zoomHistory) {
+    recalculate: function(zoom, zoomHistory) {
         this.paint = new PaintProperties[this.type]();
 
         for (var k in this._transitions) {
             this.paint[k] = this._transitions[k].at(z, zoomHistory);
         }
 
-        this.hidden = (
-            (this.minzoom && z < this.minzoom) ||
-            (this.maxzoom && z >= this.maxzoom) ||
-            (this.layout.visibility === 'none')
-        );
-
-        if (this.paint[this.type + '-opacity'] === 0) {
-            this.hidden = true;
-        } else {
+        if (!this.isHidden(zoom)) {
             StyleLayer._premultiplyLayer(this.paint, this.type);
+            return false;
+        } else {
+            return true;
         }
-
-        return !this.hidden;
     },
 
     json: function() {

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -127,14 +127,6 @@ StyleLayer.prototype = {
         for (var k in this._transitions) {
             this.paint[k] = this._transitions[k].at(zoom, zoomHistory);
         }
-
-        if (!this.isHidden(zoom)) {
-            this.premultiply();
-        }
-    },
-
-    premultiply: function() {
-        this.paint[this.type + '-color'] = util.premultiply(this.paint[this.type + '-color'], this.paint[this.type + '-opacity']);
     },
 
     json: function() {

--- a/js/style/style_layer/background_style_layer.js
+++ b/js/style/style_layer/background_style_layer.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var util = require('../../util/util');
+var StyleLayer = require('../style_layer');
+
+function BackgroundStyleLayer() {
+    StyleLayer.apply(this, arguments);
+}
+
+module.exports = BackgroundStyleLayer;
+
+BackgroundStyleLayer.prototype = util.inherit(StyleLayer, {});

--- a/js/style/style_layer/circle_style_layer.js
+++ b/js/style/style_layer/circle_style_layer.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var util = require('../../util/util');
+var StyleLayer = require('../style_layer');
+
+function CircleStyleLayer() {
+    StyleLayer.apply(this, arguments);
+}
+
+module.exports = CircleStyleLayer;
+
+CircleStyleLayer.prototype = util.inherit(StyleLayer, {});

--- a/js/style/style_layer/fill_style_layer.js
+++ b/js/style/style_layer/fill_style_layer.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var util = require('../../util/util');
+var StyleLayer = require('../style_layer');
+
+function FillStyleLayer() {
+    StyleLayer.apply(this, arguments);
+}
+
+module.exports = FillStyleLayer;
+
+FillStyleLayer.prototype = util.inherit(StyleLayer, {});

--- a/js/style/style_layer/fill_style_layer.js
+++ b/js/style/style_layer/fill_style_layer.js
@@ -9,11 +9,4 @@ function FillStyleLayer() {
 
 module.exports = FillStyleLayer;
 
-FillStyleLayer.prototype = util.inherit(StyleLayer, {
-
-    premultiply: function() {
-        this.paint['fill-color'] = util.premultiply(this.paint['fill-color'], this.paint['fill-opacity']);
-        this.paint['fill-outline-color'] = util.premultiply(this.paint['fill-outline-color'], this.paint['fill-opacity']);
-    }
-
-});
+FillStyleLayer.prototype = util.inherit(StyleLayer, {});

--- a/js/style/style_layer/fill_style_layer.js
+++ b/js/style/style_layer/fill_style_layer.js
@@ -9,4 +9,11 @@ function FillStyleLayer() {
 
 module.exports = FillStyleLayer;
 
-FillStyleLayer.prototype = util.inherit(StyleLayer, {});
+FillStyleLayer.prototype = util.inherit(StyleLayer, {
+
+    premultiply: function() {
+        this.paint['fill-color'] = util.premultiply(this.paint['fill-color'], this.paint['fill-opacity']);
+        this.paint['fill-outline-color'] = util.premultiply(this.paint['fill-outline-color'], this.paint['fill-opacity']);
+    }
+
+});

--- a/js/style/style_layer/line_style_layer.js
+++ b/js/style/style_layer/line_style_layer.js
@@ -29,8 +29,6 @@ LineStyleLayer.prototype = util.inherit(StyleLayer, {
             dashArray.fromScale *= lineWidth;
             dashArray.toScale *= lineWidth;
         }
-
-        return !this.isHidden(zoom);
     }
 
 });

--- a/js/style/style_layer/line_style_layer.js
+++ b/js/style/style_layer/line_style_layer.js
@@ -17,7 +17,7 @@ LineStyleLayer.prototype = util.inherit(StyleLayer, {
         // If the line is dashed, scale the dash lengths by the line
         // width at the previous round zoom level.
         if (this._transitions['line-dasharray']) {
-            
+
             var lineWidth;
             if (this._transitions['line-width']) {
                 lineWidth = this._transitions['line-width'].at(Math.floor(zoom), Infinity);
@@ -30,7 +30,7 @@ LineStyleLayer.prototype = util.inherit(StyleLayer, {
             dashArray.toScale *= lineWidth;
         }
 
-        return !this.hidden;
+        return !this.isHidden(zoom);
     }
 
 });

--- a/js/style/style_layer/line_style_layer.js
+++ b/js/style/style_layer/line_style_layer.js
@@ -9,4 +9,28 @@ function LineStyleLayer() {
 
 module.exports = LineStyleLayer;
 
-LineStyleLayer.prototype = util.inherit(StyleLayer, {});
+LineStyleLayer.prototype = util.inherit(StyleLayer, {
+
+    recalculate: function(zoom) {
+        StyleLayer.prototype.recalculate.apply(this, arguments);
+
+        // If the line is dashed, scale the dash lengths by the line
+        // width at the previous round zoom level.
+        if (this._transitions['line-dasharray']) {
+            
+            var lineWidth;
+            if (this._transitions['line-width']) {
+                lineWidth = this._transitions['line-width'].at(Math.floor(zoom), Infinity);
+            } else {
+                lineWidth = this.paint['line-width'];
+            }
+
+            var dashArray = this.paint['line-dasharray'];
+            dashArray.fromScale *= lineWidth;
+            dashArray.toScale *= lineWidth;
+        }
+
+        return !this.hidden;
+    }
+
+});

--- a/js/style/style_layer/line_style_layer.js
+++ b/js/style/style_layer/line_style_layer.js
@@ -11,24 +11,18 @@ module.exports = LineStyleLayer;
 
 LineStyleLayer.prototype = util.inherit(StyleLayer, {
 
-    recalculate: function(zoom) {
-        StyleLayer.prototype.recalculate.apply(this, arguments);
+    getPaintValue: function(name, zoom) {
+        var output = StyleLayer.prototype.getPaintValue.apply(this, arguments);
 
         // If the line is dashed, scale the dash lengths by the line
         // width at the previous round zoom level.
-        if (this._transitions['line-dasharray']) {
-
-            var lineWidth;
-            if (this._transitions['line-width']) {
-                lineWidth = this._transitions['line-width'].at(Math.floor(zoom), Infinity);
-            } else {
-                lineWidth = this.paint['line-width'];
-            }
-
-            var dashArray = this.paint['line-dasharray'];
-            dashArray.fromScale *= lineWidth;
-            dashArray.toScale *= lineWidth;
+        if (name === 'line-dasharray') {
+            var lineWidth = this.getPaintValue('line-width', Math.floor(zoom), Infinity);
+            output.fromScale *= lineWidth;
+            output.toScale *= lineWidth;
         }
+
+        return output;
     }
 
 });

--- a/js/style/style_layer/line_style_layer.js
+++ b/js/style/style_layer/line_style_layer.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var util = require('../../util/util');
+var StyleLayer = require('../style_layer');
+
+function LineStyleLayer() {
+    StyleLayer.apply(this, arguments);
+}
+
+module.exports = LineStyleLayer;
+
+LineStyleLayer.prototype = util.inherit(StyleLayer, {});

--- a/js/style/style_layer/raster_style_layer.js
+++ b/js/style/style_layer/raster_style_layer.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var util = require('../../util/util');
+var StyleLayer = require('../style_layer');
+
+function RasterStyleLayer() {
+    StyleLayer.apply(this, arguments);
+}
+
+module.exports = RasterStyleLayer;
+
+RasterStyleLayer.prototype = util.inherit(StyleLayer, {});

--- a/js/style/style_layer/raster_style_layer.js
+++ b/js/style/style_layer/raster_style_layer.js
@@ -9,8 +9,4 @@ function RasterStyleLayer() {
 
 module.exports = RasterStyleLayer;
 
-RasterStyleLayer.prototype = util.inherit(StyleLayer, {
-
-    premultiply: function() {}
-
-});
+RasterStyleLayer.prototype = util.inherit(StyleLayer, {});

--- a/js/style/style_layer/raster_style_layer.js
+++ b/js/style/style_layer/raster_style_layer.js
@@ -9,4 +9,8 @@ function RasterStyleLayer() {
 
 module.exports = RasterStyleLayer;
 
-RasterStyleLayer.prototype = util.inherit(StyleLayer, {});
+RasterStyleLayer.prototype = util.inherit(StyleLayer, {
+
+    premultiply: function() {}
+
+});

--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -14,14 +14,6 @@ module.exports = SymbolStyleLayer;
 
 SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
 
-    premultiply: function() {
-        this.paint['text-color'] = util.premultiply(this.paint['text-color'], this.paint['text-opacity']);
-        this.paint['text-halo-color'] = util.premultiply(this.paint['text-halo-color'], this.paint['text-opacity']);
-
-        this.paint['icon-color'] = util.premultiply(this.paint['icon-color'], this.paint['icon-opacity']);
-        this.paint['icon-halo-color'] = util.premultiply(this.paint['icon-halo-color'], this.paint['icon-opacity']);
-    },
-
     isHidden: function() {
         if (StyleLayer.prototype.isHidden.apply(this, arguments)) return true;
 

--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -55,9 +55,6 @@ SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
             StyleLayer._premultiplyLayer(this.paint, 'text');
             StyleLayer._premultiplyLayer(this.paint, 'icon');
         }
-
-        return !this.isHidden();
-
     }
 
 });

--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var util = require('../../util/util');
+var StyleLayer = require('../style_layer');
+
+function SymbolStyleLayer() {
+    StyleLayer.apply(this, arguments);
+}
+
+module.exports = SymbolStyleLayer;
+
+SymbolStyleLayer.prototype = util.inherit(StyleLayer, {});

--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -14,6 +14,16 @@ module.exports = SymbolStyleLayer;
 
 SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
 
+    isHidden: function() {
+        if (StyleLayer.prototype.isHidden.apply(this, arguments)) return true;
+
+        var isTextHidden = this.paint['text-opacity'] === 0 || !this.layout['text-field'];
+        var isIconHidden = this.paint['icon-opacity'] === 0 || !this.layout['icon-image'];
+        if (isTextHidden && isIconHidden) return true;
+
+        return false;
+    },
+
     resolveLayout: function() {
         StyleLayer.prototype.resolveLayout.apply(this, arguments);
 
@@ -41,15 +51,12 @@ SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
     recalculate: function() {
         StyleLayer.prototype.recalculate.apply(this, arguments);
 
-        if ((this.paint['text-opacity'] === 0 || !this.layout['text-field']) &&
-            (this.paint['icon-opacity'] === 0 || !this.layout['icon-image'])) {
-            this.hidden = true;
-        } else {
+        if (!this.isHidden()) {
             StyleLayer._premultiplyLayer(this.paint, 'text');
             StyleLayer._premultiplyLayer(this.paint, 'icon');
         }
 
-        return !this.hidden;
+        return !this.isHidden();
 
     }
 

--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -2,6 +2,9 @@
 
 var util = require('../../util/util');
 var StyleLayer = require('../style_layer');
+var StyleDeclarationSet = require('../style_declaration_set');
+var StyleTransition = require('../style_transition');
+
 
 function SymbolStyleLayer() {
     StyleLayer.apply(this, arguments);
@@ -9,4 +12,45 @@ function SymbolStyleLayer() {
 
 module.exports = SymbolStyleLayer;
 
-SymbolStyleLayer.prototype = util.inherit(StyleLayer, {});
+SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
+
+    resolveLayout: function() {
+        StyleLayer.prototype.resolveLayout.apply(this, arguments);
+
+        if (this.layout && this.layout['symbol-placement'] === 'line') {
+            if (!this.layout.hasOwnProperty('text-rotation-alignment')) {
+                this.layout['text-rotation-alignment'] = 'map';
+            }
+            if (!this.layout.hasOwnProperty('icon-rotation-alignment')) {
+                this.layout['icon-rotation-alignment'] = 'map';
+            }
+        }
+    },
+
+    cascade: function(classes, options, globalTrans) {
+        StyleLayer.prototype.cascade.apply(this, arguments);
+
+        // the -size properties are used both as layout and paint.
+        // In the spec they are layout properties. This adds them
+        // as internal paint properties.
+        var resolvedLayout = new StyleDeclarationSet('layout', this.type, this.layout);
+        this._transitions['text-size'] = new StyleTransition(resolvedLayout.values()['text-size'], undefined, globalTrans);
+        this._transitions['icon-size'] = new StyleTransition(resolvedLayout.values()['icon-size'], undefined, globalTrans);
+    },
+
+    recalculate: function() {
+        StyleLayer.prototype.recalculate.apply(this, arguments);
+
+        if ((this.paint['text-opacity'] === 0 || !this.layout['text-field']) &&
+            (this.paint['icon-opacity'] === 0 || !this.layout['icon-image'])) {
+            this.hidden = true;
+        } else {
+            StyleLayer._premultiplyLayer(this.paint, 'text');
+            StyleLayer._premultiplyLayer(this.paint, 'icon');
+        }
+
+        return !this.hidden;
+
+    }
+
+});

--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -14,6 +14,14 @@ module.exports = SymbolStyleLayer;
 
 SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
 
+    premultiply: function() {
+        this.paint['text-color'] = util.premultiply(this.paint['text-color'], this.paint['text-opacity']);
+        this.paint['text-halo-color'] = util.premultiply(this.paint['text-halo-color'], this.paint['text-opacity']);
+
+        this.paint['icon-color'] = util.premultiply(this.paint['icon-color'], this.paint['icon-opacity']);
+        this.paint['icon-halo-color'] = util.premultiply(this.paint['icon-halo-color'], this.paint['icon-opacity']);
+    },
+
     isHidden: function() {
         if (StyleLayer.prototype.isHidden.apply(this, arguments)) return true;
 
@@ -46,15 +54,6 @@ SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
         var resolvedLayout = new StyleDeclarationSet('layout', this.type, this.layout);
         this._transitions['text-size'] = new StyleTransition(resolvedLayout.values()['text-size'], undefined, globalTrans);
         this._transitions['icon-size'] = new StyleTransition(resolvedLayout.values()['icon-size'], undefined, globalTrans);
-    },
-
-    recalculate: function() {
-        StyleLayer.prototype.recalculate.apply(this, arguments);
-
-        if (!this.isHidden()) {
-            StyleLayer._premultiplyLayer(this.paint, 'text');
-            StyleLayer._premultiplyLayer(this.paint, 'icon');
-        }
     }
 
 });

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -54,15 +54,21 @@ exports.ease = exports.bezier(0.25, 0.1, 0.25, 1);
  * RGBA, return a version for which the RGB components are multiplied
  * by the A (alpha) component
  *
- * @param {Array<number>} c color array
+ * @param {Array<number>} color color array
+ * @param {number} [additionalOpacity] additional opacity to be multiplied into
+ *     the color's alpha component.
  * @returns {Array<number>} premultiplied color array
  * @private
  */
-exports.premultiply = function (c) {
-    c[0] *= c[3];
-    c[1] *= c[3];
-    c[2] *= c[3];
-    return c;
+exports.premultiply = function (color, additionalOpacity) {
+    if (!color) return null;
+    var opacity = color[3] * additionalOpacity;
+    return [
+        color[0] * opacity,
+        color[1] * opacity,
+        color[2] * opacity,
+        opacity
+    ];
 };
 
 /**

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -11,6 +11,16 @@ test('StyleLayer', function(t) {
         t.equal(layer._layer, rawLayer);
         t.end();
     });
+
+    t.test('sets properties from ref', function (t) {
+        var layer = StyleLayer.create(
+            {ref: 'ref'},
+            StyleLayer.create({type: 'fill'})
+        );
+
+        t.equal(layer.type, 'fill');
+        t.end();
+    });
 });
 
 test('StyleLayer#resolveLayout', function(t) {
@@ -18,16 +28,6 @@ test('StyleLayer#resolveLayout', function(t) {
         var layer = StyleLayer.create({type: 'fill'});
         layer.resolveLayout({});
         t.ok(layer.layout instanceof LayoutProperties.fill);
-        t.end();
-    });
-});
-
-test('StyleLayer#resolveReference', function(t) {
-    t.test('sets properties from ref', function (t) {
-        var layer = StyleLayer.create({ref: 'ref'}),
-            referent = StyleLayer.create({type: 'fill'});
-        layer.resolveReference({ref: referent});
-        t.equal(layer.type, 'fill');
         t.end();
     });
 });

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -47,25 +47,6 @@ test('StyleLayer#resolvePaint', function(t) {
     });
 });
 
-//test('StyleLayer#cascade', function(t) {
-//    t.test('applies default transitions', function(t) {
-//        var layer = StyleLayer.create({
-//            type: 'fill',
-//            paint: {
-//                'fill-color': 'blue'
-//            }
-//        });
-//
-//        layer.resolvePaint({});
-//
-//        var declaration = layer._resolved['']['fill-color'];
-//        t.deepEqual(declaration.value, [0, 0, 1, 1]);
-//        t.deepEqual(declaration.transition, {delay: 0, duration: 300});
-//
-//        t.end();
-//    });
-//});
-
 test('StyleLayer#setPaintProperty', function(t) {
     t.test('sets new property value', function(t) {
         var layer = StyleLayer.create({

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -50,7 +50,7 @@ test('StyleLayer#resolvePaint', function(t) {
 
         layer.resolvePaint({});
 
-        t.deepEqual(Object.keys(layer._resolved), ['', 'night']);
+        t.deepEqual(Object.keys(layer._classes), ['', 'night']);
         t.end();
     });
 });

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -7,7 +7,7 @@ var LayoutProperties = require('../../../js/style/layout_properties');
 test('StyleLayer', function(t) {
     t.test('sets raw layer', function (t) {
         var rawLayer = {type: 'fill'},
-            layer = new StyleLayer(rawLayer);
+            layer = StyleLayer.create(rawLayer);
         t.equal(layer._layer, rawLayer);
         t.end();
     });
@@ -15,7 +15,7 @@ test('StyleLayer', function(t) {
 
 test('StyleLayer#resolveLayout', function(t) {
     t.test('creates layout properties', function (t) {
-        var layer = new StyleLayer({type: 'fill'});
+        var layer = StyleLayer.create({type: 'fill'});
         layer.resolveLayout({});
         t.ok(layer.layout instanceof LayoutProperties.fill);
         t.end();
@@ -24,8 +24,8 @@ test('StyleLayer#resolveLayout', function(t) {
 
 test('StyleLayer#resolveReference', function(t) {
     t.test('sets properties from ref', function (t) {
-        var layer = new StyleLayer({ref: 'ref'}),
-            referent = new StyleLayer({type: 'fill'});
+        var layer = StyleLayer.create({ref: 'ref'}),
+            referent = StyleLayer.create({type: 'fill'});
         layer.resolveReference({ref: referent});
         t.equal(layer.type, 'fill');
         t.end();
@@ -34,7 +34,7 @@ test('StyleLayer#resolveReference', function(t) {
 
 test('StyleLayer#resolvePaint', function(t) {
     t.test('calculates paint classes', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             type: 'fill',
             'paint': {},
             'paint.night': {}
@@ -49,7 +49,7 @@ test('StyleLayer#resolvePaint', function(t) {
 
 //test('StyleLayer#cascade', function(t) {
 //    t.test('applies default transitions', function(t) {
-//        var layer = new StyleLayer({
+//        var layer = StyleLayer.create({
 //            type: 'fill',
 //            paint: {
 //                'fill-color': 'blue'
@@ -68,7 +68,7 @@ test('StyleLayer#resolvePaint', function(t) {
 
 test('StyleLayer#setPaintProperty', function(t) {
     t.test('sets new property value', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "background",
             "type": "background"
         });
@@ -80,7 +80,7 @@ test('StyleLayer#setPaintProperty', function(t) {
     });
 
     t.test('updates property value', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "background",
             "type": "background",
             "paint": {
@@ -96,7 +96,7 @@ test('StyleLayer#setPaintProperty', function(t) {
     });
 
     t.test('unsets property value', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "background",
             "type": "background",
             "paint": {
@@ -112,7 +112,7 @@ test('StyleLayer#setPaintProperty', function(t) {
     });
 
     t.test('sets classed paint value', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "background",
             "type": "background",
             "paint.night": {
@@ -128,7 +128,7 @@ test('StyleLayer#setPaintProperty', function(t) {
     });
 
     t.test('unsets classed paint value', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "background",
             "type": "background",
             "paint.night": {
@@ -144,7 +144,7 @@ test('StyleLayer#setPaintProperty', function(t) {
     });
 
     t.test('preserves existing transition', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "background",
             "type": "background",
             "paint": {
@@ -163,7 +163,7 @@ test('StyleLayer#setPaintProperty', function(t) {
     });
 
     t.test('sets transition', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "background",
             "type": "background",
             "paint": {
@@ -181,7 +181,7 @@ test('StyleLayer#setPaintProperty', function(t) {
 
 test('StyleLayer#setLayoutProperty', function(t) {
     t.test('sets new property value', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "symbol",
             "type": "symbol"
         });
@@ -194,7 +194,7 @@ test('StyleLayer#setLayoutProperty', function(t) {
     });
 
     t.test('updates property value', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "symbol",
             "type": "symbol",
             "layout": {
@@ -210,7 +210,7 @@ test('StyleLayer#setLayoutProperty', function(t) {
     });
 
     t.test('unsets property value', function(t) {
-        var layer = new StyleLayer({
+        var layer = StyleLayer.create({
             "id": "symbol",
             "type": "symbol",
             "layout": {

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -2,6 +2,7 @@
 
 var test = require('prova');
 var StyleLayer = require('../../../js/style/style_layer');
+var FillStyleLayer = require('../../../js/style/style_layer/fill_style_layer');
 var LayoutProperties = require('../../../js/style/layout_properties');
 
 test('StyleLayer', function(t) {
@@ -19,6 +20,13 @@ test('StyleLayer', function(t) {
         );
 
         t.equal(layer.type, 'fill');
+        t.end();
+    });
+
+    t.test('instantiates the correct subclass', function (t) {
+        var layer = StyleLayer.create({type: 'fill'});
+
+        t.ok(layer instanceof FillStyleLayer);
         t.end();
     });
 });

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -9,7 +9,7 @@ test('util', function(t) {
     t.equal(util.easeCubicInOut(0.2), 0.03200000000000001);
     t.equal(util.easeCubicInOut(0.5), 0.5, 'easeCubicInOut=0.5');
     t.equal(util.easeCubicInOut(1), 1, 'easeCubicInOut=1');
-    t.deepEqual(util.premultiply([0, 1, 2, 2]), [0, 2, 4, 2], 'premultiply');
+    t.deepEqual(util.premultiply([0, 0.5, 1, 0.5], 0.5), [0, 0.125, 0.25, 0.25], 'premultiply');
     t.deepEqual(util.keysDifference({a:1}, {}), ['a'], 'keysDifference');
     t.deepEqual(util.keysDifference({a:1}, {a:1}), [], 'keysDifference');
     t.deepEqual(util.extend({a:1}, {b:2}), {a:1, b:2}, 'extend');


### PR DESCRIPTION
This PR is some housecleaning before I tackle #1957 

# Next Steps

 - [x] Add `StyleLayer.create` factory function
 - [x] Remove `StyleLayer#resolveReference` method
 - [x] Shore up `StyleLayer` terminology
 - [x] Add `StyleLayer` subclasses
 - [x] Move all layer-type-specific logic into `StyleLayer` subclasses
 - [x] Traipse back in time to remove source-layer TODO and _refLayer property
 - [x] Create `StyleLayer#isHidden` method
 - [x] Inline `premultiplyLayer`
 - [x] Rename `source-layer` to `sourceLayer`
 - [x] Performance testing
