### PR TITLE
Pin webworkify to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "unitbezier": "^0.0.0",
     "vector-tile": "^1.2.1",
     "vt-pbf": "^2.0.2",
-    "webworkify": "^1.0.2",
+    "webworkify": "1.2.0",
     "whoots-js": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
An upstream bug in `webworkerify` https://github.com/substack/webworkify/issues/26 is causing GL JS to not work in IE. This PR pins the dependency pending an upstream fix.

fixes #2677