### PR TITLE
look for loaded parent tiles in cache

### DIFF
--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -195,7 +195,12 @@ TilePyramid.prototype = {
             var tile = this._tiles[coord.id];
             if (tile && tile.loaded) {
                 retain[coord.id] = true;
-                return tile;
+                return true;
+            }
+            if (this._cache.has(coord.id)) {
+                this.addTile(coord);
+                retain[coord.id] = true;
+                return true;
             }
         }
     },


### PR DESCRIPTION
When the required tiles aren't loaded yet it tries to find parent tiles that area loaded that a cover the area. It used to just look for parents in the set of previously rendered tiles. There are many cases where the parents aren't in that set but they are in the cache.

This reduces the amount of the viewport not covered by tiles. It makes tile loading look a lot faster.

It helps a lot when you:
- zoom in and the pan around
- zoom in quickly and then zoom out more slowly

fixes #1918

---

This only loads parents, not children. I tried also loading children but it looked weird sometimes. Try the 
[load-children-from-cache](https://github.com/mapbox/mapbox-gl-js/tree/load-children-from-cache) branch to see what it's like.

If children are loaded from the cache you sometimes see flashes of high resolution tiles while zooming in. Seeing the area change from too-low-resolution to too-high-resolution to just-right-resolution is more jarring than just too-low-resolution to just-right-resolution.

:eyes: @mourner