### PR TITLE
make sure icons fit before the ends of the line

### DIFF
--- a/js/symbol/get_anchors.js
+++ b/js/symbol/get_anchors.js
@@ -48,6 +48,12 @@ function getAnchors(line, spacing, maxAngle, shapedText, shapedIcon, glyphSize, 
 
 function resample(line, offset, spacing, angleWindowSize, maxAngle, labelLength, continuedLine, placeAtMiddle, tileExtent) {
 
+    var halfLabelLength = labelLength / 2;
+    var lineLength = 0;
+    for (var k = 0; k < line.length - 1; k++) {
+        lineLength += line[k].dist(line[k + 1]);
+    }
+
     var distance = 0,
         markedDistance = offset - spacing;
 
@@ -68,7 +74,12 @@ function resample(line, offset, spacing, angleWindowSize, maxAngle, labelLength,
                 x = interpolate(a.x, b.x, t),
                 y = interpolate(a.y, b.y, t);
 
-            if (x >= 0 && x < tileExtent && y >= 0 && y < tileExtent) {
+            // Check that the point is within the tile boundaries and that
+            // the label would fit before the beginning and end of the line
+            // if placed at this point.
+            if (x >= 0 && x < tileExtent && y >= 0 && y < tileExtent &&
+                    markedDistance - halfLabelLength >= 0 &&
+                    markedDistance + halfLabelLength <= lineLength) {
                 x = Math.round(x);
                 y = Math.round(y);
                 var anchor = new Anchor(x, y, angle, i);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^1.5.0",
     "eslint-config-mourner": "^1.0.0",
     "istanbul": "^0.4.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#118cf6f20049b95658602c6cf59774f8b8c06704",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2d31dd1f35e79f3bca2752c84747f117ea19ee9e",
     "prova": "^2.1.2",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
fixes #2062

This skips anchors if there is not enough room before the end of the line for the icon to fit.

Previously it allowed icons that extended past the end of a line as long as the icon's anchor fit on the line. This changes it so that the icon itself has to fit on the line. With these changes there are no icons on really short lines and no icons right at the end of lines.

The test suite changes (https://github.com/mapbox/mapbox-gl-test-suite/commit/6b6a03ebe8c106db1a85e88572293e523c71ba72) make it look like this is a huge change, but in actual maps it only drops a small number of icons that are right at the ends of lines or are on really short lines.

#2062 would also be fixed by https://github.com/mapbox/mapbox-gl-js/issues/2067 (which we should still do).

:eyes: @lucaswoj @jfirebaugh 