### PR TITLE
Use tile uid to associate tiles with workers

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -138,14 +138,16 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             options.data = JSON.stringify(data);
         }
 
+        var workerKey = options.url || options.data;
+
         // target {this.type}.loadData rather than literally geojson.loadData,
         // so that other geojson-like source types can easily reuse this
         // implementation
-        this.workerID = this.dispatcher.send(this.type + '.loadData', options, function(err) {
+        this.dispatcher.send(this.type + '.loadData', options, function(err) {
             this._loaded = true;
             callback(err);
-
-        }.bind(this));
+            this._workerKey = workerKey;
+        }.bind(this), workerKey);
     },
 
     loadTile: function (tile, callback) {
@@ -164,7 +166,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 
-        tile.workerID = this.dispatcher.send('load tile', params, function(err, data) {
+        this.dispatcher.send('load tile', params, function(err, data) {
 
             tile.unloadVectorData(this.map.painter);
 
@@ -184,7 +186,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
 
             return callback(null);
 
-        }.bind(this), this.workerID);
+        }.bind(this), this._workerKey);
     },
 
     abortTile: function(tile) {
@@ -193,7 +195,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
 
     unloadTile: function(tile) {
         tile.unloadVectorData(this.map.painter);
-        this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, function() {}, tile.workerID);
+        this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, function() {}, this._workerKey);
     },
 
     serialize: function() {

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -387,7 +387,8 @@ SourceCache.prototype = util.inherit(Evented, {
         if (!tile) {
             var zoom = coord.z;
             var overscaling = zoom > this.maxzoom ? Math.pow(2, zoom - this.maxzoom) : 1;
-            tile = new Tile(wrapped, this.tileSize * overscaling, this.maxzoom);
+            var tileUID = this.id + coord.id;
+            tile = new Tile(tileUID, wrapped, this.tileSize * overscaling, this.maxzoom);
             this.loadTile(tile, this._tileLoaded.bind(this, tile));
         }
 

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -22,9 +22,9 @@ module.exports = Tile;
  * @param {number} size
  * @private
  */
-function Tile(coord, size, sourceMaxZoom) {
+function Tile(id, coord, size, sourceMaxZoom) {
     this.coord = coord;
-    this.uid = util.uniqueId();
+    this.uid = id;
     this.uses = 0;
     this.tileSize = size;
     this.sourceMaxZoom = sourceMaxZoom;
@@ -131,7 +131,7 @@ Tile.prototype = {
             angle: source.map.transform.angle,
             pitch: source.map.transform.pitch,
             showCollisionBoxes: source.map.showCollisionBoxes
-        }, done.bind(this), this.workerID);
+        }, done.bind(this), this.uid);
 
         function done(_, data) {
             this.reloadSymbolData(data, source.map.painter, source.map.style);

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -58,11 +58,11 @@ VectorTileSource.prototype = util.inherit(Evented, {
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 
-        if (tile.workerID) {
+        if (tile.state === 'loaded') {
             params.rawTileData = tile.rawTileData;
-            this.dispatcher.send('reload tile', params, done.bind(this), tile.workerID);
+            this.dispatcher.send('reload tile', params, done.bind(this), tile.uid);
         } else {
-            tile.workerID = this.dispatcher.send('load tile', params, done.bind(this));
+            this.dispatcher.send('load tile', params, done.bind(this), tile.uid);
         }
 
         function done(err, data) {
@@ -85,11 +85,11 @@ VectorTileSource.prototype = util.inherit(Evented, {
     },
 
     abortTile: function(tile) {
-        this.dispatcher.send('abort tile', { uid: tile.uid, source: this.id }, null, tile.workerID);
+        this.dispatcher.send('abort tile', { uid: tile.uid, source: this.id }, null, tile.uid);
     },
 
     unloadTile: function(tile) {
         tile.unloadVectorData(this.map.painter);
-        this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, null, tile.workerID);
+        this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, null, tile.uid);
     }
 });

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -177,7 +177,7 @@ test('GeoJSONSource#update', function(t) {
 
         source.on('load', function () {
             source.setData({});
-            source.loadTile(new Tile(new TileCoord(0, 0, 0), 512), function () {});
+            source.loadTile(new Tile('0', new TileCoord(0, 0, 0), 512), function () {});
         });
     });
 

--- a/test/js/source/tile.test.js
+++ b/test/js/source/tile.test.js
@@ -17,7 +17,7 @@ test('querySourceFeatures', function(t) {
 
 
     t.test('geojson tile', function(t) {
-        var tile = new Tile(new TileCoord(1, 1, 1));
+        var tile = new Tile('0', new TileCoord(1, 1, 1));
         var result;
 
         result = [];
@@ -42,7 +42,7 @@ test('querySourceFeatures', function(t) {
     });
 
     t.test('vector tile', function(t) {
-        var tile = new Tile(new TileCoord(1, 1, 1));
+        var tile = new Tile('0', new TileCoord(1, 1, 1));
         var result;
 
         result = [];


### PR DESCRIPTION
Instead of returning a workerID and then using that to retarget the same
worker that loaded a tile, use a scheme where the tile's coordinates
determine its uid, and its uid determines which worker does the work.