### PR TITLE
Better text label style

### DIFF
--- a/docs/_posts/examples/3400-01-14-filter-markers-by-input.html
+++ b/docs/_posts/examples/3400-01-14-filter-markers-by-input.html
@@ -130,10 +130,16 @@ map.on('load', function() {
                     "icon-image": symbol + "-15",
                     "icon-allow-overlap": true,
                     "text-field": symbol,
-                    "text-offset": [0, 1]
+                    "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+                    "text-size": 11,
+                    "text-transform": "uppercase",
+                    "text-letter-spacing": 0.05,
+                    "text-offset": [0, 1.5]
                 },
                 "paint": {
-                    "text-color": "#3887BE"
+                    "text-color": "#202",
+                    "text-halo-color": "#fff",
+                    "text-halo-width": 2
                 },
                 "filter": ["==", "marker-symbol", symbol]
             });


### PR DESCRIPTION
I should have checked the previous pr out locally. These labels shouldn't look like link attributes. This is a light commit that cleans up the labels under markers by a hair

<img width="749" alt="screen shot 2016-03-03 at 11 46 34 pm" src="https://cloud.githubusercontent.com/assets/61150/13518317/6913c5aa-e19a-11e5-83fc-6a81314c68b2.png">