### PR TITLE
fix #2541, scale circles in pitch views

### DIFF
--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -27,7 +27,9 @@ function drawCircles(painter, source, layer, coords) {
 
         var program = painter.useProgram('circle', bucket.getProgramMacros('circle', layer));
 
-        gl.uniform2fv(program.u_extrude_scale, painter.transform.pixelsToGLUnits);
+        gl.uniform2f(program.u_extrude_scale,
+                painter.transform.pixelsToGLUnits[0] * painter.transform.altitude,
+                painter.transform.pixelsToGLUnits[1] * painter.transform.altitude);
         gl.uniform1f(program.u_blur, layer.paint['circle-blur']);
         gl.uniform1f(program.u_devicepixelratio, browser.devicePixelRatio);
         gl.uniform1f(program.u_opacity, layer.paint['circle-opacity']);

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -69,9 +69,7 @@ void main(void) {
     // in extrusion data
     gl_Position = u_matrix * vec4(floor(a_pos * 0.5), 0, 1);
 
-    // gl_Position is divided by gl_Position.w after this shader runs.
-    // Multiply the extrude by it so that it isn't affected by it.
-    gl_Position.xy += extrude * gl_Position.w;
+    gl_Position.xy += extrude;
 
 #ifdef ATTRIBUTE_A_COLOR
     v_color = a_color / 255.0;


### PR DESCRIPTION
fix #2541 

Based on the comments in the old code the old the behaviour was intentional but I think the behavior expected in #2541 is better.

<img width="670" alt="screen shot 2016-05-07 at 6 21 49 pm" src="https://cloud.githubusercontent.com/assets/1421652/15094912/b679f2d8-1480-11e6-9d09-182871687eff.png">


:eyes: @lucaswoj 