### PR TITLE
Switch from the deprecated "mapbox-gl-js-supported" npm module to the supported "mapbox-gl-supported" module

### DIFF
--- a/js/util/browser/browser.js
+++ b/js/util/browser/browser.js
@@ -74,7 +74,7 @@ exports.timed = function (fn, dur, ctx) {
  *   expected (i.e. a software renderer would be used)
  * @return {boolean}
  */
-exports.supported = require('mapbox-gl-js-supported');
+exports.supported = require('mapbox-gl-supported');
 
 exports.hardwareConcurrency = navigator.hardwareConcurrency || 4;
 

--- a/js/util/browser/canvas.js
+++ b/js/util/browser/canvas.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('../util');
-var isSupported = require('mapbox-gl-js-supported');
+var isSupported = require('mapbox-gl-supported');
 
 module.exports = Canvas;
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gl-matrix": "^2.3.1",
     "grid-index": "^0.1.0",
     "mapbox-gl-function": "^1.2.1",
-    "mapbox-gl-js-supported": "^1.1.0",
+    "mapbox-gl-supported": "^1.1.0",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#59e998295d548f208ee3ec10cdd21ff2630e2079",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#194fc55b6a7dd54c1e2cf2dd9048fbb5e836716d",
     "minifyify": "^7.0.1",


### PR DESCRIPTION
fixes #2756 