### PR TITLE
deduplicate vector-tile geometry -> geojson geometry code

### DIFF
--- a/js/util/vectortile_to_geojson.js
+++ b/js/util/vectortile_to_geojson.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var VectorTileFeature = require('vector-tile').VectorTileFeature;
-
 module.exports = Feature;
 
 function Feature(vectorTileFeature, z, x, y) {
@@ -22,31 +20,10 @@ Feature.prototype = {
 
     get geometry() {
         if (this._geometry === undefined) {
-            var feature = this._vectorTileFeature;
-            var coords = projectCoords(
-                feature.loadGeometry(),
-                feature.extent,
-                feature._z, feature._x, feature._y);
-
-            var type = VectorTileFeature.types[feature.type];
-
-            if (type === 'Point' && coords.length === 1) {
-                coords = coords[0][0];
-            } else if (type === 'Point') {
-                coords = coords[0];
-                type = 'MultiPoint';
-            } else if (type === 'LineString' && coords.length === 1) {
-                coords = coords[0];
-            } else if (type === 'LineString') {
-                type = 'MultiLineString';
-            }
-
-            this._geometry = {
-                type: type,
-                coordinates: coords
-            };
-
-            this._vectorTileFeature = null;
+            this._geometry = this._vectorTileFeature.toGeoJSON(
+                this._vectorTileFeature._x,
+                this._vectorTileFeature._y,
+                this._vectorTileFeature._z).geometry;
         }
         return this._geometry;
     },
@@ -64,21 +41,3 @@ Feature.prototype = {
         return json;
     }
 };
-
-function projectCoords(coords, extent, z, x, y) {
-    var size = extent * Math.pow(2, z),
-        x0 = extent * x,
-        y0 = extent * y;
-    for (var i = 0; i < coords.length; i++) {
-        var line = coords[i];
-        for (var j = 0; j < line.length; j++) {
-            var p = line[j];
-            var y2 = 180 - (p.y + y0) * 360 / size;
-            line[j] = [
-                (p.x + x0) * 360 / size - 180,
-                360 / Math.PI * Math.atan(Math.exp(y2 * Math.PI / 180)) - 90
-            ];
-        }
-    }
-    return coords;
-}


### PR DESCRIPTION
`queryRenderedFeatures` returns geojson-like objects that lazily generate geometries. The vector-tile -> geojson implementation was copied from vector-tile-js. 

https://github.com/mapbox/mapbox-gl-js/blob/c53751f1434ca9c7cf6a9a75d3603db2c6a854de/js/util/vectortile_to_geojson.js
https://github.com/mapbox/vector-tile-js/blob/40f73eb2c417979601be973e046e169c74147ca7/lib/vectortilefeature.js#L136-L156

It would be good to deduplicate this.