### PR TITLE
make symbol sorting more deterministic

### DIFF
--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -302,7 +302,7 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
             // the buffers for both tiles and clipped to tile boundaries at draw time.
             var addToBuffers = inside || mayOverlap;
 
-            this.symbolInstances.push(new SymbolInstance(anchor, line, shapedText, shapedIcon, layout, addToBuffers,
+            this.symbolInstances.push(new SymbolInstance(anchor, line, shapedText, shapedIcon, layout, addToBuffers, this.symbolInstances.length,
                         textBoxScale, textPadding, textAlongLine,
                         iconBoxScale, iconPadding, iconAlongLine));
         }
@@ -362,9 +362,9 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, buffers, collisio
             cos = Math.cos(angle);
 
         this.symbolInstances.sort(function(a, b) {
-            var aRotated = sin * a.x + cos * a.y;
-            var bRotated = sin * b.x + cos * b.y;
-            return aRotated - bRotated;
+            var aRotated = (sin * a.x + cos * a.y) | 0;
+            var bRotated = (sin * b.x + cos * b.y) | 0;
+            return (aRotated - bRotated) || (b.index - a.index);
         });
     }
 
@@ -530,12 +530,13 @@ SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
     }
 };
 
-function SymbolInstance(anchor, line, shapedText, shapedIcon, layout, addToBuffers,
+function SymbolInstance(anchor, line, shapedText, shapedIcon, layout, addToBuffers, index,
                         textBoxScale, textPadding, textAlongLine,
                         iconBoxScale, iconPadding, iconAlongLine) {
 
     this.x = anchor.x;
     this.y = anchor.y;
+    this.index = index;
     this.hasText = !!shapedText;
     this.hasIcon = !!shapedIcon;
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#fc48788c123b13ab0f8b1304bd7d20ec301eaf15",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7ebad0438ea47721235434f56eb0dba2db66ddb5",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
The order of symbols with the same y value (after rotation) was undefined, which was causing some rendering differences with -native.

test-suite changes:
https://github.com/mapbox/mapbox-gl-test-suite/commit/7ebad0438ea47721235434f56eb0dba2db66ddb5

I'll make the same change in -native.

:eyes: @lucaswoj 