### PR TITLE
fix deleted features still visible with featuresAt

### DIFF
--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -155,13 +155,16 @@ util.extend(Worker.prototype, {
 
         // if (!geoJSONTile) console.log('not found', this.geoJSONIndexes[source], coord);
 
-        if (!geoJSONTile) return callback(null, null); // nothing in the given tile
-
-        var tile = new WorkerTile(params);
-        tile.parse(new GeoJSONWrapper(geoJSONTile.features), this.layers, this.actor, callback);
+        var tile = geoJSONTile ? new WorkerTile(params) : undefined;
 
         this.loaded[source] = this.loaded[source] || {};
         this.loaded[source][params.uid] = tile;
+
+        if (geoJSONTile) {
+            tile.parse(new GeoJSONWrapper(geoJSONTile.features), this.layers, this.actor, callback);
+        } else {
+            return callback(null, null); // nothing in the given tile
+        }
     },
 
     'query features': function(params, callback) {


### PR DESCRIPTION
fix #2177

If deleting a feature resulted in an empty tile then the WorkerTile for the old non-empty tile was never removed. This fixes that.

:eyes: @mourner 