### PR TITLE
Update coordinates of image/video sources

### DIFF
--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -16,7 +16,6 @@ module.exports = ImageSource;
  * @param {Object} [options]
  * @param {string} options.url A string URL of an image file
  * @param {Array} options.coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the image. Does not have to be a rectangle.
- * starting at the top left: tl, tr, br, bl
  * @example
  * var sourceObj = new mapboxgl.ImageSource({
  *    url: 'https://www.mapbox.com/images/foo.png',

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -68,13 +68,13 @@ ImageSource.prototype = util.inherit(Evented, {
      */
     setCoordinates: function(coordinates) {
         this.coordinates = coordinates;
-        
+
         /**
          * Calculate which mercator tile is suitable for rendering the image in
          * and create a buffer with the corner coordinates. These coordinates
          * may be outside the tile, because raster tiles aren't clipped when rendering.
          */
-                
+
         var map = this.map;
         var cornerZ0Coords = coordinates.map(function(coord) {
             return map.transform.locationCoordinate(LngLat.convert(coord)).zoomTo(0);
@@ -104,9 +104,9 @@ ImageSource.prototype = util.inherit(Evented, {
         this.tile.boundsBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, this.tile.boundsBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
-        
+
         this.fire('change');
-        
+
         return this;
     },
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -47,8 +47,7 @@ function ImageSource(options) {
         this._loaded = true;
 
         if (this.map) {
-            this.createTile(options.coordinates);
-            this.fire('change');
+            this.setCoordinates(options.coordinates);
         }
     }.bind(this));
 }
@@ -57,19 +56,27 @@ ImageSource.prototype = util.inherit(Evented, {
     onAdd: function(map) {
         this.map = map;
         if (this.image) {
-            this.createTile();
+            this.setCoordinates();
         }
     },
 
     /**
-     * Calculate which mercator tile is suitable for rendering the image in
-     * and create a buffer with the corner coordinates. These coordinates
-     * may be outside the tile, because raster tiles aren't clipped when rendering.
-     * @private
+     * Update image coordinates and rerender map
+     *
+     * @param {Array} coordinates lng, lat coordinates in order clockwise
+     * @returns {ImageSource} this
      */
-    createTile: function(cornerGeoCoords) {
+    setCoordinates: function(coordinates) {
+        this.coordinates = coordinates;
+        
+        /**
+         * Calculate which mercator tile is suitable for rendering the image in
+         * and create a buffer with the corner coordinates. These coordinates
+         * may be outside the tile, because raster tiles aren't clipped when rendering.
+         */
+                
         var map = this.map;
-        var cornerZ0Coords = cornerGeoCoords.map(function(coord) {
+        var cornerZ0Coords = coordinates.map(function(coord) {
             return map.transform.locationCoordinate(LngLat.convert(coord)).zoomTo(0);
         });
 
@@ -97,6 +104,10 @@ ImageSource.prototype = util.inherit(Evented, {
         this.tile.boundsBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, this.tile.boundsBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
+        
+        this.fire('change');
+        
+        return this;
     },
 
     loaded: function() {

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -15,7 +15,7 @@ module.exports = ImageSource;
  * @class ImageSource
  * @param {Object} [options]
  * @param {string} options.url A string URL of an image file
- * @param {Array} options.coordinates lng, lat coordinates in order clockwise
+ * @param {Array} options.coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the image. Does not have to be a rectangle.
  * starting at the top left: tl, tr, br, bl
  * @example
  * var sourceObj = new mapboxgl.ImageSource({
@@ -56,24 +56,22 @@ ImageSource.prototype = util.inherit(Evented, {
     onAdd: function(map) {
         this.map = map;
         if (this.image) {
-            this.setCoordinates();
+            this.setCoordinates(this.coordinates);
         }
     },
 
     /**
      * Update image coordinates and rerender map
      *
-     * @param {Array} coordinates lng, lat coordinates in order clockwise
+     * @param {Array} coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the image. Does not have to be a rectangle.
      * @returns {ImageSource} this
      */
     setCoordinates: function(coordinates) {
         this.coordinates = coordinates;
 
-        /**
-         * Calculate which mercator tile is suitable for rendering the image in
-         * and create a buffer with the corner coordinates. These coordinates
-         * may be outside the tile, because raster tiles aren't clipped when rendering.
-         */
+        // Calculate which mercator tile is suitable for rendering the image in
+        // and create a buffer with the corner coordinates. These coordinates
+        // may be outside the tile, because raster tiles aren't clipped when rendering.
 
         var map = this.map;
         var cornerZ0Coords = coordinates.map(function(coord) {

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -15,7 +15,7 @@ module.exports = VideoSource;
  * @class VideoSource
  * @param {Object} [options]
  * @param {Array<string>} options.urls An array of URLs to video files
- * @param {Array} options.coordinates lng, lat coordinates in order clockwise starting at the top left: tl, tr, br, bl
+ * @param {Array} options.coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the image. Does not have to be a rectangle.
  * @example
  * var sourceObj = new mapboxgl.VideoSource({
  *    url: [
@@ -81,24 +81,22 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
         this.map = map;
         if (this.video) {
             this.video.play();
-            this.setCoordinates();
+            this.setCoordinates(this.coordinates);
         }
     },
 
     /**
      * Update video coordinates and rerender map
      *
-     * @param {Array} coordinates lng, lat coordinates in order clockwise
+     * @param {Array} coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the image. Does not have to be a rectangle.
      * @returns {VideoSource} this
      */
     setCoordinates: function(coordinates) {
         this.coordinates = coordinates;
 
-        /*
-         * Calculate which mercator tile is suitable for rendering the video in
-         * and create a buffer with the corner coordinates. These coordinates
-         * may be outside the tile, because raster tiles aren't clipped when rendering.
-         */
+        // Calculate which mercator tile is suitable for rendering the video in
+        // and create a buffer with the corner coordinates. These coordinates
+        // may be outside the tile, because raster tiles aren't clipped when rendering.
 
         var map = this.map;
         var cornerZ0Coords = coordinates.map(function(coord) {

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -93,13 +93,13 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
      */
     setCoordinates: function(coordinates) {
         this.coordinates = coordinates;
-      
+
         /*
          * Calculate which mercator tile is suitable for rendering the video in
          * and create a buffer with the corner coordinates. These coordinates
          * may be outside the tile, because raster tiles aren't clipped when rendering.
          */
-        
+
         var map = this.map;
         var cornerZ0Coords = coordinates.map(function(coord) {
             return map.transform.locationCoordinate(LngLat.convert(coord)).zoomTo(0);
@@ -129,9 +129,9 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
         this.tile.boundsBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, this.tile.boundsBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
-        
+
         this.fire('change');
-        
+
         return this;
     },
 

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -60,8 +60,7 @@ function VideoSource(options) {
 
         if (this.map) {
             this.video.play();
-            this.createTile(options.coordinates);
-            this.fire('change');
+            this.setCoordinates(options.coordinates);
         }
     }.bind(this));
 }
@@ -82,18 +81,27 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
         this.map = map;
         if (this.video) {
             this.video.play();
-            this.createTile();
+            this.setCoordinates();
         }
     },
 
-    createTile: function(cornerGeoCoords) {
+    /**
+     * Update video coordinates and rerender map
+     *
+     * @param {Array} coordinates lng, lat coordinates in order clockwise
+     * @returns {VideoSource} this
+     */
+    setCoordinates: function(coordinates) {
+        this.coordinates = coordinates;
+      
         /*
          * Calculate which mercator tile is suitable for rendering the video in
          * and create a buffer with the corner coordinates. These coordinates
          * may be outside the tile, because raster tiles aren't clipped when rendering.
          */
+        
         var map = this.map;
-        var cornerZ0Coords = cornerGeoCoords.map(function(coord) {
+        var cornerZ0Coords = coordinates.map(function(coord) {
             return map.transform.locationCoordinate(LngLat.convert(coord)).zoomTo(0);
         });
 
@@ -121,6 +129,10 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
         this.tile.boundsBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, this.tile.boundsBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
+        
+        this.fire('change');
+        
+        return this;
     },
 
     loaded: function() {

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -15,7 +15,7 @@ module.exports = VideoSource;
  * @class VideoSource
  * @param {Object} [options]
  * @param {Array<string>} options.urls An array of URLs to video files
- * @param {Array} options.coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the image. Does not have to be a rectangle.
+ * @param {Array} options.coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the video. Does not have to be a rectangle.
  * @example
  * var sourceObj = new mapboxgl.VideoSource({
  *    url: [
@@ -88,7 +88,7 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
     /**
      * Update video coordinates and rerender map
      *
-     * @param {Array} coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the image. Does not have to be a rectangle.
+     * @param {Array} coordinates Four geographical [lng, lat] coordinates in clockwise order defining the corners (starting with top left) of the video. Does not have to be a rectangle.
      * @returns {VideoSource} this
      */
     setCoordinates: function(coordinates) {


### PR DESCRIPTION
This fixes #1880 by adding support for updating the coordinates on image- and video sources.

While doing this I noticed this part which I don't really understand how it's supposed to work:

```
    onAdd: function(map) {
        this.map = map;
        if (this.image) {
            this.setCoordinates();
        }
    }
```

Won't a call without arguments to setCoordinates (perviously createTile) cause an error on the subsequent coordinates.map() in that function? 