### PR TITLE
Add custom @2x handling for mapbox v4 tile API when tileSize: 512

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -51,7 +51,7 @@ RasterTileSource.prototype = util.inherit(Evented, {
     getTile: Source._getTile,
 
     _loadTile: function(tile) {
-        var url = normalizeURL(tile.coord.url(this.tiles), this.url);
+        var url = normalizeURL(tile.coord.url(this.tiles), this.url, this.tileSize);
 
         tile.request = ajax.getImage(url, done.bind(this));
 

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -65,11 +65,15 @@ module.exports.normalizeSpriteURL = function(url, format, ext, accessToken) {
     return normalizeURL('mapbox://' + user + '/' + style + draft + '/sprite' + format + ext, '/styles/v1/', accessToken);
 };
 
-module.exports.normalizeTileURL = function(url, sourceUrl) {
+module.exports.normalizeTileURL = function(url, sourceUrl, tileSize) {
     if (!sourceUrl || !sourceUrl.match(/^mapbox:\/\//))
         return url;
 
+    // The v4 mapbox tile API supports 512x512 image tiles only when @2x
+    // is appended to the tile URL. If `tileSize: 512` is specified for
+    // a Mapbox raster source force the @2x suffix even if a non hidpi
+    // device.
     url = url.replace(/([?&]access_token=)tk\.[^&]+/, '$1' + config.ACCESS_TOKEN);
     var extension = browser.supportsWebp ? 'webp' : '$1';
-    return url.replace(/\.((?:png|jpg)\d*)(?=$|\?)/, browser.devicePixelRatio >= 2 ? '@2x.' + extension : '.' + extension);
+    return url.replace(/\.((?:png|jpg)\d*)(?=$|\?)/, browser.devicePixelRatio >= 2 || tileSize === 512 ? '@2x.' + extension : '.' + extension);
 };

--- a/test/js/util/mapbox.test.js
+++ b/test/js/util/mapbox.test.js
@@ -119,6 +119,14 @@ test("mapbox", function(t) {
             t.end();
         });
 
+        t.test('inserts @2x when tileSize == 512', function(t) {
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource, 512), 'http://path.png/tile@2x.png');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource, 512), 'http://path.png/tile@2x.png32');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource, 512), 'http://path.png/tile@2x.jpg70');
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource, 512), 'http://path.png/tile@2x.png?access_token=foo');
+            t.end();
+        });
+
         t.test('replaces img extension with webp on supporting devices', function(t) {
             browser.supportsWebp = true;
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile.webp');


### PR DESCRIPTION
This rerolls https://github.com/mapbox/mapbox-gl-js/pull/1964.

If tileSize: 512 is specified for a Mapbox raster source force the @2x suffix even if a non hidpi device. Per @jfirebaugh's paraphrase:

> One way of looking at mapbox/mapbox-gl-js#1964 is that it makes tileSize: 512 a knob for turning off retina support in exchange for 512px tiles, with the caveat that it's only viable if you don't mind showing what are purportedly retina tiles at twice their "intended" display size.