### PR TITLE
better symbol fading with texture lookups

### DIFF
--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -143,11 +143,9 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
 
     gl.uniform1f(program.u_zoom, (painter.transform.zoom - zoomAdjust) * 10); // current zoom level
 
-    var f = painter.frameHistory.getFadeProperties(300);
-    gl.uniform1f(program.u_fadedist, f.fadedist * 10);
-    gl.uniform1f(program.u_minfadezoom, Math.floor(f.minfadezoom * 10));
-    gl.uniform1f(program.u_maxfadezoom, Math.floor(f.maxfadezoom * 10));
-    gl.uniform1f(program.u_fadezoom, (painter.transform.zoom + f.bump) * 10);
+    gl.activeTexture(gl.TEXTURE1);
+    painter.frameHistory.bind(gl);
+    gl.uniform1i(program.u_fadetexture, 1);
 
     var group, offset, count, elementOffset;
 

--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -65,13 +65,13 @@ var definitions = {
         fragmentSource: fs.readFileSync(path.join(__dirname, '../../../shaders/icon.fragment.glsl'), 'utf8'),
         vertexSource: fs.readFileSync(path.join(__dirname, '../../../shaders/icon.vertex.glsl'), 'utf8'),
         attributeNames: ['a_pos', 'a_offset', 'a_data1', 'a_data2'],
-        uniformNames: ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_opacity', 'u_skewed', 'u_extra']
+        uniformNames: ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_zoom', 'u_fadetexture', 'u_opacity', 'u_skewed', 'u_extra']
     },
     sdf: {
         fragmentSource: fs.readFileSync(path.join(__dirname, '../../../shaders/sdf.fragment.glsl'), 'utf8'),
         vertexSource: fs.readFileSync(path.join(__dirname, '../../../shaders/sdf.vertex.glsl'), 'utf8'),
         attributeNames: ['a_pos', 'a_offset', 'a_data1', 'a_data2'],
-        uniformNames: ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_color', 'u_gamma', 'u_buffer', 'u_zoom', 'u_fadedist', 'u_minfadezoom', 'u_maxfadezoom', 'u_fadezoom', 'u_skewed', 'u_extra']
+        uniformNames: ['u_matrix', 'u_exmatrix', 'u_texture', 'u_texsize', 'u_color', 'u_gamma', 'u_buffer', 'u_zoom', 'u_fadetexture', 'u_skewed', 'u_extra']
     },
     collisionbox: {
         fragmentSource: fs.readFileSync(path.join(__dirname, '../../../shaders/collisionbox.fragment.glsl'), 'utf8'),

--- a/shaders/icon.fragment.glsl
+++ b/shaders/icon.fragment.glsl
@@ -1,10 +1,13 @@
 precision mediump float;
 
 uniform sampler2D u_texture;
+uniform sampler2D u_fadetexture;
+uniform lowp float u_opacity;
 
 varying vec2 v_tex;
-varying float v_alpha;
+varying vec2 v_fade_tex;
 
 void main() {
-    gl_FragColor = texture2D(u_texture, v_tex) * v_alpha;
+    lowp float alpha = texture2D(u_fadetexture, v_fade_tex).a * u_opacity;
+    gl_FragColor = texture2D(u_texture, v_tex) * alpha;
 }

--- a/shaders/icon.vertex.glsl
+++ b/shaders/icon.vertex.glsl
@@ -11,18 +11,13 @@ attribute vec4 a_data2;
 uniform mat4 u_matrix;
 uniform mat4 u_exmatrix;
 uniform mediump float u_zoom;
-uniform mediump float u_fadedist;
-uniform mediump float u_minfadezoom;
-uniform mediump float u_maxfadezoom;
-uniform mediump float u_fadezoom;
-uniform lowp float u_opacity;
 uniform bool u_skewed;
 uniform float u_extra;
 
 uniform vec2 u_texsize;
 
 varying vec2 v_tex;
-varying float v_alpha;
+varying vec2 v_fade_tex;
 
 void main() {
     vec2 a_tex = a_data1.xy;
@@ -36,24 +31,6 @@ void main() {
     // u_zoom is the current zoom level adjusted for the change in font size
     mediump float z = 2.0 - step(a_minzoom, u_zoom) - (1.0 - step(a_maxzoom, u_zoom));
 
-    // fade out labels
-    mediump float alpha = clamp((u_fadezoom - a_labelminzoom) / u_fadedist, 0.0, 1.0);
-
-    if (u_fadedist >= 0.0) {
-        v_alpha = alpha;
-    } else {
-        v_alpha = 1.0 - alpha;
-    }
-    if (u_maxfadezoom < a_labelminzoom) {
-        v_alpha = 0.0;
-    }
-    if (u_minfadezoom >= a_labelminzoom) {
-        v_alpha = 1.0;
-    }
-
-    // if label has been faded out, clip it
-    z += step(v_alpha, 0.0);
-
     if (u_skewed) {
         vec4 extrude = u_exmatrix * vec4(a_offset / 64.0, 0, 0);
         gl_Position = u_matrix * vec4(a_pos + extrude.xy, 0, 1);
@@ -64,6 +41,5 @@ void main() {
     }
 
     v_tex = a_tex / u_texsize;
-
-    v_alpha *= u_opacity;
+    v_fade_tex = vec2(a_labelminzoom / 255.0, 0.0);
 }

--- a/shaders/sdf.fragment.glsl
+++ b/shaders/sdf.fragment.glsl
@@ -1,17 +1,19 @@
 precision mediump float;
 
 uniform sampler2D u_texture;
+uniform sampler2D u_fadetexture;
 uniform lowp vec4 u_color;
 uniform lowp float u_buffer;
 uniform lowp float u_gamma;
 
 varying vec2 v_tex;
-varying float v_alpha;
+varying vec2 v_fade_tex;
 varying float v_gamma_scale;
 
 void main() {
-    lowp float gamma = u_gamma * v_gamma_scale;
     lowp float dist = texture2D(u_texture, v_tex).a;
-    lowp float alpha = smoothstep(u_buffer - gamma, u_buffer + gamma, dist) * v_alpha;
+    lowp float fade_alpha = texture2D(u_fadetexture, v_fade_tex).a;
+    lowp float gamma = u_gamma * v_gamma_scale;
+    lowp float alpha = smoothstep(u_buffer - gamma, u_buffer + gamma, dist) * fade_alpha;
     gl_FragColor = u_color * alpha;
 }

--- a/shaders/sdf.vertex.glsl
+++ b/shaders/sdf.vertex.glsl
@@ -12,17 +12,13 @@ uniform mat4 u_matrix;
 uniform mat4 u_exmatrix;
 
 uniform mediump float u_zoom;
-uniform mediump float u_fadedist;
-uniform mediump float u_minfadezoom;
-uniform mediump float u_maxfadezoom;
-uniform mediump float u_fadezoom;
 uniform bool u_skewed;
 uniform float u_extra;
 
 uniform vec2 u_texsize;
 
 varying vec2 v_tex;
-varying float v_alpha;
+varying vec2 v_fade_tex;
 varying float v_gamma_scale;
 
 void main() {
@@ -34,24 +30,6 @@ void main() {
 
     // u_zoom is the current zoom level adjusted for the change in font size
     mediump float z = 2.0 - step(a_minzoom, u_zoom) - (1.0 - step(a_maxzoom, u_zoom));
-
-    // fade out labels
-    mediump float alpha = clamp((u_fadezoom - a_labelminzoom) / u_fadedist, 0.0, 1.0);
-
-    if (u_fadedist >= 0.0) {
-        v_alpha = alpha;
-    } else {
-        v_alpha = 1.0 - alpha;
-    }
-    if (u_maxfadezoom < a_labelminzoom) {
-        v_alpha = 0.0;
-    }
-    if (u_minfadezoom >= a_labelminzoom) {
-        v_alpha = 1.0;
-    }
-
-    // if label has been faded out, clip it
-    z += step(v_alpha, 0.0);
 
     if (u_skewed) {
         vec4 extrude = u_exmatrix * vec4(a_offset / 64.0, 0, 0);
@@ -69,4 +47,5 @@ void main() {
     v_gamma_scale = perspective_scale;
 
     v_tex = a_tex / u_texsize;
+    v_fade_tex = vec2(a_labelminzoom / 255.0, 0.0);
 }


### PR DESCRIPTION
fix #590

I revived a [branch from August 2014](https://github.com/mapbox/mapbox-gl-js/issues/590#issuecomment-49822040). Remember this @mourner? This branch uses fragment texture lookups instead of vertex texture lookups to avoid concerns about vertex texture support.

- this is simpler than predicting opacity based on current zooming speed
- this is smoother: symbols don't flicker when changing zoom speed or when zooming in
  and out rapidly.


:eyes: @mourner @lucaswoj 