### PR TITLE
Fix transitions for *-translate properties

### DIFF
--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -7,15 +7,13 @@ var util = require('../util/util');
 module.exports = StyleDeclaration;
 
 function StyleDeclaration(reference, value) {
-    this.type = reference.type;
-    this.transitionable = reference.transition;
     this.value = util.clone(value);
     this.isFunction = MapboxGLFunction.isFunctionDefinition(value);
 
     // immutable representation of value. used for comparison
     this.json = JSON.stringify(this.value);
 
-    var parsedValue = this.type === 'color' ? parseColor(this.value) : value;
+    var parsedValue = reference.type === 'color' ? parseColor(this.value) : value;
     this.calculate = MapboxGLFunction[reference.function || 'piecewise-constant'](parsedValue);
     this.isFeatureConstant = this.calculate.isFeatureConstant;
     this.isZoomConstant = this.calculate.isZoomConstant;

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -291,9 +291,9 @@ StyleLayer.prototype = util.inherit(Evented, {
     // set paint transition based on a given paint declaration
     _applyPaintDeclaration: function (name, declaration, options, globalOptions, animationLoop) {
         var oldTransition = options.transition ? this._paintTransitions[name] : undefined;
+        var spec = this._paintSpecifications[name];
 
         if (declaration === null || declaration === undefined) {
-            var spec = this._paintSpecifications[name];
             declaration = new StyleDeclaration(spec, spec.default);
         }
 
@@ -305,7 +305,7 @@ StyleLayer.prototype = util.inherit(Evented, {
         }, globalOptions, this.getPaintProperty(name + TRANSITION_SUFFIX));
 
         var newTransition = this._paintTransitions[name] =
-                new StyleTransition(declaration, oldTransition, transitionOptions);
+            new StyleTransition(spec, declaration, oldTransition, transitionOptions);
 
         if (!newTransition.instant()) {
             newTransition.loopID = animationLoop.set(newTransition.endTime - Date.now());

--- a/js/style/style_transition.js
+++ b/js/style/style_transition.js
@@ -8,16 +8,15 @@ module.exports = StyleTransition;
 /*
  * Represents a transition between two declarations
  */
-function StyleTransition(declaration, oldTransition, value) {
+function StyleTransition(reference, declaration, oldTransition, value) {
 
     this.declaration = declaration;
     this.startTime = this.endTime = (new Date()).getTime();
 
-    var type = declaration.type;
-    if ((type === 'string' || type === 'array') && declaration.transitionable) {
+    if (reference.function === 'piecewise-constant' && reference.transition) {
         this.interp = interpZoomTransitioned;
     } else {
-        this.interp = interpolate[type];
+        this.interp = interpolate[reference.type];
     }
 
     this.oldTransition = oldTransition;

--- a/test/manual/2762.html
+++ b/test/manual/2762.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel='stylesheet' href='../../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<script src='../../dist/mapbox-gl-dev.js'></script>
+<script>
+    var map = new mapboxgl.Map({
+        container: 'map',
+        style: {
+            "version": 8,
+            "sources": {
+                "geojson": {
+                    "type": "geojson",
+                    "data": {
+                        "type": "Point",
+                        "coordinates": [
+                            0,
+                            0
+                        ]
+                    }
+                }
+            },
+            "transition": {
+                "duration": 1000
+            },
+            "layers": [
+                {
+                    "id": "circle",
+                    "type": "circle",
+                    "source": "geojson",
+                    "paint": {
+                        "circle-translate": [
+                            -50,
+                            -50
+                        ]
+                    }
+                }
+            ]
+        }
+    });
+
+    map.on('click', function(e) {
+        map.setPaintProperty("circle", "circle-color", "red");
+        map.setPaintProperty("circle", "circle-translate", [50, 50]);
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #2762, see https://github.com/mapbox/mapbox-gl-js/issues/2762#issuecomment-227278278 for details.

Setting a 0-duration transition doesn't work for testing this bug, because it short circuits the code that was at fault. So in order for this to be testable in the test suite, we need to tackle https://github.com/mapbox/mapbox-gl-test-suite/issues/116. I'm going to look into that next.