### PR TITLE
Enable ci.sh to run on osx

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -22,8 +22,10 @@ tap --reporter dot --coverage --no-coverage-report test/js/*/*.js test/build/web
 # allow writing core files for render tests
 ulimit -c unlimited -S
 echo 'ulimit -c: '`ulimit -c`
-echo '/proc/sys/kernel/core_pattern: '`cat /proc/sys/kernel/core_pattern`
-sysctl kernel.core_pattern
+if [[ $(uname -s) == 'Linux' ]]; then
+    echo '/proc/sys/kernel/core_pattern: '`cat /proc/sys/kernel/core_pattern`
+    sysctl kernel.core_pattern
+fi
 
 # run render tests
 istanbul cover --dir .nyc_output --include-pid --report none --print none test/render.test.js &&
@@ -34,10 +36,12 @@ EXIT_CODE=$?
 if [[ ${EXIT_CODE} != 0 ]]; then
     echo "The program crashed with exit code ${EXIT_CODE}. We're now trying to output the core dump."
 fi
-for DUMP in $(find ./ -maxdepth 1 -name 'core*' -print); do
-    gdb `which node` ${DUMP} -ex "thread apply all bt" -ex "set pagination 0" -batch
-    rm -rf ${DUMP}
-done
+if [[ $(uname -s) == 'Linux' ]]; then
+    for DUMP in $(find ./ -maxdepth 1 -name 'core*' -print); do
+        gdb `which node` ${DUMP} -ex "thread apply all bt" -ex "set pagination 0" -batch
+        rm -rf ${DUMP}
+    done
+fi
 
 # send coverage report to coveralls
 nyc report --reporter=lcov


### PR DESCRIPTION
This prepares `ci.sh` to run on OS X. Per chat with @lucaswoj we are going to try using OS X machines on circleci. If this works this could provide a fallback if headless-gl stability on linux continues to be a problem.  This can be tested by:

 - merging this PR
 - going to https://circleci.com/gh/mapbox/mapbox-gl-js/edit#build-environment and flipping the build environment to OS X

@lucaswoj - let's sync up tomorrow morning before enabling.