### PR TITLE
Don't call map.stop() on mouseout, and fix typo

### DIFF
--- a/js/ui/bind_handlers.js
+++ b/js/ui/bind_handlers.js
@@ -39,7 +39,6 @@ module.exports = function bindHandlers(map, options) {
     el.addEventListener('contextmenu', onContextMenu, false);
 
     function onMouseOut(e) {
-        map.stop();
         fireMouseEvent('mouseout', e);
     }
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1207,7 +1207,7 @@ function removeNode(node) {
    * @event mouseout
    * @memberof Map
    * @instance
-   * @property {EventData} data Original event data: a [mouseup event](https://developer.mozilla.org/en-US/docs/Web/Events/mouseout)
+   * @property {EventData} data Original event data: a [mouseout event](https://developer.mozilla.org/en-US/docs/Web/Events/mouseout)
    */
 
   /**


### PR DESCRIPTION
Fixes issues with #2777

Sorry for the noise, I'm a little rusty

