### PR TITLE
queryRenderedFeatures: default params to empty object instead of throwing error

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -644,7 +644,7 @@ Style.prototype = util.inherit(Evented, {
         }
 
         var includedSources = {};
-        if (params.layers) {
+        if (params && params.layers) {
             for (var i = 0; i < params.layers.length; i++) {
                 var layerId = params.layers[i];
                 includedSources[this._layers[layerId].source] = true;

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -454,7 +454,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * [Feature objects](http://geojson.org/geojson-spec.html#feature-objects)
      * representing visible features that satisfy the query parameters.
      *
-     * @param {PointLike|Array<PointLike>} [region] - The geometry of the query region:
+     * @param {PointLike|Array<PointLike>} [geometry] - The geometry of the query region:
      * either a single point or southwest and northeast points describing a bounding box.
      * Omitting this parameter (i.e. calling [`Map#queryRenderedFeatures`](#Map#queryRenderedFeatures) with zero arguments,
      * or with only a `parameters` argument) is equivalent to passing a bounding box encompassing the entire
@@ -513,15 +513,29 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * // Query all rendered features from a single layer
      * var features = map.queryRenderedFeatures({ layers: ['my-layer-name'] });
      */
-    queryRenderedFeatures: function(pointbox, params) {
-        var parameters = params || {};
-        var pointOrBox = pointbox || undefined;
-        if (!(pointOrBox instanceof Point || Array.isArray(pointOrBox))) {
-            parameters = pointOrBox;
-            pointOrBox = undefined;
+    queryRenderedFeatures: function() {
+        var params = {};
+        var geometry;
+
+        if (arguments.length === 2) {
+            geometry = arguments[0];
+            params = arguments[1];
+        } else if (arguments.length === 1 && isPointLike(arguments[0])) {
+            geometry = arguments[0];
+        } else if (arguments.length === 1) {
+            params = arguments[0];
         }
-        var queryGeometry = this._makeQueryGeometry(pointOrBox);
-        return this.style.queryRenderedFeatures(queryGeometry, parameters, this.transform.zoom, this.transform.angle);
+
+        return this.style.queryRenderedFeatures(
+            this._makeQueryGeometry(geometry),
+            params,
+            this.transform.zoom,
+            this.transform.angle
+        );
+
+        function isPointLike(input) {
+            return input instanceof Point || Array.isArray(input);
+        }
     },
 
     _makeQueryGeometry: function(pointOrBox) {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -514,12 +514,14 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * var features = map.queryRenderedFeatures({ layers: ['my-layer-name'] });
      */
     queryRenderedFeatures: function(pointOrBox, params) {
+        var parameters = params || {};
         if (!(pointOrBox instanceof Point || Array.isArray(pointOrBox))) {
-            params = pointOrBox;
+            console.log('we get here');
+            parameters = pointOrBox;
             pointOrBox = undefined;
         }
         var queryGeometry = this._makeQueryGeometry(pointOrBox);
-        return this.style.queryRenderedFeatures(queryGeometry, params, this.transform.zoom, this.transform.angle);
+        return this.style.queryRenderedFeatures(queryGeometry, parameters, this.transform.zoom, this.transform.angle);
     },
 
     _makeQueryGeometry: function(pointOrBox) {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -516,7 +516,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     queryRenderedFeatures: function(pointOrBox, params) {
         var parameters = params || {};
         if (!(pointOrBox instanceof Point || Array.isArray(pointOrBox))) {
-            console.log('we get here');
             parameters = pointOrBox;
             pointOrBox = undefined;
         }

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -513,8 +513,9 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * // Query all rendered features from a single layer
      * var features = map.queryRenderedFeatures({ layers: ['my-layer-name'] });
      */
-    queryRenderedFeatures: function(pointOrBox, params) {
+    queryRenderedFeatures: function(pointbox, params) {
         var parameters = params || {};
+        var pointOrBox = pointbox || undefined;
         if (!(pointOrBox instanceof Point || Array.isArray(pointOrBox))) {
             parameters = pointOrBox;
             pointOrBox = undefined;

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -593,6 +593,26 @@ test('Map', function(t) {
                 map.queryRenderedFeatures(map.project(new LngLat(360, 0)), opts);
             });
 
+            t.test('if no options, defaults to empty object', function(t) {
+                map.style.queryRenderedFeatures = function (coords, o) {
+                    t.ok(coords);
+                    t.deepEqual(o, {}, 'options are set to a default object');
+                    t.end();
+                };
+
+                map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
+            });
+
+            t.test('options carry through query', function(t) {
+                map.style.queryRenderedFeatures = function (coords, o) {
+                    t.ok(coords);
+                    t.deepEqual(o, {foo: 'bar'}, 'options are expected');
+                    t.end();
+                };
+
+                map.queryRenderedFeatures(map.project(new LngLat(0, 0)), {foo: 'bar'});
+            });
+
             t.end();
         });
     });

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -564,6 +564,32 @@ test('Map', function(t) {
         map.on('style.load', function() {
             var opts = {};
 
+            t.test('if no parameters provided, use defaults', function(t) {
+                var results = map.queryRenderedFeatures();
+                t.deepEqual(results, [], 'expected results');
+                t.end();
+            });
+
+            t.test('if no options, defaults to empty object', function(t) {
+                map.style.queryRenderedFeatures = function (coords, o) {
+                    t.ok(coords);
+                    t.deepEqual(o, {}, 'options are set to a default object');
+                    t.end();
+                };
+
+                map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
+            });
+
+            t.test('options carry through query', function(t) {
+                map.style.queryRenderedFeatures = function (coords, o) {
+                    t.ok(coords);
+                    t.deepEqual(o, {foo: 'bar'}, 'options are expected');
+                    t.end();
+                };
+
+                map.queryRenderedFeatures(map.project(new LngLat(0, 0)), {foo: 'bar'});
+            });
+
             t.test('normal coords', function(t) {
                 map.style.queryRenderedFeatures = function (coords, o, zoom, bearing) {
                     t.deepEqual(coords, [{ column: 0.5, row: 0.5, zoom: 0 }]);
@@ -591,26 +617,6 @@ test('Map', function(t) {
                 };
 
                 map.queryRenderedFeatures(map.project(new LngLat(360, 0)), opts);
-            });
-
-            t.test('if no options, defaults to empty object', function(t) {
-                map.style.queryRenderedFeatures = function (coords, o) {
-                    t.ok(coords);
-                    t.deepEqual(o, {}, 'options are set to a default object');
-                    t.end();
-                };
-
-                map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
-            });
-
-            t.test('options carry through query', function(t) {
-                map.style.queryRenderedFeatures = function (coords, o) {
-                    t.ok(coords);
-                    t.deepEqual(o, {foo: 'bar'}, 'options are expected');
-                    t.end();
-                };
-
-                map.queryRenderedFeatures(map.project(new LngLat(0, 0)), {foo: 'bar'});
             });
 
             t.end();

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -13,8 +13,8 @@ var fixed = require('../../testutil/fixed');
 var fixedNum = fixed.Num;
 var fixedLngLat = fixed.LngLat;
 
-function createMap(options) {
-    return new Map(extend({
+function createMap(options, callback) {
+    var map = new Map(extend({
         container: {
             offsetWidth: 200,
             offsetHeight: 200,
@@ -25,13 +25,24 @@ function createMap(options) {
         },
         interactive: false,
         attributionControl: false,
-        trackResize: true
+        trackResize: true,
+        style: {
+            "version": 8,
+            "sources": {},
+            "layers": []
+        }
     }, options));
+
+    if (callback) map.on('load', function() {
+        callback(null, map);
+    });
+
+    return map;
 }
 
 test('Map', function(t) {
     t.test('constructor', function(t) {
-        var map = createMap({interactive: true});
+        var map = createMap({interactive: true, style: null});
         t.ok(map.getContainer());
         t.equal(map.getStyle(), undefined);
         t.ok(map.boxZoom.isEnabled());
@@ -554,73 +565,90 @@ test('Map', function(t) {
     });
 
     t.test('#queryRenderedFeatures', function(t) {
-        var map = createMap();
-        map.setStyle({
-            "version": 8,
-            "sources": {},
-            "layers": []
-        });
 
-        map.on('style.load', function() {
-            var opts = {};
+        t.test('if no arguments provided', function(t) {
+            createMap({}, function(err, map) {
+                t.error(err);
+                sinon.spy(map.style, 'queryRenderedFeatures');
 
-            t.test('if no parameters provided, use defaults', function(t) {
-                var results = map.queryRenderedFeatures();
-                t.deepEqual(results, [], 'expected results');
+                var output = map.queryRenderedFeatures();
+
+                var args = map.style.queryRenderedFeatures.getCall(0).args;
+                t.ok(args[0]);
+                t.deepEqual(args[1], {});
+                t.deepEqual(output, []);
+
                 t.end();
             });
-
-            t.test('if no options, defaults to empty object', function(t) {
-                map.style.queryRenderedFeatures = function (coords, o) {
-                    t.ok(coords);
-                    t.deepEqual(o, {}, 'options are set to a default object');
-                    t.end();
-                };
-
-                map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
-            });
-
-            t.test('options carry through query', function(t) {
-                map.style.queryRenderedFeatures = function (coords, o) {
-                    t.ok(coords);
-                    t.deepEqual(o, {foo: 'bar'}, 'options are expected');
-                    t.end();
-                };
-
-                map.queryRenderedFeatures(map.project(new LngLat(0, 0)), {foo: 'bar'});
-            });
-
-            t.test('normal coords', function(t) {
-                map.style.queryRenderedFeatures = function (coords, o, zoom, bearing) {
-                    t.deepEqual(coords, [{ column: 0.5, row: 0.5, zoom: 0 }]);
-                    t.equal(o, opts);
-                    t.equal(bearing, map.transform.angle);
-                    t.equal(zoom, map.getZoom());
-                    t.end();
-                };
-
-                map.queryRenderedFeatures(map.project(new LngLat(0, 0)), opts);
-            });
-
-            t.test('does not wrap coords', function(t) {
-                map.style.queryRenderedFeatures = function (coords, o, zoom, bearing) {
-                    // avoid floating point issues
-                    t.equal(parseFloat(coords[0].column.toFixed(4)), 1.5);
-                    t.equal(coords[0].row, 0.5);
-                    t.equal(coords[0].zoom, 0);
-
-                    t.equal(o, opts);
-                    t.equal(bearing, map.transform.angle);
-                    t.equal(zoom, map.getZoom());
-
-                    t.end();
-                };
-
-                map.queryRenderedFeatures(map.project(new LngLat(360, 0)), opts);
-            });
-
-            t.end();
         });
+
+        t.test('if only "geometry" provided', function(t) {
+            createMap({}, function(err, map) {
+                t.error(err);
+                sinon.spy(map.style, 'queryRenderedFeatures');
+
+                var output = map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
+
+                var args = map.style.queryRenderedFeatures.getCall(0).args;
+                t.deepEqual(args[0], [{ column: 0.5, row: 0.5, zoom: 0 }]); // query geometry
+                t.deepEqual(args[1], {}); // params
+                t.deepEqual(args[2], 0); // bearing
+                t.deepEqual(args[3], 0); // zoom
+                t.deepEqual(output, []);
+
+                t.end();
+            });
+        });
+
+        t.test('if only "params" provided', function(t) {
+            createMap({}, function(err, map) {
+                t.error(err);
+                sinon.spy(map.style, 'queryRenderedFeatures');
+
+                var output = map.queryRenderedFeatures({filter: ['all']});
+
+                var args = map.style.queryRenderedFeatures.getCall(0).args;
+                t.ok(args[0]);
+                t.deepEqual(args[1], {filter: ['all']});
+                t.deepEqual(output, []);
+
+                t.end();
+            });
+        });
+
+        t.test('if both "geometry" and "params" provided', function(t) {
+            createMap({}, function(err, map) {
+                t.error(err);
+                sinon.spy(map.style, 'queryRenderedFeatures');
+
+                var output = map.queryRenderedFeatures({filter: ['all']});
+
+                var args = map.style.queryRenderedFeatures.getCall(0).args;
+                t.ok(args[0]);
+                t.deepEqual(args[1], {filter: ['all']});
+                t.deepEqual(output, []);
+
+                t.end();
+            });
+        });
+
+        t.test('if "geometry" with unwrapped coords provided', function(t) {
+            createMap({}, function(err, map) {
+                t.error(err);
+                sinon.spy(map.style, 'queryRenderedFeatures');
+
+                map.queryRenderedFeatures(map.project(new LngLat(360, 0)));
+
+                var coords = map.style.queryRenderedFeatures.getCall(0).args[0];
+                t.equal(parseFloat(coords[0].column.toFixed(4)), 1.5);
+                t.equal(coords[0].row, 0.5);
+                t.equal(coords[0].zoom, 0);
+
+                t.end();
+            });
+        });
+
+        t.end();
     });
 
     t.test('#setLayoutProperty', function (t) {


### PR DESCRIPTION
#### What changed

Added a default empty object `{}` to `map.queryRenderedFeatures()` if nothing is passed through. Currently gl-js throws an error if the query is missing a second parameter. In order to pass linting tests, I had to rename `params` to `parameters` within the logic of `queryRenderedFeatures`.

fixes #2969

#### Tests

Added two new tests that confirm the object is generated if it isn't passed through, and a test that confirms all parameters are preserved in the output (happy to remove this if it's unnecessary).

#### Refs

#2647 

cc @lucaswoj @bhousel @mollymerp 
