### PR TITLE
Fix popup location with preceding sibling elements (fixes #2308)

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -106,6 +106,8 @@
 
 .mapboxgl-popup {
     position: absolute;
+    top: 0;
+    left: 0;
     display: -webkit-flex;
     display: flex;
     will-change: transform;


### PR DESCRIPTION
CSS had `position: absolute` but was missing (0, 0) origin.