### PR TITLE
Fix broken asset image link

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -20,7 +20,7 @@ options: full
     <div class='prose space-bottom2'>
       <p>Mapbox GL JS is a JavaScript library that uses WebGL to render interactive maps from <a href='https://www.mapbox.com/blog/vector-tiles'>vector tiles</a> and <a href='https://www.mapbox.com/mapbox-gl-style-spec'>Mapbox GL styles</a><p>
       <p>It is part of the <a href='https://github.com/mapbox/mapbox-gl'>Mapbox GL ecosystem</a> which includes <a href='https://www.mapbox.com/mobile/'>Mapbox Mobile</a>, a compatible renderer written in C++ with bindings for desktop and mobile platforms.</p>
-      <a href='https://www.mapbox.com/gallery/'><img width='981' alt='Mapbox GL JS gallery' src='{{site.baseurl}}/mapbox-gl-js/assets/gallery.png'></a>
+      <a href='https://www.mapbox.com/gallery/'><img width='981' alt='Mapbox GL JS gallery' src='{{site.baseurl}}/assets/gallery.png'></a>
     </div>
 
     <h2 class='space'>Using Mapbox GL JS with a <code>&lt;script&gt;</code> tag</h2>


### PR DESCRIPTION
`https://www.mapbox.com/mapbox-gl-js/mapbox-gl-js/assets/gallery.png` -> `https://www.mapbox.com/mapbox-gl-js/assets/gallery.png`

cc @tmcw 