### PR TITLE
[not ready] Fire a `geolocate` event

### DIFF
--- a/js/ui/control/control.js
+++ b/js/ui/control/control.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var util = require('../../util/util');
+var Evented = require('../../util/evented');
 module.exports = Control;
 
 /**
@@ -47,3 +49,5 @@ Control.prototype = {
         return this;
     }
 };
+
+util.extend(Control.prototype, Evented);

--- a/js/ui/control/geolocate.js
+++ b/js/ui/control/geolocate.js
@@ -59,10 +59,13 @@ Geolocate.prototype = util.inherit(Control, {
             bearing: 0,
             pitch: 0
         });
+
+        this.fire('geolocate', position);
         this._finish();
     },
 
-    _error: function() {
+    _error: function(error) {
+        this.fire('error', error);
         this._finish();
     },
 
@@ -73,3 +76,22 @@ Geolocate.prototype = util.inherit(Control, {
 
 });
 
+ /**
+  * geolocate event.
+  *
+  * @event geolocate
+  * @memberof Control
+  * @instance
+  * @property {EventData} data The returned Position object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition)
+  *
+  */
+
+ /**
+  * error event.
+  *
+  * @event error
+  * @memberof Control
+  * @instance
+  * @property {EventData} data The returned PositionError object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition)
+  *
+  */


### PR DESCRIPTION
Inspired by this [StackOverflow question](http://stackoverflow.com/questions/36984884/mapbox-gl-geolocate-not-showing-an-indicator-of-where-i-am). Fire a `geolocate` event on success of `navigator.geolocation.getCurrentPosition`:

```js
map.addControl(new mapboxgl.Geolocate());
map.on('geolocate', function(e) {
  // console.log(e.coords)
});
```

### TODOs

- [x] Document this addition.
- [ ] There aren't currently UI tests for the geolocate control. I'm guessing this is complicated to do as it requires a user prompt to enable.

cc @jfirebaugh @lucaswoj 