### PR TITLE
Rename debug settings

### DIFF
--- a/bench/buffer_benchmark.js
+++ b/bench/buffer_benchmark.js
@@ -143,7 +143,7 @@ function runSample(stylesheet, getGlyphs, getIcons, getTile, callback) {
             overscaling: 1,
             angle: 0,
             pitch: 0,
-            collisionDebug: false,
+            showCollisionBoxes: false,
             source: 'composite',
             uid: url
         });

--- a/debug/index.html
+++ b/debug/index.html
@@ -39,8 +39,8 @@
 <body>
 <div id='map'></div>
 <div id='checkboxes'>
-  <input id='tile-debug-checkbox' name='tile-debug' type='checkbox'> <label for='tile-debug'>tile debug</label><br />
-  <input id='collision-debug-checkbox' name='collision-debug' type='checkbox'> <label for='collision-debug'>collision debug</label><br />
+  <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
+  <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br />
   <input id='buffer-checkbox' name='buffer' type='checkbox'> <label for='buffer'>buffer stats</label>
 </div>
 

--- a/debug/site.js
+++ b/debug/site.js
@@ -82,12 +82,12 @@ map.on('click', function(e) {
         .addTo(map);
 });
 
-document.getElementById('tile-debug-checkbox').onclick = function() {
-    map.tileDebug = !!this.checked;
+document.getElementById('show-tile-boundaries-checkbox').onclick = function() {
+    map.showTileBoundaries = !!this.checked;
 };
 
-document.getElementById('collision-debug-checkbox').onclick = function() {
-    map.collisionDebug = !!this.checked;
+document.getElementById('show-symbol-collision-boxes-checkbox').onclick = function() {
+    map.showCollisionBoxes = !!this.checked;
 };
 
 document.getElementById('buffer-checkbox').onclick = function() {

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -26,7 +26,7 @@ module.exports = SymbolBucket;
 
 function SymbolBucket(options) {
     Bucket.apply(this, arguments);
-    this.collisionDebug = options.collisionDebug;
+    this.showCollisionBoxes = options.showCollisionBoxes;
     this.overscaling = options.overscaling;
 }
 
@@ -227,7 +227,7 @@ SymbolBucket.prototype.populateBuffers = function(collisionTile, stacks, icons) 
         }
     }
 
-    this.placeFeatures(collisionTile, this.collisionDebug);
+    this.placeFeatures(collisionTile, this.showCollisionBoxes);
 
     this.trimBuffers();
 };
@@ -329,7 +329,7 @@ SymbolBucket.prototype.anchorIsTooClose = function(text, repeatDistance, anchor)
     return false;
 };
 
-SymbolBucket.prototype.placeFeatures = function(collisionTile, collisionDebug) {
+SymbolBucket.prototype.placeFeatures = function(collisionTile, showCollisionBoxes) {
     // Calculate which labels can be shown and when they can be shown and
     // create the bufers used for rendering.
 
@@ -429,7 +429,7 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, collisionDebug) {
 
     }
 
-    if (collisionDebug) this.addToDebugBuffers(collisionTile);
+    if (showCollisionBoxes) this.addToDebugBuffers(collisionTile);
 };
 
 SymbolBucket.prototype.addSymbols = function(shaderName, quads, scale, keepUpright, alongLine, placementAngle) {

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -180,7 +180,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             overscaling: overscaling,
             angle: this.map.transform.angle,
             pitch: this.map.transform.pitch,
-            collisionDebug: this.map.collisionDebug
+            showCollisionBoxes: this.map.showCollisionBoxes
         };
 
         tile.workerID = this.dispatcher.send('load geojson tile', params, function(err, data) {

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -133,7 +133,7 @@ Tile.prototype = {
             source: source.id,
             angle: source.map.transform.angle,
             pitch: source.map.transform.pitch,
-            collisionDebug: source.map.collisionDebug
+            showCollisionBoxes: source.map.showCollisionBoxes
         }, done.bind(this), this.workerID);
 
         function done(_, data) {

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -68,7 +68,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
             overscaling: overscaling,
             angle: this.map.transform.angle,
             pitch: this.map.transform.pitch,
-            collisionDebug: this.map.collisionDebug
+            showCollisionBoxes: this.map.showCollisionBoxes
         };
 
         if (tile.workerID) {

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -100,7 +100,7 @@ util.extend(Worker.prototype, {
 
         if (loaded && loaded[uid]) {
             var tile = loaded[uid];
-            var result = tile.redoPlacement(params.angle, params.pitch, params.collisionDebug);
+            var result = tile.redoPlacement(params.angle, params.pitch, params.showCollisionBoxes);
 
             if (result.result) {
                 callback(null, result.result, result.transferables);

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -15,7 +15,7 @@ function WorkerTile(params) {
     this.overscaling = params.overscaling;
     this.angle = params.angle;
     this.pitch = params.pitch;
-    this.collisionDebug = params.collisionDebug;
+    this.showCollisionBoxes = params.showCollisionBoxes;
 }
 
 WorkerTile.prototype.parse = function(data, layers, actor, callback) {
@@ -48,7 +48,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
             layer: layer,
             zoom: this.zoom,
             overscaling: this.overscaling,
-            collisionDebug: this.collisionDebug
+            showCollisionBoxes: this.showCollisionBoxes
         });
         bucket.createFilter();
 
@@ -195,7 +195,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, callback) {
     }
 };
 
-WorkerTile.prototype.redoPlacement = function(angle, pitch, collisionDebug) {
+WorkerTile.prototype.redoPlacement = function(angle, pitch, showCollisionBoxes) {
     if (this.status !== 'done') {
         this.redoPlacementAfterDone = true;
         this.angle = angle;
@@ -206,7 +206,7 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, collisionDebug) {
     var buckets = this.symbolBuckets;
 
     for (var i = buckets.length - 1; i >= 0; i--) {
-        buckets[i].placeFeatures(collisionTile, collisionDebug);
+        buckets[i].placeFeatures(collisionTile, showCollisionBoxes);
     }
 
     return {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -859,7 +859,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         }
 
         this.painter.render(this.style, {
-            debug: this.tileDebug,
+            debug: this.showTileBoundaries,
             vertices: this.vertices,
             rotating: this.rotating,
             zooming: this.zooming
@@ -998,31 +998,32 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
 util.extendAll(Map.prototype, /** @lends Map.prototype */{
 
     /**
-     * Enable tile debugging mode
+     * Draw an outline around each rendered tile for debugging.
      *
-     * @name tileDebug
+     * @name showTileBoundaries
      * @type {boolean}
      */
-    _tileDebug: false,
-    get tileDebug() { return this._tileDebug; },
-    set tileDebug(value) {
-        if (this._tileDebug === value) return;
-        this._tileDebug = value;
+    _showTileBoundaries: false,
+    get showTileBoundaries() { return this._showTileBoundaries; },
+    set showTileBoundaries(value) {
+        if (this._showTileBoundaries === value) return;
+        this._showTileBoundaries = value;
         this._update();
     },
 
     /**
-     * Show collision boxes: useful for debugging label placement
-     * in styles.
+     * Draw boxes around all symbols in the data source, showing which were
+     * rendered and which were hidden due to collisions with other symbols for
+     * style debugging.
      *
-     * @name collisionDebug
+     * @name showCollisionBoxes
      * @type {boolean}
      */
-    _collisionDebug: false,
-    get collisionDebug() { return this._collisionDebug; },
-    set collisionDebug(value) {
-        if (this._collisionDebug === value) return;
-        this._collisionDebug = value;
+    _showCollisionBoxes: false,
+    get showCollisionBoxes() { return this._showCollisionBoxes; },
+    set showCollisionBoxes(value) {
+        if (this._showCollisionBoxes === value) return;
+        this._showCollisionBoxes = value;
         this.style._redoPlacement();
     },
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -28,8 +28,8 @@ suite.run('js', {tests: tests}, function(style, options, callback) {
         attributionControl: false
     });
 
-    if (options.debug) map.tileDebug = true;
-    if (options.collisionDebug) map.collisionDebug = true;
+    if (options.debug) map.showTileBoundaries = true;
+    if (options.collisionDebug) map.showCollisionBoxes = true;
 
     var gl = map.painter.gl;
 


### PR DESCRIPTION
@bhousel raised some good points about the vocabulary we use for debug settings in #2280 

If we're going to make a breaking change to this API, I want to make certain that we are changing to something we are keen on supporting _forever_. 

As with any public API, I want to choose a name that is

 - short
 - grounded in well-known domain terminology
 - self documenting (i.e. a smart user could figure out what it does without checking the docs)

This PR renames

 - `collisionDebug` --> `showCollisionBoxes`
 - `debug` / `tileDebug` --> `showTileBoundaries`

cc @bhousel @mourner @bhousel @ansis 