### PR TITLE
Guard transition.declaration being undefined

### DIFF
--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -259,7 +259,7 @@ StyleLayer.prototype = util.inherit(Evented, {
             declaration = new StyleDeclaration(spec, spec.default);
         }
 
-        if (oldTransition && oldTransition.declaration.json === declaration.json) return;
+        if (oldTransition && oldTransition.declaration && oldTransition.declaration.json === declaration.json) return;
 
         var transitionOptions = util.extend({
             duration: 300,


### PR DESCRIPTION
We've seen many cases where the declaration object is undefined for a
transitions in Studio. Adding a guard.