### PR TITLE
Add assertions to DictionaryCoder

### DIFF
--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -49,6 +49,7 @@ WorkerTile.prototype.parse = function(data, layers, actor, rawTileData, callback
         if (layer.minzoom && this.zoom < layer.minzoom) continue;
         if (layer.maxzoom && this.zoom >= layer.maxzoom) continue;
         if (layer.layout && layer.layout.visibility === 'none') continue;
+        if (data.layers && !data.layers[layer['source-layer']]) continue;
 
         bucket = Bucket.create({
             layer: layer,

--- a/js/util/dictionary_coder.js
+++ b/js/util/dictionary_coder.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assert = require('assert');
+
 module.exports = DictionaryCoder;
 
 function DictionaryCoder(strings) {
@@ -13,9 +15,11 @@ function DictionaryCoder(strings) {
 }
 
 DictionaryCoder.prototype.encode = function(string) {
+    assert(string in this._stringToNumber);
     return this._stringToNumber[string];
 };
 
 DictionaryCoder.prototype.decode = function(n) {
+    assert(n < this._numberToString.length);
     return this._numberToString[n];
 };


### PR DESCRIPTION
I hit a hard-to-debug error caused by `DictionaryCoder` silently returning `undefined` for keys not in its lookup table. 

Do these `assert` statements make sense, @ansis? 