### PR TITLE
data driven styling without code generation

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -163,7 +163,6 @@ Bucket.prototype.createArrays = function() {
             var ElementArrayType = createElementBufferType(programInterface.elementBufferComponents);
             arrays[elementBufferName] = new ElementArrayType();
             arrayTypes[elementBufferName] = ElementArrayType.serialize();
-            this[this.getAddMethodName(programName, 'element')] = createElementAddMethod(this.arrays[elementBufferName]);
         }
 
         if (programInterface.secondElementBuffer) {
@@ -171,7 +170,6 @@ Bucket.prototype.createArrays = function() {
             var SecondElementArrayType = createElementBufferType(programInterface.secondElementBufferComponents);
             arrays[secondElementBufferName] = new SecondElementArrayType();
             arrayTypes[secondElementBufferName] = SecondElementArrayType.serialize();
-            this[this.getAddMethodName(programName, 'secondElement')] = createElementAddMethod(this.arrays[secondElementBufferName]);
         }
 
         elementGroups[programName] = [];
@@ -273,16 +271,6 @@ Bucket.prototype.bindBuffers = function(programInterfaceName, gl, options) {
 };
 
 /**
- * Get the name of the method used to add an item to a buffer.
- * @param {string} programName The name of the program that will use the buffer
- * @param {string} type One of "vertex", "element", or "secondElement"
- * @returns {string}
- */
-Bucket.prototype.getAddMethodName = function(programName, type) {
-    return 'add' + capitalize(programName) + capitalize(type);
-};
-
-/**
  * Get the name of a buffer.
  * @param {string} programName The name of the program that will use the buffer
  * @param {string} type One of "vertex", "element", or "secondElement"
@@ -352,12 +340,6 @@ Bucket.prototype.addPaintAttributes = function(interfaceName, globalProperties, 
         }
     }
 };
-
-function createElementAddMethod(buffer) {
-    return function(one, two, three) {
-        return buffer.emplaceBack(one, two, three);
-    };
-}
 
 function createElementBufferType(components) {
     return new StructArrayType({

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -20,21 +20,21 @@ function CircleBucket() {
 
 CircleBucket.prototype = util.inherit(Bucket, {});
 
+CircleBucket.prototype.addCircleVertex = function(x, y, extrudeX, extrudeY) {
+    return this.arrays.circleVertex.emplaceBack(
+            (x * 2) + ((extrudeX + 1) / 2),
+            (y * 2) + ((extrudeY + 1) / 2));
+};
+
 CircleBucket.prototype.programInterfaces = {
     circle: {
         vertexBuffer: true,
         elementBuffer: true,
 
-        attributeArgs: ['globalProperties', 'featureProperties', 'x', 'y', 'extrudeX', 'extrudeY'],
-
         attributes: [{
             name: 'pos',
             components: 2,
-            type: 'Int16',
-            value: [
-                '(x * 2) + ((extrudeX + 1) / 2)',
-                '(y * 2) + ((extrudeY + 1) / 2)'
-            ]
+            type: 'Int16'
         }, {
             name: 'color',
             components: 4,
@@ -84,10 +84,10 @@ CircleBucket.prototype.addFeature = function(feature) {
 
             var group = this.makeRoomFor('circle', 4);
 
-            var index = this.addCircleVertex(globalProperties, feature.properties, x, y, -1, -1) - group.vertexStartIndex;
-            this.addCircleVertex(globalProperties, feature.properties, x, y, 1, -1);
-            this.addCircleVertex(globalProperties, feature.properties, x, y, 1, 1);
-            this.addCircleVertex(globalProperties, feature.properties, x, y, -1, 1);
+            var index = this.addCircleVertex(x, y, -1, -1) - group.vertexStartIndex;
+            this.addCircleVertex(x, y, 1, -1);
+            this.addCircleVertex(x, y, 1, 1);
+            this.addCircleVertex(x, y, -1, 1);
             group.vertexLength += 4;
 
             this.addCircleElement(index, index + 1, index + 2);

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -90,8 +90,8 @@ CircleBucket.prototype.addFeature = function(feature) {
             this.addCircleVertex(x, y, -1, 1);
             group.vertexLength += 4;
 
-            this.addCircleElement(index, index + 1, index + 2);
-            this.addCircleElement(index, index + 3, index + 2);
+            this.arrays.circleElement.emplaceBack(index, index + 1, index + 2);
+            this.arrays.circleElement.emplaceBack(index, index + 3, index + 2);
             group.elementLength += 2;
         }
     }

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -39,7 +39,9 @@ CircleBucket.prototype.programInterfaces = {
             name: 'color',
             components: 4,
             type: 'Uint8',
-            value: 'this._premultiplyColor(layer.getPaintValue("circle-color", globalProperties, featureProperties))',
+            getValue: function(layer, globalProperties, featureProperties) {
+                return util.premultiply(layer.getPaintValue("circle-color", globalProperties, featureProperties));
+            },
             multiplier: 255,
             paintProperty: 'circle-color'
         }, {
@@ -47,7 +49,9 @@ CircleBucket.prototype.programInterfaces = {
             components: 1,
             type: 'Uint16',
             isLayerConstant: false,
-            value: ['layer.getPaintValue("circle-radius", globalProperties, featureProperties)'],
+            getValue: function(layer, globalProperties, featureProperties) {
+                return [layer.getPaintValue("circle-radius", globalProperties, featureProperties)];
+            },
             multiplier: 10,
             paintProperty: 'circle-radius'
         }]
@@ -57,6 +61,8 @@ CircleBucket.prototype.programInterfaces = {
 CircleBucket.prototype.addFeature = function(feature) {
     var globalProperties = {zoom: this.zoom};
     var geometries = loadGeometry(feature);
+
+    var startIndex = this.arrays.circleVertex.length;
 
     for (var j = 0; j < geometries.length; j++) {
         for (var k = 0; k < geometries[j].length; k++) {
@@ -90,4 +96,5 @@ CircleBucket.prototype.addFeature = function(feature) {
         }
     }
 
+    this.addPaintAttributes('circle', globalProperties, feature.properties, startIndex, this.arrays.circleVertex.length);
 };

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -32,11 +32,11 @@ CircleBucket.prototype.programInterfaces = {
         elementBuffer: true,
 
         attributes: [{
-            name: 'pos',
+            name: 'a_pos',
             components: 2,
             type: 'Int16'
         }, {
-            name: 'color',
+            name: 'a_color',
             components: 4,
             type: 'Uint8',
             getValue: function(layer, globalProperties, featureProperties) {
@@ -45,7 +45,7 @@ CircleBucket.prototype.programInterfaces = {
             multiplier: 255,
             paintProperty: 'circle-color'
         }, {
-            name: 'radius',
+            name: 'a_radius',
             components: 1,
             type: 'Uint16',
             isLayerConstant: false,

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -24,7 +24,7 @@ FillBucket.prototype.programInterfaces = {
         secondElementBufferComponents: 2,
 
         attributes: [{
-            name: 'pos',
+            name: 'a_pos',
             components: 2,
             type: 'Int16'
         }]

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -12,6 +12,10 @@ function FillBucket() {
 
 FillBucket.prototype = util.inherit(Bucket, {});
 
+FillBucket.prototype.addFillVertex = function(x, y) {
+    return this.arrays.fillVertex.emplaceBack(x, y);
+};
+
 FillBucket.prototype.programInterfaces = {
     fill: {
         vertexBuffer: true,
@@ -19,13 +23,10 @@ FillBucket.prototype.programInterfaces = {
         secondElementBuffer: true,
         secondElementBufferComponents: 2,
 
-        attributeArgs: ['x', 'y'],
-
         attributes: [{
             name: 'pos',
             components: 2,
-            type: 'Int16',
-            value: ['x', 'y']
+            type: 'Int16'
         }]
     }
 };

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -67,12 +67,12 @@ FillBucket.prototype.addFill = function(vertices) {
 
         // Only add triangles that have distinct vertices.
         if (i >= 2 && (currentVertex.x !== vertices[0].x || currentVertex.y !== vertices[0].y)) {
-            this.addFillElement(firstIndex, prevIndex, currentIndex);
+            this.arrays.fillElement.emplaceBack(firstIndex, prevIndex, currentIndex);
             group.elementLength++;
         }
 
         if (i >= 1) {
-            this.addFillSecondElement(prevIndex, currentIndex);
+            this.arrays.fillSecondElement.emplaceBack(prevIndex, currentIndex);
             group.secondElementLength++;
         }
 

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -375,7 +375,7 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal
     if (endLeft) extrude._sub(normal.perp()._mult(endLeft));
     this.e3 = this.addLineVertex(currentVertex, extrude, tx, 0, endLeft, distance) - group.vertexStartIndex;
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.addLineElement(this.e1, this.e2, this.e3);
+        this.arrays.lineElement.emplaceBack(this.e1, this.e2, this.e3);
         group.elementLength++;
     }
     this.e1 = this.e2;
@@ -385,7 +385,7 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal
     if (endRight) extrude._sub(normal.perp()._mult(endRight));
     this.e3 = this.addLineVertex(currentVertex, extrude, tx, 1, -endRight, distance) - group.vertexStartIndex;
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.addLineElement(this.e1, this.e2, this.e3);
+        this.arrays.lineElement.emplaceBack(this.e1, this.e2, this.e3);
         group.elementLength++;
     }
     this.e1 = this.e2;
@@ -420,7 +420,7 @@ LineBucket.prototype.addPieSliceVertex = function(currentVertex, distance, extru
     group.vertexLength++;
 
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.addLineElement(this.e1, this.e2, this.e3);
+        this.arrays.lineElement.emplaceBack(this.e1, this.e2, this.e3);
         group.elementLength++;
     }
 

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -74,11 +74,11 @@ LineBucket.prototype.programInterfaces = {
         elementBuffer: true,
 
         attributes: [{
-            name: 'pos',
+            name: 'a_pos',
             components: 2,
             type: 'Int16'
         }, {
-            name: 'data',
+            name: 'a_data',
             components: 4,
             type: 'Uint8'
         }]

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -437,7 +437,7 @@ SymbolBucket.prototype.addSymbols = function(programName, quads, scale, keepUpri
     var group = this.makeRoomFor(programName, 4 * quads.length);
 
     // TODO manual curry
-    var addElement = this[this.getAddMethodName(programName, 'element')].bind(this);
+    var elementArray = this.arrays[this.getBufferName(programName, 'element')];
     var vertexArray = this.arrays[this.getBufferName(programName, 'vertex')];
 
     var zoom = this.zoom;
@@ -473,8 +473,8 @@ SymbolBucket.prototype.addSymbols = function(programName, quads, scale, keepUpri
         addVertex(vertexArray, anchorPoint.x, anchorPoint.y, br.x, br.y, tex.x + tex.w, tex.y + tex.h, minZoom, maxZoom, placementZoom);
         group.vertexLength += 4;
 
-        addElement(index, index + 1, index + 2);
-        addElement(index + 1, index + 2, index + 3);
+        elementArray.emplaceBack(index, index + 1, index + 2);
+        elementArray.emplaceBack(index + 1, index + 2, index + 3);
         group.elementLength += 2;
     }
 

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -34,19 +34,19 @@ function SymbolBucket(options) {
 SymbolBucket.prototype = util.inherit(Bucket, {});
 
 var programAttributes = [{
-    name: 'pos',
+    name: 'a_pos',
     components: 2,
     type: 'Int16'
 }, {
-    name: 'offset',
+    name: 'a_offset',
     components: 2,
     type: 'Int16'
 }, {
-    name: 'data1',
+    name: 'a_data1',
     components: 4,
     type: 'Uint8'
 }, {
-    name: 'data2',
+    name: 'a_data2',
     components: 2,
     type: 'Uint8'
 }];
@@ -100,15 +100,15 @@ SymbolBucket.prototype.programInterfaces = {
         vertexBuffer: true,
 
         attributes: [{
-            name: 'pos',
+            name: 'a_pos',
             components: 2,
             type: 'Int16'
         }, {
-            name: 'extrude',
+            name: 'a_extrude',
             components: 2,
             type: 'Int16'
         }, {
-            name: 'data',
+            name: 'a_data',
             components: 2,
             type: 'Uint8'
         }]

--- a/js/data/buffer.js
+++ b/js/data/buffer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assert = require('assert');
+
 module.exports = Buffer;
 
 /**
@@ -39,6 +41,42 @@ Buffer.prototype.bind = function(gl) {
         this.arrayBuffer = null;
     } else {
         gl.bindBuffer(type, this.buffer);
+    }
+};
+
+/**
+ * @enum {string} AttributeType
+ * @private
+ * @readonly
+ */
+var AttributeType = {
+    Int8:   'BYTE',
+    Uint8:  'UNSIGNED_BYTE',
+    Int16:  'SHORT',
+    Uint16: 'UNSIGNED_SHORT'
+};
+
+/**
+ * Set the attribute pointers in a WebGL context
+ * @private
+ * @param gl The WebGL context
+ * @param program The active WebGL program
+ * @param {number} offset The index offset of the attribute data in the currently bound GL buffer.
+ */
+Buffer.prototype.setVertexAttribPointers = function(gl, program, offset) {
+    for (var j = 0; j < this.attributes.length; j++) {
+        var member = this.attributes[j];
+        var attribIndex = program[member.name];
+        assert(attribIndex !== undefined, 'array member "' + member.name + '" name does not match shader attribute name');
+
+        gl.vertexAttribPointer(
+            attribIndex,
+            member.components,
+            gl[AttributeType[member.type]],
+            false,
+            this.arrayType.bytesPerElement,
+            offset * this.arrayType.bytesPerElement + member.offset
+        );
     }
 };
 

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -42,10 +42,10 @@ function drawCircles(painter, source, layer, coords) {
         for (var k = 0; k < elementGroups.length; k++) {
             var group = elementGroups[k];
             var count = group.elementLength * 3;
-            bucket.bindBuffers('circle', gl);
-            bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom});
-            bucket.bindPaintBuffer('circle', gl, layer.id);
-            bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom}, true);
+            bucket.bindLayoutBuffers('circle', gl);
+            bucket.setAttribPointers('circle', gl, program, group.vertexOffset);
+            bucket.bindPaintBuffer(gl, 'circle', layer.id, program, group.vertexStartIndex);
+            bucket.setUniforms(gl, 'circle', program, layer, {zoom: painter.transform.zoom});
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
         }
     }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -43,7 +43,7 @@ function drawCircles(painter, source, layer, coords) {
         for (var k = 0; k < elementGroups.length; k++) {
             var group = elementGroups[k];
             var count = group.elementLength * 3;
-            bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, [{zoom: painter.transform.zoom}]);
+            bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom});
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
         }
     }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -39,11 +39,13 @@ function drawCircles(painter, source, layer, coords) {
         ));
         painter.setExMatrix(painter.transform.exMatrix);
 
-        bucket.bindBuffers('circle', gl);
         for (var k = 0; k < elementGroups.length; k++) {
             var group = elementGroups[k];
             var count = group.elementLength * 3;
+            bucket.bindBuffers('circle', gl);
             bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom});
+            bucket.bindPaintBuffer('circle', gl, layer.id);
+            bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom}, true);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
         }
     }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -18,7 +18,7 @@ function drawCollisionDebug(painter, source, layer, coords) {
         if (!bucket.buffers) continue;
         if (elementGroups[0].vertexLength === 0) continue;
 
-        bucket.bindBuffers('collisionBox', gl);
+        bucket.bindLayoutBuffers('collisionBox', gl);
         bucket.setAttribPointers('collisionBox', gl, program, elementGroups[0].vertexOffset, layer);
 
         painter.setPosMatrix(coord.posMatrix);

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -115,7 +115,7 @@ function drawFill(painter, source, layer, coord) {
     var fillProgram = painter.useProgram('fill');
     painter.setPosMatrix(translatedPosMatrix);
 
-    bucket.bindBuffers('fill', gl);
+    bucket.bindLayoutBuffers('fill', gl);
 
     for (var i = 0; i < elementGroups.length; i++) {
         var group = elementGroups[i];
@@ -183,7 +183,7 @@ function drawStroke(painter, source, layer, coord) {
     if (image) { setPattern(image, opacity, tile, coord, painter, program); }
 
     // Draw all buffers
-    bucket.bindBuffers('fill', gl, {secondElement: true});
+    bucket.bindLayoutBuffers('fill', gl, {secondElement: true});
 
     painter.enableTileClippingMask(coord);
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -163,7 +163,7 @@ module.exports = function drawLine(painter, source, layer, coords) {
             gl.uniform1f(program.u_ratio, ratio);
         }
 
-        bucket.bindBuffers('line', gl);
+        bucket.bindLayoutBuffers('line', gl);
 
         for (var i = 0; i < elementGroups.length; i++) {
             var group = elementGroups[i];

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -145,7 +145,7 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
 
     var group, count;
 
-    bucket.bindBuffers(programInterfaceName, gl);
+    bucket.bindLayoutBuffers(programInterfaceName, gl);
 
     if (sdf) {
         var sdfPx = 8;
@@ -179,7 +179,7 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
 
         for (var i = 0; i < elementGroups.length; i++) {
             group = elementGroups[i];
-            bucket.bindBuffers(programInterfaceName, gl);
+            bucket.bindLayoutBuffers(programInterfaceName, gl);
             bucket.setAttribPointers(programInterfaceName, gl, program, group.vertexOffset, layer);
 
             count = group.elementLength * 3;

--- a/js/util/struct_array.js
+++ b/js/util/struct_array.js
@@ -169,8 +169,7 @@ function createEmplaceBack(members, bytesPerElement) {
     var argNames = [];
     var body = '' +
     'var i = this.length;\n' +
-    'this.length++;\n' +
-    'if (this.length > this.capacity) this._resize(this.length);\n';
+    'this.resize(this.length + 1);\n';
 
     for (var m = 0; m < members.length; m++) {
         var member = members[m];
@@ -240,9 +239,8 @@ function StructArray(serialized) {
 
     // Create a new StructArray
     } else {
-        this.length = 0;
-        this.capacity = 0;
-        this._resize(this.DEFAULT_CAPACITY);
+        this.capacity = -1;
+        this.resize(0);
     }
 }
 
@@ -294,17 +292,21 @@ StructArray.prototype.trim = function() {
 };
 
 /**
- * Resize the array so that it fits at least `n` elements.
- * @private
- * @param {number} n The number of elements that must fit in the array after the resize.
+ * Resize the array.
+ * If `n` is greater than the current length then additional elements with undefined values are added.
+ * If `n` is less than the current length then the array will be reduced to the first `n` elements.
+ * @param {number} n The new size of the array.
  */
-StructArray.prototype._resize = function(n) {
-    this.capacity = Math.max(n, Math.floor(this.capacity * this.RESIZE_MULTIPLIER));
-    this.arrayBuffer = new ArrayBuffer(this.capacity * this.bytesPerElement);
+StructArray.prototype.resize = function(n) {
+    this.length = n;
+    if (n > this.capacity) {
+        this.capacity = Math.max(n, Math.floor(this.capacity * this.RESIZE_MULTIPLIER), this.DEFAULT_CAPACITY);
+        this.arrayBuffer = new ArrayBuffer(this.capacity * this.bytesPerElement);
 
-    var oldUint8Array = this.uint8;
-    this._refreshViews();
-    if (oldUint8Array) this.uint8.set(oldUint8Array);
+        var oldUint8Array = this.uint8;
+        this._refreshViews();
+        if (oldUint8Array) this.uint8.set(oldUint8Array);
+    }
 };
 
 /**

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -23,10 +23,17 @@ varying lowp vec4 v_color;
 varying lowp float v_antialiasblur;
 
 void main(void) {
+
+#ifdef ATTRIBUTE_RADIUS
+    mediump float radius = a_radius / 10.0;
+#else
+    mediump float radius = a_radius;
+#endif
+
     // unencode the extrusion vector that we snuck into the a_pos vector
     v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
 
-    vec4 extrude = u_exmatrix * vec4(v_extrude * a_radius / 10.0, 0, 0);
+    vec4 extrude = u_exmatrix * vec4(v_extrude * radius, 0, 0);
     // multiply a_pos by 0.5, since we had it * 2 in order to sneak
     // in extrusion data
     gl_Position = u_matrix * vec4(floor(a_pos * 0.5), 0, 1);
@@ -35,10 +42,14 @@ void main(void) {
     // Multiply the extrude by it so that it isn't affected by it.
     gl_Position += extrude * gl_Position.w;
 
+#ifdef ATTRIBUTE_COLOR
     v_color = a_color / 255.0;
+#else
+    v_color = a_color;
+#endif
 
     // This is a minimum blur distance that serves as a faux-antialiasing for
     // the circle. since blur is a ratio of the circle's size and the intent is
     // to keep the blur at roughly 1px, the two are inversely related.
-    v_antialiasblur = 1.0 / u_devicepixelratio / (a_radius / 10.0);
+    v_antialiasblur = 1.0 / u_devicepixelratio / radius;
 }

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -6,13 +6,13 @@ uniform float u_devicepixelratio;
 
 attribute vec2 a_pos;
 
-#ifdef ATTRIBUTE_COLOR
+#ifdef ATTRIBUTE_A_COLOR
 attribute lowp vec4 a_color;
 #else
 uniform lowp vec4 a_color;
 #endif
 
-#ifdef ATTRIBUTE_RADIUS
+#ifdef ATTRIBUTE_A_RADIUS
 attribute mediump float a_radius;
 #else
 uniform mediump float a_radius;
@@ -24,7 +24,7 @@ varying lowp float v_antialiasblur;
 
 void main(void) {
 
-#ifdef ATTRIBUTE_RADIUS
+#ifdef ATTRIBUTE_A_RADIUS
     mediump float radius = a_radius / 10.0;
 #else
     mediump float radius = a_radius;
@@ -42,7 +42,7 @@ void main(void) {
     // Multiply the extrude by it so that it isn't affected by it.
     gl_Position += extrude * gl_Position.w;
 
-#ifdef ATTRIBUTE_COLOR
+#ifdef ATTRIBUTE_A_COLOR
     v_color = a_color / 255.0;
 #else
     v_color = a_color;

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -24,15 +24,17 @@ test('Bucket', function(t) {
                 attributeArgs: options.attributeArgs || ['x', 'y'],
 
                 attributes: options.attributes || [{
-                    name: 'map',
-                    type: 'Int16',
-                    value: ['x'],
-                    paintProperty: 'circle-color'
-                }, {
                     name: 'box',
                     components: 2,
                     type: 'Int16',
                     value: ['x * 2', 'y * 2']
+                }, {
+                    name: 'map',
+                    type: 'Int16',
+                    getValue: function(layer, globalProperties, featureProperties) {
+                        return [featureProperties.x];
+                    },
+                    paintProperty: 'circle-color'
                 }]
             }
         };
@@ -40,9 +42,11 @@ test('Bucket', function(t) {
         Class.prototype.addFeature = function(feature) {
             this.makeRoomFor('test', 1);
             var point = feature.loadGeometry()[0][0];
+            var startIndex = this.arrays.testVertex.length;
             this.addTestVertex(point.x, point.y);
             this.addTestElement(1, 2, 3);
             this.addTestSecondElement(point.x, point.y);
+            this.addPaintAttributes('test', {}, feature.properties, startIndex, this.arrays.testVertex.length, this.debug);
         };
 
         return Class;
@@ -52,6 +56,9 @@ test('Bucket', function(t) {
         return {
             loadGeometry: function() {
                 return [[{x: x, y: y}]];
+            },
+            properties: {
+                x: x
             }
         };
     }
@@ -140,7 +147,7 @@ test('Bucket', function(t) {
             attributes: [{
                 name: 'map',
                 type: 'Int16',
-                value: ['5'],
+                getValue: function() { return [5]; },
                 paintProperty: 'circle-color'
             }],
             layers: [

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -21,13 +21,10 @@ test('Bucket', function(t) {
                 secondElementBuffer: 'testSecondElement',
                 secondElementBufferComponents: 2,
 
-                attributeArgs: options.attributeArgs || ['x', 'y'],
-
                 attributes: options.attributes || [{
                     name: 'box',
                     components: 2,
-                    type: 'Int16',
-                    value: ['x * 2', 'y * 2']
+                    type: 'Int16'
                 }, {
                     name: 'map',
                     type: 'Int16',
@@ -37,6 +34,10 @@ test('Bucket', function(t) {
                     paintProperty: 'circle-color'
                 }]
             }
+        };
+
+        Class.prototype.addTestVertex = function(x, y) {
+            return this.arrays.testVertex.emplaceBack(x * 2, y * 2);
         };
 
         Class.prototype.addFeature = function(feature) {
@@ -171,8 +172,7 @@ test('Bucket', function(t) {
         var bucket = create({
             attributes: [{
                 name: 'map',
-                type: 'Int16',
-                value: '[17]'
+                type: 'Int16'
             }]
         });
 
@@ -180,7 +180,7 @@ test('Bucket', function(t) {
         bucket.populateBuffers();
 
         var v0 = bucket.arrays.testVertex.get(0);
-        t.equal(v0.layerid__map, 17);
+        t.equal(v0.layerid__map, 34);
 
         t.end();
     });

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -47,7 +47,7 @@ test('Bucket', function(t) {
             this.addTestVertex(point.x, point.y);
             this.arrays.testElement.emplaceBack(1, 2, 3);
             this.arrays.testSecondElement.emplaceBack(point.x, point.y);
-            this.addPaintAttributes('test', {}, feature.properties, startIndex, this.arrays.testVertex.length, this.debug);
+            this.addPaintAttributes('test', {}, feature.properties, startIndex, this.arrays.testVertex.length);
         };
 
         return Class;
@@ -105,9 +105,12 @@ test('Bucket', function(t) {
         var testVertex = bucket.arrays.testVertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.layerid__map, 17);
-        t.equal(v0.layerid__box0, 34);
-        t.equal(v0.layerid__box1, 84);
+        t.equal(v0.box0, 34);
+        t.equal(v0.box1, 84);
+        var paintVertex = bucket.arrays.layeridTest;
+        t.equal(paintVertex.length, 1);
+        var p0 = paintVertex.get(0);
+        t.equal(p0.map, 17);
 
         var testElement = bucket.arrays.testElement;
         t.equal(testElement.length, 1);
@@ -135,10 +138,12 @@ test('Bucket', function(t) {
         bucket.populateBuffers();
 
         var v0 = bucket.arrays.testVertex.get(0);
-        t.equal(v0.one__map, 17);
-        t.equal(v0.two__map, 17);
-        t.equal(v0.one__box0, 34);
-        t.equal(v0.one__box1, 84);
+        var a0 = bucket.arrays.oneTest.get(0);
+        var b0 = bucket.arrays.twoTest.get(0);
+        t.equal(a0.map, 17);
+        t.equal(b0.map, 17);
+        t.equal(v0.box0, 34);
+        t.equal(v0.box1, 84);
 
         t.end();
     });
@@ -161,7 +166,7 @@ test('Bucket', function(t) {
 
         t.equal(bucket.arrays.testVertex.bytesPerElement, 0);
         t.deepEqual(
-            bucket.attributes.test.disabled[0].getValue.call(bucket),
+            bucket.attributes.test.paintAttributes.one.disabled[0].getValue.call(bucket),
             [5]
         );
 
@@ -180,7 +185,7 @@ test('Bucket', function(t) {
         bucket.populateBuffers();
 
         var v0 = bucket.arrays.testVertex.get(0);
-        t.equal(v0.layerid__map, 34);
+        t.equal(v0.map, 34);
 
         t.end();
     });
@@ -214,9 +219,12 @@ test('Bucket', function(t) {
         var testVertex = bucket.arrays.testVertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.layerid__map, 17);
-        t.equal(v0.layerid__box0, 34);
-        t.equal(v0.layerid__box1, 84);
+        t.equal(v0.box0, 34);
+        t.equal(v0.box1, 84);
+        var testPaintVertex = bucket.arrays.layeridTest;
+        t.equal(testPaintVertex.length, 1);
+        var p0 = testPaintVertex.get(0);
+        t.equal(p0.map, 17);
 
         var testElement = bucket.arrays.testElement;
         t.equal(testElement.length, 1);
@@ -249,9 +257,12 @@ test('Bucket', function(t) {
         var testVertex = bucket.arrays.testVertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.layerid__map, 17);
-        t.equal(v0.layerid__box0, 34);
-        t.equal(v0.layerid__box1, 84);
+        t.equal(v0.box0, 34);
+        t.equal(v0.box1, 84);
+        var testPaintVertex = bucket.arrays.layeridTest;
+        t.equal(testPaintVertex.length, 1);
+        var p0 = testPaintVertex.get(0);
+        t.equal(p0.map, 17);
 
         var testElement = bucket.arrays.testElement;
         t.equal(testElement.length, 1);

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -45,8 +45,8 @@ test('Bucket', function(t) {
             var point = feature.loadGeometry()[0][0];
             var startIndex = this.arrays.testVertex.length;
             this.addTestVertex(point.x, point.y);
-            this.addTestElement(1, 2, 3);
-            this.addTestSecondElement(point.x, point.y);
+            this.arrays.testElement.emplaceBack(1, 2, 3);
+            this.arrays.testSecondElement.emplaceBack(point.x, point.y);
             this.addPaintAttributes('test', {}, feature.properties, startIndex, this.arrays.testVertex.length, this.debug);
         };
 


### PR DESCRIPTION
This removes code generation from `Bucket` so that it's closer to something we could implement in -native.

:eyes: @lucaswoj 

Instead of adding paint attributes in the main vertex loop they are added in a separate loop later. This has a couple advantages:
- The value of a paint attribute is the same for all vertices in a feature. The value is now calculated once per feature instead of once for each vertex which. This should help with performance for data driven lines, fills and symbols.
- Adding them in a separate loop let's us use regular functions for the `addVertex` methods.

We don't have any benchmarks for data driven attributes yet I haven't measured whether this makes data driven attributes slower or faster. Evaluating the style function only once per feature should help with performance.  I think [this](https://github.com/mapbox/mapbox-gl-js/compare/data-driven-styling...data-driven-styling-less-code-generation?expand=1#diff-c1d5cefb566acef357121481a5a8e27eR346) is a very hot loop that we might need to optimize more. If we can't get it fast enough without code generation we could add a StructArray method that fills in a single value for a range of elements.

The commit messages explain my thinking for each individual commit.
