### PR TITLE
Require min style in both places. Fixes #2997

### DIFF
--- a/js/style/style_spec.js
+++ b/js/style/style_spec.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('mapbox-gl-style-spec/reference/latest');
+module.exports = require('mapbox-gl-style-spec/reference/latest.min');


### PR DESCRIPTION
This requires `latest.min` in both the validation and spec code, thus eliminating dead code.

* Before: du -sh dist/mapbox-gl.js -> 512K
* After: du -sh dist/mapbox-gl.js -> 476K

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] [document any changes or additions to public APIs](https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md)
 - [x] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks)
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [x] get a PR review :+1: / :-1:

