### PR TITLE
Organize Map*Events in docs TOC

### DIFF
--- a/documentation.yml
+++ b/documentation.yml
@@ -51,8 +51,10 @@ toc:
       This event functionality is used by Mapbox GL JS itself
       and can be useful to other developers who want to create
       [Controls](#Control) or other extensions.
-  - MapEventData
   - Evented
+  - MapMouseEvent
+  - MapTouchEvent
+  - MapBoxZoomEvent
   - name: Types
     description: |
       These are types used in the documentation above to describe arguments,


### PR DESCRIPTION
I put the Map*Events in the Events section of the documentation.

I think this just got missed as in one of the revisions of the event docs.