### PR TITLE
reset line distance when it is near max representable distance

### DIFF
--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -53,17 +53,19 @@ LineBucket.prototype.shaders = {
         }, {
             name: 'data',
             components: 4,
-            type: Bucket.AttributeType.BYTE,
+            type: Bucket.AttributeType.UNSIGNED_BYTE,
             value: [
-                'Math.round(' + EXTRUDE_SCALE + ' * extrude.x)',
-                'Math.round(' + EXTRUDE_SCALE + ' * extrude.y)',
+                // add 128 to store an byte in an unsigned byte
+                'Math.round(' + EXTRUDE_SCALE + ' * extrude.x) + 128',
+                'Math.round(' + EXTRUDE_SCALE + ' * extrude.y) + 128',
 
-                // Encode the -1/0/1 direction value into .zw coordinates of a_data, which is normally covered
-                // by linesofar, so we need to merge them.
-                // The z component's first bit, as well as the sign bit is reserved for the direction,
-                // so we need to shift the linesofar.
-                '((dir < 0) ? -1 : 1) * ((dir ? 1 : 0) | ((linesofar << 1) & 0x7F))',
-                '(linesofar >> 6) & 0x7F'
+                // Encode the -1/0/1 direction value into the first two bits of .z of a_data.
+                // Combine it with the lower 6 bits of `linesofar` (shifted by 2 bites to make
+                // room for the direction value). The upper 8 bits of `linesofar` are placed in
+                // the `w` component. `linesofar` is scaled down by `LINE_DISTANCE_SCALE` so that
+                // we can store longer distances while sacrificing precision.
+                '((dir === 0 ? 0 : (dir < 0 ? -1 : 1)) + 1) | (((linesofar * ' + LINE_DISTANCE_SCALE + ') & 0x3F) << 2)',
+                '(linesofar * ' + LINE_DISTANCE_SCALE + ') >> 6'
             ]
         }]
     }

--- a/js/data/line_bucket.js
+++ b/js/data/line_bucket.js
@@ -113,8 +113,6 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
 
     var beginCap = cap,
         endCap = closed ? 'butt' : cap,
-        flip = 1,
-        distance = 0,
         startOfLine = true,
         currentVertex, prevVertex, nextVertex, prevNormal, nextNormal, offsetA, offsetB;
 
@@ -175,8 +173,8 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
             var prevSegmentLength = currentVertex.dist(prevVertex);
             if (prevSegmentLength > 2 * sharpCornerOffset) {
                 var newPrevVertex = currentVertex.sub(currentVertex.sub(prevVertex)._mult(sharpCornerOffset / prevSegmentLength)._round());
-                distance += newPrevVertex.dist(prevVertex);
-                this.addCurrentVertex(newPrevVertex, flip, distance, prevNormal.mult(1), 0, 0, false);
+                this.distance += newPrevVertex.dist(prevVertex);
+                this.addCurrentVertex(newPrevVertex, this.distance, prevNormal.mult(1), 0, 0, false);
                 prevVertex = newPrevVertex;
             }
         }
@@ -213,7 +211,7 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
         if (currentJoin === 'miter') {
 
             joinNormal._mult(miterLength);
-            this.addCurrentVertex(currentVertex, flip, distance, joinNormal, 0, 0, false);
+            this.addCurrentVertex(currentVertex, this.distance, joinNormal, 0, 0, false);
 
         } else if (currentJoin === 'flipbevel') {
             // miter is too big, flip the direction to make a beveled join
@@ -227,11 +225,11 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
                 var bevelLength = miterLength * prevNormal.add(nextNormal).mag() / prevNormal.sub(nextNormal).mag();
                 joinNormal._perp()._mult(bevelLength * direction);
             }
-            this.addCurrentVertex(currentVertex, flip, distance, joinNormal, 0, 0, false);
-            this.addCurrentVertex(currentVertex, -flip, distance, joinNormal, 0, 0, false);
+            this.addCurrentVertex(currentVertex, this.distance, joinNormal, 0, 0, false);
+            this.addCurrentVertex(currentVertex, this.distance, joinNormal.mult(-1), 0, 0, false);
 
         } else if (currentJoin === 'bevel' || currentJoin === 'fakeround') {
-            var lineTurnsLeft = flip * (prevNormal.x * nextNormal.y - prevNormal.y * nextNormal.x) > 0;
+            var lineTurnsLeft = (prevNormal.x * nextNormal.y - prevNormal.y * nextNormal.x) > 0;
             var offset = -Math.sqrt(miterLength * miterLength - 1);
             if (lineTurnsLeft) {
                 offsetB = 0;
@@ -243,7 +241,7 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
 
             // Close previous segment with a bevel
             if (!startOfLine) {
-                this.addCurrentVertex(currentVertex, flip, distance, prevNormal, offsetA, offsetB, false);
+                this.addCurrentVertex(currentVertex, this.distance, prevNormal, offsetA, offsetB, false);
             }
 
             if (currentJoin === 'fakeround') {
@@ -259,70 +257,68 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
 
                 for (var m = 0; m < n; m++) {
                     approxFractionalJoinNormal = nextNormal.mult((m + 1) / (n + 1))._add(prevNormal)._unit();
-                    this.addPieSliceVertex(currentVertex, flip, distance, approxFractionalJoinNormal, lineTurnsLeft);
+                    this.addPieSliceVertex(currentVertex, this.distance, approxFractionalJoinNormal, lineTurnsLeft);
                 }
 
-                this.addPieSliceVertex(currentVertex, flip, distance, joinNormal, lineTurnsLeft);
+                this.addPieSliceVertex(currentVertex, this.distance, joinNormal, lineTurnsLeft);
 
                 for (var k = n - 1; k >= 0; k--) {
                     approxFractionalJoinNormal = prevNormal.mult((k + 1) / (n + 1))._add(nextNormal)._unit();
-                    this.addPieSliceVertex(currentVertex, flip, distance, approxFractionalJoinNormal, lineTurnsLeft);
+                    this.addPieSliceVertex(currentVertex, this.distance, approxFractionalJoinNormal, lineTurnsLeft);
                 }
             }
 
             // Start next segment
             if (nextVertex) {
-                this.addCurrentVertex(currentVertex, flip, distance, nextNormal, -offsetA, -offsetB, false);
+                this.addCurrentVertex(currentVertex, this.distance, nextNormal, -offsetA, -offsetB, false);
             }
 
         } else if (currentJoin === 'butt') {
             if (!startOfLine) {
                 // Close previous segment with a butt
-                this.addCurrentVertex(currentVertex, flip, distance, prevNormal, 0, 0, false);
+                this.addCurrentVertex(currentVertex, this.distance, prevNormal, 0, 0, false);
             }
 
             // Start next segment with a butt
             if (nextVertex) {
-                this.addCurrentVertex(currentVertex, flip, distance, nextNormal, 0, 0, false);
+                this.addCurrentVertex(currentVertex, this.distance, nextNormal, 0, 0, false);
             }
 
         } else if (currentJoin === 'square') {
 
             if (!startOfLine) {
                 // Close previous segment with a square cap
-                this.addCurrentVertex(currentVertex, flip, distance, prevNormal, 1, 1, false);
+                this.addCurrentVertex(currentVertex, this.distance, prevNormal, 1, 1, false);
 
                 // The segment is done. Unset vertices to disconnect segments.
                 this.e1 = this.e2 = -1;
-                flip = 1;
             }
 
             // Start next segment
             if (nextVertex) {
-                this.addCurrentVertex(currentVertex, flip, distance, nextNormal, -1, -1, false);
+                this.addCurrentVertex(currentVertex, this.distance, nextNormal, -1, -1, false);
             }
 
         } else if (currentJoin === 'round') {
 
             if (!startOfLine) {
                 // Close previous segment with butt
-                this.addCurrentVertex(currentVertex, flip, distance, prevNormal, 0, 0, false);
+                this.addCurrentVertex(currentVertex, this.distance, prevNormal, 0, 0, false);
 
                 // Add round cap or linejoin at end of segment
-                this.addCurrentVertex(currentVertex, flip, distance, prevNormal, 1, 1, true);
+                this.addCurrentVertex(currentVertex, this.distance, prevNormal, 1, 1, true);
 
                 // The segment is done. Unset vertices to disconnect segments.
                 this.e1 = this.e2 = -1;
-                flip = 1;
             }
 
 
             // Start next segment with a butt
             if (nextVertex) {
                 // Add round cap before first segment
-                this.addCurrentVertex(currentVertex, flip, distance, nextNormal, -1, -1, true);
+                this.addCurrentVertex(currentVertex, this.distance, nextNormal, -1, -1, true);
 
-                this.addCurrentVertex(currentVertex, flip, distance, nextNormal, 0, 0, false);
+                this.addCurrentVertex(currentVertex, this.distance, nextNormal, 0, 0, false);
             }
         }
 
@@ -330,8 +326,8 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
             var nextSegmentLength = currentVertex.dist(nextVertex);
             if (nextSegmentLength > 2 * sharpCornerOffset) {
                 var newCurrentVertex = currentVertex.add(nextVertex.sub(currentVertex)._mult(sharpCornerOffset / nextSegmentLength)._round());
-                distance += newCurrentVertex.dist(currentVertex);
-                this.addCurrentVertex(newCurrentVertex, flip, distance, nextNormal.mult(1), 0, 0, false);
+                this.distance += newCurrentVertex.dist(currentVertex);
+                this.addCurrentVertex(newCurrentVertex, this.distance, nextNormal.mult(1), 0, 0, false);
                 currentVertex = newCurrentVertex;
             }
         }
@@ -345,20 +341,19 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
  * Add two vertices to the buffers.
  *
  * @param {Object} currentVertex the line vertex to add buffer vertices for
- * @param {number} flip -1 if the vertices should be flipped, 1 otherwise
  * @param {number} distance the distance from the beginning of the line to the vertex
  * @param {number} endLeft extrude to shift the left vertex along the line
  * @param {number} endRight extrude to shift the left vertex along the line
  * @param {boolean} round whether this is a round cap
  * @private
  */
-LineBucket.prototype.addCurrentVertex = function(currentVertex, flip, distance, normal, endLeft, endRight, round) {
+LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal, endLeft, endRight, round) {
     var tx = round ? 1 : 0;
     var extrude;
     var group = this.elementGroups.line.current;
     group.vertexLength += 2;
 
-    extrude = normal.mult(flip);
+    extrude = normal.clone();
     if (endLeft) extrude._sub(normal.perp()._mult(endLeft));
     this.e3 = this.addLineVertex(currentVertex, extrude, tx, 0, endLeft, distance) - group.vertexStartIndex;
     if (this.e1 >= 0 && this.e2 >= 0) {
@@ -368,7 +363,7 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, flip, distance, 
     this.e1 = this.e2;
     this.e2 = this.e3;
 
-    extrude = normal.mult(-flip);
+    extrude = normal.mult(-1);
     if (endRight) extrude._sub(normal.perp()._mult(endRight));
     this.e3 = this.addLineVertex(currentVertex, extrude, tx, 1, -endRight, distance) - group.vertexStartIndex;
     if (this.e1 >= 0 && this.e2 >= 0) {
@@ -377,6 +372,15 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, flip, distance, 
     }
     this.e1 = this.e2;
     this.e2 = this.e3;
+
+    // There is a maximum "distance along the line" that we can store in the buffers.
+    // When we get close to the distance, reset it to zero and add the vertex again with
+    // a distance of zero. The max distance is determined by the number of bits we allocate
+    // to `linesofar`.
+    if (distance > MAX_LINE_DISTANCE / 2) {
+        this.distance = 0;
+        this.addCurrentVertex(currentVertex, this.distance, normal, endLeft, endRight, round);
+    }
 };
 
 /**
@@ -384,15 +388,14 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, flip, distance, 
  * This adds a pie slice triangle near a join to simulate round joins
  *
  * @param {Object} currentVertex the line vertex to add buffer vertices for
- * @param {number} flip -1 if the vertices should be flipped, 1 otherwise
  * @param {number} distance the distance from the beggining of the line to the vertex
  * @param {Object} extrude the offset of the new vertex from the currentVertex
  * @param {boolean} whether the line is turning left or right at this angle
  * @private
  */
-LineBucket.prototype.addPieSliceVertex = function(currentVertex, flip, distance, extrude, lineTurnsLeft) {
+LineBucket.prototype.addPieSliceVertex = function(currentVertex, distance, extrude, lineTurnsLeft) {
     var ty = lineTurnsLeft ? 1 : 0;
-    extrude = extrude.mult(flip * (lineTurnsLeft ? -1 : 1));
+    extrude = extrude.mult(lineTurnsLeft ? -1 : 1);
     var group = this.elementGroups.line.current;
 
     this.e3 = this.addLineVertex(currentVertex, extrude, 0, ty, 0, distance) - group.vertexStartIndex;

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -203,13 +203,6 @@ Transform.prototype = {
         this.center = this.coordinateLocation(coordCenter._sub(translate));
     },
 
-    setZoomAround: function(zoom, center) {
-        var p;
-        if (center) p = this.locationPoint(center);
-        this.zoom = zoom;
-        if (center) this.setLocationAtPoint(center, p);
-    },
-
     /**
      * Given a location, return the screen point that corresponds to it
      * @param {LngLat} lnglat location

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -210,13 +210,6 @@ Transform.prototype = {
         if (center) this.setLocationAtPoint(center, p);
     },
 
-    setBearingAround: function(bearing, center) {
-        var p;
-        if (center) p = this.locationPoint(center);
-        this.bearing = bearing;
-        if (center) this.setLocationAtPoint(center, p);
-    },
-
     /**
      * Given a location, return the screen point that corresponds to it
      * @param {LngLat} lnglat location

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -174,7 +174,7 @@ module.exports = function drawLine(painter, source, layer, coords) {
             var group = elementGroups.groups[i];
             var vtxOffset = group.vertexStartIndex * vertex.itemSize;
             gl.vertexAttribPointer(shader.a_pos, 2, gl.SHORT, false, 8, vtxOffset + 0);
-            gl.vertexAttribPointer(shader.a_data, 4, gl.BYTE, false, 8, vtxOffset + 4);
+            gl.vertexAttribPointer(shader.a_data, 4, gl.UNSIGNED_BYTE, false, 8, vtxOffset + 4);
 
             var count = group.elementLength * 3;
             var elementOffset = group.elementStartIndex * element.itemSize;

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -409,5 +409,5 @@ TilePyramid.prototype = {
 };
 
 function compareKeyZoom(a, b) {
-    return (b % 32) - (a % 32);
+    return (a % 32) - (b % 32);
 }

--- a/js/ui/handler/scroll_zoom.js
+++ b/js/ui/handler/scroll_zoom.js
@@ -125,7 +125,8 @@ ScrollZoomHandler.prototype = {
 
         map.zoomTo(targetZoom, {
             duration: 0,
-            around: map.unproject(this._pos)
+            around: map.unproject(this._pos),
+            delayEndEvents: 200
         }, { originalEvent: e });
     }
 };

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -782,11 +782,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             this.style._recalculate(this.transform.zoom);
         }
 
-        if (this.style && this._sourcesDirty && !this._sourcesDirtyTimeout) {
+        if (this.style && this._sourcesDirty) {
             this._sourcesDirty = false;
-            this._sourcesDirtyTimeout = setTimeout(function() {
-                this._sourcesDirtyTimeout = null;
-            }.bind(this), 50);
             this.style._updateSources(this.transform);
         }
 
@@ -826,7 +823,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     remove: function() {
         if (this._hash) this._hash.remove();
         browser.cancelFrame(this._frameId);
-        clearTimeout(this._sourcesDirtyTimeout);
         this.setStyle(null);
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);

--- a/shaders/line.vertex.glsl
+++ b/shaders/line.vertex.glsl
@@ -23,8 +23,8 @@ varying float v_linesofar;
 varying float v_gamma_scale;
 
 void main() {
-    vec2 a_extrude = a_data.xy;
-    float a_direction = sign(a_data.z) * mod(a_data.z, 2.0);
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
 
     // We store the texture normals in the most insignificant bit
     // transform y so that 0 => -1 and 1 => 1

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -24,9 +24,9 @@ varying float v_linesofar;
 varying float v_gamma_scale;
 
 void main() {
-    vec2 a_extrude = a_data.xy;
-    float a_direction = sign(a_data.z) * mod(a_data.z, 2.0);
-    float a_linesofar = abs(floor(a_data.z / 2.0)) + a_data.w * 64.0;
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+    float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
 
     // We store the texture normals in the most insignificant bit
     // transform y so that 0 => -1 and 1 => 1

--- a/shaders/linesdfpattern.vertex.glsl
+++ b/shaders/linesdfpattern.vertex.glsl
@@ -28,9 +28,9 @@ varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
 void main() {
-    vec2 a_extrude = a_data.xy;
-    float a_direction = sign(a_data.z) * mod(a_data.z, 2.0);
-    float a_linesofar = abs(floor(a_data.z / 2.0)) + a_data.w * 64.0;
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+    float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
 
     // We store the texture normals in the most insignificant bit
     // transform y so that 0 => -1 and 1 => 1

--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -54,30 +54,6 @@ test('transform', function(t) {
         t.end();
     });
 
-    t.test('setZoomAround', function(t) {
-        var transform = new Transform();
-        transform.resize(500, 500);
-        t.deepEqual(transform.center, { lng: 0, lat: 0 });
-        t.equal(transform.zoom, 0);
-        t.equal(transform.setZoomAround(10, transform.pointLocation(new Point(10, 10))), undefined);
-        t.equal(transform.zoom, 10);
-        t.deepEqual(fixedLngLat(transform.center), fixedLngLat({ lng: -168.585205078125, lat: 83.9619496687153 }));
-        t.end();
-    });
-
-    t.test('setZoomAround tilted', function(t) {
-        var transform = new Transform();
-        transform.resize(500, 500);
-        transform.pitch = 50;
-        transform.zoom = 4;
-        t.deepEqual(transform.center, { lng: 0, lat: 0 });
-        t.equal(transform.zoom, 4);
-        t.equal(transform.setZoomAround(10, transform.pointLocation(new Point(10, 10))), undefined);
-        t.equal(transform.zoom, 10);
-        t.deepEqual(fixedLngLat(transform.center), fixedLngLat({ lng: -16.7821339897, lat: 25.2490827509 }));
-        t.end();
-    });
-
     t.test('setLocationAt', function(t) {
         var transform = new Transform();
         transform.resize(500, 500);

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -72,7 +72,10 @@ test('GeoJSONSource#reload', function(t) {
 test('GeoJSONSource#update', function(t) {
     var transform = new Transform();
     transform.resize(200, 200);
-    transform.setZoomAround(15, LngLat.convert([-122.486052, 37.830348]));
+    var lngLat = LngLat.convert([-122.486052, 37.830348]);
+    var point = transform.locationPoint(lngLat);
+    transform.zoom = 15;
+    transform.setLocationAtPoint(lngLat, point);
 
     t.test('sends parse request to dispatcher', function(t) {
         var source = new GeoJSONSource({data: {}});

--- a/test/js/source/tile_pyramid.test.js
+++ b/test/js/source/tile_pyramid.test.js
@@ -376,11 +376,11 @@ test('TilePyramid#update', function(t) {
         pyramid.update(true, transform);
 
         t.deepEqual(pyramid.orderedIDs(), [
+            new TileCoord(0, 0, 0).id,
             new TileCoord(1, 0, 0).id,
             new TileCoord(1, 1, 0).id,
             new TileCoord(1, 0, 1).id,
-            new TileCoord(1, 1, 1).id,
-            new TileCoord(0, 0, 0).id
+            new TileCoord(1, 1, 1).id
         ]);
         t.end();
     });
@@ -404,11 +404,11 @@ test('TilePyramid#update', function(t) {
         pyramid.update(true, transform);
 
         t.deepEqual(pyramid.orderedIDs(), [
+            new TileCoord(0, 0, 0, 1).id,
             new TileCoord(1, 0, 0, 1).id,
             new TileCoord(1, 1, 0, 1).id,
             new TileCoord(1, 0, 1, 1).id,
-            new TileCoord(1, 1, 1, 1).id,
-            new TileCoord(0, 0, 0, 1).id
+            new TileCoord(1, 1, 1, 1).id
         ]);
         t.end();
     });
@@ -615,5 +615,27 @@ test('TilePyramid#loaded (with errors)', function (t) {
     pyramid.addTile(coord);
 
     t.ok(pyramid.loaded());
+    t.end();
+});
+
+test('TilePyramid#orderedIDs (ascending order by zoom level)', function(t) {
+    var ids = [
+        new TileCoord(0, 0, 0),
+        new TileCoord(3, 0, 0),
+        new TileCoord(1, 0, 0),
+        new TileCoord(2, 0, 0)
+    ];
+
+    var pyramid = createPyramid({});
+    for (var i = 0; i < ids.length; i++) {
+        pyramid._tiles[ids[i].id] = {};
+    }
+    var orderedIDs = pyramid.orderedIDs();
+    t.deepEqual(orderedIDs, [
+        new TileCoord(0, 0, 0).id,
+        new TileCoord(1, 0, 0).id,
+        new TileCoord(2, 0, 0).id,
+        new TileCoord(3, 0, 0).id
+    ]);
     t.end();
 });

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -245,14 +245,14 @@ test('camera', function(t) {
         t.test('pans by specified amount', function(t) {
             var camera = createCamera();
             camera.panBy([100, 0], { duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 70.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 70.3125, lat: 0 });
             t.end();
         });
 
         t.test('pans relative to viewport on a rotated camera', function(t) {
             var camera = createCamera({bearing: 180});
             camera.panBy([100, 0], { duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: -70.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -70.3125, lat: 0 });
             t.end();
         });
 
@@ -302,14 +302,14 @@ test('camera', function(t) {
         t.test('pans with specified offset', function(t) {
             var camera = createCamera();
             camera.panTo([100, 0], { offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 29.6875, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 29.6875, lat: 0 });
             t.end();
         });
 
         t.test('pans with specified offset relative to viewport on a rotated camera', function(t) {
             var camera = createCamera({bearing: 180});
             camera.panTo([100, 0], { offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 170.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 170.3125, lat: 0 });
             t.end();
         });
 

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -555,7 +555,7 @@ test('camera', function(t) {
         t.test('noop', function(t) {
             var camera = createCamera();
             camera.easeTo({ duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 0, lat: 0 });
             t.equal(camera.getZoom(), 0);
             t.equal(camera.getBearing(), 0);
             t.end();
@@ -564,7 +564,7 @@ test('camera', function(t) {
         t.test('noop with offset', function(t) {
             var camera = createCamera();
             camera.easeTo({ offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 0, lat: 0 });
             t.equal(camera.getZoom(), 0);
             t.equal(camera.getBearing(), 0);
             t.end();
@@ -573,14 +573,14 @@ test('camera', function(t) {
         t.test('pans with specified offset', function(t) {
             var camera = createCamera();
             camera.easeTo({ center: [100, 0], offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 29.6875, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 29.6875, lat: 0 });
             t.end();
         });
 
         t.test('pans with specified offset relative to viewport on a rotated camera', function(t) {
             var camera = createCamera({ bearing: 180 });
             camera.easeTo({ center: [100, 0], offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 170.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 170.3125, lat: 0 });
             t.end();
         });
 
@@ -721,7 +721,7 @@ test('camera', function(t) {
         t.test('noop', function(t) {
             var camera = createCamera();
             camera.flyTo({ animate: false });
-            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 0, lat: 0 });
             t.equal(camera.getZoom(), 0);
             t.equal(camera.getBearing(), 0);
             t.end();
@@ -730,7 +730,7 @@ test('camera', function(t) {
         t.test('noop with offset', function(t) {
             var camera = createCamera();
             camera.flyTo({ offset: [100, 0], animate: false });
-            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 0, lat: 0 });
             t.equal(camera.getZoom(), 0);
             t.equal(camera.getBearing(), 0);
             t.end();
@@ -746,7 +746,7 @@ test('camera', function(t) {
         t.test('pans with specified offset relative to viewport on a rotated camera', function(t) {
             var camera = createCamera({ bearing: 180 });
             camera.easeTo({ center: [100, 0], offset: [100, 0], animate: false });
-            t.deepEqual(camera.getCenter(), { lng: 170.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 170.3125, lat: 0 });
             t.end();
         });
 


### PR DESCRIPTION
fix #2099 

When the distance of the current vertex is > half the maximum distance that can be represented, reset the distance. This fixes the original problem where a line with many segments is longer than the maximum distance.

We still need to make sure we can represent the distance of the longest possible segment so we need to make two more changes:
- improve how `linesofar` is packed into the buffer so that we have two more bits
- scale the distance down before adding it to the buffer to increase the maximum distance that can be represented

I don't like how `var distance` changed to `this.distance` but `addCurrentVertex` needs to be able to reset the distance and I'm not seeing a better way to do this.

:eyes: @lucaswoj 
