### PR TITLE
support 'tms' tile scheme

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -9,7 +9,7 @@ var normalizeURL = require('../util/mapbox').normalizeTileURL;
 module.exports = RasterTileSource;
 
 function RasterTileSource(options) {
-    util.extend(this, util.pick(options, ['url', 'tileSize']));
+    util.extend(this, util.pick(options, ['url', 'scheme', 'tileSize']));
 
     Source._loadTileJSON.call(this, options);
 }
@@ -18,6 +18,7 @@ RasterTileSource.prototype = util.inherit(Evented, {
     minzoom: 0,
     maxzoom: 22,
     roundZoom: true,
+    scheme: 'xyz',
     tileSize: 512,
     _loaded: false,
 
@@ -51,7 +52,7 @@ RasterTileSource.prototype = util.inherit(Evented, {
     getTile: Source._getTile,
 
     _loadTile: function(tile) {
-        var url = normalizeURL(tile.coord.url(this.tiles), this.url, this.tileSize);
+        var url = normalizeURL(tile.coord.url(this.tiles, null, this.scheme), this.url, this.tileSize);
 
         tile.request = ajax.getImage(url, done.bind(this));
 

--- a/js/source/tile_coord.js
+++ b/js/source/tile_coord.js
@@ -51,12 +51,12 @@ TileCoord.fromID = function(id) {
 };
 
 // given a list of urls, choose a url template and return a tile URL
-TileCoord.prototype.url = function(urls, sourceMaxZoom) {
+TileCoord.prototype.url = function(urls, sourceMaxZoom, scheme) {
     return urls[(this.x + this.y) % urls.length]
         .replace('{prefix}', (this.x % 16).toString(16) + (this.y % 16).toString(16))
         .replace('{z}', Math.min(this.z, sourceMaxZoom || this.z))
         .replace('{x}', this.x)
-        .replace('{y}', this.y);
+        .replace('{y}', scheme === 'tms' ? (Math.pow(2, this.z) - this.y - 1) : this.y);
 };
 
 // Return the coordinate of the parent tile

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -8,7 +8,7 @@ var normalizeURL = require('../util/mapbox').normalizeTileURL;
 module.exports = VectorTileSource;
 
 function VectorTileSource(options) {
-    util.extend(this, util.pick(options, ['url', 'tileSize']));
+    util.extend(this, util.pick(options, ['url', 'scheme', 'tileSize']));
     this._options = util.extend({ type: 'vector' }, options);
 
     if (this.tileSize !== 512) {
@@ -21,6 +21,7 @@ function VectorTileSource(options) {
 VectorTileSource.prototype = util.inherit(Evented, {
     minzoom: 0,
     maxzoom: 22,
+    scheme: 'xyz',
     tileSize: 512,
     reparseOverscaled: true,
     _loaded: false,
@@ -59,7 +60,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
     _loadTile: function(tile) {
         var overscaling = tile.coord.z > this.maxzoom ? Math.pow(2, tile.coord.z - this.maxzoom) : 1;
         var params = {
-            url: normalizeURL(tile.coord.url(this.tiles, this.maxzoom), this.url),
+            url: normalizeURL(tile.coord.url(this.tiles, this.maxzoom, this.scheme), this.url),
             uid: tile.uid,
             coord: tile.coord,
             zoom: tile.coord.z,


### PR DESCRIPTION
Issue: #1616

Specs: https://www.mapbox.com/mapbox-gl-style-spec/#sources

> Tiled sources (vector and raster) must specify their details in terms of the TileJSON specification

Reference: https://github.com/mapbox/tilejson-spec/blob/master/2.1.0/schema.json#L28

(a new clean attempt for #2480)