### PR TITLE
Disable drag on mousedown in boxzoom handler

### DIFF
--- a/js/ui/handler/box_zoom.js
+++ b/js/ui/handler/box_zoom.js
@@ -31,6 +31,7 @@ BoxZoom.prototype = {
         document.addEventListener('keydown', this._onKeyDown, false);
         document.addEventListener('mouseup', this._onMouseUp, false);
 
+        DOM.disableDrag();
         this._startPos = DOM.mousePos(this._el, e);
         this.active = true;
     },
@@ -42,9 +43,6 @@ BoxZoom.prototype = {
         if (!this._box) {
             this._box = DOM.create('div', 'mapboxgl-boxzoom', this._container);
             this._container.classList.add('mapboxgl-crosshair');
-
-            DOM.disableDrag();
-
             this._fireEvent('boxzoomstart', e);
         }
 


### PR DESCRIPTION
This just disables userselect on mousedown when boxzooming.  The previous code disabled it on mousemove, which was too late to avoid extending the user selection.
(closes #1907)

For comparison, select some text in the sidebar and then do a boxzoom on the map:
previous:  http://codepen.io/anon/pen/adWvOO
current:  http://codepen.io/bhousel/pen/OMZRwM
