### PR TITLE
Fixing the Evented documentation

### DIFF
--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -13,6 +13,7 @@ var Evented = {
      *
      * @param {string} type Event type
      * @param {Function} listener Function to be called when the event is fired
+     * @returns {Object} `this`
      */
     on: function(type, listener) {
         this._events = this._events || {};
@@ -27,6 +28,7 @@ var Evented = {
      *
      * @param {string} [type] Event type. If none is specified, remove all listeners
      * @param {Function} [listener] Function to be called when the event is fired. If none is specified all listeners are removed
+     * @returns {Object} `this`
      */
     off: function(type, listener) {
         if (!type) {
@@ -57,6 +59,7 @@ var Evented = {
      *
      * @param {string} type Event type.
      * @param {Function} listener Function to be called once when the event is fired
+     * @returns {Object} `this`
      */
     once: function(type, listener) {
         var wrapper = function(data) {

--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -14,10 +14,10 @@ var Evented = {
      * @param {string} type Event type
      * @param {Function} listener Function to be called when the event is fired
      */
-    on: function(type, fn) {
+    on: function(type, listener) {
         this._events = this._events || {};
         this._events[type] = this._events[type] || [];
-        this._events[type].push(fn);
+        this._events[type].push(listener);
 
         return this;
     },
@@ -28,7 +28,7 @@ var Evented = {
      * @param {string} [type] Event type. If none is specified, remove all listeners
      * @param {Function} [listener] Function to be called when the event is fired. If none is specified all listeners are removed
      */
-    off: function(type, fn) {
+    off: function(type, listener) {
         if (!type) {
             // clear all listeners if no arguments specified
             delete this._events;
@@ -37,8 +37,8 @@ var Evented = {
 
         if (!this.listens(type)) return this;
 
-        if (fn) {
-            var idx = this._events[type].indexOf(fn);
+        if (listener) {
+            var idx = this._events[type].indexOf(listener);
             if (idx >= 0) {
                 this._events[type].splice(idx, 1);
             }
@@ -58,10 +58,10 @@ var Evented = {
      * @param {string} type Event type.
      * @param {Function} listener Function to be called once when the event is fired
      */
-    once: function(type, fn) {
+    once: function(type, listener) {
         var wrapper = function(data) {
             this.off(type, wrapper);
-            fn.call(this, data);
+            listener.call(this, data);
         }.bind(this);
         this.on(type, wrapper);
         return this;


### PR DESCRIPTION
The Evented documentation is a bit broken
https://www.mapbox.com/mapbox-gl-js/api/#Evented

It starts with a Parameters field (not sure what that is for)
For `off`/`on`/`once` there are 3 parameters, but really these all just have 2 parameters.

Pretty certain this is because the parameter name in the docs doesn't line up with the actual parameter name, so I've renamed the parameters to match the docs

I can't run the docs because I'm on windows :( So someone will need to check this fixes the issue. Thanks!