### PR TITLE
Don't run "npm update" on CI unless testing "master"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     version: '4'
 dependencies:
   override:
-    - npm update
+    - if [ "$(git symbolic-ref --short -q HEAD)" == "master" ]; then npm update; else npm install; fi;
 test:
   override:
     - ./ci.sh


### PR DESCRIPTION
Regularly running `npm update` is good practice. We want to test and use all the latest dependencies for GL JS. 

One downside to running `npm update` is that it takes much longer (7 minutes) than `npm install` (31 seconds).

By only running `npm update` for builds of the `master` branch, we regularly test the latest dependencies, keep our cached `node_modules` directory up to date, ensure all released versions of GL JS use the latest dependencies, and shorten our PR build time by 7 minutes. 

Any downsides to this design that I'm missing?

cc @mourner @jfirebaugh @mollymerp @tmcw 