### PR TITLE
fix queryRenderedFeatures for newly empty tiles

### DIFF
--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -96,6 +96,10 @@ Tile.prototype = {
             bucket.destroy(painter.gl);
         }
 
+        this.collisionBoxArray = null;
+        this.collisionTile = null;
+        this.featureIndex = null;
+        this.rawTileData = null;
         this.buckets = null;
         this.loaded = false;
         this.isUnloaded = true;


### PR DESCRIPTION
fix #2353 

:eyes: @mourner 