### PR TITLE
Fix redoPlacement exception thrown when rotating the map

### DIFF
--- a/js/source/vector_tile_worker_source.js
+++ b/js/source/vector_tile_worker_source.js
@@ -124,5 +124,23 @@ VectorTileWorkerSource.prototype = {
             var tile =  new vt.VectorTile(new Protobuf(new Uint8Array(data)));
             callback(err, { tile: tile, rawTileData: data });
         }
+    },
+
+    redoPlacement: function(params, callback) {
+        var loaded = this.loaded[params.source],
+            loading = this.loading[params.source],
+            uid = params.uid;
+
+        if (loaded && loaded[uid]) {
+            var tile = loaded[uid];
+            var result = tile.redoPlacement(params.angle, params.pitch, params.showCollisionBoxes);
+
+            if (result.result) {
+                callback(null, result.result, result.transferables);
+            }
+
+        } else if (loading && loading[uid]) {
+            loading[uid].angle = params.angle;
+        }
     }
 };

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -160,4 +160,3 @@ function createLayerFamilies(layers) {
 
     return families;
 }
-

--- a/test/js/source/vector_tile_worker_source.test.js
+++ b/test/js/source/vector_tile_worker_source.test.js
@@ -8,47 +8,95 @@ var styleLayers = {
     getLayerFamilies: function () {}
 };
 
-test('VectorWorkerTile#abortTile', function(t) {
+test('abortTile', function(t) {
     t.test('aborts pending request', function(t) {
-        var vectorWorkerSource = new VectorTileWorkerSource(null, styleLayers);
+        var source = new VectorTileWorkerSource(null, styleLayers);
 
-        vectorWorkerSource.loadTile({
+        source.loadTile({
             source: 'source',
             uid: 0,
             url: 'http://localhost:2900/abort'
         }, t.fail);
 
-        vectorWorkerSource.abortTile({
+        source.abortTile({
             source: 'source',
             uid: 0
         });
 
-        t.deepEqual(vectorWorkerSource.loading, { source: {} });
+        t.deepEqual(source.loading, { source: {} });
         t.end();
     });
 
     t.end();
 });
 
-test('remove tile', function(t) {
+test('removeTile', function(t) {
     t.test('removes loaded tile', function(t) {
-        var vectorWorkerSource = new VectorTileWorkerSource(null, styleLayers);
+        var source = new VectorTileWorkerSource(null, styleLayers);
 
-        vectorWorkerSource.loaded = {
+        source.loaded = {
             source: {
                 '0': {}
             }
         };
 
-        vectorWorkerSource.removeTile({
+        source.removeTile({
             source: 'source',
             uid: 0
         });
 
-        t.deepEqual(vectorWorkerSource.loaded, { source: {} });
+        t.deepEqual(source.loaded, { source: {} });
         t.end();
     });
 
     t.end();
 });
 
+test('redoPlacement', function(t) {
+
+    t.test('on loaded tile', function(t) {
+        var source = new VectorTileWorkerSource(null, styleLayers);
+        var tile = {
+            redoPlacement: function(angle, pitch, showCollisionBoxes) {
+                t.equal(angle, 60);
+                t.equal(pitch, 30);
+                t.equal(showCollisionBoxes, false);
+                return {
+                    result: {isResult: true},
+                    transferables: {isTransferrables: true}
+                };
+            }
+        };
+        source.loaded = {mapbox: {3: tile}};
+
+        source.redoPlacement({
+            uid: 3,
+            source: 'mapbox',
+            angle: 60,
+            pitch: 30,
+            showCollisionBoxes: false
+        }, function(err, result, transferables) {
+            t.error(err);
+            t.ok(result.isResult);
+            t.ok(transferables.isTransferrables);
+            t.end();
+        });
+    });
+
+    t.test('on loading tile', function(t) {
+        var source = new VectorTileWorkerSource(null, styleLayers);
+        var tile = {};
+        source.loading = {mapbox: {3: tile}};
+
+        source.redoPlacement({
+            uid: 3,
+            source: 'mapbox',
+            angle: 60
+        });
+
+        t.equal(source.loading.mapbox[3].angle, 60);
+        t.end();
+    });
+
+    t.end();
+});

--- a/test/js/source/worker.test.js
+++ b/test/js/source/worker.test.js
@@ -87,6 +87,18 @@ test('update layers', function(t) {
     t.end();
 });
 
+test('redo placement', function(t) {
+    var worker = new Worker(_self);
+    _self.registerWorkerSource('test', function() {
+        this.redoPlacement = function(options) {
+            t.ok(options.mapbox);
+            t.end();
+        };
+    });
+
+    worker['redo placement']({type: 'test', mapbox: true});
+});
+
 test('after', function(t) {
     server.close(t.end);
 });


### PR DESCRIPTION
In #2648, `VectorTileWorker` did not implement the `redoPlacement` method. When this method gets called, such as when the map rotates, an exception is triggered. 

This PR restores the `redoPlacement` method to `VectorTileWorkerSource` and, by inheritance, `GeoJSONWorkerSource`

fixes #2983

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] write unit tests for `VectorTileWorkerSource#redoPlacement`
 - [x] write test-suite regression tests for map rotation _ticketed in https://github.com/mapbox/mapbox-gl-test-suite/issues/133_
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [ ] get a PR review :+1: / :-1: