### PR TITLE
Windows testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,32 @@ cd mapbox-gl-js &&
 npm install
 ```
 
+### Windows
+
+Install [git](https://git-scm.com/), [node.js](https://nodejs.org/) (version 4 or greater)
+Setup NPM and node-gyp according to Microsofts instructions here: https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules
+
+Clone the repository
+```bash
+git clone git@github.com:mapbox/mapbox-gl-js.git
+```
+
+Install node module dependencies
+```bash
+cd mapbox-gl-js
+npm install
+```
+
+Install headless-gl dependencies https://github.com/stackgl/headless-gl#windows
+```
+copy node_modules/headless-gl/deps/windows/dll/x64/*.dll c:\windows\system32
+```
+
+Install the benchmark data manually
+```
+Download https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_land.geojson to bench/data/naturalearth-land.json
+```
+
 ## Serving the Debug Page
 
 Start the debug server

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lint": "eslint js test bench",
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve -w",
     "start": "npm run download-bench-data && node server.js",
-    "test-suite": "node test/render.test.js && node test/query.test.js # update ci.sh if test invocation changes",
-    "test": "npm run lint && npm run build-min && tap --reporter dot test/js/*/*.js # update ci.sh if test invocation changes"
+    "test-suite": "node test/render.test.js && node test/query.test.js",
+    "test": "npm run lint && npm run build-min && tap --reporter dot test/js/*/*.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,7 +1,43 @@
 var express = require('express');
 var app = express();
 var browserify = require('browserify-middleware');
+var request = require('request');
+var fs = require('fs');
 
+var benchDataFile = './bench/data/naturalearth-land.json';
+fs.access(benchDataFile, fs.F_OK, function(err) {
+    // Err here means the file doesn't exist
+    if (err !== null) {
+        var CR = "\x1b[0G";
+        console.log("Once off downloading bench data")
+        var data = fs.createWriteStream(benchDataFile);
+        var targetSize = 0;
+        var totalSize = 0;
+        request
+            .get({
+                uri: 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_land.geojson',
+                gzip: true
+            })
+            .on('response', function(response) {
+                targetSize = parseInt(response.headers['content-length']);
+                if (isNaN(targetSize))
+                    targetSize = 0;
+                if (targetSize !== 0)
+                    process.stdout.write(CR + "0%");
+            })
+            .on('data', function(data) {
+                totalSize += data.length;
+                if (targetSize !== 0)
+                    process.stdout.write(CR + (totalSize / targetSize * 100).toFixed(0) + "%");
+            })
+            .pipe(data)
+            .on('finish', function() {
+                console.log(CR + "Bench data finished downloading - ready");
+            });
+    } else {
+        console.log("Bench data already exists - ready");
+    }
+});
 
 app.get('/mapbox-gl.js', browserify('./js/mapbox-gl.js', {
     standalone: 'mapboxgl',


### PR DESCRIPTION
1. `#` doesn't terminate the windows command like it does on osx/nix, but `# && rem` does.  The side effect of this was the word test in the comments was passing the render/query tests to the standard test runner which was causing a timeout.
2. Added a `[.bat` that takes the bash `-f FILENAME` and performs the file exists test so that once the benchmark data has been downloaded all the npm scripts will run.
3. Updated the `CONTRIBUTING.md` to include all the instructions I followed to get mapbox development running under windows.