### PR TITLE
Fix bug preventing attribution from being displayed

### DIFF
--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -35,6 +35,7 @@ function SourceCache(id, options, dispatcher) {
         this.roundZoom = source.roundZoom;
         this.reparseOverscaled = source.reparseOverscaled;
         this.isTileClipped = source.isTileClipped;
+        this.attribution = source.attribution;
 
         this.vectorLayerIds = source.vectorLayerIds;
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -49,6 +49,16 @@ function createSourceCache(options, used) {
     return sc;
 }
 
+test('SourceCache#attribution is set', function(t) {
+    var sourceCache = createSourceCache({
+        attribution: 'Mapbox Heavy Industries'
+    });
+    sourceCache.on('load', function() {
+        t.equal(sourceCache.attribution, 'Mapbox Heavy Industries');
+        t.end();
+    });
+});
+
 test('SourceCache#addTile', function(t) {
     t.test('loads tile when uncached', function(t) {
         var coord = new TileCoord(0, 0, 0);


### PR DESCRIPTION
A million gold stars to @tristen for noticing this 🌟 🌟 🌟 🌟 🌟 🌟 🌟 🌟 🌟 🌟 🌟 🌟 

Since #2667 we have not been displaying any attribution on our maps! Fortunately this PR has not gone out in a release yet. We _desperately_ need to tackle #1550. 

This PR fixes the bug by setting an `attribution` property on `SourceCache`. 

cc @anandthakker @tristen @mourner @mollymerp 

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] [document any changes or additions to public APIs](https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md)
 - [x] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks) (if you made a non-trivial code change)
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [x] get a PR review :+1: / :-1:

