### PR TITLE
add all points to circle bucket not just outer ring

### DIFF
--- a/js/data/circle_bucket.js
+++ b/js/data/circle_bucket.js
@@ -41,34 +41,38 @@ CircleBucket.prototype.shaders = {
 
 CircleBucket.prototype.addFeature = function(feature) {
 
-    var geometries = loadGeometry(feature)[0];
+    var geometries = loadGeometry(feature);
     for (var j = 0; j < geometries.length; j++) {
-        var group = this.makeRoomFor('circle', 4);
+        var geometry = geometries[j];
 
-        var x = geometries[j].x;
-        var y = geometries[j].y;
+        for (var k = 0; k < geometry.length; k++) {
+            var group = this.makeRoomFor('circle', 4);
 
-        // Do not include points that are outside the tile boundaries.
-        if (x < 0 || x >= EXTENT || y < 0 || y >= EXTENT) continue;
+            var x = geometry[k].x;
+            var y = geometry[k].y;
 
-        // this geometry will be of the Point type, and we'll derive
-        // two triangles from it.
-        //
-        // ┌─────────┐
-        // │ 3     2 │
-        // │         │
-        // │ 0     1 │
-        // └─────────┘
+            // Do not include points that are outside the tile boundaries.
+            if (x < 0 || x >= EXTENT || y < 0 || y >= EXTENT) continue;
 
-        var index = this.addCircleVertex(x, y, -1, -1) - group.vertexStartIndex;
-        this.addCircleVertex(x, y, 1, -1);
-        this.addCircleVertex(x, y, 1, 1);
-        this.addCircleVertex(x, y, -1, 1);
-        group.vertexLength += 4;
+            // this geometry will be of the Point type, and we'll derive
+            // two triangles from it.
+            //
+            // ┌─────────┐
+            // │ 3     2 │
+            // │         │
+            // │ 0     1 │
+            // └─────────┘
 
-        this.addCircleElement(index, index + 1, index + 2);
-        this.addCircleElement(index, index + 3, index + 2);
-        group.elementLength += 2;
+            var index = this.addCircleVertex(x, y, -1, -1) - group.vertexStartIndex;
+            this.addCircleVertex(x, y, 1, -1);
+            this.addCircleVertex(x, y, 1, 1);
+            this.addCircleVertex(x, y, -1, 1);
+            group.vertexLength += 4;
+
+            this.addCircleElement(index, index + 1, index + 2);
+            this.addCircleElement(index, index + 3, index + 2);
+            group.elementLength += 2;
+        }
     }
 
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7ebad0438ea47721235434f56eb0dba2db66ddb5",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#bd74e2c8aef40651f5fcc9d5544b89b6707787ae",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
CircleBucket used to only add points from the outer ring. It now adds all of them just like -native.

test-suite: https://github.com/mapbox/mapbox-gl-test-suite/tree/multi-circle

:eyes: @lucaswoj 