### PR TITLE
Make "Map#load" fire, even if "Not Found" errors were encountered

### DIFF
--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -83,6 +83,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
             return;
 
         if (err) {
+            tile.errored = true;
             this.fire('tile.error', {tile: tile, error: err});
             return;
         }


### PR DESCRIPTION
ref #1985 
ref #1800 

If a vector tile request gets a 404 response, the `Map#load` event doesn't fire. 

#1800 is about a feature request that is different than this bug but the two have been conflated.

cc @jfirebaugh @ansis @geografa @laurenancona 