### PR TITLE
Run linter during npm test and CI builds.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -9,6 +9,9 @@ export PATH=$(pwd)/node_modules/.bin:$PATH
 # set up code coverage instrumentation
 rm -rf coverage .nyc_output
 
+# run linters
+npm run lint
+
 # run unit tests
 tap --reporter dot --coverage --no-coverage-report test/js/*/*.js
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "production": "browserify js/mapbox-gl.js --debug --transform unassertify --plugin [minifyify --map mapbox-gl.js.map --output dist/mapbox-gl.js.map] --standalone mapboxgl > dist/mapbox-gl.js",
     "prepublish": "npm run build && npm run production",
     "docs": "documentation --github --format html --theme ./docs/_theme --output docs/api/",
-    "test": "tap --reporter dot test/js/*/*.js # update ci.sh if test invocation changes",
+    "test": "npm run lint && tap --reporter dot test/js/*/*.js # update ci.sh if test invocation changes",
     "test-suite": "node test/render.test.js && node test/query.test.js # update ci.sh if test invocation changes"
   }
 }


### PR DESCRIPTION
As of #2314 we unintentionally stopped running the linter on `npm test` and CI builds. 