### PR TITLE
Remove util.premultiply

### DIFF
--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -41,7 +41,7 @@ CircleBucket.prototype.programInterfaces = {
             components: 4,
             type: 'Uint8',
             getValue: function(layer, globalProperties, featureProperties) {
-                return util.premultiply(layer.getPaintValue("circle-color", globalProperties, featureProperties));
+                return layer.getPaintValue("circle-color", globalProperties, featureProperties);
             },
             multiplier: 255,
             paintProperty: 'circle-color'

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -33,7 +33,7 @@ FillBucket.prototype.programInterfaces = {
             components: 4,
             type: 'Uint8',
             getValue: function(layer, globalProperties, featureProperties) {
-                return util.premultiply(layer.getPaintValue("fill-color", globalProperties, featureProperties));
+                return layer.getPaintValue("fill-color", globalProperties, featureProperties);
             },
             multiplier: 255,
             paintProperty: 'fill-color'
@@ -42,7 +42,7 @@ FillBucket.prototype.programInterfaces = {
             components: 4,
             type: 'Uint8',
             getValue: function(layer, globalProperties, featureProperties) {
-                return util.premultiply(layer.getPaintValue("fill-outline-color", globalProperties, featureProperties));
+                return layer.getPaintValue("fill-outline-color", globalProperties, featureProperties);
             },
             multiplier: 255,
             paintProperty: 'fill-outline-color'

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -2,7 +2,6 @@
 
 var TilePyramid = require('../source/tile_pyramid');
 var pyramid = new TilePyramid({ tileSize: 512 });
-var util = require('../util/util');
 var pixelsToTileUnits = require('../source/pixels_to_tile_units');
 var createUniformPragmas = require('./create_uniform_pragmas');
 
@@ -11,7 +10,7 @@ module.exports = drawBackground;
 function drawBackground(painter, source, layer) {
     var gl = painter.gl;
     var transform = painter.transform;
-    var color = util.premultiply(layer.paint['background-color']);
+    var color = layer.paint['background-color'];
     var image = layer.paint['background-pattern'];
     var opacity = layer.paint['background-opacity'];
     var program;

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var util = require('../util/util');
 var pixelsToTileUnits = require('../source/pixels_to_tile_units');
 
 module.exports = draw;
@@ -9,7 +8,7 @@ function draw(painter, source, layer, coords) {
     var gl = painter.gl;
     gl.enable(gl.STENCIL_TEST);
 
-    var color = util.premultiply(layer.paint['fill-color']);
+    var color = layer.paint['fill-color'];
     var image = layer.paint['fill-pattern'];
     var opacity = layer.paint['fill-opacity'];
     var isOutlineColorDefined = layer.getPaintProperty('fill-outline-color');

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -2,7 +2,6 @@
 
 var browser = require('../util/browser');
 var mat2 = require('gl-matrix').mat2;
-var util = require('../util/util');
 var pixelsToTileUnits = require('../source/pixels_to_tile_units');
 
 /**
@@ -31,7 +30,7 @@ module.exports = function drawLine(painter, source, layer, coords) {
     var antialiasing = 1 / browser.devicePixelRatio;
 
     var blur = layer.paint['line-blur'] + antialiasing;
-    var color = util.premultiply(layer.paint['line-color']);
+    var color = layer.paint['line-color'];
 
     var tr = painter.transform;
 

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -2,7 +2,6 @@
 
 var browser = require('../util/browser');
 var drawCollisionDebug = require('./draw_collision_debug');
-var util = require('../util/util');
 var pixelsToTileUnits = require('../source/pixels_to_tile_units');
 
 
@@ -68,9 +67,6 @@ function drawLayerSymbols(painter, source, layer, coords, isText,
         haloBlur,
         opacity,
         color) {
-
-    haloColor = util.premultiply(haloColor);
-    color = util.premultiply(color);
 
     for (var j = 0; j < coords.length; j++) {
         var tile = source.getTile(coords[j]);

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -50,26 +50,6 @@ exports.bezier = function(p1x, p1y, p2x, p2y) {
 exports.ease = exports.bezier(0.25, 0.1, 0.25, 1);
 
 /**
- * Given a four-element array of numbers that represents a color in
- * RGBA, return a version for which the RGB components are multiplied
- * by the A (alpha) component
- *
- * @param {Array<number>} color color array
- * @returns {Array<number>} premultiplied color array
- * @private
- */
-exports.premultiply = function (color) {
-    if (!color) return null;
-    var opacity = color[3];
-    return [
-        color[0] * opacity,
-        color[1] * opacity,
-        color[2] * opacity,
-        opacity
-    ];
-};
-
-/**
  * constrain n to the given range via min + max
  *
  * @param {number} n value

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -9,7 +9,6 @@ test('util', function(t) {
     t.equal(util.easeCubicInOut(0.2), 0.03200000000000001);
     t.equal(util.easeCubicInOut(0.5), 0.5, 'easeCubicInOut=0.5');
     t.equal(util.easeCubicInOut(1), 1, 'easeCubicInOut=1');
-    t.deepEqual(util.premultiply([0, 0.5, 1, 0.5]), [0, 0.25, 0.5, 0.5], 'premultiply');
     t.deepEqual(util.keysDifference({a:1}, {}), ['a'], 'keysDifference');
     t.deepEqual(util.keysDifference({a:1}, {a:1}), [], 'keysDifference');
     t.deepEqual(util.extend({a:1}, {b:2}), {a:1, b:2}, 'extend');


### PR DESCRIPTION
GL JS had the notion of "premultiplying" colors just before rendering them, transforming rgba arrays into the color format expected by GL (all components between 0 and 1, all components multiplied by the alpha value).

This PR removes the premultiply step, opting instead to format the colors in the format expected by GL end-to-end in order to

 - reduce the complexity of GL JS
 - get minor perf gains in regular rendering
 - get big perf gains in data-driven styling rendering

### Frame Duration Benchmark

**this branch** 9.9 ms per frame. 4% of frames took longer than 16ms.
**master** 10.3 ms per frame. 5% of frames took longer than 16ms.

cc @mollymerp @jfirebaugh @mourner 