### PR TITLE
fix garbled labels while zooming

### DIFF
--- a/js/data/symbol_bucket.js
+++ b/js/data/symbol_bucket.js
@@ -346,6 +346,10 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, buffers, collisio
     elementGroups.glyph.adjustedSize = this.adjustedTextSize;
     elementGroups.icon.adjustedSize = this.adjustedIconSize;
 
+    // Transfer the name of the fonstack back to the main thread along with the buffers.
+    // The draw function needs to know which fonstack's glyph atlas to bind when rendering.
+    elementGroups.glyph.fontstack = layout['text-font'].join(',');
+
     var textAlongLine = layout['text-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';
     var iconAlongLine = layout['icon-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';
 

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -120,8 +120,9 @@ function drawSymbol(painter, layer, posMatrix, tile, elementGroups, prefix, sdf,
     }
 
     if (text) {
-        var textfont = layer.layout['text-font'];
-        var fontstack = textfont && textfont.join(',');
+        // use the fonstack used when parsing the tile, not the fontstack
+        // at the current zoom level (layout['text-font']).
+        var fontstack = elementGroups.fontstack;
         var glyphAtlas = fontstack && painter.glyphSource.getGlyphAtlas(fontstack);
         if (!glyphAtlas) return;
 


### PR DESCRIPTION
fix #2012

Use the fonstack used by the bucket not the fontstack for the current zoom level. They can be different when the text-font is a function of zoom.

:eyes: @lucaswoj @bhousel 