### PR TITLE
Store classes as an array internally

### DIFF
--- a/js/source/source.js
+++ b/js/source/source.js
@@ -92,7 +92,7 @@ function mergeRenderedFeatureLayers(tiles) {
     return result;
 }
 
-exports._queryRenderedVectorFeatures = function(queryGeometry, params, classes, zoom, bearing) {
+exports._queryRenderedVectorFeatures = function(queryGeometry, params, zoom, bearing) {
     if (!this._pyramid)
         return {};
 

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -193,7 +193,7 @@ Style.prototype = util.inherit(Evented, {
         };
 
         for (var id in this._layers) {
-            this._layers[id].cascade(classes, options,
+            this._layers[id].cascade(classes || [], options,
                 this.stylesheet.transition || {},
                 this.animationLoop);
         }
@@ -628,12 +628,12 @@ Style.prototype = util.inherit(Evented, {
         return features;
     },
 
-    queryRenderedFeatures: function(queryGeometry, params, classes, zoom, bearing) {
+    queryRenderedFeatures: function(queryGeometry, params, zoom, bearing) {
         var sourceResults = [];
         for (var id in this.sources) {
             var source = this.sources[id];
             if (source.queryRenderedFeatures) {
-                sourceResults.push(source.queryRenderedFeatures(queryGeometry, params, classes, zoom, bearing));
+                sourceResults.push(source.queryRenderedFeatures(queryGeometry, params, zoom, bearing));
             }
         }
         return this._flattenRenderedFeatures(sourceResults);

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -183,8 +183,8 @@ StyleLayer.prototype = util.inherit(Evented, {
     // update all paint transitions and layout/paint constant values
     cascade: function(classes, options, globalOptions, animationLoop) {
         var declarations = util.extend({}, this._paintDeclarations['']);
-        for (var klass in classes) {
-            util.extend(declarations, this._paintDeclarations[klass]);
+        for (var i = 0; i < classes.length; i++) {
+            util.extend(declarations, this._paintDeclarations[classes[i]]);
         }
 
         var name;

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -131,7 +131,7 @@ var Map = module.exports = function(options) {
     }
 
     this.stacks = {};
-    this._classes = {};
+    this._classes = [];
 
     this.resize();
 
@@ -198,11 +198,12 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @returns {Map} `this`
      */
     addClass: function(klass, options) {
-        if (this._classes[klass]) return;
-        this._classes[klass] = true;
+        if (this._classes.indexOf(klass) >= 0 || klass === '') return this;
+        this._classes.push(klass);
         this._classOptions = options;
+
         if (this.style) this.style.cascade();
-        this._update(true);
+        return this._update(true);
     },
 
     /**
@@ -214,11 +215,13 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @returns {Map} `this`
      */
     removeClass: function(klass, options) {
-        if (!this._classes[klass]) return;
-        delete this._classes[klass];
+        var i = this._classes.indexOf(klass);
+        if (i < 0 || klass === '') return this;
+        this._classes.splice(i, 1);
         this._classOptions = options;
+
         if (this.style) this.style.cascade();
-        this._update(true);
+        return this._update(true);
     },
 
     /**
@@ -230,13 +233,15 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @returns {Map} `this`
      */
     setClasses: function(klasses, options) {
-        this._classes = {};
-        this._classOptions = options;
+        var uniqueClasses = {};
         for (var i = 0; i < klasses.length; i++) {
-            this._classes[klasses[i]] = true;
+            if (klasses[i] !== '') uniqueClasses[klasses[i]] = true;
         }
+        this._classes = Object.keys(uniqueClasses);
+        this._classOptions = options;
+
         if (this.style) this.style.cascade();
-        this._update(true);
+        return this._update(true);
     },
 
     /**
@@ -246,7 +251,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @returns {boolean}
      */
     hasClass: function(klass) {
-        return !!this._classes[klass];
+        return this._classes.indexOf(klass) >= 0;
     },
 
     /**
@@ -255,7 +260,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @returns {boolean}
      */
     getClasses: function() {
-        return Object.keys(this._classes);
+        return this._classes;
     },
 
     /**
@@ -404,7 +409,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             pointOrBox = undefined;
         }
         var queryGeometry = this._makeQueryGeometry(pointOrBox);
-        return this.style.queryRenderedFeatures(queryGeometry, params, this._classes, this.transform.zoom, this.transform.angle);
+        return this.style.queryRenderedFeatures(queryGeometry, params, this.transform.zoom, this.transform.angle);
     },
 
     _makeQueryGeometry: function(pointOrBox) {

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -949,32 +949,32 @@ test('Style#queryRenderedFeatures', function(t) {
         };
 
         t.test('returns feature type', function(t) {
-            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0);
+            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
             t.equal(results[0].geometry.type, 'Line');
             t.end();
         });
 
         t.test('filters by `layers` option', function(t) {
-            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: 'land'}, {}, 0, 0);
+            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: 'land'}, 0, 0);
             t.equal(results.length, 2);
             t.end();
         });
 
         t.test('includes layout properties', function(t) {
-            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0);
+            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
             var layout = results[0].layer.layout;
             t.deepEqual(layout['line-cap'], 'round');
             t.end();
         });
 
         t.test('includes paint properties', function(t) {
-            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0);
+            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
             t.deepEqual(results[2].layer.paint['line-color'], [1, 0, 0, 1]);
             t.end();
         });
 
         t.test('ref layer inherits properties', function(t) {
-            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0);
+            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
             var layer = results[1].layer;
             var refLayer = results[0].layer;
             t.deepEqual(layer.layout, refLayer.layout);
@@ -985,7 +985,7 @@ test('Style#queryRenderedFeatures', function(t) {
         });
 
         t.test('includes metadata', function(t) {
-            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, {}, 0, 0);
+            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
 
             var layer = results[1].layer;
             t.equal(layer.metadata.something, 'else');
@@ -994,7 +994,7 @@ test('Style#queryRenderedFeatures', function(t) {
         });
 
         t.test('include multiple layers', function(t) {
-            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land', 'landref']}, {}, 0, 0);
+            var results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land', 'landref']}, 0, 0);
             t.equals(results.length, 3);
             t.end();
         });

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -40,10 +40,10 @@ test('StyleLayer#cascade', function (t) {
             }
         });
 
-        layer.cascade({}, {transition: false}, null, createAnimationLoop());
+        layer.cascade([], {transition: false}, null, createAnimationLoop());
         t.equal(layer.getPaintValue('fill-opacity'), 0);
 
-        layer.cascade({blue: true}, {transition: false}, null, createAnimationLoop());
+        layer.cascade(['blue'], {transition: false}, null, createAnimationLoop());
         t.equal(layer.getPaintValue('fill-opacity'), 1);
 
         t.end();
@@ -89,9 +89,9 @@ test('StyleLayer#setPaintProperty', function(t) {
                 "background-opacity": 1
             }
         });
-        layer.cascade({}, {transition: false}, null, createAnimationLoop());
+        layer.cascade([], {transition: false}, null, createAnimationLoop());
         layer.setPaintProperty('background-color', null);
-        layer.cascade({}, {transition: false}, null, createAnimationLoop());
+        layer.cascade([], {transition: false}, null, createAnimationLoop());
 
         t.deepEqual(layer.getPaintValue('background-color'), [0, 0, 0, 1]);
         t.equal(layer.getPaintProperty('background-color'), undefined);
@@ -129,12 +129,12 @@ test('StyleLayer#setPaintProperty', function(t) {
                 "background-opacity": 0.1
             }
         });
-        layer.cascade({night: true}, {transition: false}, null, createAnimationLoop());
+        layer.cascade(['night'], {transition: false}, null, createAnimationLoop());
         t.deepEqual(layer.getPaintProperty('background-color', 'night'), 'blue');
         t.deepEqual(layer.getPaintValue('background-color'), [0, 0, 1, 1]);
 
         layer.setPaintProperty('background-color', null, 'night');
-        layer.cascade({night: true}, {transition: false}, null, createAnimationLoop());
+        layer.cascade(['night'], {transition: false}, null, createAnimationLoop());
         t.deepEqual(layer.getPaintValue('background-color'), [1, 0, 0, 1]);
         t.equal(layer.getPaintProperty('background-color', 'night'), undefined);
 
@@ -184,7 +184,7 @@ test('StyleLayer#setPaintProperty', function(t) {
         });
 
         layer.setPaintProperty('background-color-transition', {duration: 400}, 'background-color');
-        layer.cascade({}, {transition: false}, null, createAnimationLoop());
+        layer.cascade([], {transition: false}, null, createAnimationLoop());
         t.deepEqual(layer.getPaintProperty('background-color-transition', 'background-color'), {duration: 400});
         t.end();
     });

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -471,10 +471,9 @@ test('Map', function(t) {
             var opts = {};
 
             t.test('normal coords', function(t) {
-                map.style.queryRenderedFeatures = function (coords, o, classes, zoom, bearing) {
+                map.style.queryRenderedFeatures = function (coords, o, zoom, bearing) {
                     t.deepEqual(coords, [{ column: 0.5, row: 0.5, zoom: 0 }]);
                     t.equal(o, opts);
-                    t.deepEqual(classes, map._classes);
                     t.equal(bearing, map.transform.angle);
                     t.equal(zoom, map.getZoom());
                     t.end();
@@ -484,14 +483,13 @@ test('Map', function(t) {
             });
 
             t.test('does not wrap coords', function(t) {
-                map.style.queryRenderedFeatures = function (coords, o, classes, zoom, bearing) {
+                map.style.queryRenderedFeatures = function (coords, o, zoom, bearing) {
                     // avoid floating point issues
                     t.equal(parseFloat(coords[0].column.toFixed(4)), 1.5);
                     t.equal(coords[0].row, 0.5);
                     t.equal(coords[0].zoom, 0);
 
                     t.equal(o, opts);
-                    t.deepEqual(classes, map._classes);
                     t.equal(bearing, map.transform.angle);
                     t.equal(zoom, map.getZoom());
 


### PR DESCRIPTION
Storing classes as an array internally guarantees consistent class application order, as discussed in #2357 and #2381. Closes #969.

Additionally, I made `setClasses`/`addClass`/`removeClass` chainable (returning `this`).

:eyes: @lucaswoj 