### PR TITLE
Override tileSize, tile API urls for mapbox raster sources

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -5,11 +5,14 @@ var ajax = require('../util/ajax');
 var Evented = require('../util/evented');
 var Source = require('./source');
 var normalizeURL = require('../util/mapbox').normalizeTileURL;
+var normalizeTileSize = require('../util/mapbox').normalizeTileSize;
 
 module.exports = RasterTileSource;
 
 function RasterTileSource(options) {
     util.extend(this, util.pick(options, ['url', 'tileSize']));
+
+    this.tileSize = normalizeTileSize(this.tileSize, this.url);
 
     Source._loadTileJSON.call(this, options);
 }

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -69,7 +69,16 @@ module.exports.normalizeTileURL = function(url, sourceUrl) {
     if (!sourceUrl || !sourceUrl.match(/^mapbox:\/\//))
         return url;
 
+    // Mapbox raster sources always use the @2x suffix on the v4 tile API
+    // to ensure a maximum 512 image size.
     url = url.replace(/([?&]access_token=)tk\.[^&]+/, '$1' + config.ACCESS_TOKEN);
     var extension = browser.supportsWebp ? 'webp' : '$1';
-    return url.replace(/\.((?:png|jpg)\d*)(?=$|\?)/, browser.devicePixelRatio >= 2 ? '@2x.' + extension : '.' + extension);
+    return url.replace(/\.((?:png|jpg)\d*)(?=$|\?)/, '@2x.' + extension);
 };
+
+module.exports.normalizeTileSize = function(tileSize, sourceUrl) {
+    if (!sourceUrl || !sourceUrl.match(/^mapbox:\/\//))
+        return tileSize;
+    return browser.devicePixelRatio >= 2 ? 256 : 512;
+};
+

--- a/test/js/util/mapbox.test.js
+++ b/test/js/util/mapbox.test.js
@@ -102,29 +102,25 @@ test("mapbox", function(t) {
     });
 
     t.test('.normalizeTileURL', function(t) {
-        t.test('does nothing on 1x devices', function(t) {
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile.png');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile.png32');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile.jpg70');
+        t.test('no-op for all vector URLs', function(t) {
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.vector.pbf', mapboxSource), 'http://path.png/tile.vector.pbf');
             t.end();
         });
 
-        t.test('inserts @2x on 2x devices', function(t) {
-            browser.devicePixelRatio = 2;
+        t.test('inserts @2x for all image URLs', function(t) {
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile@2x.png');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile@2x.png32');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile@2x.jpg70');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource), 'http://path.png/tile@2x.png?access_token=foo');
-            browser.devicePixelRatio = 1;
             t.end();
         });
 
         t.test('replaces img extension with webp on supporting devices', function(t) {
             browser.supportsWebp = true;
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile.webp');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile.webp');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile.webp');
-            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource), 'http://path.png/tile.webp?access_token=foo');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile@2x.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile@2x.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile@2x.webp');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource), 'http://path.png/tile@2x.webp?access_token=foo');
             browser.supportsWebp = false;
             t.end();
         });
@@ -140,9 +136,9 @@ test("mapbox", function(t) {
         });
 
         t.test('replace temp access tokens with the latest token', function(t) {
-            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tk.abc.123', mapboxSource), 'http://example.com/tile.png?access_token=key');
-            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?foo=bar&access_token=tk.abc.123', mapboxSource), 'http://example.com/tile.png?foo=bar&access_token=key');
-            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tk.abc.123&foo=bar', 'mapbox://user.map'), 'http://example.com/tile.png?access_token=key&foo=bar');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tk.abc.123', mapboxSource), 'http://example.com/tile@2x.png?access_token=key');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?foo=bar&access_token=tk.abc.123', mapboxSource), 'http://example.com/tile@2x.png?foo=bar&access_token=key');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tk.abc.123&foo=bar', 'mapbox://user.map'), 'http://example.com/tile@2x.png?access_token=key&foo=bar');
             t.end();
         });
 
@@ -152,8 +148,44 @@ test("mapbox", function(t) {
         });
 
         t.test('does not modify the access token for non temp tokens', function(t) {
-            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=pk.abc.123', mapboxSource), 'http://example.com/tile.png?access_token=pk.abc.123');
-            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tkk.abc.123', mapboxSource), 'http://example.com/tile.png?access_token=tkk.abc.123');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=pk.abc.123', mapboxSource), 'http://example.com/tile@2x.png?access_token=pk.abc.123');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tkk.abc.123', mapboxSource), 'http://example.com/tile@2x.png?access_token=tkk.abc.123');
+            t.end();
+        });
+
+        t.end();
+    });
+
+    t.test('.normalizeTileSize', function(t) {
+        t.test('512 on 1x devices', function(t) {
+            t.equal(mapbox.normalizeTileSize(64, mapboxSource), 512);
+            t.equal(mapbox.normalizeTileSize(128, mapboxSource), 512);
+            t.equal(mapbox.normalizeTileSize(256, mapboxSource), 512);
+            t.equal(mapbox.normalizeTileSize(512, mapboxSource), 512);
+            t.end();
+        });
+
+        t.test('256 on 2x devices', function(t) {
+            browser.devicePixelRatio = 2;
+            t.equal(mapbox.normalizeTileSize(64, mapboxSource), 256);
+            t.equal(mapbox.normalizeTileSize(128, mapboxSource), 256);
+            t.equal(mapbox.normalizeTileSize(256, mapboxSource), 256);
+            t.equal(mapbox.normalizeTileSize(512, mapboxSource), 256);
+            browser.devicePixelRatio = 1;
+            t.end();
+        });
+
+        t.test('no-op on non-mapbox sources', function(t) {
+            t.equal(mapbox.normalizeTileSize(64, nonMapboxSource), 64);
+            t.equal(mapbox.normalizeTileSize(128, nonMapboxSource), 128);
+            t.equal(mapbox.normalizeTileSize(256, nonMapboxSource), 256);
+            t.equal(mapbox.normalizeTileSize(512, nonMapboxSource), 512);
+            browser.devicePixelRatio = 2;
+            t.equal(mapbox.normalizeTileSize(64, nonMapboxSource), 64);
+            t.equal(mapbox.normalizeTileSize(128, nonMapboxSource), 128);
+            t.equal(mapbox.normalizeTileSize(256, nonMapboxSource), 256);
+            t.equal(mapbox.normalizeTileSize(512, nonMapboxSource), 512);
+            browser.devicePixelRatio = 1;
             t.end();
         });
 


### PR DESCRIPTION
Revision of https://github.com/mapbox/mapbox-gl-js/pull/1964. After discussion with @jfirebaugh, settled on the following approach:

- Always uses the max dimension image tiles from the mapbox v4 tile API (atm 512x512 tiles using the `@2x` suffix).
- Ignore the source-defined `tileSize` parameter for `mapbox://` raster sources. Instead, pick an optimal `tileSize` based on the `devicePixelRatio` -- in this case, 256 for hidpi devices and 512 for all others.

The main effect of this change is that users on non hidpi devices will load and render fewer tiles at a time (as they cover much more screenspace). Also by removing consideration of the `tileSize` property on Mapbox sources we're leaving no obligations to custom styles in the future when we're ready to make adjustments to this behavior.

cc @jfirebaugh @kkaefer 