### PR TITLE
Add "renderstable" event

### DIFF
--- a/debug/events.html
+++ b/debug/events.html
@@ -189,7 +189,8 @@ var checkboxContainer = document.querySelector('#checkboxes');
  'zoomstart', 'zoom', 'zoomend',
  'rotatestart', 'rotate', 'rotateend',
  'pitchstart', 'pitch', 'pitchend',
- 'boxzoomstart', 'boxzoomend', 'boxzoomcancel'
+ 'boxzoomstart', 'boxzoomend', 'boxzoomcancel',
+ 'renderstable'
 ].forEach(function (type) {
     var name = 'show-' + type;
     var input = document.createElement('input');

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1028,3 +1028,13 @@ function removeNode(node) {
         node.parentNode.removeChild(node);
     }
 }
+
+/**
+ * This event is fired when the map becomes "render stable." The map is
+ * considered "render stable" when all the resources needed to display the
+ * current viewport have been loaded. See also `Map#isRenderStable`.
+ *
+ * @event renderstable
+ * @memberof Map
+ * @instance
+ */


### PR DESCRIPTION
_This pull request isn't quite ready. I am publishing now to get some 👀  on the proposal and implementation._

Mapbox GL JS downloads many resources (glyphs, sprites, tiles, and styles) over the network. Giving our developers the right primitives to understand the state of these resources and respond to changes in that state is a hard problem. 

To that end, this PR adds the `data` and `dataend` events:

 - **`data` event** a resource has been loaded, changed, or removed. 
 - **`dataend` event** all resources for the current viewport have been loaded. Fired at most once per frame.

This PR also renames `Map#loaded` to `isDataStable`, to disambiguate the concept of "data stable" (all resources for the current viewport have been loaded) from "loaded" (all resources for the FIRST viewport have been loaded).

We could do more to simplify the existing events infrastructure. Once this pull request is merged, we should consider deprecating some granular `*.add`, `*.remove`, `*.load`, and `*.change` events.

fixes #1715 

cc @ansis @jfirebaugh @mourner @tmcw @scothis 
