### PR TITLE
allow tms scheme to be passed to urls

### DIFF
--- a/js/source/source.js
+++ b/js/source/source.js
@@ -15,7 +15,7 @@ exports._loadTileJSON = function(options) {
         }
 
         util.extend(this, util.pick(tileJSON,
-            ['tiles', 'minzoom', 'maxzoom', 'attribution']));
+            ['tiles', 'minzoom', 'maxzoom', 'attribution', 'scheme']));
 
         if (tileJSON.vector_layers) {
             this.vectorLayers = tileJSON.vector_layers;


### PR DESCRIPTION
fixes an issue with using third party TMS raster tile sources. On tile_coord.js line 64 "Tilecoord.prototype.url" scheme always gets passed as 'xyz' even if it is set to 'tms'.

With a source like this:
`map.addSource('fdsa', {
   type: 'raster',
   url: api,
   tileSize: 256
});`

And a url response like this:

`const tile = `${tileUrl}+${response.data[0].time}/{z}/{x}/{y}.png${qs}`;
 const testRes = {
   "format":"png",
   "id":"12345",
   "name":"Test Tiles",
   "private":false,
   "scheme":"tms",
   "tilejson":"1.0.0",
   "tiles":[
     tile.replace('{s}', 1),
     tile.replace('{s}', 2),
     tile.replace('{s}', 3),
     tile.replace('{s}', 4),
     tile.replace('{s}', 5)
   ],
   "version":"1.0.0",
 };
res.status(200).json(testRes);`