### PR TITLE
Add initialization code to "Getting Started" section in docs

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -36,7 +36,7 @@ options: full
 <link href='{{site.tileApi}}/mapbox-gl-js/{{site.version}}/mapbox-gl.css' rel='stylesheet' />{% endhighlight html %}
     </div>
     <div class='pad1x small quiet space-bottom1'>
-      Include the JavaScript and CSS files in your <code>&lt;head&gt;</code>.
+      Include the JavaScript and CSS files in the <code>&lt;head&gt;</code> of your HTML file.
     </div>
 
     <div class='fill-white space-bottom1'>
@@ -53,7 +53,7 @@ var map = new mapboxgl.Map({
       {% highlight html %}{{ getting_started_html | insert_token }}{% endhighlight %}
     </div>
     <div class='pad1x small quiet'>
-      Include the initialization code in your <code>&lt;body&gt;</code>.
+      Include this code in the <code>&lt;body&gt;</code> of your HTML file to initialize a map on the page.
       <a class='truncate rcon next' href='{{site.baseurl}}/examples/'>View basic example</a>
     </div>
   </div>

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -35,8 +35,26 @@ options: full
 <script src='{{site.tileApi}}/mapbox-gl-js/{{site.version}}/mapbox-gl.js'></script>
 <link href='{{site.tileApi}}/mapbox-gl-js/{{site.version}}/mapbox-gl.css' rel='stylesheet' />{% endhighlight html %}
     </div>
+    <div class='pad1x small quiet space-bottom1'>
+      Include the JavaScript and CSS files in your <code>&lt;head&gt;</code>.
+    </div>
+
+    <div class='fill-white space-bottom1'>
+{% capture getting_started_html %}
+<div id='map' style='width: 400px; height: 300px;'></div>
+<script>
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v8'
+});
+</script>
+{% endcapture %}
+
+      {% highlight html %}{{ getting_started_html | insert_token }}{% endhighlight %}
+    </div>
     <div class='pad1x small quiet'>
-    Include the Mapbox GL JS and CSS files in your HTML header and use <a href='#Map'><code>mapboxgl.Map()</code></a> to load your first map. <a class='truncate rcon next' href='{{site.baseurl}}/examples/'>View basic example</a>
+      Include the initialization code in your <code>&lt;body&gt;</code>.
+      <a class='truncate rcon next' href='{{site.baseurl}}/examples/'>View basic example</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
cc @lyzidiamond 

Is this an acceptable compromise? We can include the initialization code without any other cruft. 

<img width="764" alt="screen shot 2016-04-27 at 1 46 40 pm" src="https://cloud.githubusercontent.com/assets/281306/14867707/a4433354-0c7e-11e6-856d-0d95eef7fffc.png">
