### PR TITLE
add a cpu frame duration benchmark

### DIFF
--- a/bench/benchmarks/frame_duration.js
+++ b/bench/benchmarks/frame_duration.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var Evented = require('../../js/util/evented');
+var util = require('../../js/util/util');
+var formatNumber = require('../lib/format_number');
+
+var DURATION_MILLISECONDS = 1 * 5000;
+
+var zooms = [4, 8, 11, 13, 15, 17];
+var results = [];
+
+module.exports = function(options) {
+    var evented = util.extend({}, Evented);
+
+    asyncSeries(zooms.length, runZoom, done);
+
+    function runZoom(times, callback) {
+        var index = zooms.length - times;
+
+        measureFrameTime(options, zooms[index], function(err_, result) {
+            results[index] = result;
+            evented.fire('log', {
+                message: formatNumber(result.sum / result.count) + ' ms per frame at zoom ' + zooms[index] + '. ' +
+                    formatNumber(result.countAbove16 / result.count * 100) + '% of frames took longer than 16ms.'
+            });
+            callback();
+        });
+    }
+
+    function done() {
+        document.getElementById('map').remove();
+
+        var sum = 0;
+        var count = 0;
+        var countAbove16 = 0;
+        for (var i = 0; i < results.length; i++) {
+            var result = results[i];
+            sum += result.sum;
+            count += result.count;
+            countAbove16 += result.countAbove16;
+        }
+        evented.fire('end', {
+            message: formatNumber(sum / count * 10) / 10 + ' ms per frame. ' + formatNumber(countAbove16 / count * 100) + '% of frames took longer than 16ms.',
+            score: sum / count
+        });
+    }
+
+    return evented;
+};
+
+function measureFrameTime(options, zoom, callback) {
+
+    var map = options.createMap({
+        width: 1024,
+        height: 768,
+        zoom: zoom,
+        center: [-77.032194, 38.912753],
+        style: 'mapbox://styles/mapbox/streets-v8'
+    });
+
+    map.on('load', function() {
+
+        map.repaint = true;
+
+        // adding a delay seems to make the results more consistent
+        window.setTimeout(function() {
+            var sum = 0;
+            var count = 0;
+            var countAbove16 = 0;
+            var start = performance.now();
+
+            map._realrender = map._render;
+            map._render = function() {
+                map._styleDirty = true;
+                map._sourcesDirty = true;
+
+                var frameStart = performance.now();
+                map._realrender();
+                var frameEnd = performance.now();
+                var duration = frameEnd - frameStart;
+
+                sum += duration;
+                count++;
+                if (duration >= 16) countAbove16++;
+
+                if (frameEnd - start > DURATION_MILLISECONDS) {
+                    map.repaint = false;
+                    map.remove();
+                    callback(undefined, {
+                        sum: sum,
+                        count: count,
+                        countAbove16: countAbove16
+                    });
+                }
+            };
+        }, 100);
+    });
+}
+
+function asyncSeries(times, work, callback) {
+    if (times > 0) {
+        work(times, function(err) {
+            if (err) callback(err);
+            else asyncSeries(times - 1, work, callback);
+        });
+    } else {
+        callback();
+    }
+}
+

--- a/bench/index.js
+++ b/bench/index.js
@@ -16,6 +16,7 @@ function main() {
     var benchmarks = {
         buffer: require('./benchmarks/buffer'),
         fps: require('./benchmarks/fps'),
+        'frame-duration': require('./benchmarks/frame_duration'),
         'query-point': require('./benchmarks/query_point'),
         'query-box': require('./benchmarks/query_box'),
         'geojson-setdata-small': require('./benchmarks/geojson_setdata_small'),


### PR DESCRIPTION
Why have this when we already have a fps benchmark?
- if a particular example is bottlnecked by the gpu on particular hardware then cpu changes that are relevant on other devices/styles or that will be after [future gpu optimizations](https://github.com/mapbox/mapbox-gl-js/pull/1606) might not affect the results
- actual frames are often synchronized with a screen refresh rate. If every frame takes exactly 17ms to render it might have to spend 15ms waiting around doing nothing. FPS can be a staircase function of frame duration
- this measures the duration more directly so I think it should be more accurate

<img width="633" alt="screen shot 2016-04-20 at 12 35 00 pm" src="https://cloud.githubusercontent.com/assets/1421652/14687840/5cc1e6cc-06f4-11e6-8789-5036f611382d.png">

:eyes: @lucaswoj 