### PR TITLE
don't trigger a zoom by 0

### DIFF
--- a/js/ui/handler/scroll_zoom.js
+++ b/js/ui/handler/scroll_zoom.js
@@ -97,6 +97,7 @@ ScrollZoom.prototype = {
     },
 
     _zoom: function (delta, e) {
+        if (delta === 0) return;
         var map = this._map;
 
         // Scale by sigmoid of scroll wheel delta.


### PR DESCRIPTION
Touching a trackpad with two fingers was triggering a zoom by 0, which was making icons jump around (switching from nearest neighbour to linear interpolation).

look ok @lucaswoj?