### PR TITLE
fix #2236 raster tile flickering

### DIFF
--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -9,6 +9,9 @@ function drawRaster(painter, source, layer, coords) {
 
     var gl = painter.gl;
 
+    gl.enable(gl.DEPTH_TEST);
+    painter.depthMask(true);
+
     // Change depth function to prevent double drawing in areas where tiles overlap.
     gl.depthFunc(gl.LESS);
 
@@ -21,7 +24,8 @@ function drawRaster(painter, source, layer, coords) {
 
 function drawRasterTile(painter, source, layer, coord) {
 
-    painter.setDepthSublayer(0);
+    // the smallest possible coord.z is 10 smaller than the current zoom level, so set that to sublayer 0
+    painter.setDepthSublayer(coord.z - painter.transform.tileZoom + 10);
 
     var gl = painter.gl;
 

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -15,17 +15,19 @@ function drawRaster(painter, source, layer, coords) {
     // Change depth function to prevent double drawing in areas where tiles overlap.
     gl.depthFunc(gl.LESS);
 
+    var minTileZ = coords.length && coords[0].z;
+
     for (var i = 0; i < coords.length; i++) {
-        drawRasterTile(painter, source, layer, coords[i]);
+        var coord = coords[i];
+        // set the lower zoom level to sublayer 0, and higher zoom levels to higher sublayers
+        painter.setDepthSublayer(coord.z - minTileZ);
+        drawRasterTile(painter, source, layer, coord);
     }
 
     gl.depthFunc(gl.LEQUAL);
 }
 
 function drawRasterTile(painter, source, layer, coord) {
-
-    // the smallest possible coord.z is 10 smaller than the current zoom level, so set that to sublayer 0
-    painter.setDepthSublayer(coord.z - painter.transform.tileZoom + 10);
 
     var gl = painter.gl;
 

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -5,6 +5,7 @@ var browser = require('../util/browser');
 var mat4 = require('gl-matrix').mat4;
 var FrameHistory = require('./frame_history');
 var TileCoord = require('../source/tile_coord');
+var TilePyramid = require('../source/tile_pyramid');
 var EXTENT = require('../data/bucket').EXTENT;
 
 module.exports = Painter;
@@ -25,9 +26,9 @@ function Painter(gl, transform) {
 
     this.setup();
 
-    // Within each layer there are 3 distinct z-planes that can be drawn to.
+    // Within each layer there are multiple distinct z-planes that can be drawn to.
     // This is implemented using the WebGL depth buffer.
-    this.numSublayers = 3;
+    this.numSublayers = TilePyramid.maxUnderzooming + TilePyramid.maxOverzooming + 1;
     this.depthEpsilon = 1 / Math.pow(2, 16);
 }
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -2,6 +2,7 @@
 
 var util = require('../util/util');
 var Tile = require('./tile');
+var TileCoord = require('./tile_coord');
 var LngLat = require('../geo/lng_lat');
 var Point = require('point-geometry');
 var Evented = require('../util/evented');
@@ -78,6 +79,8 @@ ImageSource.prototype = util.inherit(Evented, {
         });
 
         var centerCoord = this.centerCoord = util.getCoordinatesCenter(cornerZ0Coords);
+        centerCoord.column = Math.round(centerCoord.column);
+        centerCoord.row = Math.round(centerCoord.row);
 
         var tileCoords = cornerZ0Coords.map(function(coord) {
             var zoomedCoord = coord.zoomTo(centerCoord.zoom);
@@ -95,7 +98,7 @@ ImageSource.prototype = util.inherit(Evented, {
             tileCoords[2].x, tileCoords[2].y, maxInt16, maxInt16
         ]);
 
-        this.tile = new Tile();
+        this.tile = new Tile(new TileCoord(centerCoord.zoom, centerCoord.column, centerCoord.row));
         this.tile.buckets = {};
 
         this.tile.boundsBuffer = gl.createBuffer();
@@ -140,7 +143,7 @@ ImageSource.prototype = util.inherit(Evented, {
     },
 
     getVisibleCoordinates: function() {
-        if (this.centerCoord) return [this.centerCoord];
+        if (this.tile) return [this.tile.coord];
         else return [];
     },
 

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -40,6 +40,10 @@ function TilePyramid(options) {
     this._filterRendered = this._filterRendered.bind(this);
 }
 
+
+TilePyramid.maxOverzooming = 10;
+TilePyramid.maxUnderzooming = 3;
+
 TilePyramid.prototype = {
     /**
      * Confirm that every tracked tile is loaded.
@@ -236,8 +240,8 @@ TilePyramid.prototype = {
 
         // Determine the overzooming/underzooming amounts.
         var zoom = (this.roundZoom ? Math.round : Math.floor)(this.getZoom(transform));
-        var minCoveringZoom = Math.max(zoom - 10, this.minzoom);
-        var maxCoveringZoom = Math.max(zoom + 3,  this.minzoom);
+        var minCoveringZoom = Math.max(zoom - TilePyramid.maxOverzooming, this.minzoom);
+        var maxCoveringZoom = Math.max(zoom + TilePyramid.maxUnderzooming,  this.minzoom);
 
         // Retain is a list of tiles that we shouldn't delete, even if they are not
         // the most ideal tile for the current viewport. This may include tiles like

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -2,6 +2,7 @@
 
 var util = require('../util/util');
 var Tile = require('./tile');
+var TileCoord = require('./tile_coord');
 var LngLat = require('../geo/lng_lat');
 var Point = require('point-geometry');
 var Evented = require('../util/evented');
@@ -104,6 +105,9 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
         });
 
         var centerCoord = this.centerCoord = util.getCoordinatesCenter(cornerZ0Coords);
+        centerCoord.column = Math.round(centerCoord.column);
+        centerCoord.row = Math.round(centerCoord.row);
+
 
         var tileCoords = cornerZ0Coords.map(function(coord) {
             var zoomedCoord = coord.zoomTo(centerCoord.zoom);
@@ -121,7 +125,7 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
             tileCoords[2].x, tileCoords[2].y, maxInt16, maxInt16
         ]);
 
-        this.tile = new Tile();
+        this.tile = new Tile(new TileCoord(centerCoord.zoom, centerCoord.column, centerCoord.row));
         this.tile.buckets = {};
 
         this.tile.boundsBuffer = gl.createBuffer();
@@ -167,7 +171,7 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
     },
 
     getVisibleCoordinates: function() {
-        if (this.centerCoord) return [this.centerCoord];
+        if (this.tile) return [this.tile.coord];
         else return [];
     },
 


### PR DESCRIPTION
- draw tiles from different zoom levels in different z planes to avoid
  z-fighting
- make sure depth testing and writing is enabled for raster layers

Unfortunately we can't test this with a render test.

fix #2236

:eyes: @lucaswoj 