### PR TITLE
Pass event data with move events caused by DoubleClickZoomHandler

### DIFF
--- a/js/ui/handler/dblclick_zoom.js
+++ b/js/ui/handler/dblclick_zoom.js
@@ -47,7 +47,10 @@ DoubleClickZoomHandler.prototype = {
     },
 
     _onDblClick: function (e) {
-        this._map.zoomTo(this._map.getZoom() +
-            (e.originalEvent.shiftKey ? -1 : 1), {around: e.lngLat});
+        this._map.zoomTo(
+            this._map.getZoom() + (e.originalEvent.shiftKey ? -1 : 1),
+            {around: e.lngLat},
+            e
+        );
     }
 };


### PR DESCRIPTION
ref https://github.com/mapbox/mapbox-gl-js/pull/2755#issuecomment-229963592

cc @davidtheclark