### PR TITLE
Change default hardwareConcurrency from 8 to 4

### DIFF
--- a/js/util/browser/browser.js
+++ b/js/util/browser/browser.js
@@ -76,7 +76,7 @@ exports.timed = function (fn, dur, ctx) {
  */
 exports.supported = require('mapbox-gl-js-supported');
 
-exports.hardwareConcurrency = navigator.hardwareConcurrency || 8;
+exports.hardwareConcurrency = navigator.hardwareConcurrency || 4;
 
 Object.defineProperty(exports, 'devicePixelRatio', {
     get: function() { return window.devicePixelRatio; }


### PR DESCRIPTION
Currently, the default value for `browser.hardwareConcurrency` is 8.  I'd suggest that this be changed to 4, because:
 - `navigator.hardwareConcurrency` is [not supported in IE and has poor mobile support](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency)
 - In a certain (rather large) sample of website visitors, among unique visitors whose browsers _did_ support `hardwareConcurrency`, 4 was _much_ more common than 8 or 2.