### PR TITLE
Fix Bucket#trimArrays

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -268,12 +268,15 @@ Bucket.prototype.destroy = function(gl) {
 
 Bucket.prototype.trimArrays = function() {
     for (var programName in this.arrayGroups) {
-        var programArrays = this.arrayGroups[programName];
-        for (var paintArray in programArrays.paint) {
-            programArrays.paint[paintArray].trim();
-        }
-        for (var layoutArray in programArrays.layout) {
-            programArrays.layout[layoutArray].trim();
+        var arrayGroups = this.arrayGroups[programName];
+        for (var i = 0; i < arrayGroups.length; i++) {
+            var arrayGroup = arrayGroups[i];
+            for (var paintArray in arrayGroup.paint) {
+                arrayGroup.paint[paintArray].trim();
+            }
+            for (var layoutArray in arrayGroup.layout) {
+                arrayGroup.layout[layoutArray].trim();
+            }
         }
     }
 };

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -202,6 +202,21 @@ test('Bucket', function(t) {
         t.end();
     });
 
+    t.test('trimArrays', function(t) {
+        var bucket = create();
+
+        bucket.createArrays();
+        bucket.prepareArrayGroup('test', 10);
+        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.length);
+        t.notEqual(0, bucket.arrayGroups.test[0].layout.vertex.capacity);
+
+        bucket.trimArrays();
+        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.length);
+        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.capacity);
+
+        t.end();
+    });
+
     t.test('add features after resetting buffers', function(t) {
         var bucket = create();
 


### PR DESCRIPTION
The prior implementation was a no-op, because it skipped a level in the object hierarchy.

Fixing this produced a meaningful benchmark improvement. Buffer benchmark before: 997ms; after: 895ms.