### PR TITLE
Fix edge case in Buffer#populatePaintArrays

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -42,11 +42,12 @@ Bucket.create = function(options) {
 Bucket.EXTENT = 8192;
 
 /**
- * The maximum size of the arrays in an "array group."
+ * The maximum size of a vertex array. This limit is imposed by WebGL's 16 bit
+ * addressing of vertex buffers.
  * @private
  * @readonly
  */
-Bucket.MAX_ARRAY_LENGTH = 65535;
+Bucket.MAX_VERTEX_ARRAY_LENGTH = Math.pow(2, 16) - 1;
 
 /**
  * The `Bucket` class is the single point of knowledge about turning vector
@@ -152,7 +153,7 @@ Bucket.prototype.prepareArrayGroup = function(programName, numVertices) {
     var groups = this.arrayGroups[programName];
     var currentGroup = groups.length && groups[groups.length - 1];
 
-    if (!currentGroup || currentGroup.layout.vertex.length + numVertices > Bucket.MAX_ARRAY_LENGTH) {
+    if (!currentGroup || currentGroup.layout.vertex.length + numVertices > Bucket.MAX_VERTEX_ARRAY_LENGTH) {
 
         var arrayTypes = this.arrayTypes[programName];
         var VertexArrayType = arrayTypes.layout.vertex;

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -42,6 +42,13 @@ Bucket.create = function(options) {
 Bucket.EXTENT = 8192;
 
 /**
+ * The maximum size of the arrays in an "array group."
+ * @private
+ * @readonly
+ */
+Bucket.MAX_ARRAY_LENGTH = 65535;
+
+/**
  * The `Bucket` class is the single point of knowledge about turning vector
  * tiles into WebGL buffers.
  *
@@ -145,7 +152,7 @@ Bucket.prototype.prepareArrayGroup = function(programName, numVertices) {
     var groups = this.arrayGroups[programName];
     var currentGroup = groups.length && groups[groups.length - 1];
 
-    if (!currentGroup || currentGroup.layout.vertex.length + numVertices > 65535) {
+    if (!currentGroup || currentGroup.layout.vertex.length + numVertices > Bucket.MAX_ARRAY_LENGTH) {
 
         var arrayTypes = this.arrayTypes[programName];
         var VertexArrayType = arrayTypes.layout.vertex;

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -337,7 +337,8 @@ Bucket.prototype.populatePaintArrays = function(interfaceName, globalProperties,
                 var multiplier = attribute.multiplier || 1;
                 var components = attribute.components || 1;
 
-                for (var i = startIndex; i < length; i++) {
+                var start = g === startGroup.index  ? startIndex : 0;
+                for (var i = start; i < length; i++) {
                     var vertex = vertexArray.get(i);
                     for (var c = 0; c < components; c++) {
                         var memberName = components > 1 ? (attribute.name + c) : attribute.name;

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -17,7 +17,7 @@ var feature = vt.layers.water.feature(0);
 function createFeature(points) {
     return {
         loadGeometry: function() {
-            return points[0] instanceof Point ? [points] : points;
+            return points;
         }
     };
 }
@@ -35,16 +35,16 @@ test('FillBucket', function(t) {
     });
     bucket.createArrays();
 
-    t.equal(bucket.addFeature(createFeature([
+    t.equal(bucket.addFeature(createFeature([[
         new Point(0, 0),
         new Point(10, 10)
-    ])), undefined);
+    ]])), undefined);
 
-    t.equal(bucket.addFeature(createFeature([
+    t.equal(bucket.addFeature(createFeature([[
         new Point(0, 0),
         new Point(10, 10),
         new Point(10, 20)
-    ])), undefined);
+    ]])), undefined);
 
     t.equal(bucket.addFeature(feature), undefined);
 
@@ -57,8 +57,8 @@ test('FillBucket', function(t) {
 test('FillBucket - feature split across array groups', function (t) {
     // temporarily reduce the max array length so we can test features
     // breaking across array groups without tests taking a _long_ time.
-    var prevMaxArrayLength = Bucket.MAX_ARRAY_LENGTH;
-    Bucket.MAX_ARRAY_LENGTH = 1023;
+    var prevMaxArrayLength = Bucket.MAX_VERTEX_ARRAY_LENGTH;
+    Bucket.MAX_VERTEX_ARRAY_LENGTH = 1023;
 
     var layer = new StyleLayer({
         id: 'test',
@@ -84,11 +84,11 @@ test('FillBucket - feature split across array groups', function (t) {
 
     // first add an initial, small feature to make sure the next one starts at
     // a non-zero offset
-    bucket.addFeature(createFeature(createPolygon(10)));
+    bucket.addFeature(createFeature([createPolygon(10)]));
 
     // add a feature that will break across the group boundary (65536)
     bucket.addFeature(createFeature([
-        Bucket.MAX_ARRAY_LENGTH - 20, // the first polygon fits within the bucket
+        Bucket.MAX_VERTEX_ARRAY_LENGTH - 20, // the first polygon fits within the bucket
         20 // but the second one breaks across the boundary.
     ].map(createPolygon)));
 
@@ -100,7 +100,7 @@ test('FillBucket - feature split across array groups', function (t) {
     // feature and the first polygon of the second feature, and the second
     // group to include the _entire_ second polygon of the second feature.
     var expectedLengths = [
-        10 + (Bucket.MAX_ARRAY_LENGTH - 20),
+        10 + (Bucket.MAX_VERTEX_ARRAY_LENGTH - 20),
         20
     ];
     t.equal(groups[0].paint.test.length, expectedLengths[0], 'group 0 length, paint');
@@ -126,7 +126,7 @@ test('FillBucket - feature split across array groups', function (t) {
     }
 
     // restore
-    Bucket.MAX_ARRAY_LENGTH = prevMaxArrayLength;
+    Bucket.MAX_VERTEX_ARRAY_LENGTH = prevMaxArrayLength;
 
     t.end();
 });

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var Protobuf = require('pbf');
 var VectorTile = require('vector-tile').VectorTile;
 var Point = require('point-geometry');
+var Bucket = require('../../../js/data/bucket');
 var FillBucket = require('../../../js/data/bucket/fill_bucket');
 var path = require('path');
 var StyleLayer = require('../../../js/style/style_layer');
@@ -16,7 +17,7 @@ var feature = vt.layers.water.feature(0);
 function createFeature(points) {
     return {
         loadGeometry: function() {
-            return [points];
+            return points[0] instanceof Point ? [points] : points;
         }
     };
 }
@@ -54,6 +55,11 @@ test('FillBucket', function(t) {
 });
 
 test('FillBucket - feature split across array groups', function (t) {
+    // temporarily reduce the max array length so we can test features
+    // breaking across array groups without tests taking a _long_ time.
+    var prevMaxArrayLength = Bucket.MAX_ARRAY_LENGTH;
+    Bucket.MAX_ARRAY_LENGTH = 1023;
+
     var layer = new StyleLayer({
         id: 'test',
         type: 'fill',
@@ -75,51 +81,60 @@ test('FillBucket - feature split across array groups', function (t) {
     });
     bucket.createArrays();
 
-    // add an initial feature
-    bucket.addFeature(createBigFeature(32768));
-    // now add a feature that will break across the group boundary
-    bucket.addFeature(createBigFeature(32768 + 1));
+
+    // first add an initial, small feature to make sure the next one starts at
+    // a non-zero offset
+    bucket.addFeature(createFeature(createPolygon(10)));
+
+    // add a feature that will break across the group boundary (65536)
+    bucket.addFeature(createFeature([
+        Bucket.MAX_ARRAY_LENGTH - 20, // the first polygon fits within the bucket
+        20 // but the second one breaks across the boundary.
+    ].map(createPolygon)));
+
+    var groups = bucket.arrayGroups.fill;
+
+    // check array group lengths
+    // FillBucket#addPolygon does NOT allow a single polygon to break across
+    // group boundary, so we expect the first group to include the first
+    // feature and the first polygon of the second feature, and the second
+    // group to include the _entire_ second polygon of the second feature.
+    var expectedLengths = [
+        10 + (Bucket.MAX_ARRAY_LENGTH - 20),
+        20
+    ];
+    t.equal(groups[0].paint.test.length, expectedLengths[0], 'group 0 length, paint');
+    t.equal(groups[0].layout.vertex.length, expectedLengths[0], 'group 0 length, layout');
+    t.equal(groups[1].paint.test.length, expectedLengths[1], 'group 1 length, paint');
+    t.equal(groups[1].layout.vertex.length, expectedLengths[1], 'group 1 length, layout');
 
     // check that every vertex's color values match the first vertex
-    var groups = bucket.arrayGroups.fill;
-    var expected = groups[0].paint.test.get(0);
-    expected = [
-        expected['a_color0'],
-        expected['a_color1'],
-        expected['a_color2'],
-        expected['a_color3']
-    ];
+    var expected = [0, 0, 255, 255];
+    t.same(getVertexColor(0, 0), expected, 'first vertex');
+    t.same(getVertexColor(0, expectedLengths[0] - 1), expected, 'last vertex of first group');
+    t.same(getVertexColor(1, 0), expected, 'first vertex of second group');
+    t.same(getVertexColor(1, expectedLengths[1] - 1), expected, 'last vertex');
 
-    for (var g = 0; g < groups.length; g++) {
-        var group = groups[g];
-        for (var i = 0; i < group.paint.test.length; i++) {
-            var vertex = group.paint.test.get(i);
-            var color = [
-                vertex['a_color0'],
-                vertex['a_color1'],
-                vertex['a_color2'],
-                vertex['a_color3']
-            ];
-
-            // do this instead of t.deepEqual so as not to pollute test output
-            // with > 65536 assertions
-            if (expected.join(',') !== color.join(',')) {
-                t.fail('Vertex ' + i + ' does not match first vertex; found ' + color + ', but expected ' + expected);
-                t.end();
-                return;
-            }
-        }
+    function getVertexColor(g, i) {
+        var vertex = groups[g].paint.test.get(i);
+        return [
+            vertex['a_color0'],
+            vertex['a_color1'],
+            vertex['a_color2'],
+            vertex['a_color3']
+        ];
     }
+
+    // restore
+    Bucket.MAX_ARRAY_LENGTH = prevMaxArrayLength;
 
     t.end();
-
-
 });
 
-function createBigFeature (numPoints) {
+function createPolygon (numPoints) {
     var points = [];
     for (var i = 0; i < numPoints; i++) {
-        points.push(new Point(10 * Math.sin(i / numPoints), 10 * Math.cos(i / numPoints)));
+        points.push(new Point(i / numPoints, i / numPoints));
     }
-    return createFeature(points);
+    return points;
 }

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -75,17 +75,10 @@ test('FillBucket - feature split across array groups', function (t) {
     });
     bucket.createArrays();
 
-    // add an initial, small feature
-    bucket.addFeature(createFeature([new Point(0, 0), new Point(1, 0)]));
-
+    // add an initial feature
+    bucket.addFeature(createBigFeature(32768));
     // now add a feature that will break across the group boundary
-    var numPoints = 65536;
-    var points = [];
-    var i;
-    for (i = 0; i < numPoints; i++) {
-        points.push(new Point(10 * Math.sin(i / numPoints), 10 * Math.cos(i / numPoints)));
-    }
-    bucket.addFeature(createFeature(points));
+    bucket.addFeature(createBigFeature(32768 + 1));
 
     // check that every vertex's color values match the first vertex
     var groups = bucket.arrayGroups.fill;
@@ -99,7 +92,7 @@ test('FillBucket - feature split across array groups', function (t) {
 
     for (var g = 0; g < groups.length; g++) {
         var group = groups[g];
-        for (i = 0; i < group.paint.test.length; i++) {
+        for (var i = 0; i < group.paint.test.length; i++) {
             var vertex = group.paint.test.get(i);
             var color = [
                 vertex['a_color0'],
@@ -112,10 +105,21 @@ test('FillBucket - feature split across array groups', function (t) {
             // with > 65536 assertions
             if (expected.join(',') !== color.join(',')) {
                 t.fail('Vertex ' + i + ' does not match first vertex; found ' + color + ', but expected ' + expected);
+                t.end();
+                return;
             }
         }
     }
 
     t.end();
+
+
 });
 
+function createBigFeature (numPoints) {
+    var points = [];
+    for (var i = 0; i < numPoints; i++) {
+        points.push(new Point(10 * Math.sin(i / numPoints), 10 * Math.cos(i / numPoints)));
+    }
+    return createFeature(points);
+}


### PR DESCRIPTION
I believe this test expresses a potential bug / edge case in `populatePaintArrays` -- specifically, where an inner loop is [initialized to `startIndex`](https://github.com/mapbox/mapbox-gl-js/blob/master/js/data/bucket.js#L340) not only for the first group, but also for subsequent groups.  If I'm understanding how this array group thing works, I'd expect something like:

```js
var startIndexForThisGroup = g === startGroup.index  ? startIndex : 0
for (var i =  startIndexForThisGroup; i < length; i++) 
```

