### PR TITLE
Bucket: Arrays and buffers

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -268,12 +268,15 @@ Bucket.prototype.destroy = function(gl) {
 
 Bucket.prototype.trimArrays = function() {
     for (var programName in this.arrayGroups) {
-        var programArrays = this.arrayGroups[programName];
-        for (var paintArray in programArrays.paint) {
-            programArrays.paint[paintArray].trim();
-        }
-        for (var layoutArray in programArrays.layout) {
-            programArrays.layout[layoutArray].trim();
+        var arrayGroups = this.arrayGroups[programName];
+        for (var i = 0; i < arrayGroups.length; i++) {
+            var arrayGroup = arrayGroups[i];
+            for (var paintArray in arrayGroup.paint) {
+                arrayGroup.paint[paintArray].trim();
+            }
+            for (var layoutArray in arrayGroup.layout) {
+                arrayGroup.layout[layoutArray].trim();
+            }
         }
     }
 };

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -265,6 +265,38 @@ Bucket.prototype.trimArrays = function() {
     }
 };
 
+Bucket.prototype.isEmpty = function() {
+    for (var programName in this.arrayGroups) {
+        var arrayGroups = this.arrayGroups[programName];
+        for (var i = 0; i < arrayGroups.length; i++) {
+            var arrayGroup = arrayGroups[i];
+            if (arrayGroup.vertexArray.length > 0) {
+                return false;
+            }
+        }
+    }
+    return true;
+};
+
+Bucket.prototype.getTransferables = function(transferables) {
+    for (var programName in this.arrayGroups) {
+        var arrayGroups = this.arrayGroups[programName];
+        for (var i = 0; i < arrayGroups.length; i++) {
+            var arrayGroup = arrayGroups[i];
+            transferables.push(arrayGroup.vertexArray.arrayBuffer);
+            if (arrayGroup.elementArray) {
+                transferables.push(arrayGroup.elementArray.arrayBuffer);
+            }
+            if (arrayGroup.elementArray2) {
+                transferables.push(arrayGroup.elementArray2.arrayBuffer);
+            }
+            for (var paintArray in arrayGroup.paintArrays) {
+                transferables.push(arrayGroup.paintArrays[paintArray].arrayBuffer);
+            }
+        }
+    }
+};
+
 Bucket.prototype.setUniforms = function(gl, programName, program, layer, globalProperties) {
     var uniforms = this.paintAttributes[programName][layer.id].uniforms;
     for (var i = 0; i < uniforms.length; i++) {

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -124,10 +124,10 @@ function Bucket(options) {
 }
 
 /**
- * Build the buffers! Features are set directly to the `features` property.
+ * Build the arrays! Features are set directly to the `features` property.
  * @private
  */
-Bucket.prototype.populateBuffers = function() {
+Bucket.prototype.populateArrays = function() {
     this.createArrays();
     this.recalculateStyleLayers();
 
@@ -141,7 +141,7 @@ Bucket.prototype.populateBuffers = function() {
 /**
  * Check if there is enough space available in the current array group for
  * `vertexLength` vertices. If not, append a new array group. Should be called
- * by `populateBuffers` and its callees.
+ * by `populateArrays` and its callees.
  *
  * Array groups are added to this.arrayGroups[programName].
  * An individual array group looks like:

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -83,7 +83,7 @@ CircleBucket.prototype.addFeature = function(feature) {
     var geometries = loadGeometry(feature);
 
     var startGroup = this.prepareArrayGroup('circle', 0);
-    var startIndex = startGroup.layout.vertex.length;
+    var startIndex = startGroup.vertexArray.length;
 
     for (var j = 0; j < geometries.length; j++) {
         for (var k = 0; k < geometries[j].length; k++) {
@@ -104,15 +104,15 @@ CircleBucket.prototype.addFeature = function(feature) {
             // └─────────┘
 
             var group = this.prepareArrayGroup('circle', 4);
-            var vertexArray = group.layout.vertex;
+            var vertexArray = group.vertexArray;
 
             var index = this.addCircleVertex(vertexArray, x, y, -1, -1);
             this.addCircleVertex(vertexArray, x, y, 1, -1);
             this.addCircleVertex(vertexArray, x, y, 1, 1);
             this.addCircleVertex(vertexArray, x, y, -1, 1);
 
-            group.layout.element.emplaceBack(index, index + 1, index + 2);
-            group.layout.element.emplaceBack(index, index + 3, index + 2);
+            group.elementArray.emplaceBack(index, index + 1, index + 2);
+            group.elementArray.emplaceBack(index, index + 3, index + 2);
         }
     }
 

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -20,15 +20,15 @@ function CircleBucket() {
 
 CircleBucket.prototype = util.inherit(Bucket, {});
 
-CircleBucket.prototype.addCircleVertex = function(vertexArray, x, y, extrudeX, extrudeY) {
-    return vertexArray.emplaceBack(
+CircleBucket.prototype.addCircleVertex = function(layoutVertexArray, x, y, extrudeX, extrudeY) {
+    return layoutVertexArray.emplaceBack(
             (x * 2) + ((extrudeX + 1) / 2),
             (y * 2) + ((extrudeY + 1) / 2));
 };
 
 CircleBucket.prototype.programInterfaces = {
     circle: {
-        vertexArrayType: new Bucket.VertexArrayType([{
+        layoutVertexArrayType: new Bucket.VertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
@@ -83,7 +83,7 @@ CircleBucket.prototype.addFeature = function(feature) {
     var geometries = loadGeometry(feature);
 
     var startGroup = this.prepareArrayGroup('circle', 0);
-    var startIndex = startGroup.vertexArray.length;
+    var startIndex = startGroup.layoutVertexArray.length;
 
     for (var j = 0; j < geometries.length; j++) {
         for (var k = 0; k < geometries[j].length; k++) {
@@ -104,12 +104,12 @@ CircleBucket.prototype.addFeature = function(feature) {
             // └─────────┘
 
             var group = this.prepareArrayGroup('circle', 4);
-            var vertexArray = group.vertexArray;
+            var layoutVertexArray = group.layoutVertexArray;
 
-            var index = this.addCircleVertex(vertexArray, x, y, -1, -1);
-            this.addCircleVertex(vertexArray, x, y, 1, -1);
-            this.addCircleVertex(vertexArray, x, y, 1, 1);
-            this.addCircleVertex(vertexArray, x, y, -1, 1);
+            var index = this.addCircleVertex(layoutVertexArray, x, y, -1, -1);
+            this.addCircleVertex(layoutVertexArray, x, y, 1, -1);
+            this.addCircleVertex(layoutVertexArray, x, y, 1, 1);
+            this.addCircleVertex(layoutVertexArray, x, y, -1, 1);
 
             group.elementArray.emplaceBack(index, index + 1, index + 2);
             group.elementArray.emplaceBack(index, index + 3, index + 2);

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -28,14 +28,13 @@ CircleBucket.prototype.addCircleVertex = function(vertexArray, x, y, extrudeX, e
 
 CircleBucket.prototype.programInterfaces = {
     circle: {
-        vertexBuffer: true,
-        elementBuffer: true,
-
-        layoutAttributes: [{
+        vertexArrayType: new Bucket.VertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
-        }],
+        }]),
+        elementArrayType: new Bucket.ElementArrayType(),
+
         paintAttributes: [{
             name: 'a_color',
             components: 4,

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -61,7 +61,7 @@ FillBucket.prototype.addFeature = function(feature) {
     var polygons = classifyRings(lines, EARCUT_MAX_RINGS);
 
     var startGroup = this.prepareArrayGroup('fill', 0);
-    var startIndex = startGroup.layout.vertex.length;
+    var startIndex = startGroup.vertexArray.length;
 
     for (var i = 0; i < polygons.length; i++) {
         this.addPolygon(polygons[i]);
@@ -79,7 +79,7 @@ FillBucket.prototype.addPolygon = function(polygon) {
     var group = this.prepareArrayGroup('fill', numVertices);
     var flattened = [];
     var holeIndices = [];
-    var startIndex = group.layout.vertex.length;
+    var startIndex = group.vertexArray.length;
 
     for (var r = 0; r < polygon.length; r++) {
         var ring = polygon[r];
@@ -89,10 +89,10 @@ FillBucket.prototype.addPolygon = function(polygon) {
         for (var v = 0; v < ring.length; v++) {
             var vertex = ring[v];
 
-            var index = group.layout.vertex.emplaceBack(vertex.x, vertex.y);
+            var index = group.vertexArray.emplaceBack(vertex.x, vertex.y);
 
             if (v >= 1) {
-                group.layout.element2.emplaceBack(index - 1, index);
+                group.elementArray2.emplaceBack(index - 1, index);
             }
 
             // convert to format used by earcut
@@ -104,6 +104,6 @@ FillBucket.prototype.addPolygon = function(polygon) {
     var triangleIndices = earcut(flattened, holeIndices);
 
     for (var i = 0; i < triangleIndices.length; i++) {
-        group.layout.element.emplaceBack(triangleIndices[i] + startIndex);
+        group.elementArray.emplaceBack(triangleIndices[i] + startIndex);
     }
 };

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -17,7 +17,7 @@ FillBucket.prototype = util.inherit(Bucket, {});
 
 FillBucket.prototype.programInterfaces = {
     fill: {
-        vertexArrayType: new Bucket.VertexArrayType([{
+        layoutVertexArrayType: new Bucket.VertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
@@ -61,7 +61,7 @@ FillBucket.prototype.addFeature = function(feature) {
     var polygons = classifyRings(lines, EARCUT_MAX_RINGS);
 
     var startGroup = this.prepareArrayGroup('fill', 0);
-    var startIndex = startGroup.vertexArray.length;
+    var startIndex = startGroup.layoutVertexArray.length;
 
     for (var i = 0; i < polygons.length; i++) {
         this.addPolygon(polygons[i]);
@@ -79,7 +79,7 @@ FillBucket.prototype.addPolygon = function(polygon) {
     var group = this.prepareArrayGroup('fill', numVertices);
     var flattened = [];
     var holeIndices = [];
-    var startIndex = group.vertexArray.length;
+    var startIndex = group.layoutVertexArray.length;
 
     for (var r = 0; r < polygon.length; r++) {
         var ring = polygon[r];
@@ -89,7 +89,7 @@ FillBucket.prototype.addPolygon = function(polygon) {
         for (var v = 0; v < ring.length; v++) {
             var vertex = ring[v];
 
-            var index = group.vertexArray.emplaceBack(vertex.x, vertex.y);
+            var index = group.layoutVertexArray.emplaceBack(vertex.x, vertex.y);
 
             if (v >= 1) {
                 group.elementArray2.emplaceBack(index - 1, index);

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -17,17 +17,14 @@ FillBucket.prototype = util.inherit(Bucket, {});
 
 FillBucket.prototype.programInterfaces = {
     fill: {
-        vertexBuffer: true,
-        elementBuffer: true,
-        elementBufferComponents: 1,
-        elementBuffer2: true,
-        elementBuffer2Components: 2,
-
-        layoutAttributes: [{
+        vertexArrayType: new Bucket.VertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
-        }],
+        }]),
+        elementArrayType: new Bucket.ElementArrayType(1),
+        elementArrayType2: new Bucket.ElementArrayType(2),
+
         paintAttributes: [{
             name: 'a_color',
             components: 4,

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -50,8 +50,8 @@ function LineBucket() {
 
 LineBucket.prototype = util.inherit(Bucket, {});
 
-LineBucket.prototype.addLineVertex = function(vertexBuffer, point, extrude, tx, ty, dir, linesofar) {
-    return vertexBuffer.emplaceBack(
+LineBucket.prototype.addLineVertex = function(layoutVertexBuffer, point, extrude, tx, ty, dir, linesofar) {
+    return layoutVertexBuffer.emplaceBack(
             // a_pos
             (point.x << 1) | tx,
             (point.y << 1) | ty,
@@ -70,7 +70,7 @@ LineBucket.prototype.addLineVertex = function(vertexBuffer, point, extrude, tx, 
 
 LineBucket.prototype.programInterfaces = {
     line: {
-        vertexArrayType: new Bucket.VertexArrayType([{
+        layoutVertexArrayType: new Bucket.VertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
@@ -363,12 +363,12 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal
     var tx = round ? 1 : 0;
     var extrude;
     var arrayGroup = this.arrayGroups.line[this.arrayGroups.line.length - 1];
-    var vertexArray = arrayGroup.vertexArray;
+    var layoutVertexArray = arrayGroup.layoutVertexArray;
     var elementArray = arrayGroup.elementArray;
 
     extrude = normal.clone();
     if (endLeft) extrude._sub(normal.perp()._mult(endLeft));
-    this.e3 = this.addLineVertex(vertexArray, currentVertex, extrude, tx, 0, endLeft, distance);
+    this.e3 = this.addLineVertex(layoutVertexArray, currentVertex, extrude, tx, 0, endLeft, distance);
     if (this.e1 >= 0 && this.e2 >= 0) {
         elementArray.emplaceBack(this.e1, this.e2, this.e3);
     }
@@ -377,7 +377,7 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal
 
     extrude = normal.mult(-1);
     if (endRight) extrude._sub(normal.perp()._mult(endRight));
-    this.e3 = this.addLineVertex(vertexArray, currentVertex, extrude, tx, 1, -endRight, distance);
+    this.e3 = this.addLineVertex(layoutVertexArray, currentVertex, extrude, tx, 1, -endRight, distance);
     if (this.e1 >= 0 && this.e2 >= 0) {
         elementArray.emplaceBack(this.e1, this.e2, this.e3);
     }
@@ -408,10 +408,10 @@ LineBucket.prototype.addPieSliceVertex = function(currentVertex, distance, extru
     var ty = lineTurnsLeft ? 1 : 0;
     extrude = extrude.mult(lineTurnsLeft ? -1 : 1);
     var arrayGroup = this.arrayGroups.line[this.arrayGroups.line.length - 1];
-    var vertexArray = arrayGroup.vertexArray;
+    var layoutVertexArray = arrayGroup.layoutVertexArray;
     var elementArray = arrayGroup.elementArray;
 
-    this.e3 = this.addLineVertex(vertexArray, currentVertex, extrude, 0, ty, 0, distance);
+    this.e3 = this.addLineVertex(layoutVertexArray, currentVertex, extrude, 0, ty, 0, distance);
 
     if (this.e1 >= 0 && this.e2 >= 0) {
         elementArray.emplaceBack(this.e1, this.e2, this.e3);

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -362,9 +362,9 @@ LineBucket.prototype.addLine = function(vertices, join, cap, miterLimit, roundLi
 LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal, endLeft, endRight, round) {
     var tx = round ? 1 : 0;
     var extrude;
-    var layoutArrays = this.arrayGroups.line[this.arrayGroups.line.length - 1].layout;
-    var vertexArray = layoutArrays.vertex;
-    var elementArray = layoutArrays.element;
+    var arrayGroup = this.arrayGroups.line[this.arrayGroups.line.length - 1];
+    var vertexArray = arrayGroup.vertexArray;
+    var elementArray = arrayGroup.elementArray;
 
     extrude = normal.clone();
     if (endLeft) extrude._sub(normal.perp()._mult(endLeft));
@@ -407,9 +407,9 @@ LineBucket.prototype.addCurrentVertex = function(currentVertex, distance, normal
 LineBucket.prototype.addPieSliceVertex = function(currentVertex, distance, extrude, lineTurnsLeft) {
     var ty = lineTurnsLeft ? 1 : 0;
     extrude = extrude.mult(lineTurnsLeft ? -1 : 1);
-    var layoutArrays = this.arrayGroups.line[this.arrayGroups.line.length - 1].layout;
-    var vertexArray = layoutArrays.vertex;
-    var elementArray = layoutArrays.element;
+    var arrayGroup = this.arrayGroups.line[this.arrayGroups.line.length - 1];
+    var vertexArray = arrayGroup.vertexArray;
+    var elementArray = arrayGroup.elementArray;
 
     this.e3 = this.addLineVertex(vertexArray, currentVertex, extrude, 0, ty, 0, distance);
 

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -70,10 +70,7 @@ LineBucket.prototype.addLineVertex = function(vertexBuffer, point, extrude, tx, 
 
 LineBucket.prototype.programInterfaces = {
     line: {
-        vertexBuffer: true,
-        elementBuffer: true,
-
-        layoutAttributes: [{
+        vertexArrayType: new Bucket.VertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
@@ -81,7 +78,8 @@ LineBucket.prototype.programInterfaces = {
             name: 'a_data',
             components: 4,
             type: 'Uint8'
-        }]
+        }]),
+        elementArrayType: new Bucket.ElementArrayType()
     }
 };
 

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -51,7 +51,7 @@ SymbolBucket.prototype.serialize = function() {
     return serialized;
 };
 
-var programAttributes = [{
+var vertexArrayType = new Bucket.VertexArrayType([{
     name: 'a_pos',
     components: 2,
     type: 'Int16'
@@ -67,7 +67,9 @@ var programAttributes = [{
     name: 'a_data2',
     components: 2,
     type: 'Uint8'
-}];
+}]);
+
+var elementArrayType = new Bucket.ElementArrayType();
 
 function addVertex(array, x, y, ox, oy, tx, ty, minzoom, maxzoom, labelminzoom, labelangle) {
     return array.emplaceBack(
@@ -103,21 +105,17 @@ SymbolBucket.prototype.addCollisionBoxVertex = function(vertexArray, point, extr
 SymbolBucket.prototype.programInterfaces = {
 
     glyph: {
-        vertexBuffer: true,
-        elementBuffer: true,
-        layoutAttributes: programAttributes
+        vertexArrayType: vertexArrayType,
+        elementArrayType: elementArrayType
     },
 
     icon: {
-        vertexBuffer: true,
-        elementBuffer: true,
-        layoutAttributes: programAttributes
+        vertexArrayType: vertexArrayType,
+        elementArrayType: elementArrayType
     },
 
     collisionBox: {
-        vertexBuffer: true,
-
-        layoutAttributes: [{
+        vertexArrayType: new Bucket.VertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
@@ -129,7 +127,7 @@ SymbolBucket.prototype.programInterfaces = {
             name: 'a_data',
             components: 2,
             type: 'Uint8'
-        }]
+        }])
     }
 };
 

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -51,7 +51,7 @@ SymbolBucket.prototype.serialize = function() {
     return serialized;
 };
 
-var vertexArrayType = new Bucket.VertexArrayType([{
+var layoutVertexArrayType = new Bucket.VertexArrayType([{
     name: 'a_pos',
     components: 2,
     type: 'Int16'
@@ -89,8 +89,8 @@ function addVertex(array, x, y, ox, oy, tx, ty, minzoom, maxzoom, labelminzoom, 
             Math.min(maxzoom || 25, 25) * 10); // minzoom
 }
 
-SymbolBucket.prototype.addCollisionBoxVertex = function(vertexArray, point, extrude, maxZoom, placementZoom) {
-    return vertexArray.emplaceBack(
+SymbolBucket.prototype.addCollisionBoxVertex = function(layoutVertexArray, point, extrude, maxZoom, placementZoom) {
+    return layoutVertexArray.emplaceBack(
             // pos
             point.x,
             point.y,
@@ -105,17 +105,17 @@ SymbolBucket.prototype.addCollisionBoxVertex = function(vertexArray, point, extr
 SymbolBucket.prototype.programInterfaces = {
 
     glyph: {
-        vertexArrayType: vertexArrayType,
+        layoutVertexArrayType: layoutVertexArrayType,
         elementArrayType: elementArrayType
     },
 
     icon: {
-        vertexArrayType: vertexArrayType,
+        layoutVertexArrayType: layoutVertexArrayType,
         elementArrayType: elementArrayType
     },
 
     collisionBox: {
-        vertexArrayType: new Bucket.VertexArrayType([{
+        layoutVertexArrayType: new Bucket.VertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
@@ -455,7 +455,7 @@ SymbolBucket.prototype.addSymbols = function(programName, quadsStart, quadsEnd, 
     var group = this.prepareArrayGroup(programName, 4 * (quadsEnd - quadsStart));
 
     var elementArray = group.elementArray;
-    var vertexArray = group.vertexArray;
+    var layoutVertexArray = group.layoutVertexArray;
 
     var zoom = this.zoom;
     var placementZoom = Math.max(Math.log(scale) / Math.LN2 + zoom, 0);
@@ -486,10 +486,10 @@ SymbolBucket.prototype.addSymbols = function(programName, quadsStart, quadsEnd, 
         // Encode angle of glyph
         var glyphAngle = Math.round((symbol.glyphAngle / (Math.PI * 2)) * 256);
 
-        var index = addVertex(vertexArray, anchorPoint.x, anchorPoint.y, tl.x, tl.y, tex.x, tex.y, minZoom, maxZoom, placementZoom, glyphAngle);
-        addVertex(vertexArray, anchorPoint.x, anchorPoint.y, tr.x, tr.y, tex.x + tex.w, tex.y, minZoom, maxZoom, placementZoom, glyphAngle);
-        addVertex(vertexArray, anchorPoint.x, anchorPoint.y, bl.x, bl.y, tex.x, tex.y + tex.h, minZoom, maxZoom, placementZoom, glyphAngle);
-        addVertex(vertexArray, anchorPoint.x, anchorPoint.y, br.x, br.y, tex.x + tex.w, tex.y + tex.h, minZoom, maxZoom, placementZoom, glyphAngle);
+        var index = addVertex(layoutVertexArray, anchorPoint.x, anchorPoint.y, tl.x, tl.y, tex.x, tex.y, minZoom, maxZoom, placementZoom, glyphAngle);
+        addVertex(layoutVertexArray, anchorPoint.x, anchorPoint.y, tr.x, tr.y, tex.x + tex.w, tex.y, minZoom, maxZoom, placementZoom, glyphAngle);
+        addVertex(layoutVertexArray, anchorPoint.x, anchorPoint.y, bl.x, bl.y, tex.x, tex.y + tex.h, minZoom, maxZoom, placementZoom, glyphAngle);
+        addVertex(layoutVertexArray, anchorPoint.x, anchorPoint.y, br.x, br.y, tex.x + tex.w, tex.y + tex.h, minZoom, maxZoom, placementZoom, glyphAngle);
 
         elementArray.emplaceBack(index, index + 1, index + 2);
         elementArray.emplaceBack(index + 1, index + 2, index + 3);
@@ -519,7 +519,7 @@ SymbolBucket.prototype.updateFont = function(stacks) {
 
 SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
     var group = this.prepareArrayGroup('collisionBox', 0);
-    var vertexArray = group.vertexArray;
+    var layoutVertexArray = group.layoutVertexArray;
     var angle = -collisionTile.angle;
     var yStretch = collisionTile.yStretch;
 
@@ -544,14 +544,14 @@ SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
                 var maxZoom = Math.max(0, Math.min(25, this.zoom + Math.log(box.maxScale) / Math.LN2));
                 var placementZoom = Math.max(0, Math.min(25, this.zoom + Math.log(box.placementScale) / Math.LN2));
 
-                this.addCollisionBoxVertex(vertexArray, anchorPoint, tl, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(vertexArray, anchorPoint, tr, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(vertexArray, anchorPoint, tr, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(vertexArray, anchorPoint, br, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(vertexArray, anchorPoint, br, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(vertexArray, anchorPoint, bl, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(vertexArray, anchorPoint, bl, maxZoom, placementZoom);
-                this.addCollisionBoxVertex(vertexArray, anchorPoint, tl, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(layoutVertexArray, anchorPoint, tl, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(layoutVertexArray, anchorPoint, tr, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(layoutVertexArray, anchorPoint, tr, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(layoutVertexArray, anchorPoint, br, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(layoutVertexArray, anchorPoint, br, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(layoutVertexArray, anchorPoint, bl, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(layoutVertexArray, anchorPoint, bl, maxZoom, placementZoom);
+                this.addCollisionBoxVertex(layoutVertexArray, anchorPoint, tl, maxZoom, placementZoom);
             }
         }
     }

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -454,8 +454,8 @@ SymbolBucket.prototype.addSymbols = function(programName, quadsStart, quadsEnd, 
 
     var group = this.prepareArrayGroup(programName, 4 * (quadsEnd - quadsStart));
 
-    var elementArray = group.layout.element;
-    var vertexArray = group.layout.vertex;
+    var elementArray = group.elementArray;
+    var vertexArray = group.vertexArray;
 
     var zoom = this.zoom;
     var placementZoom = Math.max(Math.log(scale) / Math.LN2 + zoom, 0);
@@ -519,7 +519,7 @@ SymbolBucket.prototype.updateFont = function(stacks) {
 
 SymbolBucket.prototype.addToDebugBuffers = function(collisionTile) {
     var group = this.prepareArrayGroup('collisionBox', 0);
-    var vertexArray = group.layout.vertex;
+    var vertexArray = group.vertexArray;
     var angle = -collisionTile.angle;
     var yStretch = collisionTile.yStretch;
 

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -131,7 +131,7 @@ SymbolBucket.prototype.programInterfaces = {
     }
 };
 
-SymbolBucket.prototype.populateBuffers = function(collisionTile, stacks, icons) {
+SymbolBucket.prototype.populateArrays = function(collisionTile, stacks, icons) {
 
     // To reduce the number of labels that jump around when zooming we need
     // to use a text-size value that is the same for all zoom levels.

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -56,7 +56,7 @@ function drawCircles(painter, source, layer, coords) {
 
         for (var k = 0; k < bufferGroups.length; k++) {
             var group = bufferGroups[k];
-            group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer, group.paintBuffers[layer.id]);
+            group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer, group.paintVertexBuffers[layer.id]);
             gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
         }
     }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -56,8 +56,8 @@ function drawCircles(painter, source, layer, coords) {
 
         for (var k = 0; k < bufferGroups.length; k++) {
             var group = bufferGroups[k];
-            group.vaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element, group.paint[layer.id]);
-            gl.drawElements(gl.TRIANGLES, group.layout.element.length * 3, gl.UNSIGNED_SHORT, 0);
+            group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer, group.paintBuffers[layer.id]);
+            gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
         }
     }
 }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -16,7 +16,7 @@ function drawCollisionDebug(painter, source, layer, coords) {
 
         if (!bufferGroups || !bufferGroups.length) continue;
         var group = bufferGroups[0];
-        if (group.vertexBuffer.length === 0) continue;
+        if (group.layoutVertexBuffer.length === 0) continue;
 
         gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
@@ -27,7 +27,7 @@ function drawCollisionDebug(painter, source, layer, coords) {
         gl.uniform1f(program.u_zoom, painter.transform.zoom * 10);
         gl.uniform1f(program.u_maxzoom, (tile.coord.z + 1) * 10);
 
-        group.vaos[layer.id].bind(gl, program, group.vertexBuffer);
-        gl.drawArrays(gl.LINES, 0, group.vertexBuffer.length);
+        group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer);
+        gl.drawArrays(gl.LINES, 0, group.layoutVertexBuffer.length);
     }
 }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -16,7 +16,7 @@ function drawCollisionDebug(painter, source, layer, coords) {
 
         if (!bufferGroups || !bufferGroups.length) continue;
         var group = bufferGroups[0];
-        if (group.layout.vertex.length === 0) continue;
+        if (group.vertexBuffer.length === 0) continue;
 
         gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
@@ -27,7 +27,7 @@ function drawCollisionDebug(painter, source, layer, coords) {
         gl.uniform1f(program.u_zoom, painter.transform.zoom * 10);
         gl.uniform1f(program.u_maxzoom, (tile.coord.z + 1) * 10);
 
-        group.vaos[layer.id].bind(gl, program, group.layout.vertex);
-        gl.drawArrays(gl.LINES, 0, group.layout.vertex.length);
+        group.vaos[layer.id].bind(gl, program, group.vertexBuffer);
+        gl.drawArrays(gl.LINES, 0, group.vertexBuffer.length);
     }
 }

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -99,8 +99,8 @@ function drawFill(painter, source, layer, coord) {
 
     for (var i = 0; i < bufferGroups.length; i++) {
         var group = bufferGroups[i];
-        group.vaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element, group.paint[layer.id]);
-        gl.drawElements(gl.TRIANGLES, group.layout.element.length, gl.UNSIGNED_SHORT, 0);
+        group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer, group.paintBuffers[layer.id]);
+        gl.drawElements(gl.TRIANGLES, group.elementBuffer.length, gl.UNSIGNED_SHORT, 0);
     }
 }
 
@@ -147,8 +147,8 @@ function drawStroke(painter, source, layer, coord) {
 
     for (var k = 0; k < bufferGroups.length; k++) {
         var group = bufferGroups[k];
-        group.secondVaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element2, group.paint[layer.id]);
-        gl.drawElements(gl.LINES, group.layout.element2.length * 2, gl.UNSIGNED_SHORT, 0);
+        group.secondVaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer2, group.paintBuffers[layer.id]);
+        gl.drawElements(gl.LINES, group.elementBuffer2.length * 2, gl.UNSIGNED_SHORT, 0);
     }
 }
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -99,7 +99,7 @@ function drawFill(painter, source, layer, coord) {
 
     for (var i = 0; i < bufferGroups.length; i++) {
         var group = bufferGroups[i];
-        group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer, group.paintBuffers[layer.id]);
+        group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer, group.paintVertexBuffers[layer.id]);
         gl.drawElements(gl.TRIANGLES, group.elementBuffer.length, gl.UNSIGNED_SHORT, 0);
     }
 }
@@ -147,7 +147,7 @@ function drawStroke(painter, source, layer, coord) {
 
     for (var k = 0; k < bufferGroups.length; k++) {
         var group = bufferGroups[k];
-        group.secondVaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer2, group.paintBuffers[layer.id]);
+        group.secondVaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer2, group.paintVertexBuffers[layer.id]);
         gl.drawElements(gl.LINES, group.elementBuffer2.length * 2, gl.UNSIGNED_SHORT, 0);
     }
 }

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -155,8 +155,8 @@ module.exports = function drawLine(painter, source, layer, coords) {
 
         for (var i = 0; i < bufferGroups.length; i++) {
             var group = bufferGroups[i];
-            group.vaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element);
-            gl.drawElements(gl.TRIANGLES, group.layout.element.length * 3, gl.UNSIGNED_SHORT, 0);
+            group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer);
+            gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
         }
     }
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -155,7 +155,7 @@ module.exports = function drawLine(painter, source, layer, coords) {
 
         for (var i = 0; i < bufferGroups.length; i++) {
             var group = bufferGroups[i];
-            group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer);
+            group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer);
             gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
         }
     }

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -182,8 +182,8 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
 
             for (var j = 0; j < bufferGroups.length; j++) {
                 group = bufferGroups[j];
-                group.vaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element);
-                gl.drawElements(gl.TRIANGLES, group.layout.element.length * 3, gl.UNSIGNED_SHORT, 0);
+                group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer);
+                gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
             }
         }
 
@@ -197,16 +197,16 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
 
         for (var i = 0; i < bufferGroups.length; i++) {
             group = bufferGroups[i];
-            group.vaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element);
-            gl.drawElements(gl.TRIANGLES, group.layout.element.length * 3, gl.UNSIGNED_SHORT, 0);
+            group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer);
+            gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
         }
 
     } else {
         gl.uniform1f(program.u_opacity, opacity);
         for (var k = 0; k < bufferGroups.length; k++) {
             group = bufferGroups[k];
-            group.vaos[layer.id].bind(gl, program, group.layout.vertex, group.layout.element);
-            gl.drawElements(gl.TRIANGLES, group.layout.element.length * 3, gl.UNSIGNED_SHORT, 0);
+            group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer);
+            gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
         }
     }
 }

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -182,7 +182,7 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
 
             for (var j = 0; j < bufferGroups.length; j++) {
                 group = bufferGroups[j];
-                group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer);
+                group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer);
                 gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
             }
         }
@@ -197,7 +197,7 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
 
         for (var i = 0; i < bufferGroups.length; i++) {
             group = bufferGroups[i];
-            group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer);
+            group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer);
             gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
         }
 
@@ -205,7 +205,7 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
         gl.uniform1f(program.u_opacity, opacity);
         for (var k = 0; k < bufferGroups.length; k++) {
             group = bufferGroups[k];
-            group.vaos[layer.id].bind(gl, program, group.vertexBuffer, group.elementBuffer);
+            group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer);
             gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
         }
     }

--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -12,7 +12,7 @@ function VertexArrayObject() {
     this.vao = null;
 }
 
-VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, elementBuffer, vertexBuffer2) {
+VertexArrayObject.prototype.bind = function(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2) {
 
     if (gl.extVertexArrayObject === undefined) {
         gl.extVertexArrayObject = gl.getExtension("OES_vertex_array_object");
@@ -21,19 +21,19 @@ VertexArrayObject.prototype.bind = function(gl, program, vertexBuffer, elementBu
     var isFreshBindRequired = (
         !this.vao ||
         this.boundProgram !== program ||
-        this.boundVertexBuffer !== vertexBuffer ||
+        this.boundVertexBuffer !== layoutVertexBuffer ||
         this.boundVertexBuffer2 !== vertexBuffer2 ||
         this.boundElementBuffer !== elementBuffer
     );
 
     if (!gl.extVertexArrayObject || isFreshBindRequired) {
-        this.freshBind(gl, program, vertexBuffer, elementBuffer, vertexBuffer2);
+        this.freshBind(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2);
     } else {
         gl.extVertexArrayObject.bindVertexArrayOES(this.vao);
     }
 };
 
-VertexArrayObject.prototype.freshBind = function(gl, program, vertexBuffer, elementBuffer, vertexBuffer2) {
+VertexArrayObject.prototype.freshBind = function(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2) {
     var numPrevAttributes;
     var numNextAttributes = program.numAttributes;
 
@@ -45,7 +45,7 @@ VertexArrayObject.prototype.freshBind = function(gl, program, vertexBuffer, elem
 
         // store the arguments so that we can verify them when the vao is bound again
         this.boundProgram = program;
-        this.boundVertexBuffer = vertexBuffer;
+        this.boundVertexBuffer = layoutVertexBuffer;
         this.boundVertexBuffer2 = vertexBuffer2;
         this.boundElementBuffer = elementBuffer;
 
@@ -67,8 +67,8 @@ VertexArrayObject.prototype.freshBind = function(gl, program, vertexBuffer, elem
         gl.enableVertexAttribArray(j);
     }
 
-    vertexBuffer.bind(gl);
-    vertexBuffer.setVertexAttribPointers(gl, program);
+    layoutVertexBuffer.bind(gl);
+    layoutVertexBuffer.setVertexAttribPointers(gl, program);
     if (vertexBuffer2) {
         vertexBuffer2.bind(gl);
         vertexBuffer2.setVertexAttribPointers(gl, program);

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -185,7 +185,7 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, rawTileData, c
 
     function parseBucket(tile, bucket) {
         var now = Date.now();
-        bucket.populateBuffers(collisionTile, stacks, icons);
+        bucket.populateArrays(collisionTile, stacks, icons);
         var time = Date.now() - now;
 
 

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -216,8 +216,7 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, rawTileData, c
         var symbolInstancesArray = tile.symbolInstancesArray.serialize();
         var symbolQuadsArray = tile.symbolQuadsArray.serialize();
         var transferables = [rawTileData].concat(featureIndex_.transferables).concat(collisionTile_.transferables);
-
-        var nonEmptyBuckets = buckets.filter(isBucketEmpty);
+        var nonEmptyBuckets = buckets.filter(isBucketNonEmpty);
 
         callback(null, {
             buckets: nonEmptyBuckets.map(serializeBucket),
@@ -248,8 +247,7 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, showCollisionBoxes) 
     }
 
     var collisionTile_ = collisionTile.serialize();
-
-    var nonEmptyBuckets = buckets.filter(isBucketEmpty);
+    var nonEmptyBuckets = buckets.filter(isBucketNonEmpty);
 
     return {
         result: {
@@ -260,20 +258,8 @@ WorkerTile.prototype.redoPlacement = function(angle, pitch, showCollisionBoxes) 
     };
 };
 
-function isBucketEmpty(bucket) {
-    for (var programName in bucket.arrayGroups) {
-        var programArrayGroups = bucket.arrayGroups[programName];
-        for (var k = 0; k < programArrayGroups.length; k++) {
-            var programArrayGroup = programArrayGroups[k];
-            for (var layoutOrPaint in programArrayGroup) {
-                var arrays = programArrayGroup[layoutOrPaint];
-                for (var bufferName in arrays) {
-                    if (arrays[bufferName].length > 0) return true;
-                }
-            }
-        }
-    }
-    return false;
+function isBucketNonEmpty(bucket) {
+    return !bucket.isEmpty();
 }
 
 function serializeBucket(bucket) {
@@ -283,19 +269,7 @@ function serializeBucket(bucket) {
 function getTransferables(buckets) {
     var transferables = [];
     for (var i in buckets) {
-        var bucket = buckets[i];
-        for (var programName in bucket.arrayGroups) {
-            var programArrayGroups = bucket.arrayGroups[programName];
-            for (var k = 0; k < programArrayGroups.length; k++) {
-                var programArrayGroup = programArrayGroups[k];
-                for (var layoutOrPaint in programArrayGroup) {
-                    var arrays = programArrayGroup[layoutOrPaint];
-                    for (var bufferName in arrays) {
-                        transferables.push(arrays[bufferName].arrayBuffer);
-                    }
-                }
-            }
-        }
+        buckets[i].getTransferables(transferables);
     }
     return transferables;
 }

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -95,7 +95,7 @@ test('Bucket', function(t) {
         var bucket = create();
 
         bucket.features = [createFeature(17, 42)];
-        bucket.populateBuffers();
+        bucket.populateArrays();
 
         var testVertex = bucket.arrayGroups.test[0].vertexArray;
         t.equal(testVertex.length, 1);
@@ -130,7 +130,7 @@ test('Bucket', function(t) {
         ]});
 
         bucket.features = [createFeature(17, 42)];
-        bucket.populateBuffers();
+        bucket.populateArrays();
 
         var v0 = bucket.arrayGroups.test[0].vertexArray.get(0);
         var a0 = bucket.arrayGroups.test[0].paintArrays.one.get(0);
@@ -158,7 +158,7 @@ test('Bucket', function(t) {
         });
 
         bucket.features = [createFeature(17, 42)];
-        bucket.populateBuffers();
+        bucket.populateArrays();
 
         t.equal(bucket.arrayGroups.test[0].vertexArray.bytesPerElement, 0);
         t.deepEqual(
@@ -179,7 +179,7 @@ test('Bucket', function(t) {
         });
 
         bucket.features = [createFeature(17, 42)];
-        bucket.populateBuffers();
+        bucket.populateArrays();
 
         var v0 = bucket.arrayGroups.test[0].vertexArray.get(0);
         t.equal(v0.a_map, 34);
@@ -191,7 +191,7 @@ test('Bucket', function(t) {
         var bucket = create();
 
         bucket.features = [createFeature(17, 42)];
-        bucket.populateBuffers();
+        bucket.populateArrays();
 
         t.equal(bucket.arrayGroups.test.length, 1);
         bucket.createArrays();
@@ -219,10 +219,10 @@ test('Bucket', function(t) {
         var bucket = create();
 
         bucket.features = [createFeature(1, 5)];
-        bucket.populateBuffers();
+        bucket.populateArrays();
         bucket.createArrays();
         bucket.features = [createFeature(17, 42)];
-        bucket.populateBuffers();
+        bucket.populateArrays();
 
         var testVertex = bucket.arrayGroups.test[0].vertexArray;
         t.equal(testVertex.length, 1);
@@ -260,7 +260,7 @@ test('Bucket', function(t) {
         var bucket = create();
 
         bucket.features = [createFeature(17, 42)];
-        bucket.populateBuffers();
+        bucket.populateArrays();
 
         var testVertex = bucket.arrayGroups.test[0].vertexArray;
         t.equal(testVertex.length, 1);

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -16,16 +16,14 @@ test('Bucket', function(t) {
 
         Class.prototype.programInterfaces = {
             test: {
-                vertexBuffer: 'testVertex',
-                elementBuffer: 'testElement',
-                elementBuffer2: 'testElement2',
-                elementBuffer2Components: 2,
-
-                layoutAttributes: options.layoutAttributes || [{
+                vertexArrayType: new Bucket.VertexArrayType(options.layoutAttributes || [{
                     name: 'a_box',
                     components: 2,
                     type: 'Int16'
-                }],
+                }]),
+                elementArrayType: new Bucket.ElementArrayType(),
+                elementArrayType2: new Bucket.ElementArrayType(2),
+
                 paintAttributes: options.paintAttributes || [{
                     name: 'a_map',
                     type: 'Int16',

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -16,7 +16,7 @@ test('Bucket', function(t) {
 
         Class.prototype.programInterfaces = {
             test: {
-                vertexArrayType: new Bucket.VertexArrayType(options.layoutAttributes || [{
+                layoutVertexArrayType: new Bucket.VertexArrayType(options.layoutAttributes || [{
                     name: 'a_box',
                     components: 2,
                     type: 'Int16'
@@ -38,8 +38,8 @@ test('Bucket', function(t) {
         Class.prototype.addFeature = function(feature) {
             var group = this.prepareArrayGroup('test', 1);
             var point = feature.loadGeometry()[0][0];
-            var startIndex = group.vertexArray.length;
-            group.vertexArray.emplaceBack(point.x * 2, point.y * 2);
+            var startIndex = group.layoutVertexArray.length;
+            group.layoutVertexArray.emplaceBack(point.x * 2, point.y * 2);
             group.elementArray.emplaceBack(1, 2, 3);
             group.elementArray2.emplaceBack(point.x, point.y);
             this.populatePaintArrays('test', {}, feature.properties, group, startIndex);
@@ -97,12 +97,12 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateArrays();
 
-        var testVertex = bucket.arrayGroups.test[0].vertexArray;
+        var testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        var paintVertex = bucket.arrayGroups.test[0].paintArrays.layerid;
+        var paintVertex = bucket.arrayGroups.test[0].paintVertexArrays.layerid;
         t.equal(paintVertex.length, 1);
         var p0 = paintVertex.get(0);
         t.equal(p0.a_map, 17);
@@ -132,9 +132,9 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateArrays();
 
-        var v0 = bucket.arrayGroups.test[0].vertexArray.get(0);
-        var a0 = bucket.arrayGroups.test[0].paintArrays.one.get(0);
-        var b0 = bucket.arrayGroups.test[0].paintArrays.two.get(0);
+        var v0 = bucket.arrayGroups.test[0].layoutVertexArray.get(0);
+        var a0 = bucket.arrayGroups.test[0].paintVertexArrays.one.get(0);
+        var b0 = bucket.arrayGroups.test[0].paintVertexArrays.two.get(0);
         t.equal(a0.a_map, 17);
         t.equal(b0.a_map, 17);
         t.equal(v0.a_box0, 34);
@@ -160,7 +160,7 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateArrays();
 
-        t.equal(bucket.arrayGroups.test[0].vertexArray.bytesPerElement, 0);
+        t.equal(bucket.arrayGroups.test[0].layoutVertexArray.bytesPerElement, 0);
         t.deepEqual(
             bucket.paintAttributes.test.one.uniforms[0].getValue.call(bucket),
             [5]
@@ -181,7 +181,7 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateArrays();
 
-        var v0 = bucket.arrayGroups.test[0].vertexArray.get(0);
+        var v0 = bucket.arrayGroups.test[0].layoutVertexArray.get(0);
         t.equal(v0.a_map, 34);
 
         t.end();
@@ -205,12 +205,12 @@ test('Bucket', function(t) {
 
         bucket.createArrays();
         bucket.prepareArrayGroup('test', 10);
-        t.equal(0, bucket.arrayGroups.test[0].vertexArray.length);
-        t.notEqual(0, bucket.arrayGroups.test[0].vertexArray.capacity);
+        t.equal(0, bucket.arrayGroups.test[0].layoutVertexArray.length);
+        t.notEqual(0, bucket.arrayGroups.test[0].layoutVertexArray.capacity);
 
         bucket.trimArrays();
-        t.equal(0, bucket.arrayGroups.test[0].vertexArray.length);
-        t.equal(0, bucket.arrayGroups.test[0].vertexArray.capacity);
+        t.equal(0, bucket.arrayGroups.test[0].layoutVertexArray.length);
+        t.equal(0, bucket.arrayGroups.test[0].layoutVertexArray.capacity);
 
         t.end();
     });
@@ -238,10 +238,10 @@ test('Bucket', function(t) {
         bucket.getTransferables(transferables);
 
         t.equal(4, transferables.length);
-        t.equal(bucket.arrayGroups.test[0].vertexArray.arrayBuffer, transferables[0]);
+        t.equal(bucket.arrayGroups.test[0].layoutVertexArray.arrayBuffer, transferables[0]);
         t.equal(bucket.arrayGroups.test[0].elementArray.arrayBuffer, transferables[1]);
         t.equal(bucket.arrayGroups.test[0].elementArray2.arrayBuffer, transferables[2]);
-        t.equal(bucket.arrayGroups.test[0].paintArrays.layerid.arrayBuffer, transferables[3]);
+        t.equal(bucket.arrayGroups.test[0].paintVertexArrays.layerid.arrayBuffer, transferables[3]);
 
         t.end();
     });
@@ -255,12 +255,12 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateArrays();
 
-        var testVertex = bucket.arrayGroups.test[0].vertexArray;
+        var testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        var testPaintVertex = bucket.arrayGroups.test[0].paintArrays.layerid;
+        var testPaintVertex = bucket.arrayGroups.test[0].paintVertexArrays.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
         t.equal(p0.a_map, 17);
@@ -293,12 +293,12 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateArrays();
 
-        var testVertex = bucket.arrayGroups.test[0].vertexArray;
+        var testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        var testPaintVertex = bucket.arrayGroups.test[0].paintArrays.layerid;
+        var testPaintVertex = bucket.arrayGroups.test[0].paintVertexArrays.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
         t.equal(p0.a_map, 17);

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -215,6 +215,37 @@ test('Bucket', function(t) {
         t.end();
     });
 
+    t.test('isEmpty', function(t) {
+        var bucket = create();
+        t.ok(bucket.isEmpty());
+
+        bucket.createArrays();
+        t.ok(bucket.isEmpty());
+
+        bucket.features = [createFeature(17, 42)];
+        bucket.populateArrays();
+        t.ok(!bucket.isEmpty());
+
+        t.end();
+    });
+
+    t.test('getTransferables', function(t) {
+        var bucket = create();
+        bucket.features = [createFeature(17, 42)];
+        bucket.populateArrays();
+
+        var transferables = [];
+        bucket.getTransferables(transferables);
+
+        t.equal(4, transferables.length);
+        t.equal(bucket.arrayGroups.test[0].vertexArray.arrayBuffer, transferables[0]);
+        t.equal(bucket.arrayGroups.test[0].elementArray.arrayBuffer, transferables[1]);
+        t.equal(bucket.arrayGroups.test[0].elementArray2.arrayBuffer, transferables[2]);
+        t.equal(bucket.arrayGroups.test[0].paintArrays.layerid.arrayBuffer, transferables[3]);
+
+        t.end();
+    });
+
     t.test('add features after resetting buffers', function(t) {
         var bucket = create();
 

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -38,10 +38,10 @@ test('Bucket', function(t) {
         Class.prototype.addFeature = function(feature) {
             var group = this.prepareArrayGroup('test', 1);
             var point = feature.loadGeometry()[0][0];
-            var startIndex = group.layout.vertex.length;
-            group.layout.vertex.emplaceBack(point.x * 2, point.y * 2);
-            group.layout.element.emplaceBack(1, 2, 3);
-            group.layout.element2.emplaceBack(point.x, point.y);
+            var startIndex = group.vertexArray.length;
+            group.vertexArray.emplaceBack(point.x * 2, point.y * 2);
+            group.elementArray.emplaceBack(1, 2, 3);
+            group.elementArray2.emplaceBack(point.x, point.y);
             this.populatePaintArrays('test', {}, feature.properties, group, startIndex);
         };
 
@@ -97,24 +97,24 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrayGroups.test[0].layout.vertex;
+        var testVertex = bucket.arrayGroups.test[0].vertexArray;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        var paintVertex = bucket.arrayGroups.test[0].paint.layerid;
+        var paintVertex = bucket.arrayGroups.test[0].paintArrays.layerid;
         t.equal(paintVertex.length, 1);
         var p0 = paintVertex.get(0);
         t.equal(p0.a_map, 17);
 
-        var testElement = bucket.arrayGroups.test[0].layout.element;
+        var testElement = bucket.arrayGroups.test[0].elementArray;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testElement2 = bucket.arrayGroups.test[0].layout.element2;
+        var testElement2 = bucket.arrayGroups.test[0].elementArray2;
         t.equal(testElement2.length, 1);
         var e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);
@@ -132,9 +132,9 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var v0 = bucket.arrayGroups.test[0].layout.vertex.get(0);
-        var a0 = bucket.arrayGroups.test[0].paint.one.get(0);
-        var b0 = bucket.arrayGroups.test[0].paint.two.get(0);
+        var v0 = bucket.arrayGroups.test[0].vertexArray.get(0);
+        var a0 = bucket.arrayGroups.test[0].paintArrays.one.get(0);
+        var b0 = bucket.arrayGroups.test[0].paintArrays.two.get(0);
         t.equal(a0.a_map, 17);
         t.equal(b0.a_map, 17);
         t.equal(v0.a_box0, 34);
@@ -160,7 +160,7 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        t.equal(bucket.arrayGroups.test[0].layout.vertex.bytesPerElement, 0);
+        t.equal(bucket.arrayGroups.test[0].vertexArray.bytesPerElement, 0);
         t.deepEqual(
             bucket.paintAttributes.test.one.uniforms[0].getValue.call(bucket),
             [5]
@@ -181,7 +181,7 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var v0 = bucket.arrayGroups.test[0].layout.vertex.get(0);
+        var v0 = bucket.arrayGroups.test[0].vertexArray.get(0);
         t.equal(v0.a_map, 34);
 
         t.end();
@@ -205,12 +205,12 @@ test('Bucket', function(t) {
 
         bucket.createArrays();
         bucket.prepareArrayGroup('test', 10);
-        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.length);
-        t.notEqual(0, bucket.arrayGroups.test[0].layout.vertex.capacity);
+        t.equal(0, bucket.arrayGroups.test[0].vertexArray.length);
+        t.notEqual(0, bucket.arrayGroups.test[0].vertexArray.capacity);
 
         bucket.trimArrays();
-        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.length);
-        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.capacity);
+        t.equal(0, bucket.arrayGroups.test[0].vertexArray.length);
+        t.equal(0, bucket.arrayGroups.test[0].vertexArray.capacity);
 
         t.end();
     });
@@ -224,24 +224,24 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrayGroups.test[0].layout.vertex;
+        var testVertex = bucket.arrayGroups.test[0].vertexArray;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        var testPaintVertex = bucket.arrayGroups.test[0].paint.layerid;
+        var testPaintVertex = bucket.arrayGroups.test[0].paintArrays.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
         t.equal(p0.a_map, 17);
 
-        var testElement = bucket.arrayGroups.test[0].layout.element;
+        var testElement = bucket.arrayGroups.test[0].elementArray;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testElement2 = bucket.arrayGroups.test[0].layout.element2;
+        var testElement2 = bucket.arrayGroups.test[0].elementArray2;
         t.equal(testElement2.length, 1);
         var e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);
@@ -262,24 +262,24 @@ test('Bucket', function(t) {
         bucket.features = [createFeature(17, 42)];
         bucket.populateBuffers();
 
-        var testVertex = bucket.arrayGroups.test[0].layout.vertex;
+        var testVertex = bucket.arrayGroups.test[0].vertexArray;
         t.equal(testVertex.length, 1);
         var v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        var testPaintVertex = bucket.arrayGroups.test[0].paint.layerid;
+        var testPaintVertex = bucket.arrayGroups.test[0].paintArrays.layerid;
         t.equal(testPaintVertex.length, 1);
         var p0 = testPaintVertex.get(0);
         t.equal(p0.a_map, 17);
 
-        var testElement = bucket.arrayGroups.test[0].layout.element;
+        var testElement = bucket.arrayGroups.test[0].elementArray;
         t.equal(testElement.length, 1);
         var e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        var testElement2 = bucket.arrayGroups.test[0].layout.element2;
+        var testElement2 = bucket.arrayGroups.test[0].elementArray2;
         t.equal(testElement2.length, 1);
         var e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -202,6 +202,21 @@ test('Bucket', function(t) {
         t.end();
     });
 
+    t.test('trimArrays', function(t) {
+        var bucket = create();
+
+        bucket.createArrays();
+        bucket.prepareArrayGroup('test', 10);
+        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.length);
+        t.notEqual(0, bucket.arrayGroups.test[0].layout.vertex.capacity);
+
+        bucket.trimArrays();
+        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.length);
+        t.equal(0, bucket.arrayGroups.test[0].layout.vertex.capacity);
+
+        t.end();
+    });
+
     t.test('add features after resetting buffers', function(t) {
         var bucket = create();
 

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -103,10 +103,10 @@ test('FillBucket - feature split across array groups', function (t) {
         10 + (Bucket.MAX_VERTEX_ARRAY_LENGTH - 20),
         20
     ];
-    t.equal(groups[0].paintArrays.test.length, expectedLengths[0], 'group 0 length, paint');
-    t.equal(groups[0].vertexArray.length, expectedLengths[0], 'group 0 length, layout');
-    t.equal(groups[1].paintArrays.test.length, expectedLengths[1], 'group 1 length, paint');
-    t.equal(groups[1].vertexArray.length, expectedLengths[1], 'group 1 length, layout');
+    t.equal(groups[0].paintVertexArrays.test.length, expectedLengths[0], 'group 0 length, paint');
+    t.equal(groups[0].layoutVertexArray.length, expectedLengths[0], 'group 0 length, layout');
+    t.equal(groups[1].paintVertexArrays.test.length, expectedLengths[1], 'group 1 length, paint');
+    t.equal(groups[1].layoutVertexArray.length, expectedLengths[1], 'group 1 length, layout');
 
     // check that every vertex's color values match the first vertex
     var expected = [0, 0, 255, 255];
@@ -116,7 +116,7 @@ test('FillBucket - feature split across array groups', function (t) {
     t.same(getVertexColor(1, expectedLengths[1] - 1), expected, 'last vertex');
 
     function getVertexColor(g, i) {
-        var vertex = groups[g].paintArrays.test.get(i);
+        var vertex = groups[g].paintVertexArrays.test.get(i);
         return [
             vertex['a_color0'],
             vertex['a_color1'],

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -103,10 +103,10 @@ test('FillBucket - feature split across array groups', function (t) {
         10 + (Bucket.MAX_VERTEX_ARRAY_LENGTH - 20),
         20
     ];
-    t.equal(groups[0].paint.test.length, expectedLengths[0], 'group 0 length, paint');
-    t.equal(groups[0].layout.vertex.length, expectedLengths[0], 'group 0 length, layout');
-    t.equal(groups[1].paint.test.length, expectedLengths[1], 'group 1 length, paint');
-    t.equal(groups[1].layout.vertex.length, expectedLengths[1], 'group 1 length, layout');
+    t.equal(groups[0].paintArrays.test.length, expectedLengths[0], 'group 0 length, paint');
+    t.equal(groups[0].vertexArray.length, expectedLengths[0], 'group 0 length, layout');
+    t.equal(groups[1].paintArrays.test.length, expectedLengths[1], 'group 1 length, paint');
+    t.equal(groups[1].vertexArray.length, expectedLengths[1], 'group 1 length, layout');
 
     // check that every vertex's color values match the first vertex
     var expected = [0, 0, 255, 255];
@@ -116,7 +116,7 @@ test('FillBucket - feature split across array groups', function (t) {
     t.same(getVertexColor(1, expectedLengths[1] - 1), expected, 'last vertex');
 
     function getVertexColor(g, i) {
-        var vertex = groups[g].paint.test.get(i);
+        var vertex = groups[g].paintArrays.test.get(i);
         return [
             vertex['a_color0'],
             vertex['a_color1'],

--- a/test/js/data/symbol_bucket.test.js
+++ b/test/js/data/symbol_bucket.test.js
@@ -62,13 +62,13 @@ test('SymbolBucket', function(t) {
 
     // add feature from bucket A
     var a = collision.grid.keys.length;
-    t.equal(bucketA.populateBuffers(collision, stacks), undefined);
+    t.equal(bucketA.populateArrays(collision, stacks), undefined);
     var b = collision.grid.keys.length;
     t.notEqual(a, b, 'places feature');
 
     // add same feature from bucket B
     var a2 = collision.grid.keys.length;
-    t.equal(bucketB.populateBuffers(collision, stacks), undefined);
+    t.equal(bucketB.populateArrays(collision, stacks), undefined);
     var b2 = collision.grid.keys.length;
     t.equal(a2, b2, 'detects collision and does not place feature');
 


### PR DESCRIPTION
Some refactoring of `Bucket` to reduce overhead, simplify object structure, improve naming conventions, and make the use of the terms "array" and "buffer" consistent (the latter always referring specifically to an instance of `Buffer`, not loosely as any kind of data collection).

cc @lucaswoj 