### PR TITLE
Fire mouseout events

### DIFF
--- a/debug/events.html
+++ b/debug/events.html
@@ -166,7 +166,7 @@ function checkEvent(type, checked) {
 var checkboxContainer = document.querySelector('#checkboxes');
 
 ['touchstart', 'touchend', 'touchmove', 'touchcancel',
- 'mousedown', 'mouseup', 'mousemove',
+ 'mouseout', 'mousedown', 'mouseup', 'mousemove',
  'click', 'dblclick', 'contextmenu',
  'dragstart', 'drag', 'dragend',
  'movestart', 'move', 'moveend',

--- a/docs/_posts/examples/3400-01-04-hover-styles.html
+++ b/docs/_posts/examples/3400-01-04-hover-styles.html
@@ -65,5 +65,10 @@ map.on('load', function () {
             map.setFilter("route-hover", ["==", "name", ""]);
         }
     });
+
+    // Reset the route-hover layer's filter when the mouse leaves the map
+    map.on("mouseout", function(e) {
+        map.setFilter("route-hover", ["==", "name", ""]);
+    }
 });
 </script>

--- a/js/ui/bind_handlers.js
+++ b/js/ui/bind_handlers.js
@@ -26,6 +26,7 @@ module.exports = function bindHandlers(map, options) {
         }
     }
 
+    el.addEventListener('mouseout', onMouseOut, false);
     el.addEventListener('mousedown', onMouseDown, false);
     el.addEventListener('mouseup', onMouseUp, false);
     el.addEventListener('mousemove', onMouseMove, false);
@@ -36,6 +37,11 @@ module.exports = function bindHandlers(map, options) {
     el.addEventListener('click', onClick, false);
     el.addEventListener('dblclick', onDblClick, false);
     el.addEventListener('contextmenu', onContextMenu, false);
+
+    function onMouseOut(e) {
+        map.stop();
+        fireMouseEvent('mouseout', e);
+    }
 
     function onMouseDown(e) {
         map.stop();

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1202,6 +1202,15 @@ function removeNode(node) {
    */
 
   /**
+   * Mouse out event.
+   *
+   * @event mouseout
+   * @memberof Map
+   * @instance
+   * @property {EventData} data Original event data: a [mouseup event](https://developer.mozilla.org/en-US/docs/Web/Events/mouseout)
+   */
+
+  /**
    * Mouse down event.
    *
    * @event mousedown


### PR DESCRIPTION
Allows developers to hide popups / clear highlighted areas which can clutter the screen after the user moves the mouse pointer out of context.