### PR TITLE
[not ready] setMinZoom() and setMaxZoom()

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -21,6 +21,8 @@ var LngLatBounds = require('../geo/lng_lat_bounds');
 var Point = require('point-geometry');
 var Attribution = require('./control/attribution');
 
+var defaultMinZoom = 0;
+var defaultMaxZoom = 20;
 /**
  * Options common to Map#addClass, Map#removeClass, and Map#setClasses, controlling
  * whether or not to smoothly transition property changes triggered by the class change.
@@ -145,8 +147,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         bearing: 0,
         pitch: 0,
 
-        minZoom: 0,
-        maxZoom: 20,
+        minZoom: defaultMinZoom,
+        maxZoom: defaultMaxZoom,
 
         interactive: true,
 
@@ -305,8 +307,49 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             this._update();
         }
         return this;
+
+    },
+    /**
+     * Set the map's minimum zoom level, and zooms map to that level if it is currently below it. If no parameter provided, unsets the current minimum zoom (sets it to 0)
+     * @param {zoom} any number between 0 and 20
+     * @returns {Map} `this`
+     */
+    setMinZoom: function(minZoom) {
+
+        minZoom = minZoom === null || minZoom === undefined ? defaultMinZoom : minZoom;
+
+        if (minZoom >= defaultMinZoom && minZoom <= this.options.maxZoom) {
+            this.transform.minZoom = minZoom;
+            this._update();
+
+            if (this.getZoom() < minZoom) this.setZoom(minZoom);
+
+            return this;
+        }
+
+        else throw new Error('minZoom must be between ' + defaultMinZoom + ' and the current maxZoom, inclusive');
     },
 
+    /**
+     * Set the map's maximum zoom level, and zooms map to that level if it is currently above it. If no parameter provided, unsets the current maximum zoom (sets it to 20)
+     * @param {zoom} any number between 0 and 20
+     * @returns {Map} `this`
+     */
+    setMaxZoom: function(maxZoom) {
+
+        maxZoom = maxZoom === null || maxZoom === undefined ? defaultMaxZoom : maxZoom;
+
+        if (maxZoom >= this.options.minZoom && maxZoom <= defaultMaxZoom) {
+            this.transform.maxZoom = maxZoom;
+            this._update();
+
+            if (this.getZoom() > maxZoom) this.setZoom(maxZoom);
+
+            return this;
+        }
+
+        else throw new Error('maxZoom must be between the current minZoom and ' + defaultMaxZoom + ', inclusive');
+    },
     /**
      * Get pixel coordinates (relative to map container) given a geographical location
      *

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -326,7 +326,58 @@ test('Map', function(t) {
                 [bounds[1][0].toFixed(n), bounds[1][1].toFixed(n)]
             ];
         }
+    });
 
+    t.test('#setMinZoom', function(t) {
+        var map = createMap({zoom:5});
+        map.setMinZoom(3.5);
+        map.setZoom(1);
+        t.equal(map.getZoom(), 3.5);
+        t.end();
+    });
+
+    t.test('unset minZoom', function(t) {
+        var map = createMap({minZoom:5});
+        map.setMinZoom(null);
+        map.setZoom(1);
+        t.equal(map.getZoom(), 1);
+        t.end();
+    });
+
+    t.test('ignore minZooms over maxZoom', function(t) {
+        var map = createMap({zoom:2, maxZoom:5});
+        t.throws(function() {
+            map.setMinZoom(6);
+        });
+        map.setZoom(0);
+        t.equal(map.getZoom(), 0);
+        t.end();
+    });
+
+    t.test('#setMaxZoom', function (t) {
+        var map = createMap({zoom:0});
+        map.setMaxZoom(3.5);
+        map.setZoom(4);
+        t.equal(map.getZoom(), 3.5);
+        t.end();
+    });
+
+    t.test('unset maxZoom', function(t) {
+        var map = createMap({maxZoom:5});
+        map.setMaxZoom(null);
+        map.setZoom(6);
+        t.equal(map.getZoom(), 6);
+        t.end();
+    });
+
+    t.test('ignore maxZooms over minZoom', function(t) {
+        var map = createMap({minZoom:5});
+        t.throws(function() {
+            map.setMaxZoom(4);
+        });
+        map.setZoom(5);
+        t.equal(map.getZoom(), 5);
+        t.end();
     });
 
     t.test('#remove', function(t) {


### PR DESCRIPTION
Solves https://github.com/mapbox/mapbox-gl-js/issues/2235.

Per chat with @lucaswoj, splitting `min` and `max` bounds into separate methods would relieve developers from tracking the state of both bounds, in order to change either one.

### To dos

- [ ] Unit tests