### PR TITLE
Cache posMatrix in coordinate

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -5,6 +5,8 @@ var LngLat = require('./lng_lat'),
     Coordinate = require('./coordinate'),
     wrap = require('../util/util').wrap,
     interp = require('../util/interpolate'),
+    TileCoord = require('../source/tile_coord'),
+    EXTENT = require('../data/bucket').EXTENT,
     glmatrix = require('gl-matrix');
 
 var vec4 = glmatrix.vec4,
@@ -322,6 +324,33 @@ Transform.prototype = {
         mat4.scale(m, m, [this.width / 2, -this.height / 2, 1]);
         mat4.translate(m, m, [1, -1, 0]);
         return m;
+    },
+
+    /**
+     * Calculate the posMatrix that, given a tile coordinate, would be used to display the tile on a map.
+     * @param {TileCoord|Coordinate} coord
+     * @param {Number} maxZoom maximum source zoom to account for overscaling
+     * @private
+     */
+    calculatePosMatrix: function(coord, maxZoom) {
+        if (coord instanceof TileCoord) coord = coord.toCoordinate();
+        if (maxZoom === undefined) maxZoom = Infinity;
+
+        // Initialize model-view matrix that converts from the tile coordinates to screen coordinates.
+
+        // if z > maxzoom then the tile is actually a overscaled maxzoom tile,
+        // so calculate the matrix the maxzoom tile would use.
+        var z = Math.min(coord.zoom, maxZoom);
+
+        var scale = this.worldSize / Math.pow(2, z);
+        var posMatrix = new Float64Array(16);
+
+        mat4.identity(posMatrix);
+        mat4.translate(posMatrix, posMatrix, [coord.column * scale, coord.row * scale, 0]);
+        mat4.scale(posMatrix, posMatrix, [ scale / EXTENT, scale / EXTENT, 1 ]);
+        mat4.multiply(posMatrix, this.projMatrix, posMatrix);
+
+        return new Float32Array(posMatrix);
     },
 
     _constrain: function() {

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -91,7 +91,7 @@ function drawBackground(painter, source, layer) {
             gl.uniform2fv(program.u_offset_b, [offsetBx, offsetBy]);
         }
 
-        painter.setPosMatrix(painter.calculatePosMatrix(coord));
+        painter.setPosMatrix(painter.transform.calculatePosMatrix(coord));
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
     }
 

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -43,7 +43,7 @@ function drawCircles(painter, source, layer, coords) {
         var elements = bucket.buffers.circleElement;
 
         painter.setPosMatrix(painter.translatePosMatrix(
-            painter.calculatePosMatrix(coord, source.maxzoom),
+            coord.posMatrix,
             tile,
             layer.paint['circle-translate'],
             layer.paint['circle-translate-anchor']

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -22,8 +22,7 @@ function drawCollisionDebug(painter, source, layer, coords) {
         buffer.bind(gl);
         buffer.setAttribPointers(gl, program, 0);
 
-        var posMatrix = painter.calculatePosMatrix(coord, source.maxzoom);
-        painter.setPosMatrix(posMatrix);
+        painter.setPosMatrix(coord.posMatrix);
 
         painter.enableTileClippingMask(coord);
 

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -22,7 +22,7 @@ function drawDebugTile(painter, source, coord) {
     gl.disable(gl.STENCIL_TEST);
     painter.lineWidth(1 * browser.devicePixelRatio);
 
-    var posMatrix = painter.calculatePosMatrix(coord, source.maxzoom);
+    var posMatrix = coord.posMatrix;
     var program = painter.useProgram('debug', posMatrix);
 
     // draw bounding rectangle

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -81,7 +81,7 @@ function drawFill(painter, source, layer, coord) {
     var image = layer.paint['fill-pattern'];
     var opacity = layer.paint['fill-opacity'];
 
-    var posMatrix = painter.calculatePosMatrix(coord, source.maxzoom);
+    var posMatrix = coord.posMatrix;
     var translatedPosMatrix = painter.translatePosMatrix(posMatrix, tile, layer.paint['fill-translate'], layer.paint['fill-translate-anchor']);
 
     // Draw the stencil mask.
@@ -175,7 +175,7 @@ function drawStroke(painter, source, layer, coord) {
     var program = image ? painter.useProgram('outlinepattern') : painter.useProgram('outline');
 
     painter.setPosMatrix(painter.translatePosMatrix(
-        painter.calculatePosMatrix(coord, source.maxzoom),
+        coord.posMatrix,
         tile,
         layer.paint['fill-translate'],
         layer.paint['fill-translate-anchor']

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -135,7 +135,7 @@ module.exports = function drawLine(painter, source, layer, coords) {
         painter.enableTileClippingMask(coord);
 
         // set uniforms that are different for each tile
-        var posMatrix = painter.translatePosMatrix(painter.calculatePosMatrix(coord, source.maxzoom), tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
+        var posMatrix = painter.translatePosMatrix(coord.posMatrix, tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
 
         painter.setPosMatrix(posMatrix);
         painter.setExMatrix(painter.transform.exMatrix);

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -34,7 +34,7 @@ function drawRasterTile(painter, source, layer, coord) {
     gl.disable(gl.STENCIL_TEST);
 
     var tile = source.getTile(coord);
-    var posMatrix = painter.calculatePosMatrix(coord, source.maxzoom);
+    var posMatrix = painter.transform.calculatePosMatrix(coord, source.maxzoom);
 
     var program = painter.useProgram('raster', posMatrix);
 

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -33,7 +33,7 @@ function drawSymbols(painter, source, layer, coords) {
     painter.depthMask(false);
     gl.disable(gl.DEPTH_TEST);
 
-    var tile, elementGroups, bucket, posMatrix;
+    var tile, elementGroups, bucket;
 
     for (var i = 0; i < coords.length; i++) {
         tile = source.getTile(coords[i]);
@@ -42,9 +42,8 @@ function drawSymbols(painter, source, layer, coords) {
         elementGroups = bucket.elementGroups;
         if (!elementGroups.icon.length) continue;
 
-        posMatrix = painter.calculatePosMatrix(coords[i], source.maxzoom);
         painter.enableTileClippingMask(coords[i]);
-        drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups.icon, 'icon', elementGroups.sdfIcons, elementGroups.iconsNeedLinear);
+        drawSymbol(painter, layer, coords[i].posMatrix, tile, bucket, elementGroups.icon, 'icon', elementGroups.sdfIcons, elementGroups.iconsNeedLinear);
     }
 
     for (var j = 0; j < coords.length; j++) {
@@ -54,9 +53,8 @@ function drawSymbols(painter, source, layer, coords) {
         elementGroups = bucket.elementGroups;
         if (!elementGroups.glyph.length) continue;
 
-        posMatrix = painter.calculatePosMatrix(coords[j], source.maxzoom);
         painter.enableTileClippingMask(coords[j]);
-        drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups.glyph, 'text', true, false);
+        drawSymbol(painter, layer, coords[j].posMatrix, tile, bucket, elementGroups.glyph, 'text', true, false);
     }
 
     gl.enable(gl.DEPTH_TEST);

--- a/js/source/tile_coord.js
+++ b/js/source/tile_coord.js
@@ -22,6 +22,9 @@ function TileCoord(z, x, y, w) {
     if (w < 0) w = w * -1 - 1;
     var dim = 1 << this.z;
     this.id = ((dim * dim * w + dim * this.y + this.x) * 32) + this.z;
+
+    // for caching pos matrix calculation when rendering
+    this.posMatrix = null;
 }
 
 TileCoord.prototype.toString = function() {

--- a/test/js/source/tile_coord.test.js
+++ b/test/js/source/tile_coord.test.js
@@ -78,7 +78,7 @@ test('TileCoord', function(t) {
                     {column: 0, row: 2, zoom: 2}
                 ],
                 res = TileCoord.cover(z, coords, z);
-            t.deepEqual(res, [{id: 130, w: 0, x: 0, y: 1, z: 2}]);
+            t.deepEqual(res, [{id: 130, w: 0, x: 0, y: 1, z: 2, posMatrix: null}]);
             t.end();
         });
 
@@ -91,7 +91,7 @@ test('TileCoord', function(t) {
                     {column: 12, row: 2, zoom: 2}
                 ],
                 res = TileCoord.cover(z, coords, z);
-            t.deepEqual(res, [{id: 3202, w: 3, x: 0, y: 1, z: 2}]);
+            t.deepEqual(res, [{id: 3202, w: 3, x: 0, y: 1, z: 2, posMatrix: null}]);
             t.end();
         });
 
@@ -104,7 +104,7 @@ test('TileCoord', function(t) {
                     {column: -1, row: 2, zoom: 2}
                 ],
                 res = TileCoord.cover(z, coords, z);
-            t.deepEqual(res, [{id: 738, w: -1, x: 3, y: 1, z: 2}]);
+            t.deepEqual(res, [{id: 738, w: -1, x: 3, y: 1, z: 2, posMatrix: null}]);
             t.end();
         });
 
@@ -117,7 +117,7 @@ test('TileCoord', function(t) {
                     {column: -13, row: 2, zoom: 2}
                 ],
                 res = TileCoord.cover(z, coords, z);
-            t.deepEqual(res, [{id: 3810, w: -4, x: 3, y: 1, z: 2}]);
+            t.deepEqual(res, [{id: 3810, w: -4, x: 3, y: 1, z: 2, posMatrix: null}]);
             t.end();
         });
 
@@ -130,7 +130,9 @@ test('TileCoord', function(t) {
                     {column: -0.5, row: 2, zoom: 2}
                 ],
                 res = TileCoord.cover(z, coords, z);
-            t.deepEqual(res, [{id: 130, w: 0, x: 0, y: 1, z: 2}, {id: 738, w: -1, x: 3, y: 1, z: 2}]);
+            t.deepEqual(res, [
+                {id: 130, w: 0, x: 0, y: 1, z: 2, posMatrix: null},
+                {id: 738, w: -1, x: 3, y: 1, z: 2, posMatrix: null}]);
             t.end();
         });
 


### PR DESCRIPTION
Closes #1993. Makes `calculatePosMatrix` take ~0.7% rather than 6-10% of the main thread. :eyes: @ansis 