### PR TITLE
add overdraw inspector

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -41,6 +41,7 @@
 <div id='checkboxes'>
   <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
   <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br />
+  <input id='show-overdraw-checkbox' name='show-overdraw' type='checkbox'> <label for='show-overdraw'>overdraw debug</label><br />
   <input id='buffer-checkbox' name='buffer' type='checkbox'> <label for='buffer'>buffer stats</label>
 </div>
 

--- a/debug/site.js
+++ b/debug/site.js
@@ -107,6 +107,10 @@ document.getElementById('show-symbol-collision-boxes-checkbox').onclick = functi
     map.showCollisionBoxes = !!this.checked;
 };
 
+document.getElementById('show-overdraw-checkbox').onclick = function() {
+    map.showOverdrawInspector = !!this.checked;
+};
+
 document.getElementById('buffer-checkbox').onclick = function() {
     document.getElementById('buffer').style.display = this.checked ? 'block' : 'none';
 };

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -64,7 +64,6 @@ Painter.prototype.resize = function(width, height) {
 
 };
 
-
 Painter.prototype.setup = function() {
     var gl = this.gl;
 
@@ -225,6 +224,8 @@ Painter.prototype.render = function(style, options) {
     this.clearColor();
     this.clearDepth();
 
+    this.showOverdrawInspector(options.showOverdrawInspector);
+
     this.depthRange = (style._order.length + 2) * this.numSublayers * this.depthEpsilon;
 
     this.renderPass({isOpaquePass: true});
@@ -255,7 +256,9 @@ Painter.prototype.renderPass = function(options) {
         }
 
         if (isOpaquePass) {
-            this.gl.disable(this.gl.BLEND);
+            if (!this._showOverdrawInspector) {
+                this.gl.disable(this.gl.BLEND);
+            }
             this.isOpaquePass = true;
         } else {
             this.gl.enable(this.gl.BLEND);
@@ -373,4 +376,21 @@ Painter.prototype.setExMatrix = function(exMatrix) {
 
 Painter.prototype.lineWidth = function(width) {
     this.gl.lineWidth(util.clamp(width, this.lineWidthRange[0], this.lineWidthRange[1]));
+};
+
+Painter.prototype.showOverdrawInspector = function(enabled) {
+    if (!enabled && !this._showOverdrawInspector) return;
+    this._showOverdrawInspector = enabled;
+
+    var gl = this.gl;
+    if (enabled) {
+        gl.blendFunc(gl.CONSTANT_COLOR, gl.ONE);
+        var numOverdrawSteps = 8;
+        var a = 1 / numOverdrawSteps;
+        gl.blendColor(a, a, a, 0);
+        gl.clearColor(0, 0, 0, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+    } else {
+        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+    }
 };

--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -112,6 +112,10 @@ module.exports._createProgram = function(name, macros) {
 
 module.exports._createProgramCached = function(name, macros) {
     this.cache = this.cache || {};
+    if (this._showOverdrawInspector) {
+        macros = macros || [];
+        macros.push('OVERDRAW_INSPECTOR');
+    }
     var key = JSON.stringify({name: name, macros: macros});
     if (!this.cache[key]) {
         this.cache[key] = this._createProgram(name, macros);

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -877,6 +877,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
 
         this.painter.render(this.style, {
             debug: this.showTileBoundaries,
+            showOverdrawInspector: this._showOverdrawInspector,
             vertices: this.vertices,
             rotating: this.rotating,
             zooming: this.zooming
@@ -1025,6 +1026,21 @@ util.extendAll(Map.prototype, /** @lends Map.prototype */{
         if (this._showCollisionBoxes === value) return;
         this._showCollisionBoxes = value;
         this.style._redoPlacement();
+    },
+
+    /*
+     * Show how many times each fragment has been shaded. White fragments have
+     * been shaded 8 or more times. Black fragments have been shaded 0 times.
+     *
+     * @name showOverdraw
+     * @type {boolean}
+     */
+    _showOverdrawInspector: false,
+    get showOverdrawInspector() { return this._showOverdrawInspector; },
+    set showOverdrawInspector(value) {
+        if (this._showOverdrawInspector === value) return;
+        this._showOverdrawInspector = value;
+        this._update();
     },
 
     /**

--- a/shaders/circle.fragment.glsl
+++ b/shaders/circle.fragment.glsl
@@ -10,4 +10,8 @@ varying lowp float v_antialiasblur;
 void main() {
     float t = smoothstep(1.0 - max(u_blur, v_antialiasblur), 1.0, length(v_extrude));
     gl_FragColor = v_color * (1.0 - t) * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/fill.fragment.glsl
+++ b/shaders/fill.fragment.glsl
@@ -5,4 +5,8 @@ uniform lowp float u_opacity;
 
 void main() {
     gl_FragColor = u_color * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/icon.fragment.glsl
+++ b/shaders/icon.fragment.glsl
@@ -10,4 +10,8 @@ varying vec2 v_fade_tex;
 void main() {
     lowp float alpha = texture2D(u_fadetexture, v_fade_tex).a * u_opacity;
     gl_FragColor = texture2D(u_texture, v_tex) * alpha;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/line.fragment.glsl
+++ b/shaders/line.fragment.glsl
@@ -20,4 +20,8 @@ void main() {
     float alpha = clamp(min(dist - (u_linewidth.t - blur), u_linewidth.s - dist) / blur, 0.0, 1.0);
 
     gl_FragColor = u_color * (alpha * u_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -41,4 +41,8 @@ void main() {
     alpha *= u_opacity;
 
     gl_FragColor = color * alpha;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/linesdfpattern.fragment.glsl
+++ b/shaders/linesdfpattern.fragment.glsl
@@ -29,4 +29,8 @@ void main() {
     alpha *= smoothstep(0.5 - u_sdfgamma, 0.5 + u_sdfgamma, sdfdist);
 
     gl_FragColor = u_color * (alpha * u_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/outline.fragment.glsl
+++ b/shaders/outline.fragment.glsl
@@ -9,4 +9,8 @@ void main() {
     float dist = length(v_pos - gl_FragCoord.xy);
     float alpha = smoothstep(1.0, 0.0, dist);
     gl_FragColor = u_color * (alpha * u_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/outlinepattern.fragment.glsl
+++ b/shaders/outlinepattern.fragment.glsl
@@ -29,4 +29,8 @@ void main() {
     
 
     gl_FragColor = mix(color1, color2, u_mix) * alpha * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/pattern.fragment.glsl
+++ b/shaders/pattern.fragment.glsl
@@ -23,4 +23,8 @@ void main() {
     vec4 color2 = texture2D(u_image, pos2);
 
     gl_FragColor = mix(color1, color2, u_mix) * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/raster.fragment.glsl
+++ b/shaders/raster.fragment.glsl
@@ -40,4 +40,8 @@ void main() {
     vec3 u_low_vec = vec3(u_brightness_high, u_brightness_high, u_brightness_high);
 
     gl_FragColor = vec4(mix(u_high_vec, u_low_vec, rgb), color.a);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }

--- a/shaders/sdf.fragment.glsl
+++ b/shaders/sdf.fragment.glsl
@@ -17,4 +17,8 @@ void main() {
     lowp float gamma = u_gamma * v_gamma_scale;
     lowp float alpha = smoothstep(u_buffer - gamma, u_buffer + gamma, dist) * fade_alpha;
     gl_FragColor = u_color * (alpha * u_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
 }


### PR DESCRIPTION
The overdraw inspector shows how many time each fragment has been shaded. White fragments were shaded 8 or more times. Black fragments were shaded 0 times. Lower is better.

This only counts shaded fragments that were written to the color buffer. Fragments that are written only to the stencil buffer are not included.

`map.showOverdrawInspector = true`

<img width="545" alt="screen shot 2016-04-22 at 4 15 09 pm" src="https://cloud.githubusercontent.com/assets/1421652/14757189/9ca4bf5a-08a5-11e6-9bb3-750eb2bb27d8.png">
mapbox-streets landuse overdraws a lot:
<img width="605" alt="screen shot 2016-04-22 at 4 15 31 pm" src="https://cloud.githubusercontent.com/assets/1421652/14757186/9ca26840-08a5-11e6-9bb0-563914397775.png">
mapbox-streets terrain overdraws a lot:
<img width="659" alt="screen shot 2016-04-22 at 4 16 15 pm" src="https://cloud.githubusercontent.com/assets/1421652/14757187/9ca31ee8-08a5-11e6-9596-27c177fff2bc.png">


:eyes: @kkaefer @mourner @lucaswoj 