### PR TITLE
fix background-pattern texture bug

### DIFF
--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -39,6 +39,7 @@ function drawBackground(painter, source, layer) {
         gl.uniform1f(program.u_scale_a, image.fromScale);
         gl.uniform1f(program.u_scale_b, image.toScale);
 
+        gl.activeTexture(gl.TEXTURE0);
         painter.spriteAtlas.bind(gl, true);
 
         painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "express": "^4.13.4",
     "gl": "^2.1.5",
     "istanbul": "^0.4.2",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2960d05a0135e5132271f0b0485db217380ed78a",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3ea937569bae52b6636388baba3fe13ebeccf5e6",
     "nyc": "^6.1.1",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
fixes #2523 
I'm planning on adding at least one new test to the test suite that would catch this kind of texture collision

_before_
<img width="351" alt="screen shot 2016-05-10 at 6 40 01 pm" src="https://cloud.githubusercontent.com/assets/2425307/15167566/d19844ec-16de-11e6-9cca-43e85b65828b.png">

_after_
<img width="465" alt="screen shot 2016-05-10 at 6 39 41 pm" src="https://cloud.githubusercontent.com/assets/2425307/15167574/de427d70-16de-11e6-972c-2b2f087a4479.png">

👓 @lucaswoj @jfirebaugh 