### PR TITLE
Allow user to set headers for XHR vector tile get

### DIFF
--- a/bench/benchmarks/buffer.js
+++ b/bench/benchmarks/buffer.js
@@ -105,7 +105,7 @@ function preloadAssets(stylesheet, callback) {
         }
 
         function getTile(url, callback) {
-            ajax.getArrayBuffer(url, function(err, response) {
+            ajax.getArrayBuffer(url, null, function(err, response) {
                 assets.tiles[url] = response;
                 callback(err, response);
             });

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -10,7 +10,7 @@ module.exports = VectorTileSource;
 function VectorTileSource(id, options, dispatcher) {
     this.id = id;
     this.dispatcher = dispatcher;
-    util.extend(this, util.pick(options, ['url', 'scheme', 'tileSize']));
+    util.extend(this, util.pick(options, ['headers', 'url', 'scheme', 'tileSize']));
     this._options = util.extend({ type: 'vector' }, options);
 
     if (this.tileSize !== 512) {
@@ -55,7 +55,8 @@ VectorTileSource.prototype = util.inherit(Evented, {
             overscaling: overscaling,
             angle: this.map.transform.angle,
             pitch: this.map.transform.pitch,
-            showCollisionBoxes: this.map.showCollisionBoxes
+            showCollisionBoxes: this.map.showCollisionBoxes,
+            headers: this.headers
         };
 
         if (tile.workerID) {

--- a/js/source/vector_tile_worker_source.js
+++ b/js/source/vector_tile_worker_source.js
@@ -117,7 +117,7 @@ VectorTileWorkerSource.prototype = {
      * @param {string} params.url The URL of the tile PBF to load.
      */
     loadVectorData: function (params, callback) {
-        var xhr = ajax.getArrayBuffer(params.url, done.bind(this));
+        var xhr = ajax.getArrayBuffer(params.url, params.headers, done.bind(this));
         return function abort () { xhr.abort(); };
         function done(err, data) {
             if (err) { return callback(err); }

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -105,7 +105,7 @@ GlyphSource.prototype.loadRange = function(fontstack, range, callback) {
         var rangeName = (range * 256) + '-' + (range * 256 + 255);
         var url = glyphUrl(fontstack, rangeName, this.url);
 
-        getArrayBuffer(url, function(err, data) {
+        getArrayBuffer(url, null, function(err, data) {
             var glyphs = !err && new Glyphs(new Protobuf(new Uint8Array(data)));
             for (var i = 0; i < loading[range].length; i++) {
                 loading[range][i](err, range, glyphs);

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -46,7 +46,7 @@ exports.getJSON = function(url, callback) {
     });
 };
 
-exports.getArrayBuffer = function(url, callback) {
+exports.getArrayBuffer = function(url, headers, callback) {
     if (cache[url]) return cached(cache[url], callback);
     return request({url: url, encoding: null}, function(error, response, body) {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {

--- a/js/util/browser/ajax.js
+++ b/js/util/browser/ajax.js
@@ -24,13 +24,20 @@ exports.getJSON = function(url, callback) {
     return xhr;
 };
 
-exports.getArrayBuffer = function(url, callback) {
+exports.getArrayBuffer = function(url, headers, callback) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', url, true);
     xhr.responseType = 'arraybuffer';
     xhr.onerror = function(e) {
         callback(e);
     };
+
+    if (headers !== undefined && headers !== null) {
+        for (var i = 0; i < headers.length; i++) {
+            xhr.setRequestHeader(headers[i][0], headers[i][1]);
+        }
+    }
+
     xhr.onload = function() {
         if (xhr.status >= 200 && xhr.status < 300 && xhr.response) {
             callback(null, xhr.response);
@@ -49,7 +56,7 @@ function sameOrigin(url) {
 }
 
 exports.getImage = function(url, callback) {
-    return exports.getArrayBuffer(url, function(err, imgData) {
+    return exports.getArrayBuffer(url, null, function(err, imgData) {
         if (err) return callback(err);
         var img = new Image();
         img.onload = function() {


### PR DESCRIPTION
In some cases I would like to set a header to authenticate a user for getting a vector tile. It needs to be set per source and authentication is often done in the header.

I added the following format to the source style.

```
  headers: [
    ["HEADER-NAME", "HEADER-VALUE"]
  ]
```

Added headers to ajax getArrayBuffer call.

Not sure about the what source format or if this is something that you want to support.