### PR TITLE
Add webpack documentation. Fixes #1649

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ var map = new mapboxgl.Map({
 });
 ```
 
+## Using Mapbox GL JS with [Webpack](https://webpack.github.io/)
+
+To use the [vector tiles](https://www.mapbox.com/maps/) and styles hosted on http://mapbox.com, you must [create an account](https://www.mapbox.com/studio/signup/) and then [obtain an access token](https://www.mapbox.com/studio/account/tokens/). You may learn more about access tokens [here](https://www.mapbox.com/help/define-access-token/).
+
+Install the [`mapbox-gl` npm package](https://www.npmjs.com/package/mapbox-gl)
+and the required loaders.
+
+```bash
+npm install --save mapbox-gl
+npm install --save transform-loader
+npm install --save json-loader
+npm install --save webworkify-webpack
+```
+
+Add the [required additional options from webpack.config.example.js](webpack.config.example.js)
+to your webpack configuration.
+
+Instantiate `mapboxgl.Map`
+
+```js
+var mapboxgl = require('mapbox-gl');
+mapboxgl.accessToken = '<your access token here>';
+var map = new mapboxgl.Map({
+    container: '<your HTML element id>',
+    style: 'mapbox://styles/mapbox/streets-v8'
+});
+```
+
 ## Contributing to Mapbox GL JS
 
 See [CONTRIBUTING.md](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ var map = new mapboxgl.Map({
 });
 ```
 
+### Using import
+
+If you're using the ES6 module system, you can import `mapboxgl` like so:
+
+```js
+import mapboxgl from 'mapbox-gl';
+```
+
 ## Contributing to Mapbox GL JS
 
 See [CONTRIBUTING.md](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md).

--- a/webpack.config.example.js
+++ b/webpack.config.example.js
@@ -1,0 +1,63 @@
+const webpack = require('webpack');
+const path = require('path');
+
+/**
+ * Mapbox GL JS example webpack configuration. This demonstrates the options
+ * you'll need to add to your existing webpack configuration in order to successfully
+ * use Mapbox GL JS.
+ *
+ * This configuration refers to specific paths, especially in its configuration
+ * of the brfs transform. You'll likely need to change these paths so that
+ * they point at the correct file in Mapbox GL JS.
+ *
+ * Additional dependencies:
+ *
+ *     npm install --save transform-loader
+ *     npm install --save json-loader
+ *     npm install --save webworkify-webpack
+ *
+ * Why these dependencies?
+ *
+ * json-loader
+ * By default, browserify and node allow you to use the `require` method
+ * with JSON files. Webpack doesn't have this built-in, so we include
+ * the json loader.
+ *
+ * transform-loader
+ * Mapbox GL JS uses the brfs browserify transform to allow it to use
+ * the fs.readFileSync method in order to load its shaders for WebGL. Adding
+ * the transform loader lets webpack use brfs as well.
+ *
+ * webworkify-webpack
+ * Mapbox GL JS uses the webworkify module by default, and that module
+ * does things very specific to browserify's module loading system. In this
+ * configuration, we alias webworkify to webworkify-webpack to add webpack
+ * support.
+ */
+module.exports = {
+    entry: './test.js',
+    output: {
+        path: './',
+        filename: 'test.bundle.js',
+    },
+    resolve: {
+        alias: {
+            'webworkify': 'webworkify-webpack'
+        }
+    },
+    module: {
+        loaders: [{
+            test: /\.json$/,
+            loader: 'json-loader'
+        }, {
+            test: /\.js$/,
+            include: path.resolve(__dirname, 'js/render/painter/use_program.js'),
+            loader: 'transform/cacheable?brfs'
+        }],
+        postLoaders: [{
+            include: /node_modules\/mapbox-gl/,
+            loader: 'transform',
+            query: 'brfs'
+        }]
+    }
+}


### PR DESCRIPTION
cc @twelch

cc @lucaswoj for the review

Tail tasks:

* [ ] Add webpack instructions to website
* [x] Document es6 import semantics
* [ ] comms

Adds a 'usage with webpack' section to the README.md, as well as an example webpack configuration.