### PR TITLE
Fix overdraw inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "express": "^4.13.4",
     "gl": "^2.1.5",
     "istanbul": "^0.4.2",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#a7facaea4d1fefa4b713a3c5324513c69fb52d75",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#c971675cf98eb929bb4182a6732b34273151d8d2",
     "nyc": "^6.1.1",
     "sinon": "^1.15.4",
     "st": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "express": "^4.13.4",
     "gl": "^2.1.5",
     "istanbul": "^0.4.2",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#c971675cf98eb929bb4182a6732b34273151d8d2",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#5d51f251a04ef919a0e37ccc5bb60a270e8b41fa",
     "nyc": "^6.1.1",
     "sinon": "^1.15.4",
     "st": "^1.0.0",

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -35,6 +35,7 @@ module.exports = function(style, options, _callback) {
 
     if (options.debug) map.showTileBoundaries = true;
     if (options.collisionDebug) map.showCollisionBoxes = true;
+    if (options.showOverdrawInspector) map.showOverdrawInspector = true;
 
     var gl = map.painter.gl;
 


### PR DESCRIPTION
per https://github.com/mapbox/mapbox-gl-js/pull/2585#discussion_r64285284

fixes the overdraw inspector, as regressed by https://github.com/mapbox/mapbox-gl-js/pull/2585

This is a tricky thing to test because the output of the overdraw inspector may change unexpectedly as our implementation changes. @jfirebaugh do you think it would be appropriate to create a test-suite case for this? 