### PR TITLE
Rebind VAOs when program changes, fixing "line-pattern" and "fill-pattern" rendering

### DIFF
--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -27,8 +27,15 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, elementBu
         util.warnOnce('Not using VertexArrayObject extension.');
     }
 
-    if (!this.boundProgram) {
+    var isFreshBindRequired = !(
+        this.boundProgram &&
+        this.boundProgram === program &&
+        this.boundVertexBuffer === vertexBuffer &&
+        this.boundVertexBuffer2 === vertexBuffer2 &&
+        this.boundElementBuffer === elementBuffer
+    );
 
+    if (isFreshBindRequired) {
         var numPrevAttributes = ext ? 0 : (gl.currentNumAttributes || 0);
         var numNextAttributes = program.numAttributes;
         var i;
@@ -66,13 +73,6 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, elementBu
             this.boundVertexBuffer2 = vertexBuffer2;
             this.boundElementBuffer = elementBuffer;
         }
-
-    } else {
-        // verify that bind was called with the same arguments
-        assert(this.boundProgram === program, 'trying to bind a VAO to a different shader');
-        assert(this.boundVertexBuffer === vertexBuffer, 'trying to bind a VAO to a different vertex buffer');
-        assert(this.boundVertexBuffer2 === vertexBuffer2, 'trying to bind a VAO to a different vertex buffer');
-        assert(this.boundElementBuffer === elementBuffer, 'trying to bind a VAO to a different element buffer');
     }
 };
 

--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -19,22 +19,19 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, elementBu
         gl.extVertexArrayObject = gl.getExtension("OES_vertex_array_object");
     }
 
-    if (this.isFreshBindRequired(gl, program, vertexBuffer, elementBuffer, vertexBuffer2)) {
-        this.freshBind(gl, program, vertexBuffer, elementBuffer, vertexBuffer2);
-    } else {
-        gl.extVertexArrayObject.bindVertexArrayOES(this.vao);
-    }
-};
-
-VertexArrayObject.prototype.isFreshBindRequired = function(gl, program, vertexBuffer, elementBuffer, vertexBuffer2) {
-    return (
+    var isFreshBindRequired = (
         !this.vao ||
-        !this.boundProgram ||
         this.boundProgram !== program ||
         this.boundVertexBuffer !== vertexBuffer ||
         this.boundVertexBuffer2 !== vertexBuffer2 ||
         this.boundElementBuffer !== elementBuffer
     );
+
+    if (!gl.extVertexArrayObject || isFreshBindRequired) {
+        this.freshBind(gl, program, vertexBuffer, elementBuffer, vertexBuffer2);
+    } else {
+        gl.extVertexArrayObject.bindVertexArrayOES(this.vao);
+    }
 };
 
 VertexArrayObject.prototype.freshBind = function(gl, program, vertexBuffer, elementBuffer, vertexBuffer2) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "express": "^4.13.4",
     "gl": "^2.1.5",
     "istanbul": "^0.4.2",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f6ab579451c8d929584d586ecd85b9b38d124a87",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#8e37472e9b5fd2a3a7385ec68e79b052a9e6035c",
     "nyc": "^6.1.1",
     "sinon": "^1.15.4",
     "st": "^1.0.0",


### PR DESCRIPTION
continuation of #2550 

fixes #2533 

The more I think about this problem, the more certain I am that this is the right solution. 

@ansis envisioned our `VertexArrayObject` class as a thing that maintains a persistent VAO per bucket per layer. We didn't consider that sometimes the VAO must change without a bucket being reloaded (namely, for when calling `setPaintProperty` for `"line-pattern"` or `"fill-pattern"`) and thus we cannot maintain a persistent VAO. 

This PR re-envisions the `VertexArrayObject` class as a proxy for some GL calls which uses a VAO when possible. 

Alternate solutions involve too much coupling (passing the `style` to each `tile`, deleting VAOs whenever the style changes) or nasty performance regressions (reducing the gains made by earcut) (reverting this commit) or a high risk of memory leaks (storing VAOs on `Painter`, deleting VAOs whenever a tile is unloaded)

This solution _does_ branch on system capabilities. However both forks run on any modern machine, creating a low chance of uncaught regressions due to untested code.

It is a huge bummer that #2592 can't help us test this code. Fortunately, there is only 1 line of code not being tested:

```js
gl.extVertexArrayObject.bindVertexArrayOES(this.vao);
```

cc @ansis @jfirebaugh @mourner 