### PR TITLE
Fix local ajax calls

### DIFF
--- a/js/util/browser/ajax.js
+++ b/js/util/browser/ajax.js
@@ -8,7 +8,8 @@ exports.getJSON = function(url, callback) {
         callback(e);
     };
     xhr.onload = function() {
-        if (xhr.status >= 200 && xhr.status < 300 && xhr.response) {
+        // xhr.status does not need to be checked because onload implies success
+        if (xhr.response) {
             var data;
             try {
                 data = JSON.parse(xhr.response);
@@ -32,7 +33,8 @@ exports.getArrayBuffer = function(url, callback) {
         callback(e);
     };
     xhr.onload = function() {
-        if (xhr.status >= 200 && xhr.status < 300 && xhr.response) {
+        // xhr.status does not need to be checked because onload implies success
+        if (xhr.response) {
             callback(null, xhr.response);
         } else {
             callback(new Error(xhr.statusText));


### PR DESCRIPTION
Loading json, images or sprites from the local system will fire XMLHttpRequest onload event with status 0.

XMLHttpRequest onload event is only fired when the request completed successfully, there is no need for the status check -- so the status check should be removed.
