### PR TITLE
Add points to API writing guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,17 @@ Mapbox GL JS has [API documentation](#api-documentation) and [examples](#example
 
 API documentation is written as [JSDoc comments](http://usejsdoc.org/) and processed with [documentationjs](http://documentation.js.org/).
 
- - Classes, methods, events and anything else in the public interface must be documented with a JSDoc comment. Everything outside of the public interface may be documented and must be tagged as `@private`.
- - Text within JSDoc comments may use markdown formatting. Code identifiers must be surrounded by \`backticks\`.
- - Documentation must be written in complete gramatically-correct sentences.
- - Documentation must specify measurement units when applicable.
- - Documentation descriptions must contain more information than what is obvious from the identifier and JSDoc metadata.
- - `@param` and `@property` descriptions should be capitalized and written as if completing a sentance beginning with "This is..." or "This...".
+* Classes, methods, events, and anything else in the public interface must be documented with JSDoc comments. Everything outside of the public interface may be documented and must be tagged as `@private`.
+* Text within JSDoc comments may use markdown formatting. Code identifiers must be surrounded by \`backticks\`.
+* Documentation must be written in grammatically correct sentences ending with periods.
+* Documentation must specify measurement units when applicable.
+* Documentation descriptions must contain more information than what is obvious from the identifier and JSDoc metadata.
+* Class descriptions should describe what the class *is*, or what its instances *are*. They do not document the constructor, but the class. They should begin with either a complete sentence or a phrase that would complete a sentence beginning with "A `T` is..." or "The `T` class is..." Examples: "Lists are ordered indexed dense collections." "A class used for asynchronous computations."
+* Function descriptions should begin with a third person singular present tense verb, as if completing a sentence beginning with "This function..." If the primary purpose of the function is to return a value, the description should begin with "Returns..." Examples: "Returns the layer with the specified id." "Sets the map's center point."
+* `@param`, `@property`, and `@returns` descriptions should be capitalized and end with a period. They should begin as if completing a sentence beginning with "This is..." or "This..."
+* Functions that do not return a value (return `undefined`), should not have a `@returns` annotation.
+* Member descriptions should document what a member represents or gets and sets. They should also indicate whether the member is read-only.
+* Event descriptions should begin with "Fired when..." and so should describe when the event fires. Event entries should clearly document any data passed to the handler, with a link to MDN documentation of native Event objects when applicable.
 
 ## Writing Examples
 


### PR DESCRIPTION
I read the API documentation from start to finish while [creating a Flow type definition file](https://github.com/mapbox/studio/pull/6899). It's pretty great! I did notice some inconsistencies, though, which I think detracted from the clarity and the professional sheen of the document. I thought I'd propose some new "Writing API Documentation" guidelines to target those; and, **after feedback and if you think the modifications worthwhile, I will follow through with a PR tweaking the JSDocs comments to fit the guidelines.**

*Please do not hesitate to tell me if you think this is not worth the trouble.* I'm just trying to figure out how I can help, and totally defer to you on what is or is not important for our API users. But here a few reasons I think these guidelines might be valuable:

- Could make it easier to write the documentation, because you have more of a formula to follow and more consistent examples to imitate.
- Could make it easier to read the documentation quickly, because you'll become familiar with the formula so know what information to expect, where.
- Would improve the professionalism of the documentation. This might be kind of important since our JS libraries are important to the business model.

Below I'll add a note or two about each proposed guideline and some examples of what revisions each would entail. *I'd love any feedback you have on these proposals, other formulas you think might work better!* The most important feature of a guideline is just that it facilitates consistency.

> * Class descriptions should describe what the class *is*, or what its instances *are*. They should begin with either a complete sentence or a phrase that would complete a sentence beginning with "A `T` is..." or "The `T` class is..." Examples: "Lists are ordered indexed dense collections." "A class used for asynchronous computations."

Because of the format of the generated docs, the constructor examples appear *below* the description, which I think means that the description should not describe the constructor as a function (e.g. "Create a Map ..."), but should instead describe the class first, constructor side-effects second.

Good: "The `BoxZoomHandler` allows a user to zoom the map to fit a bounding box."

Revise: "Create a GeoJSON data source instance given an options object" => "A data source containing GeoJSON."

> * Function descriptions should begin with a third person singular present tense verb, as if completing a sentence beginning with "This function..." If the primary purpose of the function is to return a value, the description should begin with "Returns..." Examples: "Returns the layer with the specified id." "Sets the map's center point."

Good: "Removes a style class from a map."
Good: "Adds a style class to a map."

Revise: "Get the current bearing in degrees" => "Returns the map's current bearing in degrees."
Revise: "Update source geojson data and rerender map" => "Sets the source's GeoJSON data and re-renders the map."

> * Functions that do not return a value (returns `undefined`), should not have a `@returns` annotation.

Or should we go the other way and *always* document a return value, even if `undefined`? One or the other, but not both.

> * Member descriptions should document what a member represents or gets and sets. They should also indicate whether the member is ready-only, or else what happens if it is changed.

I found it hardest to come up with a formula for these member/property descriptions.

Revise: "Draw an outline around each rendered tile for debugging." => "Boolean that controls whether an outline will be drawn around each rendered tile. These outlines can be useful for debugging."

Revise: "A default error handler for [...] events." => "The default error handler for [...] events (read-only)."

> * Event descriptions should begin with "Fired when..." and so should describe when the event fires. Event entries should clearly document any data passed to the handler, with a link to MDN documentation of native Event objects when applicable.

Revise: "Double click event." => "Fired when a pointing device is clicked twice on a single element."
Revise: "Boxzoom end event. This event is emitted at the end of a box zoom interaction" => "Fired at the end of a box zoom interaction."

cc @mapbox/copycop @mapbox/support 