### PR TITLE
fire a popup "close" event

### DIFF
--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -89,7 +89,7 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
          * @type {Object}
          * @property {Popup} popup object that was closed
          */
-        this.fire('close', {popup: this});
+        this.fire('close');
 
         return this;
     },

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -11,6 +11,7 @@ var LngLat = require('../geo/lng_lat');
  * A popup component.
  *
  * @class Popup
+ * @fires close to indicate when a popup has been removed via the 'x' or programatically
  * @param {Object} [options]
  * @param {boolean} [options.closeButton=true] If `true`, a close button will appear in the
  *   top right corner of the popup.
@@ -79,6 +80,8 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
             this._map.off('click', this._onClickClose);
             delete this._map;
         }
+
+        this.fire('close', {popup: this});
 
         return this;
     },

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -11,7 +11,6 @@ var LngLat = require('../geo/lng_lat');
  * A popup component.
  *
  * @class Popup
- * @fires close to indicate when a popup has been removed via the 'x' or programatically
  * @param {Object} [options]
  * @param {boolean} [options.closeButton=true] If `true`, a close button will appear in the
  *   top right corner of the popup.
@@ -81,6 +80,15 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
             delete this._map;
         }
 
+        /**
+         * Fired when the popup is closed manually or programatically.
+         *
+         * @event close
+         * @memberof Popup
+         * @instance
+         * @type {Object}
+         * @property {Popup} popup object that was closed
+         */
         this.fire('close', {popup: this});
 
         return this;


### PR DESCRIPTION
Working on a popup `close` event for #2584 

### How should the user subscribe to the event? Options are to:

1. fire `close` on the popup itself:
        
        var popup = new mapboxgl.Popup().on('close', function(p) { ... });

1. fire `popup.close` on the map object itself:

        map.on('popup.close', function(p) { ... });

1. both!

### TODO

- [x] determine above ^
- [x] ~~tests~~ https://github.com/mapbox/mapbox-gl-js/issues/1550
- [x] docs
- [x] review

cc @lucaswoj @mollymerp @jfirebaugh 