### PR TITLE
Added fs as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "unassertify": "^2.0.0",
     "unitbezier": "^0.0.0",
     "vector-tile": "^1.2.0",
-    "webworkify": "^1.0.2"
+    "webworkify": "^1.0.2",
+    "fs": "0.0.2"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",


### PR DESCRIPTION
Added `fs` as dependency as it's required by `render/shaders.js`.

https://github.com/mapbox/mapbox-gl-js/blob/master/js/render/shaders.js#L3

Error was caused when building with Webpack.

> ERROR in ./~/mapbox-gl/js/render/shaders.js
Module not found: Error: Cannot resolve module 'fs' in /home/denis/test/node_modules/mapbox-gl/js/render
 @ ./~/mapbox-gl/js/render/shaders.js 3:9-22
