### PR TITLE
support tiles with extent != 4096

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -49,7 +49,6 @@ Bucket.AttributeType = Buffer.AttributeType;
  */
 function Bucket(options) {
     this.zoom = options.zoom;
-    this.tileExtent = options.tileExtent;
 
     this.layer = StyleLayer.create(options.layer);
     this.layer.recalculate(this.zoom, { lastIntegerZoom: Infinity, lastIntegerZoomTime: 0, lastZoom: 0 });

--- a/js/data/buffer.js
+++ b/js/data/buffer.js
@@ -250,6 +250,22 @@ Buffer.AttributeType = {
 Buffer.ELEMENT_ATTRIBUTE_TYPE = Buffer.AttributeType.UNSIGNED_SHORT;
 
 /**
+ * The maximum extent of a feature that can be safely stored in the buffer.
+ * In practice, all features are converted to this extent before being added.
+ *
+ * Positions are stored as signed 16bit integers.
+ * One bit is lost for signedness to support featuers extending past the left edge of the tile.
+ * One bit is lost because the line vertex buffer packs 1 bit of other data into the int.
+ * One bit is lost to support features extending past the extent on the right edge of the tile.
+ * This leaves us with 2^13 = 8192
+ *
+ * @property {number}
+ * @private
+ * @readonly
+ */
+Buffer.EXTENT = 8192;
+
+/**
  * @property {number}
  * @private
  * @readonly

--- a/js/data/circle_bucket.js
+++ b/js/data/circle_bucket.js
@@ -2,6 +2,8 @@
 
 var Bucket = require('./bucket');
 var util = require('../util/util');
+var loadGeometry = require('./load_geometry');
+var EXTENT = require('./buffer').EXTENT;
 
 module.exports = CircleBucket;
 
@@ -39,7 +41,7 @@ CircleBucket.prototype.shaders = {
 
 CircleBucket.prototype.addFeature = function(feature) {
 
-    var geometries = feature.loadGeometry()[0];
+    var geometries = loadGeometry(feature)[0];
     for (var j = 0; j < geometries.length; j++) {
         var group = this.makeRoomFor('circle', 4);
 
@@ -47,7 +49,7 @@ CircleBucket.prototype.addFeature = function(feature) {
         var y = geometries[j].y;
 
         // Do not include points that are outside the tile boundaries.
-        if (x < 0 || x >= this.tileExtent || y < 0 || y >= this.tileExtent) continue;
+        if (x < 0 || x >= EXTENT || y < 0 || y >= EXTENT) continue;
 
         // this geometry will be of the Point type, and we'll derive
         // two triangles from it.

--- a/js/data/fill_bucket.js
+++ b/js/data/fill_bucket.js
@@ -2,6 +2,7 @@
 
 var Bucket = require('./bucket');
 var util = require('../util/util');
+var loadGeometry = require('./load_geometry');
 
 module.exports = FillBucket;
 
@@ -30,7 +31,7 @@ FillBucket.prototype.shaders = {
 };
 
 FillBucket.prototype.addFeature = function(feature) {
-    var lines = feature.loadGeometry();
+    var lines = loadGeometry(feature);
     for (var i = 0; i < lines.length; i++) {
         this.addFill(lines[i]);
     }

--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -2,6 +2,7 @@
 
 var Bucket = require('./bucket');
 var util = require('../util/util');
+var loadGeometry = require('./load_geometry');
 
 // NOTE ON EXTRUDE SCALE:
 // scale the extrusion vector so that the normal length is this value.
@@ -54,7 +55,7 @@ LineBucket.prototype.shaders = {
 };
 
 LineBucket.prototype.addFeature = function(feature) {
-    var lines = feature.loadGeometry();
+    var lines = loadGeometry(feature);
     for (var i = 0; i < lines.length; i++) {
         this.addLine(
             lines[i],

--- a/js/data/load_geometry.js
+++ b/js/data/load_geometry.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var EXTENT = require('./buffer').EXTENT;
+
+/**
+ * Loads a geometry from a VectorTileFeature and scales it to the common extent
+ * used internally.
+ * @private
+ */
+module.exports = function loadGeometry(feature) {
+    var scale = EXTENT / feature.extent;
+    var geometry = feature.loadGeometry();
+    for (var r = 0; r < geometry.length; r++) {
+        var ring = geometry[r];
+        for (var p = 0; p < ring.length; p++) {
+            var point = ring[p];
+            // round here because mapbox-gl-native uses integers to represent
+            // points and we need to do the same to avoid renering differences.
+            point.x = Math.round(point.x * scale);
+            point.y = Math.round(point.y * scale);
+        }
+    }
+    return geometry;
+};

--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -17,6 +17,8 @@ var getGlyphQuads = Quads.getGlyphQuads;
 var getIconQuads = Quads.getIconQuads;
 var clipLine = require('../symbol/clip_line');
 var util = require('../util/util');
+var loadGeometry = require('./load_geometry');
+var EXTENT = require('./buffer').EXTENT;
 
 var CollisionFeature = require('../symbol/collision_feature');
 
@@ -125,7 +127,7 @@ SymbolBucket.prototype.shaders = {
 
 SymbolBucket.prototype.addFeatures = function(collisionTile, stacks, icons) {
     var tileSize = 512 * this.overscaling;
-    this.tilePixelRatio = this.tileExtent / tileSize;
+    this.tilePixelRatio = EXTENT / tileSize;
     this.compareText = {};
     this.symbolInstances = [];
     this.iconsNeedLinear = false;
@@ -176,7 +178,7 @@ SymbolBucket.prototype.addFeatures = function(collisionTile, stacks, icons) {
 
     var geometries = [];
     for (var g = 0; g < features.length; g++) {
-        geometries.push(features[g].loadGeometry());
+        geometries.push(loadGeometry(features[g]));
     }
 
     if (layout['symbol-placement'] === 'line') {
@@ -251,7 +253,7 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
         textRepeatDistance = symbolMinDistance / 2;
 
     if (isLine) {
-        lines = clipLine(lines, 0, 0, this.tileExtent, this.tileExtent);
+        lines = clipLine(lines, 0, 0, EXTENT, EXTENT);
     }
 
     for (var i = 0; i < lines.length; i++) {
@@ -269,7 +271,7 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
                 glyphSize,
                 textMaxBoxScale,
                 this.overscaling,
-                this.tileExtent
+                EXTENT
             );
         } else {
             anchors = [ new Anchor(line[0].x, line[0].y, 0) ];
@@ -285,7 +287,7 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
                 }
             }
 
-            var inside = !(anchor.x < 0 || anchor.x > this.tileExtent || anchor.y < 0 || anchor.y > this.tileExtent);
+            var inside = !(anchor.x < 0 || anchor.x > EXTENT || anchor.y < 0 || anchor.y > EXTENT);
 
             if (avoidEdges && !inside) continue;
 

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -3,6 +3,7 @@
 var TilePyramid = require('../source/tile_pyramid');
 var pyramid = new TilePyramid({ tileSize: 512 });
 var util = require('../util/util');
+var EXTENT = require('../data/buffer').EXTENT;
 
 module.exports = drawBackground;
 
@@ -34,7 +35,7 @@ function drawBackground(painter, source, layer) {
 
         gl.uniform1f(shader.u_mix, image.t);
 
-        var factor = (painter.tileExtent / transform.tileSize) / Math.pow(2, 0);
+        var factor = (EXTENT / transform.tileSize) / Math.pow(2, 0);
 
         gl.uniform2fv(shader.u_patternscale_a, [
             1 / (imagePosA.size[0] * factor * image.fromScale),
@@ -69,7 +70,7 @@ function drawBackground(painter, source, layer) {
     // we don't have so much going on in the stencil buffer.
     var coords = pyramid.coveringTiles(transform);
     for (var c = 0; c < coords.length; c++) {
-        gl.setPosMatrix(painter.calculatePosMatrix(coords[c], painter.tileExtent));
+        gl.setPosMatrix(painter.calculatePosMatrix(coords[c]));
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
     }
 

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -43,7 +43,7 @@ function drawCircles(painter, source, layer, coords) {
         var elements = tile.buffers.circleElement;
 
         gl.setPosMatrix(painter.translatePosMatrix(
-            painter.calculatePosMatrix(coord, tile.tileExtent, source.maxzoom),
+            painter.calculatePosMatrix(coord, source.maxzoom),
             tile,
             layer.paint['circle-translate'],
             layer.paint['circle-translate-anchor']

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -10,7 +10,7 @@ function drawCollisionDebug(painter, layer, coord, tile) {
     var gl = painter.gl;
     var buffer = tile.buffers.collisionBoxVertex;
     var shader = painter.collisionBoxShader;
-    var posMatrix = painter.calculatePosMatrix(coord, tile.tileExtent);
+    var posMatrix = painter.calculatePosMatrix(coord);
 
     gl.enable(gl.STENCIL_TEST);
     painter.enableTileClippingMask(coord);

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -18,7 +18,7 @@ function drawDebugTile(painter, coord) {
     var gl = painter.gl;
 
     var shader = painter.debugShader;
-    gl.switchShader(shader, painter.calculatePosMatrix(coord, painter.tileExtent));
+    gl.switchShader(shader, painter.calculatePosMatrix(coord));
 
     // draw bounding rectangle
     gl.bindBuffer(gl.ARRAY_BUFFER, painter.debugBuffer);

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -62,7 +62,7 @@ function drawFill(painter, source, layer, coord) {
     var image = layer.paint['fill-pattern'];
     var opacity = layer.paint['fill-opacity'];
 
-    var posMatrix = painter.calculatePosMatrix(coord, tile.tileExtent, source.maxzoom);
+    var posMatrix = painter.calculatePosMatrix(coord, source.maxzoom);
     var translatedPosMatrix = painter.translatePosMatrix(posMatrix, tile, layer.paint['fill-translate'], layer.paint['fill-translate-anchor']);
 
     // Draw the stencil mask.
@@ -137,7 +137,6 @@ function drawFill(painter, source, layer, coord) {
         gl.uniform1f(shader.u_mix, image.t);
 
         var scale = Math.pow(2, painter.transform.tileZoom - tile.coord.z);
-        var factor = tile.tileExtent / tile.tileSize;
 
         var imageSizeScaledA = [
             (imagePosA.size[0] * image.fromScale) / scale,
@@ -149,13 +148,13 @@ function drawFill(painter, source, layer, coord) {
         ];
 
         gl.uniform2fv(shader.u_patternscale_a, [
-            1 / (imageSizeScaledA[0] * factor),
-            1 / (imageSizeScaledA[1] * factor)
+            1 / (imageSizeScaledA[0] * tile.pixelRatio),
+            1 / (imageSizeScaledA[1] * tile.pixelRatio)
         ]);
 
         gl.uniform2fv(shader.u_patternscale_b, [
-            1 / (imageSizeScaledB[0] * factor),
-            1 / (imageSizeScaledB[1] * factor)
+            1 / (imageSizeScaledB[0] * tile.pixelRatio),
+            1 / (imageSizeScaledB[1] * tile.pixelRatio)
         ]);
 
         // shift images to match at tile boundaries
@@ -195,7 +194,7 @@ function drawStroke(painter, source, layer, coord) {
     var elementGroups = tile.elementGroups[layer.ref || layer.id].fill;
 
     gl.setPosMatrix(painter.translatePosMatrix(
-        painter.calculatePosMatrix(coord, tile.tileExtent, source.maxzoom),
+        painter.calculatePosMatrix(coord, source.maxzoom),
         tile,
         layer.paint['fill-translate'],
         layer.paint['fill-translate-anchor']

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -136,33 +136,33 @@ function drawFill(painter, source, layer, coord) {
         gl.uniform1f(shader.u_opacity, opacity);
         gl.uniform1f(shader.u_mix, image.t);
 
-        var scale = Math.pow(2, painter.transform.tileZoom - tile.coord.z);
-
         var imageSizeScaledA = [
-            (imagePosA.size[0] * image.fromScale) / scale,
-            (imagePosA.size[1] * image.fromScale) / scale
+            (imagePosA.size[0] * image.fromScale),
+            (imagePosA.size[1] * image.fromScale)
         ];
         var imageSizeScaledB = [
-            (imagePosB.size[0] * image.toScale) / scale,
-            (imagePosB.size[1] * image.toScale) / scale
+            (imagePosB.size[0] * image.toScale),
+            (imagePosB.size[1] * image.toScale)
         ];
 
         gl.uniform2fv(shader.u_patternscale_a, [
-            1 / (imageSizeScaledA[0] * tile.pixelRatio),
-            1 / (imageSizeScaledA[1] * tile.pixelRatio)
+            1 / tile.pixelsToTileUnits(imageSizeScaledA[0], painter.transform.tileZoom),
+            1 / tile.pixelsToTileUnits(imageSizeScaledA[1], painter.transform.tileZoom)
         ]);
 
         gl.uniform2fv(shader.u_patternscale_b, [
-            1 / (imageSizeScaledB[0] * tile.pixelRatio),
-            1 / (imageSizeScaledB[1] * tile.pixelRatio)
+            1 / tile.pixelsToTileUnits(imageSizeScaledB[0], painter.transform.tileZoom),
+            1 / tile.pixelsToTileUnits(imageSizeScaledB[1], painter.transform.tileZoom)
         ]);
 
-        // shift images to match at tile boundaries
-        var offsetAx = ((tile.tileSize % imageSizeScaledA[0]) * (tile.coord.x + coord.w * Math.pow(2, tile.coord.z))) / imageSizeScaledA[0];
-        var offsetAy = ((tile.tileSize % imageSizeScaledA[1]) * tile.coord.y) / imageSizeScaledA[1];
+        var tileSizeAtNearestZoom = tile.tileSize * Math.pow(2, painter.transform.tileZoom - tile.coord.z);
 
-        var offsetBx = ((tile.tileSize % imageSizeScaledB[0]) * (tile.coord.x + coord.w * Math.pow(2, tile.coord.z))) / imageSizeScaledB[0];
-        var offsetBy = ((tile.tileSize % imageSizeScaledB[1]) * tile.coord.y) / imageSizeScaledB[1];
+        // shift images to match at tile boundaries
+        var offsetAx = ((tileSizeAtNearestZoom / imageSizeScaledA[0]) % 1) * (tile.coord.x + coord.w * Math.pow(2, tile.coord.z));
+        var offsetAy = ((tileSizeAtNearestZoom / imageSizeScaledA[1]) % 1) * tile.coord.y;
+
+        var offsetBx = ((tileSizeAtNearestZoom / imageSizeScaledB[0]) % 1) * (tile.coord.x + coord.w * Math.pow(2, tile.coord.z));
+        var offsetBy = ((tileSizeAtNearestZoom / imageSizeScaledB[1]) % 1) * tile.coord.y;
 
         gl.uniform2fv(shader.u_offset_a, [offsetAx, offsetAy]);
         gl.uniform2fv(shader.u_offset_b, [offsetBx, offsetBy]);

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -132,18 +132,15 @@ module.exports = function drawLine(painter, source, layer, coords) {
         painter.enableTileClippingMask(coord);
 
         // set uniforms that are different for each tile
-        var posMatrix = painter.translatePosMatrix(painter.calculatePosMatrix(coord, tile.tileExtent, source.maxzoom), tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
+        var posMatrix = painter.translatePosMatrix(painter.calculatePosMatrix(coord, source.maxzoom), tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
 
         gl.setPosMatrix(posMatrix);
         gl.setExMatrix(painter.transform.exMatrix);
-        var ratio = painter.transform.scale / (1 << coord.z) / (tile.tileExtent / tile.tileSize);
+        var ratio = painter.transform.scale / (1 << coord.z) / tile.pixelRatio;
 
 
         if (dasharray) {
-            // how much the tile is overscaled by
-            var overscaling = tile.tileSize / painter.transform.tileSize;
-
-            var patternratio = Math.pow(2, Math.floor(Math.log(painter.transform.scale) / Math.LN2) - coord.z) / 8 * overscaling;
+            var patternratio = Math.pow(2, Math.floor(Math.log(painter.transform.scale) / Math.LN2) - coord.z) / tile.pixelRatio;
             var scaleA = [patternratio / posA.width / dasharray.fromScale, -posA.height / 2];
             var gammaA = painter.lineAtlas.width / (dasharray.fromScale * posA.width * 256 * browser.devicePixelRatio) / 2;
             var scaleB = [patternratio / posB.width / dasharray.toScale, -posB.height / 2];
@@ -154,7 +151,7 @@ module.exports = function drawLine(painter, source, layer, coords) {
             gl.uniform1f(shader.u_sdfgamma, Math.max(gammaA, gammaB));
 
         } else if (image) {
-            var factor = tile.tileExtent / tile.tileSize / Math.pow(2, painter.transform.tileZoom - coord.z);
+            var factor = tile.pixelRatio / Math.pow(2, painter.transform.tileZoom - coord.z);
             gl.uniform1f(shader.u_ratio, ratio);
             gl.uniform2fv(shader.u_pattern_size_a, [imagePosA.size[0] * factor * image.fromScale, imagePosB.size[1] ]);
             gl.uniform2fv(shader.u_pattern_size_b, [imagePosB.size[0] * factor * image.toScale, imagePosB.size[1] ]);

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -28,7 +28,7 @@ function drawRasterTile(painter, source, layer, coord) {
     gl.disable(gl.STENCIL_TEST);
 
     var tile = source.getTile(coord);
-    var posMatrix = painter.calculatePosMatrix(coord, tile.tileExtent, source.maxzoom);
+    var posMatrix = painter.calculatePosMatrix(coord, source.maxzoom);
 
     var shader = painter.rasterShader;
     gl.switchShader(shader, posMatrix);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -86,7 +86,7 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf,
 
     if (skewed) {
         exMatrix = mat4.create();
-        s = tile.pixelRatio / Math.pow(2, painter.transform.zoom - tile.coord.z);
+        s = tile.pixelsToTileUnits(1, painter.transform.zoom);
         gammaScale = 1 / Math.cos(tr._pitch);
     } else {
         exMatrix = mat4.clone(painter.transform.exMatrix);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -39,7 +39,7 @@ function drawSymbols(painter, source, layer, coords) {
         if (!elementGroups) continue;
         if (!elementGroups.icon.groups.length) continue;
 
-        posMatrix = painter.calculatePosMatrix(coords[i], tile.tileExtent, source.maxzoom);
+        posMatrix = painter.calculatePosMatrix(coords[i], source.maxzoom);
         painter.enableTileClippingMask(coords[i]);
         drawSymbol(painter, layer, posMatrix, tile, elementGroups.icon, 'icon', elementGroups.sdfIcons, elementGroups.iconsNeedLinear);
     }
@@ -52,7 +52,7 @@ function drawSymbols(painter, source, layer, coords) {
         if (!elementGroups) continue;
         if (!elementGroups.glyph.groups.length) continue;
 
-        posMatrix = painter.calculatePosMatrix(coords[j], tile.tileExtent, source.maxzoom);
+        posMatrix = painter.calculatePosMatrix(coords[j], source.maxzoom);
         painter.enableTileClippingMask(coords[j]);
         drawSymbol(painter, layer, posMatrix, tile, elementGroups.glyph, 'text', true, false);
     }
@@ -86,7 +86,7 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf,
 
     if (skewed) {
         exMatrix = mat4.create();
-        s = tile.tileExtent / tile.tileSize / Math.pow(2, painter.transform.zoom - tile.coord.z);
+        s = tile.pixelRatio / Math.pow(2, painter.transform.zoom - tile.coord.z);
         gammaScale = 1 / Math.cos(tr._pitch);
     } else {
         exMatrix = mat4.clone(painter.transform.exMatrix);

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -350,10 +350,9 @@ Painter.prototype.translatePosMatrix = function(matrix, tile, translate, anchor)
         ];
     }
 
-    var ratio = this.transform.scale / (1 << tile.coord.z) / tile.pixelRatio;
     var translation = [
-        translate[0] / ratio,
-        translate[1] / ratio,
+        tile.pixelsToTileUnits(translate[0], this.transform.zoom),
+        tile.pixelsToTileUnits(translate[1], this.transform.zoom),
         0
     ];
 

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -46,7 +46,9 @@ function GeoJSONSource(options) {
 
     if (options.maxzoom !== undefined) this.maxzoom = options.maxzoom;
 
-    this.geojsonVtOptions = {maxZoom: this.maxzoom};
+    this.geojsonVtOptions = {
+        maxZoom: this.maxzoom
+    };
     if (options.buffer !== undefined) this.geojsonVtOptions.buffer = options.buffer;
     if (options.tolerance !== undefined) this.geojsonVtOptions.tolerance = options.tolerance;
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -6,6 +6,7 @@ var LngLat = require('../geo/lng_lat');
 var Point = require('point-geometry');
 var Evented = require('../util/evented');
 var ajax = require('../util/ajax');
+var EXTENT = require('../data/buffer').EXTENT;
 
 module.exports = ImageSource;
 
@@ -71,12 +72,11 @@ ImageSource.prototype = util.inherit(Evented, {
 
         var centerCoord = this.centerCoord = util.getCoordinatesCenter(cornerZ0Coords);
 
-        var tileExtent = 4096;
         var tileCoords = cornerZ0Coords.map(function(coord) {
             var zoomedCoord = coord.zoomTo(centerCoord.zoom);
             return new Point(
-                Math.round((zoomedCoord.column - centerCoord.column) * tileExtent),
-                Math.round((zoomedCoord.row - centerCoord.row) * tileExtent));
+                Math.round((zoomedCoord.column - centerCoord.column) * EXTENT),
+                Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
         var gl = map.painter.gl;

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -80,7 +80,6 @@ exports._vectorFeaturesAt = function(coord, params, callback) {
         uid: result.tile.uid,
         x: result.x,
         y: result.y,
-        tileExtent: result.tile.tileExtent,
         scale: result.scale,
         source: this.id,
         params: params

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -21,10 +21,27 @@ function Tile(coord, size, sourceMaxZoom) {
     this.uses = 0;
     this.tileSize = size;
     this.sourceMaxZoom = sourceMaxZoom;
-    this.pixelRatio = EXTENT / size;
 }
 
 Tile.prototype = {
+
+    /**
+     * Converts a pixel value at a the given zoom level to tile units.
+     *
+     * The shaders mostly calculate everything in tile units so style
+     * properties need to be converted from pixels to tile units using this.
+     *
+     * For example, a translation by 30 pixels at zoom 6.5 will be a
+     * translation by pixelsToTileUnits(30, 6.5) tile units.
+     *
+     * @param {number} pixelValue
+     * @param {number} z
+     * @returns {number} value in tile units
+     * @private
+     */
+    pixelsToTileUnits: function(pixelValue, z) {
+        return pixelValue * (EXTENT / (this.tileSize * Math.pow(2, z - this.coord.z)));
+    },
 
     /**
      * Given a coordinate position, zoom that coordinate to my zoom and

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -2,6 +2,7 @@
 
 var util = require('../util/util');
 var Buffer = require('../data/buffer');
+var EXTENT = require('../data/buffer').EXTENT;
 
 module.exports = Tile;
 
@@ -20,11 +21,10 @@ function Tile(coord, size, sourceMaxZoom) {
     this.uses = 0;
     this.tileSize = size;
     this.sourceMaxZoom = sourceMaxZoom;
+    this.pixelRatio = EXTENT / size;
 }
 
 Tile.prototype = {
-    // todo unhardcode
-    tileExtent: 4096,
 
     /**
      * Given a coordinate position, zoom that coordinate to my zoom and
@@ -36,8 +36,8 @@ Tile.prototype = {
     positionAt: function(coord) {
         var zoomedCoord = coord.zoomTo(Math.min(this.coord.z, this.sourceMaxZoom));
         return {
-            x: (zoomedCoord.column - this.coord.x) * this.tileExtent,
-            y: (zoomedCoord.row - this.coord.y) * this.tileExtent
+            x: (zoomedCoord.column - this.coord.x) * EXTENT,
+            y: (zoomedCoord.row - this.coord.y) * EXTENT
         };
     },
 
@@ -58,7 +58,6 @@ Tile.prototype = {
 
         this.buffers = unserializeBuffers(data.buffers);
         this.elementGroups = data.elementGroups;
-        this.tileExtent = data.extent;
     },
 
     /**
@@ -111,7 +110,6 @@ Tile.prototype = {
 
         this.elementGroups = null;
         this.buffers = null;
-        this.tileExtent = null;
     },
 
     redoPlacement: function(source) {

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -5,6 +5,7 @@ var TileCoord = require('./tile_coord');
 var Point = require('point-geometry');
 var Cache = require('../util/mru_cache');
 var util = require('../util/util');
+var EXTENT = require('../data/buffer').EXTENT;
 
 module.exports = TilePyramid;
 
@@ -360,7 +361,7 @@ TilePyramid.prototype = {
         for (var i = 0; i < ids.length; i++) {
             var tile = this._tiles[ids[i]];
             var pos = tile.positionAt(coord);
-            if (pos && pos.x >= 0 && pos.x < tile.tileExtent && pos.y >= 0 && pos.y < tile.tileExtent) {
+            if (pos && pos.x >= 0 && pos.x < EXTENT && pos.y >= 0 && pos.y < EXTENT) {
                 // The click is within the viewport. There is only ever one tile in
                 // a layer that has this property.
                 return {
@@ -390,7 +391,7 @@ TilePyramid.prototype = {
                 tile.positionAt(bounds[0]),
                 tile.positionAt(bounds[1])
             ];
-            if (tileSpaceBounds[0].x < tile.tileExtent && tileSpaceBounds[0].y < tile.tileExtent &&
+            if (tileSpaceBounds[0].x < EXTENT && tileSpaceBounds[0].y < EXTENT &&
                 tileSpaceBounds[1].x >= 0 && tileSpaceBounds[1].y >= 0) {
                 result.push({
                     tile: tile,

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -6,6 +6,7 @@ var LngLat = require('../geo/lng_lat');
 var Point = require('point-geometry');
 var Evented = require('../util/evented');
 var ajax = require('../util/ajax');
+var EXTENT = require('../data/buffer').EXTENT;
 
 module.exports = VideoSource;
 
@@ -95,12 +96,11 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
 
         var centerCoord = this.centerCoord = util.getCoordinatesCenter(cornerZ0Coords);
 
-        var tileExtent = 4096;
         var tileCoords = cornerZ0Coords.map(function(coord) {
             var zoomedCoord = coord.zoomTo(centerCoord.zoom);
             return new Point(
-                Math.round((zoomedCoord.column - centerCoord.column) * tileExtent),
-                Math.round((zoomedCoord.row - centerCoord.row) * tileExtent));
+                Math.round((zoomedCoord.column - centerCoord.column) * EXTENT),
+                Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
         var gl = map.painter.gl;

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -32,8 +32,6 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         bucketsBySourceLayer = {},
         i, layer, sourceLayerId, bucket;
 
-    var extent = this.extent = getExtent(data.layers);
-
     // Map non-ref layers to buckets.
     for (i = 0; i < layers.length; i++) {
         layer = layers[i];
@@ -49,8 +47,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
             buffers: buffers,
             zoom: this.zoom,
             overscaling: this.overscaling,
-            collisionDebug: this.collisionDebug,
-            tileExtent: extent
+            collisionDebug: this.collisionDebug
         });
 
         bucketsById[layer.id] = bucket;
@@ -96,7 +93,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         symbolBuckets = this.symbolBuckets = [],
         otherBuckets = [];
 
-    var collisionTile = new CollisionTile(this.angle, this.pitch, extent);
+    var collisionTile = new CollisionTile(this.angle, this.pitch);
 
     for (var id in bucketsById) {
         bucket = bucketsById[id];
@@ -195,7 +192,6 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         callback(null, {
             elementGroups: getElementGroups(buckets),
             buffers: buffers,
-            extent: extent,
             bucketStats: stats
         }, getTransferables(buffers));
     }
@@ -210,7 +206,7 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, collisionDebug) {
     }
 
     var buffers = {},
-        collisionTile = new CollisionTile(angle, pitch, this.extent);
+        collisionTile = new CollisionTile(angle, pitch);
 
     for (var i = this.symbolBuckets.length - 1; i >= 0; i--) {
         this.symbolBuckets[i].placeFeatures(collisionTile, buffers, collisionDebug);
@@ -244,14 +240,4 @@ function getTransferables(buffers) {
         buffers[k].push = null;
     }
     return transferables;
-}
-
-function getExtent(layers) {
-    var extent = 4096;
-    if (!layers) return extent;
-    for (var key in layers) {
-        var layer = layers[key];
-        if (layer && layer.extent) extent = layer.extent;
-    }
-    return extent;
 }

--- a/js/symbol/collision_tile.js
+++ b/js/symbol/collision_tile.js
@@ -3,6 +3,7 @@
 var rbush = require('rbush');
 var CollisionBox = require('./collision_box');
 var Point = require('point-geometry');
+var EXTENT = require('../data/buffer').EXTENT;
 
 module.exports = CollisionTile;
 
@@ -16,7 +17,7 @@ module.exports = CollisionTile;
  * @param {number} pitch
  * @private
  */
-function CollisionTile(angle, pitch, extent) {
+function CollisionTile(angle, pitch) {
     this.tree = rbush();
     this.angle = angle;
 
@@ -36,11 +37,11 @@ function CollisionTile(angle, pitch, extent) {
         //left
         new CollisionBox(new Point(0, 0), 0, -Infinity, 0, Infinity, Infinity),
         // right
-        new CollisionBox(new Point(extent, 0), 0, -Infinity, 0, Infinity, Infinity),
+        new CollisionBox(new Point(EXTENT, 0), 0, -Infinity, 0, Infinity, Infinity),
         // top
         new CollisionBox(new Point(0, 0), -Infinity, 0, Infinity, 0, Infinity),
         // bottom
-        new CollisionBox(new Point(0, extent), -Infinity, 0, Infinity, 0, Infinity)
+        new CollisionBox(new Point(0, EXTENT), -Infinity, 0, Infinity, 0, Infinity)
     ];
 }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7a17d43bd8482a01dc165de6fff6ae4c33c4fc5d",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#fc48788c123b13ab0f8b1304bd7d20ec301eaf15",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",

--- a/test/js/source/tile_pyramid.test.js
+++ b/test/js/source/tile_pyramid.test.js
@@ -513,8 +513,7 @@ test('TilePyramid#tilesIn', function (t) {
                 loaded: true,
                 uses: 1,
                 tileSize: 512,
-                sourceMaxZoom: 14,
-                pixelRatio: 16
+                sourceMaxZoom: 14
             },
             minX: 4096,
             maxX: 12288,
@@ -527,8 +526,7 @@ test('TilePyramid#tilesIn', function (t) {
                 loaded: true,
                 uses: 1,
                 tileSize: 512,
-                sourceMaxZoom: 14,
-                pixelRatio: 16
+                sourceMaxZoom: 14
             },
             minX: -4096,
             maxX: 4096,

--- a/test/js/source/tile_pyramid.test.js
+++ b/test/js/source/tile_pyramid.test.js
@@ -250,7 +250,7 @@ test('TilePyramid#tileAt', function(t) {
     t.deepEqual(result.tile.coord.id, 65);
     t.deepEqual(result.scale, 724.0773439350247);
     t.deepEqual(result.x, 0);
-    t.deepEqual(result.y, 2048);
+    t.deepEqual(result.y, 4096);
 
     t.end();
 });
@@ -513,12 +513,13 @@ test('TilePyramid#tilesIn', function (t) {
                 loaded: true,
                 uses: 1,
                 tileSize: 512,
-                sourceMaxZoom: 14
+                sourceMaxZoom: 14,
+                pixelRatio: 16
             },
-            minX: 2048,
-            maxX: 6144,
-            minY: 1024,
-            maxY: 3072
+            minX: 4096,
+            maxX: 12288,
+            minY: 2048,
+            maxY: 6144
         },
         {
             tile: {
@@ -526,12 +527,13 @@ test('TilePyramid#tilesIn', function (t) {
                 loaded: true,
                 uses: 1,
                 tileSize: 512,
-                sourceMaxZoom: 14
+                sourceMaxZoom: 14,
+                pixelRatio: 16
             },
-            minX: -2048,
-            maxX: 2048,
-            minY: 1024,
-            maxY: 3072
+            minX: -4096,
+            maxX: 4096,
+            minY: 2048,
+            maxY: 6144
         }
     ]);
 


### PR DESCRIPTION
This supports layers with extent != 4096 by converting all data to the maximum extent (8192) supported by our buffers. After the conversion, only the constant maximum extent is used.

fixes https://github.com/mapbox/mapbox-gl-js/issues/1093

If a layer has an extent > 8192 it will lose precision when it is converted down to 8192. It will render ok, but it will be less exact when it is very overscaled. In order to increase the maximum extent, we would need to:
- pack the line extrude direction bits in either the `extrude` or `linesofar` values instead of the position. The reduce precision in `extrude` or `linesofar` could cause issues. https://github.com/mapbox/mapbox-gl-js/blob/3280d6dd85ff9cbadf4b5f6afc4daa5b21abeb56/js/data/line_bucket.js#L34-L35
- use unsigned integers and translate everything by EXTENT / 2 before adding it to the buffers. And then using the posMatrix to translate it back in the shader.

I'm not sure whether either of those changes are worthwhile right now. 8192 seems high enough

:eyes: @jfirebaugh @lucaswoj @mourner 