### PR TITLE
split paint attributes into a separate buffer

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -202,75 +202,23 @@ Bucket.prototype.trimArrays = function() {
 };
 
 /**
- * @enum {string} AttributeType
- * @private
- * @readonly
- */
-var AttributeType = {
-    Int8:   'BYTE',
-    Uint8:  'UNSIGNED_BYTE',
-    Int16:  'SHORT',
-    Uint16: 'UNSIGNED_SHORT'
-};
-
-/**
  * Set the attribute pointers in a WebGL context
  * @private
  * @param gl The WebGL context
  * @param program The active WebGL program
  * @param {number} offset The offset of the attribute data in the currently bound GL buffer.
- * @param {Array} arguments to be passed to disabled attribute value functions
  */
-Bucket.prototype.setAttribPointers = function(programName, gl, program, offset, layer, globalProperties, bindPaint) {
-    var attribute;
+Bucket.prototype.setAttribPointers = function(programName, gl, program, offset) {
+    var vertexBuffer = this.buffers[this.getBufferName(programName, 'vertex')];
+    vertexBuffer.setVertexAttribPointers(gl, program, offset / vertexBuffer.itemSize);
+};
 
-    if (bindPaint) {
-        // Set disabled attributes
-        var disabledAttributes = this.attributes[programName].paintAttributes[layer.id].disabled;
-        for (var i = 0; i < disabledAttributes.length; i++) {
-            attribute = disabledAttributes[i];
-            var attributeId = program[attribute.name];
-            gl['uniform' + attribute.components + 'fv'](attributeId, attribute.getValue(layer, globalProperties));
-        }
-    }
-
-    // Set enabled attributes
-    var enabledAttributes = bindPaint ?
-        this.attributes[programName].paintAttributes[layer.id].enabled :
-        this.attributes[programName].coreAttributes;
-
-    var vertexBuffer = bindPaint ?
-        this.buffers[this.getBufferName(layer.id, programName)] :
-        this.buffers[this.getBufferName(programName, 'vertex')];
-
-    if (bindPaint) {
-        // TODO remove
-        var bytesPerElement = this.buffers[this.getBufferName(programName, 'vertex')].itemSize;
-        offset = offset / bytesPerElement * vertexBuffer.itemSize;
-    }
-
-    for (var j = 0; j < enabledAttributes.length; j++) {
-        attribute = enabledAttributes[j];
-        if (!getMember(attribute.name)) continue;
-
-        gl.vertexAttribPointer(
-            program[attribute.name],
-            attribute.components,
-            gl[AttributeType[attribute.type]],
-            false,
-            vertexBuffer.arrayType.bytesPerElement,
-            offset + getMember(attribute.name).offset
-        );
-    }
-
-    function getMember(memberName) {
-        var members = vertexBuffer.arrayType.members;
-        for (var k = 0; k < members.length; k++) {
-            var member = members[k];
-            if (member.name === memberName) {
-                return member;
-            }
-        }
+Bucket.prototype.setUniforms = function(gl, programName, program, layer, globalProperties) {
+    var disabledAttributes = this.attributes[programName].paintAttributes[layer.id].disabled;
+    for (var i = 0; i < disabledAttributes.length; i++) {
+        var attribute = disabledAttributes[i];
+        var attributeId = program[attribute.name];
+        gl['uniform' + attribute.components + 'fv'](attributeId, attribute.getValue(layer, globalProperties));
     }
 };
 
@@ -293,8 +241,10 @@ Bucket.prototype.bindBuffers = function(programInterfaceName, gl, options) {
     }
 };
 
-Bucket.prototype.bindPaintBuffer = function(programInterfaceName, gl, layerID) {
-    this.buffers[this.getBufferName(layerID, programInterfaceName)].bind(gl);
+Bucket.prototype.bindPaintBuffer = function(gl, interfaceName, layerID, program, vertexStartIndex) {
+    var buffer = this.buffers[this.getBufferName(layerID, interfaceName)];
+    buffer.bind(gl);
+    buffer.setVertexAttribPointers(gl, program, vertexStartIndex);
 };
 
 /**

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -32,11 +32,11 @@ CircleBucket.prototype.programInterfaces = {
         elementBuffer: true,
 
         attributes: [{
-            name: 'pos',
+            name: 'a_pos',
             components: 2,
             type: 'Int16'
         }, {
-            name: 'color',
+            name: 'a_color',
             components: 4,
             type: 'Uint8',
             getValue: function(layer, globalProperties, featureProperties) {
@@ -45,7 +45,7 @@ CircleBucket.prototype.programInterfaces = {
             multiplier: 255,
             paintProperty: 'circle-color'
         }, {
-            name: 'radius',
+            name: 'a_radius',
             components: 1,
             type: 'Uint16',
             isLayerConstant: false,

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -24,7 +24,7 @@ FillBucket.prototype.programInterfaces = {
         secondElementBufferComponents: 2,
 
         attributes: [{
-            name: 'pos',
+            name: 'a_pos',
             components: 2,
             type: 'Int16'
         }]

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -74,11 +74,11 @@ LineBucket.prototype.programInterfaces = {
         elementBuffer: true,
 
         attributes: [{
-            name: 'pos',
+            name: 'a_pos',
             components: 2,
             type: 'Int16'
         }, {
-            name: 'data',
+            name: 'a_data',
             components: 4,
             type: 'Uint8'
         }]

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -34,19 +34,19 @@ function SymbolBucket(options) {
 SymbolBucket.prototype = util.inherit(Bucket, {});
 
 var programAttributes = [{
-    name: 'pos',
+    name: 'a_pos',
     components: 2,
     type: 'Int16'
 }, {
-    name: 'offset',
+    name: 'a_offset',
     components: 2,
     type: 'Int16'
 }, {
-    name: 'data1',
+    name: 'a_data1',
     components: 4,
     type: 'Uint8'
 }, {
-    name: 'data2',
+    name: 'a_data2',
     components: 2,
     type: 'Uint8'
 }];
@@ -100,15 +100,15 @@ SymbolBucket.prototype.programInterfaces = {
         vertexBuffer: true,
 
         attributes: [{
-            name: 'pos',
+            name: 'a_pos',
             components: 2,
             type: 'Int16'
         }, {
-            name: 'extrude',
+            name: 'a_extrude',
             components: 2,
             type: 'Int16'
         }, {
-            name: 'data',
+            name: 'a_data',
             components: 2,
             type: 'Uint8'
         }]

--- a/js/data/buffer.js
+++ b/js/data/buffer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assert = require('assert');
+
 module.exports = Buffer;
 
 /**
@@ -39,6 +41,42 @@ Buffer.prototype.bind = function(gl) {
         this.arrayBuffer = null;
     } else {
         gl.bindBuffer(type, this.buffer);
+    }
+};
+
+/**
+ * @enum {string} AttributeType
+ * @private
+ * @readonly
+ */
+var AttributeType = {
+    Int8:   'BYTE',
+    Uint8:  'UNSIGNED_BYTE',
+    Int16:  'SHORT',
+    Uint16: 'UNSIGNED_SHORT'
+};
+
+/**
+ * Set the attribute pointers in a WebGL context
+ * @private
+ * @param gl The WebGL context
+ * @param program The active WebGL program
+ * @param {number} offset The index offset of the attribute data in the currently bound GL buffer.
+ */
+Buffer.prototype.setVertexAttribPointers = function(gl, program, offset) {
+    for (var j = 0; j < this.attributes.length; j++) {
+        var member = this.attributes[j];
+        var attribIndex = program[member.name];
+        assert(attribIndex !== undefined, 'array member "' + member.name + '" name does not match shader attribute name');
+
+        gl.vertexAttribPointer(
+            attribIndex,
+            member.components,
+            gl[AttributeType[member.type]],
+            false,
+            this.arrayType.bytesPerElement,
+            offset * this.arrayType.bytesPerElement + member.offset
+        );
     }
 };
 

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -43,9 +43,9 @@ function drawCircles(painter, source, layer, coords) {
             var group = elementGroups[k];
             var count = group.elementLength * 3;
             bucket.bindBuffers('circle', gl);
-            bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom});
-            bucket.bindPaintBuffer('circle', gl, layer.id);
-            bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom}, true);
+            bucket.setAttribPointers('circle', gl, program, group.vertexOffset);
+            bucket.bindPaintBuffer(gl, 'circle', layer.id, program, group.vertexStartIndex);
+            bucket.setUniforms(gl, 'circle', program, layer, {zoom: painter.transform.zoom});
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
         }
     }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -39,11 +39,13 @@ function drawCircles(painter, source, layer, coords) {
         ));
         painter.setExMatrix(painter.transform.exMatrix);
 
-        bucket.bindBuffers('circle', gl);
         for (var k = 0; k < elementGroups.length; k++) {
             var group = elementGroups[k];
             var count = group.elementLength * 3;
+            bucket.bindBuffers('circle', gl);
             bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom});
+            bucket.bindPaintBuffer('circle', gl, layer.id);
+            bucket.setAttribPointers('circle', gl, program, group.vertexOffset, layer, {zoom: painter.transform.zoom}, true);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
         }
     }

--- a/js/util/struct_array.js
+++ b/js/util/struct_array.js
@@ -170,7 +170,7 @@ function createEmplaceBack(members, bytesPerElement) {
     var body = '' +
     'var i = this.length;\n' +
     'this.length++;\n' +
-    'if (this.length > this.capacity) this._resize(this.length);\n';
+    'if (this.length > this.capacity) this.reserve(this.length);\n';
 
     for (var m = 0; m < members.length; m++) {
         var member = members[m];
@@ -242,7 +242,7 @@ function StructArray(serialized) {
     } else {
         this.length = 0;
         this.capacity = 0;
-        this._resize(this.DEFAULT_CAPACITY);
+        this.reserve(this.DEFAULT_CAPACITY);
     }
 }
 
@@ -296,15 +296,26 @@ StructArray.prototype.trim = function() {
 /**
  * Resize the array so that it fits at least `n` elements.
  * @private
- * @param {number} n The number of elements that must fit in the array after the resize.
+ * @param {number} n The number of elements that must fit in allocated buffer.
  */
-StructArray.prototype._resize = function(n) {
+StructArray.prototype.reserve = function(n) {
     this.capacity = Math.max(n, Math.floor(this.capacity * this.RESIZE_MULTIPLIER));
     this.arrayBuffer = new ArrayBuffer(this.capacity * this.bytesPerElement);
 
     var oldUint8Array = this.uint8;
     this._refreshViews();
     if (oldUint8Array) this.uint8.set(oldUint8Array);
+};
+
+/**
+ * Resize the array.
+ * If `n` is greater than the current length then additional elements with undefined values are added.
+ * If `n` is less than the current length then the array will be reduced to the first `n` elements.
+ * @param {number} n The new size of the array.
+ */
+StructArray.prototype.resize = function(n) {
+    this.length = n;
+    if (this.length > this.capacity) this.reserve(n);
 };
 
 /**

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -6,13 +6,13 @@ uniform float u_devicepixelratio;
 
 attribute vec2 a_pos;
 
-#ifdef ATTRIBUTE_COLOR
+#ifdef ATTRIBUTE_A_COLOR
 attribute lowp vec4 a_color;
 #else
 uniform lowp vec4 a_color;
 #endif
 
-#ifdef ATTRIBUTE_RADIUS
+#ifdef ATTRIBUTE_A_RADIUS
 attribute mediump float a_radius;
 #else
 uniform mediump float a_radius;
@@ -24,7 +24,7 @@ varying lowp float v_antialiasblur;
 
 void main(void) {
 
-#ifdef ATTRIBUTE_RADIUS
+#ifdef ATTRIBUTE_A_RADIUS
     mediump float radius = a_radius / 10.0;
 #else
     mediump float radius = a_radius;
@@ -42,7 +42,7 @@ void main(void) {
     // Multiply the extrude by it so that it isn't affected by it.
     gl_Position += extrude * gl_Position.w;
 
-#ifdef ATTRIBUTE_COLOR
+#ifdef ATTRIBUTE_A_COLOR
     v_color = a_color / 255.0;
 #else
     v_color = a_color;

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -100,14 +100,19 @@ test('Bucket', function(t) {
         var bucket = create();
 
         bucket.features = [createFeature(17, 42)];
+        bucket.debug = true;
         bucket.populateBuffers();
+        bucket.debug = false;
 
         var testVertex = bucket.arrays.testVertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.layerid__map, 17);
-        t.equal(v0.layerid__box0, 34);
-        t.equal(v0.layerid__box1, 84);
+        t.equal(v0.box0, 34);
+        t.equal(v0.box1, 84);
+        var paintVertex = bucket.arrays.layeridTest;
+        t.equal(paintVertex.length, 1);
+        var p0 = paintVertex.get(0);
+        t.equal(p0.map, 17);
 
         var testElement = bucket.arrays.testElement;
         t.equal(testElement.length, 1);
@@ -135,10 +140,12 @@ test('Bucket', function(t) {
         bucket.populateBuffers();
 
         var v0 = bucket.arrays.testVertex.get(0);
-        t.equal(v0.one__map, 17);
-        t.equal(v0.two__map, 17);
-        t.equal(v0.one__box0, 34);
-        t.equal(v0.one__box1, 84);
+        var a0 = bucket.arrays.oneTest.get(0);
+        var b0 = bucket.arrays.twoTest.get(0);
+        t.equal(a0.map, 17);
+        t.equal(b0.map, 17);
+        t.equal(v0.box0, 34);
+        t.equal(v0.box1, 84);
 
         t.end();
     });
@@ -161,7 +168,7 @@ test('Bucket', function(t) {
 
         t.equal(bucket.arrays.testVertex.bytesPerElement, 0);
         t.deepEqual(
-            bucket.attributes.test.disabled[0].getValue.call(bucket),
+            bucket.attributes.test.paintAttributes.one.disabled[0].getValue.call(bucket),
             [5]
         );
 
@@ -180,7 +187,7 @@ test('Bucket', function(t) {
         bucket.populateBuffers();
 
         var v0 = bucket.arrays.testVertex.get(0);
-        t.equal(v0.layerid__map, 34);
+        t.equal(v0.map, 34);
 
         t.end();
     });
@@ -214,9 +221,12 @@ test('Bucket', function(t) {
         var testVertex = bucket.arrays.testVertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.layerid__map, 17);
-        t.equal(v0.layerid__box0, 34);
-        t.equal(v0.layerid__box1, 84);
+        t.equal(v0.box0, 34);
+        t.equal(v0.box1, 84);
+        var testPaintVertex = bucket.arrays.layeridTest;
+        t.equal(testPaintVertex.length, 1);
+        var p0 = testPaintVertex.get(0);
+        t.equal(p0.map, 17);
 
         var testElement = bucket.arrays.testElement;
         t.equal(testElement.length, 1);
@@ -249,9 +259,12 @@ test('Bucket', function(t) {
         var testVertex = bucket.arrays.testVertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.layerid__map, 17);
-        t.equal(v0.layerid__box0, 34);
-        t.equal(v0.layerid__box1, 84);
+        t.equal(v0.box0, 34);
+        t.equal(v0.box1, 84);
+        var testPaintVertex = bucket.arrays.layeridTest;
+        t.equal(testPaintVertex.length, 1);
+        var p0 = testPaintVertex.get(0);
+        t.equal(p0.map, 17);
 
         var testElement = bucket.arrays.testElement;
         t.equal(testElement.length, 1);


### PR DESCRIPTION
- avoids the need to namespace attribute names with string concatenation
- this let's us use attribute.name as the shader attribute name
- this will let us use instanced rendering (#1898) with a smaller buffer when that extension is available

With instanced rendering we could store one paint attribute value that is shared by 4 vertices, cutting down the paint attribute buffer size to 1/4 it's previous length.

:eyes: @lucaswoj 

I used to think this was a bad idea because interwoven attributes are suggested, but I think this makes sense if we use instanced rendering.