### PR TITLE
Add contextual "key"s to validateStyle calls

### DIFF
--- a/js/style/style_batch.js
+++ b/js/style/style_batch.js
@@ -55,6 +55,7 @@ styleBatch.prototype = {
     addLayer: function(layer, before) {
         if (!(layer instanceof StyleLayer)) {
             if (validateStyle.emitErrors(this._style, validateStyle.layer({
+                key: 'layers.' + layer.id,
                 value: layer,
                 style: this._style.serialize(),
                 styleSpec: styleSpec,
@@ -133,6 +134,7 @@ styleBatch.prototype = {
 
     setFilter: function(layerId, filter) {
         if (validateStyle.emitErrors(this._style, validateStyle.filter({
+            key: 'layers.' + layerId + '.filter',
             value: filter,
             style: this._style.serialize(),
             styleSpec: styleSpec
@@ -181,6 +183,7 @@ styleBatch.prototype = {
 
         if (!Source.is(source)) {
             if (validateStyle.emitErrors(this._style, validateStyle.source({
+                key: 'sources.' + id,
                 style: this._style.serialize(),
                 value: source,
                 styleSpec: styleSpec

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -73,6 +73,7 @@ StyleLayer.prototype = util.inherit(Evented, {
             delete this._layoutDeclarations[name];
         } else {
             if (validateStyle.emitErrors(this, validateStyle.layoutProperty({
+                key: 'layers.' + this.id + '.layout.' + name,
                 layerType: this.type,
                 objectKey: name,
                 value: value,
@@ -101,6 +102,7 @@ StyleLayer.prototype = util.inherit(Evented, {
     },
 
     setPaintProperty: function(name, value, klass) {
+        var validateStyleKey = 'layers.' + this.id + (klass ? '["paint.' + klass + '"].' : '.paint.') + name;
 
         if (util.endsWith(name, TRANSITION_SUFFIX)) {
             if (!this._paintTransitionOptions[klass || '']) {
@@ -110,6 +112,7 @@ StyleLayer.prototype = util.inherit(Evented, {
                 delete this._paintTransitionOptions[klass || ''][name];
             } else {
                 if (validateStyle.emitErrors(this, validateStyle.paintProperty({
+                    key: validateStyleKey,
                     layerType: this.type,
                     objectKey: name,
                     value: value,
@@ -125,6 +128,7 @@ StyleLayer.prototype = util.inherit(Evented, {
                 delete this._paintDeclarations[klass || ''][name];
             } else {
                 if (validateStyle.emitErrors(this, validateStyle.paintProperty({
+                    key: validateStyleKey,
                     layerType: this.type,
                     objectKey: name,
                     value: value,


### PR DESCRIPTION
These keys are contextual clues for users to help trace the errors. Before this PR, a style validation error might appear as

```
Error: undefined: number expected, boolean found
```

after this PR, the same error would appear as

```
Error: layers.roads.paint.line-width: number expected, boolean found
```

fixes #2170 

cc @ansis 