### PR TITLE
Fix webpack support

### DIFF
--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -14,7 +14,7 @@ var rewind = require('geojson-rewind');
 var GeoJSONWrapper = require('./geojson_wrapper');
 var vtpbf = require('vt-pbf');
 
-module.exports = function(self) {
+module.exports = function MapboxGlWorker(self) {
     return new Worker(self);
 };
 

--- a/webpack.config.example.js
+++ b/webpack.config.example.js
@@ -32,7 +32,8 @@ const path = require('path');
  * Mapbox GL JS uses the webworkify module by default, and that module
  * does things very specific to browserify's module loading system. In this
  * configuration, we alias webworkify to webworkify-webpack to add webpack
- * support.
+ * support. NOTE: there is a known caveat when using 'eval'-related devtool
+ * settings, make sure to double-check your configuration.
  */
 module.exports = {
     entry: './test.js',
@@ -59,5 +60,6 @@ module.exports = {
             loader: 'transform',
             query: 'brfs'
         }]
-    }
+    },
+    devtool: 'cheap-source-map' // don't use eval-related options
 }


### PR DESCRIPTION
Fixes a [known issue](https://github.com/borisirota/webworkify-webpack#caveats) with anonymous functions and workerify-webpack in webpack-based build environments. See [original issue](https://github.com/borisirota/webworkify-webpack/issues/10#issuecomment-231610587).

Actual error message:

> blob:http://localhost:3000/e44fa451-b7fd-4eb3-871c-e5f0a502f7dd:12
> Uncaught TypeError: Cannot read property 'call' of undefined


