### PR TITLE
switch circle render tests to poi_label source layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "express": "^4.13.4",
     "gl": "^2.1.5",
     "istanbul": "^0.4.2",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#5e94c9d0f90aaa6fd557625a35b3c4c00aba901d",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#a42cd0cb818356d91fc6b61e2b64801e57486ac0",
     "nyc": "^6.1.1",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
When -native renders circles in still mode it needs neighbouring tiles to contain points in identical locations. The `road` layer didn't have this so I switched the tests to the `poi_label` layer.