### PR TITLE
preserveDrawingBuffer documentation addition

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -84,7 +84,7 @@ var defaultOptions = {
  * @param {Array} [options.classes] Style class names with which to initialize the map
  * @param {boolean} [options.attributionControl=true] If `true`, an attribution control will be added to the map.
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than expected.
- * @param {boolean} [options.preserveDrawingBuffer=false] If `true`, The maps canvas can be exported to a PNG using `map.getCanvas().toDataURL();`. This is false by default as a performance optimization.
+ * @param {boolean} [options.preserveDrawingBuffer=false] If `true`, The maps canvas can be exported to a PNG using `map.getCanvas().toDataURL();`. This is false by default as a performance optimization. Firefox will not print the map unless this is true.
  * @param {LngLatBounds|Array<Array<number>>} [options.maxBounds] If set, the map is constrained to the given bounds.
  * @param {boolean} [options.scrollZoom=true] If `true`, enable the "scroll to zoom" interaction (see `ScrollZoomHandler`)
  * @param {boolean} [options.boxZoom=true] If `true`, enable the "box zoom" interaction (see `BoxZoomHandler`)


### PR DESCRIPTION
Added note that Firefox will not print the map unless this is set to true (longstanding/unassigned [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=976173)). Not sure if this is the appropriate place for a browser specific note or not, but it might save someone some hair pulling. As this bug has been open and unassigned for 2.5 years I don't think the Mozilla folks are fixing it any time soon.