### PR TITLE
Allow updatePaintTransition to be called with extraneous classes

### DIFF
--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -231,7 +231,10 @@ StyleLayer.prototype = util.inherit(Evented, {
     updatePaintTransition: function(name, classes, options, globalOptions, animationLoop) {
         var declaration = this._paintDeclarations[''][name];
         for (var i = 0; i < classes.length; i++) {
-            declaration = this._paintDeclarations[classes[i]][name] || declaration;
+            var classPaintDeclarations = this._paintDeclarations[classes[i]];
+            if (classPaintDeclarations && classPaintDeclarations[name]) {
+                declaration = classPaintDeclarations[name];
+            }
         }
         this._applyPaintDeclaration(name, declaration, options, globalOptions, animationLoop);
     },

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -26,6 +26,53 @@ test('StyleLayer', function(t) {
     t.end();
 });
 
+test('StyleLayer#updatePaintTransition', function (t) {
+
+    t.test('updates paint transition', function(t) {
+        var layer = StyleLayer.create({
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "red"
+            }
+        });
+        layer.updatePaintTransition('background-color', [], {});
+        t.deepEqual(layer.getPaintValue('background-color'), [1, 0, 0, 1]);
+        t.end();
+    });
+
+    t.test('updates paint transition with class', function(t) {
+        var layer = StyleLayer.create({
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "red"
+            },
+            "paint.mapbox": {
+                "background-color": "blue"
+            }
+        });
+        layer.updatePaintTransition('background-color', ['mapbox'], {});
+        t.deepEqual(layer.getPaintValue('background-color'), [0, 0, 1, 1]);
+        t.end();
+    });
+
+    t.test('updates paint transition with extraneous class', function(t) {
+        var layer = StyleLayer.create({
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "red"
+            }
+        });
+        layer.updatePaintTransition('background-color', ['mapbox'], {});
+        t.deepEqual(layer.getPaintValue('background-color'), [1, 0, 0, 1]);
+        t.end();
+    });
+
+    t.end();
+});
+
 test('StyleLayer#updatePaintTransitions', function (t) {
     t.test('respects classes regardless of layer properties order', function (t) {
         var layer = StyleLayer.create({


### PR DESCRIPTION
fixes #2477

cc @averas @ansis 