### PR TITLE
Add mapbox-gl-supported plugin and update example 

### DIFF
--- a/docs/_posts/examples/3400-01-02-check-for-support.html
+++ b/docs/_posts/examples/3400-01-02-check-for-support.html
@@ -4,7 +4,9 @@ category: example
 title: Check for browser support
 description: Check for Mapbox GL browser support
 ---
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-supported/v0.0.1/mapbox-gl-supported.js'></script>
 <div id='map'></div>
+
 <script>
 if (!mapboxgl.supported()) {
     alert('Your browser does not support Mapbox GL');

--- a/docs/_posts/plugins/0100-01-01-mapbox-gl-supported.html
+++ b/docs/_posts/plugins/0100-01-01-mapbox-gl-supported.html
@@ -1,0 +1,12 @@
+---
+layout: default
+categories: plugin
+title: mapbox-gl-supported
+prefix: mapbox-gl-supported
+description: Determine if a browser supports Mapbox GL JS
+tags:
+  - bsd
+code: https://github.com/mapbox/mapbox-gl-supported
+license: BSD
+---
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-supported/v1.1.1/mapbox-gl-supported.js'></script>

--- a/docs/_posts/redirects/3400-01-05-featuresat.html
+++ b/docs/_posts/redirects/3400-01-05-featuresat.html
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /example/featuresat/
 redirect: /example/queryrenderedfeatures/
 ---

--- a/docs/_posts/redirects/3400-01-05-mapbox-gl-supported.html
+++ b/docs/_posts/redirects/3400-01-05-mapbox-gl-supported.html
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /example/mapbox-gl-supported/
+redirect: /example/check-for-support/
+---

--- a/docs/_posts/redirects/3400-01-05-marker-popup.html
+++ b/docs/_posts/redirects/3400-01-05-marker-popup.html
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /example/marker-popup/
 redirect: /example/popup-on-click/
 ---

--- a/docs/_posts/redirects/3400-01-19-using-featuresin.html
+++ b/docs/_posts/redirects/3400-01-19-using-featuresin.html
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /example/using-featuresin/
 redirect: /example/using-box-queryrenderedfeatures/
 ---


### PR DESCRIPTION
Adds [mapbox-gl-supported](https://github.com/mapbox/mapbox-gl-supported) to the plugins page and updates the existing GL supported example to use the plugin instead of Mapbox GL JS's built-in method. 

Still needs: 

- [ ] Comments and description updates for the `check-for-support` example 

cc @tristen 