### PR TITLE
eliminate element groups and optimize some things

### DIFF
--- a/bench/benchmarks/frame_duration.js
+++ b/bench/benchmarks/frame_duration.js
@@ -6,6 +6,16 @@ var formatNumber = require('../lib/format_number');
 
 var DURATION_MILLISECONDS = 1 * 5000;
 
+// The goal of this benchmark is to measure the time it takes to run the cpu
+// part of rendering. While the gpu rendering happens asynchronously, sometimes
+// when the gpu falls behind the cpu commands synchronously wait for the gpu to catch up.
+// This ends up affecting the duration of the call on the cpu.
+//
+// Setting the devicePixelRatio to a small number makes the canvas very small.
+// This greatly reduces the amount of work the gpu needs to do and reduces the
+// impact the actual rendering has on this benchmark.
+window.devicePixelRatio = 1 / 16;
+
 var zooms = [4, 8, 11, 13, 15, 17];
 var results = [];
 
@@ -20,7 +30,7 @@ module.exports = function(options) {
         measureFrameTime(options, zooms[index], function(err_, result) {
             results[index] = result;
             evented.fire('log', {
-                message: formatNumber(result.sum / result.count) + ' ms per frame at zoom ' + zooms[index] + '. ' +
+                message: formatNumber(result.sum / result.count * 10) / 10 + ' ms per frame at zoom ' + zooms[index] + '. ' +
                     formatNumber(result.countAbove16 / result.count * 100) + '% of frames took longer than 16ms.'
             });
             callback();

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -20,8 +20,8 @@ function CircleBucket() {
 
 CircleBucket.prototype = util.inherit(Bucket, {});
 
-CircleBucket.prototype.addCircleVertex = function(x, y, extrudeX, extrudeY) {
-    return this.arrays.circle.layout.vertex.emplaceBack(
+CircleBucket.prototype.addCircleVertex = function(vertexArray, x, y, extrudeX, extrudeY) {
+    return vertexArray.emplaceBack(
             (x * 2) + ((extrudeX + 1) / 2),
             (y * 2) + ((extrudeY + 1) / 2));
 };
@@ -63,7 +63,8 @@ CircleBucket.prototype.addFeature = function(feature) {
     var globalProperties = {zoom: this.zoom};
     var geometries = loadGeometry(feature);
 
-    var startIndex = this.arrays.circle.layout.vertex.length;
+    var startGroup = this.makeRoomFor('circle', 0);
+    var startIndex = startGroup.layout.vertex.length;
 
     for (var j = 0; j < geometries.length; j++) {
         for (var k = 0; k < geometries[j].length; k++) {
@@ -84,18 +85,17 @@ CircleBucket.prototype.addFeature = function(feature) {
             // └─────────┘
 
             var group = this.makeRoomFor('circle', 4);
+            var vertexArray = group.layout.vertex;
 
-            var index = this.addCircleVertex(x, y, -1, -1) - group.vertexStartIndex;
-            this.addCircleVertex(x, y, 1, -1);
-            this.addCircleVertex(x, y, 1, 1);
-            this.addCircleVertex(x, y, -1, 1);
-            group.vertexLength += 4;
+            var index = this.addCircleVertex(vertexArray, x, y, -1, -1);
+            this.addCircleVertex(vertexArray, x, y, 1, -1);
+            this.addCircleVertex(vertexArray, x, y, 1, 1);
+            this.addCircleVertex(vertexArray, x, y, -1, 1);
 
-            this.arrays.circle.layout.element.emplaceBack(index, index + 1, index + 2);
-            this.arrays.circle.layout.element.emplaceBack(index, index + 3, index + 2);
-            group.elementLength += 2;
+            group.layout.element.emplaceBack(index, index + 1, index + 2);
+            group.layout.element.emplaceBack(index, index + 3, index + 2);
         }
     }
 
-    this.addPaintAttributes('circle', globalProperties, feature.properties, startIndex, this.arrays.circle.layout.vertex.length);
+    this.addPaintAttributes('circle', globalProperties, feature.properties, startGroup, startIndex);
 };

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -12,16 +12,12 @@ function FillBucket() {
 
 FillBucket.prototype = util.inherit(Bucket, {});
 
-FillBucket.prototype.addFillVertex = function(x, y) {
-    return this.arrays.fill.layout.vertex.emplaceBack(x, y);
-};
-
 FillBucket.prototype.programInterfaces = {
     fill: {
         vertexBuffer: true,
         elementBuffer: true,
-        secondElementBuffer: true,
-        secondElementBufferComponents: 2,
+        elementBuffer2: true,
+        elementBuffer2Components: 2,
 
         layoutAttributes: [{
             name: 'a_pos',
@@ -61,19 +57,16 @@ FillBucket.prototype.addFill = function(vertices) {
     for (var i = 0; i < vertices.length; i++) {
         var currentVertex = vertices[i];
 
-        var currentIndex = this.addFillVertex(currentVertex.x, currentVertex.y) - group.vertexStartIndex;
-        group.vertexLength++;
+        var currentIndex = group.layout.vertex.emplaceBack(currentVertex.x, currentVertex.y);
         if (i === 0) firstIndex = currentIndex;
 
         // Only add triangles that have distinct vertices.
         if (i >= 2 && (currentVertex.x !== vertices[0].x || currentVertex.y !== vertices[0].y)) {
-            this.arrays.fill.layout.element.emplaceBack(firstIndex, prevIndex, currentIndex);
-            group.elementLength++;
+            group.layout.element.emplaceBack(firstIndex, prevIndex, currentIndex);
         }
 
         if (i >= 1) {
-            this.arrays.fill.layout.secondElement.emplaceBack(prevIndex, currentIndex);
-            group.secondElementLength++;
+            group.layout.element2.emplaceBack(prevIndex, currentIndex);
         }
 
         prevIndex = currentIndex;

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -50,8 +50,8 @@ function LineBucket() {
 
 LineBucket.prototype = util.inherit(Bucket, {});
 
-LineBucket.prototype.addLineVertex = function(point, extrude, tx, ty, dir, linesofar) {
-    return this.arrays.line.layout.vertex.emplaceBack(
+LineBucket.prototype.addLineVertex = function(vertexBuffer, point, extrude, tx, ty, dir, linesofar) {
+    return vertexBuffer.emplaceBack(
             // a_pos
             (point.x << 1) | tx,
             (point.y << 1) | ty,
@@ -368,25 +368,24 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
 LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal, endLeft, endRight, round) {
     var tx = round ? 1 : 0;
     var extrude;
-    var group = this.elementGroups.line[this.elementGroups.line.length - 1];
-    group.vertexLength += 2;
+    var layoutArrays = this.arrayGroups.line[this.arrayGroups.line.length - 1].layout;
+    var vertexArray = layoutArrays.vertex;
+    var elementArray = layoutArrays.element;
 
     extrude = normal.clone();
     if (endLeft) extrude._sub(normal.perp()._mult(endLeft));
-    this.e3 = this.addLineVertex(currentVertex, extrude, tx, 0, endLeft, distance) - group.vertexStartIndex;
+    this.e3 = this.addLineVertex(vertexArray, currentVertex, extrude, tx, 0, endLeft, distance);
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.arrays.line.layout.element.emplaceBack(this.e1, this.e2, this.e3);
-        group.elementLength++;
+        elementArray.emplaceBack(this.e1, this.e2, this.e3);
     }
     this.e1 = this.e2;
     this.e2 = this.e3;
 
     extrude = normal.mult(-1);
     if (endRight) extrude._sub(normal.perp()._mult(endRight));
-    this.e3 = this.addLineVertex(currentVertex, extrude, tx, 1, -endRight, distance) - group.vertexStartIndex;
+    this.e3 = this.addLineVertex(vertexArray, currentVertex, extrude, tx, 1, -endRight, distance);
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.arrays.line.layout.element.emplaceBack(this.e1, this.e2, this.e3);
-        group.elementLength++;
+        elementArray.emplaceBack(this.e1, this.e2, this.e3);
     }
     this.e1 = this.e2;
     this.e2 = this.e3;
@@ -414,14 +413,14 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal
 LineBucket.prototype.addPieSliceVertex = function(currentVertex, distance, extrude, lineTurnsLeft) {
     var ty = lineTurnsLeft ? 1 : 0;
     extrude = extrude.mult(lineTurnsLeft ? -1 : 1);
-    var group = this.elementGroups.line[this.elementGroups.line.length - 1];
+    var layoutArrays = this.arrayGroups.line[this.arrayGroups.line.length - 1].layout;
+    var vertexArray = layoutArrays.vertex;
+    var elementArray = layoutArrays.element;
 
-    this.e3 = this.addLineVertex(currentVertex, extrude, 0, ty, 0, distance) - group.vertexStartIndex;
-    group.vertexLength++;
+    this.e3 = this.addLineVertex(vertexArray, currentVertex, extrude, 0, ty, 0, distance);
 
     if (this.e1 >= 0 && this.e2 >= 0) {
-        this.arrays.line.layout.element.emplaceBack(this.e1, this.e2, this.e3);
-        group.elementLength++;
+        elementArray.emplaceBack(this.e1, this.e2, this.e3);
     }
 
     if (lineTurnsLeft) {

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -29,9 +29,25 @@ function SymbolBucket(options) {
     this.showCollisionBoxes = options.showCollisionBoxes;
     this.overscaling = options.overscaling;
     this.collisionBoxArray = options.collisionBoxArray;
+
+    this.sdfIcons = options.sdfIcons;
+    this.iconsNeedLinear = options.iconsNeedLinear;
+    this.adjustedTextSize = options.adjustedTextSize;
+    this.adjustedIconSize = options.adjustedIconSize;
+    this.fontstack = options.fontstack;
 }
 
 SymbolBucket.prototype = util.inherit(Bucket, {});
+
+SymbolBucket.prototype.serialize = function() {
+    var serialized = Bucket.prototype.serialize.apply(this);
+    serialized.sdfIcons = this.sdfIcons;
+    serialized.iconsNeedLinear = this.iconsNeedLinear;
+    serialized.adjustedTextSize = this.adjustedTextSize;
+    serialized.adjustedIconSize = this.adjustedIconSize;
+    serialized.fontstack = this.fontstack;
+    return serialized;
+};
 
 var programAttributes = [{
     name: 'a_pos',
@@ -69,8 +85,8 @@ function addVertex(array, x, y, ox, oy, tx, ty, minzoom, maxzoom, labelminzoom) 
             Math.min(maxzoom || 25, 25) * 10); // minzoom
 }
 
-SymbolBucket.prototype.addCollisionBoxVertex = function(point, extrude, maxZoom, placementZoom) {
-    return this.arrays.collisionBox.layout.vertex.emplaceBack(
+SymbolBucket.prototype.addCollisionBoxVertex = function(vertexArray, point, extrude, maxZoom, placementZoom) {
+    return vertexArray.emplaceBack(
             // pos
             point.x,
             point.y,
@@ -175,7 +191,7 @@ SymbolBucket.prototype.populateBuffers = function(collisionTile, stacks, icons) 
     var maxWidth = layout['symbol-placement'] !== 'line' ? layout['text-max-width'] * oneEm : 0;
     var spacing = layout['text-letter-spacing'] * oneEm;
     var textOffset = [layout['text-offset'][0] * oneEm, layout['text-offset'][1] * oneEm];
-    var fontstack = layout['text-font'].join(',');
+    var fontstack = this.fontstack = layout['text-font'].join(',');
 
     var geometries = [];
     for (var g = 0; g < features.length; g++) {
@@ -339,22 +355,9 @@ SymbolBucket.prototype.placeFeatures = function(collisionTile, showCollisionBoxe
 
     this.createArrays();
 
-    var elementGroups = this.elementGroups = {
-        glyph: [],
-        icon: [],
-        sdfIcons: this.sdfIcons,
-        iconsNeedLinear: this.iconsNeedLinear
-    };
-
     var layout = this.layer.layout;
+
     var maxScale = collisionTile.maxScale;
-
-    elementGroups.glyph.adjustedSize = this.adjustedTextSize;
-    elementGroups.icon.adjustedSize = this.adjustedIconSize;
-
-    // Transfer the name of the fonstack back to the main thread along with the buffers.
-    // The draw function needs to know which fonstack's glyph atlas to bind when rendering.
-    elementGroups.glyph.fontstack = layout['text-font'].join(',');
 
     var textAlongLine = layout['text-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';
     var iconAlongLine = layout['icon-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';
@@ -436,8 +439,8 @@ SymbolBucket.prototype.addSymbols = function(programName, quads, scale, keepUpri
 
     var group = this.makeRoomFor(programName, 4 * quads.length);
 
-    var elementArray = this.arrays[programName].layout.element;
-    var vertexArray = this.arrays[programName].layout.vertex;
+    var elementArray = group.layout.element;
+    var vertexArray = group.layout.vertex;
 
     var zoom = this.zoom;
     var placementZoom = Math.max(Math.log(scale) / Math.LN2 + zoom, 0);
@@ -466,15 +469,13 @@ SymbolBucket.prototype.addSymbols = function(programName, quads, scale, keepUpri
         // Lower min zoom so that while fading out the label it can be shown outside of collision-free zoom levels
         if (minZoom === placementZoom) minZoom = 0;
 
-        var index = addVertex(vertexArray, anchorPoint.x, anchorPoint.y, tl.x, tl.y, tex.x, tex.y, minZoom, maxZoom, placementZoom) - group.vertexStartIndex;
+        var index = addVertex(vertexArray, anchorPoint.x, anchorPoint.y, tl.x, tl.y, tex.x, tex.y, minZoom, maxZoom, placementZoom);
         addVertex(vertexArray, anchorPoint.x, anchorPoint.y, tr.x, tr.y, tex.x + tex.w, tex.y, minZoom, maxZoom, placementZoom);
         addVertex(vertexArray, anchorPoint.x, anchorPoint.y, bl.x, bl.y, tex.x, tex.y + tex.h, minZoom, maxZoom, placementZoom);
         addVertex(vertexArray, anchorPoint.x, anchorPoint.y, br.x, br.y, tex.x + tex.w, tex.y + tex.h, minZoom, maxZoom, placementZoom);
-        group.vertexLength += 4;
 
         elementArray.emplaceBack(index, index + 1, index + 2);
         elementArray.emplaceBack(index + 1, index + 2, index + 3);
-        group.elementLength += 2;
     }
 
 };
@@ -500,8 +501,8 @@ SymbolBucket.prototype.updateFont = function(stacks) {
 };
 
 SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
-    this.elementGroups.collisionBox = [];
     var group = this.makeRoomFor('collisionBox', 0);
+    var vertexArray = group.layout.vertex;
     var angle = -collisionTile.angle;
     var yStretch = collisionTile.yStretch;
 
@@ -522,15 +523,14 @@ SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
                 var maxZoom = Math.max(0, Math.min(25, this.zoom + Math.log(box.maxScale) / Math.LN2));
                 var placementZoom = Math.max(0, Math.min(25, this.zoom + Math.log(box.placementScale) / Math.LN2));
 
-                this.addCollisionBoxVertex(anchorPoint, tl, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(anchorPoint, tr, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(anchorPoint, tr, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(anchorPoint, br, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(anchorPoint, br, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(anchorPoint, bl, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(anchorPoint, bl, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(anchorPoint, tl, maxZoom, placementZoom);
-                group.vertexLength += 8;
+                this.addCollisionBoxVertex(vertexArray, anchorPoint, tl, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(vertexArray, anchorPoint, tr, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(vertexArray, anchorPoint, tr, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(vertexArray, anchorPoint, br, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(vertexArray, anchorPoint, br, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(vertexArray, anchorPoint, bl, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(vertexArray, anchorPoint, bl, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(vertexArray, anchorPoint, tl, maxZoom, placementZoom);
             }
         }
     }

--- a/js/data/buffer.js
+++ b/js/data/buffer.js
@@ -60,9 +60,8 @@ var AttributeType = {
  * @private
  * @param gl The WebGL context
  * @param program The active WebGL program
- * @param {number} offset The index offset of the attribute data in the currently bound GL buffer.
  */
-Buffer.prototype.setVertexAttribPointers = function(gl, program, offset) {
+Buffer.prototype.setVertexAttribPointers = function(gl, program) {
     for (var j = 0; j < this.attributes.length; j++) {
         var member = this.attributes[j];
         var attribIndex = program[member.name];
@@ -74,7 +73,7 @@ Buffer.prototype.setVertexAttribPointers = function(gl, program, offset) {
             gl[AttributeType[member.type]],
             false,
             this.arrayType.bytesPerElement,
-            offset * this.arrayType.bytesPerElement + member.offset
+            member.offset
         );
     }
 };

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -131,10 +131,7 @@ Transform.prototype = {
         this.width = width;
         this.height = height;
 
-        // The extrusion matrix
-        this.exMatrix = mat4.create();
-        mat4.ortho(this.exMatrix, 0, width, height, 0, 0, -1);
-
+        this.pixelsToGLUnits = [2 / width, -2 / height];
         this._calcProjMatrix();
         this._constrain();
     },

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -91,7 +91,7 @@ function drawBackground(painter, source, layer) {
             gl.uniform2fv(program.u_offset_b, [offsetBx, offsetBy]);
         }
 
-        painter.setPosMatrix(painter.transform.calculatePosMatrix(coord));
+        gl.uniformMatrix4fv(program.u_matrix, false, painter.transform.calculatePosMatrix(coord));
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.length);
     }
 

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -36,7 +36,7 @@ function drawBackground(painter, source, layer) {
 
         painter.spriteAtlas.bind(gl, true);
 
-        painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
+        painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer);
     } else {
         // Draw filling rectangle.
         if (painter.isOpaquePass !== (color[3] === 1)) return;
@@ -44,7 +44,7 @@ function drawBackground(painter, source, layer) {
         program = painter.useProgram('fill');
         gl.uniform4fv(program.u_color, color);
         gl.uniform1f(program.u_opacity, opacity);
-        painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
+        painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer);
     }
 
     gl.disable(gl.STENCIL_TEST);

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -27,19 +27,19 @@ function drawCircles(painter, source, layer, coords) {
 
         var program = painter.useProgram('circle', bucket.getProgramMacros('circle', layer));
 
+        gl. uniformMatrix4fv(program.u_exmatrix, false, painter.transform.exMatrix);
         gl.uniform1f(program.u_blur, layer.paint['circle-blur']);
         gl.uniform1f(program.u_devicepixelratio, browser.devicePixelRatio);
         gl.uniform1f(program.u_opacity, layer.paint['circle-opacity']);
 
-        bucket.setUniforms(gl, 'circle', program, layer, {zoom: painter.transform.zoom});
-
-        painter.setPosMatrix(painter.translatePosMatrix(
+        gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
             coord.posMatrix,
             tile,
             layer.paint['circle-translate'],
             layer.paint['circle-translate-anchor']
         ));
-        painter.setExMatrix(painter.transform.exMatrix);
+
+        bucket.setUniforms(gl, 'circle', program, layer, {zoom: painter.transform.zoom});
 
         var buffers = bucket.buffers.circle;
         var vertexBuffer = buffers.layout.vertex;

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -27,7 +27,7 @@ function drawCircles(painter, source, layer, coords) {
 
         var program = painter.useProgram('circle', bucket.getProgramMacros('circle', layer));
 
-        gl. uniformMatrix4fv(program.u_exmatrix, false, painter.transform.exMatrix);
+        gl.uniform2fv(program.u_extrude_scale, painter.transform.pixelsToGLUnits);
         gl.uniform1f(program.u_blur, layer.paint['circle-blur']);
         gl.uniform1f(program.u_devicepixelratio, browser.devicePixelRatio);
         gl.uniform1f(program.u_opacity, layer.paint['circle-opacity']);

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -22,8 +22,8 @@ function drawCircles(painter, source, layer, coords) {
         var tile = source.getTile(coord);
         var bucket = tile.getBucket(layer);
         if (!bucket) continue;
-        var elementGroups = bucket.elementGroups.circle;
-        if (!elementGroups) continue;
+        var bufferGroups = bucket.bufferGroups.circle;
+        if (!bufferGroups) continue;
 
         var program = painter.useProgram('circle', bucket.getProgramMacros('circle', layer));
 
@@ -41,16 +41,10 @@ function drawCircles(painter, source, layer, coords) {
 
         bucket.setUniforms(gl, 'circle', program, layer, {zoom: painter.transform.zoom});
 
-        var buffers = bucket.buffers.circle;
-        var vertexBuffer = buffers.layout.vertex;
-        var elementBuffer = buffers.layout.element;
-        var paintVertexBuffer = buffers.paint[layer.id];
-
-        for (var k = 0; k < elementGroups.length; k++) {
-            var group = elementGroups[k];
-            var count = group.elementLength * 3;
-            group.vaos[layer.id].bind(gl, program, vertexBuffer, paintVertexBuffer, group.vertexStartIndex, elementBuffer);
-            gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+        for (var k = 0; k < bufferGroups.length; k++) {
+            var group = bufferGroups[k];
+            group.vaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element, group.paint[layer.id]);
+            gl.drawElements(gl.TRIANGLES, group.layout.element.length * 3, gl.UNSIGNED_SHORT, 0);
         }
     }
 }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -12,11 +12,11 @@ function drawCollisionDebug(painter, source, layer, coords) {
         var tile = source.getTile(coord);
         var bucket = tile.getBucket(layer);
         if (!bucket) continue;
-        var elementGroups = bucket.elementGroups.collisionBox;
+        var bufferGroups = bucket.bufferGroups.collisionBox;
 
-        if (!elementGroups) continue;
-        if (!bucket.buffers) continue;
-        if (elementGroups[0].vertexLength === 0) continue;
+        if (!bufferGroups || !bufferGroups.length) continue;
+        var group = bufferGroups[0];
+        if (group.layout.vertex.length === 0) continue;
 
         gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
@@ -27,13 +27,7 @@ function drawCollisionDebug(painter, source, layer, coords) {
         gl.uniform1f(program.u_zoom, painter.transform.zoom * 10);
         gl.uniform1f(program.u_maxzoom, (tile.coord.z + 1) * 10);
 
-        var buffers = bucket.buffers.collisionBox;
-        var vertexBuffer = buffers.layout.vertex;
-        elementGroups[0].vaos[layer.id].bind(gl, program, vertexBuffer, undefined, elementGroups[0].vertexStartIndex, undefined);
-        gl.drawArrays(
-            gl.LINES,
-            elementGroups[0].vertexStartIndex,
-            elementGroups[0].vertexLength
-        );
+        group.vaos[layer.id].bind(gl, program, group.layout.vertex);
+        gl.drawArrays(gl.LINES, 0, group.layout.vertex.length);
     }
 }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -18,7 +18,7 @@ function drawCollisionDebug(painter, source, layer, coords) {
         if (!bucket.buffers) continue;
         if (elementGroups[0].vertexLength === 0) continue;
 
-        painter.setPosMatrix(coord.posMatrix);
+        gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
         painter.enableTileClippingMask(coord);
 

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -29,7 +29,7 @@ function drawDebugTile(painter, source, coord) {
 
     gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
     gl.uniform4f(program.u_color, 1, 0, 0, 1);
-    painter.debugVAO.bind(gl, program, painter.debugBuffer, undefined, 0, undefined);
+    painter.debugVAO.bind(gl, program, painter.debugBuffer);
     gl.drawArrays(gl.LINE_STRIP, 0, painter.debugBuffer.length);
 
     var vertices = textVertices(coord.toString(), 50, 200, 5);
@@ -39,7 +39,7 @@ function drawDebugTile(painter, source, coord) {
     }
     var debugTextBuffer = new Buffer(debugTextArray.serialize(), painter.PosArray.serialize(), Buffer.BufferType.VERTEX);
     var debugTextVAO = new VertexArrayObject();
-    debugTextVAO.bind(gl, program, debugTextBuffer, undefined, 0, undefined);
+    debugTextVAO.bind(gl, program, debugTextBuffer);
     gl.uniform4f(program.u_color, 1, 1, 1, 1);
 
     // Draw the halo with multiple 1px lines instead of one wider line because
@@ -49,7 +49,7 @@ function drawDebugTile(painter, source, coord) {
     var translations = [[-1, -1], [-1, 1], [1, -1], [1, 1]];
     for (var i = 0; i < translations.length; i++) {
         var translation = translations[i];
-        gl.uniformMatrix4fv(program.u_matrix, false, mat4.translate([], posMatrix, [onePixel * translation[0], onePixel * translation[1], 0]))
+        gl.uniformMatrix4fv(program.u_matrix, false, mat4.translate([], posMatrix, [onePixel * translation[0], onePixel * translation[1], 0]));
         gl.drawArrays(gl.LINES, 0, debugTextBuffer.length);
     }
 

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -26,8 +26,8 @@ function drawDebugTile(painter, source, coord) {
 
     var posMatrix = coord.posMatrix;
     var program = painter.useProgram('debug');
-    painter.setPosMatrix(posMatrix);
 
+    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
     gl.uniform4f(program.u_color, 1, 0, 0, 1);
     painter.debugVAO.bind(gl, program, painter.debugBuffer, undefined, 0, undefined);
     gl.drawArrays(gl.LINE_STRIP, 0, painter.debugBuffer.length);
@@ -49,11 +49,11 @@ function drawDebugTile(painter, source, coord) {
     var translations = [[-1, -1], [-1, 1], [1, -1], [1, 1]];
     for (var i = 0; i < translations.length; i++) {
         var translation = translations[i];
-        painter.setPosMatrix(mat4.translate([], posMatrix, [onePixel * translation[0], onePixel * translation[1], 0]));
+        gl.uniformMatrix4fv(program.u_matrix, false, mat4.translate([], posMatrix, [onePixel * translation[0], onePixel * translation[1], 0]))
         gl.drawArrays(gl.LINES, 0, debugTextBuffer.length);
     }
 
     gl.uniform4f(program.u_color, 0, 0, 0, 1);
-    painter.setPosMatrix(posMatrix);
+    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
     gl.drawArrays(gl.LINES, 0, debugTextBuffer.length);
 }

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -74,8 +74,8 @@ function drawFill(painter, source, layer, coord) {
     var tile = source.getTile(coord);
     var bucket = tile.getBucket(layer);
     if (!bucket) return;
-    var elementGroups = bucket.elementGroups.fill;
-    if (!elementGroups) return;
+    var bufferGroups = bucket.bufferGroups.fill;
+    if (!bufferGroups) return;
 
     var gl = painter.gl;
 
@@ -115,15 +115,10 @@ function drawFill(painter, source, layer, coord) {
     var fillProgram = painter.useProgram('fill');
     gl.uniformMatrix4fv(fillProgram.u_matrix, false, translatedPosMatrix);
 
-    var buffers = bucket.buffers.fill.layout;
-    var vertexBuffer = buffers.vertex;
-    var elementBuffer = buffers.element;
-
-    for (var i = 0; i < elementGroups.length; i++) {
-        var group = elementGroups[i];
-        var count = group.elementLength * 3;
-        group.vaos[layer.id].bind(gl, fillProgram, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
-        gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+    for (var i = 0; i < bufferGroups.length; i++) {
+        var group = bufferGroups[i];
+        group.vaos[layer.id].bind(gl, fillProgram, group.layout.vertex, group.layout.element);
+        gl.drawElements(gl.TRIANGLES, group.layout.element.length * 3, gl.UNSIGNED_SHORT, 0);
     }
 
     // Now that we have the stencil mask in the stencil buffer, we can start
@@ -144,14 +139,14 @@ function drawFill(painter, source, layer, coord) {
         gl.activeTexture(gl.TEXTURE0);
         painter.spriteAtlas.bind(gl, true);
 
-        painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
+        painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer);
 
     } else {
         // Draw filling rectangle.
         program = painter.useProgram('fill');
         gl.uniform4fv(fillProgram.u_color, color);
         gl.uniform1f(fillProgram.u_opacity, opacity);
-        painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
+        painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer);
     }
 
     gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
@@ -170,7 +165,7 @@ function drawStroke(painter, source, layer, coord) {
     if (!bucket) return;
 
     var gl = painter.gl;
-    var elementGroups = bucket.elementGroups.fill;
+    var bufferGroups = bucket.bufferGroups.fill;
 
     var image = layer.paint['fill-pattern'];
     var opacity = layer.paint['fill-opacity'];
@@ -185,17 +180,12 @@ function drawStroke(painter, source, layer, coord) {
 
     if (image) { setPattern(image, opacity, tile, coord, painter, program); }
 
-    var buffers = bucket.buffers.fill.layout;
-    var vertexBuffer = buffers.vertex;
-    var elementBuffer = buffers.secondElement;
-
     painter.enableTileClippingMask(coord);
 
-    for (var k = 0; k < elementGroups.length; k++) {
-        var group = elementGroups[k];
-        var count = group.secondElementLength * 2;
-        group.secondVaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
-        gl.drawElements(gl.LINES, count, gl.UNSIGNED_SHORT, group.secondElementOffset);
+    for (var k = 0; k < bufferGroups.length; k++) {
+        var group = bufferGroups[k];
+        group.secondVaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element2);
+        gl.drawElements(gl.LINES, group.layout.element2.length * 2, gl.UNSIGNED_SHORT, 0);
     }
 }
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -113,7 +113,7 @@ function drawFill(painter, source, layer, coord) {
 
     // Draw the actual triangle fan into the stencil buffer.
     var fillProgram = painter.useProgram('fill');
-    painter.setPosMatrix(translatedPosMatrix);
+    gl.uniformMatrix4fv(fillProgram.u_matrix, false, translatedPosMatrix);
 
     var buffers = bucket.buffers.fill.layout;
     var vertexBuffer = buffers.vertex;
@@ -154,7 +154,7 @@ function drawFill(painter, source, layer, coord) {
         painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer, undefined, 0, undefined);
     }
 
-    painter.setPosMatrix(posMatrix);
+    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
 
     // Only draw regions that we marked
     gl.stencilFunc(gl.NOTEQUAL, 0x0, 0x07);
@@ -176,7 +176,7 @@ function drawStroke(painter, source, layer, coord) {
     var opacity = layer.paint['fill-opacity'];
     var program = image ? painter.useProgram('outlinepattern') : painter.useProgram('outline');
 
-    painter.setPosMatrix(painter.translatePosMatrix(
+    gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
         coord.posMatrix,
         tile,
         layer.paint['fill-translate'],

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -132,9 +132,8 @@ module.exports = function drawLine(painter, source, layer, coords) {
 
         // set uniforms that are different for each tile
         var posMatrix = painter.translatePosMatrix(coord.posMatrix, tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
+        gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
 
-        painter.setPosMatrix(posMatrix);
-        painter.setExMatrix(painter.transform.exMatrix);
         var ratio = 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom);
 
         if (dasharray) {

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -125,8 +125,8 @@ module.exports = function drawLine(painter, source, layer, coords) {
         var tile = source.getTile(coord);
         var bucket = tile.getBucket(layer);
         if (!bucket) continue;
-        var elementGroups = bucket.elementGroups.line;
-        if (!elementGroups) continue;
+        var bufferGroups = bucket.bufferGroups.line;
+        if (!bufferGroups) continue;
 
         painter.enableTileClippingMask(coord);
 
@@ -162,15 +162,10 @@ module.exports = function drawLine(painter, source, layer, coords) {
             gl.uniform1f(program.u_ratio, ratio);
         }
 
-        var buffers = bucket.buffers.line;
-        var vertexBuffer = buffers.layout.vertex;
-        var elementBuffer = buffers.layout.element;
-
-        for (var i = 0; i < elementGroups.length; i++) {
-            var group = elementGroups[i];
-            var count = group.elementLength * 3;
-            group.vaos[layer.id].bind(gl, program, vertexBuffer, undefined, group.vertexStartIndex, elementBuffer);
-            gl.drawElements(gl.TRIANGLES, count, gl.UNSIGNED_SHORT, group.elementOffset);
+        for (var i = 0; i < bufferGroups.length; i++) {
+            var group = bufferGroups[i];
+            group.vaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element);
+            gl.drawElements(gl.TRIANGLES, group.layout.element.length * 3, gl.UNSIGNED_SHORT, 0);
         }
     }
 

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -83,7 +83,7 @@ function drawRasterTile(painter, source, layer, coord) {
 
     var buffer = tile.boundsBuffer || painter.rasterBoundsBuffer;
     var vao = tile.boundsVAO || painter.rasterBoundsVAO;
-    vao.bind(gl, program, buffer, undefined, 0, undefined);
+    vao.bind(gl, program, buffer);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
 }
 

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -45,7 +45,7 @@ function drawRasterTile(painter, source, layer, coord) {
     var posMatrix = painter.transform.calculatePosMatrix(coord, source.maxzoom);
 
     var program = painter.useProgram('raster');
-    painter.setPosMatrix(posMatrix);
+    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
 
     // color parameters
     gl.uniform1f(program.u_brightness_low, layer.paint['raster-brightness-min']);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -144,8 +144,8 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, elementGroups, isTe
     gl.activeTexture(gl.TEXTURE0);
 
     var program = painter.useProgram(sdf ? 'sdf' : 'icon');
-    painter.setPosMatrix(posMatrix);
-    painter.setExMatrix(exMatrix);
+    gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(posMatrix, tile, translate, translateAnchor));
+    gl.uniformMatrix4fv(program.u_exmatrix, false, exMatrix);
 
     var texsize;
     if (isText) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -151,7 +151,7 @@ Painter.prototype._renderTileClippingMasks = function(coords) {
         gl.stencilFunc(gl.ALWAYS, id, 0xF8);
 
         var program = this.useProgram('fill');
-        this.setPosMatrix(coord.posMatrix);
+        gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
         // Draw the clipping mask
         this.tileExtentVAO.bind(gl, program, this.tileExtentBuffer, undefined, 0, undefined);
@@ -267,6 +267,7 @@ Painter.prototype.depthMask = function(mask) {
 Painter.prototype.renderLayer = function(painter, source, layer, coords) {
     if (layer.isHidden(this.transform.zoom)) return;
     if (layer.type !== 'background' && !coords.length) return;
+    this.id = layer.id;
     draw[layer.type](painter, source, layer, coords);
 };
 
@@ -312,28 +313,6 @@ Painter.prototype.saveTexture = function(texture) {
 Painter.prototype.getTexture = function(size) {
     var textures = this.reusableTextures[size];
     return textures && textures.length > 0 ? textures.pop() : null;
-};
-
-// Update the matrices if necessary. Note: This relies on object identity!
-// This means changing the matrix values without the actual matrix object
-// will FAIL to update the matrix properly.
-Painter.prototype.setPosMatrix = function(posMatrix) {
-    var program = this.currentProgram;
-    if (program.posMatrix !== posMatrix) {
-        this.gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
-        program.posMatrix = posMatrix;
-    }
-};
-
-// Update the matrices if necessary. Note: This relies on object identity!
-// This means changing the matrix values without the actual matrix object
-// will FAIL to update the matrix properly.
-Painter.prototype.setExMatrix = function(exMatrix) {
-    var program = this.currentProgram;
-    if (exMatrix && program.exMatrix !== exMatrix && program.u_exmatrix) {
-        this.gl.uniformMatrix4fv(program.u_exmatrix, false, exMatrix);
-        program.exMatrix = exMatrix;
-    }
 };
 
 Painter.prototype.lineWidth = function(width) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -154,7 +154,7 @@ Painter.prototype._renderTileClippingMasks = function(coords) {
         gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
         // Draw the clipping mask
-        this.tileExtentVAO.bind(gl, program, this.tileExtentBuffer, undefined, 0, undefined);
+        this.tileExtentVAO.bind(gl, program, this.tileExtentBuffer);
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, this.tileExtentBuffer.length);
     }
 

--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -8,14 +8,13 @@ function VertexArrayObject() {
     this.boundProgram = null;
     this.boundVertexBuffer = null;
     this.boundVertexBuffer2 = null;
-    this.boundVertexOffset = null;
     this.boundElementBuffer = null;
     this.vao = null;
 }
 
 var reported = false;
 
-VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, vertexBuffer2, vertexOffset, elementBuffer) {
+VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, elementBuffer, vertexBuffer2) {
 
     var ext = gl.extVertexArrayObject;
     if (ext === undefined) {
@@ -53,10 +52,10 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, vertexBuf
         }
 
         vertexBuffer.bind(gl);
-        vertexBuffer.setVertexAttribPointers(gl, program, vertexOffset);
+        vertexBuffer.setVertexAttribPointers(gl, program);
         if (vertexBuffer2) {
             vertexBuffer2.bind(gl);
-            vertexBuffer2.setVertexAttribPointers(gl, program, vertexOffset);
+            vertexBuffer2.setVertexAttribPointers(gl, program);
         }
         if (elementBuffer) {
             elementBuffer.bind(gl);
@@ -67,7 +66,6 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, vertexBuf
             this.boundProgram = program;
             this.boundVertexBuffer = vertexBuffer;
             this.boundVertexBuffer2 = vertexBuffer2;
-            this.boundVertexOffset = vertexOffset;
             this.boundElementBuffer = elementBuffer;
         }
 
@@ -76,7 +74,6 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, vertexBuf
         assert(this.boundProgram === program, 'trying to bind a VAO to a different shader');
         assert(this.boundVertexBuffer === vertexBuffer, 'trying to bind a VAO to a different vertex buffer');
         assert(this.boundVertexBuffer2 === vertexBuffer2, 'trying to bind a VAO to a different vertex buffer');
-        assert(this.boundVertexOffset === vertexOffset, 'trying to bind a VAO to a different vertex offset');
         assert(this.boundElementBuffer === elementBuffer, 'trying to bind a VAO to a different element buffer');
     }
 };

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -243,12 +243,15 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, showCollisionBoxes) 
 };
 
 function isBucketEmpty(bucket) {
-    for (var programName in bucket.arrays) {
-        var programArrays = bucket.arrays[programName];
-        for (var layoutOrPaint in programArrays) {
-            var arrays = programArrays[layoutOrPaint];
-            for (var bufferName in arrays) {
-                if (arrays[bufferName].length > 0) return true;
+    for (var programName in bucket.arrayGroups) {
+        var programArrayGroups = bucket.arrayGroups[programName];
+        for (var k = 0; k < programArrayGroups.length; k++) {
+            var programArrayGroup = programArrayGroups[k];
+            for (var layoutOrPaint in programArrayGroup) {
+                var arrays = programArrayGroup[layoutOrPaint];
+                for (var bufferName in arrays) {
+                    if (arrays[bufferName].length > 0) return true;
+                }
             }
         }
     }
@@ -263,12 +266,15 @@ function getTransferables(buckets) {
     var transferables = [];
     for (var i in buckets) {
         var bucket = buckets[i];
-        for (var programName in bucket.arrays) {
-            var programArrays = bucket.arrays[programName];
-            for (var layoutOrPaint in programArrays) {
-                var arrays = programArrays[layoutOrPaint];
-                for (var bufferName in arrays) {
-                    transferables.push(arrays[bufferName].arrayBuffer);
+        for (var programName in bucket.arrayGroups) {
+            var programArrayGroups = bucket.arrayGroups[programName];
+            for (var k = 0; k < programArrayGroups.length; k++) {
+                var programArrayGroup = programArrayGroups[k];
+                for (var layoutOrPaint in programArrayGroup) {
+                    var arrays = programArrayGroup[layoutOrPaint];
+                    for (var bufferName in arrays) {
+                        transferables.push(arrays[bufferName].arrayBuffer);
+                    }
                 }
             }
         }

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -1,7 +1,7 @@
 precision highp float;
 
 uniform mat4 u_matrix;
-uniform mat4 u_exmatrix;
+uniform vec2 u_extrude_scale;
 uniform float u_devicepixelratio;
 
 attribute vec2 a_pos;
@@ -64,14 +64,14 @@ void main(void) {
     // unencode the extrusion vector that we snuck into the a_pos vector
     v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
 
-    vec4 extrude = u_exmatrix * vec4(v_extrude * radius, 0, 0);
+    vec2 extrude = v_extrude * radius * u_extrude_scale;
     // multiply a_pos by 0.5, since we had it * 2 in order to sneak
     // in extrusion data
     gl_Position = u_matrix * vec4(floor(a_pos * 0.5), 0, 1);
 
     // gl_Position is divided by gl_Position.w after this shader runs.
     // Multiply the extrude by it so that it isn't affected by it.
-    gl_Position += extrude * gl_Position.w;
+    gl_Position.xy += extrude * gl_Position.w;
 
 #ifdef ATTRIBUTE_A_COLOR
     v_color = a_color / 255.0;

--- a/shaders/icon.vertex.glsl
+++ b/shaders/icon.vertex.glsl
@@ -9,10 +9,11 @@ attribute vec4 a_data2;
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
 uniform mat4 u_matrix;
-uniform mat4 u_exmatrix;
+
 uniform mediump float u_zoom;
 uniform bool u_skewed;
 uniform float u_extra;
+uniform vec2 u_extrude_scale;
 
 uniform vec2 u_texsize;
 
@@ -26,18 +27,15 @@ void main() {
     mediump float a_minzoom = a_zoom[0];
     mediump float a_maxzoom = a_zoom[1];
 
-    float a_fadedist = 10.0;
-
     // u_zoom is the current zoom level adjusted for the change in font size
     mediump float z = 2.0 - step(a_minzoom, u_zoom) - (1.0 - step(a_maxzoom, u_zoom));
 
+    vec2 extrude = u_extrude_scale * (a_offset / 64.0);
     if (u_skewed) {
-        vec4 extrude = u_exmatrix * vec4(a_offset / 64.0, 0, 0);
-        gl_Position = u_matrix * vec4(a_pos + extrude.xy, 0, 1);
+        gl_Position = u_matrix * vec4(a_pos + extrude, 0, 1);
         gl_Position.z += z * gl_Position.w;
     } else {
-        vec4 extrude = u_exmatrix * vec4(a_offset / 64.0, z, 0);
-        gl_Position = u_matrix * vec4(a_pos, 0, 1) + extrude;
+        gl_Position = u_matrix * vec4(a_pos, 0, 1) + vec4(extrude, 0, 0);
     }
 
     v_tex = a_tex / u_texsize;

--- a/shaders/sdf.vertex.glsl
+++ b/shaders/sdf.vertex.glsl
@@ -9,11 +9,11 @@ attribute vec4 a_data2;
 // matrix is for the vertex position, exmatrix is for rotating and projecting
 // the extrusion vector.
 uniform mat4 u_matrix;
-uniform mat4 u_exmatrix;
 
 uniform mediump float u_zoom;
 uniform bool u_skewed;
 uniform float u_extra;
+uniform vec2 u_extrude_scale;
 
 uniform vec2 u_texsize;
 
@@ -31,13 +31,12 @@ void main() {
     // u_zoom is the current zoom level adjusted for the change in font size
     mediump float z = 2.0 - step(a_minzoom, u_zoom) - (1.0 - step(a_maxzoom, u_zoom));
 
+    vec2 extrude = u_extrude_scale * (a_offset / 64.0);
     if (u_skewed) {
-        vec4 extrude = u_exmatrix * vec4(a_offset / 64.0, 0, 0);
-        gl_Position = u_matrix * vec4(a_pos + extrude.xy, 0, 1);
+        gl_Position = u_matrix * vec4(a_pos + extrude, 0, 1);
         gl_Position.z += z * gl_Position.w;
     } else {
-        vec4 extrude = u_exmatrix * vec4(a_offset / 64.0, z, 0);
-        gl_Position = u_matrix * vec4(a_pos, 0, 1) + extrude;
+        gl_Position = u_matrix * vec4(a_pos, 0, 1) + vec4(extrude, 0, 0);
     }
 
     // position of y on the screen

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -18,8 +18,8 @@ test('Bucket', function(t) {
             test: {
                 vertexBuffer: 'testVertex',
                 elementBuffer: 'testElement',
-                secondElementBuffer: 'testSecondElement',
-                secondElementBufferComponents: 2,
+                elementBuffer2: 'testElement2',
+                elementBuffer2Components: 2,
 
                 layoutAttributes: options.layoutAttributes || [{
                     name: 'box',
@@ -37,18 +37,14 @@ test('Bucket', function(t) {
             }
         };
 
-        Class.prototype.addTestVertex = function(x, y) {
-            return this.arrays.test.layout.vertex.emplaceBack(x * 2, y * 2);
-        };
-
         Class.prototype.addFeature = function(feature) {
-            this.makeRoomFor('test', 1);
+            var group = this.makeRoomFor('test', 1);
             var point = feature.loadGeometry()[0][0];
-            var startIndex = this.arrays.test.layout.vertex.length;
-            this.addTestVertex(point.x, point.y);
-            this.arrays.test.layout.element.emplaceBack(1, 2, 3);
-            this.arrays.test.layout.secondElement.emplaceBack(point.x, point.y);
-            this.addPaintAttributes('test', {}, feature.properties, startIndex, this.arrays.test.layout.vertex.length);
+            var startIndex = group.layout.vertex.length;
+            group.layout.vertex.emplaceBack(point.x * 2, point.y * 2);
+            group.layout.element.emplaceBack(1, 2, 3);
+            group.layout.element2.emplaceBack(point.x, point.y);
+            this.addPaintAttributes('test', {}, feature.properties, group, startIndex);
         };
 
         return Class;
@@ -103,26 +99,26 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrays.test.layout.vertex;
+        var testVertex = bucket.arrayGroups.test[0].layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.box0, 34);
         t.equal(v0.box1, 84);
-        var paintVertex = bucket.arrays.test.paint.layerid;
+        var paintVertex = bucket.arrayGroups.test[0].paint.layerid;
         t.equal(paintVertex.length, 1);
         var p0 = paintVertex.get(0);
         t.equal(p0.map, 17);
 
-        var testElement = bucket.arrays.test.layout.element;
+        var testElement = bucket.arrayGroups.test[0].layout.element;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testSecondElement = bucket.arrays.test.layout.secondElement;
-        t.equal(testSecondElement.length, 1);
-        var e2 = testSecondElement.get(0);
+        var testElement2 = bucket.arrayGroups.test[0].layout.element2;
+        t.equal(testElement2.length, 1);
+        var e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);
         t.equal(e2.vertices1, 42);
 
@@ -138,9 +134,9 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var v0 = bucket.arrays.test.layout.vertex.get(0);
-        var a0 = bucket.arrays.test.paint.one.get(0);
-        var b0 = bucket.arrays.test.paint.two.get(0);
+        var v0 = bucket.arrayGroups.test[0].layout.vertex.get(0);
+        var a0 = bucket.arrayGroups.test[0].paint.one.get(0);
+        var b0 = bucket.arrayGroups.test[0].paint.two.get(0);
         t.equal(a0.map, 17);
         t.equal(b0.map, 17);
         t.equal(v0.box0, 34);
@@ -166,7 +162,7 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        t.equal(bucket.arrays.test.layout.vertex.bytesPerElement, 0);
+        t.equal(bucket.arrayGroups.test[0].layout.vertex.bytesPerElement, 0);
         t.deepEqual(
             bucket.paintAttributes.test.one.uniforms[0].getValue.call(bucket),
             [5]
@@ -187,7 +183,7 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var v0 = bucket.arrays.test.layout.vertex.get(0);
+        var v0 = bucket.arrayGroups.test[0].layout.vertex.get(0);
         t.equal(v0.map, 34);
 
         t.end();
@@ -199,13 +195,9 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
+        t.equal(bucket.arrayGroups.test.length, 1);
         bucket.createArrays();
-        var arrays = bucket.arrays;
-
-        t.equal(bucket.arrays, arrays);
-        t.equal(arrays.test.layout.element.length, 0);
-        t.equal(arrays.test.layout.secondElement.length, 0);
-        t.equal(bucket.elementGroups.test.length, 0);
+        t.equal(bucket.arrayGroups.test.length, 0);
 
         t.end();
     });
@@ -219,26 +211,26 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrays.test.layout.vertex;
+        var testVertex = bucket.arrayGroups.test[0].layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.box0, 34);
         t.equal(v0.box1, 84);
-        var testPaintVertex = bucket.arrays.test.paint.layerid;
+        var testPaintVertex = bucket.arrayGroups.test[0].paint.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
         t.equal(p0.map, 17);
 
-        var testElement = bucket.arrays.test.layout.element;
+        var testElement = bucket.arrayGroups.test[0].layout.element;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testSecondElement = bucket.arrays.test.layout.secondElement;
-        t.equal(testSecondElement.length, 1);
-        var e2 = testSecondElement.get(0);
+        var testElement2 = bucket.arrayGroups.test[0].layout.element2;
+        t.equal(testElement2.length, 1);
+        var e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);
         t.equal(e2.vertices1, 42);
 
@@ -257,26 +249,26 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrays.test.layout.vertex;
+        var testVertex = bucket.arrayGroups.test[0].layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.box0, 34);
         t.equal(v0.box1, 84);
-        var testPaintVertex = bucket.arrays.test.paint.layerid;
+        var testPaintVertex = bucket.arrayGroups.test[0].paint.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
         t.equal(p0.map, 17);
 
-        var testElement = bucket.arrays.test.layout.element;
+        var testElement = bucket.arrayGroups.test[0].layout.element;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testSecondElement = bucket.arrays.test.layout.secondElement;
-        t.equal(testSecondElement.length, 1);
-        var e2 = testSecondElement.get(0);
+        var testElement2 = bucket.arrayGroups.test[0].layout.element2;
+        t.equal(testElement2.length, 1);
+        var e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);
         t.equal(e2.vertices1, 42);
 

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -61,7 +61,7 @@ test('basic', function(t) {
 
         tile.parse(new Wrapper(features), layerFamilies, {}, null, function(err, result) {
             t.equal(err, null);
-            t.equal(Object.keys(result.buckets[0].elementGroups).length, 1, 'element groups exclude hidden layer');
+            t.equal(Object.keys(result.buckets[0].arrays).length, 1, 'array groups exclude hidden layer');
             t.end();
         });
     });


### PR DESCRIPTION
- replaces element groups with buffer groups. Each buffer group has it's own buffers.
- cleans up and optimizes some things in drawSymbol
- makes frame-duration benchmark more independent of gpu performance

```
master:         11.7 ms
this branch:    8.6 ms
master:         11.3 ms
this branch:    8.3 ms
master:         11.9 ms
this branch:    9.3 ms

master average:         11.63 ms
this branch average:    8.7 ms
```

This branch (which includes the [unmerged vao changes](https://github.com/mapbox/mapbox-gl-js/pull/2483)) takes **75%** of the time it takes master to run through the render loop.

:eyes: @lucaswoj 