### PR TITLE
Fix errors when unsetting and resetting a style property

### DIFF
--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -254,7 +254,7 @@ StyleLayer.prototype = util.inherit(Evented, {
     _applyPaintDeclaration: function (name, declaration, options, globalOptions, animationLoop) {
         var oldTransition = options.transition ? this._paintTransitions[name] : undefined;
 
-        if (declaration === null) {
+        if (declaration === null || declaration === undefined) {
             var spec = this._paintSpecifications[name];
             declaration = new StyleDeclaration(spec, spec.default);
         }


### PR DESCRIPTION
Replaces #2460 

This bug could also be fixed by changing [this line](https://github.com/mapbox/mapbox-gl-js/blob/unset-undefined-2460/js/style/style_layer.js#L207) to 

```js
var declaration = this._paintDeclarations[''][name] || null;
```

I chose this solution instead because all our other APIs support either `null` or `undefined` as a value to indicate that a property should be unset. 

cc @scothis 