### PR TITLE
Add filter support for $id keys

### DIFF
--- a/js/util/vectortile_to_geojson.js
+++ b/js/util/vectortile_to_geojson.js
@@ -10,7 +10,7 @@ function Feature(vectorTileFeature, z, x, y) {
 
     this.properties = vectorTileFeature.properties;
 
-    if (vectorTileFeature.id) {
+    if (vectorTileFeature.id != null) {
         this.id = vectorTileFeature.id;
     }
 }

--- a/js/util/vectortile_to_geojson.js
+++ b/js/util/vectortile_to_geojson.js
@@ -10,8 +10,8 @@ function Feature(vectorTileFeature, z, x, y) {
 
     this.properties = vectorTileFeature.properties;
 
-    if (vectorTileFeature._id) {
-        this.id = vectorTileFeature._id;
+    if (vectorTileFeature.id) {
+        this.id = vectorTileFeature.id;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "supercluster": "^2.0.1",
     "unassertify": "^2.0.0",
     "unitbezier": "^0.0.0",
-    "vector-tile": "1.2.1",
+    "vector-tile": "^1.3.0",
     "vt-pbf": "^2.0.2",
     "webworkify": "^1.3.0",
     "whoots-js": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "earcut": "^2.0.3",
     "feature-filter": "^2.2.0",
     "geojson-rewind": "^0.1.0",
-    "geojson-vt": "^2.3.0",
+    "geojson-vt": "^2.4.0",
     "gl-matrix": "^2.3.1",
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "csscolorparser": "^1.0.2",
     "earcut": "^2.0.3",
-    "feature-filter": "^2.1.0",
+    "feature-filter": "^2.2.0",
     "geojson-rewind": "^0.1.0",
     "geojson-vt": "^2.3.0",
     "gl-matrix": "^2.3.1",


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-style-spec/issues/391

Before merging, we need to following upstream changes to be integrated and released:

* [x] geojson-vt: [Add id feature property to tiles](https://github.com/mapbox/geojson-vt/pull/60)
* [x] vector-tile-js: [`id` should be a public property](https://github.com/mapbox/vector-tile-js/issues/43)