### PR TITLE
Require node v4 in package.json engines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Install the Xcode Command Line Tools Package
 xcode-select --install
 ```
 
-Install [node.js](https://nodejs.org/)
+Install [node.js](https://nodejs.org/) version 4 or greater
 ```bash
 brew install node
 ```
@@ -47,7 +47,7 @@ npm install
 
 ### Linux
 
-Install [git](https://git-scm.com/), [node.js](https://nodejs.org/), [GNU Make](http://www.gnu.org/software/make/), and libglew-dev
+Install [git](https://git-scm.com/), [node.js](https://nodejs.org/) (version 4 or greater), [GNU Make](http://www.gnu.org/software/make/), and libglew-dev
 ```bash
 sudo apt-get update &&
 sudo apt-get install build-essential git nodejs libglew-dev

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "git://github.com/mapbox/mapbox-gl-js.git"
   },
+  "engines": { "node" : ">=4.0.0" },
   "dependencies": {
     "csscolorparser": "^1.0.2",
     "earcut": "^2.0.3",


### PR DESCRIPTION
`npm install` recently began failing on Node v0.10 with this error message:

```
uglify-js failed on node_modules/mapbox-gl-shaders/index.js : Unterminated string constant (line: 60, col: 22, pos: 33204)
```

Is it time to start requiring Node v4? Or should we try to fix Node v0.10?

cc @jfirebaugh @tmcw @mourner @bhousel @mollymerp 