### PR TITLE
upgrade geojson-vt

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "earcut": "^2.0.3",
     "feature-filter": "^2.1.0",
     "geojson-rewind": "^0.1.0",
-    "geojson-vt": "^2.2.0",
+    "geojson-vt": "^2.3.0",
     "gl-matrix": "^2.3.1",
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "^1.2.1",

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -883,26 +883,34 @@ test('Map', function(t) {
 
     t.test('error event', function (t) {
         t.test('logs errors to console when it has NO listeners', function (t) {
+            var map = createMap({ style: { version: 8, sources: {}, layers: [] } });
+
+            sinon.spy(map, 'fire');
             sinon.stub(console, 'error', function(error) {
-                console.error.restore();
-                t.equal(error.message, 'version: expected one of [8], 7 found');
-                t.end();
+                if (error.message === 'version: expected one of [8], 7 found') {
+                    t.notOk(map.fire.calledWith('error'));
+                    console.error.restore();
+                    map.fire.restore();
+                    t.end();
+                } else {
+                    console.log(error);
+                }
             });
 
-            createMap({ style: { version: 7, sources: {}, layers: [] } });
+            map.setStyle({ version: 7, sources: {}, layers: [] });
         });
 
         t.test('calls listeners', function (t) {
-            sinon.stub(console, 'error', function(event) {
-                t.fail(event.error);
-            });
-
             var map = createMap({ style: { version: 8, sources: {}, layers: [] } });
+
+            sinon.spy(console, 'error');
             map.on('error', function(event) {
                 t.equal(event.error.message, 'version: expected one of [8], 7 found');
+                t.notOk(console.error.calledWith('version: expected one of [8], 7 found'));
                 console.error.restore();
                 t.end();
             });
+
             map.setStyle({ version: 7, sources: {}, layers: [] });
         });
 
@@ -941,7 +949,6 @@ test('Map', function(t) {
         });
         t.end();
     });
-
 
     t.end();
 });


### PR DESCRIPTION
In version 2.3.0 of geojson-vt a fix was added to make sure any geojson between +/-540 lng would be rendered. Before, if there were no features between +/-180 an undefined error would be thrown.

As this is tested upstream, I'm not sure if we want tests here. I can add them if you want.

This closes #2912.