### PR TITLE
Fix Webpack Example Config

### DIFF
--- a/webpack.config.example.js
+++ b/webpack.config.example.js
@@ -51,11 +51,11 @@ module.exports = {
             loader: 'json-loader'
         }, {
             test: /\.js$/,
-            include: path.resolve(__dirname, 'js/render/painter/use_program.js'),
+            include: path.resolve('node_modules/mapbox-gl-shaders/index.js'),
             loader: 'transform/cacheable?brfs'
         }],
         postLoaders: [{
-            include: /node_modules\/mapbox-gl/,
+            include: /node_modules\/mapbox-gl-shaders/,
             loader: 'transform',
             query: 'brfs'
         }]


### PR DESCRIPTION
It looks like the `fs.readFileSync` method calls have moved out of `mapbox-gl-js` and into `mapbox-gl-shaders` as of f36efdf06349f56724b3fa60203a378d29ffe4cd. In order for Webpack to build, this example needs to apply the brfs transform to `mapbox-gl-shaders/index.js` instead of `mapbox-gl/js/render/painter/use_program.js`.