### PR TITLE
Rework color switcher example

### DIFF
--- a/docs/_posts/examples/3400-01-04-color-switcher.html
+++ b/docs/_posts/examples/3400-01-04-color-switcher.html
@@ -5,50 +5,77 @@ title: Change a layer's color with buttons
 description: Using setPaintProperty to change a layer's fill color
 ---
 <style>
-    #colorSwitcherWater {
-        margin: 0;
-        padding: 0;
-        position: fixed;
-        top: 0;
-        right: 0;
-        width: 70px;
-        height: 95%;
-        list-style-type: none;
-    }
+.map-overlay {
+    font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    position: absolute;
+    width: 200px;
+    top: 0;
+    left: 0;
+    padding: 10px;
+}
 
-    #colorSwitcherBuilding {
-        margin: 0;
-        padding: 0;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 70px;
-        height: 100%;
-        list-style-type: none;
-    }
+.map-overlay .map-overlay-inner {
+    background-color: #fff;
+    box-shadow:0 1px 2px rgba(0, 0, 0, 0.10);
+    border-radius: 3px;
+    padding: 10px;
+    margin-bottom: 10px;
+}
 
-    .color-swatch {
-        height: 20%;
-        width: 100%;
-        cursor: pointer;
-    }
+.map-overlay-inner fieldset {
+    border: none;
+    padding: 0;
+    margin: 0 0 10px;
+}
+
+.map-overlay-inner fieldset:last-child {
+    margin: 0;
+}
+
+.map-overlay-inner select {
+    width: 100%;
+}
+
+.map-overlay-inner label {
+    display: block;
+    font-weight: bold;
+    margin: 0 0 5px;
+}
+
+.map-overlay-inner button {
+    display: inline-block;
+    width: 36px;
+    height: 20px;
+    border: none;
+    cursor: pointer;
+}
+
+.map-overlay-inner button:focus {
+    outline: none;
+}
+
+.map-overlay-inner button:hover {
+    box-shadow:inset 0 0 0 3px rgba(0, 0, 0, 0.10);
+}
 </style>
-<div id='map'></div>
-<ul id='colorSwitcherWater'>
-    <li class="color-swatch" onclick="switchColor('#ffffcc', 'water')" style="background-color: #ffffcc"></li>
-    <li class="color-swatch" onclick="switchColor('#a1dab4', 'water')" style="background-color: #a1dab4"></li>
-    <li class="color-swatch" onclick="switchColor('#41b6c4', 'water')" style="background-color: #41b6c4"></li>
-    <li class="color-swatch" onclick="switchColor('#2c7fb8', 'water')" style="background-color: #2c7fb8"></li>
-    <li class="color-swatch" onclick="switchColor('#253494', 'water')" style="background-color: #253494"></li>
-</ul>
 
-<ul id='colorSwitcherBuilding'>
-    <li class="color-swatch" onclick="switchColor('#fed976', 'building')" style="background-color: #fed976"></li>
-    <li class="color-swatch" onclick="switchColor('#feb24c', 'building')" style="background-color: #feb24c"></li>
-    <li class="color-swatch" onclick="switchColor('#fd8d3c', 'building')" style="background-color: #fd8d3c"></li>
-    <li class="color-swatch" onclick="switchColor('#f03b20', 'building')" style="background-color: #f03b20"></li>
-    <li class="color-swatch" onclick="switchColor('#bd0026', 'building')" style="background-color: #bd0026"></li>
-</ul>
+<div id='map'></div>
+<div class='map-overlay top'>
+    <div class='map-overlay-inner'>
+        <fieldset>
+            <label>Select layer</label>
+            <select id='layer' name='layer'>
+                <option value='water'>Water</option>
+                <option value='building'>Buildings</option>
+            </select>
+        </fieldset>
+        <fieldset>
+            <label>Choose a color</label>
+            <div id='swatches'></div>
+        </fieldset>
+    </div>
+</div>
+
 <script>
 var map = new mapboxgl.Map({
     container: 'map',
@@ -57,7 +84,27 @@ var map = new mapboxgl.Map({
     zoom: 17.4
 });
 
-function switchColor(myColor, layer) {
-    map.setPaintProperty(layer, 'fill-color', myColor);
-}
+var swatches = document.getElementById('swatches');
+var layers = document.getElementById('layers');
+var colors = [
+    '#ffffcc',
+    '#a1dab4',
+    '#41b6c4',
+    '#2c7fb8',
+    '#253494',
+    '#fed976',
+    '#feb24c',
+    '#fd8d3c',
+    '#f03b20',
+    '#bd0026'
+];
+
+colors.forEach(function(color) {
+    var swatch = document.createElement('button');
+    swatch.style.backgroundColor = color;
+    swatch.addEventListener('click', function() {
+        map.setPaintProperty(layer.value, 'fill-color', color);
+    });
+    swatches.appendChild(swatch);
+});
 </script>


### PR DESCRIPTION
![color-switcher](https://cloud.githubusercontent.com/assets/61150/13464395/08ac3080-e05f-11e5-9592-fe6b4522d7e3.gif)

Removes `onClick` attribute from `<li>` elements and derives swatch elements with events by appending them in sequence. This also standardizes the container/ui style to match other examples.

cc @jfirebaugh 