### PR TITLE
Fix color-switcher example typo

### DIFF
--- a/docs/_posts/examples/3400-01-04-color-switcher.html
+++ b/docs/_posts/examples/3400-01-04-color-switcher.html
@@ -85,7 +85,7 @@ var map = new mapboxgl.Map({
 });
 
 var swatches = document.getElementById('swatches');
-var layers = document.getElementById('layers');
+var layer = document.getElementById('layer');
 var colors = [
     '#ffffcc',
     '#a1dab4',


### PR DESCRIPTION
The `layer` variable is not declared but automatically created via the `id=layer`.