### PR TITLE
fix tile render order for layer-by-layer

### DIFF
--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -409,5 +409,5 @@ TilePyramid.prototype = {
 };
 
 function compareKeyZoom(a, b) {
-    return (b % 32) - (a % 32);
+    return (a % 32) - (b % 32);
 }

--- a/test/js/source/tile_pyramid.test.js
+++ b/test/js/source/tile_pyramid.test.js
@@ -376,11 +376,11 @@ test('TilePyramid#update', function(t) {
         pyramid.update(true, transform);
 
         t.deepEqual(pyramid.orderedIDs(), [
+            new TileCoord(0, 0, 0).id,
             new TileCoord(1, 0, 0).id,
             new TileCoord(1, 1, 0).id,
             new TileCoord(1, 0, 1).id,
-            new TileCoord(1, 1, 1).id,
-            new TileCoord(0, 0, 0).id
+            new TileCoord(1, 1, 1).id
         ]);
         t.end();
     });
@@ -404,11 +404,11 @@ test('TilePyramid#update', function(t) {
         pyramid.update(true, transform);
 
         t.deepEqual(pyramid.orderedIDs(), [
+            new TileCoord(0, 0, 0, 1).id,
             new TileCoord(1, 0, 0, 1).id,
             new TileCoord(1, 1, 0, 1).id,
             new TileCoord(1, 0, 1, 1).id,
-            new TileCoord(1, 1, 1, 1).id,
-            new TileCoord(0, 0, 0, 1).id
+            new TileCoord(1, 1, 1, 1).id
         ]);
         t.end();
     });
@@ -615,5 +615,27 @@ test('TilePyramid#loaded (with errors)', function (t) {
     pyramid.addTile(coord);
 
     t.ok(pyramid.loaded());
+    t.end();
+});
+
+test('TilePyramid#orderedIDs (ascending order by zoom level)', function(t) {
+    var ids = [
+        new TileCoord(0, 0, 0),
+        new TileCoord(3, 0, 0),
+        new TileCoord(1, 0, 0),
+        new TileCoord(2, 0, 0)
+    ];
+
+    var pyramid = createPyramid({});
+    for (var i = 0; i < ids.length; i++) {
+        pyramid._tiles[ids[i].id] = {};
+    }
+    var orderedIDs = pyramid.orderedIDs();
+    t.deepEqual(orderedIDs, [
+        new TileCoord(0, 0, 0).id,
+        new TileCoord(1, 0, 0).id,
+        new TileCoord(2, 0, 0).id,
+        new TileCoord(3, 0, 0).id
+    ]);
     t.end();
 });


### PR DESCRIPTION
Sort tiles by ascending zoom level instead of descending.

Child tiles had lower priority than parent tiles so child tiles weren't visible if their parent was also loaded. **This delayed newly loaded tiles from rendering while zooming in.**

Before layer-by-layer rendering clipping masks would be clipped by previously drawn tiles. Now clipping masks are drawn over other clipping masks. This means that clipping masks need to be drawn in the opposite order form before.

It's not possible to add a render test for this right now because we can't set up the tile state to reproduce this.

:eyes: @lucaswoj @jfirebaugh 