### PR TITLE
Fix for issue #2680, root cause map.options is no longer available

### DIFF
--- a/js/ui/bind_handlers.js
+++ b/js/ui/bind_handlers.js
@@ -13,15 +13,15 @@ var handlers = {
     touchZoomRotate: require('./handler/touch_zoom_rotate')
 };
 
-module.exports = function bindHandlers(map, options) {
+module.exports = function bindHandlers(map, bindOptions, mapOptions) {
     var el = map.getCanvasContainer();
     var contextMenuEvent = null;
     var startPos = null;
     var tapped = null;
 
     for (var name in handlers) {
-        map[name] = new handlers[name](map);
-        if (options[name]) {
+        map[name] = new handlers[name](map, mapOptions);
+        if (bindOptions[name]) {
             map[name].enable();
         }
     }

--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -20,7 +20,7 @@ var inertiaLinearity = 0.25,
 function DragRotateHandler(map, options) {
     this._map = map;
     this._el = map.getCanvasContainer();
-    this._options = options;
+    this._bearingSnap = options.bearingSnap;
 
     util.bindHandlers(this);
 }
@@ -139,7 +139,7 @@ DragRotateHandler.prototype = {
             inertia = this._inertia;
 
         var finish = function() {
-            if (Math.abs(mapBearing) < this._options.bearingSnap) {
+            if (Math.abs(mapBearing) < this._bearingSnap) {
                 map.resetNorth({noMoveStart: true}, { originalEvent: e });
             } else {
                 this._fireEvent('moveend', e);
@@ -174,7 +174,7 @@ DragRotateHandler.prototype = {
 
         bearing += offset;
 
-        if (Math.abs(map._normalizeBearing(bearing, 0)) < this._options.bearingSnap) {
+        if (Math.abs(map._normalizeBearing(bearing, 0)) < this._bearingSnap) {
             bearing = map._normalizeBearing(0, bearing);
         }
 

--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -17,9 +17,10 @@ var inertiaLinearity = 0.25,
  * dragging the cursor while holding the right mouse button or the `ctrl` key.
  * @class DragRotateHandler
  */
-function DragRotateHandler(map) {
+function DragRotateHandler(map, options) {
     this._map = map;
     this._el = map.getCanvasContainer();
+    this._options = options;
 
     util.bindHandlers(this);
 }
@@ -138,7 +139,7 @@ DragRotateHandler.prototype = {
             inertia = this._inertia;
 
         var finish = function() {
-            if (Math.abs(mapBearing) < map.options.bearingSnap) {
+            if (Math.abs(mapBearing) < this._options.bearingSnap) {
                 map.resetNorth({noMoveStart: true}, { originalEvent: e });
             } else {
                 this._fireEvent('moveend', e);
@@ -173,7 +174,7 @@ DragRotateHandler.prototype = {
 
         bearing += offset;
 
-        if (Math.abs(map._normalizeBearing(bearing, 0)) < map.options.bearingSnap) {
+        if (Math.abs(map._normalizeBearing(bearing, 0)) < this._options.bearingSnap) {
             bearing = map._normalizeBearing(0, bearing);
         }
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -175,7 +175,7 @@ var Map = module.exports = function(options) {
         keyboard: options.interactive && options.keyboard,
         doubleClickZoom: options.interactive && options.doubleClickZoom,
         touchZoomRotate: options.interactive && options.touchZoomRotate
-    });
+    }, options);
 
     this._hash = options.hash && (new Hash()).addTo(this);
     // don't set position from options if set through hash


### PR DESCRIPTION
Now pass all the mapOptions to the constructor of each handler to fix #2680 