### PR TITLE
[circleci] adapt circle.yml to osx environment

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-set -e
+source ./nvm/nvm.sh
+nvm use ${NODE_VERSION}
+
+set -eu
 set -o pipefail
 
 # add npm packages to $PATH

--- a/ci.sh
+++ b/ci.sh
@@ -9,11 +9,6 @@ set -o pipefail
 # add npm packages to $PATH
 export PATH=$(pwd)/node_modules/.bin:$PATH
 
-# disable spotlight to ensure we waste no CPU on needless file indexing
-if [[ $(uname -s) == 'Darwin' ]]; then
-    sudo mdutil -i off /
-fi
-
 # set up code coverage instrumentation
 rm -rf coverage .nyc_output
 

--- a/ci.sh
+++ b/ci.sh
@@ -9,6 +9,11 @@ set -o pipefail
 # add npm packages to $PATH
 export PATH=$(pwd)/node_modules/.bin:$PATH
 
+# disable spotlight to ensure we waste no CPU on needless file indexing
+if [[ $(uname -s) == 'Darwin' ]]; then
+    sudo mdutil -i off /
+fi
+
 # set up code coverage instrumentation
 rm -rf coverage .nyc_output
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ dependencies:
   cache_directories:
     - './nvm'
   override:
+    # disable spotlight to ensure we waste no CPU on needless file indexing
+    - if [[ $(uname -s) == 'Darwin' ]]; then sudo mdutil -i off /; fi;
     - |
       if [[ ! -d ./nvm ]]; then
           git clone --depth 1 https://github.com/creationix/nvm.git ./nvm

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,26 @@
 machine:
-  node:
-    version: '4'
+  xcode:
+    version: 7.3
+  environment:
+    XCODE_SCHEME: "no"
+    XCODE_WORKSPACE: "no"
+    NODE_VERSION: 4
+
 dependencies:
+  cache_directories:
+    - './nvm'
   override:
-    - if [ "$(git symbolic-ref --short -q HEAD)" == "master" ]; then npm update; else npm install; fi;
+    - |
+      if [[ ! -d ./nvm ]]; then
+          git clone --depth 1 https://github.com/creationix/nvm.git ./nvm
+      fi
+    - source ./nvm/nvm.sh && nvm install ${NODE_VERSION}
+    - |
+      if [ "$(git symbolic-ref --short -q HEAD)" == "master" ]; then
+          source ./nvm/nvm.sh && nvm use ${NODE_VERSION} && npm update
+      else
+          source ./nvm/nvm.sh && nvm use ${NODE_VERSION} && npm install
+      fi
 test:
   override:
     - ./ci.sh


### PR DESCRIPTION
This PR modifies the circle.yml to be able to be run on the circle OS X environment. It builds off of #2958.

The overall motivation is to be able to run all tests without segfaults (that are common on linux due to uncontrolled factors: bugs in headless-gl or mesa?).

Key changes:

  - Installs node with nvm because circleci OS X machines do not support:

```
 machine:
 -  node:
 -    version: '4'
```

  - Provides new environment options: `XCODE_SCHEME` and `XCODE_WORKSPACE` to trigger no-op in circleci configuration setup.

Background: The circleci OS X support assumes you are developing iOS applications with an xcodeproject (https://circleci.com/docs/ios-builds-on-os-x/). So this project will fail by default when an xcode project is not found. This PR fixes this problem by telling circleci to not look for xcode files.


More notes:

   - Speed is slightly slower than the previous build that passed on master
     - Build was: https://circleci.com/gh/mapbox/mapbox-gl-js/4346
     - Total time: 13:19 master/linux, 15:14 PR/osx
     - Install deps from cache: 1:08 master/linux, 0:38 PR/osx
     - Save cache: 0:02 master/linux, 1:06 PR/osx
     - Run build/tests: 11:04 master/linux, 12:23 PR/osx