### PR TITLE
fix reparsing overscaled geojson

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -68,6 +68,7 @@ function GeoJSONSource(options) {
         tileSize: this.tileSize,
         minzoom: this.minzoom,
         maxzoom: this.maxzoom,
+        reparseOverscaled: true,
         cacheSize: 20,
         load: this._loadTile.bind(this),
         abort: this._abortTile.bind(this),

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -135,7 +135,7 @@ util.extend(Worker.prototype, {
 
         // console.time('tile ' + coord.z + ' ' + coord.x + ' ' + coord.y);
 
-        var geoJSONTile = this.geoJSONIndexes[source].getTile(coord.z, coord.x, coord.y);
+        var geoJSONTile = this.geoJSONIndexes[source].getTile(Math.min(coord.z, params.maxZoom), coord.x, coord.y);
 
         // console.timeEnd('tile ' + coord.z + ' ' + coord.x + ' ' + coord.y);
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#09f6c89fa6552a2953e4903afd72dd27239217d2",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3fe57d5b2c885f758cc7667dbcce14a214b790e0",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
fix #1651

new render test: https://github.com/mapbox/mapbox-gl-test-suite/tree/geojson-reparse-overscaled

@mourner can you review?