### PR TITLE
Add Popup#setDOMContent method

### DIFF
--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -111,18 +111,16 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
      * @returns {Popup} `this`
      */
     setHTML: function(html) {
-        this._createContent();
-
+        var frag = document.createDocumentFragment();
         var temp = document.createElement('body'), child;
         temp.innerHTML = html;
         while (true) {
             child = temp.firstChild;
             if (!child) break;
-            this._content.appendChild(child);
+            frag.appendChild(child);
         }
 
-        this._update();
-        return this;
+        return this.setDOMContent(frag);
     },
 
     /**

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -102,7 +102,7 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
      * @returns {Popup} `this`
      */
     setText: function(text) {
-        return this.setContent(document.createTextNode(text));
+        return this.setDOMContent(document.createTextNode(text));
     },
 
     /**

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -102,11 +102,7 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
      * @returns {Popup} `this`
      */
     setText: function(text) {
-        this._createContent();
-        this._content.appendChild(document.createTextNode(text));
-
-        this._update();
-        return this;
+        return this.setContent(document.createTextNode(text));
     },
 
     /**
@@ -125,6 +121,18 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
             this._content.appendChild(child);
         }
 
+        this._update();
+        return this;
+    },
+
+    /**
+     * Fill a popup element with DOM content
+     * @param {HTMLElement|Text} htmlNode Popup content as a DOM node
+     * @returns {Popup} `this`
+     */
+    setDOMContent: function(htmlNode) {
+        this._createContent();
+        this._content.appendChild(htmlNode);
         this._update();
         return this;
     },

--- a/test/manual/1671.html
+++ b/test/manual/1671.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel='stylesheet' href='../../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<script src='../../dist/mapbox-gl-dev.js'></script>
+<script>
+    mapboxgl.accessToken = 'pk.eyJ1IjoiamZpcmUiLCJhIjoiZTFlNmQ3N2MzYmM2YzVjMzhkOTM2NTRhYzNiNGZiNGYifQ.1W47kmoEUpTJa3YIFefxUQ';
+
+    var map = new mapboxgl.Map({
+        container: 'map',
+        style: 'mapbox://styles/mapbox/bright-v8'
+    });
+
+    var tooltip = new mapboxgl.Popup({closeOnClick: false});
+
+    var popupContent = document.createElement('div');
+    popupContent.innerHTML = '<h1>Position</h1><span id="popup-position" ></span>';
+    tooltip.setDOMContent(popupContent)
+
+    map.on('mousemove', function(e) {
+        popupContent.querySelector('#popup-position').innerText = e.lngLat;
+        tooltip
+            .setLngLat(e.lngLat)
+            .addTo(map);
+    });
+</script>
+</body>
+</html>

--- a/test/manual/1671.html
+++ b/test/manual/1671.html
@@ -35,6 +35,16 @@
             .setLngLat(e.lngLat)
             .addTo(map);
     });
+
+    (new mapboxgl.Popup())
+        .setLngLat(map.unproject([10, 10]))
+        .setText('confirm no setText regression')
+        .addTo(map);
+
+    (new mapboxgl.Popup())
+        .setLngLat(map.unproject([100, 100]))
+        .setHTML('<em>confirm</em><span> no </span><code>setHTML</code> regression')
+        .addTo(map);
 </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #1671 

👀 @jfirebaugh 

 - Used `setDOMContent` instead of `setElement` or `setContent` just be totally explicit.  Can change it to whatever.
 - The only test I added was a manual one because I didn't see any other unit tests for popups.
 - `setText` refactored to reuse code in `setDOMContent`
 - Is it worth having `setDOMContent` accept a NodeList, too?  If so, `setHTML` could also just delegate to this.
