### PR TITLE
make panning while zooming more linear

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -203,13 +203,6 @@ Transform.prototype = {
         this.center = this.coordinateLocation(coordCenter._sub(translate));
     },
 
-    setZoomAround: function(zoom, center) {
-        var p;
-        if (center) p = this.locationPoint(center);
-        this.zoom = zoom;
-        if (center) this.setLocationAtPoint(center, p);
-    },
-
     /**
      * Given a location, return the screen point that corresponds to it
      * @param {LngLat} lnglat location

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -210,13 +210,6 @@ Transform.prototype = {
         if (center) this.setLocationAtPoint(center, p);
     },
 
-    setBearingAround: function(bearing, center) {
-        var p;
-        if (center) p = this.locationPoint(center);
-        this.bearing = bearing;
-        if (center) this.setLocationAtPoint(center, p);
-    },
-
     /**
      * Given a location, return the screen point that corresponds to it
      * @param {LngLat} lnglat location

--- a/js/ui/handler/scroll_zoom.js
+++ b/js/ui/handler/scroll_zoom.js
@@ -125,7 +125,8 @@ ScrollZoomHandler.prototype = {
 
         map.zoomTo(targetZoom, {
             duration: 0,
-            around: map.unproject(this._pos)
+            around: map.unproject(this._pos),
+            delayEndEvents: 200
         }, { originalEvent: e });
     }
 };

--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -54,30 +54,6 @@ test('transform', function(t) {
         t.end();
     });
 
-    t.test('setZoomAround', function(t) {
-        var transform = new Transform();
-        transform.resize(500, 500);
-        t.deepEqual(transform.center, { lng: 0, lat: 0 });
-        t.equal(transform.zoom, 0);
-        t.equal(transform.setZoomAround(10, transform.pointLocation(new Point(10, 10))), undefined);
-        t.equal(transform.zoom, 10);
-        t.deepEqual(fixedLngLat(transform.center), fixedLngLat({ lng: -168.585205078125, lat: 83.9619496687153 }));
-        t.end();
-    });
-
-    t.test('setZoomAround tilted', function(t) {
-        var transform = new Transform();
-        transform.resize(500, 500);
-        transform.pitch = 50;
-        transform.zoom = 4;
-        t.deepEqual(transform.center, { lng: 0, lat: 0 });
-        t.equal(transform.zoom, 4);
-        t.equal(transform.setZoomAround(10, transform.pointLocation(new Point(10, 10))), undefined);
-        t.equal(transform.zoom, 10);
-        t.deepEqual(fixedLngLat(transform.center), fixedLngLat({ lng: -16.7821339897, lat: 25.2490827509 }));
-        t.end();
-    });
-
     t.test('setLocationAt', function(t) {
         var transform = new Transform();
         transform.resize(500, 500);

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -72,7 +72,10 @@ test('GeoJSONSource#reload', function(t) {
 test('GeoJSONSource#update', function(t) {
     var transform = new Transform();
     transform.resize(200, 200);
-    transform.setZoomAround(15, LngLat.convert([-122.486052, 37.830348]));
+    var lngLat = LngLat.convert([-122.486052, 37.830348]);
+    var point = transform.locationPoint(lngLat);
+    transform.zoom = 15;
+    transform.setLocationAtPoint(lngLat, point);
 
     t.test('sends parse request to dispatcher', function(t) {
         var source = new GeoJSONSource({data: {}});

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -245,14 +245,14 @@ test('camera', function(t) {
         t.test('pans by specified amount', function(t) {
             var camera = createCamera();
             camera.panBy([100, 0], { duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 70.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 70.3125, lat: 0 });
             t.end();
         });
 
         t.test('pans relative to viewport on a rotated camera', function(t) {
             var camera = createCamera({bearing: 180});
             camera.panBy([100, 0], { duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: -70.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -70.3125, lat: 0 });
             t.end();
         });
 
@@ -302,14 +302,14 @@ test('camera', function(t) {
         t.test('pans with specified offset', function(t) {
             var camera = createCamera();
             camera.panTo([100, 0], { offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 29.6875, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 29.6875, lat: 0 });
             t.end();
         });
 
         t.test('pans with specified offset relative to viewport on a rotated camera', function(t) {
             var camera = createCamera({bearing: 180});
             camera.panTo([100, 0], { offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 170.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 170.3125, lat: 0 });
             t.end();
         });
 

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -555,7 +555,7 @@ test('camera', function(t) {
         t.test('noop', function(t) {
             var camera = createCamera();
             camera.easeTo({ duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 0, lat: 0 });
             t.equal(camera.getZoom(), 0);
             t.equal(camera.getBearing(), 0);
             t.end();
@@ -564,7 +564,7 @@ test('camera', function(t) {
         t.test('noop with offset', function(t) {
             var camera = createCamera();
             camera.easeTo({ offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 0, lat: 0 });
             t.equal(camera.getZoom(), 0);
             t.equal(camera.getBearing(), 0);
             t.end();
@@ -573,14 +573,14 @@ test('camera', function(t) {
         t.test('pans with specified offset', function(t) {
             var camera = createCamera();
             camera.easeTo({ center: [100, 0], offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 29.6875, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 29.6875, lat: 0 });
             t.end();
         });
 
         t.test('pans with specified offset relative to viewport on a rotated camera', function(t) {
             var camera = createCamera({ bearing: 180 });
             camera.easeTo({ center: [100, 0], offset: [100, 0], duration: 0 });
-            t.deepEqual(camera.getCenter(), { lng: 170.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 170.3125, lat: 0 });
             t.end();
         });
 
@@ -721,7 +721,7 @@ test('camera', function(t) {
         t.test('noop', function(t) {
             var camera = createCamera();
             camera.flyTo({ animate: false });
-            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 0, lat: 0 });
             t.equal(camera.getZoom(), 0);
             t.equal(camera.getBearing(), 0);
             t.end();
@@ -730,7 +730,7 @@ test('camera', function(t) {
         t.test('noop with offset', function(t) {
             var camera = createCamera();
             camera.flyTo({ offset: [100, 0], animate: false });
-            t.deepEqual(camera.getCenter(), { lng: 0, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 0, lat: 0 });
             t.equal(camera.getZoom(), 0);
             t.equal(camera.getBearing(), 0);
             t.end();
@@ -746,7 +746,7 @@ test('camera', function(t) {
         t.test('pans with specified offset relative to viewport on a rotated camera', function(t) {
             var camera = createCamera({ bearing: 180 });
             camera.easeTo({ center: [100, 0], offset: [100, 0], animate: false });
-            t.deepEqual(camera.getCenter(), { lng: 170.3125, lat: 0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 170.3125, lat: 0 });
             t.end();
         });
 


### PR DESCRIPTION
fix #2070

easeTo used to interpolate locations based on projected values. As zoom changed the new screen distance of these projected values changed either speeding up or slowing down the perceived panning.

With this change, the new center moves across the screen from it's previous point location to it's new point location linearly.

This also implements `panTo`, `rotateTo`, and `zoomTo` with `easeTo` to remove a lot of duplication. If you want I can split that out into a separate pr.

:eyes: @mourner @lucaswoj @bhousel 