### PR TITLE
use glsl macros instead of custom templating

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -328,26 +328,16 @@ Bucket.prototype.recalculateStyleLayers = function() {
     }
 };
 
-Bucket.prototype.getUseProgramTokens = function(programInterface, layer) {
-    var tokens = {};
-
+Bucket.prototype.getProgramMacros = function(programInterface, layer) {
+    var macros = [];
     var enabledAttributes = this.attributes[programInterface].enabled;
     for (var i = 0; i < enabledAttributes.length; i++) {
         var enabledAttribute = enabledAttributes[i];
-        if (enabledAttribute.isLayerConstant || enabledAttribute.layerId === layer.id) {
-            tokens[enabledAttribute.typeTokenName] = 'attribute';
+        if (enabledAttribute.isLayerConstant === false && enabledAttribute.layerId === layer.id) {
+            macros.push(enabledAttribute.macro);
         }
     }
-
-    var disabledAttributes = this.attributes[programInterface].disabled;
-    for (var j = 0; j < this.attributes[programInterface].disabled.length; j++) {
-        var disabledAttribute = disabledAttributes[j];
-        if (disabledAttribute.isLayerConstant || disabledAttribute.layerId === layer.id) {
-            tokens[disabledAttribute.typeTokenName] = 'uniform';
-        }
-    }
-
-    return tokens;
+    return macros;
 };
 
 var createVertexAddMethodCache = {};
@@ -465,7 +455,6 @@ function createAttributes(bucket) {
                         programName: 'a_' + attribute.name,
                         layerId: layer.id,
                         layerIndex: j,
-                        typeTokenName: attribute.name + 'Type',
                         isLayerConstant: isLayerConstant,
                         components: attribute.components || 1
                     }));
@@ -475,7 +464,7 @@ function createAttributes(bucket) {
                         programName: 'a_' + attribute.name,
                         layerId: layer.id,
                         layerIndex: j,
-                        typeTokenName: attribute.name + 'Type',
+                        macro: 'ATTRIBUTE_' + attribute.name.toUpperCase(),
                         isLayerConstant: isLayerConstant,
                         components: attribute.components || 1
                     }));

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -31,7 +31,7 @@ function drawCircles(painter, source, layer, coords) {
         var elementGroups = bucket.elementGroups.circle;
         if (!elementGroups) continue;
 
-        var program = painter.useProgram('circle', bucket.getUseProgramTokens('circle', layer));
+        var program = painter.useProgram('circle', bucket.getProgramMacros('circle', layer));
 
         gl.uniform1f(program.u_blur, Math.max(layer.paint['circle-blur'], antialias));
         gl.uniform1f(program.u_size, layer.paint['circle-radius']);

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -6,7 +6,11 @@ uniform mediump float u_size;
 
 attribute vec2 a_pos;
 
-{{colorType}} lowp vec4 a_color;
+#ifdef ATTRIBUTE_COLOR
+attribute lowp vec4 a_color;
+#else
+uniform lowp vec4 a_color;
+#endif
 
 varying vec2 v_extrude;
 varying lowp vec4 v_color;


### PR DESCRIPTION
Using macros and preprocessor directives is the glsl way of doing this. After this change the .glsl files are valid glsl.

I personally think it's clearer to have both variations explicitly written in .glsl files.

:eyes: @lucaswoj 