### PR TITLE
Add style API validation

### DIFF
--- a/js/source/source.js
+++ b/js/source/source.js
@@ -139,11 +139,24 @@ exports.create = function(source) {
         image: require('./image_source')
     };
 
+    return exports.is(source) ? source : new sources[source.type](source);
+};
+
+exports.is = function(source) {
+    // This is not at file scope in order to avoid a circular require.
+    var sources = {
+        vector: require('./vector_tile_source'),
+        raster: require('./raster_tile_source'),
+        geojson: require('./geojson_source'),
+        video: require('./video_source'),
+        image: require('./image_source')
+    };
+
     for (var type in sources) {
         if (source instanceof sources[type]) {
-            return source;
+            return true;
         }
     }
 
-    return new sources[source.type](source);
+    return false;
 };

--- a/js/style/style_spec.js
+++ b/js/style/style_spec.js
@@ -1,2 +1,3 @@
 'use strict';
+
 module.exports = require('mapbox-gl-style-spec/reference/latest');

--- a/js/style/validate_style.js
+++ b/js/style/validate_style.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = require('mapbox-gl-style-spec/lib/validate_style.min');
+
+module.exports.emitErrors = function throwErrors(emitter, errors) {
+    if (errors && errors.length) {
+        for (var i = 0; i < errors.length; i++) {
+            emitter.fire('error', { error: new Error(errors[i].message) });
+        }
+        return true;
+    } else {
+        return false;
+    }
+};

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -134,6 +134,7 @@ var Map = module.exports = function(options) {
     this.on('style.error', this.onError);
     this.on('source.error', this.onError);
     this.on('tile.error', this.onError);
+    this.on('layer.error', this.onError);
 };
 
 util.extend(Map.prototype, Evented);
@@ -419,6 +420,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
                 .off('source.change', this._onSourceUpdate)
                 .off('layer.add', this._forwardLayerEvent)
                 .off('layer.remove', this._forwardLayerEvent)
+                .off('layer.error', this._forwardLayerEvent)
                 .off('tile.add', this._forwardTileEvent)
                 .off('tile.remove', this._forwardTileEvent)
                 .off('tile.load', this._update)
@@ -450,6 +452,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             .on('source.change', this._onSourceUpdate)
             .on('layer.add', this._forwardLayerEvent)
             .on('layer.remove', this._forwardLayerEvent)
+            .on('layer.error', this._forwardLayerEvent)
             .on('tile.add', this._forwardTileEvent)
             .on('tile.remove', this._forwardTileEvent)
             .on('tile.load', this._update)
@@ -834,7 +837,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     /**
-     * A default error handler for `style.error`, `source.error`, and `tile.error` events.
+     * A default error handler for `style.error`, `source.error`, `layer.error`,
+     * and `tile.error` events.
      * It logs the error via `console.error`.
      *
      * @example
@@ -842,6 +846,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * map.off('style.error', map.onError);
      * map.off('source.error', map.onError);
      * map.off('tile.error', map.onError);
+     * map.off('layer.error', map.onError);
      */
     onError: function(e) {
         console.error(e.error);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "geojson-vt": "^2.1.0",
     "gl-matrix": "^2.3.1",
     "mapbox-gl-function": "^1.0.0",
-    "mapbox-gl-style-spec": "^8.4.1",
+    "mapbox-gl-style-spec": "^8.4.2",
     "minifyify": "^7.0.1",
     "pbf": "^1.3.2",
     "pngjs": "^2.2.0",

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -93,6 +93,7 @@ test('Map', function(t) {
             map.off('style.error', map.onError);
             map.off('source.error', map.onError);
             map.off('tile.error', map.onError);
+            map.off('layer.error', map.onError);
 
             t.plan(10);
             map.setStyle(style); // Fires load
@@ -105,6 +106,7 @@ test('Map', function(t) {
             style.fire('tile.load');
             style.fire('tile.error');
             style.fire('tile.remove');
+            style.fire('layer.error');
         });
 
         t.test('can be called more than once', function(t) {


### PR DESCRIPTION
fixes #1632 

# Remaining Tasks

 - [x] unify approach to errors (fire `error` event vs throw `Error`)
 - [x] write `getEffectiveStyle` API :grimacing: #1982 (or find alternative to passing style object to validator)
 - [x] add unit tests 
