### PR TITLE
Blazing fast layer update

### DIFF
--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -30,6 +30,15 @@ util.extend(Worker.prototype, {
         this.layers = layers;
     },
 
+    'update layers': function(layers) {
+        for (var i = 0; i < layers.length; i++) {
+            for (var j = 0; j < this.layers.length; j++) {
+                if (this.layers[j].id === layers[i].id)
+                    this.layers[j] = layers[i];
+            }
+        }
+    },
+
     'load tile': function(params, callback) {
         var source = params.source,
             uid = params.uid;

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -31,11 +31,13 @@ util.extend(Worker.prototype, {
     },
 
     'update layers': function(layers) {
-        for (var i = 0; i < layers.length; i++) {
-            for (var j = 0; j < this.layers.length; j++) {
-                if (this.layers[j].id === layers[i].id)
-                    this.layers[j] = layers[i];
-            }
+        var layersById = {};
+        var i;
+        for (i = 0; i < layers.length; i++) {
+            layersById[layers[i].id] = layers[i];
+        }
+        for (i = 0; i < this.layers.length; i++) {
+            this.layers[i] = layersById[this.layers[i].id] || this.layers[i];
         }
     },
 

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -167,10 +167,18 @@ Style.prototype = util.inherit(Evented, {
         }
     },
 
-    _broadcastLayers: function() {
-        this.dispatcher.broadcast('set layers', this._order.map(function(id) {
-            return this._layers[id].serialize({includeRefProperties: true});
-        }, this));
+    _broadcastLayers: function(ids) {
+        this.dispatcher.broadcast(ids ? 'update layers' : 'set layers', this._serializeLayers(ids));
+    },
+
+    _serializeLayers: function(ids) {
+        ids = ids || this._order;
+        var serialized = [];
+        var options = {includeRefProperties: true};
+        for (var i = 0; i < ids.length; i++) {
+            serialized.push(this._layers[ids[i]].serialize(options));
+        }
+        return serialized;
     },
 
     _cascade: function(classes, options) {

--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -107,8 +107,8 @@ styleBatch.prototype = {
         return this;
     },
 
-    setPaintProperty: function(layer, name, value, klass) {
-        this._style.getLayer(layer).setPaintProperty(name, value, klass);
+    setPaintProperty: function(layerId, name, value, klass) {
+        this._style.getLayer(layerId).setPaintProperty(name, value, klass);
         this._change = true;
 
         return this;
@@ -116,6 +116,8 @@ styleBatch.prototype = {
 
     setLayoutProperty: function(layerId, name, value) {
         var layer = this._style.getReferentLayer(layerId);
+        if (layer.getLayoutProperty(name) === value) return this;
+
         layer.setLayoutProperty(name, value);
 
         this._broadcastLayers[layerId] = true;
@@ -136,6 +138,7 @@ styleBatch.prototype = {
         }))) return this;
 
         var layer = this._style.getReferentLayer(layerId);
+        if (filtersEqual(layer.filter, filter)) return this;
         layer.filter = filter;
 
         this._broadcastLayers[layerId] = true;
@@ -149,6 +152,8 @@ styleBatch.prototype = {
 
     setLayerZoomRange: function(layerId, minzoom, maxzoom) {
         var layer = this._style.getReferentLayer(layerId);
+        if (layer.minzoom === minzoom && layer.maxzoom === maxzoom) return this;
+
         if (minzoom != null) {
             layer.minzoom = minzoom;
         }
@@ -224,5 +229,16 @@ styleBatch.prototype = {
         return this;
     }
 };
+
+function filtersEqual(a, b) {
+    if (Array.isArray(a)) {
+        if (!Array.isArray(b) || a.length !== b.length) return false;
+        for (var i = 0; i < a.length; i++) {
+            if (!filtersEqual(a[i], b[i])) return false;
+        }
+        return true;
+    }
+    return a === b;
+}
 
 module.exports = styleBatch;

--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -15,9 +15,9 @@ function styleBatch(style, work) {
 
     batch._style = style;
     batch._groupLayers = false;
-    batch._broadcastAllLayers = false;
-    batch._broadcastLayers = {};
-    batch._reloadSources = {};
+    batch._updateAllLayers = false;
+    batch._updatedLayers = {};
+    batch._updatedSources = {};
     batch._events = [];
     batch._change = false;
 
@@ -27,17 +27,17 @@ function styleBatch(style, work) {
         batch._style._groupLayers();
     }
 
-    if (batch._broadcastAllLayers) {
+    if (batch._updateAllLayers) {
         batch._style._broadcastLayers();
 
     } else {
-        var updatedIds = Object.keys(batch._broadcastLayers);
+        var updatedIds = Object.keys(batch._updatedLayers);
         if (updatedIds.length) {
             batch._style._broadcastLayers(updatedIds);
         }
     }
 
-    Object.keys(batch._reloadSources).forEach(function(sourceId) {
+    Object.keys(batch._updatedSources).forEach(function(sourceId) {
         batch._style._reloadSource(sourceId);
     });
 
@@ -74,9 +74,9 @@ styleBatch.prototype = {
         this._style._order.splice(before ? this._style._order.indexOf(before) : Infinity, 0, layer.id);
 
         this._groupLayers = true;
-        this._broadcastAllLayers = true;
+        this._updateAllLayers = true;
         if (layer.source) {
-            this._reloadSources[layer.source] = true;
+            this._updatedSources[layer.source] = true;
         }
         this._events.push(['layer.add', {layer: layer}]);
         this._change = true;
@@ -101,7 +101,7 @@ styleBatch.prototype = {
         this._style._order.splice(this._style._order.indexOf(id), 1);
 
         this._groupLayers = true;
-        this._broadcastAllLayers = true;
+        this._updateAllLayers = true;
         this._events.push(['layer.remove', {layer: layer}]);
         this._change = true;
 
@@ -121,10 +121,10 @@ styleBatch.prototype = {
 
         layer.setLayoutProperty(name, value);
 
-        this._broadcastLayers[layerId] = true;
+        this._updatedLayers[layerId] = true;
 
         if (layer.source) {
-            this._reloadSources[layer.source] = true;
+            this._updatedSources[layer.source] = true;
         }
         this._change = true;
 
@@ -142,9 +142,9 @@ styleBatch.prototype = {
         if (util.deepEqual(layer.filter, filter)) return this;
         layer.filter = filter;
 
-        this._broadcastLayers[layerId] = true;
+        this._updatedLayers[layerId] = true;
         if (layer.source) {
-            this._reloadSources[layer.source] = true;
+            this._updatedSources[layer.source] = true;
         }
         this._change = true;
 
@@ -162,9 +162,9 @@ styleBatch.prototype = {
             layer.maxzoom = maxzoom;
         }
 
-        this._broadcastLayers[layerId] = true;
+        this._updatedLayers[layerId] = true;
         if (layer.source) {
-            this._reloadSources[layer.source] = true;
+            this._updatedSources[layer.source] = true;
         }
         this._change = true;
 

--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -4,6 +4,7 @@ var Source = require('../source/source');
 var StyleLayer = require('./style_layer');
 var validateStyle = require('./validate_style');
 var styleSpec = require('./style_spec');
+var util = require('../util/util');
 
 function styleBatch(style, work) {
     if (!style._loaded) {
@@ -138,7 +139,7 @@ styleBatch.prototype = {
         }))) return this;
 
         var layer = this._style.getReferentLayer(layerId);
-        if (filtersEqual(layer.filter, filter)) return this;
+        if (util.deepEqual(layer.filter, filter)) return this;
         layer.filter = filter;
 
         this._broadcastLayers[layerId] = true;
@@ -229,16 +230,5 @@ styleBatch.prototype = {
         return this;
     }
 };
-
-function filtersEqual(a, b) {
-    if (Array.isArray(a)) {
-        if (!Array.isArray(b) || a.length !== b.length) return false;
-        for (var i = 0; i < a.length; i++) {
-            if (!filtersEqual(a[i], b[i])) return false;
-        }
-        return true;
-    }
-    return a === b;
-}
 
 module.exports = styleBatch;

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -446,3 +446,30 @@ exports.filterObject = function(input, iterator, context) {
     }
     return output;
 };
+
+/**
+ * Deeply compares two object literals.
+ * @param {Object} obj1
+ * @param {Object} obj2
+ * @returns {boolean}
+ * @private
+ */
+exports.deepEqual = function deepEqual(a, b) {
+    if (Array.isArray(a)) {
+        if (!Array.isArray(b) || a.length !== b.length) return false;
+        for (var i = 0; i < a.length; i++) {
+            if (!deepEqual(a[i], b[i])) return false;
+        }
+        return true;
+    }
+    if (typeof a === 'object') {
+        if (!(typeof b === 'object')) return false;
+        var keys = Object.keys(a);
+        if (keys.length !== Object.keys(b).length) return false;
+        for (var key in a) {
+            if (!deepEqual(a[key], b[key])) return false;
+        }
+        return true;
+    }
+    return a === b;
+};

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -162,6 +162,34 @@ test('Style#_broadcastLayers', function(t) {
     });
 });
 
+test('Style#_broadcastLayers with specific ids', function(t) {
+    var style = new Style({
+        'version': 8,
+        'sources': {
+            'source': {
+                'type': 'vector'
+            }
+        },
+        'layers': [
+            {id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer'},
+            {id: 'second', source: 'source', type: 'fill', 'source-layer': 'source-layer'},
+            {id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer'}
+        ]
+    });
+
+    style.on('error', function(error) { t.error(error); });
+
+    style.on('load', function() {
+        style.dispatcher.broadcast = function(key, value) {
+            t.equal(key, 'update layers');
+            t.deepEqual(value.map(function(layer) { return layer.id; }), ['second', 'third']);
+            t.end();
+        };
+
+        style._broadcastLayers(['second', 'third']);
+    });
+});
+
 test('Style#_resolve', function(t) {
     t.test('creates StyleLayers', function(t) {
         var style = new Style({

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -257,6 +257,24 @@ test('util', function(t) {
         t.end();
     });
 
+    t.test('deepEqual', function(t) {
+        var a = {
+            foo: 'bar',
+            bar: {
+                baz: 5,
+                lol: ["cat", 2]
+            }
+        };
+        var b = JSON.parse(JSON.stringify(a));
+        var c = JSON.parse(JSON.stringify(a));
+        c.bar.lol[0] = "z";
+
+        t.ok(util.deepEqual(a, b));
+        t.notOk(util.deepEqual(a, c));
+
+        t.end();
+    });
+
     if (process.browser) {
         t.test('timed: no duration', function(t) {
             var context = { foo: 'bar' };


### PR DESCRIPTION
Makes `setLayoutProperty`, `setFilter` and `setLayerZoomRange` much faster by limiting the style->worker transfer to just the updated layers instead of the whole style.

Closes #2082 and makes this hover example https://jsfiddle.net/0Lk8awwp/1/ fast and smooth again: https://jsfiddle.net/Mourner/0Lk8awwp/3/

cc @lyzidiamond @lucaswoj @scothis