### PR TITLE
Error if geometry extents exceeds allowed internal extent

### DIFF
--- a/js/data/load_geometry.js
+++ b/js/data/load_geometry.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var EXTENT = require('./bucket').EXTENT;
+var EXTENT_MIN = EXTENT * -2;
+var EXTENT_MAX = (EXTENT * 2) - 1;
 
 /**
  * Loads a geometry from a VectorTileFeature and scales it to the common extent
@@ -18,6 +20,12 @@ module.exports = function loadGeometry(feature) {
             // points and we need to do the same to avoid renering differences.
             point.x = Math.round(point.x * scale);
             point.y = Math.round(point.y * scale);
+            if (point.x < EXTENT_MIN ||
+                point.x > EXTENT_MAX ||
+                point.y < EXTENT_MIN ||
+                point.y > EXTENT_MAX) {
+                console.warn('Geometry exceeds allowed extent, reduce your vector tile buffer size');
+            }
         }
     }
     return geometry;

--- a/test/js/data/load_geometry.test.js
+++ b/test/js/data/load_geometry.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var Protobuf = require('pbf');
+var VectorTile = require('vector-tile').VectorTile;
+var loadGeometry = require('../../../js/data/load_geometry.js');
+
+// Load a line feature from fixture tile.
+var vt = new VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
+
+test('loadGeometry', function(t) {
+    var feature = vt.layers.road.feature(0);
+    var originalGeometry = feature.loadGeometry();
+    var scaledGeometry = loadGeometry(feature);
+    t.equal(scaledGeometry[0][0].x, originalGeometry[0][0].x * 2, 'scales x coords by 2x');
+    t.equal(scaledGeometry[0][0].y, originalGeometry[0][0].y * 2, 'scales y coords by 2x');
+    t.end();
+});
+
+test('loadGeometry extent error', function(t) {
+    var feature = vt.layers.road.feature(0);
+    feature.extent = 2048;
+
+    var numWarnings = 0;
+
+    // Use a custom console.warn to count warnings
+    var warn = console.warn;
+    console.warn = function(warning) {
+        if (warning.match(/Geometry exceeds allowed extent, reduce your vector tile buffer size/)) {
+            numWarnings++;
+        }
+    };
+
+    loadGeometry(feature);
+
+    t.equal(numWarnings, 877);
+
+    // Put it back
+    console.warn = warn;
+
+    t.end();
+});
+


### PR DESCRIPTION
Follow up to https://github.com/mapbox/mapbox-gl-js/pull/2010, throw an error if geometry exceeds internal extent after scaling.

- [ ] @ansis :eyes: for review? Not sure I got the negative min extent right.
- [ ] native port (error or warning)