### PR TITLE
make featuresAt return symbols and use style properties

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -72,7 +72,6 @@ function Bucket(options) {
     this.features = [];
     this.id = this.layer.id;
     this['source-layer'] = this.layer['source-layer'];
-    this.interactive = this.layer.interactive;
     this.minZoom = this.layer.minzoom;
     this.maxZoom = this.layer.maxzoom;
 

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -67,7 +67,7 @@ function Bucket(options) {
     this.overscaling = options.overscaling;
     this.layer = options.layer;
 
-    this.layers = [this.layer.id];
+    this.layerIDs = [this.layer.id];
     this.type = this.layer.type;
     this.features = [];
     this.id = this.layer.id;

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -223,7 +223,7 @@ SymbolBucket.prototype.populateBuffers = function(collisionTile, stacks, icons) 
         }
 
         if (shapedText || shapedIcon) {
-            this.addFeature(geometries[k], shapedText, shapedIcon);
+            this.addFeature(geometries[k], shapedText, shapedIcon, features[k]);
         }
     }
 
@@ -232,7 +232,7 @@ SymbolBucket.prototype.populateBuffers = function(collisionTile, stacks, icons) 
     this.trimBuffers();
 };
 
-SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
+SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon, feature) {
     var layout = this.layer.layout;
 
     var glyphSize = 24;
@@ -304,7 +304,8 @@ SymbolBucket.prototype.addFeature = function(lines, shapedText, shapedIcon) {
             // the buffers for both tiles and clipped to tile boundaries at draw time.
             var addToBuffers = inside || mayOverlap;
 
-            this.symbolInstances.push(new SymbolInstance(anchor, line, shapedText, shapedIcon, layout, addToBuffers, this.symbolInstances.length,
+            this.symbolInstances.push(new SymbolInstance(anchor, line, shapedText, shapedIcon, layout,
+                        addToBuffers, this.symbolInstances.length, feature, this.layerIDs,
                         textBoxScale, textPadding, textAlongLine,
                         iconBoxScale, iconPadding, iconAlongLine));
         }
@@ -410,18 +411,14 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, showCollisionBoxe
         // Insert final placement into collision tree and add glyphs/icons to buffers
 
         if (hasText) {
-            if (!layout['text-ignore-placement']) {
-                collisionTile.insertCollisionFeature(symbolInstance.textCollisionFeature, glyphScale);
-            }
+            collisionTile.insertCollisionFeature(symbolInstance.textCollisionFeature, glyphScale, layout['text-ignore-placement']);
             if (glyphScale <= maxScale) {
                 this.addSymbols('glyph', symbolInstance.glyphQuads, glyphScale, layout['text-keep-upright'], textAlongLine, collisionTile.angle);
             }
         }
 
         if (hasIcon) {
-            if (!layout['icon-ignore-placement']) {
-                collisionTile.insertCollisionFeature(symbolInstance.iconCollisionFeature, iconScale);
-            }
+            collisionTile.insertCollisionFeature(symbolInstance.iconCollisionFeature, iconScale, layout['icon-ignore-placement']);
             if (iconScale <= maxScale) {
                 this.addSymbols('icon', symbolInstance.iconQuads, iconScale, layout['icon-keep-upright'], iconAlongLine, collisionTile.angle);
             }
@@ -540,7 +537,7 @@ SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
     }
 };
 
-function SymbolInstance(anchor, line, shapedText, shapedIcon, layout, addToBuffers, index,
+function SymbolInstance(anchor, line, shapedText, shapedIcon, layout, addToBuffers, index, feature, layerIDs,
                         textBoxScale, textPadding, textAlongLine,
                         iconBoxScale, iconPadding, iconAlongLine) {
 
@@ -552,11 +549,11 @@ function SymbolInstance(anchor, line, shapedText, shapedIcon, layout, addToBuffe
 
     if (this.hasText) {
         this.glyphQuads = addToBuffers ? getGlyphQuads(anchor, shapedText, textBoxScale, line, layout, textAlongLine) : [];
-        this.textCollisionFeature = new CollisionFeature(line, anchor, shapedText, textBoxScale, textPadding, textAlongLine, false);
+        this.textCollisionFeature = new CollisionFeature(line, anchor, feature, layerIDs, shapedText, textBoxScale, textPadding, textAlongLine, false);
     }
 
     if (this.hasIcon) {
         this.iconQuads = addToBuffers ? getIconQuads(anchor, shapedIcon, iconBoxScale, line, layout, iconAlongLine) : [];
-        this.iconCollisionFeature = new CollisionFeature(line, anchor, shapedIcon, iconBoxScale, iconPadding, iconAlongLine, true);
+        this.iconCollisionFeature = new CollisionFeature(line, anchor, feature, layerIDs, shapedIcon, iconBoxScale, iconPadding, iconAlongLine, true);
     }
 }

--- a/js/data/feature_tree.js
+++ b/js/data/feature_tree.js
@@ -2,11 +2,11 @@
 
 var rbush = require('rbush');
 var Point = require('point-geometry');
-var vt = require('vector-tile');
 var util = require('../util/util');
 var loadGeometry = require('./load_geometry');
-var EXTENT = require('./bucket').EXTENT;
 var CollisionBox = require('../symbol/collision_box');
+var EXTENT = require('./bucket').EXTENT;
+var featureFilter = require('feature-filter');
 
 module.exports = FeatureTree;
 
@@ -50,6 +50,7 @@ FeatureTree.prototype.query = function(args, styleLayersByID) {
 
     var params = args.params || {},
         pixelsToTileUnits = EXTENT / args.tileSize / args.scale,
+        filter = featureFilter(params.filter),
         result = [];
 
     // Features are indexed their original geometries. The rendered geometries may
@@ -94,11 +95,9 @@ FeatureTree.prototype.query = function(args, styleLayersByID) {
 
     for (var k = 0; k < matching.length; k++) {
         var feature = matching[k].feature,
-            layerIDs = matching[k].layerIDs,
-            type = vt.VectorTileFeature.types[feature.type];
+            layerIDs = matching[k].layerIDs;
 
-        if (params.$type && type !== params.$type)
-            continue;
+        if (!filter(feature)) continue;
 
         var geoJSON = feature.toGeoJSON(this.x, this.y, this.z);
 

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -254,9 +254,9 @@ Transform.prototype = {
             this.yLat(coord.row, worldSize));
     },
 
-    pointCoordinate: function(p, targetZ) {
+    pointCoordinate: function(p) {
 
-        if (targetZ === undefined) targetZ = 0;
+        var targetZ = 0;
 
         var matrix = this.coordinatePointMatrix(this.tileZoom);
         mat4.invert(matrix, matrix);

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -137,8 +137,8 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     getVisibleCoordinates: Source._getVisibleCoordinates,
     getTile: Source._getTile,
 
-    queryFeatures: Source._queryVectorFeatures,
-    getTileData: Source._getVectorTileData,
+    queryRenderedFeatures: Source._queryRenderedVectorFeatures,
+    querySourceFeatures: Source._querySourceFeatures,
 
     _updateData: function() {
         this._dirty = false;

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -139,6 +139,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
 
     featuresAt: Source._vectorFeaturesAt,
     featuresIn: Source._vectorFeaturesIn,
+    getTileData: Source._getVectorTileData,
 
     _updateData: function() {
         this._dirty = false;

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -137,8 +137,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     getVisibleCoordinates: Source._getVisibleCoordinates,
     getTile: Source._getTile,
 
-    featuresAt: Source._vectorFeaturesAt,
-    featuresIn: Source._vectorFeaturesIn,
+    queryFeatures: Source._queryVectorFeatures,
     getTileData: Source._getVectorTileData,
 
     _updateData: function() {

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -156,7 +156,7 @@ ImageSource.prototype = util.inherit(Evented, {
      * be selectable, so always return an empty array.
      * @private
      */
-    queryFeatures: function(point, params, callback) {
+    queryRenderedFeatures: function(point, params, callback) {
         return callback(null, []);
     },
 
@@ -164,7 +164,7 @@ ImageSource.prototype = util.inherit(Evented, {
      * An ImageSource doesn't have any tiled data.
      * @private
      */
-    getTileData: function(params, callback) {
+    querySourceFeatures: function(params, callback) {
         return callback(null, []);
     },
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -164,6 +164,14 @@ ImageSource.prototype = util.inherit(Evented, {
         return callback(null, []);
     },
 
+    /**
+     * An ImageSource doesn't have any tiled data.
+     * @private
+     */
+    getTileData: function(params, callback) {
+        return callback(null, []);
+    },
+
     serialize: function() {
         return {
             type: 'image',

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -156,11 +156,7 @@ ImageSource.prototype = util.inherit(Evented, {
      * be selectable, so always return an empty array.
      * @private
      */
-    featuresAt: function(point, params, callback) {
-        return callback(null, []);
-    },
-
-    featuresIn: function(bbox, params, callback) {
+    queryFeatures: function(point, params, callback) {
         return callback(null, []);
     },
 

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -116,11 +116,7 @@ RasterTileSource.prototype = util.inherit(Evented, {
         if (tile.texture) this.map.painter.saveTexture(tile.texture);
     },
 
-    featuresAt: function(point, params, callback) {
-        callback(null, []);
-    },
-
-    featuresIn: function(bbox, params, callback) {
+    queryFeatures: function(point, params, callback) {
         callback(null, []);
     },
 

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -116,11 +116,11 @@ RasterTileSource.prototype = util.inherit(Evented, {
         if (tile.texture) this.map.painter.saveTexture(tile.texture);
     },
 
-    queryFeatures: function(point, params, callback) {
+    queryRenderedFeatures: function(point, params, callback) {
         callback(null, []);
     },
 
-    getTileData: function(params, callback) {
+    querySourceFeatures: function(params, callback) {
         return callback(null, []);
     }
 });

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -122,5 +122,9 @@ RasterTileSource.prototype = util.inherit(Evented, {
 
     featuresIn: function(bbox, params, callback) {
         callback(null, []);
+    },
+
+    getTileData: function(params, callback) {
+        return callback(null, []);
     }
 });

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -119,7 +119,10 @@ exports._querySourceFeatures = function(params, callback) {
             params: params
         }, callback, tile.workerID);
     }.bind(this), function(err, results) {
-        callback(err, results.filter(function(x) { return !!x; }));
+        callback(err, results.reduce(function(array, d) {
+            if (d) array = array.concat(d);
+            return array;
+        }, []));
     });
 };
 

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -67,7 +67,7 @@ exports._getVisibleCoordinates = function() {
     else return this._pyramid.renderedIDs().map(TileCoord.fromID);
 };
 
-exports._vectorFeaturesAt = function(coord, params, callback) {
+exports._vectorFeaturesAt = function(coord, params, classes, zoom, bearing, callback) {
     if (!this._pyramid)
         return callback(null, []);
 
@@ -81,13 +81,16 @@ exports._vectorFeaturesAt = function(coord, params, callback) {
         y: result.y,
         scale: result.scale,
         tileSize: result.tileSize,
+        classes: classes,
+        zoom: zoom,
+        bearing: bearing,
         source: this.id,
         params: params
     }, callback, result.tile.workerID);
 };
 
 
-exports._vectorFeaturesIn = function(bounds, params, callback) {
+exports._vectorFeaturesIn = function(bounds, params, classes, zoom, bearing, callback) {
     if (!this._pyramid)
         return callback(null, []);
 
@@ -103,6 +106,11 @@ exports._vectorFeaturesIn = function(bounds, params, callback) {
             maxX: result.maxX,
             minY: result.minY,
             maxY: result.maxY,
+            scale: result.scale,
+            tileSize: result.tileSize,
+            classes: classes,
+            zoom: zoom,
+            bearing: bearing,
             params: params
         }, cb, result.tile.workerID);
     }.bind(this), function done(err, features) {

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -67,7 +67,7 @@ exports._getVisibleCoordinates = function() {
     else return this._pyramid.renderedIDs().map(TileCoord.fromID);
 };
 
-exports._queryVectorFeatures = function(queryGeometry, params, classes, zoom, bearing, callback) {
+exports._queryRenderedVectorFeatures = function(queryGeometry, params, classes, zoom, bearing, callback) {
     if (!this._pyramid)
         return callback(null, []);
 
@@ -76,7 +76,7 @@ exports._queryVectorFeatures = function(queryGeometry, params, classes, zoom, be
         return callback(null, []);
 
     util.asyncAll(results, function queryTile(result, cb) {
-        this.dispatcher.send('query features', {
+        this.dispatcher.send('query rendered features', {
             uid: result.tile.uid,
             source: this.id,
             queryGeometry: result.queryGeometry,
@@ -92,7 +92,7 @@ exports._queryVectorFeatures = function(queryGeometry, params, classes, zoom, be
     });
 };
 
-exports._getVectorTileData = function(params, callback) {
+exports._querySourceFeatures = function(params, callback) {
     if (!this._pyramid) {
         return callback(null, []);
     }
@@ -113,7 +113,7 @@ exports._getVectorTileData = function(params, callback) {
 
     util.asyncAll(Object.keys(dataTiles), function(dataID, callback) {
         var tile = dataTiles[dataID];
-        this.dispatcher.send('get tile data', {
+        this.dispatcher.send('query source features', {
             uid: tile.uid,
             source: this.id,
             params: params

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -67,34 +67,11 @@ exports._getVisibleCoordinates = function() {
     else return this._pyramid.renderedIDs().map(TileCoord.fromID);
 };
 
-exports._vectorFeaturesAt = function(coord, params, classes, zoom, bearing, callback) {
+exports._queryVectorFeatures = function(queryGeometry, params, classes, zoom, bearing, callback) {
     if (!this._pyramid)
         return callback(null, []);
 
-    var result = this._pyramid.tileAt(coord);
-    if (!result)
-        return callback(null, []);
-
-    this.dispatcher.send('query features', {
-        uid: result.tile.uid,
-        x: result.x,
-        y: result.y,
-        scale: result.scale,
-        tileSize: result.tileSize,
-        classes: classes,
-        zoom: zoom,
-        bearing: bearing,
-        source: this.id,
-        params: params
-    }, callback, result.tile.workerID);
-};
-
-
-exports._vectorFeaturesIn = function(bounds, params, classes, zoom, bearing, callback) {
-    if (!this._pyramid)
-        return callback(null, []);
-
-    var results = this._pyramid.tilesIn(bounds);
+    var results = this._pyramid.tilesIn(queryGeometry);
     if (!results)
         return callback(null, []);
 
@@ -102,12 +79,9 @@ exports._vectorFeaturesIn = function(bounds, params, classes, zoom, bearing, cal
         this.dispatcher.send('query features', {
             uid: result.tile.uid,
             source: this.id,
-            minX: result.minX,
-            maxX: result.maxX,
-            minY: result.minY,
-            maxY: result.maxY,
+            queryGeometry: result.queryGeometry,
             scale: result.scale,
-            tileSize: result.tileSize,
+            tileSize: result.tile.tileSize,
             classes: classes,
             zoom: zoom,
             bearing: bearing,

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -53,8 +53,8 @@ VectorTileSource.prototype = util.inherit(Evented, {
     getVisibleCoordinates: Source._getVisibleCoordinates,
     getTile: Source._getTile,
 
-    queryFeatures: Source._queryVectorFeatures,
-    getTileData: Source._getVectorTileData,
+    queryRenderedFeatures: Source._queryRenderedVectorFeatures,
+    querySourceFeatures: Source._querySourceFeatures,
 
     _loadTile: function(tile) {
         var overscaling = tile.coord.z > this.maxzoom ? Math.pow(2, tile.coord.z - this.maxzoom) : 1;

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -55,6 +55,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
 
     featuresAt: Source._vectorFeaturesAt,
     featuresIn: Source._vectorFeaturesIn,
+    getTileData: Source._getVectorTileData,
 
     _loadTile: function(tile) {
         var overscaling = tile.coord.z > this.maxzoom ? Math.pow(2, tile.coord.z - this.maxzoom) : 1;

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -53,8 +53,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
     getVisibleCoordinates: Source._getVisibleCoordinates,
     getTile: Source._getTile,
 
-    featuresAt: Source._vectorFeaturesAt,
-    featuresIn: Source._vectorFeaturesIn,
+    queryFeatures: Source._queryVectorFeatures,
     getTileData: Source._getVectorTileData,
 
     _loadTile: function(tile) {

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -187,6 +187,10 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
         return callback(null, []);
     },
 
+    getTileData: function(params, callback) {
+        return callback(null, []);
+    },
+
     serialize: function() {
         return {
             type: 'video',

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -179,11 +179,7 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
         return this.tile;
     },
 
-    featuresAt: function(point, params, callback) {
-        return callback(null, []);
-    },
-
-    featuresIn: function(bbox, params, callback) {
+    queryFeatures: function(point, params, callback) {
         return callback(null, []);
     },
 

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -179,11 +179,11 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
         return this.tile;
     },
 
-    queryFeatures: function(point, params, callback) {
+    queryRenderedFeatures: function(point, params, callback) {
         return callback(null, []);
     },
 
-    getTileData: function(params, callback) {
+    getSourceFeatures: function(params, callback) {
         return callback(null, []);
     },
 

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -217,7 +217,7 @@ util.extend(Worker.prototype, {
     'query source features': function(params, callback) {
         var tile = this.loaded[params.source] && this.loaded[params.source][params.uid];
         if (tile) {
-            callback(null, tile.getData(params.params));
+            callback(null, tile.querySourceFeatures(params.params));
         } else {
             callback(null, null);
         }

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -187,7 +187,7 @@ util.extend(Worker.prototype, {
         }
     },
 
-    'query features': function(params, callback) {
+    'query rendered features': function(params, callback) {
         var tile = this.loaded[params.source] && this.loaded[params.source][params.uid];
         if (tile) {
 
@@ -214,7 +214,7 @@ util.extend(Worker.prototype, {
         }
     },
 
-    'get tile data': function(params, callback) {
+    'query source features': function(params, callback) {
         var tile = this.loaded[params.source] && this.loaded[params.source][params.uid];
         if (tile) {
             callback(null, tile.getData(params.params));

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -212,5 +212,14 @@ util.extend(Worker.prototype, {
         } else {
             callback(null, []);
         }
+    },
+
+    'get tile data': function(params, callback) {
+        var tile = this.loaded[params.source] && this.loaded[params.source][params.uid];
+        if (tile) {
+            callback(null, tile.getData(params.params));
+        } else {
+            callback(null, null);
+        }
     }
 });

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -166,7 +166,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         bucket.populateBuffers(collisionTile, stacks, icons);
         var time = Date.now() - now;
 
-        if (bucket.interactive && bucket.type !== 'symbol') {
+        if (bucket.type !== 'symbol') {
             for (var i = 0; i < bucket.features.length; i++) {
                 var feature = bucket.features[i];
                 tile.featureTree.insert(feature.bbox(), bucket.layerIDs, feature);

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -241,7 +241,7 @@ function getTransferables(buckets) {
     return transferables;
 }
 
-WorkerTile.prototype.getData = function(params) {
+WorkerTile.prototype.querySourceFeatures = function(params) {
     if (!this.data) return null;
 
     var layer = this.data.layers ?
@@ -256,13 +256,11 @@ WorkerTile.prototype.getData = function(params) {
     for (var i = 0; i < layer.length; i++) {
         var feature = layer.feature(i);
         if (filter(feature)) {
-            features.push(feature.toGeoJSON(this.coord.x, this.coord.y, this.coord.z));
+            var geojsonFeature = feature.toGeoJSON(this.coord.x, this.coord.y, this.coord.z);
+            geojsonFeature.tile = { z: this.coord.z, x: this.coord.x, y: this.coord.y };
+            features.push(geojsonFeature);
         }
     }
 
-    return {
-        type: 'FeatureCollection',
-        features: features,
-        coord: { z: this.coord.z, x: this.coord.x, y: this.coord.y }
-    };
+    return features;
 };

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -245,7 +245,7 @@ WorkerTile.prototype.querySourceFeatures = function(params) {
     if (!this.data) return null;
 
     var layer = this.data.layers ?
-        this.data.layers[params['source-layer']] :
+        this.data.layers[params.sourceLayer] :
         this.data;
 
     if (!layer) return null;

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -22,7 +22,8 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
 
     this.status = 'parsing';
 
-    this.featureTree = new FeatureTree(this.coord, this.overscaling);
+    var collisionTile = new CollisionTile(this.angle, this.pitch);
+    this.featureTree = new FeatureTree(this.coord, this.overscaling, collisionTile);
 
     var stats = { _total: 0 };
 
@@ -65,7 +66,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
     for (i = 0; i < layers.length; i++) {
         layer = layers[i];
         if (layer.source === this.source && layer.ref && bucketsById[layer.ref]) {
-            bucketsById[layer.ref].layers.push(layer.id);
+            bucketsById[layer.ref].layerIDs.push(layer.id);
         }
     }
 
@@ -94,8 +95,6 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
     var buckets = [],
         symbolBuckets = this.symbolBuckets = [],
         otherBuckets = [];
-
-    var collisionTile = new CollisionTile(this.angle, this.pitch);
 
     for (var id in bucketsById) {
         bucket = bucketsById[id];
@@ -167,10 +166,10 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
         bucket.populateBuffers(collisionTile, stacks, icons);
         var time = Date.now() - now;
 
-        if (bucket.interactive) {
+        if (bucket.interactive && bucket.type !== 'symbol') {
             for (var i = 0; i < bucket.features.length; i++) {
                 var feature = bucket.features[i];
-                tile.featureTree.insert(feature.bbox(), bucket.layers, feature);
+                tile.featureTree.insert(feature.bbox(), bucket.layerIDs, feature);
             }
         }
 
@@ -203,6 +202,7 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, showCollisionBoxes) 
     }
 
     var collisionTile = new CollisionTile(angle, pitch);
+    this.featureTree.setCollisionTile(collisionTile);
     var buckets = this.symbolBuckets;
 
     for (var i = buckets.length - 1; i >= 0; i--) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -410,15 +410,7 @@ Style.prototype = util.inherit(Evented, {
         }, function(value) { return value !== undefined; });
     },
 
-    featuresAt: function(coord, params, classes, zoom, bearing, callback) {
-        this._queryFeatures('featuresAt', coord, params, classes, zoom, bearing, callback);
-    },
-
-    featuresIn: function(bbox, params, classes, zoom, bearing, callback) {
-        this._queryFeatures('featuresIn', bbox, params, classes, zoom, bearing, callback);
-    },
-
-    _queryFeatures: function(queryType, bboxOrCoords, params, classes, zoom, bearing, callback) {
+    queryFeatures: function(queryGeometry, params, classes, zoom, bearing, callback) {
         var features = [];
         var error = null;
 
@@ -428,7 +420,7 @@ Style.prototype = util.inherit(Evented, {
 
         util.asyncAll(Object.keys(this.sources), function(id, callback) {
             var source = this.sources[id];
-            source[queryType](bboxOrCoords, params, classes, zoom, bearing, function(err, result) {
+            source.queryFeatures(queryGeometry, params, classes, zoom, bearing, function(err, result) {
                 if (result) features = features.concat(result);
                 if (err) error = err;
                 callback();

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -410,7 +410,7 @@ Style.prototype = util.inherit(Evented, {
         }, function(value) { return value !== undefined; });
     },
 
-    queryFeatures: function(queryGeometry, params, classes, zoom, bearing, callback) {
+    queryRenderedFeatures: function(queryGeometry, params, classes, zoom, bearing, callback) {
         var features = [];
         var error = null;
 
@@ -420,7 +420,7 @@ Style.prototype = util.inherit(Evented, {
 
         util.asyncAll(Object.keys(this.sources), function(id, callback) {
             var source = this.sources[id];
-            source.queryFeatures(queryGeometry, params, classes, zoom, bearing, function(err, result) {
+            source.queryRenderedFeatures(queryGeometry, params, classes, zoom, bearing, function(err, result) {
                 if (result) features = features.concat(result);
                 if (err) error = err;
                 callback();

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -410,15 +410,15 @@ Style.prototype = util.inherit(Evented, {
         }, function(value) { return value !== undefined; });
     },
 
-    featuresAt: function(coord, params, callback) {
-        this._queryFeatures('featuresAt', coord, params, callback);
+    featuresAt: function(coord, params, classes, zoom, bearing, callback) {
+        this._queryFeatures('featuresAt', coord, params, classes, zoom, bearing, callback);
     },
 
-    featuresIn: function(bbox, params, callback) {
-        this._queryFeatures('featuresIn', bbox, params, callback);
+    featuresIn: function(bbox, params, classes, zoom, bearing, callback) {
+        this._queryFeatures('featuresIn', bbox, params, classes, zoom, bearing, callback);
     },
 
-    _queryFeatures: function(queryType, bboxOrCoords, params, callback) {
+    _queryFeatures: function(queryType, bboxOrCoords, params, classes, zoom, bearing, callback) {
         var features = [];
         var error = null;
 
@@ -428,7 +428,7 @@ Style.prototype = util.inherit(Evented, {
 
         util.asyncAll(Object.keys(this.sources), function(id, callback) {
             var source = this.sources[id];
-            source[queryType](bboxOrCoords, params, function(err, result) {
+            source[queryType](bboxOrCoords, params, classes, zoom, bearing, function(err, result) {
                 if (result) features = features.concat(result);
                 if (err) error = err;
                 callback();

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -34,7 +34,6 @@ function StyleLayer(layer, refLayer) {
     this.minzoom = (refLayer || layer).minzoom;
     this.maxzoom = (refLayer || layer).maxzoom;
     this.filter = (refLayer || layer).filter;
-    this.interactive = (refLayer || layer).interactive;
 
     this.paint = {};
     this.layout = {};
@@ -262,8 +261,7 @@ StyleLayer.prototype = util.inherit(Evented, {
             'ref': this.ref,
             'metadata': this.metadata,
             'minzoom': this.minzoom,
-            'maxzoom': this.maxzoom,
-            'interactive': this.interactive
+            'maxzoom': this.maxzoom
         };
 
         for (var klass in this._paintDeclarations) {

--- a/js/symbol/collision_box.js
+++ b/js/symbol/collision_box.js
@@ -41,9 +41,11 @@ module.exports = CollisionBox;
  * @param {number} x2 The distance from the anchor to the right edge.
  * @param {number} y2 The distance from the anchor to the bottom edge.
  * @param {number} maxScale The maximum scale this box can block other boxes at.
+ * @param {VectorTileFeature} feature The VectorTileFeature that this CollisionBox was created for.
+ * @param {Array<string>} layerIDs The IDs of the layers that this CollisionBox is a part of.
  * @private
  */
-function CollisionBox(anchorPoint, x1, y1, x2, y2, maxScale) {
+function CollisionBox(anchorPoint, x1, y1, x2, y2, maxScale, feature, layerIDs) {
     // the box is centered around the anchor point
     this.anchorPoint = anchorPoint;
 
@@ -56,6 +58,12 @@ function CollisionBox(anchorPoint, x1, y1, x2, y2, maxScale) {
     // the box is only valid for scales < maxScale.
     // The box does not block other boxes at scales >= maxScale;
     this.maxScale = maxScale;
+
+    // the index of the feature in the original vectortile
+    this.feature = feature;
+
+    // the IDs of the layers this feature collision box appears in
+    this.layerIDs = layerIDs;
 
     // the scale at which the label can first be shown
     this.placementScale = 0;

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -130,7 +130,6 @@ var Map = module.exports = function(options) {
         this.jumpTo(options);
     }
 
-    this.sources = {};
     this.stacks = {};
     this._classes = {};
 
@@ -443,6 +442,30 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
           )
         ].map(this.transform.pointCoordinate.bind(this.transform));
         this.style.featuresIn(bounds, params, this._classes, this.transform.zoom, this.transform.angle, callback);
+        return this;
+    },
+
+
+    /**
+     * Get data from vector tiles as an array of GeoJSON FeatureCollections FeatureCollections.
+     *
+     * @param {string} sourceID source ID
+     * @param {Object} params
+     * @param {string} [params.source-layer] The name of the vector tile layer to get features from.
+     * @param {Array} [params.filter] A mapbox-gl-style-spec filter.
+     * @param {callback} callback function that receives the results
+     *
+     * @returns {Map} `this`
+     */
+    getSourceTileData: function(sourceID, params, callback) {
+        var source = this.getSource(sourceID);
+
+        if (!source) {
+            return callback("No source with id '" + sourceID + "'.", []);
+        }
+
+        source.getTileData(params, callback);
+
         return this;
     },
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -436,7 +436,9 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             new Point(bounds[1].x, bounds[0].y),
             bounds[1],
             new Point(bounds[0].x, bounds[1].y),
-            bounds[0]].map(this.transform.pointCoordinate.bind(this.transform));
+            bounds[0]
+        ].map(this.transform.pointCoordinate.bind(this.transform));
+
         this.style.queryFeatures(queryGeometry, params, this._classes, this.transform.zoom, this.transform.angle, callback);
         return this;
     },

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -398,7 +398,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     featuresAt: function(point, params, callback) {
         var location = this.unproject(point).wrap();
         var coord = this.transform.locationCoordinate(location);
-        this.style.featuresAt(coord, params, this._classes, this.transform.zoom, this.transform.angle, callback);
+        this.style.queryFeatures([coord], params, this._classes, this.transform.zoom, this.transform.angle, callback);
         return this;
     },
 
@@ -430,17 +430,14 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             ];
         }
         bounds = bounds.map(Point.convert.bind(Point));
-        bounds = [
-            new Point(
-            Math.min(bounds[0].x, bounds[1].x),
-            Math.min(bounds[0].y, bounds[1].y)
-          ),
-            new Point(
-            Math.max(bounds[0].x, bounds[1].x),
-            Math.max(bounds[0].y, bounds[1].y)
-          )
-        ].map(this.transform.pointCoordinate.bind(this.transform));
-        this.style.featuresIn(bounds, params, this._classes, this.transform.zoom, this.transform.angle, callback);
+
+        var queryGeometry = [
+            bounds[0],
+            new Point(bounds[1].x, bounds[0].y),
+            bounds[1],
+            new Point(bounds[0].x, bounds[1].y),
+            bounds[0]].map(this.transform.pointCoordinate.bind(this.transform));
+        this.style.queryFeatures(queryGeometry, params, this._classes, this.transform.zoom, this.transform.angle, callback);
         return this;
     },
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -385,6 +385,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @param {Object} params
      * @param {string|Array<string>} [params.layer] Only return features from a given layer or layers
      * @param {boolean} [params.includeGeometry=false] If `true`, geometry of features will be included in the results at the expense of a much slower query time.
+     * @param {Array} [params.filter] A mapbox-gl-style-spec filter.
      * @param {featuresCallback} callback function that receives the results
      *
      * @returns {Map} `this`

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -402,7 +402,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     featuresAt: function(point, params, callback) {
         var location = this.unproject(point).wrap();
         var coord = this.transform.locationCoordinate(location);
-        this.style.featuresAt(coord, params, callback);
+        this.style.featuresAt(coord, params, this._classes, this.transform.zoom, this.transform.angle, callback);
         return this;
     },
 
@@ -446,7 +446,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             Math.max(bounds[0].y, bounds[1].y)
           )
         ].map(this.transform.pointCoordinate.bind(this.transform));
-        this.style.featuresIn(bounds, params, callback);
+        this.style.featuresIn(bounds, params, this._classes, this.transform.zoom, this.transform.angle, callback);
         return this;
     },
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -383,7 +383,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      *
      * @param {Array<number>} point [x, y] pixel coordinates
      * @param {Object} params
-     * @param {number} [params.radius=0] Radius in pixels to search in
      * @param {string|Array<string>} [params.layer] Only return features from a given layer or layers
      * @param {string} [params.type] Either `raster` or `vector`
      * @param {boolean} [params.includeGeometry=false] If `true`, geometry of features will be included in the results at the expense of a much slower query time.

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -442,7 +442,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      *
      * @param {string} sourceID source ID
      * @param {Object} params
-     * @param {string} [params.source-layer] The name of the vector tile layer to get features from.
+     * @param {string} [params.sourceLayer] The name of the vector tile layer to get features from.
      * @param {Array} [params.filter] A mapbox-gl-style-spec filter.
      * @param {callback} callback function that receives the results
      *

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -382,8 +382,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     /**
      * Query features at a point, or within a certain radius thereof.
      *
-     * To use this method, you must set the style property `"interactive": true` on layers you wish to query.
-     *
      * @param {Array<number>} point [x, y] pixel coordinates
      * @param {Object} params
      * @param {number} [params.radius=0] Radius in pixels to search in
@@ -408,8 +406,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
 
     /**
      * Query features within a rectangle.
-     *
-     * To use this method, you must set the style property `"interactive": true` on layers you wish to query.
      *
      * @param {Array<Point>|Array<Array<number>>} [bounds] Coordinates of opposite corners of bounding rectangle, in pixel coordinates. Optional: use entire viewport if omitted.
      * @param {Object} params

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -11,7 +11,7 @@ var PNG = require('pngjs').PNG;
  *
  * @callback {getJSONCallback} `this`
  * @param {Object|null} err Error _If any_
- * @param {Array} features Displays a JSON array of features given the passed parameters of `featuresAt`
+ * @param {Array} features Displays a JSON array of features.
  *
  * @example
  * mapboxgl.util.getJSON('style.json', function (err, style) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express": "^4.13.4",
     "gl": "^2.1.5",
     "istanbul": "^0.4.2",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#d577ac4d1c0839e19fb7b873faaf459269a7e385",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7ef3f507d3b48cea9f3524f01a8f2489848821a9",
     "nyc": "^6.1.1",
     "sinon": "^1.15.4",
     "st": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express": "^4.13.4",
     "gl": "^2.1.5",
     "istanbul": "^0.4.2",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#a0c61bcc5ce6ff9fd92c2a837cad76d298513e03",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#d577ac4d1c0839e19fb7b873faaf459269a7e385",
     "nyc": "^6.1.1",
     "sinon": "^1.15.4",
     "st": "^1.0.0",

--- a/test/js/data/feature_tree.test.js
+++ b/test/js/data/feature_tree.test.js
@@ -3,6 +3,7 @@
 var test = require('tap').test;
 var vt = require('vector-tile');
 var fs = require('fs');
+var Point = require('point-geometry');
 var Protobuf = require('pbf');
 var FeatureTree = require('../../../js/data/feature_tree');
 var path = require('path');
@@ -42,8 +43,7 @@ test('featuretree', function(t) {
         scale: 1,
         tileSize: 512,
         params: { },
-        x: 0,
-        y: 0
+        queryGeometry: [new Point(0, 0)]
     }, styleLayers), []);
     t.end();
 });
@@ -65,8 +65,7 @@ test('featuretree with args', function(t) {
         params: {},
         scale: 1,
         tileSize: 512,
-        x: 0,
-        y: 0
+        queryGeometry: [new Point(0, 0)]
     }, styleLayers), []);
     t.end();
 });
@@ -86,8 +85,7 @@ test('featuretree point query', function(t) {
         params: {
             includeGeometry: true
         },
-        x: -180,
-        y: 1780
+        queryGeometry: [new Point(-180, 1780)]
     }, styleLayers);
     t.notEqual(features.length, 0, 'non-empty results for queryFeatures');
     features.forEach(function(f) {
@@ -116,10 +114,13 @@ test('featuretree rect query', function(t) {
         params: {
             includeGeometry: true
         },
-        minX: 0,
-        minY: 3072,
-        maxX: 2048,
-        maxY: 4096
+        queryGeometry: [
+            new Point(0, 3072),
+            new Point(2048, 3072),
+            new Point(2048, 4096),
+            new Point(0, 4096),
+            new Point(0, 3072)
+        ]
     }, styleLayers);
     t.notEqual(features.length, 0, 'non-empty results for queryFeatures');
     features.forEach(function(f) {
@@ -164,8 +165,7 @@ test('featuretree query with layerIds', function(t) {
         params: {
             layerIds: ['water']
         },
-        x: -180,
-        y: 1780
+        queryGeometry: [new Point(-180, 1780)]
     }, styleLayers);
 
     t.equal(features.length, 1);
@@ -177,8 +177,7 @@ test('featuretree query with layerIds', function(t) {
         params: {
             layerIds: ['none']
         },
-        x: 1842,
-        y: 2014
+        queryGeometry: [new Point(1842, 2014)]
     }, styleLayers);
 
     t.equal(features2.length, 0);

--- a/test/js/data/feature_tree.test.js
+++ b/test/js/data/feature_tree.test.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 var Protobuf = require('pbf');
 var FeatureTree = require('../../../js/data/feature_tree');
 var path = require('path');
+var CollisionTile = require('../../../js/symbol/collision_tile');
 
 test('featuretree', function(t) {
     var tile = new vt.VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
@@ -15,12 +16,14 @@ test('featuretree', function(t) {
     function getGeometry(feature) {
         return feature.loadGeometry();
     }
-    var ft = new FeatureTree(getGeometry, getType);
+    var ft = new FeatureTree(getGeometry, getType, new CollisionTile(0, 0));
     var feature = tile.layers.road.feature(0);
     t.ok(feature);
     t.ok(ft, 'can be created');
     ft.insert(feature.bbox(), 'road', feature);
     ft.query({
+        scale: 1,
+        tileSize: 512,
         params: { },
         scale: 1,
         tileSize: 512,
@@ -41,7 +44,7 @@ test('featuretree with args', function(t) {
     function getGeometry(feature) {
         return feature.loadGeometry();
     }
-    var ft = new FeatureTree(getGeometry, getType);
+    var ft = new FeatureTree(getGeometry, getType, new CollisionTile(0, 0));
     var feature = tile.layers.road.feature(0);
     t.ok(feature);
     t.ok(ft, 'can be created');
@@ -63,7 +66,7 @@ test('featuretree with args', function(t) {
 
 test('featuretree point query', function(t) {
     var tile = new vt.VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
-    var ft = new FeatureTree({ x: 18, y: 23, z: 6 }, 1);
+    var ft = new FeatureTree({ x: 18, y: 23, z: 6 }, 1, new CollisionTile(0, 0));
 
     for (var i = 0; i < tile.layers.water._features.length; i++) {
         var feature = tile.layers.water.feature(i);
@@ -96,7 +99,7 @@ test('featuretree point query', function(t) {
 
 test('featuretree rect query', function(t) {
     var tile = new vt.VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
-    var ft = new FeatureTree({ x: 18, y: 23, z: 6 }, 1);
+    var ft = new FeatureTree({ x: 18, y: 23, z: 6 }, 1, new CollisionTile(0, 0));
 
     for (var i = 0; i < tile.layers.water._features.length; i++) {
         var feature = tile.layers.water.feature(i);
@@ -146,7 +149,7 @@ test('featuretree query with layerIds', function(t) {
     function getGeometry(feature) {
         return feature.loadGeometry();
     }
-    var ft = new FeatureTree(getGeometry, getType);
+    var ft = new FeatureTree(getGeometry, getType, new CollisionTile(0, 0));
 
     for (var i = 0; i < tile.layers.water._features.length; i++) {
         var feature = tile.layers.water.feature(i);

--- a/test/js/data/feature_tree.test.js
+++ b/test/js/data/feature_tree.test.js
@@ -62,9 +62,7 @@ test('featuretree with args', function(t) {
     t.ok(ft, 'can be created');
     ft.insert(feature.bbox(), ['road'], feature);
     t.deepEqual(ft.query({
-        params: {
-            radius: 5
-        },
+        params: {},
         scale: 1,
         tileSize: 512,
         x: 0,
@@ -86,11 +84,10 @@ test('featuretree point query', function(t) {
         scale: 1.4142135624,
         tileSize: 512,
         params: {
-            radius: 30,
             includeGeometry: true
         },
-        x: 1842,
-        y: 2014
+        x: -180,
+        y: 1780
     }, styleLayers);
     t.notEqual(features.length, 0, 'non-empty results for queryFeatures');
     features.forEach(function(f) {
@@ -165,21 +162,19 @@ test('featuretree query with layerIds', function(t) {
         scale: 1.4142135624,
         tileSize: 512,
         params: {
-            radius: 30,
             layerIds: ['water']
         },
-        x: 1842,
-        y: 2014
+        x: -180,
+        y: 1780
     }, styleLayers);
 
-    t.equal(features.length, 2);
+    t.equal(features.length, 1);
 
     var features2 = ft.query({
         source: "mapbox.mapbox-streets-v5",
         scale: 1.4142135624,
         tileSize: 512,
         params: {
-            radius: 30,
             layerIds: ['none']
         },
         x: 1842,

--- a/test/js/source/tile_pyramid.test.js
+++ b/test/js/source/tile_pyramid.test.js
@@ -245,82 +245,6 @@ test('TilePyramid#removeTile', function(t) {
     t.end();
 });
 
-test('TilePyramid#tileAt', function(t) {
-    t.test('regular tile', function(t) {
-        var pyramid = createPyramid({
-            load: function(tile) { tile.loaded = true; },
-            minzoom: 1,
-            maxzoom: 1,
-            tileSize: 512
-        });
-
-        var transform = new Transform();
-        transform.resize(512, 512);
-        transform.zoom = 1.5;
-        pyramid.update(true, transform);
-
-        var result = pyramid.tileAt(new Coordinate(0, 3, 2));
-
-        t.deepEqual(result.tile.coord.id, 65);
-        t.deepEqual(result.scale, 1.4142135623730951);
-        t.deepEqual(result.tileSize, 512);
-        t.deepEqual(result.x, 0);
-        t.deepEqual(result.y, 4096);
-
-        t.end();
-    });
-
-    t.test('reparsed overscaled tile', function(t) {
-        var pyramid = createPyramid({
-            load: function(tile) { tile.loaded = true; },
-            reparseOverscaled: true,
-            minzoom: 1,
-            maxzoom: 1,
-            tileSize: 512
-        });
-
-        var transform = new Transform();
-        transform.resize(512, 512);
-        transform.zoom = 2.5;
-        pyramid.update(true, transform);
-
-        var result = pyramid.tileAt(new Coordinate(0, 3, 2));
-
-        t.deepEqual(result.tile.coord.id, 130);
-        t.deepEqual(result.scale, 1.4142135623730951);
-        t.deepEqual(result.tileSize, 1024);
-        t.deepEqual(result.x, 0);
-        t.deepEqual(result.y, 4096);
-        t.end();
-    });
-
-    t.test('overscaled tile', function(t) {
-        var pyramid = createPyramid({
-            load: function(tile) { tile.loaded = true; },
-            minzoom: 1,
-            maxzoom: 1,
-            tileSize: 512
-        });
-
-        var transform = new Transform();
-        transform.resize(512, 512);
-        transform.zoom = 2.5;
-        pyramid.update(true, transform);
-
-        var result = pyramid.tileAt(new Coordinate(0, 3, 2));
-
-        t.deepEqual(result.tile.coord.id, 65);
-        t.deepEqual(result.scale, 2 * 1.4142135623730951);
-        t.deepEqual(result.tileSize, 512);
-        t.deepEqual(result.x, 0);
-        t.deepEqual(result.y, 4096);
-
-        t.end();
-    });
-
-    t.end();
-});
-
 test('TilePyramid#update', function(t) {
     t.test('loads no tiles if used is false', function(t) {
         var transform = new Transform();
@@ -549,46 +473,131 @@ test('TilePyramid#clearTiles', function(t) {
 });
 
 test('TilePyramid#tilesIn', function (t) {
-    var transform = new Transform();
-    transform.resize(511, 511);
-    transform.zoom = 1;
+    t.test('regular tiles', function(t) {
+        var transform = new Transform();
+        transform.resize(511, 511);
+        transform.zoom = 1;
 
-    var pyramid = createPyramid({
-        load: function(tile) {
-            tile.loaded = true;
-        }
+        var pyramid = createPyramid({
+            load: function(tile) {
+                tile.loaded = true;
+            }
+        });
+
+        pyramid.update(true, transform);
+
+        t.deepEqual(pyramid.orderedIDs(), [
+            new TileCoord(1, 0, 0).id,
+            new TileCoord(1, 1, 0).id,
+            new TileCoord(1, 0, 1).id,
+            new TileCoord(1, 1, 1).id
+        ]);
+
+        var tiles = pyramid.tilesIn([
+            new Coordinate(0.5, 0.25, 1),
+            new Coordinate(1.5, 0.75, 1)
+        ]);
+
+        tiles.sort(function (a, b) { return a.tile.coord.x - b.tile.coord.x; });
+        tiles.forEach(function (result) { delete result.tile.uid; });
+
+        t.equal(tiles[0].tile.coord.id, 1);
+        t.equal(tiles[0].tile.tileSize, 512);
+        t.equal(tiles[0].scale, 1);
+        t.deepEqual(tiles[0].queryGeometry, [{x: 4096, y: 2048}, {x:12288, y: 6144}]);
+
+        t.equal(tiles[1].tile.coord.id, 33);
+        t.equal(tiles[1].tile.tileSize, 512);
+        t.equal(tiles[1].scale, 1);
+        t.deepEqual(tiles[1].queryGeometry, [{x: -4096, y: 2048}, {x: 4096, y: 6144}]);
+
+        t.end();
     });
 
-    pyramid.update(true, transform);
+    t.test('reparsed overscaled tiles', function(t) {
+        var pyramid = createPyramid({
+            load: function(tile) { tile.loaded = true; },
+            reparseOverscaled: true,
+            minzoom: 1,
+            maxzoom: 1,
+            tileSize: 512
+        });
 
-    t.deepEqual(pyramid.orderedIDs(), [
-        new TileCoord(1, 0, 0).id,
-        new TileCoord(1, 1, 0).id,
-        new TileCoord(1, 0, 1).id,
-        new TileCoord(1, 1, 1).id
-    ]);
+        var transform = new Transform();
+        transform.resize(512, 512);
+        transform.zoom = 2.0;
+        pyramid.update(true, transform);
 
-    var tiles = pyramid.tilesIn([
-        new Coordinate(0.5, 0.25, 1),
-        new Coordinate(1.5, 0.75, 1)
-    ]);
+        t.deepEqual(pyramid.orderedIDs(), [
+            new TileCoord(2, 0, 0).id,
+            new TileCoord(2, 1, 0).id,
+            new TileCoord(2, 0, 1).id,
+            new TileCoord(2, 1, 1).id
+        ]);
 
-    tiles.sort(function (a, b) { return a.tile.coord.x - b.tile.coord.x; });
-    tiles.forEach(function (result) { delete result.tile.uid; });
+        var tiles = pyramid.tilesIn([
+            new Coordinate(0.5, 0.25, 1),
+            new Coordinate(1.5, 0.75, 1)
+        ]);
 
-    t.equal(tiles[0].tile.coord.id, 1);
-    t.equal(tiles[0].minX, 4096);
-    t.equal(tiles[0].maxX, 12288);
-    t.equal(tiles[0].minY, 2048);
-    t.equal(tiles[0].maxY, 6144);
+        tiles.sort(function (a, b) { return a.tile.coord.x - b.tile.coord.x; });
+        tiles.forEach(function (result) { delete result.tile.uid; });
 
-    t.equal(tiles[1].tile.coord.id, 33);
-    t.equal(tiles[1].minX, -4096);
-    t.equal(tiles[1].maxX, 4096);
-    t.equal(tiles[1].minY, 2048);
-    t.equal(tiles[1].maxY, 6144);
+        t.equal(tiles[0].tile.coord.id, 2);
+        t.equal(tiles[0].tile.tileSize, 1024);
+        t.equal(tiles[0].scale, 1);
+        t.deepEqual(tiles[0].queryGeometry, [{x: 4096, y: 2048}, {x:12288, y: 6144}]);
 
-    t.equal(tiles.length, 2);
+        t.equal(tiles[1].tile.coord.id, 34);
+        t.equal(tiles[1].tile.tileSize, 1024);
+        t.equal(tiles[1].scale, 1);
+        t.deepEqual(tiles[1].queryGeometry, [{x: -4096, y: 2048}, {x: 4096, y: 6144}]);
+
+        t.end();
+    });
+
+    t.test('overscaled tiles', function(t) {
+        var pyramid = createPyramid({
+            load: function(tile) { tile.loaded = true; },
+            reparseOverscaled: false,
+            minzoom: 1,
+            maxzoom: 1,
+            tileSize: 512
+        });
+
+        var transform = new Transform();
+        transform.resize(512, 512);
+        transform.zoom = 2.0;
+        pyramid.update(true, transform);
+
+
+        t.deepEqual(pyramid.orderedIDs(), [
+            new TileCoord(1, 0, 0).id,
+            new TileCoord(1, 1, 0).id,
+            new TileCoord(1, 0, 1).id,
+            new TileCoord(1, 1, 1).id
+        ]);
+
+        var tiles = pyramid.tilesIn([
+            new Coordinate(0.5, 0.25, 1),
+            new Coordinate(1.5, 0.75, 1)
+        ]);
+
+        tiles.sort(function (a, b) { return a.tile.coord.x - b.tile.coord.x; });
+        tiles.forEach(function (result) { delete result.tile.uid; });
+
+        t.equal(tiles[0].tile.coord.id, 1);
+        t.equal(tiles[0].tile.tileSize, 512);
+        t.equal(tiles[0].scale, 2);
+        t.deepEqual(tiles[0].queryGeometry, [{x: 4096, y: 2048}, {x:12288, y: 6144}]);
+
+        t.equal(tiles[1].tile.coord.id, 33);
+        t.equal(tiles[1].tile.tileSize, 512);
+        t.equal(tiles[1].scale, 2);
+        t.deepEqual(tiles[1].queryGeometry, [{x: -4096, y: 2048}, {x: 4096, y: 6144}]);
+
+        t.end();
+    });
 
     t.end();
 });

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -53,7 +53,7 @@ test('basic', function(t) {
     t.end();
 });
 
-test('getData', function(t) {
+test('querySourceFeatures', function(t) {
     var features = [{
         type: 1,
         geometry: [0, 0],
@@ -65,15 +65,14 @@ test('getData', function(t) {
         var tile = new WorkerTile({uid: '', zoom: 0, maxZoom: 20, tileSize: 512, source: 'source',
             coord: new TileCoord(1, 1, 1), overscaling: 1 });
 
-        t.equal(tile.getData({}), null);
+        t.equal(tile.querySourceFeatures({}), null);
 
         tile.data = new Wrapper(features);
 
-        t.equal(tile.getData({}).type, 'FeatureCollection');
-        t.equal(tile.getData({}).features.length, 1);
-        t.deepEqual(tile.getData({}).features[0].properties, features[0].tags);
-        t.equal(tile.getData({ filter: ['==', 'oneway', true]}).features.length, 1);
-        t.equal(tile.getData({ filter: ['!=', 'oneway', true]}).features.length, 0);
+        t.equal(tile.querySourceFeatures({}).length, 1);
+        t.deepEqual(tile.querySourceFeatures({})[0].properties, features[0].tags);
+        t.equal(tile.querySourceFeatures({ filter: ['==', 'oneway', true]}).length, 1);
+        t.equal(tile.querySourceFeatures({ filter: ['!=', 'oneway', true]}).length, 0);
         t.end();
     });
 
@@ -81,18 +80,17 @@ test('getData', function(t) {
         var tile = new WorkerTile({uid: '', zoom: 0, maxZoom: 20, tileSize: 512, source: 'source',
             coord: new TileCoord(1, 1, 1), overscaling: 1 });
 
-        t.equal(tile.getData({}), null);
+        t.equal(tile.querySourceFeatures({}), null);
 
         tile.data = new vt.VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
 
-        t.equal(tile.getData({ 'source-layer': 'does-not-exist'}), null);
+        t.equal(tile.querySourceFeatures({ 'source-layer': 'does-not-exist'}), null);
 
-        var roads = tile.getData({ 'source-layer': 'road' });
-        t.equal(roads.type, 'FeatureCollection');
-        t.equal(roads.features.length, 3);
+        var roads = tile.querySourceFeatures({ 'source-layer': 'road' });
+        t.equal(roads.length, 3);
 
-        t.equal(tile.getData({ 'source-layer': 'road', filter: ['==', 'class', 'main'] }).features.length, 1);
-        t.equal(tile.getData({ 'source-layer': 'road', filter: ['!=', 'class', 'main'] }).features.length, 2);
+        t.equal(tile.querySourceFeatures({ 'source-layer': 'road', filter: ['==', 'class', 'main'] }).length, 1);
+        t.equal(tile.querySourceFeatures({ 'source-layer': 'road', filter: ['!=', 'class', 'main'] }).length, 2);
 
         t.end();
     });

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -4,6 +4,10 @@ var test = require('tap').test;
 var WorkerTile = require('../../../js/source/worker_tile');
 var Wrapper = require('../../../js/source/geojson_wrapper');
 var TileCoord = require('../../../js/source/tile_coord');
+var vt = require('vector-tile');
+var fs = require('fs');
+var path = require('path');
+var Protobuf = require('pbf');
 
 test('basic', function(t) {
     var buckets = [{
@@ -45,6 +49,54 @@ test('basic', function(t) {
             t.end();
         });
     });
+
+    t.end();
+});
+
+test('getData', function(t) {
+    var features = [{
+        type: 1,
+        geometry: [0, 0],
+        tags: { oneway: true }
+    }];
+
+
+    t.test('geojson tile', function(t) {
+        var tile = new WorkerTile({uid: '', zoom: 0, maxZoom: 20, tileSize: 512, source: 'source',
+            coord: new TileCoord(1, 1, 1), overscaling: 1 });
+
+        t.equal(tile.getData({}), null);
+
+        tile.data = new Wrapper(features);
+
+        t.equal(tile.getData({}).type, 'FeatureCollection');
+        t.equal(tile.getData({}).features.length, 1);
+        t.deepEqual(tile.getData({}).features[0].properties, features[0].tags);
+        t.equal(tile.getData({ filter: ['==', 'oneway', true]}).features.length, 1);
+        t.equal(tile.getData({ filter: ['!=', 'oneway', true]}).features.length, 0);
+        t.end();
+    });
+
+    t.test('vector tile', function(t) {
+        var tile = new WorkerTile({uid: '', zoom: 0, maxZoom: 20, tileSize: 512, source: 'source',
+            coord: new TileCoord(1, 1, 1), overscaling: 1 });
+
+        t.equal(tile.getData({}), null);
+
+        tile.data = new vt.VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
+
+        t.equal(tile.getData({ 'source-layer': 'does-not-exist'}), null);
+
+        var roads = tile.getData({ 'source-layer': 'road' });
+        t.equal(roads.type, 'FeatureCollection');
+        t.equal(roads.features.length, 3);
+
+        t.equal(tile.getData({ 'source-layer': 'road', filter: ['==', 'class', 'main'] }).features.length, 1);
+        t.equal(tile.getData({ 'source-layer': 'road', filter: ['!=', 'class', 'main'] }).features.length, 2);
+
+        t.end();
+    });
+
 
     t.end();
 });

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -84,13 +84,13 @@ test('querySourceFeatures', function(t) {
 
         tile.data = new vt.VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
 
-        t.equal(tile.querySourceFeatures({ 'source-layer': 'does-not-exist'}), null);
+        t.equal(tile.querySourceFeatures({ 'sourceLayer': 'does-not-exist'}), null);
 
-        var roads = tile.querySourceFeatures({ 'source-layer': 'road' });
+        var roads = tile.querySourceFeatures({ 'sourceLayer': 'road' });
         t.equal(roads.length, 3);
 
-        t.equal(tile.querySourceFeatures({ 'source-layer': 'road', filter: ['==', 'class', 'main'] }).length, 1);
-        t.equal(tile.querySourceFeatures({ 'source-layer': 'road', filter: ['!=', 'class', 'main'] }).length, 2);
+        t.equal(tile.querySourceFeatures({ 'sourceLayer': 'road', filter: ['==', 'class', 'main'] }).length, 1);
+        t.equal(tile.querySourceFeatures({ 'sourceLayer': 'road', filter: ['!=', 'class', 'main'] }).length, 2);
 
         t.end();
     });

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -871,7 +871,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.end();
 });
 
-test('Style#featuresAt - race condition', function(t) {
+test('Style#queryFeatures - race condition', function(t) {
     var style = new Style({
         "version": 8,
         "sources": {
@@ -899,7 +899,7 @@ test('Style#featuresAt - race condition', function(t) {
         style._cascade([]);
         style._recalculate(0);
 
-        style.sources.mapbox.featuresAt = function(position, params, classes, zoom, bearing, callback) {
+        style.sources.mapbox.queryFeatures = function(position, params, classes, zoom, bearing, callback) {
             var features = [{
                 type: 'Feature',
                 layer: 'land',
@@ -911,8 +911,8 @@ test('Style#featuresAt - race condition', function(t) {
             }, 10);
         };
 
-        t.test('featuresAt race condition', function(t) {
-            style.featuresAt([256, 256], {}, {}, 0, 0, function(err, results) {
+        t.test('queryFeatures race condition', function(t) {
+            style.queryFeatures([256, 256], {}, {}, 0, 0, function(err, results) {
                 t.error(err);
                 t.equal(results.length, 0);
                 t.end();
@@ -923,7 +923,7 @@ test('Style#featuresAt - race condition', function(t) {
     });
 });
 
-test('Style#featuresAt', function(t) {
+test('Style#queryFeatures', function(t) {
     var style = new Style({
         "version": 8,
         "sources": {
@@ -959,7 +959,7 @@ test('Style#featuresAt', function(t) {
         style._cascade([]);
         style._recalculate(0);
 
-        style.sources.mapbox.featuresAt = style.sources.mapbox.featuresIn = function(position, params, classes, zoom, bearing, callback) {
+        style.sources.mapbox.queryFeatures = function(position, params, classes, zoom, bearing, callback) {
             var features = [{
                 type: 'Feature',
                 layer: 'land',
@@ -991,77 +991,71 @@ test('Style#featuresAt', function(t) {
             }, 10);
         };
 
-        [
-            style.featuresAt.bind(style, [256, 256]),
-            style.featuresIn.bind(style, [256, 256, 512, 512])
-        ].forEach(function (featuresInOrAt) {
-            t.test('returns feature type', function(t) {
-                featuresInOrAt({}, {}, 0, 0, function(err, results) {
-                    t.error(err);
-                    t.equal(results[0].geometry.type, 'Polygon');
-                    t.end();
-                });
+        t.test('returns feature type', function(t) {
+            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+                t.error(err);
+                t.equal(results[0].geometry.type, 'Polygon');
+                t.end();
             });
+        });
 
-            t.test('filters by `layer` option', function(t) {
-                featuresInOrAt({layer: 'land'}, {}, 0, 0, function(err, results) {
-                    t.error(err);
-                    t.equal(results.length, 2);
-                    t.end();
-                });
+        t.test('filters by `layer` option', function(t) {
+            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {layer: 'land'}, {}, 0, 0, function(err, results) {
+                t.error(err);
+                t.equal(results.length, 2);
+                t.end();
             });
+        });
 
-            t.test('includes layout properties', function(t) {
-                featuresInOrAt({}, {}, 0, 0, function(err, results) {
-                    t.error(err);
-                    var layout = results[0].layer.layout;
-                    t.deepEqual(layout['line-cap'], 'round');
-                    t.end();
-                });
+        t.test('includes layout properties', function(t) {
+            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+                t.error(err);
+                var layout = results[0].layer.layout;
+                t.deepEqual(layout['line-cap'], 'round');
+                t.end();
             });
+        });
 
-            t.test('includes paint properties', function(t) {
-                featuresInOrAt({}, {}, 0, 0, function(err, results) {
-                    t.error(err);
-                    t.deepEqual(results[0].layer.paint['line-color'], 'red');
-                    t.end();
-                });
+        t.test('includes paint properties', function(t) {
+            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+                t.error(err);
+                t.deepEqual(results[0].layer.paint['line-color'], 'red');
+                t.end();
             });
+        });
 
-            t.test('ref layer inherits properties', function(t) {
-                featuresInOrAt({}, {}, 0, 0, function(err, results) {
-                    t.error(err);
+        t.test('ref layer inherits properties', function(t) {
+            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+                t.error(err);
 
-                    var layer = results[1].layer;
-                    var refLayer = results[2].layer;
-                    t.deepEqual(layer.layout, refLayer.layout);
-                    t.deepEqual(layer.type, refLayer.type);
-                    t.deepEqual(layer.id, refLayer.ref);
-                    t.notEqual(layer.paint, refLayer.paint);
+                var layer = results[1].layer;
+                var refLayer = results[2].layer;
+                t.deepEqual(layer.layout, refLayer.layout);
+                t.deepEqual(layer.type, refLayer.type);
+                t.deepEqual(layer.id, refLayer.ref);
+                t.notEqual(layer.paint, refLayer.paint);
 
-                    t.end();
-                });
+                t.end();
             });
+        });
 
-            t.test('includes metadata', function(t) {
-                featuresInOrAt({}, {}, 0, 0, function(err, results) {
-                    t.error(err);
+        t.test('includes metadata', function(t) {
+            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+                t.error(err);
 
-                    var layer = results[0].layer;
-                    t.equal(layer.metadata.something, 'else');
+                var layer = results[0].layer;
+                t.equal(layer.metadata.something, 'else');
 
-                    t.end();
-                });
+                t.end();
             });
+        });
 
-            t.test('include multiple layers', function(t) {
-                featuresInOrAt({layer: ['land', 'landref']}, {}, 0, 0, function(err, results) {
-                    t.error(err);
-                    t.equals(results.length, 3);
-                    t.end();
-                });
+        t.test('include multiple layers', function(t) {
+            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {layer: ['land', 'landref']}, {}, 0, 0, function(err, results) {
+                t.error(err);
+                t.equals(results.length, 3);
+                t.end();
             });
-
         });
 
         t.end();

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -899,7 +899,7 @@ test('Style#featuresAt - race condition', function(t) {
         style._cascade([]);
         style._recalculate(0);
 
-        style.sources.mapbox.featuresAt = function(position, params, callback) {
+        style.sources.mapbox.featuresAt = function(position, params, classes, zoom, bearing, callback) {
             var features = [{
                 type: 'Feature',
                 layer: 'land',
@@ -912,7 +912,7 @@ test('Style#featuresAt - race condition', function(t) {
         };
 
         t.test('featuresAt race condition', function(t) {
-            style.featuresAt([256, 256], {}, function(err, results) {
+            style.featuresAt([256, 256], {}, {}, 0, 0, function(err, results) {
                 t.error(err);
                 t.equal(results.length, 0);
                 t.end();
@@ -959,7 +959,7 @@ test('Style#featuresAt', function(t) {
         style._cascade([]);
         style._recalculate(0);
 
-        style.sources.mapbox.featuresAt = style.sources.mapbox.featuresIn = function(position, params, callback) {
+        style.sources.mapbox.featuresAt = style.sources.mapbox.featuresIn = function(position, params, classes, zoom, bearing, callback) {
             var features = [{
                 type: 'Feature',
                 layer: 'land',
@@ -996,7 +996,7 @@ test('Style#featuresAt', function(t) {
             style.featuresIn.bind(style, [256, 256, 512, 512])
         ].forEach(function (featuresInOrAt) {
             t.test('returns feature type', function(t) {
-                featuresInOrAt({}, function(err, results) {
+                featuresInOrAt({}, {}, 0, 0, function(err, results) {
                     t.error(err);
                     t.equal(results[0].geometry.type, 'Polygon');
                     t.end();
@@ -1004,7 +1004,7 @@ test('Style#featuresAt', function(t) {
             });
 
             t.test('filters by `layer` option', function(t) {
-                featuresInOrAt({layer: 'land'}, function(err, results) {
+                featuresInOrAt({layer: 'land'}, {}, 0, 0, function(err, results) {
                     t.error(err);
                     t.equal(results.length, 2);
                     t.end();
@@ -1012,7 +1012,7 @@ test('Style#featuresAt', function(t) {
             });
 
             t.test('includes layout properties', function(t) {
-                featuresInOrAt({}, function(err, results) {
+                featuresInOrAt({}, {}, 0, 0, function(err, results) {
                     t.error(err);
                     var layout = results[0].layer.layout;
                     t.deepEqual(layout['line-cap'], 'round');
@@ -1021,7 +1021,7 @@ test('Style#featuresAt', function(t) {
             });
 
             t.test('includes paint properties', function(t) {
-                featuresInOrAt({}, function(err, results) {
+                featuresInOrAt({}, {}, 0, 0, function(err, results) {
                     t.error(err);
                     t.deepEqual(results[0].layer.paint['line-color'], 'red');
                     t.end();
@@ -1029,7 +1029,7 @@ test('Style#featuresAt', function(t) {
             });
 
             t.test('ref layer inherits properties', function(t) {
-                featuresInOrAt({}, function(err, results) {
+                featuresInOrAt({}, {}, 0, 0, function(err, results) {
                     t.error(err);
 
                     var layer = results[1].layer;
@@ -1044,7 +1044,7 @@ test('Style#featuresAt', function(t) {
             });
 
             t.test('includes metadata', function(t) {
-                featuresInOrAt({}, function(err, results) {
+                featuresInOrAt({}, {}, 0, 0, function(err, results) {
                     t.error(err);
 
                     var layer = results[0].layer;
@@ -1055,7 +1055,7 @@ test('Style#featuresAt', function(t) {
             });
 
             t.test('include multiple layers', function(t) {
-                featuresInOrAt({layer: ['land', 'landref']}, function(err, results) {
+                featuresInOrAt({layer: ['land', 'landref']}, {}, 0, 0, function(err, results) {
                     t.error(err);
                     t.equals(results.length, 3);
                     t.end();

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -871,7 +871,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.end();
 });
 
-test('Style#queryFeatures - race condition', function(t) {
+test('Style#queryRenderedFeatures - race condition', function(t) {
     var style = new Style({
         "version": 8,
         "sources": {
@@ -899,7 +899,7 @@ test('Style#queryFeatures - race condition', function(t) {
         style._cascade([]);
         style._recalculate(0);
 
-        style.sources.mapbox.queryFeatures = function(position, params, classes, zoom, bearing, callback) {
+        style.sources.mapbox.queryRenderedFeatures = function(position, params, classes, zoom, bearing, callback) {
             var features = [{
                 type: 'Feature',
                 layer: 'land',
@@ -911,8 +911,8 @@ test('Style#queryFeatures - race condition', function(t) {
             }, 10);
         };
 
-        t.test('queryFeatures race condition', function(t) {
-            style.queryFeatures([256, 256], {}, {}, 0, 0, function(err, results) {
+        t.test('queryRenderedFeatures race condition', function(t) {
+            style.queryRenderedFeatures([256, 256], {}, {}, 0, 0, function(err, results) {
                 t.error(err);
                 t.equal(results.length, 0);
                 t.end();
@@ -923,7 +923,7 @@ test('Style#queryFeatures - race condition', function(t) {
     });
 });
 
-test('Style#queryFeatures', function(t) {
+test('Style#queryRenderedFeatures', function(t) {
     var style = new Style({
         "version": 8,
         "sources": {
@@ -959,7 +959,7 @@ test('Style#queryFeatures', function(t) {
         style._cascade([]);
         style._recalculate(0);
 
-        style.sources.mapbox.queryFeatures = function(position, params, classes, zoom, bearing, callback) {
+        style.sources.mapbox.queryRenderedFeatures = function(position, params, classes, zoom, bearing, callback) {
             var features = [{
                 type: 'Feature',
                 layer: 'land',
@@ -992,7 +992,7 @@ test('Style#queryFeatures', function(t) {
         };
 
         t.test('returns feature type', function(t) {
-            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
                 t.error(err);
                 t.equal(results[0].geometry.type, 'Polygon');
                 t.end();
@@ -1000,7 +1000,7 @@ test('Style#queryFeatures', function(t) {
         });
 
         t.test('filters by `layer` option', function(t) {
-            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {layer: 'land'}, {}, 0, 0, function(err, results) {
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layer: 'land'}, {}, 0, 0, function(err, results) {
                 t.error(err);
                 t.equal(results.length, 2);
                 t.end();
@@ -1008,7 +1008,7 @@ test('Style#queryFeatures', function(t) {
         });
 
         t.test('includes layout properties', function(t) {
-            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
                 t.error(err);
                 var layout = results[0].layer.layout;
                 t.deepEqual(layout['line-cap'], 'round');
@@ -1017,7 +1017,7 @@ test('Style#queryFeatures', function(t) {
         });
 
         t.test('includes paint properties', function(t) {
-            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
                 t.error(err);
                 t.deepEqual(results[0].layer.paint['line-color'], 'red');
                 t.end();
@@ -1025,7 +1025,7 @@ test('Style#queryFeatures', function(t) {
         });
 
         t.test('ref layer inherits properties', function(t) {
-            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
                 t.error(err);
 
                 var layer = results[1].layer;
@@ -1040,7 +1040,7 @@ test('Style#queryFeatures', function(t) {
         });
 
         t.test('includes metadata', function(t) {
-            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0, function(err, results) {
                 t.error(err);
 
                 var layer = results[0].layer;
@@ -1051,7 +1051,7 @@ test('Style#queryFeatures', function(t) {
         });
 
         t.test('include multiple layers', function(t) {
-            style.queryFeatures([{column: 1, row: 1, zoom: 1}], {layer: ['land', 'landref']}, {}, 0, 0, function(err, results) {
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layer: ['land', 'landref']}, {}, 0, 0, function(err, results) {
                 t.error(err);
                 t.equals(results.length, 3);
                 t.end();

--- a/test/js/symbol/collision_feature.js
+++ b/test/js/symbol/collision_feature.js
@@ -14,11 +14,14 @@ test('CollisionFeature', function(t) {
         bottom: 10
     };
 
+    var feature = {};
+    var layerIDs = [];
+
     test('point label', function(t) {
         var point = new Point(500, 0);
         var anchor = new Anchor(point.x, point.y, 0, undefined);
 
-        var cf = new CollisionFeature([point], anchor, shapedText, 1, 0, false);
+        var cf = new CollisionFeature([point], anchor, feature, layerIDs, shapedText, 1, 0, false);
         t.equal(cf.boxes.length, 1);
 
         var box = cf.boxes[0];
@@ -32,7 +35,7 @@ test('CollisionFeature', function(t) {
     test('line label', function(t) {
         var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
         var anchor = new Anchor(505, 95, 0, 1);
-        var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
+        var cf = new CollisionFeature(line, anchor, feature, layerIDs, shapedText, 1, 0, true);
         var boxPoints = cf.boxes.map(pluckAnchorPoint);
         t.deepEqual(boxPoints, [
             { x: 467.71052542517856, y: 93.54210508503571 },
@@ -51,7 +54,7 @@ test('CollisionFeature', function(t) {
     test('vertical line label', function(t) {
         var line = [new Point(0, 0), new Point(0, 100), new Point(0, 111), new Point(0, 112), new Point(0, 200)];
         var anchor = new Anchor(0, 110, 0, 1);
-        var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
+        var cf = new CollisionFeature(line, anchor, feature, layerIDs, shapedText, 1, 0, true);
         var boxPoints = cf.boxes.map(pluckAnchorPoint);
         t.deepEqual(boxPoints, [
             { x: 0, y: 70 },
@@ -77,7 +80,7 @@ test('CollisionFeature', function(t) {
 
         var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
         var anchor = new Anchor(505, 95, 0, 1);
-        var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
+        var cf = new CollisionFeature(line, anchor, feature, layerIDs, shapedText, 1, 0, true);
         t.equal(cf.boxes.length, 0);
         t.end();
     });
@@ -92,7 +95,7 @@ test('CollisionFeature', function(t) {
 
         var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
         var anchor = new Anchor(505, 95, 0, 1);
-        var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
+        var cf = new CollisionFeature(line, anchor, feature, layerIDs, shapedText, 1, 0, true);
         t.equal(cf.boxes.length, 0);
         t.end();
     });
@@ -107,7 +110,7 @@ test('CollisionFeature', function(t) {
 
         var line = [new Point(0, 0), new Point(500, 100), new Point(510, 90), new Point(700, 0)];
         var anchor = new Anchor(505, 95, 0, 1);
-        var cf = new CollisionFeature(line, anchor, shapedText, 1, 0, true);
+        var cf = new CollisionFeature(line, anchor, feature, layerIDs, shapedText, 1, 0, true);
         t.ok(cf.boxes.length < 30);
         t.end();
     });
@@ -116,7 +119,7 @@ test('CollisionFeature', function(t) {
         var line = [new Point(3103, 4068), new Point(3225.6206896551726, 4096)];
         var anchor = new Anchor(3144.5959947505007, 4077.498298013894, 0.22449735614507618, 0);
         var shaping = { right: 256, left: 0, bottom: 256, top: 0 };
-        var cf = new CollisionFeature(line, anchor, shaping, 1, 0, true);
+        var cf = new CollisionFeature(line, anchor, feature, layerIDs, shaping, 1, 0, true);
         t.equal(cf.boxes.length, 1);
         t.end();
     });

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -484,7 +484,7 @@ test('Map', function(t) {
     });
 
 
-    t.test('#featuresAt', function(t) {
+    t.test('#queryRenderedFeatures', function(t) {
         var map = createMap();
         map.setStyle({
             "version": 8,
@@ -497,7 +497,7 @@ test('Map', function(t) {
             var opts = {};
 
             t.test('normal coords', function(t) {
-                map.style.queryFeatures = function (coords, o, classes, zoom, bearing, cb) {
+                map.style.queryRenderedFeatures = function (coords, o, classes, zoom, bearing, cb) {
                     t.deepEqual(coords, [{ column: 0.5, row: 0.5, zoom: 0 }]);
                     t.equal(o, opts);
                     t.equal(cb, callback);
@@ -507,11 +507,11 @@ test('Map', function(t) {
                     t.end();
                 };
 
-                map.featuresAt(map.project(new LngLat(0, 0)), opts, callback);
+                map.queryRenderedFeatures(map.project(new LngLat(0, 0)), opts, callback);
             });
 
             t.test('wraps coords', function(t) {
-                map.style.queryFeatures = function (coords, o, classes, zoom, bearing, cb) {
+                map.style.queryRenderedFeatures = function (coords, o, classes, zoom, bearing, cb) {
                     // avoid floating point issues
                     t.equal(parseFloat(coords[0].column.toFixed(4)), 0.5);
                     t.equal(coords[0].row, 0.5);
@@ -526,7 +526,7 @@ test('Map', function(t) {
                     t.end();
                 };
 
-                map.featuresAt(map.project(new LngLat(360, 0)), opts, callback);
+                map.queryRenderedFeatures(map.project(new LngLat(360, 0)), opts, callback);
             });
 
             t.end();

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -497,11 +497,13 @@ test('Map', function(t) {
             var opts = {};
 
             t.test('normal coords', function(t) {
-                map.style.featuresAt = function (coords, o, cb) {
+                map.style.featuresAt = function (coords, o, classes, zoom, bearing, cb) {
                     t.deepEqual(coords, { column: 0.5, row: 0.5, zoom: 0 });
                     t.equal(o, opts);
                     t.equal(cb, callback);
-
+                    t.deepEqual(classes, map._classes);
+                    t.equal(bearing, map.transform.angle);
+                    t.equal(zoom, map.getZoom());
                     t.end();
                 };
 
@@ -509,13 +511,16 @@ test('Map', function(t) {
             });
 
             t.test('wraps coords', function(t) {
-                map.style.featuresAt = function (coords, o, cb) {
+                map.style.featuresAt = function (coords, o, classes, zoom, bearing, cb) {
                     // avoid floating point issues
                     t.equal(parseFloat(coords.column.toFixed(4)), 0.5);
                     t.equal(coords.row, 0.5);
                     t.equal(coords.zoom, 0);
 
                     t.equal(o, opts);
+                    t.deepEqual(classes, map._classes);
+                    t.equal(zoom, map.transform.angle);
+                    t.equal(zoom, map.getZoom());
                     t.equal(cb, callback);
 
                     t.end();

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -497,8 +497,8 @@ test('Map', function(t) {
             var opts = {};
 
             t.test('normal coords', function(t) {
-                map.style.featuresAt = function (coords, o, classes, zoom, bearing, cb) {
-                    t.deepEqual(coords, { column: 0.5, row: 0.5, zoom: 0 });
+                map.style.queryFeatures = function (coords, o, classes, zoom, bearing, cb) {
+                    t.deepEqual(coords, [{ column: 0.5, row: 0.5, zoom: 0 }]);
                     t.equal(o, opts);
                     t.equal(cb, callback);
                     t.deepEqual(classes, map._classes);
@@ -511,11 +511,11 @@ test('Map', function(t) {
             });
 
             t.test('wraps coords', function(t) {
-                map.style.featuresAt = function (coords, o, classes, zoom, bearing, cb) {
+                map.style.queryFeatures = function (coords, o, classes, zoom, bearing, cb) {
                     // avoid floating point issues
-                    t.equal(parseFloat(coords.column.toFixed(4)), 0.5);
-                    t.equal(coords.row, 0.5);
-                    t.equal(coords.zoom, 0);
+                    t.equal(parseFloat(coords[0].column.toFixed(4)), 0.5);
+                    t.equal(coords[0].row, 0.5);
+                    t.equal(coords[0].zoom, 0);
 
                     t.equal(o, opts);
                     t.deepEqual(classes, map._classes);

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,8 +1,7 @@
 'use strict';
 
-var Map = require('../js/ui/map');
-var browser = require('../js/util/browser');
-var suite = require('mapbox-gl-test-suite').query;
+var querySuite = require('mapbox-gl-test-suite').query;
+var suiteImplementation = require('./suite_implementation');
 
 var tests;
 
@@ -10,70 +9,4 @@ if (process.argv[1] === __filename && process.argv.length > 2) {
     tests = process.argv.slice(2);
 }
 
-suite.run('js', {tests: tests}, function(style, options, callback) {
-    browser.devicePixelRatio = options.pixelRatio;
-
-    var map = new Map({
-        container: {
-            offsetWidth: options.width,
-            offsetHeight: options.height,
-            classList: {
-                add: function() {}
-            }
-        },
-        style: style,
-        classes: options.classes,
-        interactive: false,
-        attributionControl: false
-    });
-
-    map.painter.prepareBuffers = function() {
-        var gl = this.gl;
-
-        if (!gl.renderbuffer) {
-            // Create default renderbuffer
-            gl.renderbuffer = gl.createRenderbuffer();
-            gl.bindRenderbuffer(gl.RENDERBUFFER, gl.renderbuffer);
-            gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA, gl.drawingBufferWidth, gl.drawingBufferHeight);
-        }
-
-        if (!gl.stencilbuffer) {
-            // Create default stencilbuffer
-            gl.stencilbuffer = gl.createRenderbuffer();
-            gl.bindRenderbuffer(gl.RENDERBUFFER, gl.stencilbuffer);
-            gl.renderbufferStorage(gl.RENDERBUFFER, gl.STENCIL_INDEX8, gl.drawingBufferWidth, gl.drawingBufferHeight);
-        }
-
-        if (!gl.framebuffer) {
-            // Create frame buffer
-            gl.framebuffer = gl.createFramebuffer();
-        }
-
-        gl.bindFramebuffer(gl.FRAMEBUFFER, gl.framebuffer);
-        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, gl.renderbuffer);
-        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.RENDERBUFFER, gl.stencilbuffer);
-
-        this.clearColor();
-    };
-
-    map.painter.bindDefaultFramebuffer = function() {
-        var gl = this.gl;
-        gl.bindFramebuffer(gl.FRAMEBUFFER, gl.framebuffer);
-    };
-
-    map.once('load', function() {
-        function done(err, results) {
-            if (err) return callback(err);
-            callback(null, results.map(function (r) {
-                delete r.layer;
-                return r;
-            }));
-        }
-
-        if (options.at) {
-            map.featuresAt(options.at, options, done);
-        } else {
-            map.featuresIn(options.in, options, done);
-        }
-    });
-});
+querySuite.run('js', {tests: tests}, suiteImplementation);

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1,8 +1,7 @@
 'use strict';
 
-var Map = require('../js/ui/map');
-var browser = require('../js/util/browser');
-var suite = require('mapbox-gl-test-suite').render;
+var renderSuite = require('mapbox-gl-test-suite').render;
+var suiteImplementation = require('./suite_implementation');
 
 var tests;
 
@@ -10,52 +9,4 @@ if (process.argv[1] === __filename && process.argv.length > 2) {
     tests = process.argv.slice(2);
 }
 
-suite.run('js', {tests: tests}, function(style, options, callback) {
-    browser.devicePixelRatio = options.pixelRatio;
-
-    var map = new Map({
-        container: {
-            offsetWidth: options.width,
-            offsetHeight: options.height,
-            classList: {
-                add: function() {},
-                remove: function() {}
-            }
-        },
-        style: style,
-        classes: options.classes,
-        interactive: false,
-        attributionControl: false
-    });
-
-    if (options.debug) map.showTileBoundaries = true;
-    if (options.collisionDebug) map.showCollisionBoxes = true;
-
-    var gl = map.painter.gl;
-
-    map.once('load', function() {
-        var w = options.width * browser.devicePixelRatio,
-            h = options.height * browser.devicePixelRatio;
-
-        var pixels = new Uint8Array(w * h * 4);
-        gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
-        var data = new Buffer(pixels);
-
-        map.remove();
-        gl.destroy();
-
-        // Flip the scanlines.
-        var stride = w * 4;
-        var tmp = new Buffer(stride);
-        for (var i = 0, j = h - 1; i < j; i++, j--) {
-            var start = i * stride;
-            var end = j * stride;
-            data.copy(tmp, 0, start, start + stride);
-            data.copy(data, start, end, end + stride);
-            tmp.copy(data, end);
-        }
-
-        callback(null, data);
-    });
-});
+renderSuite.run('js', {tests: tests}, suiteImplementation);

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -48,9 +48,9 @@ module.exports = function(style, options, callback) {
         }
 
         if (options.at) {
-            map.featuresAt(options.at, options, done);
+            map.queryRenderedFeatures(options.at, options, done);
         } else if (options.in) {
-            map.featuresIn(options.in, options, done);
+            map.queryRenderedFeatures(options.in, options, done);
         } else {
             done(null, []);
         }

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -1,0 +1,73 @@
+'use strict';
+
+var Map = require('../js/ui/map');
+var browser = require('../js/util/browser');
+
+
+module.exports = function(style, options, callback) {
+    browser.devicePixelRatio = options.pixelRatio;
+
+    var map = new Map({
+        container: {
+            offsetWidth: options.width,
+            offsetHeight: options.height,
+            classList: {
+                add: function() {},
+                remove: function() {}
+            }
+        },
+        style: style,
+        classes: options.classes,
+        interactive: false,
+        attributionControl: false
+    });
+
+    if (options.debug) map.showTileBoundaries = true;
+    if (options.collisionDebug) map.showCollisionBoxes = true;
+
+    var gl = map.painter.gl;
+
+    map.once('load', function() {
+        var w = options.width * browser.devicePixelRatio,
+            h = options.height * browser.devicePixelRatio;
+
+        var pixels = new Uint8Array(w * h * 4);
+        gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+        var data = new Buffer(pixels);
+
+        // Flip the scanlines.
+        var stride = w * 4;
+        var tmp = new Buffer(stride);
+        for (var i = 0, j = h - 1; i < j; i++, j--) {
+            var start = i * stride;
+            var end = j * stride;
+            data.copy(tmp, 0, start, start + stride);
+            data.copy(data, start, end, end + stride);
+            tmp.copy(data, end);
+        }
+
+        if (options.at) {
+            map.featuresAt(options.at, options, done);
+        } else if (options.in) {
+            map.featuresIn(options.in, options, done);
+        } else {
+            done(null, []);
+        }
+
+        function done(err, results) {
+            map.remove();
+            gl.destroy();
+
+            if (err) return callback(err);
+
+            results = results.map(function (r) {
+                delete r.layer;
+                return r;
+            });
+
+            callback(null, data, results);
+        }
+
+    });
+};


### PR DESCRIPTION
This adds currently visible text and icons to featuresAt results.

Style properties are used to return features whose rendered representation matches the query.

query test pr: https://github.com/mapbox/mapbox-gl-test-suite/pull/77

fix #303
fix #316
fix #862
fix #902
fix #1822
fix #2100
fix #2103

This increases worker memory usage by around 10% (a couple of MB).
1/3 of the increase comes from retaining the CollisionTile.
2/3 of the increase comes from retaining VectorTileFeatures.


SymbolBucket merges lines to improve placement. This means that sometimes there is more than one VectorTileFeature responsible for that symbol. It currently returns the first VectorTileFeature and ignores the others that were merged into it. Should it do something else?

:eyes: @jfirebaugh 