### PR TITLE
Simplify and fix cascade

### DIFF
--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -26,6 +26,32 @@ test('StyleLayer', function(t) {
     t.end();
 });
 
+test('StyleLayer#cascade', function (t) {
+    t.test('respects classes regardless of layer properties order', function (t) {
+        var layer = StyleLayer.create({
+            "id": "background",
+            "type": "fill",
+            "paint.blue": {
+                "fill-color": "#8ccbf7",
+                "fill-opacity": 1
+            },
+            "paint": {
+                "fill-opacity": 0
+            }
+        });
+
+        layer.cascade({}, {transition: false}, null, createAnimationLoop());
+        t.equal(layer.getPaintValue('fill-opacity'), 0);
+
+        layer.cascade({blue: true}, {transition: false}, null, createAnimationLoop());
+        t.equal(layer.getPaintValue('fill-opacity'), 1);
+
+        t.end();
+    });
+
+    t.end();
+});
+
 test('StyleLayer#setPaintProperty', function(t) {
     t.test('sets new property value', function(t) {
         var layer = StyleLayer.create({


### PR DESCRIPTION
Fixes #2357 and also a prerequisite for #2339 since it adds `Style` `updatePaintTransition` method.

I didn’t refactor classes into an array in this PR but going to hit this along with #2339.

:eyes: @lucaswoj @andrewharvey