### PR TITLE
Cheapo WMS support

### DIFF
--- a/js/source/tile_coord.js
+++ b/js/source/tile_coord.js
@@ -49,8 +49,20 @@ TileCoord.fromID = function(id) {
 
 // given a list of urls, choose a url template and return a tile URL
 TileCoord.prototype.url = function(urls, sourceMaxZoom) {
+    var halfWidth = 20037508.342789;
+    var halfHeight = 20037508.342789;
+    var tilesAcross = Math.pow(2, this.z);
+    var tileWidth = 2 * (halfWidth / tilesAcross);
+    var tileHeight = 2 * (halfHeight / tilesAcross);
+    var leftPosition = ((this.x / tilesAcross) * 2 * halfWidth) - halfWidth;
+    var topPosition = halfHeight - ((this.y / tilesAcross) * 2 * halfHeight);
+    var bbox = leftPosition + ',' +
+        topPosition + ',' +
+        (leftPosition + tileWidth) + ',' +
+        (topPosition + tileHeight);
     return urls[(this.x + this.y) % urls.length]
         .replace('{prefix}', (this.x % 16).toString(16) + (this.y % 16).toString(16))
+        .replace('{bbox-epsg-3857}', bbox)
         .replace('{z}', Math.min(this.z, sourceMaxZoom || this.z))
         .replace('{x}', this.x)
         .replace('{y}', this.y);


### PR DESCRIPTION

![2016-04-07 at 10 59 pm](https://cloud.githubusercontent.com/assets/32314/14373068/72e0ef1e-fd14-11e5-89d5-ddeda6ad1431.png)


(these changes would be resubmitted against master if people think this is a decent idea, this is more of a proposal than a nearly-finished PR)

This adds a `{bbox-epsg-3857}` token to URL requests. This would let
us support 3857-supporting CORS-supporting WMS servers in GL JS
with very little change - it would be a minor addition to the style
spec and easy to port to Native.

It's broken in a minor way right now: images aren't correctly
y-positioned through each zoom level. I know this is fixable,
someone with more sleep or fewer cold symptoms could probably get it
working quickly: the conversion from X/Y coords to "pseudo-meters"
or whatever you call 3857 units is wrong in a way that's probably
an off-by-one or something.

Example usage:

```js

    map.addSource('wms-test', {
        "type": "raster",
        "tiles": [
            "http://nowcoast.noaa.gov/arcgis/services/nowcoast/analysis_meteohydro_sfc_qpe_time/MapServer/WmsServer?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&LAYERS=5&STYLES=&FORMAT=image%2Fpng&TRANSPARENT=true&HEIGHT=256&WIDTH=256&SRS=EPSG%3A3857&BBOX={bbox-epsg-3857}",
        ],
        "tileSize": 256
    });

    map.addLayer({
        "id": "wms-test-layer",
        "type": "raster",
        "source": "wms-test",
        "paint": {
        }
    });
```

Refs #965