### PR TITLE
Update grid-index

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "geojson-rewind": "^0.1.0",
     "geojson-vt": "^2.2.0",
     "gl-matrix": "^2.3.1",
-    "grid-index": "^0.1.0",
+    "grid-index": "mapbox/grid-index#a896ad68dc0ce923e3f29c4d48424d091e923426",
     "mapbox-gl-function": "^1.2.1",
     "mapbox-gl-supported": "^1.1.0",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#ca9968c6703236ebf45749a9d09d767c54642398",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "geojson-rewind": "^0.1.0",
     "geojson-vt": "^2.2.0",
     "gl-matrix": "^2.3.1",
-    "grid-index": "mapbox/grid-index#a896ad68dc0ce923e3f29c4d48424d091e923426",
+    "grid-index": "^1.0.0",
     "mapbox-gl-function": "^1.2.1",
     "mapbox-gl-supported": "^1.1.0",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#ca9968c6703236ebf45749a9d09d767c54642398",


### PR DESCRIPTION
Update to `grid-index` v1.0.0

~~We are using a SHA instead of a tagged version until someone on the
team can get contributor access to grid-index on npm~~ Done!

fixes #2822
fixes #2774