### PR TITLE
bind textures to correct texture units

### DIFF
--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -26,7 +26,6 @@ function drawBackground(painter, source, layer) {
         // Draw texture fill
         shader = painter.patternShader;
         gl.switchShader(shader);
-        gl.uniform1i(shader.u_image, 0);
         gl.uniform2fv(shader.u_pattern_tl_a, imagePosA.tl);
         gl.uniform2fv(shader.u_pattern_br_a, imagePosA.br);
         gl.uniform2fv(shader.u_pattern_tl_b, imagePosB.tl);
@@ -47,6 +46,8 @@ function drawBackground(painter, source, layer) {
             1 / (imagePosB.size[1] * factor * image.toScale)
         ]);
 
+        gl.uniform1i(shader.u_image, 0);
+        gl.activeTexture(gl.TEXTURE0);
         painter.spriteAtlas.bind(gl, true);
 
     } else {

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -169,6 +169,7 @@ function drawFill(painter, source, layer, coord) {
         gl.uniform2fv(shader.u_offset_a, [offsetAx, offsetAy]);
         gl.uniform2fv(shader.u_offset_b, [offsetBx, offsetBy]);
 
+        gl.activeTexture(gl.TEXTURE0);
         painter.spriteAtlas.bind(gl, true);
 
     } else {

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -78,11 +78,13 @@ module.exports = function drawLine(painter, source, layer, coords) {
 
         posA = painter.lineAtlas.getDash(dasharray.from, layer.layout['line-cap'] === 'round');
         posB = painter.lineAtlas.getDash(dasharray.to, layer.layout['line-cap'] === 'round');
+
+        gl.uniform1i(shader.u_image, 0);
+        gl.activeTexture(gl.TEXTURE0);
         painter.lineAtlas.bind(gl);
 
         gl.uniform1f(shader.u_tex_y_a, posA.y);
         gl.uniform1f(shader.u_tex_y_b, posB.y);
-        gl.uniform1i(shader.u_image, 0);
         gl.uniform1f(shader.u_mix, dasharray.t);
 
         gl.uniform1f(shader.u_extra, extra);
@@ -94,10 +96,12 @@ module.exports = function drawLine(painter, source, layer, coords) {
         imagePosB = painter.spriteAtlas.getPosition(image.to, true);
         if (!imagePosA || !imagePosB) return;
 
-        painter.spriteAtlas.bind(gl, true);
-
         shader = painter.linepatternShader;
         gl.switchShader(shader);
+
+        gl.uniform1i(shader.u_image, 0);
+        gl.activeTexture(gl.TEXTURE0);
+        painter.spriteAtlas.bind(gl, true);
 
         gl.uniform2fv(shader.u_linewidth, [ outset, inset ]);
         gl.uniform1f(shader.u_blur, blur);


### PR DESCRIPTION
fix #2304

Raster rendering sets the active texture unit to gl.TEXTURE1 which broke all later texture binds. This fixes that by setting the correct active texture before each bind.

:eyes: @bhousel or @lucaswoj 