### PR TITLE
remove source update throttling

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -782,11 +782,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             this.style._recalculate(this.transform.zoom);
         }
 
-        if (this.style && this._sourcesDirty && !this._sourcesDirtyTimeout) {
+        if (this.style && this._sourcesDirty) {
             this._sourcesDirty = false;
-            this._sourcesDirtyTimeout = setTimeout(function() {
-                this._sourcesDirtyTimeout = null;
-            }.bind(this), 50);
             this.style._updateSources(this.transform);
         }
 
@@ -826,7 +823,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     remove: function() {
         if (this._hash) this._hash.remove();
         browser.cancelFrame(this._frameId);
-        clearTimeout(this._sourcesDirtyTimeout);
         this.setStyle(null);
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);


### PR DESCRIPTION
fix #2139 and fix #1881

Recent chrome scheduler changes aggressively de-prioritize `setTimeout` in some cases: https://code.google.com/p/chromium/issues/detail?id=567800

The unexpected setTimeout behavior was preventing tiles from being updated during zooming. Instead of fixing this, we should remove the timeout completely:

- The throttling was added when source updating was slow. Throttling increased the framerate by reducing the number of frames that went over their budget. **Source update has been heavily optimized since then and only takes 2% of the render time**.

- Throttling is not a good solution. Instead of preventing frames from exceeding their time budget by optimizing or distributing the work over a number of frames, throttling just reduces the number of frames that exceed their time.

:eyes: @jfirebaugh @lucaswoj @mourner 