### PR TITLE
Allow the GL context to be mocked

### DIFF
--- a/debug/mock.html
+++ b/debug/mock.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+        #checkboxes {
+            position: absolute;
+            background: #fff;
+            top:0;
+            left:0;
+            padding:10px;
+        }
+        #buffer {
+            position: absolute;
+            top:100px;
+            left:0;
+            pointer-events: none;
+        }
+        #buffer div {
+            background-color: #fff;
+            padding: 5px 0;
+            text-indent: 10px;
+            white-space: nowrap;
+            text-shadow:
+               -1px -1px 0 #fff,
+                1px -1px 0 #fff,
+                -1px 1px 0 #fff,
+                 1px 1px 0 #fff;
+        }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<div id='checkboxes'>
+  <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
+  <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br />
+  <input id='show-overdraw-checkbox' name='show-overdraw' type='checkbox'> <label for='show-overdraw'>overdraw debug</label><br />
+  <input id='buffer-checkbox' name='buffer' type='checkbox'> <label for='buffer'>buffer stats</label>
+</div>
+
+<div id='buffer' style="display:none">
+    <em>Waiting for data...</em>
+</div>
+
+<script src='mapbox-gl.js'></script>
+<script src='access-token.js'></script>
+
+<script>
+mapboxgl.config.MOCK_GL = true;
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-77.01866, 38.888],
+    style: 'mapbox://styles/mapbox/streets-v8',
+    hash: true
+});
+
+map.addControl(new mapboxgl.Navigation());
+map.addControl(new mapboxgl.Geolocate());
+
+map.on('load', function() {
+    map.addSource('geojson', {
+        "type": "geojson",
+        "data": "route.json"
+    });
+
+    map.addLayer({
+        "id": "route",
+        "type": "line",
+        "source": "geojson",
+        "paint": {
+            "line-color": "#EC8D8D",
+            "line-width": {
+                "base": 1.5,
+                "stops": [
+                    [
+                        5,
+                        0.75
+                    ],
+                    [
+                        18,
+                        32
+                    ]
+                ]
+            }
+        }
+    }, 'country-label-lg');
+
+    var bufferTimes = {};
+    map.on('tile.stats', function(bufferTimes) {
+        var _stats = [];
+        for (var name in bufferTimes) {
+            var value = Math.round(bufferTimes[name]);
+            if (isNaN(value)) continue;
+            var width = value;
+            _stats.push({name: name, value: value, width: width});
+        }
+        _stats = _stats.sort(function(a, b) { return b.value - a.value }).slice(0, 10);
+
+        var html = '';
+        for (var i in _stats) {
+            html += '<div style="width:' + _stats[i].width * 2 + 'px">' + _stats[i].value + 'ms - ' + _stats[i].name + '</div>';
+        }
+
+        document.getElementById('buffer').innerHTML = html;
+    });
+});
+
+map.on('click', function(e) {
+    if (e.originalEvent.shiftKey) return;
+    (new mapboxgl.Popup())
+        .setLngLat(map.unproject(e.point))
+        .setHTML("<h1>Hello World!</h1>")
+        .addTo(map);
+});
+
+document.getElementById('show-tile-boundaries-checkbox').onclick = function() {
+    map.showTileBoundaries = !!this.checked;
+};
+
+document.getElementById('show-symbol-collision-boxes-checkbox').onclick = function() {
+    map.showCollisionBoxes = !!this.checked;
+};
+
+document.getElementById('show-overdraw-checkbox').onclick = function() {
+    map.showOverdrawInspector = !!this.checked;
+};
+
+document.getElementById('buffer-checkbox').onclick = function() {
+    document.getElementById('buffer').style.display = this.checked ? 'block' : 'none';
+};
+
+// keyboard shortcut for comparing rendering with Mapbox GL native
+document.onkeypress = function(e) {
+    if (e.charCode === 111 && !e.shiftKey && !e.metaKey && !e.altKey) {
+        var center = map.getCenter();
+        location.href = "mapboxgl://?center=" + center.lat + "," + center.lng + "&zoom=" + map.getZoom() + "&bearing=" + map.getBearing();
+        return false;
+    }
+};
+</script>
+
+</body>
+</html>

--- a/js/util/browser/canvas.js
+++ b/js/util/browser/canvas.js
@@ -2,6 +2,8 @@
 
 var util = require('../util');
 var isSupported = require('mapbox-gl-js-supported');
+var config = require('../config');
+var MockWebGLRenderingContext = require('webgl-mock/src/WebGLRenderingContext');
 
 module.exports = Canvas;
 
@@ -15,6 +17,20 @@ function Canvas(parent, container) {
         this.canvas.addEventListener('webglcontextrestored', parent._contextRestored.bind(parent), false);
         this.canvas.setAttribute('tabindex', 0);
         container.appendChild(this.canvas);
+    }
+
+    if (config.MOCK_GL) {
+        var gl = new MockWebGLRenderingContext(this.canvas);
+        gl.getExtension = function (extention) {
+            // disable VAO
+            if (extention === 'OES_vertex_array_object') {
+                return undefined;
+            }
+            return MockWebGLRenderingContext.prototype.getExtension.apply(this, arguments);
+        };
+        this.getWebGLContext = function () {
+            return gl;
+        };
     }
 }
 

--- a/js/util/config.js
+++ b/js/util/config.js
@@ -2,5 +2,6 @@
 
 module.exports = {
     API_URL: 'https://api.mapbox.com',
-    REQUIRE_ACCESS_TOKEN: true
+    REQUIRE_ACCESS_TOKEN: true,
+    MOCK_GL: false
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "unitbezier": "^0.0.0",
     "vector-tile": "^1.2.1",
     "vt-pbf": "^2.0.2",
+    "webgl-mock": "0.1.6",
     "webworkify": "1.2.0",
     "whoots-js": "^2.0.0"
   },


### PR DESCRIPTION
Mocking the GL context is useful in order to integration test
applications that interact with the mapbox-gl-js APIs, but do not have
WebGL available. By mocking the GL context, gl-js will continue to
respond to method invocations and emit events normally. It will fetch
styles, sprites, glyphs and tiles normally.

To mock the GL context, set `mapboxgl.config.MOCK_GL = true` before
creating the map instance.

Issue: #2750