### PR TITLE
Replace "style.load" with "load" events in examples

### DIFF
--- a/docs/_posts/examples/3400-01-01-cluster.html
+++ b/docs/_posts/examples/3400-01-01-cluster.html
@@ -15,7 +15,7 @@ var map = new mapboxgl.Map({
     zoom: 3,
 });
 
-map.on('style.load', function(){
+map.on('load', function(){
 
     // Add a new source from our GeoJSON data and set the
     // 'cluster' option to true.

--- a/docs/_posts/examples/3400-01-01-heatmap.html
+++ b/docs/_posts/examples/3400-01-01-heatmap.html
@@ -15,7 +15,7 @@ var map = new mapboxgl.Map({
     zoom: 3,
 });
 
-map.on('style.load', function(){
+map.on('load', function(){
 
     // Add a new source from our GeoJSON data and set the
     // 'cluster' option to true.

--- a/docs/_posts/examples/3400-01-01-toggle-layers.html
+++ b/docs/_posts/examples/3400-01-01-toggle-layers.html
@@ -59,7 +59,7 @@ var map = new mapboxgl.Map({
     center: [-71.97722138410576, -13.517379300798098]
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource('museums', {
         type: 'vector',
         url: 'mapbox://mapbox.2opop9hr'
@@ -68,6 +68,9 @@ map.on('style.load', function () {
         'id': 'museums',
         'type': 'circle',
         'source': 'museums',
+        'layout': {
+            'visibility': 'visible'
+        },
         'paint': {
             'circle-radius': 8,
             'circle-color': 'rgba(55,148,179,1)'
@@ -85,6 +88,7 @@ map.on('style.load', function () {
         'source': 'contours',
         'source-layer': 'contour',
         'layout': {
+            'visibility': 'visible',
             'line-join': 'round',
             'line-cap': 'round'
         },

--- a/docs/_posts/examples/3400-01-01-vector-source.html
+++ b/docs/_posts/examples/3400-01-01-vector-source.html
@@ -13,7 +13,7 @@ var map = new mapboxgl.Map({
     center: [-122.447303, 37.753574]
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource('terrain-data', {
         type: 'vector',
         url: 'mapbox://mapbox.mapbox-terrain-v2'

--- a/docs/_posts/examples/3400-01-04-center-on-symbol.html
+++ b/docs/_posts/examples/3400-01-04-center-on-symbol.html
@@ -13,7 +13,7 @@ var map = new mapboxgl.Map({
     zoom: 8
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
 
     // add geojson data as a new source
     map.addSource("symbols", {

--- a/docs/_posts/examples/3400-01-04-geojson-layer-in-stack.html
+++ b/docs/_posts/examples/3400-01-04-geojson-layer-in-stack.html
@@ -13,7 +13,7 @@ var map = new mapboxgl.Map({
     zoom: 4
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource('urban-areas', {
         'type': 'geojson',
         'data': 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_urban_areas.geojson'

--- a/docs/_posts/examples/3400-01-04-geojson-line.html
+++ b/docs/_posts/examples/3400-01-04-geojson-line.html
@@ -13,7 +13,7 @@ var map = new mapboxgl.Map({
     zoom: 15
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource("route", {
         "type": "geojson",
         "data": {

--- a/docs/_posts/examples/3400-01-04-geojson-polygon.html
+++ b/docs/_posts/examples/3400-01-04-geojson-polygon.html
@@ -13,7 +13,7 @@ var map = new mapboxgl.Map({
     zoom: 5
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource('maine', {
         'type': 'geojson',
         'data': {

--- a/docs/_posts/examples/3400-01-04-hover-styles.html
+++ b/docs/_posts/examples/3400-01-04-hover-styles.html
@@ -13,7 +13,7 @@ var map = new mapboxgl.Map({
     zoom: 2
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource("states", {
         "type": "geojson",
         "data": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_1_states_provinces.geojson"

--- a/docs/_posts/examples/3400-01-05-geojson-markers.html
+++ b/docs/_posts/examples/3400-01-05-geojson-markers.html
@@ -13,7 +13,7 @@ var map = new mapboxgl.Map({
     zoom: 3
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource("markers", {
         "type": "geojson",
         "data": {

--- a/docs/_posts/examples/3400-01-06-polygon-popup-on-click.html
+++ b/docs/_posts/examples/3400-01-06-polygon-popup-on-click.html
@@ -23,7 +23,7 @@ var map = new mapboxgl.Map({
     zoom: 3
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     // Add marker data as a new GeoJSON source.
     map.addSource('states', {
         'type': 'geojson',

--- a/docs/_posts/examples/3400-01-06-popup-on-click.html
+++ b/docs/_posts/examples/3400-01-06-popup-on-click.html
@@ -118,7 +118,7 @@ var map = new mapboxgl.Map({
     zoom: 11.15
 });
 
-map.on('style.load', function () {
+map.on('load', function () {
     // Add marker data as a new GeoJSON source.
     map.addSource("markers", {
         "type": "geojson",

--- a/docs/_posts/examples/3400-01-06-popup-on-hover.html
+++ b/docs/_posts/examples/3400-01-06-popup-on-hover.html
@@ -118,7 +118,7 @@ var map = new mapboxgl.Map({
     zoom: 11.15
 });
 
-map.on('style.load', function() {
+map.on('load', function() {
     // Add marker data as a new GeoJSON source.
     map.addSource("markers", {
         "type": "geojson",

--- a/docs/_posts/examples/3400-01-10-live-geojson.html
+++ b/docs/_posts/examples/3400-01-10-live-geojson.html
@@ -21,7 +21,7 @@ window.setInterval(function() {
     source.setData(url);
 }, 2000);
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource('drone', source);
     map.addLayer({
         "id": "drone",

--- a/docs/_posts/examples/3400-01-10-rotating-controllable-marker.html
+++ b/docs/_posts/examples/3400-01-10-rotating-controllable-marker.html
@@ -40,7 +40,7 @@ function setPosition() {
     map.setCenter(point.coordinates);
 }
 
-map.on('style.load', function () {
+map.on('load', function () {
     map.addSource('drone', source);
 
     map.addLayer({

--- a/docs/_posts/examples/3400-01-16-point-from-geocoder-result.html
+++ b/docs/_posts/examples/3400-01-16-point-from-geocoder-result.html
@@ -41,7 +41,7 @@ map.addControl(geocoder);
 
 // After the map style has loaded on the page, add a source layer and default
 // styling for a single point.
-map.on('style.load', function() {
+map.on('load', function() {
     map.addSource('single-point', {
         "type": "geojson",
         "data": {

--- a/docs/_posts/examples/3400-01-22-measure.html
+++ b/docs/_posts/examples/3400-01-22-measure.html
@@ -53,7 +53,7 @@ var linestring = {
     }
 };
 
-map.on('style.load', function() {
+map.on('load', function() {
     map.addSource('geojson', {
         "type": "geojson",
         "data": geojson

--- a/docs/_posts/examples/3400-01-23-adjust-layer-opacity.html
+++ b/docs/_posts/examples/3400-01-23-adjust-layer-opacity.html
@@ -59,7 +59,7 @@ var map = new mapboxgl.Map({
 var slider = document.getElementById('slider');
 var sliderValue = document.getElementById('slider-value');
 
-map.on('style.load', function() {
+map.on('load', function() {
 
     // Add source/layers
     map.addSource('chicago', {


### PR DESCRIPTION
`style.load` isn’t part of our public API. Its use became widespread because of a bug with `load` a few versions back. We should always use `load` in our examples. 

I tested all the modified examples by hand and ensured they all still work as intended.

cc @tristen @bhousel @lyzidiamond @ansis 