### PR TITLE
add browserify-middleware to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "benchmark": "~1.0.0",
     "browserify": "^12.0.1",
+    "browserify-middleware": "^7.0.0",
     "coveralls": "^2.11.8",
     "documentation": "3.0.0",
     "envify": "^3.4.0",


### PR DESCRIPTION
fixes `Error: Cannot find module 'browserify-middleware'` when running `npm start`