### PR TITLE
Don't call `drawCollisionDebug` unless `showCollisionBoxes == true`

### DIFF
--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -58,7 +58,9 @@ function drawSymbols(painter, source, layer, coords) {
 
     gl.enable(gl.DEPTH_TEST);
 
-    drawCollisionDebug(painter, source, layer, coords);
+    if (source.map.showCollisionBoxes) {
+        drawCollisionDebug(painter, source, layer, coords);
+    }
 }
 
 function drawLayerSymbols(painter, source, layer, coords, isText,


### PR DESCRIPTION
fixes #2781

cc @jfirebaugh @c0 