### PR TITLE
Make sure we only call "mbutil" on Darwin systems

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -1,5 +1,5 @@
 # disable spotlight to ensure we waste no CPU on needless file indexing
-sudo mdutil -i off /;
+if [[ $(uname -s) == 'Darwin' ]]; then sudo mdutil -i off /; fi;
 
 if [[ ! -d ./nvm ]]; then
     git clone --depth 1 https://github.com/creationix/nvm.git ./nvm


### PR DESCRIPTION
This is the only macOS-ism in our CI scripts. 

cc @springmeyer 