### PR TITLE
Fix the unsetting of paint properties

### DIFF
--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -8,18 +8,12 @@ module.exports = StyleDeclaration;
 function StyleDeclaration(reference, value) {
     this.type = reference.type;
     this.transitionable = reference.transition;
-
-    if (value == null) {
-        this.value = reference.default;
-    } else {
-        this.value = value;
-    }
+    this.value = value;
 
     // immutable representation of value. used for comparison
     this.json = JSON.stringify(this.value);
 
     var parsedValue = this.type === 'color' ? parseColor(this.value) : value;
-
     if (reference.function === 'interpolated') {
         this.calculate = MapboxGLFunction.interpolated(parsedValue);
     } else {

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -52,7 +52,7 @@ test('StyleLayer#setPaintProperty', function(t) {
         t.end();
     });
 
-    t.test('unsets property value', function(t) {
+    t.test('unsets value', function(t) {
         var layer = StyleLayer.create({
             "id": "background",
             "type": "background",
@@ -60,10 +60,13 @@ test('StyleLayer#setPaintProperty', function(t) {
                 "background-color": "red"
             }
         });
-
+        layer.cascade({}, {transition: false}, null, createAnimationLoop());
         layer.setPaintProperty('background-color', null);
+        layer.cascade({}, {transition: false}, null, createAnimationLoop());
 
+        t.deepEqual(layer.getPaintValue('background-color'), [0, 0, 0, 1]);
         t.equal(layer.getPaintProperty('background-color'), undefined);
+
         t.end();
     });
 
@@ -86,14 +89,22 @@ test('StyleLayer#setPaintProperty', function(t) {
         var layer = StyleLayer.create({
             "id": "background",
             "type": "background",
-            "paint.night": {
+            "paint": {
                 "background-color": "red"
+            },
+            "paint.night": {
+                "background-color": "blue"
             }
         });
+        layer.cascade({night: true}, {transition: false}, null, createAnimationLoop());
+        t.deepEqual(layer.getPaintProperty('background-color', 'night'), 'blue');
+        t.deepEqual(layer.getPaintValue('background-color'), [0, 0, 1, 1]);
 
         layer.setPaintProperty('background-color', null, 'night');
-
+        layer.cascade({}, {transition: false}, null, createAnimationLoop());
+        t.deepEqual(layer.getPaintValue('background-color'), [1, 0, 0, 1]);
         t.equal(layer.getPaintProperty('background-color', 'night'), undefined);
+
         t.end();
     });
 
@@ -140,7 +151,7 @@ test('StyleLayer#setPaintProperty', function(t) {
         });
 
         layer.setPaintProperty('background-color-transition', {duration: 400}, 'background-color');
-        layer.cascade([], {});
+        layer.cascade({}, {transition: false}, null, createAnimationLoop());
         t.deepEqual(layer.getPaintProperty('background-color-transition', 'background-color'), {duration: 400});
         t.end();
     });
@@ -185,7 +196,8 @@ test('StyleLayer#setLayoutProperty', function(t) {
 
         layer.setLayoutProperty('text-transform', null);
 
-        t.deepEqual(layer.getLayoutProperty('text-transform'), undefined);
+        t.equal(layer.getLayoutValue('text-transform'), 'none');
+        t.equal(layer.getLayoutProperty('text-transform'), undefined);
         t.end();
     });
 });
@@ -283,3 +295,10 @@ test('StyleLayer#serialize', function(t) {
         t.end();
     });
 });
+
+function createAnimationLoop() {
+    return {
+        set: function() {},
+        cancel: function() {}
+    };
+}


### PR DESCRIPTION
The unsetting of style properties broke in the `StyleLayer` refactor. This PR fixes that regression, while preserving the breaking change at https://github.com/mapbox/mapbox-gl-js/pull/1977#discussion-diff-50592287. 

fixes #2037 

cc @scothis @jfirebaugh @ansis  @bhousel 