### PR TITLE
Disable handlers before enabling

### DIFF
--- a/js/ui/handler/box_zoom.js
+++ b/js/ui/handler/box_zoom.js
@@ -17,6 +17,7 @@ function BoxZoom(map) {
 
 BoxZoom.prototype = {
     enable: function () {
+        this.disable();
         this._el.addEventListener('mousedown', this._onMouseDown, false);
     },
 

--- a/js/ui/handler/dblclick_zoom.js
+++ b/js/ui/handler/dblclick_zoom.js
@@ -9,6 +9,7 @@ function DoubleClickZoom(map) {
 
 DoubleClickZoom.prototype = {
     enable: function () {
+        this.disable();
         this._map.on('dblclick', this._onDblClick);
     },
 

--- a/js/ui/handler/drag_pan.js
+++ b/js/ui/handler/drag_pan.js
@@ -20,6 +20,7 @@ function DragPan(map) {
 
 DragPan.prototype = {
     enable: function () {
+        this.disable();
         this._el.addEventListener('mousedown', this._onDown);
         this._el.addEventListener('touchstart', this._onDown);
     },

--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -21,6 +21,7 @@ function DragRotate(map) {
 
 DragRotate.prototype = {
     enable: function () {
+        this.disable();
         this._el.addEventListener('mousedown', this._onDown);
     },
 

--- a/js/ui/handler/keyboard.js
+++ b/js/ui/handler/keyboard.js
@@ -36,6 +36,7 @@ function Keyboard(map) {
 
 Keyboard.prototype = {
     enable: function () {
+        this.disable();
         this._el.addEventListener('keydown', this._onKeyDown, false);
     },
 

--- a/js/ui/handler/scroll_zoom.js
+++ b/js/ui/handler/scroll_zoom.js
@@ -21,6 +21,7 @@ function ScrollZoom(map) {
 
 ScrollZoom.prototype = {
     enable: function () {
+        this.disable();
         this._el.addEventListener('wheel', this._onWheel, false);
         this._el.addEventListener('mousewheel', this._onWheel, false);
     },
@@ -144,4 +145,3 @@ ScrollZoom.prototype = {
  * @instance
  * @property {EventData} data Original event data, if fired interactively
  */
-

--- a/js/ui/handler/touch_zoom_rotate.js
+++ b/js/ui/handler/touch_zoom_rotate.js
@@ -22,6 +22,7 @@ function TouchZoomRotate(map) {
 
 TouchZoomRotate.prototype = {
     enable: function () {
+        this.disable();
         this._el.addEventListener('touchstart', this._onStart, false);
     },
 


### PR DESCRIPTION
… in order to prevent duplicate event listeners from being bound

fixes #2069 

cc @mcwhittemore @bhousel @ansis 