### PR TITLE
Upgrade test suite for TMS rendering tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "istanbul": "^0.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#1619d84e76ff3434becd51237720d370c7405ee5",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7babab52fb02788ebbc38384139bf350e8e38552",
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "nyc": "6.4.0",


### PR DESCRIPTION
TMS support was added in #2565, but there are no tests for rendering styles that specify a TMS style scheme. https://github.com/mapbox/mapbox-gl-test-suite/pull/134 implements this and we should use it in GL JS.