### PR TITLE
Prevent default on mousedown

### DIFF
--- a/js/ui/interaction.js
+++ b/js/ui/interaction.js
@@ -72,6 +72,9 @@ Interaction.prototype = {
         this._map.stop();
         this._startPos = DOM.mousePos(this._el, e);
         this._fireMouseEvent('mousedown', e);
+
+        // prevent default container dragging behavior
+        e.preventDefault();
     },
 
     _onMouseUp: function (e) {


### PR DESCRIPTION
See #2334. Along with #2337, makes point dragging example much smoother.