### PR TITLE
Add dataset support the GeoJSON sources

### DIFF
--- a/debug/dataset.html
+++ b/debug/dataset.html
@@ -69,8 +69,7 @@ map.on('load', function() {
 
     map.addSource('circles', {
         "type": "geojson",
-        "data": localStorage.getItem('dataset_uri'),
-        "accessToken": localStorage.getItem('access_token')
+        "data": localStorage.getItem('dataset_uri')+'?access_token='+localStorage.getItem('access_token')
     });
 
     map.addLayer({

--- a/debug/dataset.html
+++ b/debug/dataset.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+        #checkboxes {
+            position: absolute;
+            background: #fff;
+            top:0;
+            left:0;
+            padding:10px;
+        }
+        #buffer {
+            position: absolute;
+            top:100px;
+            left:0;
+            pointer-events: none;
+        }
+        #buffer div {
+            background-color: #fff;
+            padding: 5px 0;
+            text-indent: 10px;
+            white-space: nowrap;
+            text-shadow:
+               -1px -1px 0 #fff,
+                1px -1px 0 #fff,
+                -1px 1px 0 #fff,
+                 1px 1px 0 #fff;
+        }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<div id='checkboxes'>
+  <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
+  <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br />
+  <input id='show-overdraw-checkbox' name='show-overdraw' type='checkbox'> <label for='show-overdraw'>overdraw debug</label><br />
+  <input id='buffer-checkbox' name='buffer' type='checkbox'> <label for='buffer'>buffer stats</label>
+</div>
+
+<div id='buffer' style="display:none">
+    <em>Waiting for data...</em>
+</div>
+
+<script src='mapbox-gl.js'></script>
+<script src='access-token.js'></script>
+
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-77.01866, 38.888],
+    style: 'mapbox://styles/mapbox/streets-v9',
+    hash: true
+});
+
+map.addControl(new mapboxgl.Navigation());
+map.addControl(new mapboxgl.Geolocate());
+
+map.on('load', function() {
+
+    map.addSource('circles', {
+        "type": "geojson",
+        "data": localStorage.getItem('dataset_uri'),
+        "accessToken": localStorage.getItem('access_token')
+    });
+
+    map.addLayer({
+        "id": "circles",
+        "type": "circle",
+        "source": "circles",
+        "paint": {
+            "circle-radius": {
+                property: "mapbox",
+                stops: [
+                    [{ zoom: 0, value: 0 }, 2],
+                    [{ zoom: 0, value: 100 }, 10],
+                    [{ zoom: 6, value: 0 }, 20],
+                    [{ zoom: 6, value: 100 }, 100]
+                ]
+            },
+            "circle-color": {
+                property: "mapbox",
+                stops: [
+                    [{ zoom: 0, value: 0 }, 'red'],
+                    [{ zoom: 0, value: 100 }, 'violet'],
+                    [{ zoom: 6, value: 0 }, 'blue'],
+                    [{ zoom: 6, value: 100 }, 'green']
+                ]
+            }
+        }
+    });
+
+    var bufferTimes = {};
+    map.on('tile.stats', function(bufferTimes) {
+        var _stats = [];
+        for (var name in bufferTimes) {
+            var value = Math.round(bufferTimes[name]);
+            if (isNaN(value)) continue;
+            var width = value;
+            _stats.push({name: name, value: value, width: width});
+        }
+        _stats = _stats.sort(function(a, b) { return b.value - a.value }).slice(0, 10);
+
+        var html = '';
+        for (var i in _stats) {
+            html += '<div style="width:' + _stats[i].width * 2 + 'px">' + _stats[i].value + 'ms - ' + _stats[i].name + '</div>';
+        }
+
+        document.getElementById('buffer').innerHTML = html;
+    });
+});
+
+map.on('click', function(e) {
+    if (e.originalEvent.shiftKey) return;
+    (new mapboxgl.Popup())
+        .setLngLat(map.unproject(e.point))
+        .setHTML("<h1>Hello World!</h1>")
+        .addTo(map);
+});
+
+document.getElementById('show-tile-boundaries-checkbox').onclick = function() {
+    map.showTileBoundaries = !!this.checked;
+};
+
+document.getElementById('show-symbol-collision-boxes-checkbox').onclick = function() {
+    map.showCollisionBoxes = !!this.checked;
+};
+
+document.getElementById('show-overdraw-checkbox').onclick = function() {
+    map.showOverdrawInspector = !!this.checked;
+};
+
+document.getElementById('buffer-checkbox').onclick = function() {
+    document.getElementById('buffer').style.display = this.checked ? 'block' : 'none';
+};
+
+// keyboard shortcut for comparing rendering with Mapbox GL native
+document.onkeypress = function(e) {
+    if (e.charCode === 111 && !e.shiftKey && !e.metaKey && !e.altKey) {
+        var center = map.getCenter();
+        location.href = "mapboxgl://?center=" + center.lat + "," + center.lng + "&zoom=" + map.getZoom() + "&bearing=" + map.getBearing();
+        return false;
+    }
+};
+
+</script>
+
+</body>
+</html>

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -6,6 +6,7 @@ var TilePyramid = require('./tile_pyramid');
 var Source = require('./source');
 var urlResolve = require('resolve-url');
 var EXTENT = require('../data/bucket').EXTENT;
+var normalizeDatasetUrl = require('../util/mapbox').normalizeDatasetUrl;
 
 module.exports = GeoJSONSource;
 
@@ -153,6 +154,14 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
         var data = this._data;
         if (typeof data === 'string') {
             options.url = typeof window != 'undefined' ? urlResolve(window.location.href, data) : data;
+            var normalizedUrl = normalizeDatasetUrl(options.url);
+            if (normalizedUrl !== options.url) {
+                options.isDataset = true;
+                options.url = normalizedUrl;
+            }
+            else {
+                options.isDataset = false;
+            }
         } else {
             options.data = JSON.stringify(data);
         }

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -4,7 +4,7 @@ var util = require('../util/util');
 var ajax = require('../util/ajax');
 var browser = require('../util/browser');
 var TilePyramid = require('./tile_pyramid');
-var normalizeURL = require('../util/mapbox').normalizeSourceURL;
+var normalizeSourceURL = require('../util/mapbox').normalizeSourceURL;
 var TileCoord = require('./tile_coord');
 
 exports._loadTileJSON = function(options) {
@@ -40,7 +40,7 @@ exports._loadTileJSON = function(options) {
     }.bind(this);
 
     if (options.url) {
-        ajax.getJSON(normalizeURL(options.url), loaded);
+        ajax.getJSON(normalizeSourceURL(options.url), loaded);
     } else {
         browser.frame(loaded.bind(this, null, options));
     }

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -8,7 +8,6 @@ var ajax = require('../util/ajax');
 var vt = require('vector-tile');
 var Protobuf = require('pbf');
 var supercluster = require('supercluster');
-
 var geojsonvt = require('geojson-vt');
 var rewind = require('geojson-rewind');
 var GeoJSONWrapper = require('./geojson_wrapper');
@@ -182,7 +181,9 @@ util.extend(Worker.prototype, {
         // explicit origin or absolute path.
         // ie: /foo/bar.json or http://example.com/bar.json
         // but not ../foo/bar.json
-        if (params.url) {
+        if (params.isDataset) {
+            ajax.getDataset(params.url, indexData);
+        } else if (params.url) {
             ajax.getJSON(params.url, indexData);
         } else if (typeof params.data === 'string') {
             indexData(null, JSON.parse(params.data));

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -28,7 +28,7 @@ function cached(data, callback) {
     });
 }
 
-exports.getJSON = function(url, callback) {
+var getJSON = exports.getJSON = function(url, callback) {
     if (cache[url]) return cached(cache[url], callback);
     return request(url, function(error, response, body) {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
@@ -45,6 +45,29 @@ exports.getJSON = function(url, callback) {
         }
     });
 };
+
+
+exports.getDataset = function(url, callback) {
+
+    var featureCollection = {
+        type: 'FeatureCollection',
+        features: []
+    }
+
+    function page(start) {
+        var pageUrl = start ? url +'&start='+start : url;
+        getJSON(pageUrl, function(err, data) {
+            if (err) return callback(err);
+            if (data.features.length === 0) {
+                return callback(null, featureCollection);
+            }
+            featureCollection.features = featureCollection.features.concat(data.features);
+            page(data.features[data.features.length-1].id);
+        });
+    }
+
+    page();
+}
 
 exports.getArrayBuffer = function(url, callback) {
     if (cache[url]) return cached(cache[url], callback);

--- a/js/util/browser/ajax.js
+++ b/js/util/browser/ajax.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.getJSON = function(url, callback) {
+var getJSON = exports.getJSON = function(url, callback) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', url, true);
     xhr.setRequestHeader('Accept', 'application/json');
@@ -23,6 +23,28 @@ exports.getJSON = function(url, callback) {
     xhr.send();
     return xhr;
 };
+
+exports.getDataset = function(url, callback) {
+
+    var featureCollection = {
+        type: 'FeatureCollection',
+        features: []
+    }
+
+    function page(start) {
+        var pageUrl = start ? url +'&start='+start : url;
+        getJSON(pageUrl, function(err, data) {
+            if (err) return callback(err);
+            if (data.features.length === 0) {
+                return callback(null, featureCollection);
+            }
+            featureCollection.features = featureCollection.features.concat(data.features);
+            page(data.features[data.features.length-1].id);
+        });
+    }
+
+    page();
+}
 
 exports.getArrayBuffer = function(url, callback) {
     var xhr = new XMLHttpRequest();

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -28,6 +28,18 @@ function normalizeURL(url, pathPrefix, accessToken) {
     return url;
 }
 
+module.exports.normalizeDatasetUrl = function(url, accessToken) {
+    accessToken = accessToken || config.ACCESS_TOKEN;
+
+    var urlObject = URL.parse(url);
+
+    if (urlObject.protocol !== 'mapbox:') {
+        return url;
+    } else {
+        return config.API_URL + '/datasets/v1'  + urlObject.pathname + '/features?access_token='+accessToken;
+    }
+}
+
 module.exports.normalizeStyleURL = function(url, accessToken) {
     var urlObject = URL.parse(url);
 

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -36,7 +36,7 @@ module.exports.normalizeDatasetUrl = function(url, accessToken) {
     if (urlObject.protocol !== 'mapbox:') {
         return url;
     } else {
-        return config.API_URL + '/datasets/v1'  + urlObject.pathname + '/features?access_token='+accessToken;
+        return config.API_URL + '/datasets/v1'  + urlObject.pathname + '/features'+urlObject.search
     }
 }
 

--- a/server.js
+++ b/server.js
@@ -42,8 +42,9 @@ app.use(express.static(path.join(__dirname, 'debug')));
 app.use('/dist', express.static(path.join(__dirname, 'dist')));
 
 downloadBenchData(function() {
-    app.listen(9966, function () {
-        console.log('mapbox-gl-js debug server running at http://localhost:9966');
+    var port = process.env.PORT || 9966
+    app.listen(port, function () {
+        console.log('mapbox-gl-js debug server running at http://localhost:'+port);
     });
 });
 


### PR DESCRIPTION
As the dataset editor goes into beta, it would be nice to be able to load a dataset into mapbox-gl-js via the dataset url you get out of the editor.

![image](https://cloud.githubusercontent.com/assets/1551510/16700543/adf8af0e-4528-11e6-8fe7-2bb4eb018775.png)

One problem this has is that dataset require secret keys. Puts the secret key into the url passed to the GeoJSON source. It looks like mapbox-gl-js, has a strict no secret keys rule. If this is true, maybe we should wait until public key support for datasets is possible.

@lucaswoj @rclark @scothis 