### PR TITLE
fix collision debug for overscaled tiles

### DIFF
--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -2,7 +2,7 @@
 
 module.exports = drawCollisionDebug;
 
-function drawCollisionDebug(painter, layer, coord, tile) {
+function drawCollisionDebug(painter, layer, coord, tile, source) {
     if (!tile.buffers) return;
     var elementGroups = tile.getElementGroups(layer, 'collisionBox');
     if (!elementGroups) return;
@@ -10,7 +10,7 @@ function drawCollisionDebug(painter, layer, coord, tile) {
     var gl = painter.gl;
     var buffer = tile.buffers.collisionBoxVertex;
     var shader = painter.collisionBoxShader;
-    var posMatrix = painter.calculatePosMatrix(coord, tile.tileExtent);
+    var posMatrix = painter.calculatePosMatrix(coord, tile.tileExtent, source.maxzoom);
 
     gl.enable(gl.STENCIL_TEST);
     painter.enableTileClippingMask(coord);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -60,7 +60,7 @@ function drawSymbols(painter, source, layer, coords) {
     for (var k = 0; k < coords.length; k++) {
         tile = source.getTile(coords[k]);
         painter.enableTileClippingMask(coords[k]);
-        drawCollisionDebug(painter, layer, coords[k], tile);
+        drawCollisionDebug(painter, layer, coords[k], tile, source);
     }
 
     if (drawAcrossEdges) {


### PR DESCRIPTION
Collision debug rendering was broken for overscaled tiles. Related to https://github.com/mapbox/mapbox-gl-js/issues/1912

@lucaswoj look ok?