### PR TITLE
Refactor Source interface to allow/prepare for extensibility

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -92,6 +92,70 @@ map.on('load', function() {
         }
     }, 'country-label-lg');
 
+    // Add a new source from our GeoJSON data and set the
+    // 'cluster' option to true.
+    map.addSource("earthquakes", {
+        type: "geojson-clustered",
+        // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes
+        // from 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
+        data: "https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson",
+        cluster: true,
+        clusterMaxZoom: 14, // Max zoom to cluster points on
+        clusterRadius: 50 // Radius of each cluster when clustering points (defaults to 50)
+    });
+
+    // Use the earthquakes source to create five layers:
+    // One for non-clustered markers, three for each cluster category,
+    // and one for cluster labels.
+    map.addLayer({
+        "id": "non-cluster-markers",
+        "type": "symbol",
+        "source": "earthquakes",
+        "layout": {
+            "icon-image": "marker-15"
+        }
+    });
+
+    // Display the earthquake data in three layers, each filtered to a range of
+    // count values. Each range gets a different fill color.
+    var layers = [
+        [150, '#f28cb1'],
+        [20, '#f1f075'],
+        [0, '#51bbd6']
+    ];
+
+    layers.forEach(function (layer, i) {
+        map.addLayer({
+            "id": "cluster-" + i,
+            "type": "circle",
+            "source": "earthquakes",
+            "paint": {
+                "circle-color": layer[1],
+                "circle-radius": 18
+            },
+            "filter": i === 0 ?
+                [">=", "point_count", layer[0]] :
+                ["all",
+                    [">=", "point_count", layer[0]],
+                    ["<", "point_count", layers[i - 1][0]]]
+        });
+    });
+
+    // Add a layer for the clusters' count labels
+    map.addLayer({
+        "id": "cluster-count",
+        "type": "symbol",
+        "source": "earthquakes",
+        "layout": {
+            "text-field": "{point_count}",
+            "text-font": [
+                "DIN Offc Pro Medium",
+                "Arial Unicode MS Bold"
+            ],
+            "text-size": 12
+        }
+    });
+
     var bufferTimes = {};
     map.on('tile.stats', function(bufferTimes) {
         var _stats = [];

--- a/debug/queryFeatures.html
+++ b/debug/queryFeatures.html
@@ -21,22 +21,17 @@
 var map = new mapboxgl.Map({
     container: 'map',
     zoom: 12.5,
-    center: [38.888, -77.01866],
+    center: [-77.01866, 38.888],
     hash: true,
     style: 'mapbox://styles/mapbox/streets-v8'
 });
 
 map.addControl(new mapboxgl.Navigation());
 
-var querySource = new mapboxgl.GeoJSONSource({
-  data: { type: 'FeatureCollection', features: [] }
-});
-var boxSource = new mapboxgl.GeoJSONSource({
-  data: { type: 'FeatureCollection', features: [] }
-});
+var emptyFc = { type: 'FeatureCollection', features: [] }
 
 map.on('style.load', function() {
-    map.addSource('queried', querySource);
+    map.addSource('queried', { type: 'geojson', data: emptyFc });
     map.addLayer({
         "id": "query",
         "type": "line",
@@ -47,7 +42,7 @@ map.on('style.load', function() {
         }
     }, 'country-label-sm');
 
-    map.addSource('boxsource', boxSource);
+    map.addSource('boxsource', { type: 'geojson', data: emptyFc });
     map.addLayer({
         "id": "box",
         "type": "fill",
@@ -81,28 +76,22 @@ map.on('click', function(e) {
           [boxcoords[1][0], boxcoords[0][1]],
           boxcoords[0]
         ];
+        var results = map.queryRenderedFeatures(box, {})
+        map.getSource('queried').setData({
+          type: 'FeatureCollection',
+          features: results
+        });
 
-        console.log('box', boxcoords);
-        map.queryRenderedFeatures(box, {
-          includeGeometry: true
-        }, function (err, results) {
-            console.log('queryRenderedFeatures', box, err, results);
-            querySource.setData({
-              type: 'FeatureCollection',
-              features: results
-            });
-
-            boxSource.setData({
-              type: 'FeatureCollection',
-              features: [{
-                type: 'Feature',
-                properties: {},
-                geometry: {
-                  type: 'LineString',
-                  coordinates: boxcoords
-                }
-              }]
-            });
+        map.getSource('boxsource').setData({
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            properties: {},
+            geometry: {
+              type: 'LineString',
+              coordinates: boxcoords
+            }
+          }]
         });
     }
 });

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var TilePyramid = require('../source/tile_pyramid');
-var pyramid = new TilePyramid(null, { tileSize: 512 });
 var util = require('../util/util');
 var pixelsToTileUnits = require('../source/pixels_to_tile_units');
 var createUniformPragmas = require('./create_uniform_pragmas');
+
+var tileSize = 512;
 
 module.exports = drawBackground;
 
@@ -62,10 +62,9 @@ function drawBackground(painter, source, layer) {
     // the depth and stencil buffers get into a bad state.
     // This can be refactored into a single draw call once earcut lands and
     // we don't have so much going on in the stencil buffer.
-    var coords = pyramid.coveringTiles(transform);
+    var coords = transform.coveringTiles({ tileSize: tileSize });
     for (var c = 0; c < coords.length; c++) {
         var coord = coords[c];
-        var tileSize = 512;
         // var pixelsToTileUnitsBound = pixelsToTileUnits.bind({coord:coord, tileSize: tileSize});
         if (imagePosA && imagePosB) {
             var tile = {coord:coord, tileSize: tileSize};

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var TilePyramid = require('../source/tile_pyramid');
-var pyramid = new TilePyramid({ tileSize: 512 });
+var pyramid = new TilePyramid(null, { tileSize: 512 });
 var util = require('../util/util');
 var pixelsToTileUnits = require('../source/pixels_to_tile_units');
 var createUniformPragmas = require('./create_uniform_pragmas');

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -54,7 +54,7 @@ function drawRasterTile(painter, source, layer, coord) {
     gl.uniform1f(program.u_contrast_factor, contrastFactor(layer.paint['raster-contrast']));
     gl.uniform3fv(program.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));
 
-    var parentTile = tile.source && tile.source._pyramid.findLoadedParent(coord, 0, {}),
+    var parentTile = tile.source && tile.source.findLoadedParent(coord, 0, {}),
         opacities = getOpacities(tile, parentTile, layer, painter.transform);
 
     var parentScaleBy, parentTL;

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -122,7 +122,7 @@ function getOpacities(tile, parentTile, layer, transform) {
         var sinceTile = (now - tile.timeAdded) / fadeDuration;
         var sinceParent = parentTile ? (now - parentTile.timeAdded) / fadeDuration : -1;
 
-        var idealZ = tile.source._pyramid.coveringZoomLevel(transform);
+        var idealZ = transform.coveringZoomLevel(tile.source);
         var parentFurther = parentTile ? Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ) : false;
 
         if (!parentTile || parentFurther) {

--- a/js/source/clustered_geojson_source.js
+++ b/js/source/clustered_geojson_source.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var GeoJSONSource = require('./geojson_source');
+var webworkify = require('webworkify');
+
+module.exports.create = GeoJSONSource.create;
+module.exports.workerSourceURL = URL.createObjectURL(
+    webworkify(require('./clustered_geojson_worker_source'), {bare: true})
+);
+

--- a/js/source/clustered_geojson_worker_source.js
+++ b/js/source/clustered_geojson_worker_source.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var supercluster = require('supercluster');
+var GeoJSONWorkerSource = require('./geojson_worker_base');
+
+var workerSource = Object.create(GeoJSONWorkerSource);
+workerSource.indexData = function (data, params, callback) {
+    var superclusterOptions = {
+        maxZoom: params.maxZoom,
+        extent: params.extent,
+        radius: (params.clusterRadius || 50) * params.scale,
+        log: false
+    };
+    try {
+        return callback(null, supercluster(superclusterOptions).load(data.features));
+    } catch (e) {
+        return callback(e);
+    }
+};
+
+module.exports = function (self) {
+    self.registerWorkerSource('geojson-clustered', workerSource);
+};

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -76,6 +76,10 @@ GeoJSONSource.prototype = /** @lends GeoJSONSource.prototype */{
     isTileClipped: true,
     _dirty: true,
 
+    onAdd: function (map) {
+        this.map = map;
+    },
+
     /**
      * Update source geojson data and rerender map
      *

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -1,13 +1,27 @@
 'use strict';
 
 var util = require('../util/util');
-var Evented = require('../util/evented');
-var TilePyramid = require('./tile_pyramid');
-var Source = require('./source');
 var urlResolve = require('resolve-url');
 var EXTENT = require('../data/bucket').EXTENT;
 
-module.exports = GeoJSONSource;
+var webworkify = require('webworkify');
+
+module.exports.create = function (id, options, dispatcher, onChange, callback) {
+    var source = new GeoJSONSource(id, options, dispatcher, onChange);
+
+    //TODO: is it to aggressive to do this on source creation, as opposed to
+    //lazily at the first tile request?
+    source._updateData(function done(err) {
+        if (err) {
+            return callback(err);
+        }
+        callback(null, source);
+    });
+};
+
+module.exports.workerSourceURL = URL.createObjectURL(
+    webworkify(require('./geojson_worker_source'), {bare: true})
+);
 
 /**
  * Create a GeoJSON data source instance given an options object
@@ -40,50 +54,27 @@ module.exports = GeoJSONSource;
  * map.addSource('some id', sourceObj); // add
  * map.removeSource('some id');  // remove
  */
-function GeoJSONSource(options) {
+function GeoJSONSource(id, options, dispatcher, onChange) {
+    this.id = id;
+    this.dispatcher = dispatcher;
+    this._onChange = onChange;
+
     options = options || {};
 
     this._data = options.data;
 
     if (options.maxzoom !== undefined) this.maxzoom = options.maxzoom;
 
-    var scale = EXTENT / this.tileSize;
+    this.type = options.type;
 
-    this.geojsonVtOptions = {
-        buffer: (options.buffer !== undefined ? options.buffer : 128) * scale,
-        tolerance: (options.tolerance !== undefined ? options.tolerance : 0.375) * scale,
-        extent: EXTENT,
-        maxZoom: this.maxzoom
-    };
-
-    this.cluster = options.cluster || false;
-    this.superclusterOptions = {
-        maxZoom: Math.min(options.clusterMaxZoom, this.maxzoom - 1) || (this.maxzoom - 1),
-        extent: EXTENT,
-        radius: (options.clusterRadius || 50) * scale,
-        log: false
-    };
-
-    this._pyramid = new TilePyramid({
-        tileSize: this.tileSize,
-        minzoom: this.minzoom,
-        maxzoom: this.maxzoom,
-        reparseOverscaled: true,
-        load: this._loadTile.bind(this),
-        abort: this._abortTile.bind(this),
-        unload: this._unloadTile.bind(this),
-        add: this._addTile.bind(this),
-        remove: this._removeTile.bind(this),
-        redoPlacement: this._redoTilePlacement.bind(this)
-    });
 }
 
-GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototype */{
+GeoJSONSource.prototype = /** @lends GeoJSONSource.prototype */{
     minzoom: 0,
     maxzoom: 18,
     tileSize: 512,
-    _dirty: true,
     isTileClipped: true,
+    _dirty: true,
 
     /**
      * Update source geojson data and rerender map
@@ -95,60 +86,20 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
         this._data = data;
         this._dirty = true;
 
-        this.fire('change');
-
-        if (this.map)
-            this.update(this.map.transform);
+        this._onChange();
 
         return this;
     },
 
-    onAdd: function(map) {
-        this.map = map;
-    },
-
-    loaded: function() {
-        return this._loaded && this._pyramid.loaded();
-    },
-
-    update: function(transform) {
-        if (this._dirty) {
-            this._updateData();
-        }
-
-        if (this._loaded) {
-            this._pyramid.update(this.used, transform);
-        }
-    },
-
-    reload: function() {
-        if (this._loaded) {
-            this._pyramid.reload();
-        }
-    },
-
-    serialize: function() {
-        return {
-            type: 'geojson',
-            data: this._data
-        };
-    },
-
-    getVisibleCoordinates: Source._getVisibleCoordinates,
-    getTile: Source._getTile,
-
-    queryRenderedFeatures: Source._queryRenderedVectorFeatures,
-    querySourceFeatures: Source._querySourceFeatures,
-
-    _updateData: function() {
+    _updateData: function(cb) {
         this._dirty = false;
-        var options = {
-            tileSize: this.tileSize,
+        var options = util.extend({
             source: this.id,
-            geojsonVtOptions: this.geojsonVtOptions,
-            cluster: this.cluster,
-            superclusterOptions: this.superclusterOptions
-        };
+            extent: EXTENT,
+            scale: EXTENT / this.tileSize,
+            minZoom: this.minzoom,
+            maxZoom: this.maxzoom
+        }, this.options);
 
         var data = this._data;
         if (typeof data === 'string') {
@@ -156,21 +107,31 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
         } else {
             options.data = JSON.stringify(data);
         }
-        this.workerID = this.dispatcher.send('parse geojson', options, function(err) {
+        this.workerID = this.dispatcher.send(this.type + '.parse', options, function(err) {
+            // TODO: not quite sure if we need this anymore
             this._loaded = true;
-            if (err) {
-                this.fire('error', {error: err});
-            } else {
-                this._pyramid.reload();
-                this.fire('change');
-            }
+            cb(err);
 
         }.bind(this));
     },
 
-    _loadTile: function(tile) {
+    load: function (tile, callback) {
+        if (!this._dirty) {
+            return this._load(tile, callback);
+        }
+
+        this._updateData(function (err) {
+            if (err) {
+                return callback(err);
+            }
+            this._load(tile, callback);
+        }.bind(this));
+    },
+
+    _load: function(tile, callback) {
         var overscaling = tile.coord.z > this.maxzoom ? Math.pow(2, tile.coord.z - this.maxzoom) : 1;
         var params = {
+            type: this.type,
             uid: tile.uid,
             coord: tile.coord,
             zoom: tile.coord.z,
@@ -183,7 +144,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 
-        tile.workerID = this.dispatcher.send('load geojson tile', params, function(err, data) {
+        tile.workerID = this.dispatcher.send('load tile', params, function(err, data) {
 
             tile.unloadVectorData(this.map.painter);
 
@@ -191,8 +152,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
                 return;
 
             if (err) {
-                this.fire('tile.error', {tile: tile});
-                return;
+                return callback(err);
             }
 
             tile.loadVectorData(data, this.map.style);
@@ -202,31 +162,24 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
                 tile.redoPlacement(this);
             }
 
-            this.fire('tile.load', {tile: tile});
+            return callback(null, data);
 
         }.bind(this), this.workerID);
     },
 
-    _abortTile: function(tile) {
+    abort: function(tile) {
         tile.aborted = true;
     },
 
-    _addTile: function(tile) {
-        this.fire('tile.add', {tile: tile});
-    },
-
-    _removeTile: function(tile) {
-        this.fire('tile.remove', {tile: tile});
-    },
-
-    _unloadTile: function(tile) {
+    unload: function(tile) {
         tile.unloadVectorData(this.map.painter);
         this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, null, tile.workerID);
     },
 
-    redoPlacement: Source.redoPlacement,
-
-    _redoTilePlacement: function(tile) {
-        tile.redoPlacement(this);
+    serialize: function() {
+        return {
+            type: this.type,
+            data: this._data
+        };
     }
-});
+};

--- a/js/source/geojson_worker_base.js
+++ b/js/source/geojson_worker_base.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var ajax = require('../util/ajax');
+var rewind = require('geojson-rewind');
+var GeoJSONWrapper = require('./geojson_wrapper');
+var vtpbf = require('vt-pbf');
+var geojsonvt = require('geojson-vt');
+
+/*
+ * A base prototype to use for creating GeoJSON-based source workers.  This is
+ * basically an abstract class; subclasses should implement (at least) the
+ * indexData method.
+ */
+module.exports = Object.create({
+    geoJSONIndexes: {},
+
+    // boilerplate for loadTile that uses a geojson-vt-like tile index and
+    // wraps results in VectorTile interface required by the gl-js Worker.
+    loadTile: function (params, callback) {
+        var source = params.source,
+            coord = params.coord;
+
+        if (!this.geoJSONIndexes[source]) return callback(null, null); // we couldn't load the file
+
+        var geoJSONTile = this.geoJSONIndexes[source].getTile(Math.min(coord.z, params.maxZoom), coord.x, coord.y);
+        if (geoJSONTile) {
+            var geojsonWrapper = new GeoJSONWrapper(geoJSONTile.features);
+            geojsonWrapper.name = '_geojsonTileLayer';
+            var pbf = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
+            if (pbf.byteOffset !== 0 || pbf.byteLength !== pbf.buffer.byteLength) {
+                // Compatibility with node Buffer (https://github.com/mapbox/pbf/issues/35)
+                pbf = new Uint8Array(pbf);
+            }
+            callback(null, { tile: geojsonWrapper, rawTileData: pbf.buffer });
+            // tile.parse(geojsonWrapper, this.layerFamilies, this.actor, rawTileData, callback);
+        } else {
+            return callback(null, null); // nothing in the given tile
+        }
+    },
+
+    parse: function (params, callback) {
+        var handleData = function(err, data) {
+            if (err) return callback(err);
+            if (typeof data != 'object') {
+                return callback(new Error("Input data is not a valid GeoJSON object."));
+            }
+            rewind(data, true);
+            this.indexData(data, params, function (err, indexed) {
+                if (err) { return callback(err); }
+                this.geoJSONIndexes[params.source] = indexed;
+                callback(null);
+            }.bind(this));
+        }.bind(this);
+
+        this.getData(params, handleData);
+    },
+
+    /**
+     * Get the GeoJSON data from `params`.
+     */
+    getData: function (params, callback) {
+        // Because of same origin issues, urls must either include an explicit
+        // origin or absolute path.
+        // ie: /foo/bar.json or http://example.com/bar.json
+        // but not ../foo/bar.json
+        if (params.url) {
+            ajax.getJSON(params.url, callback);
+        } else if (typeof params.data === 'string') {
+            try {
+                return callback(null, JSON.parse(params.data));
+            } catch (e) {
+                return callback(new Error("Input data is not a valid GeoJSON object."));
+            }
+        } else {
+            return callback(new Error("Input data is not a valid GeoJSON object."));
+        }
+    },
+
+    /*
+     * Index the data
+     * @param {GeoJSON} data
+     * @param {object} params forwarded from loadTile.
+     * @param {callback} (err, indexedData)
+     */
+    indexData: function (data, params, callback) {
+        var geojsonVtOptions = {
+            buffer: (params.buffer !== undefined ? params.buffer : 128) * params.scale,
+            tolerance: (params.tolerance !== undefined ? params.tolerance : 0.375) * params.scale,
+            extent: params.extent,
+            maxZoom: params.maxZoom
+        };
+        try {
+            return callback(null, geojsonvt(data, geojsonVtOptions));
+        } catch (e) {
+            return callback(e);
+        }
+    }
+});

--- a/js/source/geojson_worker_source.js
+++ b/js/source/geojson_worker_source.js
@@ -1,0 +1,5 @@
+'use strict';
+var GeojsonWorkerSource = require('./geojson_worker_base');
+module.exports = function (self) {
+    self.registerWorkerSource('geojson', Object.create(GeojsonWorkerSource));
+};

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -31,6 +31,10 @@ RasterTileSource.prototype = util.inherit(Evented, {
     tileSize: 512,
     _loaded: false,
 
+    onAdd: function (map) {
+        this.map = map;
+    },
+
     serialize: function() {
         return {
             type: 'raster',

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -54,15 +54,10 @@ function mergeRenderedFeatureLayers(tiles) {
     return result;
 }
 
-exports._queryRenderedVectorFeatures = function(queryGeometry, params, zoom, bearing) {
-    if (!this._pyramid || !this.map)
-        return {};
-
-    var tilesIn = this._pyramid.tilesIn(queryGeometry);
+exports._queryRenderedVectorFeatures = function(pyramid, styleLayers, queryGeometry, params, zoom, bearing) {
+    var tilesIn = pyramid.tilesIn(queryGeometry);
 
     tilesIn.sort(sortTilesIn);
-
-    var styleLayers = this.map.style._layers;
 
     var renderedFeatureLayers = [];
     for (var r = 0; r < tilesIn.length; r++) {
@@ -80,14 +75,9 @@ exports._queryRenderedVectorFeatures = function(queryGeometry, params, zoom, bea
     return mergeRenderedFeatureLayers(renderedFeatureLayers);
 };
 
-exports._querySourceFeatures = function(params) {
-    if (!this._pyramid) {
-        return [];
-    }
-
-    var pyramid = this._pyramid;
+exports._querySourceFeatures = function(pyramid, params) {
     var tiles = pyramid.renderedIDs().map(function(id) {
-        return pyramid.getTile(id);
+        return pyramid.getTileByID(id);
     });
 
     var result = [];

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -24,7 +24,7 @@ function TilePyramid(id, options, dispatcher) {
     this.dispatcher = dispatcher;
 
     var onChange = function () {
-        this.sourceChangedSoWeShouldUpdatePyramidNow();
+        this.update(this.transform, this.map && this.map.style.rasterFadeDuration);
     }.bind(this);
 
     // TODO: this is an ugly consequence of inverting tilepyramid / source
@@ -135,6 +135,7 @@ TilePyramid.prototype = util.inherit(Evented, {
             return;
         }
 
+        tile.source = this;
         this.fire('tile.load', {tile: tile});
         if (data && data.bucketStats) {
             this.fire('tile.stats', data.bucketStats);

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -24,6 +24,7 @@ function TilePyramid(id, options, dispatcher) {
     this.dispatcher = dispatcher;
 
     var onChange = function () {
+        this.reload();
         if (this.transform) {
             this.update(this.transform, this.map && this.map.style.rasterFadeDuration);
         }

--- a/js/source/tile_pyramid.js
+++ b/js/source/tile_pyramid.js
@@ -24,7 +24,9 @@ function TilePyramid(id, options, dispatcher) {
     this.dispatcher = dispatcher;
 
     var onChange = function () {
-        this.update(this.transform, this.map && this.map.style.rasterFadeDuration);
+        if (this.transform) {
+            this.update(this.transform, this.map && this.map.style.rasterFadeDuration);
+        }
     }.bind(this);
 
     // TODO: this is an ugly consequence of inverting tilepyramid / source
@@ -47,7 +49,7 @@ function TilePyramid(id, options, dispatcher) {
         // TODO: remove this once we eliminate need for sources to have a
         // reference to the Map instance.
         this._source = source;
-        if (this.map) { source.map = this.map; }
+        if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
 
         this._sourceLoaded = true;
 
@@ -67,6 +69,7 @@ function TilePyramid(id, options, dispatcher) {
         this._abort = (source.abort || noop).bind(source);
         this._unload = (source.unload || noop).bind(source);
         this.serialize = (source.serialize || noop).bind(source);
+        this.prepare = source.prepare && source.prepare.bind(source);
 
         this.fire('load');
     }.bind(this);
@@ -87,7 +90,9 @@ TilePyramid.prototype = util.inherit(Evented, {
     // TODO: hopefully remove the need for this
     onAdd: function (map) {
         this.map = map;
-        if (this._source) { this._source.map = map; }
+        if (this._source && this._source.onAdd) {
+            this._source.onAdd(map);
+        }
     },
 
     /**

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -9,7 +9,8 @@ module.exports.create = function (id, options, dispatcher, onChange, callback) {
         if (err) {
             return callback(err);
         }
-        var vts = new VectorTileSource(id, util.extend(options, tileJSON), dispatcher);
+        var vts = new VectorTileSource(id, options, dispatcher);
+        // TODO: not crazy about this
         util.extend(vts, tileJSON);
         callback(null, vts);
     });

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -665,9 +665,8 @@ Style.prototype = util.inherit(Evented, {
         var sourceResults = [];
         for (var id in this.sources) {
             var source = this.sources[id];
-            if (source.queryRenderedFeatures) {
-                sourceResults.push(source.queryRenderedFeatures(queryGeometry, params, zoom, bearing));
-            }
+            var results = Source._queryRenderedVectorFeatures(source, this._layers, queryGeometry, params, zoom, bearing);
+            sourceResults.push(results);
         }
         return this._flattenRenderedFeatures(sourceResults);
     },
@@ -677,7 +676,7 @@ Style.prototype = util.inherit(Evented, {
             this._handleErrors(validateStyle.filter, 'querySourceFeatures.filter', params.filter, true);
         }
         var source = this.getSource(sourceID);
-        return source && source.querySourceFeatures ? source.querySourceFeatures(params) : [];
+        return source ? Source._querySourceFeatures(source, params) : [];
     },
 
     addSourceType: function (name, sourceFactoryFn, workerSourceURL, callback) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -354,7 +354,6 @@ Style.prototype = util.inherit(Evented, {
 
         source = new TilePyramid(id, source, this.dispatcher);
         this.sources[id] = source;
-        // TODO: make sure to set `map`, `id`, and `dispatcher` on TilePyramids
         source.style = this;
         source
             .on('load', this._forwardSourceEvent)

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -14,8 +14,16 @@ var Dispatcher = require('../util/dispatcher');
 var AnimationLoop = require('./animation_loop');
 var validateStyle = require('./validate_style');
 var Source = require('../source/source');
+var TilePyramid = require('../source/tile_pyramid');
 var styleSpec = require('./style_spec');
 var StyleFunction = require('./style_function');
+
+var VectorSource = require('../source/vector_tile_source');
+var RasterSource = require('../source/raster_tile_source');
+var GeoJSONSource = require('../source/geojson_source');
+var VideoSource = require('../source/video_source');
+var ImageSource = require('../source/image_source');
+var ClusteredGeoJSONSource = require('../source/clustered_geojson_source');
 
 module.exports = Style;
 
@@ -40,13 +48,11 @@ function Style(stylesheet, animationLoop) {
 
     this._resetUpdates();
 
-    var loaded = function(err, stylesheet) {
+    var stylesheetLoaded = function(err, stylesheet) {
         if (err) {
             this.fire('error', {error: err});
             return;
         }
-
-        if (validateStyle.emitErrors(this, validateStyle(stylesheet))) return;
 
         this._loaded = true;
         this.stylesheet = stylesheet;
@@ -66,12 +72,36 @@ function Style(stylesheet, animationLoop) {
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
         this._resolve();
         this.fire('load');
+
+        if (validateStyle.emitErrors(this, validateStyle(stylesheet))) return;
     }.bind(this);
 
-    if (typeof stylesheet === 'string') {
-        ajax.getJSON(normalizeURL(stylesheet), loaded);
+    var sourceTypesLoaded = function(err) {
+        if (err) {
+            this.fire('error', {error: err});
+            return;
+        }
+
+        if (typeof stylesheet === 'string') {
+            ajax.getJSON(normalizeURL(stylesheet), stylesheetLoaded);
+        } else {
+            browser.frame(stylesheetLoaded.bind(this, null, stylesheet));
+        }
+    }.bind(this);
+
+    if (Source.getType('vector')) {
+        sourceTypesLoaded();
     } else {
-        browser.frame(loaded.bind(this, null, stylesheet));
+        util.asyncAll([
+          ['vector', VectorSource],
+          ['raster', RasterSource],
+          ['geojson', GeoJSONSource],
+          ['video', VideoSource],
+          ['image', ImageSource],
+          ['geojson-clustered', ClusteredGeoJSONSource]
+        ], function (type, done) {
+            this.addSourceType(type[0], type[1].create, type[1].workerSourceURL, done);
+        }.bind(this), sourceTypesLoaded);
     }
 
     this.on('source.load', function(event) {
@@ -318,13 +348,14 @@ Style.prototype = util.inherit(Evented, {
         if (this.sources[id] !== undefined) {
             throw new Error('There is already a source with this ID');
         }
-        if (!Source.is(source) && this._handleErrors(validateStyle.source, 'sources.' + id, source)) return this;
+        var builtIns = ['vector', 'raster', 'geojson', 'video', 'image'];
+        var shouldValidate = !Source.is(source) && builtIns.indexOf(source.type) >= 0;
+        if (shouldValidate && this._handleErrors(validateStyle.source, 'sources.' + id, source)) return this;
 
-        source = Source.create(source);
+        source = new TilePyramid(id, source, this.dispatcher);
         this.sources[id] = source;
-        source.id = id;
+        // TODO: make sure to set `map`, `id`, and `dispatcher` on TilePyramids
         source.style = this;
-        source.dispatcher = this.dispatcher;
         source
             .on('load', this._forwardSourceEvent)
             .on('error', this._forwardSourceEvent)
@@ -648,6 +679,26 @@ Style.prototype = util.inherit(Evented, {
         }
         var source = this.getSource(sourceID);
         return source && source.querySourceFeatures ? source.querySourceFeatures(params) : [];
+    },
+
+    addSourceType: function (name, sourceFactoryFn, workerSourceURL, callback) {
+        if (!callback) {
+            callback = workerSourceURL;
+        }
+        if (Source.getType(name)) {
+            return callback(new Error('A source type called "' + name + '" already exists.'));
+        }
+
+        Source.setType(name, sourceFactoryFn);
+
+        if (!workerSourceURL) {
+            return callback(null, null);
+        }
+
+        this.dispatcher.broadcast('load worker source', {
+            name: name,
+            url: workerSourceURL
+        }, callback);
     },
 
     _handleErrors: function(validate, key, value, throws, props) {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -650,7 +650,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @returns {Object}
      */
     getSource: function(id) {
-        return this.style.getSource(id);
+        return this.style.getSource(id)._source;
     },
 
     /**

--- a/js/util/browser/dispatcher.js
+++ b/js/util/browser/dispatcher.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var util = require('../util');
 var Actor = require('../actor');
 var WebWorkify = require('webworkify');
 
@@ -17,10 +18,11 @@ function Dispatcher(length, parent) {
 }
 
 Dispatcher.prototype = {
-    broadcast: function(type, data) {
-        for (var i = 0; i < this.actors.length; i++) {
-            this.actors[i].send(type, data);
-        }
+    broadcast: function(type, data, cb) {
+        cb = cb || function () {};
+        util.asyncAll(this.actors, function (actor, done) {
+            actor.send(type, data, done);
+        }, cb);
     },
 
     send: function(type, data, callback, targetID, buffers) {

--- a/js/util/dispatcher.js
+++ b/js/util/dispatcher.js
@@ -39,8 +39,8 @@ function Dispatcher(length, parent) {
 }
 
 Dispatcher.prototype = {
-    broadcast: function(type, data) {
-        this.actor.send(type, data);
+    broadcast: function(type, data, callback) {
+        this.actor.send(type, data, callback);
     },
 
     send: function(type, data, callback, targetID, buffers) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "unitbezier": "^0.0.0",
     "vector-tile": "^1.2.1",
     "vt-pbf": "^2.0.2",
-    "webworkify": "^1.0.2"
+    "webworkify": "^1.2.0"
   },
   "devDependencies": {
     "benchmark": "~2.1.0",


### PR DESCRIPTION
Replaces #2582

 - Inverts `TilePyramid` and `Source` dependencies.  `TilePyramid` now essentially serves as a common wrapper class for dealing with sources.

- Source types are now essentially:
```js
(
  name: string,
  createSource: (id, options, dispatcher, onChange, callback: (err, source: Source) => void) => void
  ?workerSourceURL: string
)
```

- And a `Source` is an object implementing:

```js
id: string // <- it's a little weird to rely on sources presenting this as a property
tileSize: number
minzoom: number
maxzoom: number
// not sure about these three properties
roundZoom: boolean
reparseOverscaled: boolean
isTileClipped: boolean

load: (tile: Tile, cb: (err, ?data) => void) => void
abort: (tile: Tile) => void
unload: (tile: Tile) => void
serialize: () => Object // plain JS
```

Various todo's and questions:
 - [ ] The `Tile` objects are used by various source types to maintain tile-specific state; ideally, this implicit contract between `TilePyramid` and `Source` should be made explicit in the Source interface.
 - [ ] Decide on an approach to `serialize()` (see note [here](https://github.com/anandthakker/mapbox-gl-js/blob/c3016aee9d46877ce9a2d386f3469c5dfcf3613c/js/source/tile_pyramid.js#L30-L38))
 - [ ] `Source.is` is only used in one place: to support passing already-created sources to `addSource` (and prevent the attempt to validate against the spec in that case).  What's the best way to do this in the factory function approach, where it's a little weird to rely on `instanceof`?
 - [ ] `Map` methods (`addSource`, `getSource`).  Related to this and the previous item: is it important to retain the ability to create sources _without_ adding them to the map?  If so, it might make the most sense to expose a `createSource` on the map obj, since creation now depends on a reference to `dispatcher`, which probably _shouldn't_ be exposed.
 - [ ] It's weird to rely on sources presenting an `id` property with the correct value.
 - [x] Reinstate query*Features
 - [ ] I'm not sure what the `data` yielded by `load` should look like.  Currently, the only thing I can see being needed by code outside of the particular source is `bucketStats`, which the pyramid uses to emit the `tile.stats` event.  

