### PR TITLE
Ensure camera animations may be triggered in moveend listeners

### DIFF
--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -481,14 +481,16 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
     },
 
     _easeToEnd: function(eventData) {
-        if (this.zooming) {
+        var wasZooming = this.zooming;
+        this.zooming = false;
+        this.rotating = false;
+        this.pitching = false;
+
+        if (wasZooming) {
             this.fire('zoomend', eventData);
         }
         this.fire('moveend', eventData);
 
-        this.zooming = false;
-        this.rotating = false;
-        this.pitching = false;
     },
 
     /**
@@ -688,11 +690,12 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
                 this.fire('pitch', eventData);
             }
         }, function() {
-            this.fire('zoomend', eventData);
-            this.fire('moveend', eventData);
             this.zooming = false;
             this.rotating = false;
             this.pitching = false;
+
+            this.fire('zoomend', eventData);
+            this.fire('moveend', eventData);
         }, options);
 
         return this;

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -627,7 +627,7 @@ test('camera', function(t) {
             var movestarted, moved, rotated, pitched, zoomstarted, zoomed,
                 eventData = { data: 'ok' };
 
-            t.plan(9);
+            t.plan(12);
 
             camera
                 .on('movestart', function(d) { movestarted = d.data; })
@@ -635,6 +635,10 @@ test('camera', function(t) {
                 .on('rotate', function(d) { rotated = d.data; })
                 .on('pitch', function(d) { pitched = d.data; })
                 .on('moveend', function(d) {
+                    t.notOk(camera.zooming);
+                    t.notOk(camera.panning);
+                    t.notOk(camera.rotating);
+
                     t.equal(movestarted, 'ok');
                     t.equal(moved, 'ok');
                     t.equal(zoomed, 'ok');
@@ -799,6 +803,10 @@ test('camera', function(t) {
                 .on('rotate', function(d) { rotated = d.data; })
                 .on('pitch', function(d) { pitched = d.data; })
                 .on('moveend', function(d) {
+                    t.notOk(this.zooming);
+                    t.notOk(this.panning);
+                    t.notOk(this.rotating);
+
                     t.equal(movestarted, 'ok');
                     t.equal(moved, 'ok');
                     t.equal(zoomed, 'ok');


### PR DESCRIPTION
We don't allow overlapping camera animations in GL JS or native. If a user tries to start an animation while the camera is already animating, we ignore the request. 

Three properties `zooming`, `rotating`, and `panning` track whether or not an animation is occurring.

We were not unsetting those properties before calling the `moveend` listeners, preventing them from starting new animations. 

fixes #2855

cc @mollymerp @bhousel @mapsam 