### PR TITLE
Change MouseUpEvent to MouseEvent

### DIFF
--- a/js/ui/handler/box_zoom.js
+++ b/js/ui/handler/box_zoom.js
@@ -150,7 +150,7 @@ BoxZoomHandler.prototype = {
 
 /**
  * @typedef {Object} MapBoxZoomEvent
- * @property {MouseUpEvent} originalEvent
+ * @property {MouseEvent} originalEvent
  * @property {LngLatBounds} boxZoomBounds The bounding box of the "box zoom" interaction.
  *   This property is only provided for `boxzoomend` events.
  */


### PR DESCRIPTION
I believe this was just a typo made during one of our recent event docs revisions.