### PR TITLE
fix fill slivers between adjacent polygons

### DIFF
--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -25,6 +25,7 @@ function draw(painter, source, layer, coords) {
     if (!painter.isOpaquePass && layer.paint['fill-antialias'] && !(layer.paint['fill-pattern'] && !strokeColor)) {
         gl.switchShader(painter.outlineShader);
         gl.lineWidth(2);
+        painter.depthMask(false);
 
         if (strokeColor) {
             // If we defined a different color for the fill outline, we are

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var browser = require('../util/browser');
 var util = require('../util/util');
 
 module.exports = draw;
@@ -25,7 +24,7 @@ function draw(painter, source, layer, coords) {
     // Draw stroke
     if (!painter.isOpaquePass && layer.paint['fill-antialias'] && !(layer.paint['fill-pattern'] && !strokeColor)) {
         gl.switchShader(painter.outlineShader);
-        gl.lineWidth(2 * browser.devicePixelRatio * 10);
+        gl.lineWidth(2);
 
         if (strokeColor) {
             // If we defined a different color for the fill outline, we are


### PR DESCRIPTION
fix #2060
fix #2079

Pixels in neighbouring polygons were being dropped by antialiasing outlines that had been written to the depth buffer. This fixes it by not writing antialiasing outlines to the depth buffer.

The `numSubLayers` change in da4dfd3657240752204e5eee766a64e18eb960ce made the bug harder to reproduce but it still existed.

:eyes: @bhousel or @lucaswoj 

cc @averas 