### PR TITLE
Fix bug breaking transparency in fill layers with property functions

### DIFF
--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -9,11 +9,12 @@ function draw(painter, source, layer, coords) {
     gl.enable(gl.STENCIL_TEST);
 
     var isOpaque = (
-        !layer.paint['fill-pattern'] &&
-        layer.isPaintValueFeatureConstant('fill-color') &&
-        layer.isPaintValueFeatureConstant('fill-opacity') &&
-        layer.paint['fill-color'] === 1 &&
-        layer.paint['fill-opacity'] === 1
+        !layer.paint['fill-pattern'] || (
+            !layer.isPaintValueFeatureConstant('fill-color') &&
+            !layer.isPaintValueFeatureConstant('fill-opacity') &&
+            layer.paint['fill-color'][3] === 1 &&
+            layer.paint['fill-opacity'] === 1
+        )
     );
 
     // Draw fill

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -8,13 +8,16 @@ function draw(painter, source, layer, coords) {
     var gl = painter.gl;
     gl.enable(gl.STENCIL_TEST);
 
-    var color = layer.paint['fill-color'];
-    var image = layer.paint['fill-pattern'];
-    var opacity = layer.paint['fill-opacity'];
-    var isOutlineColorDefined = layer.getPaintProperty('fill-outline-color');
+    var isOpaque = (
+        !layer.paint['fill-pattern'] &&
+        layer.isPaintValueFeatureConstant('fill-color') &&
+        layer.isPaintValueFeatureConstant('fill-opacity') &&
+        layer.paint['fill-color'] === 1 &&
+        layer.paint['fill-opacity'] === 1
+    );
 
     // Draw fill
-    if (image ? !painter.isOpaquePass : painter.isOpaquePass === (color[3] === 1 && opacity === 1)) {
+    if (painter.isOpaquePass === isOpaque) {
         // Once we switch to earcut drawing we can pull most of the WebGL setup
         // outside of this coords loop.
         painter.setDepthSublayer(1);
@@ -27,6 +30,7 @@ function draw(painter, source, layer, coords) {
         painter.lineWidth(2);
         painter.depthMask(false);
 
+        var isOutlineColorDefined = layer.getPaintProperty('fill-outline-color');
         if (isOutlineColorDefined || !layer.paint['fill-pattern']) {
             if (isOutlineColorDefined) {
                 // If we defined a different color for the fill outline, we are

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -8,14 +8,17 @@ function draw(painter, source, layer, coords) {
     var gl = painter.gl;
     gl.enable(gl.STENCIL_TEST);
 
-    var isOpaque = (
-        !layer.paint['fill-pattern'] || (
-            !layer.isPaintValueFeatureConstant('fill-color') &&
-            !layer.isPaintValueFeatureConstant('fill-opacity') &&
+    var isOpaque;
+    if (layer.paint['fill-pattern']) {
+        isOpaque = false;
+    } else {
+        isOpaque = (
+            layer.isPaintValueFeatureConstant('fill-color') &&
+            layer.isPaintValueFeatureConstant('fill-opacity') &&
             layer.paint['fill-color'][3] === 1 &&
             layer.paint['fill-opacity'] === 1
-        )
-    );
+        );
+    }
 
     // Draw fill
     if (painter.isOpaquePass === isOpaque) {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "istanbul": "^0.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#e40765f0ede7bfe7c55f9ffda11f2f0fbed19a2d",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#0ed5d988d81072e4b44b02581825979cbcfcf30b",
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "nyc": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "istanbul": "^0.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#dc547418019d542745ca635af38717f560444e58",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#e40765f0ede7bfe7c55f9ffda11f2f0fbed19a2d",
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "nyc": "6.4.0",


### PR DESCRIPTION
This bug is caused by `draw_fill`'s [inability to understand property functions when deciding whether to render in the opaque or translucent pass.](https://github.com/mapbox/mapbox-gl-js/blob/master/js/render/draw_fill.js#L11).

To mitigate, this PR draws all fills with property functions for `fill-color` or `fill-opacity` in the translucent pass. 

fixes #2846

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] write test-suite regression test for this bug
 - [x] [document any changes or additions to public APIs](https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md)
 - [x] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks)
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [x] get a PR review :+1: / :-1:
