### PR TITLE
Enable panning with multiple touch points

### DIFF
--- a/js/ui/handler/drag_pan.js
+++ b/js/ui/handler/drag_pan.js
@@ -94,8 +94,14 @@ DragPanHandler.prototype = {
             this._fireEvent('movestart', e);
         }
 
-        var pos = DOM.mousePos(this._el, e),
-            map = this._map;
+        var pos;
+        if (e.touches) {
+            pos = DOM.touchPos(this.el, e)[0]; // first touch point, ignore others
+        } else {
+            pos = DOM.mousePos(this.el, e); // or use mouse position
+        }
+
+        var map = this._map;
 
         map.stop();
         this._drainInertiaBuffer();
@@ -180,9 +186,7 @@ DragPanHandler.prototype = {
 
         if (map.boxZoom && map.boxZoom.isActive()) return true;
         if (map.dragRotate && map.dragRotate.isActive()) return true;
-        if (e.touches) {
-            return (e.touches.length > 1);
-        } else {
+        if (!e.touches) {
             if (e.ctrlKey) return true;
             var buttons = 1,  // left button
                 button = 0;   // left button


### PR DESCRIPTION
As proposed in #2719, it would be nice to have the ability to pan while touching with multiple fingers, this behaviour is standard on native mobile map apps and feels intuitive.

This implementation is very naive as I don't know my way around the mapbox-gl library. My specific implementation has lots of other options disabled, so I haven't considered how this will interfere with other interaction handlers that deal with rotation and zooming for example.

Can someone take a look and perhaps point out the considerations I'm missing? It would be nice if this could become a supported feature, maybe as an option on the DragPanHandler API.

fixes https://github.com/mapbox/mapbox-gl-js/issues/2618