### PR TITLE
Pre-filter sources for queryRenderFeatures

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -637,15 +637,17 @@ Style.prototype = util.inherit(Evented, {
             this._handleErrors(validateStyle.filter, 'queryRenderedFeatures.filter', params.filter, true);
         }
 
-        var includedSources;
+        var includedSources = {};
         if (params.layers) {
-            var styleLayers = this._layers;
-            includedSources = params.layers.map(function (layerId) { return styleLayers[layerId].source; });
+            for (var i = 0; i < params.layers.length; i++) {
+                var layerId = params.layers[i];
+                includedSources[this._layers[layerId].source] = true;
+            }
         }
 
         var sourceResults = [];
         for (var id in this.sources) {
-            if (includedSources && includedSources.indexOf(id) < 0) continue;
+            if (params.layers && !includedSources[id]) continue;
             var source = this.sources[id];
             if (source.queryRenderedFeatures) {
                 sourceResults.push(source.queryRenderedFeatures(queryGeometry, params, zoom, bearing));

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -638,7 +638,16 @@ Style.prototype = util.inherit(Evented, {
         }
 
         var sourceResults = [];
-        for (var id in this.sources) {
+        var sourcesToQuery = {};
+        if (params.layers) {
+            for (var i = 0; i < params.layers.length; i++) {
+                var sourceId = this._layers[params.layers[i]].source;
+                sourcesToQuery[sourceId] = true;
+            }
+        } else {
+            sourcesToQuery = this.sources;
+        }
+        for (var id in sourcesToQuery) {
             var source = this.sources[id];
             if (source.queryRenderedFeatures) {
                 sourceResults.push(source.queryRenderedFeatures(queryGeometry, params, zoom, bearing));

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -637,17 +637,15 @@ Style.prototype = util.inherit(Evented, {
             this._handleErrors(validateStyle.filter, 'queryRenderedFeatures.filter', params.filter, true);
         }
 
-        var sourceResults = [];
-        var sourcesToQuery = {};
+        var includedSources;
         if (params.layers) {
-            for (var i = 0; i < params.layers.length; i++) {
-                var sourceId = this._layers[params.layers[i]].source;
-                sourcesToQuery[sourceId] = true;
-            }
-        } else {
-            sourcesToQuery = this.sources;
+            var styleLayers = this._layers;
+            includedSources = params.layers.map(function (layerId) { return styleLayers[layerId].source; });
         }
-        for (var id in sourcesToQuery) {
+
+        var sourceResults = [];
+        for (var id in this.sources) {
+            if (includedSources && includedSources.indexOf(id) < 0) continue;
             var source = this.sources[id];
             if (source.queryRenderedFeatures) {
                 sourceResults.push(source.queryRenderedFeatures(queryGeometry, params, zoom, bearing));


### PR DESCRIPTION
This change aims to improve queryRenderedFeatures performance in cases where a `layers` parameter is present by only querying the sources referenced by the requested layers.

This can lead to significant savings in some cases because (a) the first time a newly-loaded source tile is queried, [it must parse the pbf data into a VectorTile](https://github.com/mapbox/mapbox-gl-js/blob/master/js/data/feature_index.js#L100-L103), and (b) tiles for some sources may be reloaded quite often if, for instance, `setFilter` or `setData` are being used for "hover"-like interactivity. (See also #2874)