### PR TITLE
Throttle mousemove internally

### DIFF
--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -25,6 +25,8 @@ function Interaction(map) {
     }
 
     util.bindHandlers(this);
+
+    this._onMouseMove = util.throttle(this._onMouseMove, 16);
 }
 
 Interaction.prototype = {


### PR DESCRIPTION
Ref #2334. I’ve lost count of times where I gave advice to throttle `mousemove` whenever someone had performance issues with interactivity. I think `mousemove` should be throttled internally by default — it _always_ helps with performance, and I can’t think of any drawbacks/gotchas in this particular throttling case.

This, coupled with the preventDefault fix in the example, makes the point dragging example much smoother. After we fix `setPaintProperty` triggering `cascade`, it’ll become butter-smooth.

cc @lucaswoj @jfirebaugh @ansis @tristen 