### PR TITLE
switch geojson units from 4096 to pixels

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -5,6 +5,7 @@ var Evented = require('../util/evented');
 var TilePyramid = require('./tile_pyramid');
 var Source = require('./source');
 var urlResolve = require('resolve-url');
+var EXTENT = require('../data/buffer').EXTENT;
 
 module.exports = GeoJSONSource;
 
@@ -14,10 +15,10 @@ module.exports = GeoJSONSource;
  * @param {Object} [options]
  * @param {Object|string} options.data A GeoJSON data object or URL to it. The latter is preferable in case of large GeoJSON files.
  * @param {number} [options.maxzoom=14] Maximum zoom to preserve detail at.
- * @param {number} [options.buffer] Tile buffer on each side.
- * @param {number} [options.tolerance] Simplification tolerance (higher means simpler).
+ * @param {number} [options.buffer] Tile buffer on each side in pixels.
+ * @param {number} [options.tolerance] Simplification tolerance (higher means simpler) in pixels.
  * @param {number} [options.cluster] If the data is a collection of point features, setting this to true clusters the points by radius into groups.
- * @param {number} [options.clusterRadius=400] Radius of each cluster when clustering points, relative to `4096` tile.
+ * @param {number} [options.clusterRadius=50] Radius of each cluster when clustering points, in pixels.
  * @param {number} [options.clusterMaxZoom] Max zoom to cluster points on. Defaults to one zoom less than `maxzoom` (so that last zoom features are not clustered).
 
  * @example
@@ -46,22 +47,25 @@ function GeoJSONSource(options) {
 
     if (options.maxzoom !== undefined) this.maxzoom = options.maxzoom;
 
+    var scale = EXTENT / this.tileSize;
+
     this.geojsonVtOptions = {
+        buffer: (options.buffer !== undefined ? options.buffer : 128) * scale,
+        tolerance: (options.tolerance !== undefined ? options.tolerance : 0.375) * scale,
+        extent: EXTENT,
         maxZoom: this.maxzoom
     };
-    if (options.buffer !== undefined) this.geojsonVtOptions.buffer = options.buffer;
-    if (options.tolerance !== undefined) this.geojsonVtOptions.tolerance = options.tolerance;
 
     this.cluster = options.cluster || false;
     this.superclusterOptions = {
         maxZoom: Math.max(options.clusterMaxZoom, this.maxzoom - 1) || (this.maxzoom - 1),
-        extent: 4096,
-        radius: options.clusterRadius || 400,
+        extent: EXTENT,
+        radius: (options.clusterRadius || 50) * scale,
         log: false
     };
 
     this._pyramid = new TilePyramid({
-        tileSize: 512,
+        tileSize: this.tileSize,
         minzoom: this.minzoom,
         maxzoom: this.maxzoom,
         cacheSize: 20,
@@ -77,6 +81,7 @@ function GeoJSONSource(options) {
 GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototype */{
     minzoom: 0,
     maxzoom: 14,
+    tileSize: 512,
     _dirty: true,
     isTileClipped: true,
 
@@ -136,7 +141,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
         }
         this.workerID = this.dispatcher.send('parse geojson', {
             data: data,
-            tileSize: 512,
+            tileSize: this.tileSize,
             source: this.id,
             geojsonVtOptions: this.geojsonVtOptions,
             cluster: this.cluster,
@@ -160,7 +165,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             coord: tile.coord,
             zoom: tile.coord.z,
             maxZoom: this.maxzoom,
-            tileSize: 512,
+            tileSize: this.tileSize,
             source: this.id,
             overscaling: overscaling,
             angle: this.map.transform.angle,

--- a/js/source/geojson_wrapper.js
+++ b/js/source/geojson_wrapper.js
@@ -2,6 +2,7 @@
 
 var Point = require('point-geometry');
 var VectorTileFeature = require('vector-tile').VectorTileFeature;
+var EXTENT = require('../data/buffer').EXTENT;
 
 module.exports = GeoJSONWrapper;
 
@@ -19,7 +20,7 @@ function FeatureWrapper(feature) {
     this.type = feature.type;
     this.rawGeometry = feature.type === 1 ? [feature.geometry] : feature.geometry;
     this.properties = feature.tags;
-    this.extent = 4096;
+    this.extent = EXTENT;
 }
 
 FeatureWrapper.prototype.loadGeometry = function() {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7815cccb8ab2ad960c0d876f2e3abc40ecdda291",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#09f6c89fa6552a2953e4903afd72dd27239217d2",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -91,17 +91,18 @@ test('GeoJSONSource#update', function(t) {
         var source = new GeoJSONSource({
             data: {},
             maxzoom: 10,
-            tolerance: 2,
-            buffer: 128
+            tolerance: 0.25,
+            buffer: 16
         });
 
         source.dispatcher = {
             send: function(message, params) {
                 t.equal(message, 'parse geojson');
                 t.deepEqual(params.geojsonVtOptions, {
+                    extent: 8192,
                     maxZoom: 10,
-                    tolerance: 2,
-                    buffer: 128
+                    tolerance: 4,
+                    buffer: 256
                 });
                 t.end();
             }


### PR DESCRIPTION
The units for these GeoJSONSource options changed from 4096 to pixels:
- tolerance
- buffer
- clusterSize

To convert an old value to pixels divide by 8.
An old value of 400 is the same as 400 / 8 = 50 now.

**This is a breaking change.**

This also increases the default buffer size (how much data padding exists on the sides of the tiles) to 128 pixels. Having a big enough buffer is important for crosstile label placement and to avoid clipping for at tile edges for symbols that are allowed to overlap with each other. This does make the tiles bigger but it think it's worth it.

- [x] update cluster example https://github.com/mapbox/mapbox-gl-js/pull/1967

:eyes: @mourner @jfirebaugh @lucaswoj 