### PR TITLE
Fix CSS rules in custom marker example

### DIFF
--- a/docs/_posts/examples/3400-01-24-custom-marker-icons.html
+++ b/docs/_posts/examples/3400-01-24-custom-marker-icons.html
@@ -6,9 +6,11 @@ description: 'Use Markers to add custom icons to your map.'
 ---
 <style>
 .marker {
+    display: block;
     border: none;
     border-radius: 50%;
     cursor: pointer;
+    padding: 0;
 }
 </style>
 
@@ -76,8 +78,8 @@ geojson.features.forEach(function(marker) {
     var el = document.createElement('button');
     el.className = 'marker';
     el.style.backgroundImage = 'url(https://placekitten.com/g/' + marker.properties.iconSize.join('/') + '/)';
-    el.style.width = marker.properties.iconSize[0];
-    el.style.height = marker.properties.iconSize[1];
+    el.style.width = marker.properties.iconSize[0] + 'px';
+    el.style.height = marker.properties.iconSize[1] + 'px';
 
     el.addEventListener('click', function() {
         window.alert(marker.properties.message);


### PR DESCRIPTION
Fix CSS rules in the [custom marker example](https://mapbox.com/mapbox-gl-js/example/custom-marker-icons/) with the following:

- Reset default `<button>` rules.
- Specify a unit for `width` and `height`.

## Checklist
 - [x] get a PR review :+1: / :-1:

Closes #2974