### PR TITLE
Disallow TODO comments in the code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,16 @@
 {
   "extends": "mourner",
   "rules": {
-    "object-curly-spacing": 0,
-    "key-spacing": 0,
-    "array-bracket-spacing": 0,
-    "space-before-function-paren": 0,
-    "quotes": 0,
-    "no-eq-null": 0,
-    "consistent-return": 0,
-    "global-require": 0,
-    "block-scoped-var": 2
+    "object-curly-spacing": "off",
+    "key-spacing": "off",
+    "array-bracket-spacing": "off",
+    "space-before-function-paren": "off",
+    "quotes": "off",
+    "no-eq-null": "off",
+    "consistent-return": "off",
+    "global-require": "off",
+    "block-scoped-var": "error",
+    "no-warning-comments": "error"
   },
   "env": {
     "es6": true

--- a/js/data/feature_index.js
+++ b/js/data/feature_index.js
@@ -60,8 +60,6 @@ FeatureIndex.prototype.insert = function(feature, featureIndex, sourceLayerIndex
     for (var r = 0; r < geometry.length; r++) {
         var ring = geometry[r];
 
-        // TODO: skip holes when we start using vector tile spec 2.0
-
         var bbox = [Infinity, Infinity, -Infinity, -Infinity];
         for (var i = 0; i < ring.length; i++) {
             var p = ring[i];

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -25,7 +25,7 @@ module.exports = Tile;
 function Tile(coord, size, sourceMaxZoom) {
     this.coord = coord;
     this.uid = util.uniqueId();
-    this.loaded = false; // TODO rename loaded
+    this.loaded = false;
     this.isUnloaded = false;
     this.uses = 0;
     this.tileSize = size;

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -221,7 +221,7 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, rawTileData, c
 
         callback(null, {
             buckets: nonEmptyBuckets.map(serializeBucket),
-            bucketStats: stats, // TODO put this in a separate message?
+            bucketStats: stats,
             featureIndex: featureIndex_.data,
             collisionTile: collisionTile_.data,
             collisionBoxArray: collisionBoxArray,

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -62,7 +62,6 @@ GlyphSource.prototype.getSimpleGlyphs = function(fontstack, glyphIDs, uid, callb
     if (!remaining) callback(undefined, glyphs, fontstack);
 
     var onRangeLoaded = function(err, range, data) {
-        // TODO not be silent about errors
         if (!err) {
             var stack = this.stacks[fontstack][range] = data.stacks[0];
             for (var i = 0; i < missing[range].length; i++) {

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -152,7 +152,6 @@ test('GeoJSONSource#update', function(t) {
     t.test('clears previous tiles', function(t) {
         var source = new GeoJSONSource({data: hawkHill});
 
-        // TODO: decouple
         source.used = true;
         source.dispatcher = {
             send: function(message, args, callback) {


### PR DESCRIPTION
It is bad practice to commit `// TODO` comments. These comments should either be addressed or turned into GitHub issues lest they be forgotten. 

This PR enables a lint rule that disallows `// TODO` and `// FIXME` comments and removes existing comments. Two existing comments were turned into issues (https://github.com/mapbox/mapbox-gl-js/issues/2711, https://github.com/mapbox/mapbox-gl-js/issues/2710) and the rest were dropped. 

cc @mourner @tmcw @jfirebaugh @mollymerp 