### PR TITLE
Don't apply textRotate twice

### DIFF
--- a/js/symbol/quads.js
+++ b/js/symbol/quads.js
@@ -173,8 +173,8 @@ function getGlyphQuads(anchor, shaping, boxScale, line, layout, alongLine) {
             // Prevent label from extending past the end of the line
             var glyphMinScale = Math.max(instance.minScale, labelMinScale);
 
-            var anchorAngle = (anchor.angle + textRotate + instance.offset + 2 * Math.PI) % (2 * Math.PI);
-            var glyphAngle = (instance.angle + textRotate + instance.offset + 2 * Math.PI) % (2 * Math.PI);
+            var anchorAngle = (anchor.angle + instance.offset + 2 * Math.PI) % (2 * Math.PI);
+            var glyphAngle = (instance.angle + instance.offset + 2 * Math.PI) % (2 * Math.PI);
             quads.push(new SymbolQuad(instance.anchorPoint, tl, tr, bl, br, rect, anchorAngle, glyphAngle, glyphMinScale, instance.maxScale));
         }
     }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "highlight.js": "9.3.0",
     "istanbul": "^0.4.2",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#5587d796c99145991ea2a7b749a8782b7a0cb483",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#64cf15b657e12b070fede3f2fd3f5ac4fc096e5b",
     "nyc": "^6.1.1",
     "remark": "4.2.2",
     "remark-html": "3.0.0",


### PR DESCRIPTION
Fixes bug from bad interaction between new `text-rotation-alignment` handling and `text-rotate`. Passes new render tests in https://github.com/mapbox/mapbox-gl-test-suite/pull/105.