### PR TITLE
don't check cache when looking up a parent raster for fading

### DIFF
--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -190,10 +190,11 @@ TilePyramid.prototype = {
      * @param {Coordinate} coord
      * @param {number} minCoveringZoom
      * @param {boolean} retain
+     * @param {boolean} checkCache
      * @returns {Tile} tile object
      * @private
      */
-    findLoadedParent: function(coord, minCoveringZoom, retain) {
+    findLoadedParent: function(coord, minCoveringZoom, retain, checkCache) {
         for (var z = coord.z - 1; z >= minCoveringZoom; z--) {
             coord = coord.parent(this.maxzoom);
             var tile = this._tiles[coord.id];
@@ -201,7 +202,7 @@ TilePyramid.prototype = {
                 retain[coord.id] = true;
                 return tile;
             }
-            if (this._cache.has(coord.id)) {
+            if (checkCache && this._cache.has(coord.id)) {
                 this.addTile(coord);
                 retain[coord.id] = true;
                 return this._tiles[coord.id];
@@ -266,7 +267,7 @@ TilePyramid.prototype = {
             // The tile we require is not yet loaded.
             // Retain child or parent tiles that cover the same area.
             if (!this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
-                this.findLoadedParent(coord, minCoveringZoom, retain);
+                this.findLoadedParent(coord, minCoveringZoom, retain, true);
             }
         }
 
@@ -282,7 +283,7 @@ TilePyramid.prototype = {
                 if (this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
                     retain[id] = true;
                 }
-                this.findLoadedParent(coord, minCoveringZoom, parentsForFading);
+                this.findLoadedParent(coord, minCoveringZoom, parentsForFading, true);
             }
         }
 

--- a/test/js/source/tile_pyramid.test.js
+++ b/test/js/source/tile_pyramid.test.js
@@ -655,8 +655,8 @@ test('TilePyramid#findLoadedParent', function(t) {
         var expectedRetain = {};
         expectedRetain[tile.coord.id] = true;
 
-        t.equal(pyramid.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
-        t.deepEqual(pyramid.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
+        t.equal(pyramid.findLoadedParent(new TileCoord(2, 3, 3), 0, retain, true), undefined);
+        t.deepEqual(pyramid.findLoadedParent(new TileCoord(2, 0, 0), 0, retain, true), tile);
         t.deepEqual(retain, expectedRetain);
         t.end();
     });
@@ -681,8 +681,8 @@ test('TilePyramid#findLoadedParent', function(t) {
         var expectedRetain = {};
         expectedRetain[tile.coord.id] = true;
 
-        t.equal(pyramid.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
-        t.deepEqual(pyramid.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
+        t.equal(pyramid.findLoadedParent(new TileCoord(2, 3, 3), 0, retain, true), undefined);
+        t.deepEqual(pyramid.findLoadedParent(new TileCoord(2, 0, 0), 0, retain, true), tile);
         t.deepEqual(retain, expectedRetain);
         t.equal(pyramid._cache.order.length, 0);
         t.deepEqual(pyramid._tiles[tile.coord.id], tile);


### PR DESCRIPTION
[this](https://github.com/mapbox/mapbox-gl-js/blob/e2b0560802605f6805b1b666716f5a8137075b21/js/render/draw_raster.js#L49) used to check the cache for parent tiles and call `addTile` if it found one, and add unneeded tiles to `pyramid._tiles`.

:eyes: @lucaswoj 