### PR TITLE
Allow GeoJSON to be passed as stringify JSON.

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -12,7 +12,7 @@ module.exports = GeoJSONSource;
  * Create a GeoJSON data source instance given an options object
  * @class GeoJSONSource
  * @param {Object} [options]
- * @param {Object|string} options.data A GeoJSON data object or URL to it. The latter is preferable in case of large GeoJSON files.
+ * @param {Object|string} options.data A GeoJSON data object, a JSON.stringified GeoJSON data object (slightly faster than former option), or URL to it (preferable in case of large GeoJSON files).
  * @param {number} [options.maxzoom=14] Maximum zoom to preserve detail at.
  * @param {number} [options.buffer] Tile buffer on each side.
  * @param {number} [options.tolerance] Simplification tolerance (higher means simpler).
@@ -81,7 +81,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     /**
      * Update source geojson data and rerender map
      *
-     * @param {Object|string} data A GeoJSON data object or URL to it. The latter is preferable in case of large GeoJSON files.
+     * @param {Object|string} data A GeoJSON data object, a JSON.stringified GeoJSON data object (slightly faster than former option), or URL to it (preferable in case of large GeoJSON files).
      * @returns {GeoJSONSource} this
      */
     setData: function(data) {
@@ -129,7 +129,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     _updateData: function() {
         this._dirty = false;
         var data = this._data;
-        if (typeof data === 'string' && typeof window != 'undefined') {
+        if (typeof data === 'string' && typeof window != 'undefined' && data.charAt(0) !== '{') {
             data = urlResolve(window.location.href, data);
         }
         this.workerID = this.dispatcher.send('parse geojson', {

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -122,7 +122,11 @@ util.extend(Worker.prototype, {
         // ie: /foo/bar.json or http://example.com/bar.json
         // but not ../foo/bar.json
         if (typeof params.data === 'string') {
-            ajax.getJSON(params.data, indexData);
+            if (params.data.charAt(0) === '{') {
+                indexData(null, JSON.parse(params.data));
+            } else {
+                ajax.getJSON(params.data, indexData);
+            }
         }
         else indexData(null, params.data);
     },

--- a/test/js/source/worker.test.js
+++ b/test/js/source/worker.test.js
@@ -77,6 +77,54 @@ test('remove tile', function(t) {
     });
 });
 
+test('geojson', function(t) {
+    var geojson = {
+        "type": "FeatureCollection",
+        "features": [{
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                    [-122.48369693756104, 37.83381888486939],
+                    [-122.48348236083984, 37.83317489144141]
+                ]
+            }
+        }]
+    };
+
+    // test parsing of GeoJSON in native and stringified form.
+    [geojson, JSON.stringify(geojson)].forEach(function (data) {
+        t.test('parses geojson', function(t) {
+            var worker = new Worker(_self);
+
+            worker.loaded = {
+                source: {
+                    '0': {}
+                }
+            };
+
+            t.deepEqual(worker.geoJSONIndexes, {});
+            worker['parse geojson']({
+                data: data,
+                tileSize: 512,
+                source: "test",
+                geojsonVtOptions: { maxZoom: 20 },
+                cluster: false,
+                superclusterOptions: {
+                    maxZoom: 19,
+                    extent: 4096,
+                    radius: 400,
+                    log: false
+                }
+            }, function() {
+                t.notDeepEqual(worker.geoJSONIndexes, {});
+                t.end();
+            });
+        });
+    });
+});
+
 test('after', function(t) {
     server.close(t.end);
 });


### PR DESCRIPTION
Mitigation for #1504.

With a complex GeoJSON object (say 20k features with 100k coordinates) the `postMessage` call to the worker takes several seconds on the UI thread. By manually `JSON.stringify`ing the GeoJSON object and `JSON.parse`ing on the worker side we're seeing a 6x perf improvement.

Ideally we would figure out a way to use transferables or similar (there is still a small UI freeze in our usage), but this is a step in the right direction.