### PR TITLE
use VertexArrayObject extension when available

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -41,6 +41,7 @@
 <div id='checkboxes'>
   <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
   <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br />
+  <input id='show-overdraw-checkbox' name='show-overdraw' type='checkbox'> <label for='show-overdraw'>overdraw debug</label><br />
   <input id='buffer-checkbox' name='buffer' type='checkbox'> <label for='buffer'>buffer stats</label>
 </div>
 

--- a/debug/site.js
+++ b/debug/site.js
@@ -107,6 +107,10 @@ document.getElementById('show-symbol-collision-boxes-checkbox').onclick = functi
     map.showCollisionBoxes = !!this.checked;
 };
 
+document.getElementById('show-overdraw-checkbox').onclick = function() {
+    map.showOverdrawInspector = !!this.checked;
+};
+
 document.getElementById('buffer-checkbox').onclick = function() {
     document.getElementById('buffer').style.display = this.checked ? 'block' : 'none';
 };

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -219,7 +219,21 @@ Bucket.prototype.destroy = function(gl) {
         for (var layoutBuffer in programBuffers.layout) {
             programBuffers.layout[layoutBuffer].destroy(gl);
         }
+
+        var elementGroups = this.elementGroups[programName];
+        if (elementGroups) {
+            for (var i = 0; i < elementGroups.length; i++) {
+                var elementGroup = elementGroups[i];
+                for (var j in elementGroup.vaos) {
+                    elementGroup.vaos[j].destroy(gl);
+                }
+                for (var k in elementGroup.secondVaos) {
+                    elementGroup.secondVaos[k].destroy(gl);
+                }
+            }
+        }
     }
+
 };
 
 Bucket.prototype.trimArrays = function() {

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -4,6 +4,7 @@ var featureFilter = require('feature-filter');
 var Buffer = require('./buffer');
 var util = require('../util/util');
 var StructArrayType = require('../util/struct_array');
+var VertexArrayObject = require('../render/vertex_array_object');
 
 module.exports = Bucket;
 
@@ -76,6 +77,18 @@ function Bucket(options) {
 
     if (options.elementGroups) {
         this.elementGroups = options.elementGroups;
+
+        for (var l = 0; l < this.childLayers.length; l++) {
+            for (var s in this.elementGroups) {
+                var elementGroups = this.elementGroups[s];
+                if (elementGroups) {
+                    for (var i = 0; i < elementGroups.length; i++) {
+                        elementGroups[i].vao = new VertexArrayObject();
+                    }
+                }
+            }
+        }
+
         this.buffers = util.mapObject(options.arrays, function(array, bufferName) {
             var arrayType = options.arrayTypes[bufferName];
             var type = (arrayType.members.length && arrayType.members[0].name === 'vertices' ? Buffer.BufferType.ELEMENT : Buffer.BufferType.VERTEX);

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -21,7 +21,7 @@ function CircleBucket() {
 CircleBucket.prototype = util.inherit(Bucket, {});
 
 CircleBucket.prototype.addCircleVertex = function(x, y, extrudeX, extrudeY) {
-    return this.arrays.circleVertex.emplaceBack(
+    return this.arrays.circle.layout.vertex.emplaceBack(
             (x * 2) + ((extrudeX + 1) / 2),
             (y * 2) + ((extrudeY + 1) / 2));
 };
@@ -63,7 +63,7 @@ CircleBucket.prototype.addFeature = function(feature) {
     var globalProperties = {zoom: this.zoom};
     var geometries = loadGeometry(feature);
 
-    var startIndex = this.arrays.circleVertex.length;
+    var startIndex = this.arrays.circle.layout.vertex.length;
 
     for (var j = 0; j < geometries.length; j++) {
         for (var k = 0; k < geometries[j].length; k++) {
@@ -91,11 +91,11 @@ CircleBucket.prototype.addFeature = function(feature) {
             this.addCircleVertex(x, y, -1, 1);
             group.vertexLength += 4;
 
-            this.arrays.circleElement.emplaceBack(index, index + 1, index + 2);
-            this.arrays.circleElement.emplaceBack(index, index + 3, index + 2);
+            this.arrays.circle.layout.element.emplaceBack(index, index + 1, index + 2);
+            this.arrays.circle.layout.element.emplaceBack(index, index + 3, index + 2);
             group.elementLength += 2;
         }
     }
 
-    this.addPaintAttributes('circle', globalProperties, feature.properties, startIndex, this.arrays.circleVertex.length);
+    this.addPaintAttributes('circle', globalProperties, feature.properties, startIndex, this.arrays.circle.layout.vertex.length);
 };

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -13,7 +13,7 @@ function FillBucket() {
 FillBucket.prototype = util.inherit(Bucket, {});
 
 FillBucket.prototype.addFillVertex = function(x, y) {
-    return this.arrays.fillVertex.emplaceBack(x, y);
+    return this.arrays.fill.layout.vertex.emplaceBack(x, y);
 };
 
 FillBucket.prototype.programInterfaces = {
@@ -67,12 +67,12 @@ FillBucket.prototype.addFill = function(vertices) {
 
         // Only add triangles that have distinct vertices.
         if (i >= 2 && (currentVertex.x !== vertices[0].x || currentVertex.y !== vertices[0].y)) {
-            this.arrays.fillElement.emplaceBack(firstIndex, prevIndex, currentIndex);
+            this.arrays.fill.layout.element.emplaceBack(firstIndex, prevIndex, currentIndex);
             group.elementLength++;
         }
 
         if (i >= 1) {
-            this.arrays.fillSecondElement.emplaceBack(prevIndex, currentIndex);
+            this.arrays.fill.layout.secondElement.emplaceBack(prevIndex, currentIndex);
             group.secondElementLength++;
         }
 

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -51,7 +51,7 @@ function LineBucket() {
 LineBucket.prototype = util.inherit(Bucket, {});
 
 LineBucket.prototype.addLineVertex = function(point, extrude, tx, ty, dir, linesofar) {
-    return this.arrays.lineVertex.emplaceBack(
+    return this.arrays.line.layout.vertex.emplaceBack(
             // a_pos
             (point.x << 1) | tx,
             (point.y << 1) | ty,
@@ -375,7 +375,7 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal
     if (endLeft) extrude._sub(normal.perp()._mult(endLeft));
     this.e3 = this.addLineVertex(currentVertex, extrude, tx, 0, endLeft, distance) - group.vertexStartIndex;
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.arrays.lineElement.emplaceBack(this.e1, this.e2, this.e3);
+        this.arrays.line.layout.element.emplaceBack(this.e1, this.e2, this.e3);
         group.elementLength++;
     }
     this.e1 = this.e2;
@@ -385,7 +385,7 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal
     if (endRight) extrude._sub(normal.perp()._mult(endRight));
     this.e3 = this.addLineVertex(currentVertex, extrude, tx, 1, -endRight, distance) - group.vertexStartIndex;
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.arrays.lineElement.emplaceBack(this.e1, this.e2, this.e3);
+        this.arrays.line.layout.element.emplaceBack(this.e1, this.e2, this.e3);
         group.elementLength++;
     }
     this.e1 = this.e2;
@@ -420,7 +420,7 @@ LineBucket.prototype.addPieSliceVertex = function(currentVertex, distance, extru
     group.vertexLength++;
 
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.arrays.lineElement.emplaceBack(this.e1, this.e2, this.e3);
+        this.arrays.line.layout.element.emplaceBack(this.e1, this.e2, this.e3);
         group.elementLength++;
     }
 

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -70,7 +70,7 @@ function addVertex(array, x, y, ox, oy, tx, ty, minzoom, maxzoom, labelminzoom) 
 }
 
 SymbolBucket.prototype.addCollisionBoxVertex = function(point, extrude, maxZoom, placementZoom) {
-    return this.arrays.collisionBoxVertex.emplaceBack(
+    return this.arrays.collisionBox.layout.vertex.emplaceBack(
             // pos
             point.x,
             point.y,
@@ -436,9 +436,8 @@ SymbolBucket.prototype.addSymbols = function(programName, quads, scale, keepUpri
 
     var group = this.makeRoomFor(programName, 4 * quads.length);
 
-    // TODO manual curry
-    var elementArray = this.arrays[this.getBufferName(programName, 'element')];
-    var vertexArray = this.arrays[this.getBufferName(programName, 'vertex')];
+    var elementArray = this.arrays[programName].layout.element;
+    var vertexArray = this.arrays[programName].layout.vertex;
 
     var zoom = this.zoom;
     var placementZoom = Math.max(Math.log(scale) / Math.LN2 + zoom, 0);

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -36,6 +36,7 @@ function drawBackground(painter, source, layer) {
 
         painter.spriteAtlas.bind(gl, true);
 
+        painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
     } else {
         // Draw filling rectangle.
         if (painter.isOpaquePass !== (color[3] === 1)) return;
@@ -43,12 +44,10 @@ function drawBackground(painter, source, layer) {
         program = painter.useProgram('fill');
         gl.uniform4fv(program.u_color, color);
         gl.uniform1f(program.u_opacity, opacity);
+        painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
     }
 
     gl.disable(gl.STENCIL_TEST);
-
-    gl.bindBuffer(gl.ARRAY_BUFFER, painter.tileExtentBuffer);
-    gl.vertexAttribPointer(program.a_pos, painter.tileExtentBuffer.itemSize, gl.SHORT, false, 0, 0);
 
     // We need to draw the background in tiles in order to use calculatePosMatrix
     // which applies the projection matrix (transform.projMatrix). Otherwise
@@ -93,7 +92,13 @@ function drawBackground(painter, source, layer) {
         }
 
         painter.setPosMatrix(painter.transform.calculatePosMatrix(coord));
-        gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.length);
+    }
+
+    if (imagePosA && imagePosB) {
+        painter.tileExtentPatternVAO.unbind(gl);
+    } else {
+        painter.tileExtentVAO.unbind(gl);
     }
 
     gl.stencilMask(0x00);

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -95,12 +95,6 @@ function drawBackground(painter, source, layer) {
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.length);
     }
 
-    if (imagePosA && imagePosB) {
-        painter.tileExtentPatternVAO.unbind(gl);
-    } else {
-        painter.tileExtentVAO.unbind(gl);
-    }
-
     gl.stencilMask(0x00);
     gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
 }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -41,16 +41,17 @@ function drawCircles(painter, source, layer, coords) {
         ));
         painter.setExMatrix(painter.transform.exMatrix);
 
-        var vertexBuffer = bucket.buffers.circle.layout.vertex;
-        var elementBuffer = bucket.buffers.circle.layout.element;
-        var paintVertexBuffer = bucket.buffers.circle.paint[layer.id];
+        var buffers = bucket.buffers.circle;
+        var vertexBuffer = buffers.layout.vertex;
+        var elementBuffer = buffers.layout.element;
+        var paintVertexBuffer = buffers.paint[layer.id];
 
         for (var k = 0; k < elementGroups.length; k++) {
             var group = elementGroups[k];
             var count = group.elementLength * 3;
-            group.vao.bind(gl, program, vertexBuffer, paintVertexBuffer, group.vertexStartIndex, elementBuffer);
+            group.vaos[layer.id].bind(gl, program, vertexBuffer, paintVertexBuffer, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
-            group.vao.unbind(gl);
+            group.vaos[layer.id].unbind(gl);
         }
     }
 }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -31,6 +31,8 @@ function drawCircles(painter, source, layer, coords) {
         gl.uniform1f(program.u_devicepixelratio, browser.devicePixelRatio);
         gl.uniform1f(program.u_opacity, layer.paint['circle-opacity']);
 
+        bucket.setUniforms(gl, 'circle', program, layer, {zoom: painter.transform.zoom});
+
         painter.setPosMatrix(painter.translatePosMatrix(
             coord.posMatrix,
             tile,
@@ -39,14 +41,16 @@ function drawCircles(painter, source, layer, coords) {
         ));
         painter.setExMatrix(painter.transform.exMatrix);
 
+        var vertexBuffer = bucket.buffers.circleVertex;
+        var paintVertexBuffer = bucket.buffers[layer.id + 'Circle'];
+        var elementBuffer = bucket.buffers.circleElement;
+
         for (var k = 0; k < elementGroups.length; k++) {
             var group = elementGroups[k];
             var count = group.elementLength * 3;
-            bucket.bindLayoutBuffers('circle', gl);
-            bucket.setAttribPointers('circle', gl, program, group.vertexOffset);
-            bucket.bindPaintBuffer(gl, 'circle', layer.id, program, group.vertexStartIndex);
-            bucket.setUniforms(gl, 'circle', program, layer, {zoom: painter.transform.zoom});
+            group.vao.bind(gl, program, vertexBuffer, paintVertexBuffer, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+            group.vao.unbind(gl);
         }
     }
 }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -51,7 +51,6 @@ function drawCircles(painter, source, layer, coords) {
             var count = group.elementLength * 3;
             group.vaos[layer.id].bind(gl, program, vertexBuffer, paintVertexBuffer, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
-            group.vaos[layer.id].unbind(gl);
         }
     }
 }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -41,9 +41,9 @@ function drawCircles(painter, source, layer, coords) {
         ));
         painter.setExMatrix(painter.transform.exMatrix);
 
-        var vertexBuffer = bucket.buffers.circleVertex;
-        var paintVertexBuffer = bucket.buffers[layer.id + 'Circle'];
-        var elementBuffer = bucket.buffers.circleElement;
+        var vertexBuffer = bucket.buffers.circle.layout.vertex;
+        var elementBuffer = bucket.buffers.circle.layout.element;
+        var paintVertexBuffer = bucket.buffers.circle.paint[layer.id];
 
         for (var k = 0; k < elementGroups.length; k++) {
             var group = elementGroups[k];

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -35,7 +35,5 @@ function drawCollisionDebug(painter, source, layer, coords) {
             elementGroups[0].vertexStartIndex,
             elementGroups[0].vertexLength
         );
-        elementGroups[0].vaos[layer.id].unbind(gl);
-
     }
 }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -29,13 +29,13 @@ function drawCollisionDebug(painter, source, layer, coords) {
 
         var buffers = bucket.buffers.collisionBox;
         var vertexBuffer = buffers.layout.vertex;
-        elementGroups[0].vao.bind(gl, program, vertexBuffer, undefined, elementGroups[0].vertexStartIndex, undefined);
+        elementGroups[0].vaos[layer.id].bind(gl, program, vertexBuffer, undefined, elementGroups[0].vertexStartIndex, undefined);
         gl.drawArrays(
             gl.LINES,
             elementGroups[0].vertexStartIndex,
             elementGroups[0].vertexLength
         );
-        elementGroups[0].vao.unbind(gl);
+        elementGroups[0].vaos[layer.id].unbind(gl);
 
     }
 }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -18,9 +18,6 @@ function drawCollisionDebug(painter, source, layer, coords) {
         if (!bucket.buffers) continue;
         if (elementGroups[0].vertexLength === 0) continue;
 
-        bucket.bindLayoutBuffers('collisionBox', gl);
-        bucket.setAttribPointers('collisionBox', gl, program, elementGroups[0].vertexOffset, layer);
-
         painter.setPosMatrix(coord.posMatrix);
 
         painter.enableTileClippingMask(coord);
@@ -30,11 +27,15 @@ function drawCollisionDebug(painter, source, layer, coords) {
         gl.uniform1f(program.u_zoom, painter.transform.zoom * 10);
         gl.uniform1f(program.u_maxzoom, (tile.coord.z + 1) * 10);
 
+        var buffers = bucket.buffers.collisionBox;
+        var vertexBuffer = buffers.layout.vertex;
+        elementGroups[0].vao.bind(gl, program, vertexBuffer, undefined, elementGroups[0].vertexStartIndex, undefined);
         gl.drawArrays(
             gl.LINES,
             elementGroups[0].vertexStartIndex,
             elementGroups[0].vertexLength
         );
+        elementGroups[0].vao.unbind(gl);
 
     }
 }

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -31,7 +31,6 @@ function drawDebugTile(painter, source, coord) {
     gl.uniform4f(program.u_color, 1, 0, 0, 1);
     painter.debugVAO.bind(gl, program, painter.debugBuffer, undefined, 0, undefined);
     gl.drawArrays(gl.LINE_STRIP, 0, painter.debugBuffer.length);
-    painter.debugVAO.unbind(gl);
 
     var vertices = textVertices(coord.toString(), 50, 200, 5);
     var debugTextArray = new painter.PosArray();
@@ -57,6 +56,4 @@ function drawDebugTile(painter, source, coord) {
     gl.uniform4f(program.u_color, 0, 0, 0, 1);
     painter.setPosMatrix(posMatrix);
     gl.drawArrays(gl.LINES, 0, debugTextBuffer.length);
-
-    debugTextVAO.unbind(gl);
 }

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -4,6 +4,8 @@ var textVertices = require('../lib/debugtext');
 var browser = require('../util/browser');
 var mat4 = require('gl-matrix').mat4;
 var EXTENT = require('../data/bucket').EXTENT;
+var Buffer = require('../data/buffer');
+var VertexArrayObject = require('./vertex_array_object');
 
 module.exports = drawDebug;
 
@@ -26,16 +28,19 @@ function drawDebugTile(painter, source, coord) {
     var program = painter.useProgram('debug');
     painter.setPosMatrix(posMatrix);
 
-    // draw bounding rectangle
-    gl.bindBuffer(gl.ARRAY_BUFFER, painter.debugBuffer);
-    gl.vertexAttribPointer(program.a_pos, painter.debugBuffer.itemSize, gl.SHORT, false, 0, 0);
     gl.uniform4f(program.u_color, 1, 0, 0, 1);
-    gl.drawArrays(gl.LINE_STRIP, 0, painter.debugBuffer.itemCount);
+    painter.debugVAO.bind(gl, program, painter.debugBuffer, undefined, 0, undefined);
+    gl.drawArrays(gl.LINE_STRIP, 0, painter.debugBuffer.length);
+    painter.debugVAO.unbind(gl);
 
     var vertices = textVertices(coord.toString(), 50, 200, 5);
-    gl.bindBuffer(gl.ARRAY_BUFFER, painter.debugTextBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Int16Array(vertices), gl.STREAM_DRAW);
-    gl.vertexAttribPointer(program.a_pos, painter.debugTextBuffer.itemSize, gl.SHORT, false, 0, 0);
+    var debugTextArray = new painter.PosArray();
+    for (var v = 0; v < vertices.length; v += 2) {
+        debugTextArray.emplaceBack(vertices[v], vertices[v + 1]);
+    }
+    var debugTextBuffer = new Buffer(debugTextArray.serialize(), painter.PosArray.serialize(), Buffer.BufferType.VERTEX);
+    var debugTextVAO = new VertexArrayObject();
+    debugTextVAO.bind(gl, program, debugTextBuffer, undefined, 0, undefined);
     gl.uniform4f(program.u_color, 1, 1, 1, 1);
 
     // Draw the halo with multiple 1px lines instead of one wider line because
@@ -46,10 +51,12 @@ function drawDebugTile(painter, source, coord) {
     for (var i = 0; i < translations.length; i++) {
         var translation = translations[i];
         painter.setPosMatrix(mat4.translate([], posMatrix, [onePixel * translation[0], onePixel * translation[1], 0]));
-        gl.drawArrays(gl.LINES, 0, vertices.length / painter.debugTextBuffer.itemSize);
+        gl.drawArrays(gl.LINES, 0, debugTextBuffer.length);
     }
 
     gl.uniform4f(program.u_color, 0, 0, 0, 1);
     painter.setPosMatrix(posMatrix);
-    gl.drawArrays(gl.LINES, 0, vertices.length / painter.debugTextBuffer.itemSize);
+    gl.drawArrays(gl.LINES, 0, debugTextBuffer.length);
+
+    debugTextVAO.unbind(gl);
 }

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -115,14 +115,16 @@ function drawFill(painter, source, layer, coord) {
     var fillProgram = painter.useProgram('fill');
     painter.setPosMatrix(translatedPosMatrix);
 
-    bucket.bindLayoutBuffers('fill', gl);
+    var buffers = bucket.buffers.fill.layout;
+    var vertexBuffer = buffers.vertex;
+    var elementBuffer = buffers.element;
 
     for (var i = 0; i < elementGroups.length; i++) {
         var group = elementGroups[i];
-        bucket.setAttribPointers('fill', gl, fillProgram, group.vertexOffset, layer);
-
         var count = group.elementLength * 3;
+        group.vaos[layer.id].bind(gl, fillProgram, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
         gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+        group.vaos[layer.id].unbind(gl);
     }
 
     // Now that we have the stencil mask in the stencil buffer, we can start
@@ -182,17 +184,18 @@ function drawStroke(painter, source, layer, coord) {
 
     if (image) { setPattern(image, opacity, tile, coord, painter, program); }
 
-    // Draw all buffers
-    bucket.bindLayoutBuffers('fill', gl, {secondElement: true});
+    var buffers = bucket.buffers.fill.layout;
+    var vertexBuffer = buffers.vertex;
+    var elementBuffer = buffers.secondElement;
 
     painter.enableTileClippingMask(coord);
 
     for (var k = 0; k < elementGroups.length; k++) {
         var group = elementGroups[k];
-        bucket.setAttribPointers('fill', gl, program, group.vertexOffset, layer);
-
         var count = group.secondElementLength * 2;
+        group.secondVaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
         gl.drawElements(gl.LINES, count, gl.UNSIGNED_SHORT, group.secondElementOffset);
+        group.secondVaos[layer.id].unbind(gl);
     }
 }
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -145,20 +145,28 @@ function drawFill(painter, source, layer, coord) {
         gl.activeTexture(gl.TEXTURE0);
         painter.spriteAtlas.bind(gl, true);
 
+        painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
+
     } else {
         // Draw filling rectangle.
         program = painter.useProgram('fill');
         gl.uniform4fv(fillProgram.u_color, color);
         gl.uniform1f(fillProgram.u_opacity, opacity);
+        painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
     }
 
     painter.setPosMatrix(posMatrix);
 
     // Only draw regions that we marked
     gl.stencilFunc(gl.NOTEQUAL, 0x0, 0x07);
-    gl.bindBuffer(gl.ARRAY_BUFFER, painter.tileExtentBuffer);
-    gl.vertexAttribPointer(program.a_pos, painter.tileExtentBuffer.itemSize, gl.SHORT, false, 0, 0);
-    gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.itemCount);
+
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.length);
+
+    if (image) {
+        painter.tileExtentPatternVAO.unbind(gl);
+    } else {
+        painter.tileExtentVAO.unbind(gl);
+    }
 
     gl.stencilMask(0x00);
 }

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -124,7 +124,6 @@ function drawFill(painter, source, layer, coord) {
         var count = group.elementLength * 3;
         group.vaos[layer.id].bind(gl, fillProgram, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
         gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
-        group.vaos[layer.id].unbind(gl);
     }
 
     // Now that we have the stencil mask in the stencil buffer, we can start
@@ -162,12 +161,6 @@ function drawFill(painter, source, layer, coord) {
 
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.length);
 
-    if (image) {
-        painter.tileExtentPatternVAO.unbind(gl);
-    } else {
-        painter.tileExtentVAO.unbind(gl);
-    }
-
     gl.stencilMask(0x00);
 }
 
@@ -203,7 +196,6 @@ function drawStroke(painter, source, layer, coord) {
         var count = group.secondElementLength * 2;
         group.secondVaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
         gl.drawElements(gl.LINES, count, gl.UNSIGNED_SHORT, group.secondElementOffset);
-        group.secondVaos[layer.id].unbind(gl);
     }
 }
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -163,14 +163,16 @@ module.exports = function drawLine(painter, source, layer, coords) {
             gl.uniform1f(program.u_ratio, ratio);
         }
 
-        bucket.bindLayoutBuffers('line', gl);
+        var buffers = bucket.buffers.line;
+        var vertexBuffer = buffers.layout.vertex;
+        var elementBuffer = buffers.layout.element;
 
         for (var i = 0; i < elementGroups.length; i++) {
             var group = elementGroups[i];
-            bucket.setAttribPointers('line', gl, program, group.vertexOffset, layer);
-
             var count = group.elementLength * 3;
+            group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+            group.vaos[layer.id].unbind(gl);
         }
     }
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -172,7 +172,6 @@ module.exports = function drawLine(painter, source, layer, coords) {
             var count = group.elementLength * 3;
             group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
-            group.vaos[layer.id].unbind(gl);
         }
     }
 

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -85,7 +85,6 @@ function drawRasterTile(painter, source, layer, coord) {
     var vao = tile.boundsVAO || painter.rasterBoundsVAO;
     vao.bind(gl, program, buffer, undefined, 0, undefined);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
-    vao.unbind(gl);
 }
 
 function spinWeights(angle) {

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var util = require('../util/util');
+var StructArrayType = require('../util/struct_array');
 
 module.exports = drawRaster;
 
@@ -26,6 +27,13 @@ function drawRaster(painter, source, layer, coords) {
 
     gl.depthFunc(gl.LEQUAL);
 }
+
+drawRaster.RasterBoundsArray = new StructArrayType({
+    members: [
+        { name: 'a_pos', type: 'Int16', components: 2 },
+        { name: 'a_texture_pos', type: 'Int16', components: 2 }
+    ]
+});
 
 function drawRasterTile(painter, source, layer, coord) {
 
@@ -73,11 +81,11 @@ function drawRasterTile(painter, source, layer, coord) {
     gl.uniform1i(program.u_image0, 0);
     gl.uniform1i(program.u_image1, 1);
 
-    gl.bindBuffer(gl.ARRAY_BUFFER, tile.boundsBuffer || painter.tileExtentBuffer);
-
-    gl.vertexAttribPointer(program.a_pos,         2, gl.SHORT, false, 8, 0);
-    gl.vertexAttribPointer(program.a_texture_pos, 2, gl.SHORT, false, 8, 4);
-    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    var buffer = tile.boundsBuffer || painter.rasterBoundsBuffer;
+    var vao = tile.boundsVAO || painter.rasterBoundsVAO;
+    vao.bind(gl, program, buffer, undefined, 0, undefined);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+    vao.unbind(gl);
 }
 
 function spinWeights(angle) {

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -145,7 +145,9 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
 
     var group, count;
 
-    bucket.bindLayoutBuffers(programInterfaceName, gl);
+    var buffers = bucket.buffers[programInterfaceName].layout;
+    var vertexBuffer = buffers.vertex;
+    var elementBuffer = buffers.element;
 
     if (sdf) {
         var sdfPx = 8;
@@ -164,10 +166,10 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
 
             for (var j = 0; j < elementGroups.length; j++) {
                 group = elementGroups[j];
-                bucket.setAttribPointers(programInterfaceName, gl, program, group.vertexOffset, layer);
-
                 count = group.elementLength * 3;
+                group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
                 gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+                group.vaos[layer.id].unbind(gl);
             }
         }
 
@@ -179,21 +181,20 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
 
         for (var i = 0; i < elementGroups.length; i++) {
             group = elementGroups[i];
-            bucket.bindLayoutBuffers(programInterfaceName, gl);
-            bucket.setAttribPointers(programInterfaceName, gl, program, group.vertexOffset, layer);
-
             count = group.elementLength * 3;
+            group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+            group.vaos[layer.id].unbind(gl);
         }
 
     } else {
         gl.uniform1f(program.u_opacity, layer.paint['icon-opacity']);
         for (var k = 0; k < elementGroups.length; k++) {
             group = elementGroups[k];
-            bucket.setAttribPointers(programInterfaceName, gl, program, group.vertexOffset, layer);
-
             count = group.elementLength * 3;
+            group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+            group.vaos[layer.id].unbind(gl);
         }
     }
 }

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -169,7 +169,6 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
                 count = group.elementLength * 3;
                 group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
                 gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
-                group.vaos[layer.id].unbind(gl);
             }
         }
 
@@ -184,7 +183,6 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
             count = group.elementLength * 3;
             group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
-            group.vaos[layer.id].unbind(gl);
         }
 
     } else {
@@ -194,7 +192,6 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, pref
             count = group.elementLength * 3;
             group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
             gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
-            group.vaos[layer.id].unbind(gl);
         }
     }
 }

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -64,7 +64,6 @@ Painter.prototype.resize = function(width, height) {
 
 };
 
-
 Painter.prototype.setup = function() {
     var gl = this.gl;
 
@@ -225,6 +224,8 @@ Painter.prototype.render = function(style, options) {
     this.clearColor();
     this.clearDepth();
 
+    this.showOverdrawInspector(options.showOverdrawInspector);
+
     this.depthRange = (style._order.length + 2) * this.numSublayers * this.depthEpsilon;
 
     this.renderPass({isOpaquePass: true});
@@ -255,7 +256,9 @@ Painter.prototype.renderPass = function(options) {
         }
 
         if (isOpaquePass) {
-            this.gl.disable(this.gl.BLEND);
+            if (!this._showOverdrawInspector) {
+                this.gl.disable(this.gl.BLEND);
+            }
             this.isOpaquePass = true;
         } else {
             this.gl.enable(this.gl.BLEND);
@@ -373,4 +376,21 @@ Painter.prototype.setExMatrix = function(exMatrix) {
 
 Painter.prototype.lineWidth = function(width) {
     this.gl.lineWidth(util.clamp(width, this.lineWidthRange[0], this.lineWidthRange[1]));
+};
+
+Painter.prototype.showOverdrawInspector = function(enabled) {
+    if (!enabled && !this._showOverdrawInspector) return;
+    this._showOverdrawInspector = enabled;
+
+    var gl = this.gl;
+    if (enabled) {
+        gl.blendFunc(gl.CONSTANT_COLOR, gl.ONE);
+        var numOverdrawSteps = 8;
+        var a = 1 / numOverdrawSteps;
+        gl.blendColor(a, a, a, 0);
+        gl.clearColor(0, 0, 0, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+    } else {
+        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+    }
 };

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -156,7 +156,6 @@ Painter.prototype._renderTileClippingMasks = function(coords) {
         // Draw the clipping mask
         this.tileExtentVAO.bind(gl, program, this.tileExtentBuffer, undefined, 0, undefined);
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, this.tileExtentBuffer.length);
-        this.tileExtentVAO.unbind(gl);
     }
 
     gl.stencilMask(0x00);

--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -112,6 +112,10 @@ module.exports._createProgram = function(name, macros) {
 
 module.exports._createProgramCached = function(name, macros) {
     this.cache = this.cache || {};
+    if (this._showOverdrawInspector) {
+        macros = macros || [];
+        macros.push('OVERDRAW_INSPECTOR');
+    }
     var key = JSON.stringify({name: name, macros: macros});
     if (!this.cache[key]) {
         this.cache[key] = this._createProgram(name, macros);

--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -131,22 +131,6 @@ module.exports.useProgram = function (nextProgramName, macros) {
 
     if (previousProgram !== nextProgram) {
         gl.useProgram(nextProgram.program);
-
-        var numNextAttributes = nextProgram.numAttributes;
-        var numPrevAttributes = previousProgram ? previousProgram.numAttributes : 0;
-        var i;
-
-        // Disable all attributes from the previous program that aren't used in
-        // the new program. Note: attribute indices are *not* program specific!
-        // WebGL breaks if you disable attribute 0. http://stackoverflow.com/questions/20305231
-        for (i = Math.max(1, numNextAttributes); i < numPrevAttributes; i++) {
-            gl.disableVertexAttribArray(i);
-        }
-        // Enable all attributes for the new program.
-        for (i = numPrevAttributes; i < numNextAttributes; i++) {
-            gl.enableVertexAttribArray(i);
-        }
-
         this.currentProgram = nextProgram;
     }
 

--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -87,3 +87,11 @@ VertexArrayObject.prototype.unbind = function(gl) {
         ext.bindVertexArrayOES(null);
     }
 };
+
+VertexArrayObject.prototype.destroy = function(gl) {
+    var ext = gl.extVertexArrayObject;
+    if (ext && this.vao) {
+        ext.deleteVertexArrayOES(this.vao);
+        this.vao = null;
+    }
+};

--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -54,9 +54,13 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, vertexBuf
 
         vertexBuffer.bind(gl);
         vertexBuffer.setVertexAttribPointers(gl, program, vertexOffset);
-        vertexBuffer2.bind(gl);
-        vertexBuffer2.setVertexAttribPointers(gl, program, vertexOffset);
-        elementBuffer.bind(gl);
+        if (vertexBuffer2) {
+            vertexBuffer2.bind(gl);
+            vertexBuffer2.setVertexAttribPointers(gl, program, vertexOffset);
+        }
+        if (elementBuffer) {
+            elementBuffer.bind(gl);
+        }
 
         if (ext) {
             // store the arguments so that we can verify them when the vao is bound again
@@ -78,7 +82,7 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, vertexBuf
 };
 
 VertexArrayObject.prototype.unbind = function(gl) {
-    var ext = gl.extVertexArrayObject = gl.getExtension("OES_vertex_array_object");
+    var ext = gl.extVertexArrayObject;
     if (ext) {
         ext.bindVertexArrayOES(null);
     }

--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var assert = require('assert');
+
+module.exports = VertexArrayObject;
+
+function VertexArrayObject() {
+    this.boundProgram = null;
+    this.boundVertexBuffer = null;
+    this.boundVertexBuffer2 = null;
+    this.boundVertexOffset = null;
+    this.boundElementBuffer = null;
+    this.vao = null;
+}
+
+var reported = false;
+
+VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, vertexBuffer2, vertexOffset, elementBuffer) {
+
+    var ext = gl.extVertexArrayObject;
+    if (ext === undefined) {
+        ext = gl.extVertexArrayObject = gl.getExtension("OES_vertex_array_object");
+    }
+
+    if (ext) {
+        if (!this.vao) this.vao = ext.createVertexArrayOES();
+        ext.bindVertexArrayOES(this.vao);
+    } else if (!reported) {
+        console.warn('Not using VertexArrayObject extension.');
+        reported = true;
+    }
+
+    if (!this.boundProgram) {
+
+        var numPrevAttributes = ext ? 0 : (gl.currentNumAttributes || 0);
+        var numNextAttributes = program.numAttributes;
+        var i;
+
+        // Enable all attributes for the new program.
+        for (i = numPrevAttributes; i < numNextAttributes; i++) {
+            gl.enableVertexAttribArray(i);
+        }
+
+        if (!ext) {
+            // Disable all attributes from the previous program that aren't used in
+            // the new program. Note: attribute indices are *not* program specific!
+            // WebGL breaks if you disable attribute 0. http://stackoverflow.com/questions/20305231
+            assert(i > 0);
+            for (i = numNextAttributes; i < numPrevAttributes; i++) {
+                gl.disableVertexAttribArray(i);
+            }
+            gl.currentNumAttributes = numNextAttributes;
+        }
+
+        vertexBuffer.bind(gl);
+        vertexBuffer.setVertexAttribPointers(gl, program, vertexOffset);
+        vertexBuffer2.bind(gl);
+        vertexBuffer2.setVertexAttribPointers(gl, program, vertexOffset);
+        elementBuffer.bind(gl);
+
+        if (ext) {
+            // store the arguments so that we can verify them when the vao is bound again
+            this.boundProgram = program;
+            this.boundVertexBuffer = vertexBuffer;
+            this.boundVertexBuffer2 = vertexBuffer2;
+            this.boundVertexOffset = vertexOffset;
+            this.boundElementBuffer = elementBuffer;
+        }
+
+    } else {
+        // verify that bind was called with the same arguments
+        assert(this.boundProgram === program, 'trying to bind a VAO to a different shader');
+        assert(this.boundVertexBuffer === vertexBuffer, 'trying to bind a VAO to a different vertex buffer');
+        assert(this.boundVertexBuffer2 === vertexBuffer2, 'trying to bind a VAO to a different vertex buffer');
+        assert(this.boundVertexOffset === vertexOffset, 'trying to bind a VAO to a different vertex offset');
+        assert(this.boundElementBuffer === elementBuffer, 'trying to bind a VAO to a different element buffer');
+    }
+};
+
+VertexArrayObject.prototype.unbind = function(gl) {
+    var ext = gl.extVertexArrayObject = gl.getExtension("OES_vertex_array_object");
+    if (ext) {
+        ext.bindVertexArrayOES(null);
+    }
+};

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -8,6 +8,9 @@ var Point = require('point-geometry');
 var Evented = require('../util/evented');
 var ajax = require('../util/ajax');
 var EXTENT = require('../data/bucket').EXTENT;
+var RasterBoundsArray = require('../render/draw_raster').RasterBoundsArray;
+var Buffer = require('../data/buffer');
+var VertexArrayObject = require('../render/vertex_array_object');
 
 module.exports = ImageSource;
 
@@ -89,21 +92,18 @@ ImageSource.prototype = util.inherit(Evented, /** @lends ImageSource.prototype *
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        var gl = map.painter.gl;
         var maxInt16 = 32767;
-        var array = new Int16Array([
-            tileCoords[0].x, tileCoords[0].y, 0, 0,
-            tileCoords[1].x, tileCoords[1].y, maxInt16, 0,
-            tileCoords[3].x, tileCoords[3].y, 0, maxInt16,
-            tileCoords[2].x, tileCoords[2].y, maxInt16, maxInt16
-        ]);
+        var array = new RasterBoundsArray();
+        array.emplaceBack(tileCoords[0].x, tileCoords[0].y, 0, 0);
+        array.emplaceBack(tileCoords[1].x, tileCoords[1].y, maxInt16, 0);
+        array.emplaceBack(tileCoords[3].x, tileCoords[3].y, 0, maxInt16);
+        array.emplaceBack(tileCoords[2].x, tileCoords[2].y, maxInt16, maxInt16);
 
         this.tile = new Tile(new TileCoord(centerCoord.zoom, centerCoord.column, centerCoord.row));
         this.tile.buckets = {};
 
-        this.tile.boundsBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.tile.boundsBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
+        this.tile.boundsBuffer = new Buffer(array.serialize(), RasterBoundsArray.serialize(), Buffer.BufferType.VERTEX);
+        this.tile.boundsVAO = new VertexArrayObject();
 
         this.fire('change');
 

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -243,8 +243,14 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, showCollisionBoxes) 
 };
 
 function isBucketEmpty(bucket) {
-    for (var bufferName in bucket.arrays) {
-        if (bucket.arrays[bufferName].length > 0) return true;
+    for (var programName in bucket.arrays) {
+        var programArrays = bucket.arrays[programName];
+        for (var layoutOrPaint in programArrays) {
+            var arrays = programArrays[layoutOrPaint];
+            for (var bufferName in arrays) {
+                if (arrays[bufferName].length > 0) return true;
+            }
+        }
     }
     return false;
 }
@@ -257,8 +263,14 @@ function getTransferables(buckets) {
     var transferables = [];
     for (var i in buckets) {
         var bucket = buckets[i];
-        for (var j in bucket.arrays) {
-            transferables.push(bucket.arrays[j].arrayBuffer);
+        for (var programName in bucket.arrays) {
+            var programArrays = bucket.arrays[programName];
+            for (var layoutOrPaint in programArrays) {
+                var arrays = programArrays[layoutOrPaint];
+                for (var bufferName in arrays) {
+                    transferables.push(arrays[bufferName].arrayBuffer);
+                }
+            }
         }
     }
     return transferables;

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -877,6 +877,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
 
         this.painter.render(this.style, {
             debug: this.showTileBoundaries,
+            showOverdrawInspector: this._showOverdrawInspector,
             vertices: this.vertices,
             rotating: this.rotating,
             zooming: this.zooming
@@ -1025,6 +1026,21 @@ util.extendAll(Map.prototype, /** @lends Map.prototype */{
         if (this._showCollisionBoxes === value) return;
         this._showCollisionBoxes = value;
         this.style._redoPlacement();
+    },
+
+    /*
+     * Show how many times each fragment has been shaded. White fragments have
+     * been shaded 8 or more times. Black fragments have been shaded 0 times.
+     *
+     * @name showOverdraw
+     * @type {boolean}
+     */
+    _showOverdrawInspector: false,
+    get showOverdrawInspector() { return this._showOverdrawInspector; },
+    set showOverdrawInspector(value) {
+        if (this._showOverdrawInspector === value) return;
+        this._showOverdrawInspector = value;
+        this._update();
     },
 
     /**

--- a/shaders/circle.fragment.glsl
+++ b/shaders/circle.fragment.glsl
@@ -10,4 +10,8 @@ varying lowp float v_antialiasblur;
 void main() {
     float t = smoothstep(1.0 - max(u_blur, v_antialiasblur), 1.0, length(v_extrude));
     gl_FragColor = v_color * (1.0 - t) * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/fill.fragment.glsl
+++ b/shaders/fill.fragment.glsl
@@ -5,4 +5,8 @@ uniform lowp float u_opacity;
 
 void main() {
     gl_FragColor = u_color * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/icon.fragment.glsl
+++ b/shaders/icon.fragment.glsl
@@ -10,4 +10,8 @@ varying vec2 v_fade_tex;
 void main() {
     lowp float alpha = texture2D(u_fadetexture, v_fade_tex).a * u_opacity;
     gl_FragColor = texture2D(u_texture, v_tex) * alpha;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/line.fragment.glsl
+++ b/shaders/line.fragment.glsl
@@ -20,4 +20,8 @@ void main() {
     float alpha = clamp(min(dist - (u_linewidth.t - blur), u_linewidth.s - dist) / blur, 0.0, 1.0);
 
     gl_FragColor = u_color * (alpha * u_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -41,4 +41,8 @@ void main() {
     alpha *= u_opacity;
 
     gl_FragColor = color * alpha;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/linesdfpattern.fragment.glsl
+++ b/shaders/linesdfpattern.fragment.glsl
@@ -29,4 +29,8 @@ void main() {
     alpha *= smoothstep(0.5 - u_sdfgamma, 0.5 + u_sdfgamma, sdfdist);
 
     gl_FragColor = u_color * (alpha * u_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/outline.fragment.glsl
+++ b/shaders/outline.fragment.glsl
@@ -9,4 +9,8 @@ void main() {
     float dist = length(v_pos - gl_FragCoord.xy);
     float alpha = smoothstep(1.0, 0.0, dist);
     gl_FragColor = u_color * (alpha * u_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/outlinepattern.fragment.glsl
+++ b/shaders/outlinepattern.fragment.glsl
@@ -29,4 +29,8 @@ void main() {
     
 
     gl_FragColor = mix(color1, color2, u_mix) * alpha * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/pattern.fragment.glsl
+++ b/shaders/pattern.fragment.glsl
@@ -23,4 +23,8 @@ void main() {
     vec4 color2 = texture2D(u_image, pos2);
 
     gl_FragColor = mix(color1, color2, u_mix) * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/raster.fragment.glsl
+++ b/shaders/raster.fragment.glsl
@@ -40,4 +40,8 @@ void main() {
     vec3 u_low_vec = vec3(u_brightness_high, u_brightness_high, u_brightness_high);
 
     gl_FragColor = vec4(mix(u_high_vec, u_low_vec, rgb), color.a);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/sdf.fragment.glsl
+++ b/shaders/sdf.fragment.glsl
@@ -17,4 +17,8 @@ void main() {
     lowp float gamma = u_gamma * v_gamma_scale;
     lowp float alpha = smoothstep(u_buffer - gamma, u_buffer + gamma, dist) * fade_alpha;
     gl_FragColor = u_color * (alpha * u_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -38,17 +38,17 @@ test('Bucket', function(t) {
         };
 
         Class.prototype.addTestVertex = function(x, y) {
-            return this.arrays.testVertex.emplaceBack(x * 2, y * 2);
+            return this.arrays.test.layout.vertex.emplaceBack(x * 2, y * 2);
         };
 
         Class.prototype.addFeature = function(feature) {
             this.makeRoomFor('test', 1);
             var point = feature.loadGeometry()[0][0];
-            var startIndex = this.arrays.testVertex.length;
+            var startIndex = this.arrays.test.layout.vertex.length;
             this.addTestVertex(point.x, point.y);
-            this.arrays.testElement.emplaceBack(1, 2, 3);
-            this.arrays.testSecondElement.emplaceBack(point.x, point.y);
-            this.addPaintAttributes('test', {}, feature.properties, startIndex, this.arrays.testVertex.length);
+            this.arrays.test.layout.element.emplaceBack(1, 2, 3);
+            this.arrays.test.layout.secondElement.emplaceBack(point.x, point.y);
+            this.addPaintAttributes('test', {}, feature.properties, startIndex, this.arrays.test.layout.vertex.length);
         };
 
         return Class;
@@ -103,24 +103,24 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrays.testVertex;
+        var testVertex = bucket.arrays.test.layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.box0, 34);
         t.equal(v0.box1, 84);
-        var paintVertex = bucket.arrays.layeridTest;
+        var paintVertex = bucket.arrays.test.paint.layerid;
         t.equal(paintVertex.length, 1);
         var p0 = paintVertex.get(0);
         t.equal(p0.map, 17);
 
-        var testElement = bucket.arrays.testElement;
+        var testElement = bucket.arrays.test.layout.element;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testSecondElement = bucket.arrays.testSecondElement;
+        var testSecondElement = bucket.arrays.test.layout.secondElement;
         t.equal(testSecondElement.length, 1);
         var e2 = testSecondElement.get(0);
         t.equal(e2.vertices0, 17);
@@ -138,9 +138,9 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var v0 = bucket.arrays.testVertex.get(0);
-        var a0 = bucket.arrays.oneTest.get(0);
-        var b0 = bucket.arrays.twoTest.get(0);
+        var v0 = bucket.arrays.test.layout.vertex.get(0);
+        var a0 = bucket.arrays.test.paint.one.get(0);
+        var b0 = bucket.arrays.test.paint.two.get(0);
         t.equal(a0.map, 17);
         t.equal(b0.map, 17);
         t.equal(v0.box0, 34);
@@ -166,7 +166,7 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        t.equal(bucket.arrays.testVertex.bytesPerElement, 0);
+        t.equal(bucket.arrays.test.layout.vertex.bytesPerElement, 0);
         t.deepEqual(
             bucket.paintAttributes.test.one.uniforms[0].getValue.call(bucket),
             [5]
@@ -187,7 +187,7 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var v0 = bucket.arrays.testVertex.get(0);
+        var v0 = bucket.arrays.test.layout.vertex.get(0);
         t.equal(v0.map, 34);
 
         t.end();
@@ -203,8 +203,8 @@ test('Bucket', function(t) {
         var arrays = bucket.arrays;
 
         t.equal(bucket.arrays, arrays);
-        t.equal(arrays.testElement.length, 0);
-        t.equal(arrays.testSecondElement.length, 0);
+        t.equal(arrays.test.layout.element.length, 0);
+        t.equal(arrays.test.layout.secondElement.length, 0);
         t.equal(bucket.elementGroups.test.length, 0);
 
         t.end();
@@ -219,24 +219,24 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrays.testVertex;
+        var testVertex = bucket.arrays.test.layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.box0, 34);
         t.equal(v0.box1, 84);
-        var testPaintVertex = bucket.arrays.layeridTest;
+        var testPaintVertex = bucket.arrays.test.paint.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
         t.equal(p0.map, 17);
 
-        var testElement = bucket.arrays.testElement;
+        var testElement = bucket.arrays.test.layout.element;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testSecondElement = bucket.arrays.testSecondElement;
+        var testSecondElement = bucket.arrays.test.layout.secondElement;
         t.equal(testSecondElement.length, 1);
         var e2 = testSecondElement.get(0);
         t.equal(e2.vertices0, 17);
@@ -257,24 +257,24 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrays.testVertex;
+        var testVertex = bucket.arrays.test.layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.box0, 34);
         t.equal(v0.box1, 84);
-        var testPaintVertex = bucket.arrays.layeridTest;
+        var testPaintVertex = bucket.arrays.test.paint.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
         t.equal(p0.map, 17);
 
-        var testElement = bucket.arrays.testElement;
+        var testElement = bucket.arrays.test.layout.element;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testSecondElement = bucket.arrays.testSecondElement;
+        var testSecondElement = bucket.arrays.test.layout.secondElement;
         t.equal(testSecondElement.length, 1);
         var e2 = testSecondElement.get(0);
         t.equal(e2.vertices0, 17);


### PR DESCRIPTION
fixes #1361

When the extension is available, use it to record and re-apply buffer binds and attrib pointer setting. When the extension isn't available this just sets the pointers and binds the buffers each time.

This also namespaces bucket buffers/arrays with objects instead of string concatenation.

I ran the frame-duration benchmark four times for master (3a95d00) and this branch:

```
vao:        15.3 ms
master:     17.9 ms
vao:        15.5 ms
master:     18.2 ms
vao:        14.2 ms
master:     18.5 ms
vao:        15.2 ms
master:     17.4 ms

vao average:    15 ms
master average: 18 ms
```

This branch takes **83%** of the time that master takes.

:eyes: @lucaswoj 