### PR TITLE
Upgrade eslint and some other deps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,11 @@
     "space-before-function-paren": 0,
     "quotes": 0,
     "no-eq-null": 0,
+    "consistent-return": 0,
+    "global-require": 0,
     "block-scoped-var": 2
+  },
+  "env": {
+    "es6": true
   }
 }

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -333,9 +333,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             if (this.getZoom() < minZoom) this.setZoom(minZoom);
 
             return this;
-        }
 
-        else throw new Error('minZoom must be between ' + defaultMinZoom + ' and the current maxZoom, inclusive');
+        } else throw new Error('minZoom must be between ' + defaultMinZoom + ' and the current maxZoom, inclusive');
     },
 
     /**
@@ -354,9 +353,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             if (this.getZoom() > maxZoom) this.setZoom(maxZoom);
 
             return this;
-        }
 
-        else throw new Error('maxZoom must be between the current minZoom and ' + defaultMaxZoom + ', inclusive');
+        } else throw new Error('maxZoom must be between the current minZoom and ' + defaultMaxZoom + ', inclusive');
     },
     /**
      * Get pixel coordinates (relative to map container) given a geographical location

--- a/package.json
+++ b/package.json
@@ -34,14 +34,13 @@
     "vt-pbf": "^2.0.2"
   },
   "devDependencies": {
-    "benchmark": "~1.0.0",
-    "browserify": "^12.0.1",
+    "benchmark": "~2.1.0",
+    "browserify": "^13.0.0",
     "browserify-middleware": "^7.0.0",
     "coveralls": "^2.11.8",
     "documentation": "3.0.0",
-    "envify": "^3.4.0",
-    "eslint": "^1.5.0",
-    "eslint-config-mourner": "^1.0.0",
+    "eslint": "^2.5.3",
+    "eslint-config-mourner": "^2.0.0",
     "express": "^4.13.4",
     "gl": "^2.1.5",
     "istanbul": "^0.4.2",


### PR DESCRIPTION
:eyes: @lucaswoj. 

The `es6` environment in `.eslintrc` had to be added because typed arrays are a part of ES6 spec and default environment is now ES5 which doesn’t include them.

update: [found an explanation](https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-2.0.0.md#built-in-global-variables).