### PR TITLE
split up uniforms to prepare for data driven styling

### DIFF
--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -31,20 +31,6 @@ module.exports = function drawLine(painter, source, layer, coords) {
     var antialiasing = 1 / browser.devicePixelRatio;
 
     var blur = layer.paint['line-blur'] + antialiasing;
-    var edgeWidth = layer.paint['line-width'] / 2;
-    var inset = -1;
-    var offset = 0;
-    var shift = 0;
-
-    if (layer.paint['line-gap-width'] > 0) {
-        inset = layer.paint['line-gap-width'] / 2 + antialiasing * 0.5;
-        edgeWidth = layer.paint['line-width'];
-
-        // shift outer lines half a pixel towards the middle to eliminate the crack
-        offset = inset - antialiasing / 2;
-    }
-
-    var outset = offset + edgeWidth + antialiasing / 2 + shift;
     var color = util.premultiply(layer.paint['line-color']);
 
     var tr = painter.transform;
@@ -66,7 +52,9 @@ module.exports = function drawLine(painter, source, layer, coords) {
     if (dasharray) {
         program = painter.useProgram('linesdfpattern');
 
-        gl.uniform2fv(program.u_linewidth, [ outset, inset ]);
+        gl.uniform1f(program.u_linewidth, layer.paint['line-width'] / 2);
+        gl.uniform1f(program.u_gapwidth, layer.paint['line-gap-width'] / 2);
+        gl.uniform1f(program.u_antialiasing, antialiasing / 2);
         gl.uniform1f(program.u_blur, blur);
         gl.uniform4fv(program.u_color, color);
         gl.uniform1f(program.u_opacity, layer.paint['line-opacity']);
@@ -96,7 +84,9 @@ module.exports = function drawLine(painter, source, layer, coords) {
         gl.activeTexture(gl.TEXTURE0);
         painter.spriteAtlas.bind(gl, true);
 
-        gl.uniform2fv(program.u_linewidth, [ outset, inset ]);
+        gl.uniform1f(program.u_linewidth, layer.paint['line-width'] / 2);
+        gl.uniform1f(program.u_gapwidth, layer.paint['line-gap-width'] / 2);
+        gl.uniform1f(program.u_antialiasing, antialiasing / 2);
         gl.uniform1f(program.u_blur, blur);
         gl.uniform2fv(program.u_pattern_tl_a, imagePosA.tl);
         gl.uniform2fv(program.u_pattern_br_a, imagePosA.br);
@@ -111,7 +101,9 @@ module.exports = function drawLine(painter, source, layer, coords) {
     } else {
         program = painter.useProgram('line');
 
-        gl.uniform2fv(program.u_linewidth, [ outset, inset ]);
+        gl.uniform1f(program.u_linewidth, layer.paint['line-width'] / 2);
+        gl.uniform1f(program.u_gapwidth, layer.paint['line-gap-width'] / 2);
+        gl.uniform1f(program.u_antialiasing, antialiasing / 2);
         gl.uniform1f(program.u_blur, blur);
         gl.uniform1f(program.u_extra, extra);
         gl.uniform1f(program.u_offset, -layer.paint['line-offset']);

--- a/shaders/line.fragment.glsl
+++ b/shaders/line.fragment.glsl
@@ -1,23 +1,22 @@
 precision mediump float;
 
-uniform vec2 u_linewidth;
 uniform lowp vec4 u_color;
 uniform lowp float u_opacity;
 uniform float u_blur;
 
 varying vec2 v_normal;
-varying float v_linesofar;
+varying vec2 v_linewidth;
 varying float v_gamma_scale;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * u_linewidth.s;
+    float dist = length(v_normal) * v_linewidth.s;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
     float blur = u_blur * v_gamma_scale;
-    float alpha = clamp(min(dist - (u_linewidth.t - blur), u_linewidth.s - dist) / blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linewidth.t - blur), v_linewidth.s - dist) / blur, 0.0, 1.0);
 
     gl_FragColor = u_color * (alpha * u_opacity);
 

--- a/shaders/line.vertex.glsl
+++ b/shaders/line.vertex.glsl
@@ -12,14 +12,17 @@ attribute vec2 a_pos;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
-uniform float u_ratio;
-uniform mediump vec2 u_linewidth;
-uniform float u_extra;
+uniform mediump float u_ratio;
+uniform mediump float u_linewidth;
+uniform mediump float u_gapwidth;
+uniform mediump float u_antialiasing;
+uniform mediump float u_extra;
 uniform mat2 u_antialiasingmatrix;
 uniform mediump float u_offset;
+uniform mediump float u_blur;
 
 varying vec2 v_normal;
-varying float v_linesofar;
+varying vec2 v_linewidth;
 varying float v_gamma_scale;
 
 void main() {
@@ -34,9 +37,12 @@ void main() {
     normal.y = sign(normal.y - 0.5);
     v_normal = normal;
 
+    float inset = u_gapwidth + (u_gapwidth > 0.0 ? u_antialiasing : 0.0);
+    float outset = u_gapwidth + u_linewidth * (u_gapwidth > 0.0 ? 2.0 : 1.0) + u_antialiasing;
+
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
-    mediump vec4 dist = vec4(u_linewidth.s * a_extrude * scale, 0.0, 0.0);
+    mediump vec4 dist = vec4(outset * a_extrude * scale, 0.0, 0.0);
 
     // Calculate the offset when drawing a line that is to the side of the actual line.
     // We do this by creating a vector that points towards the extrude, but rotate
@@ -59,5 +65,6 @@ void main() {
     // how much features are squished in all directions by the perspectiveness
     float perspective_scale = 1.0 / (1.0 - min(y * u_extra, 0.9));
 
+    v_linewidth = vec2(outset, inset);
     v_gamma_scale = perspective_scale * squish_scale;
 }

--- a/shaders/linepattern.fragment.glsl
+++ b/shaders/linepattern.fragment.glsl
@@ -1,6 +1,5 @@
 precision mediump float;
 
-uniform vec2 u_linewidth;
 uniform float u_point;
 uniform float u_blur;
 
@@ -16,23 +15,24 @@ uniform float u_opacity;
 uniform sampler2D u_image;
 
 varying vec2 v_normal;
+varying vec2 v_linewidth;
 varying float v_linesofar;
 varying float v_gamma_scale;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * u_linewidth.s;
+    float dist = length(v_normal) * v_linewidth.s;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
     float blur = u_blur * v_gamma_scale;
-    float alpha = clamp(min(dist - (u_linewidth.t - blur), u_linewidth.s - dist) / blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linewidth.t - blur), v_linewidth.s - dist) / blur, 0.0, 1.0);
 
     float x_a = mod(v_linesofar / u_pattern_size_a.x, 1.0);
     float x_b = mod(v_linesofar / u_pattern_size_b.x, 1.0);
-    float y_a = 0.5 + (v_normal.y * u_linewidth.s / u_pattern_size_a.y);
-    float y_b = 0.5 + (v_normal.y * u_linewidth.s / u_pattern_size_b.y);
+    float y_a = 0.5 + (v_normal.y * v_linewidth.s / u_pattern_size_a.y);
+    float y_b = 0.5 + (v_normal.y * v_linewidth.s / u_pattern_size_b.y);
     vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, vec2(x_a, y_a));
     vec2 pos2 = mix(u_pattern_tl_b, u_pattern_br_b, vec2(x_b, y_b));
 

--- a/shaders/linepattern.vertex.glsl
+++ b/shaders/linepattern.vertex.glsl
@@ -17,12 +17,15 @@ attribute vec4 a_data;
 
 uniform mat4 u_matrix;
 uniform mediump float u_ratio;
-uniform mediump vec2 u_linewidth;
-uniform float u_extra;
+uniform mediump float u_linewidth;
+uniform mediump float u_gapwidth;
+uniform mediump float u_antialiasing;
+uniform mediump float u_extra;
 uniform mat2 u_antialiasingmatrix;
 uniform mediump float u_offset;
 
 varying vec2 v_normal;
+varying vec2 v_linewidth;
 varying float v_linesofar;
 varying float v_gamma_scale;
 
@@ -39,10 +42,13 @@ void main() {
     normal.y = sign(normal.y - 0.5);
     v_normal = normal;
 
+    float inset = u_gapwidth + (u_gapwidth > 0.0 ? u_antialiasing : 0.0);
+    float outset = u_gapwidth + u_linewidth * (u_gapwidth > 0.0 ? 2.0 : 1.0) + u_antialiasing;
+
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
     mediump vec2 extrude = a_extrude * scale;
-    mediump vec2 dist = u_linewidth.s * extrude;
+    mediump vec2 dist = outset * extrude;
 
     // Calculate the offset when drawing a line that is to the side of the actual line.
     // We do this by creating a vector that points towards the extrude, but rotate
@@ -66,5 +72,6 @@ void main() {
     // how much features are squished in all directions by the perspectiveness
     float perspective_scale = 1.0 / (1.0 - min(y * u_extra, 0.9));
 
+    v_linewidth = vec2(outset, inset);
     v_gamma_scale = perspective_scale * squish_scale;
 }

--- a/shaders/linesdfpattern.fragment.glsl
+++ b/shaders/linesdfpattern.fragment.glsl
@@ -1,6 +1,5 @@
 precision mediump float;
 
-uniform vec2 u_linewidth;
 uniform lowp vec4 u_color;
 uniform lowp float u_opacity;
 uniform float u_blur;
@@ -9,19 +8,20 @@ uniform float u_sdfgamma;
 uniform float u_mix;
 
 varying vec2 v_normal;
+varying vec2 v_linewidth;
 varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
 void main() {
     // Calculate the distance of the pixel from the line in pixels.
-    float dist = length(v_normal) * u_linewidth.s;
+    float dist = length(v_normal) * v_linewidth.s;
 
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
     float blur = u_blur * v_gamma_scale;
-    float alpha = clamp(min(dist - (u_linewidth.t - blur), u_linewidth.s - dist) / blur, 0.0, 1.0);
+    float alpha = clamp(min(dist - (v_linewidth.t - blur), v_linewidth.s - dist) / blur, 0.0, 1.0);
 
     float sdfdist_a = texture2D(u_image, v_tex_a).a;
     float sdfdist_b = texture2D(u_image, v_tex_b).a;

--- a/shaders/linesdfpattern.vertex.glsl
+++ b/shaders/linesdfpattern.vertex.glsl
@@ -16,8 +16,10 @@ attribute vec2 a_pos;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
-uniform mediump vec2 u_linewidth;
 uniform mediump float u_ratio;
+uniform mediump float u_linewidth;
+uniform mediump float u_gapwidth;
+uniform mediump float u_antialiasing;
 uniform vec2 u_patternscale_a;
 uniform float u_tex_y_a;
 uniform vec2 u_patternscale_b;
@@ -27,6 +29,7 @@ uniform mat2 u_antialiasingmatrix;
 uniform mediump float u_offset;
 
 varying vec2 v_normal;
+varying vec2 v_linewidth;
 varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
@@ -44,9 +47,12 @@ void main() {
     normal.y = sign(normal.y - 0.5);
     v_normal = normal;
 
+    float inset = u_gapwidth + (u_gapwidth > 0.0 ? u_antialiasing : 0.0);
+    float outset = u_gapwidth + u_linewidth * (u_gapwidth > 0.0 ? 2.0 : 1.0) + u_antialiasing;
+
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.
-    mediump vec4 dist = vec4(u_linewidth.s * a_extrude * scale, 0.0, 0.0);
+    mediump vec4 dist = vec4(outset * a_extrude * scale, 0.0, 0.0);
 
     // Calculate the offset when drawing a line that is to the side of the actual line.
     // We do this by creating a vector that points towards the extrude, but rotate
@@ -72,5 +78,6 @@ void main() {
     // how much features are squished in all directions by the perspectiveness
     float perspective_scale = 1.0 / (1.0 - min(y * u_extra, 0.9));
 
+    v_linewidth = vec2(outset, inset);
     v_gamma_scale = perspective_scale * squish_scale;
 }

--- a/shaders/outlinepattern.vertex.glsl
+++ b/shaders/outlinepattern.vertex.glsl
@@ -1,9 +1,12 @@
 precision highp float;
 
-uniform vec2 u_patternscale_a;
-uniform vec2 u_patternscale_b;
-uniform vec2 u_offset_a;
-uniform vec2 u_offset_b;
+uniform vec2 u_pattern_size_a;
+uniform vec2 u_pattern_size_b;
+uniform vec2 u_pixel_coord_upper;
+uniform vec2 u_pixel_coord_lower;
+uniform float u_scale_a;
+uniform float u_scale_b;
+uniform float u_tile_units_to_pixels;
 
 attribute vec2 a_pos;
 
@@ -17,7 +20,29 @@ varying vec2 v_pos;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
-    v_pos_a = u_patternscale_a * a_pos + u_offset_a;
-    v_pos_b = u_patternscale_b * a_pos + u_offset_b;
-    v_pos = (gl_Position.xy/gl_Position.w + 1.0) / 2.0 * u_world;
+    vec2 scaled_size_a = u_scale_a * u_pattern_size_a;
+    vec2 scaled_size_b = u_scale_b * u_pattern_size_b;
+
+    // the correct offset needs to be calculated.
+    // 
+    // The offset depends on how many pixels are between the world origin and
+    // the edge of the tile:
+    // vec2 offset = mod(pixel_coord, size)
+    //
+    // At high zoom levels there are a ton of pixels between the world origin
+    // and the edge of the tile. The glsl spec only guarantees 16 bits of
+    // precision for highp floats. We need more than that.
+    //
+    // The pixel_coord is passed in as two 16 bit values:
+    // pixel_coord_upper = floor(pixel_coord / 2^16)
+    // pixel_coord_lower = mod(pixel_coord, 2^16)
+    //
+    // The offset is calculated in a series of steps that should preserve this precision:
+    vec2 offset_a = mod(mod(mod(u_pixel_coord_upper, scaled_size_a) * 256.0, scaled_size_a) * 256.0 + u_pixel_coord_lower, scaled_size_a);
+    vec2 offset_b = mod(mod(mod(u_pixel_coord_upper, scaled_size_b) * 256.0, scaled_size_b) * 256.0 + u_pixel_coord_lower, scaled_size_b);
+
+    v_pos_a = (u_tile_units_to_pixels * a_pos + offset_a) / scaled_size_a;
+    v_pos_b = (u_tile_units_to_pixels * a_pos + offset_b) / scaled_size_b;
+
+    v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
 }

--- a/shaders/pattern.vertex.glsl
+++ b/shaders/pattern.vertex.glsl
@@ -1,10 +1,13 @@
 precision highp float;
 
 uniform mat4 u_matrix;
-uniform vec2 u_patternscale_a;
-uniform vec2 u_patternscale_b;
-uniform vec2 u_offset_a;
-uniform vec2 u_offset_b;
+uniform vec2 u_pattern_size_a;
+uniform vec2 u_pattern_size_b;
+uniform vec2 u_pixel_coord_upper;
+uniform vec2 u_pixel_coord_lower;
+uniform float u_scale_a;
+uniform float u_scale_b;
+uniform float u_tile_units_to_pixels;
 
 attribute vec2 a_pos;
 
@@ -13,6 +16,27 @@ varying vec2 v_pos_b;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
-    v_pos_a = u_patternscale_a * a_pos + u_offset_a;
-    v_pos_b = u_patternscale_b * a_pos + u_offset_b;
+    vec2 scaled_size_a = u_scale_a * u_pattern_size_a;
+    vec2 scaled_size_b = u_scale_b * u_pattern_size_b;
+
+    // the correct offset needs to be calculated.
+    // 
+    // The offset depends on how many pixels are between the world origin and
+    // the edge of the tile:
+    // vec2 offset = mod(pixel_coord, size)
+    //
+    // At high zoom levels there are a ton of pixels between the world origin
+    // and the edge of the tile. The glsl spec only guarantees 16 bits of
+    // precision for highp floats. We need more than that.
+    //
+    // The pixel_coord is passed in as two 16 bit values:
+    // pixel_coord_upper = floor(pixel_coord / 2^16)
+    // pixel_coord_lower = mod(pixel_coord, 2^16)
+    //
+    // The offset is calculated in a series of steps that should preserve this precision:
+    vec2 offset_a = mod(mod(mod(u_pixel_coord_upper, scaled_size_a) * 256.0, scaled_size_a) * 256.0 + u_pixel_coord_lower, scaled_size_a);
+    vec2 offset_b = mod(mod(mod(u_pixel_coord_upper, scaled_size_b) * 256.0, scaled_size_b) * 256.0 + u_pixel_coord_lower, scaled_size_b);
+
+    v_pos_a = (u_tile_units_to_pixels * a_pos + offset_a) / scaled_size_a;
+    v_pos_b = (u_tile_units_to_pixels * a_pos + offset_b) / scaled_size_b;
 }


### PR DESCRIPTION
Combine line-width and line-gap-width in shader so that the input variables are independent of each other.

Split up `u_pattern_scale` into a bunch of uniforms so that all the style property inputs are independent of the inputs based on the zoom and currently calculated interpolation value.

:eyes: @lucaswoj 