### PR TITLE
fix pyramid.findLoadedParent for raster rendering

### DIFF
--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -195,12 +195,12 @@ TilePyramid.prototype = {
             var tile = this._tiles[coord.id];
             if (tile && tile.loaded) {
                 retain[coord.id] = true;
-                return true;
+                return tile;
             }
             if (this._cache.has(coord.id)) {
                 this.addTile(coord);
                 retain[coord.id] = true;
-                return true;
+                return this._tiles[coord.id];
             }
         }
     },

--- a/test/js/source/tile_pyramid.test.js
+++ b/test/js/source/tile_pyramid.test.js
@@ -648,3 +648,60 @@ test('TilePyramid#orderedIDs (ascending order by zoom level)', function(t) {
     ]);
     t.end();
 });
+
+
+test('TilePyramid#findLoadedParent', function(t) {
+
+    t.test('adds from previously used tiles (pyramid._tiles)', function(t) {
+        var pyramid = createPyramid({});
+        var tr = new Transform();
+        tr.width = 512;
+        tr.height = 512;
+        pyramid.updateCacheSize(tr);
+
+        var tile = {
+            coord: new TileCoord(1, 0, 0),
+            loaded: true
+        };
+
+        pyramid._tiles[tile.coord.id] = tile;
+
+        var retain = {};
+        var expectedRetain = {};
+        expectedRetain[tile.coord.id] = true;
+
+        t.equal(pyramid.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
+        t.deepEqual(pyramid.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
+        t.deepEqual(retain, expectedRetain);
+        t.end();
+    });
+
+
+    t.test('adds from cache', function(t) {
+        t.end();
+        var pyramid = createPyramid({});
+        var tr = new Transform();
+        tr.width = 512;
+        tr.height = 512;
+        pyramid.updateCacheSize(tr);
+
+        var tile = {
+            coord: new TileCoord(1, 0, 0),
+            loaded: true
+        };
+
+        pyramid._cache.add(tile.coord.id, tile);
+
+        var retain = {};
+        var expectedRetain = {};
+        expectedRetain[tile.coord.id] = true;
+
+        t.equal(pyramid.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
+        t.deepEqual(pyramid.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
+        t.deepEqual(retain, expectedRetain);
+        t.equal(pyramid._cache.order.length, 0);
+        t.deepEqual(pyramid._tiles[tile.coord.id], tile);
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Fixes a sloppy bug introduced by https://github.com/mapbox/mapbox-gl-js/commit/e6cb15c3f18c73cfc7aea2a797d3a33eedb946cd

I didn't notice draw_raster was using `findLoadedParent` and I didn't test with a raster style.

fix #2167
fix #2161

:eyes: @mourner @lucaswoj 