### PR TITLE
fix for #2473

### DIFF
--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -92,7 +92,7 @@ module.exports._createProgram = function(name, macros) {
     var numAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
     for (var i = 0; i < numAttributes; i++) {
         var attribute = gl.getActiveAttrib(program, i);
-        attributes[attribute.name] = i;
+        attributes[attribute.name] = gl.getAttribLocation(program, attribute.name);
     }
 
     var uniforms = {};


### PR DESCRIPTION
Index number wasn't being returned on some platforms in a reliable
order, causing the attributes variable to contained mismatched key/value
pairs and rendering errors (see screenshots in issue). Switching from index to gl.getAttribLocation() fixes the problem.