### PR TITLE
Don't record test coverage on build tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
     "./js/util/dispatcher.js": "./js/util/browser/dispatcher.js"
   },
   "scripts": {
-    "build-dev": "browserify js/mapbox-gl.js --debug --ignore-transform unassertify --standalone mapboxgl > dist/mapbox-gl-dev.js && tap test/build/dev.test.js",
+    "build-dev": "browserify js/mapbox-gl.js --debug --ignore-transform unassertify --standalone mapboxgl > dist/mapbox-gl-dev.js && tap --no-coverage test/build/dev.test.js",
     "build-docs": "documentation build --github --format html -c documentation.yml --theme ./docs/_theme --output docs/api/",
-    "build-min": "browserify js/mapbox-gl.js --debug --plugin [minifyify --map mapbox-gl.js.map --output dist/mapbox-gl.js.map] --standalone mapboxgl > dist/mapbox-gl.js && tap test/build/min.test.js",
+    "build-min": "browserify js/mapbox-gl.js --debug --plugin [minifyify --map mapbox-gl.js.map --output dist/mapbox-gl.js.map] --standalone mapboxgl > dist/mapbox-gl.js && tap --no-coverage test/build/min.test.js",
     "//": "The 'build' script is invoked by publisher when publishing docs on the mb-pages branch",
     "build": "npm run build-docs",
     "lint": "eslint js test bench server.js",


### PR DESCRIPTION
Fixes some log spew during CI builds