### PR TITLE
Cleanup event listener on popup close button

### DIFF
--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -59,6 +59,10 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
      * @returns {Popup} `this`
      */
     remove: function() {
+        if (this._closeButton) {
+            this._closeButton.removeEventListener('click', this._onClickClose);
+        }
+
         if (this._content && this._content.parentNode) {
             this._content.parentNode.removeChild(this._content);
         }
@@ -130,6 +134,10 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
     },
 
     _createContent: function() {
+        if (this._closeButton) {
+            this._closeButton.removeEventListener('click', this._onClickClose);
+        }
+
         if (this._content && this._content.parentNode) {
             this._content.parentNode.removeChild(this._content);
         }


### PR DESCRIPTION
The event listener on the popup close button is not removed when content is changed or the popup is removed from the map.