### PR TITLE
Drop smallest inner rings for earcut performance

### DIFF
--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -5,7 +5,7 @@ var util = require('../../util/util');
 var loadGeometry = require('../load_geometry');
 var earcut = require('earcut');
 var classifyRings = require('../../util/classify_rings');
-var EARCUT_MAX_RINGS = 100;
+var EARCUT_MAX_RINGS = 500;
 
 module.exports = FillBucket;
 

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -5,6 +5,7 @@ var util = require('../../util/util');
 var loadGeometry = require('../load_geometry');
 var earcut = require('earcut');
 var classifyRings = require('../../util/classify_rings');
+var EARCUT_MAX_RINGS = 100;
 
 module.exports = FillBucket;
 
@@ -32,7 +33,7 @@ FillBucket.prototype.programInterfaces = {
 
 FillBucket.prototype.addFeature = function(feature) {
     var lines = loadGeometry(feature);
-    var polygons = classifyRings(lines);
+    var polygons = classifyRings(lines, EARCUT_MAX_RINGS);
     for (var i = 0; i < polygons.length; i++) {
         this.addPolygon(polygons[i]);
     }

--- a/js/util/classify_rings.js
+++ b/js/util/classify_rings.js
@@ -35,7 +35,7 @@ module.exports = function classifyRings(rings, maxRings) {
     if (maxRings > 1) {
         for (var j = 0; j < polygons.length; j++) {
             if (polygons[j].length <= maxRings) continue;
-            quickselect(polygons[j], maxRings - 1, 1, polygon.length - 1, compareAreas);
+            quickselect(polygons[j], maxRings, 1, polygon.length - 1, compareAreas);
             polygons[j] = polygon.slice(0, maxRings);
         }
     }

--- a/js/util/classify_rings.js
+++ b/js/util/classify_rings.js
@@ -4,7 +4,7 @@ module.exports = classifyRings;
 
 // classifies an array of rings into polygons with outer rings and holes
 
-function classifyRings(rings) {
+function classifyRings(rings, maxRings) {
     var len = rings.length;
 
     if (len <= 1) return [rings];
@@ -16,6 +16,8 @@ function classifyRings(rings) {
     for (var i = 0; i < len; i++) {
         var area = signedArea(rings[i]);
         if (area === 0) continue;
+
+        rings[i].area = area;
 
         if (ccw === undefined) ccw = area < 0;
 
@@ -29,7 +31,21 @@ function classifyRings(rings) {
     }
     if (polygon) polygons.push(polygon);
 
+    if (maxRings > 1) {
+        len = polygons.length;
+        for (var j = 0; j < len; j++) {
+            var polygon = polygons[j];
+            var truncated = [polygon.shift()];
+            polygon.sort(sortByArea);
+            polygons[j] = truncated.concat(polygon.slice(0, maxRings-1));
+        }
+    }
+
     return polygons;
+}
+
+function sortByArea(a, b) {
+    return b.area - a.area;
 }
 
 function signedArea(ring) {

--- a/js/util/classify_rings.js
+++ b/js/util/classify_rings.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var quickselect = require('quickselect');
+
 module.exports = classifyRings;
 
 // classifies an array of rings into polygons with outer rings and holes
@@ -11,7 +13,6 @@ function classifyRings(rings, maxRings) {
 
     var polygons = [],
         polygon,
-        truncated,
         ccw;
 
     for (var i = 0; i < len; i++) {
@@ -35,10 +36,9 @@ function classifyRings(rings, maxRings) {
     if (maxRings > 1) {
         len = polygons.length;
         for (var j = 0; j < len; j++) {
-            polygon = polygons[j];
-            truncated = [polygon.shift()];
-            polygon.sort(sortByArea);
-            polygons[j] = truncated.concat(polygon.slice(0, maxRings - 1));
+            if (polygons[j].length <= maxRings) continue;
+            quickselect(polygons[j], maxRings - 1, 1, polygon.length - 1, sortByArea);
+            polygons[j] = polygon.slice(0, maxRings);
         }
     }
 

--- a/js/util/classify_rings.js
+++ b/js/util/classify_rings.js
@@ -17,7 +17,7 @@ function classifyRings(rings, maxRings) {
         var area = signedArea(rings[i]);
         if (area === 0) continue;
 
-        rings[i].area = area;
+        rings[i].area = Math.abs(area);
 
         if (ccw === undefined) ccw = area < 0;
 

--- a/js/util/classify_rings.js
+++ b/js/util/classify_rings.js
@@ -2,11 +2,8 @@
 
 var quickselect = require('quickselect');
 
-module.exports = classifyRings;
-
 // classifies an array of rings into polygons with outer rings and holes
-
-function classifyRings(rings, maxRings) {
+module.exports = function classifyRings(rings, maxRings) {
     var len = rings.length;
 
     if (len <= 1) return [rings];
@@ -16,7 +13,7 @@ function classifyRings(rings, maxRings) {
         ccw;
 
     for (var i = 0; i < len; i++) {
-        var area = signedArea(rings[i]);
+        var area = calculateSignedArea(rings[i]);
         if (area === 0) continue;
 
         rings[i].area = Math.abs(area);
@@ -33,23 +30,24 @@ function classifyRings(rings, maxRings) {
     }
     if (polygon) polygons.push(polygon);
 
+    // Earcut performance degrages with the # of rings in a polygon. For this
+    // reason, we limit strip out all but the `maxRings` largest rings.
     if (maxRings > 1) {
-        len = polygons.length;
-        for (var j = 0; j < len; j++) {
+        for (var j = 0; j < polygons.length; j++) {
             if (polygons[j].length <= maxRings) continue;
-            quickselect(polygons[j], maxRings - 1, 1, polygon.length - 1, sortByArea);
+            quickselect(polygons[j], maxRings - 1, 1, polygon.length - 1, compareAreas);
             polygons[j] = polygon.slice(0, maxRings);
         }
     }
 
     return polygons;
-}
+};
 
-function sortByArea(a, b) {
+function compareAreas(a, b) {
     return b.area - a.area;
 }
 
-function signedArea(ring) {
+function calculateSignedArea(ring) {
     var sum = 0;
     for (var i = 0, len = ring.length, j = len - 1, p1, p2; i < len; j = i++) {
         p1 = ring[i];

--- a/js/util/classify_rings.js
+++ b/js/util/classify_rings.js
@@ -11,6 +11,7 @@ function classifyRings(rings, maxRings) {
 
     var polygons = [],
         polygon,
+        truncated,
         ccw;
 
     for (var i = 0; i < len; i++) {
@@ -34,10 +35,10 @@ function classifyRings(rings, maxRings) {
     if (maxRings > 1) {
         len = polygons.length;
         for (var j = 0; j < len; j++) {
-            var polygon = polygons[j];
-            var truncated = [polygon.shift()];
+            polygon = polygons[j];
+            truncated = [polygon.shift()];
             polygon.sort(sortByArea);
-            polygons[j] = truncated.concat(polygon.slice(0, maxRings-1));
+            polygons[j] = truncated.concat(polygon.slice(0, maxRings - 1));
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "pbf": "^1.3.2",
     "pngjs": "^2.2.0",
     "point-geometry": "^0.0.0",
+    "quickselect": "^1.0.0",
     "request": "^2.39.0",
     "resolve-url": "^0.2.1",
     "shelf-pack": "^1.0.0",

--- a/test/js/util/classify_rings.test.js
+++ b/test/js/util/classify_rings.test.js
@@ -21,7 +21,7 @@ test('classifyRings', function(assert) {
             {x:0, y:40},
             {x:40, y:40},
             {x:40, y:0},
-            {x:0,y:0}
+            {x:0, y:0}
         ]
     ];
     classified = classifyRings(geometry);
@@ -34,14 +34,14 @@ test('classifyRings', function(assert) {
             {x:0, y:40},
             {x:40, y:40},
             {x:40, y:0},
-            {x:0,y:0}
+            {x:0, y:0}
         ],
         [
             {x:60, y:0},
             {x:60, y:40},
             {x:100, y:40},
             {x:100, y:0},
-            {x:60,y:0}
+            {x:60, y:0}
         ]
     ];
     classified = classifyRings(geometry);

--- a/test/js/util/classify_rings.test.js
+++ b/test/js/util/classify_rings.test.js
@@ -77,3 +77,50 @@ test('classifyRings', function(assert) {
     assert.end();
 });
 
+test('classifyRings + maxRings', function(assert) {
+    var geometry;
+    var classified;
+
+    geometry = [
+        [
+            {x:0, y:0},
+            {x:0, y:40},
+            {x:40, y:40},
+            {x:40, y:0},
+            {x:0, y:0}
+        ],
+        [
+            {x:30, y:30},
+            {x:32, y:30},
+            {x:32, y:32},
+            {x:30, y:30}
+        ],
+        [
+            {x:10, y:10},
+            {x:20, y:10},
+            {x:20, y:20},
+            {x:10, y:10}
+        ]
+    ];
+    classified = classifyRings(geometry);
+    assert.equal(classified.length, 1, '1 polygon');
+    assert.equal(classified[0].length, 3, 'polygon 1 has 1 exterior, 2 interior');
+    assert.equal(classified[0][0].area, -3200, 'polygon 1 exterior ring has area=-3200');
+    assert.equal(classified[0][1].area, 4, 'polygon 1 interior ring1 has area=4');
+    assert.equal(classified[0][2].area, 100, 'polygon 1 interior ring2 has area=100');
+
+    classified = classifyRings(geometry, 2);
+    assert.equal(classified.length, 1, '1 polygon');
+    assert.equal(classified[0].length, 2, 'polygon 1 has 1 exterior, 1 interior');
+    assert.equal(classified[0][0].area, -3200, 'polygon 1 exterior ring has area=-3200');
+    assert.equal(classified[0][1].area, 100, 'polygon 1 interior ring has area=100');
+
+    geometry = feature.loadGeometry();
+    classified = classifyRings(geometry, 5);
+    assert.equal(classified.length, 2, '2 polygons');
+    assert.equal(classified[0].length, 1, 'polygon 1 has 1 exterior');
+    assert.equal(classified[1].length, 5, 'polygon 2 has 1 exterior, 4 interior');
+
+    assert.end();
+});
+

--- a/test/js/util/classify_rings.test.js
+++ b/test/js/util/classify_rings.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var Protobuf = require('pbf');
+var VectorTile = require('vector-tile').VectorTile;
+var classifyRings = require('../../../js/util/classify_rings');
+
+// Load a fill feature from fixture tile.
+var vt = new VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
+var feature = vt.layers.water.feature(0);
+
+test('classifyRings', function(assert) {
+    var geometry;
+    var classified;
+
+    geometry = [
+        [
+            {x:0, y:0},
+            {x:0, y:40},
+            {x:40, y:40},
+            {x:40, y:0},
+            {x:0,y:0}
+        ]
+    ];
+    classified = classifyRings(geometry);
+    assert.equal(classified.length, 1, '1 polygon');
+    assert.equal(classified[0].length, 1, 'polygon 1 has 1 exterior');
+
+    geometry = [
+        [
+            {x:0, y:0},
+            {x:0, y:40},
+            {x:40, y:40},
+            {x:40, y:0},
+            {x:0,y:0}
+        ],
+        [
+            {x:60, y:0},
+            {x:60, y:40},
+            {x:100, y:40},
+            {x:100, y:0},
+            {x:60,y:0}
+        ]
+    ];
+    classified = classifyRings(geometry);
+    assert.equal(classified.length, 2, '2 polygons');
+    assert.equal(classified[0].length, 1, 'polygon 1 has 1 exterior');
+    assert.equal(classified[1].length, 1, 'polygon 2 has 1 exterior');
+
+    geometry = [
+        [
+            {x:0, y:0},
+            {x:0, y:40},
+            {x:40, y:40},
+            {x:40, y:0},
+            {x:0, y:0}
+        ],
+        [
+            {x:10, y:10},
+            {x:20, y:10},
+            {x:20, y:20},
+            {x:10, y:10}
+        ]
+    ];
+    classified = classifyRings(geometry);
+    assert.equal(classified.length, 1, '1 polygon');
+    assert.equal(classified[0].length, 2, 'polygon 1 has 1 exterior, 1 interior');
+
+    geometry = feature.loadGeometry();
+    classified = classifyRings(geometry);
+    assert.equal(classified.length, 2, '2 polygons');
+    assert.equal(classified[0].length, 1, 'polygon 1 has 1 exterior');
+    assert.equal(classified[1].length, 10, 'polygon 2 has 1 exterior, 9 interior');
+
+    assert.end();
+});
+

--- a/test/js/util/classify_rings.test.js
+++ b/test/js/util/classify_rings.test.js
@@ -105,14 +105,23 @@ test('classifyRings + maxRings', function(assert) {
     classified = classifyRings(geometry);
     assert.equal(classified.length, 1, '1 polygon');
     assert.equal(classified[0].length, 3, 'polygon 1 has 1 exterior, 2 interior');
-    assert.equal(classified[0][0].area, -3200, 'polygon 1 exterior ring has area=-3200');
+    assert.equal(classified[0][0].area, 3200, 'polygon 1 exterior ring has area=3200');
     assert.equal(classified[0][1].area, 4, 'polygon 1 interior ring1 has area=4');
     assert.equal(classified[0][2].area, 100, 'polygon 1 interior ring2 has area=100');
 
     classified = classifyRings(geometry, 2);
     assert.equal(classified.length, 1, '1 polygon');
     assert.equal(classified[0].length, 2, 'polygon 1 has 1 exterior, 1 interior');
-    assert.equal(classified[0][0].area, -3200, 'polygon 1 exterior ring has area=-3200');
+    assert.equal(classified[0][0].area, 3200, 'polygon 1 exterior ring has area=3200');
+    assert.equal(classified[0][1].area, 100, 'polygon 1 interior ring has area=100');
+
+    geometry[0].reverse();
+    geometry[1].reverse();
+    geometry[2].reverse();
+    classified = classifyRings(geometry, 2);
+    assert.equal(classified.length, 1, '1 polygon');
+    assert.equal(classified[0].length, 2, 'polygon 1 has 1 exterior, 1 interior');
+    assert.equal(classified[0][0].area, 3200, 'polygon 1 exterior ring has area=3200');
     assert.equal(classified[0][1].area, 100, 'polygon 1 interior ring has area=100');
 
     geometry = feature.loadGeometry();


### PR DESCRIPTION
- Adds unit tests for `classifyRings()`
- Adds sorting of inner rings for polygons by area (desc) and truncating to `EARCUT_MAX_RINGS` (currently set to 100)

### Next actions

- [x] coordinate benchmarks with @jakepruitt 
- [x] more IRL testing with various datasources to determine a good `EARCUT_MAX_RINGS` value
- [x] mapbox-gl-native PR (https://github.com/mapbox/mapbox-gl-native/issues/5145)

cc @jakepruitt @jfirebaugh 