### PR TITLE
less slanted dashed lines near sharp corners

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -49,6 +49,7 @@ Bucket.AttributeType = Buffer.AttributeType;
  */
 function Bucket(options) {
     this.zoom = options.zoom;
+    this.overscaling = options.overscaling;
 
     this.layer = StyleLayer.create(options.layer);
     this.layer.recalculate(this.zoom, { lastIntegerZoom: Infinity, lastIntegerZoomTime: 0, lastZoom: 0 });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2d31dd1f35e79f3bca2752c84747f117ea19ee9e",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#c896d35640872d61cbae2dc681a27d405e610b4e",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
This makes #967 less severe by adding extra vertices near sharp corners. This makes the slanting happen only immediately close to corners. This adds around 5% extra vertices in most views. It adds proportionally more when tiles are overscaled but the overall data density is lower in those cases.

This doesn't make corners look any better but it does make the middle of segments look better.

adding dashed outlines to buildings is one of the most extreme examples of the bug:

before:
<img width="581" alt="screen shot 2016-02-01 at 7 19 45 pm" src="https://cloud.githubusercontent.com/assets/1421652/12738807/e2621820-c918-11e5-9a6e-4af285b35a28.png">
after:
<img width="581" alt="screen shot 2016-02-01 at 7 21 28 pm" src="https://cloud.githubusercontent.com/assets/1421652/12738825/0a90b55e-c919-11e5-8b1b-4e5ec9e4ada6.png">

---

**Is this good enough to be accepted as a solution to the bug?**

The other possible improvements I can think of would require a lot more vertices (100% more vs the 5% more this adds) so we'd need some way of enabling them only for dashed lines. We would need to make line-dasharray a layout property to make that possible. And I'm sure those approaches would look bad in certain other cases.

@nickidlugash @bhousel @lucaswoj @jfirebaugh 



