### PR TITLE
Reduce shader boilerplate, refactor "Bucket"

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -298,7 +298,7 @@ Bucket.prototype.getProgramDefines = function(programInterface, layer) {
     return defines;
 };
 
-Bucket.prototype.addPaintAttributes = function(interfaceName, globalProperties, featureProperties, startGroup, startIndex) {
+Bucket.prototype.populatePaintArrays = function(interfaceName, globalProperties, featureProperties, startGroup, startIndex) {
     for (var l = 0; l < this.childLayers.length; l++) {
         var layer = this.childLayers[l];
         var groups = this.arrayGroups[interfaceName];

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -287,14 +287,15 @@ Bucket.prototype.recalculateStyleLayers = function() {
     }
 };
 
-Bucket.prototype.getProgramMacros = function(programInterface, layer) {
-    var macros = [];
+// TODO make static
+Bucket.prototype.getProgramDefines = function(programInterface, layer) {
+    var defines = [];
     var attributes = this.paintAttributes[programInterface][layer.id].attributes;
     for (var i = 0; i < attributes.length; i++) {
         var attribute = attributes[i];
-        macros.push('ATTRIBUTE_' + (attribute.isFunction ? 'ZOOM_FUNCTION_' : '') + attribute.name.toUpperCase());
+        defines.push('ATTRIBUTE_' + (attribute.isFunction ? 'ZOOM_FUNCTION_' : '') + attribute.name.toUpperCase());
     }
-    return macros;
+    return defines;
 };
 
 Bucket.prototype.addPaintAttributes = function(interfaceName, globalProperties, featureProperties, startGroup, startIndex) {

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -359,24 +359,29 @@ function createPaintAttributes(bucket) {
                 var attributeInputName = attribute.name;
                 assert(attribute.name.slice(0, 2) === 'a_');
                 var attributeInnerName = attribute.name.slice(2);
-                var definePragma = 'define(' + attributeInnerName + ')';
-                var initializePragma = 'initialize(' + attributeInnerName + ')';
+                var definePragma = 'define ' + attributeInnerName;
+                var initializePragma = 'initialize ' + attributeInnerName;
                 var attributeVaryingDefinition;
 
                 paintAttributes.fragmentPragmas[initializePragma] = '';
+
+                // This token is replaced by the first argument to the pragma,
+                // which must be the attribute's precision ("lowp", "mediump",
+                // or "highp")
+                var attributePrecision = '$1';
 
                 if (layer.isPaintValueFeatureConstant(attribute.paintProperty)) {
                     paintAttributes.uniforms.push(attribute);
 
                     paintAttributes.fragmentPragmas[definePragma] = paintAttributes.vertexPragmas[definePragma] = [
                         'uniform',
-                        attribute.precision,
+                        attributePrecision,
                         attributeType,
                         attributeInputName
                     ].join(' ') + ';';
 
                     paintAttributes.fragmentPragmas[initializePragma] = paintAttributes.vertexPragmas[initializePragma] = [
-                        attribute.precision,
+                        attributePrecision,
                         attributeType,
                         attributeInnerName,
                         '=',
@@ -390,7 +395,7 @@ function createPaintAttributes(bucket) {
 
                     attributeVaryingDefinition = [
                         'varying',
-                        attribute.precision,
+                        attributePrecision,
                         attributeType,
                         attributeInnerName
                     ].join(' ') + ';\n';
@@ -398,7 +403,7 @@ function createPaintAttributes(bucket) {
                     var attributeAttributeDefinition = [
                         paintAttributes.fragmentPragmas[definePragma],
                         'attribute',
-                        attribute.precision,
+                        attributePrecision,
                         attributeType,
                         attributeInputName
                     ].join(' ') + ';\n';
@@ -433,7 +438,7 @@ function createPaintAttributes(bucket) {
 
                     attributeVaryingDefinition = [
                         'varying',
-                        attribute.precision,
+                        attributePrecision,
                         attributeType,
                         attributeInnerName
                     ].join(' ') + ';\n';
@@ -463,7 +468,7 @@ function createPaintAttributes(bucket) {
 
                         paintAttributes.vertexPragmas[definePragma] += [
                             'attribute',
-                            attribute.precision,
+                            attributePrecision,
                             'vec4',
                             attributeInputName
                         ].join(' ') + ';\n';
@@ -488,7 +493,7 @@ function createPaintAttributes(bucket) {
                             }));
                             paintAttributes.vertexPragmas[definePragma] += [
                                 'attribute',
-                                attribute.precision,
+                                attributePrecision,
                                 attributeType,
                                 attributeInputName + k
                             ].join(' ') + ';\n';

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -44,7 +44,8 @@ CircleBucket.prototype.programInterfaces = {
                 return util.premultiply(layer.getPaintValue("circle-color", globalProperties, featureProperties));
             },
             multiplier: 255,
-            paintProperty: 'circle-color'
+            paintProperty: 'circle-color',
+            precision: 'lowp'
         }, {
             name: 'a_radius',
             components: 1,
@@ -54,7 +55,8 @@ CircleBucket.prototype.programInterfaces = {
                 return [layer.getPaintValue("circle-radius", globalProperties, featureProperties)];
             },
             multiplier: 10,
-            paintProperty: 'circle-radius'
+            paintProperty: 'circle-radius',
+            precision: 'mediump'
         }]
     }
 };

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -97,5 +97,5 @@ CircleBucket.prototype.addFeature = function(feature) {
         }
     }
 
-    this.addPaintAttributes('circle', globalProperties, feature.properties, startGroup, startIndex);
+    this.populatePaintArrays('circle', globalProperties, feature.properties, startGroup, startIndex);
 };

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -44,8 +44,7 @@ CircleBucket.prototype.programInterfaces = {
                 return util.premultiply(layer.getPaintValue("circle-color", globalProperties, featureProperties));
             },
             multiplier: 255,
-            paintProperty: 'circle-color',
-            precision: 'lowp'
+            paintProperty: 'circle-color'
         }, {
             name: 'a_radius',
             components: 1,
@@ -55,8 +54,7 @@ CircleBucket.prototype.programInterfaces = {
                 return [layer.getPaintValue("circle-radius", globalProperties, featureProperties)];
             },
             multiplier: 10,
-            paintProperty: 'circle-radius',
-            precision: 'mediump'
+            paintProperty: 'circle-radius'
         }]
     }
 };

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -25,7 +25,7 @@ function drawCircles(painter, source, layer, coords) {
         var bufferGroups = bucket.bufferGroups.circle;
         if (!bufferGroups) continue;
 
-        var program = painter.useProgram('circle', bucket.getProgramMacros('circle', layer));
+        var program = painter.useProgram('circle', bucket.getProgramDefines('circle', layer));
 
         gl.uniform2f(program.u_extrude_scale,
                 painter.transform.pixelsToGLUnits[0] * painter.transform.altitude,

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -25,7 +25,12 @@ function drawCircles(painter, source, layer, coords) {
         var bufferGroups = bucket.bufferGroups.circle;
         if (!bufferGroups) continue;
 
-        var program = painter.useProgram('circle', bucket.getProgramDefines('circle', layer));
+        var program = painter.useProgram(
+            'circle',
+            bucket.paintAttributes.circle[layer.id].defines,
+            bucket.paintAttributes.circle[layer.id].vertexPragmas,
+            bucket.paintAttributes.circle[layer.id].fragmentPragmas
+        );
 
         gl.uniform2f(program.u_extrude_scale,
                 painter.transform.pixelsToGLUnits[0] * painter.transform.altitude,

--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -61,6 +61,27 @@ var definitions = {
     }
 };
 
+var vertexSourcePrelude = (
+    'float evaluate_zoom_function_1(const vec4 values, const float t) {' +
+    '    if (t < 1.0) {' +
+    '        return mix(values[0], values[1], t);' +
+    '    } else if (t < 2.0) {' +
+    '        return mix(values[1], values[2], t - 1.0);' +
+    '    } else {' +
+    '        return mix(values[2], values[3], t - 2.0);' +
+    '    }' +
+    '}' +
+    'vec4 evaluate_zoom_function_4(const vec4 value0, const vec4 value1, const vec4 value2, const vec4 value3, const float t) {' +
+    '    if (t < 1.0) {' +
+    '        return mix(value0, value1, t);' +
+    '    } else if (t < 2.0) {' +
+    '        return mix(value1, value2, t - 1.0);' +
+    '    } else {' +
+    '        return mix(value2, value3, t - 2.0);' +
+    '    }' +
+    '}'
+);
+
 module.exports._createProgram = function(name, defines, vertexPragmas, fragmentPragmas) {
     var gl = this.gl;
     var program = gl.createProgram();
@@ -78,7 +99,7 @@ module.exports._createProgram = function(name, defines, vertexPragmas, fragmentP
     gl.attachShader(program, fragmentShader);
 
     var vertexShader = gl.createShader(gl.VERTEX_SHADER);
-    gl.shaderSource(vertexShader, applyPragmas(definesSource + definition.vertexSource, vertexPragmas));
+    gl.shaderSource(vertexShader, applyPragmas(definesSource + vertexSourcePrelude + definition.vertexSource, vertexPragmas));
     gl.compileShader(vertexShader);
     assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(vertexShader));
     gl.attachShader(program, vertexShader);

--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -61,26 +61,24 @@ var definitions = {
     }
 };
 
-module.exports._createProgram = function(name, macros) {
+module.exports._createProgram = function(name, defines) {
     var gl = this.gl;
     var program = gl.createProgram();
     var definition = definitions[name];
 
-    var defines = '';
-    if (macros) {
-        for (var m = 0; m < macros.length; m++) {
-            defines += '#define ' + macros[m] + '\n';
-        }
+    var definesSource = '';
+    for (var j = 0; definesSource && j < definesSource.length; j++) {
+        definesSource += '#define ' + defines[j] + '\;n';
     }
 
     var fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-    gl.shaderSource(fragmentShader, defines + definition.fragmentSource);
+    gl.shaderSource(fragmentShader, definesSource + definition.fragmentSource);
     gl.compileShader(fragmentShader);
     assert(gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(fragmentShader));
     gl.attachShader(program, fragmentShader);
 
     var vertexShader = gl.createShader(gl.VERTEX_SHADER);
-    gl.shaderSource(vertexShader, defines + definition.vertexSource);
+    gl.shaderSource(vertexShader, definesSource + definition.vertexSource);
     gl.compileShader(vertexShader);
     assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(vertexShader));
     gl.attachShader(program, vertexShader);
@@ -110,24 +108,26 @@ module.exports._createProgram = function(name, macros) {
     }, attributes, uniforms);
 };
 
-module.exports._createProgramCached = function(name, macros) {
+module.exports._createProgramCached = function(name, defines) {
     this.cache = this.cache || {};
-    if (this._showOverdrawInspector) {
-        macros = macros || [];
-        macros.push('OVERDRAW_INSPECTOR');
-    }
-    var key = JSON.stringify({name: name, macros: macros});
+
+    var key = JSON.stringify({name: name, defines: defines});
     if (!this.cache[key]) {
-        this.cache[key] = this._createProgram(name, macros);
+        this.cache[key] = this._createProgram(name, defines);
     }
     return this.cache[key];
 };
 
-module.exports.useProgram = function (nextProgramName, macros) {
+module.exports.useProgram = function (nextProgramName, defines) {
     var gl = this.gl;
 
-    var nextProgram = this._createProgramCached(nextProgramName, macros);
+    var nextProgram = this._createProgramCached(nextProgramName, defines);
     var previousProgram = this.currentProgram;
+
+    if (this._showOverdrawInspector) {
+        defines = defines || [];
+        defines.push('OVERDRAW_INSPECTOR');
+    }
 
     if (previousProgram !== nextProgram) {
         gl.useProgram(nextProgram.program);

--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -147,7 +147,7 @@ module.exports.useProgram = function (nextProgramName, defines, vertexPragmas, f
 
 function applyPragmas(source, pragmas) {
     for (var key in pragmas) {
-        source = source.replace('#pragma mapbox: ' + key, pragmas[key]);
+        source = source.replace(new RegExp('#pragma mapbox: ' + key + '( [a-z0-9]*)*'), pragmas[key]);
     }
     return source;
 }

--- a/js/render/painter/use_program.js
+++ b/js/render/painter/use_program.js
@@ -61,26 +61,7 @@ var definitions = {
     }
 };
 
-var vertexSourcePrelude = (
-    'float evaluate_zoom_function_1(const vec4 values, const float t) {' +
-    '    if (t < 1.0) {' +
-    '        return mix(values[0], values[1], t);' +
-    '    } else if (t < 2.0) {' +
-    '        return mix(values[1], values[2], t - 1.0);' +
-    '    } else {' +
-    '        return mix(values[2], values[3], t - 2.0);' +
-    '    }' +
-    '}' +
-    'vec4 evaluate_zoom_function_4(const vec4 value0, const vec4 value1, const vec4 value2, const vec4 value3, const float t) {' +
-    '    if (t < 1.0) {' +
-    '        return mix(value0, value1, t);' +
-    '    } else if (t < 2.0) {' +
-    '        return mix(value1, value2, t - 1.0);' +
-    '    } else {' +
-    '        return mix(value2, value3, t - 2.0);' +
-    '    }' +
-    '}'
-);
+var vertexUtilSource = fs.readFileSync(path.join(__dirname, '../../../shaders/util.vertex.glsl'), 'utf8');
 
 module.exports._createProgram = function(name, defines, vertexPragmas, fragmentPragmas) {
     var gl = this.gl;
@@ -99,7 +80,7 @@ module.exports._createProgram = function(name, defines, vertexPragmas, fragmentP
     gl.attachShader(program, fragmentShader);
 
     var vertexShader = gl.createShader(gl.VERTEX_SHADER);
-    gl.shaderSource(vertexShader, applyPragmas(definesSource + vertexSourcePrelude + definition.vertexSource, vertexPragmas));
+    gl.shaderSource(vertexShader, applyPragmas(definesSource + vertexUtilSource + definition.vertexSource, vertexPragmas));
     gl.compileShader(vertexShader);
     assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(vertexShader));
     gl.attachShader(program, vertexShader);

--- a/shaders/circle.fragment.glsl
+++ b/shaders/circle.fragment.glsl
@@ -3,13 +3,16 @@ precision mediump float;
 uniform lowp float u_blur;
 uniform lowp float u_opacity;
 
-varying lowp vec4 v_color;
 varying vec2 v_extrude;
 varying lowp float v_antialiasblur;
 
+#pragma mapbox: define(color)
+
 void main() {
+    #pragma mapbox: initialize(color)
+
     float t = smoothstep(1.0 - max(u_blur, v_antialiasblur), 1.0, length(v_extrude));
-    gl_FragColor = v_color * (1.0 - t) * u_opacity;
+    gl_FragColor = color * (1.0 - t) * u_opacity;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/shaders/circle.fragment.glsl
+++ b/shaders/circle.fragment.glsl
@@ -6,10 +6,10 @@ uniform lowp float u_opacity;
 varying vec2 v_extrude;
 varying lowp float v_antialiasblur;
 
-#pragma mapbox: define(color)
+#pragma mapbox: define color lowp
 
 void main() {
-    #pragma mapbox: initialize(color)
+    #pragma mapbox: initialize color
 
     float t = smoothstep(1.0 - max(u_blur, v_antialiasblur), 1.0, length(v_extrude));
     gl_FragColor = color * (1.0 - t) * u_opacity;

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -6,29 +6,10 @@ uniform float u_devicepixelratio;
 
 attribute vec2 a_pos;
 
-#ifdef ATTRIBUTE_A_COLOR
-attribute lowp vec4 a_color;
-#elif defined ATTRIBUTE_ZOOM_FUNCTION_A_COLOR0
-uniform lowp float u_color_t;
-attribute lowp vec4 a_color0;
-attribute lowp vec4 a_color1;
-attribute lowp vec4 a_color2;
-attribute lowp vec4 a_color3;
-#else
-uniform lowp vec4 a_color;
-#endif
-
-#ifdef ATTRIBUTE_A_RADIUS
-attribute mediump float a_radius;
-#elif defined ATTRIBUTE_ZOOM_FUNCTION_A_RADIUS
-uniform lowp float u_radius_t;
-attribute mediump vec4 a_radius;
-#else
-uniform mediump float a_radius;
-#endif
+#pragma mapbox: define(color)
+#pragma mapbox: define(radius)
 
 varying vec2 v_extrude;
-varying lowp vec4 v_color;
 varying lowp float v_antialiasblur;
 
 float evaluate_zoom_function_1(const vec4 values, const float t) {
@@ -53,13 +34,8 @@ vec4 evaluate_zoom_function_4(const vec4 value0, const vec4 value1, const vec4 v
 
 void main(void) {
 
-#ifdef ATTRIBUTE_A_RADIUS
-    mediump float radius = a_radius / 10.0;
-#elif defined ATTRIBUTE_ZOOM_FUNCTION_A_RADIUS
-    mediump float radius = evaluate_zoom_function_1(a_radius, u_radius_t) / 10.0;
-#else
-    mediump float radius = a_radius;
-#endif
+    #pragma mapbox: initialize(color)
+    #pragma mapbox: initialize(radius)
 
     // unencode the extrusion vector that we snuck into the a_pos vector
     v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
@@ -70,14 +46,6 @@ void main(void) {
     gl_Position = u_matrix * vec4(floor(a_pos * 0.5), 0, 1);
 
     gl_Position.xy += extrude;
-
-#ifdef ATTRIBUTE_A_COLOR
-    v_color = a_color / 255.0;
-#elif defined ATTRIBUTE_ZOOM_FUNCTION_A_COLOR0
-    v_color = evaluate_zoom_function_4(a_color0, a_color1, a_color2, a_color3, u_color_t) / 255.0;
-#else
-    v_color = a_color;
-#endif
 
     // This is a minimum blur distance that serves as a faux-antialiasing for
     // the circle. since blur is a ratio of the circle's size and the intent is

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -12,26 +12,6 @@ attribute vec2 a_pos;
 varying vec2 v_extrude;
 varying lowp float v_antialiasblur;
 
-float evaluate_zoom_function_1(const vec4 values, const float t) {
-    if (t < 1.0) {
-        return mix(values[0], values[1], t);
-    } else if (t < 2.0) {
-        return mix(values[1], values[2], t - 1.0);
-    } else {
-        return mix(values[2], values[3], t - 2.0);
-    }
-}
-
-vec4 evaluate_zoom_function_4(const vec4 value0, const vec4 value1, const vec4 value2, const vec4 value3, const float t) {
-    if (t < 1.0) {
-        return mix(value0, value1, t);
-    } else if (t < 2.0) {
-        return mix(value1, value2, t - 1.0);
-    } else {
-        return mix(value2, value3, t - 2.0);
-    }
-}
-
 void main(void) {
 
     #pragma mapbox: initialize(color)

--- a/shaders/circle.vertex.glsl
+++ b/shaders/circle.vertex.glsl
@@ -6,16 +6,16 @@ uniform float u_devicepixelratio;
 
 attribute vec2 a_pos;
 
-#pragma mapbox: define(color)
-#pragma mapbox: define(radius)
+#pragma mapbox: define color lowp
+#pragma mapbox: define radius mediump
 
 varying vec2 v_extrude;
 varying lowp float v_antialiasblur;
 
 void main(void) {
 
-    #pragma mapbox: initialize(color)
-    #pragma mapbox: initialize(radius)
+    #pragma mapbox: initialize color
+    #pragma mapbox: initialize radius
 
     // unencode the extrusion vector that we snuck into the a_pos vector
     v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);

--- a/shaders/util.vertex.glsl
+++ b/shaders/util.vertex.glsl
@@ -1,0 +1,18 @@
+float evaluate_zoom_function_1(const vec4 values, const float t) {
+    if (t < 1.0) {
+        return mix(values[0], values[1], t);
+    } else if (t < 2.0) {
+        return mix(values[1], values[2], t - 1.0);
+    } else {
+        return mix(values[2], values[3], t - 2.0);
+    }
+}
+vec4 evaluate_zoom_function_4(const vec4 value0, const vec4 value1, const vec4 value2, const vec4 value3, const float t) {
+    if (t < 1.0) {
+        return mix(value0, value1, t);
+    } else if (t < 2.0) {
+        return mix(value1, value2, t - 1.0);
+    } else {
+        return mix(value2, value3, t - 2.0);
+    }
+}

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -22,12 +22,12 @@ test('Bucket', function(t) {
                 elementBuffer2Components: 2,
 
                 layoutAttributes: options.layoutAttributes || [{
-                    name: 'box',
+                    name: 'a_box',
                     components: 2,
                     type: 'Int16'
                 }],
                 paintAttributes: options.paintAttributes || [{
-                    name: 'map',
+                    name: 'a_map',
                     type: 'Int16',
                     getValue: function(layer, globalProperties, featureProperties) {
                         return [featureProperties.x];
@@ -102,12 +102,12 @@ test('Bucket', function(t) {
         var testVertex = bucket.arrayGroups.test[0].layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.box0, 34);
-        t.equal(v0.box1, 84);
+        t.equal(v0.a_box0, 34);
+        t.equal(v0.a_box1, 84);
         var paintVertex = bucket.arrayGroups.test[0].paint.layerid;
         t.equal(paintVertex.length, 1);
         var p0 = paintVertex.get(0);
-        t.equal(p0.map, 17);
+        t.equal(p0.a_map, 17);
 
         var testElement = bucket.arrayGroups.test[0].layout.element;
         t.equal(testElement.length, 1);
@@ -137,10 +137,10 @@ test('Bucket', function(t) {
         var v0 = bucket.arrayGroups.test[0].layout.vertex.get(0);
         var a0 = bucket.arrayGroups.test[0].paint.one.get(0);
         var b0 = bucket.arrayGroups.test[0].paint.two.get(0);
-        t.equal(a0.map, 17);
-        t.equal(b0.map, 17);
-        t.equal(v0.box0, 34);
-        t.equal(v0.box1, 84);
+        t.equal(a0.a_map, 17);
+        t.equal(b0.a_map, 17);
+        t.equal(v0.a_box0, 34);
+        t.equal(v0.a_box1, 84);
 
         t.end();
     });
@@ -148,7 +148,7 @@ test('Bucket', function(t) {
     t.test('add features, disabled attribute', function(t) {
         var bucket = create({
             paintAttributes: [{
-                name: 'map',
+                name: 'a_map',
                 type: 'Int16',
                 getValue: function() { return [5]; },
                 paintProperty: 'circle-color'
@@ -175,7 +175,7 @@ test('Bucket', function(t) {
         var bucket = create({
             paintAttributes: [],
             layoutAttributes: [{
-                name: 'map',
+                name: 'a_map',
                 type: 'Int16'
             }]
         });
@@ -184,7 +184,7 @@ test('Bucket', function(t) {
         bucket.populateBuffers();
 
         var v0 = bucket.arrayGroups.test[0].layout.vertex.get(0);
-        t.equal(v0.map, 34);
+        t.equal(v0.a_map, 34);
 
         t.end();
     });
@@ -214,12 +214,12 @@ test('Bucket', function(t) {
         var testVertex = bucket.arrayGroups.test[0].layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.box0, 34);
-        t.equal(v0.box1, 84);
+        t.equal(v0.a_box0, 34);
+        t.equal(v0.a_box1, 84);
         var testPaintVertex = bucket.arrayGroups.test[0].paint.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
-        t.equal(p0.map, 17);
+        t.equal(p0.a_map, 17);
 
         var testElement = bucket.arrayGroups.test[0].layout.element;
         t.equal(testElement.length, 1);
@@ -252,12 +252,12 @@ test('Bucket', function(t) {
         var testVertex = bucket.arrayGroups.test[0].layout.vertex;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
-        t.equal(v0.box0, 34);
-        t.equal(v0.box1, 84);
+        t.equal(v0.a_box0, 34);
+        t.equal(v0.a_box1, 84);
         var testPaintVertex = bucket.arrayGroups.test[0].paint.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
-        t.equal(p0.map, 17);
+        t.equal(p0.a_map, 17);
 
         var testElement = bucket.arrayGroups.test[0].layout.element;
         t.equal(testElement.length, 1);

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -44,7 +44,7 @@ test('Bucket', function(t) {
             group.layout.vertex.emplaceBack(point.x * 2, point.y * 2);
             group.layout.element.emplaceBack(1, 2, 3);
             group.layout.element2.emplaceBack(point.x, point.y);
-            this.addPaintAttributes('test', {}, feature.properties, group, startIndex);
+            this.populatePaintArrays('test', {}, feature.properties, group, startIndex);
         };
 
         return Class;


### PR DESCRIPTION
## Refactoring

This pull request contains some vocabulary refactoring within bucket, aiming for conceptual correctness. For example,  the `paintAttributes` array contained much more data than just attributes.

## Pragma Statements

This pull request allows us to expand property function styling support while keeping our codebase DRY and readable. It adds `#pragma` statements to the shaders which generate definition and initialization boilerplate.

### Before

```glsl
precision highp float;

uniform mat4 u_matrix;
uniform vec2 u_extrude_scale;
uniform float u_devicepixelratio;

attribute vec2 a_pos;

#ifdef ATTRIBUTE_A_COLOR
attribute lowp vec4 a_color;
#elif defined ATTRIBUTE_ZOOM_FUNCTION_A_COLOR0
uniform lowp float u_color_t;
attribute lowp vec4 a_color0;
attribute lowp vec4 a_color1;
attribute lowp vec4 a_color2;
attribute lowp vec4 a_color3;
#else
uniform lowp vec4 a_color;
#endif

#ifdef ATTRIBUTE_A_RADIUS
attribute mediump float a_radius;
#elif defined ATTRIBUTE_ZOOM_FUNCTION_A_RADIUS
uniform lowp float u_radius_t;
attribute mediump vec4 a_radius;
#else
uniform mediump float a_radius;
#endif

varying vec2 v_extrude;
varying lowp vec4 v_color;
varying lowp float v_antialiasblur;

float evaluate_zoom_function_1(const vec4 values, const float t) {
    if (t < 1.0) {
        return mix(values[0], values[1], t);
    } else if (t < 2.0) {
        return mix(values[1], values[2], t - 1.0);
    } else {
        return mix(values[2], values[3], t - 2.0);
    }
}

vec4 evaluate_zoom_function_4(const vec4 value0, const vec4 value1, const vec4 value2, const vec4 value3, const float t) {
    if (t < 1.0) {
        return mix(value0, value1, t);
    } else if (t < 2.0) {
        return mix(value1, value2, t - 1.0);
    } else {
        return mix(value2, value3, t - 2.0);
    }
}

void main(void) {

#ifdef ATTRIBUTE_A_RADIUS
    mediump float radius = a_radius / 10.0;
#elif defined ATTRIBUTE_ZOOM_FUNCTION_A_RADIUS
    mediump float radius = evaluate_zoom_function_1(a_radius, u_radius_t) / 10.0;
#else
    mediump float radius = a_radius;
#endif

    // unencode the extrusion vector that we snuck into the a_pos vector
    v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);

    vec2 extrude = v_extrude * radius * u_extrude_scale;
    // multiply a_pos by 0.5, since we had it * 2 in order to sneak
    // in extrusion data
    gl_Position = u_matrix * vec4(floor(a_pos * 0.5), 0, 1);

    gl_Position.xy += extrude;

#ifdef ATTRIBUTE_A_COLOR
    v_color = a_color / 255.0;
#elif defined ATTRIBUTE_ZOOM_FUNCTION_A_COLOR0
    v_color = evaluate_zoom_function_4(a_color0, a_color1, a_color2, a_color3, u_color_t) / 255.0;
#else
    v_color = a_color;
#endif

    // This is a minimum blur distance that serves as a faux-antialiasing for
    // the circle. since blur is a ratio of the circle's size and the intent is
    // to keep the blur at roughly 1px, the two are inversely related.
    v_antialiasblur = 1.0 / u_devicepixelratio / radius;
}
```

## After

```glsl
precision highp float;

uniform mat4 u_matrix;
uniform vec2 u_extrude_scale;
uniform float u_devicepixelratio;

attribute vec2 a_pos;

#pragma mapbox: define(color)
#pragma mapbox: define(radius)

varying vec2 v_extrude;
varying lowp float v_antialiasblur;

void main(void) {

    #pragma mapbox: initialize(color)
    #pragma mapbox: initialize(radius)

    // unencode the extrusion vector that we snuck into the a_pos vector
    v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);

    vec2 extrude = v_extrude * radius * u_extrude_scale;
    // multiply a_pos by 0.5, since we had it * 2 in order to sneak
    // in extrusion data
    gl_Position = u_matrix * vec4(floor(a_pos * 0.5), 0, 1);

    gl_Position.xy += extrude;

    // This is a minimum blur distance that serves as a faux-antialiasing for
    // the circle. since blur is a ratio of the circle's size and the intent is
    // to keep the blur at roughly 1px, the two are inversely related.
    v_antialiasblur = 1.0 / u_devicepixelratio / radius;
}
```

cc @jfirebaugh @mourner @ansis 