### PR TITLE
New hash for gl-shaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grid-index": "^0.1.0",
     "mapbox-gl-function": "^1.2.1",
     "mapbox-gl-js-supported": "^1.1.0",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#e4737bb136d718f9c5fe8d943380f05db6249b57",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#be09fce1d01e63de69f019e953261832d16ec88c",
     "mapbox-gl-style-spec": "^8.7.0",
     "minifyify": "^7.0.1",
     "pbf": "^1.3.2",


### PR DESCRIPTION
- [x] Tests pass
- [x] Vet that shader changes are GL native compatible (https://github.com/mapbox/mapbox-gl-shaders/pull/12)