### PR TITLE
remove arrow function 

### DIFF
--- a/bench/lib/set_data_perf.js
+++ b/bench/lib/set_data_perf.js
@@ -17,7 +17,9 @@ module.exports = function(source, numCalls, geojson, cb) {
                 startTime = performance.now();
                 source.setData(geojson);
             } else {
-                var avgTileTime = times.reduce((v, t) => v + t, 0) / times.length;
+                var avgTileTime = times.reduce(function (v, t) {
+                    return v + t;
+                }, 0) / times.length;
                 source.off('tile.load', tileCounter);
                 cb(null, avgTileTime);
             }


### PR DESCRIPTION
<!--
Hello! Thanks for contributing. To help your PR be most easily reviewed, please complete
the following checklist:
-->

remove an arrow function from benchmarks that cause bench runner to fail in safari

## Checklist

 - [x] briefly describe the changes in this PR
 - [ ]  n/a write tests for all new functionality
 - [ ] n/a [document any changes or additions to public APIs](https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md)
 - [x] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks)
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [ ] get a PR review :+1: / :-1:

### this branch
buffer: 990 ms
fps: 60 fps
frame-duration: 7.7 ms, 0% > 16ms
query-point: 0.47 ms
query-box: 35.52 ms
geojson-setdata-small: 7 ms
geojson-setdata-large: 107 ms

### master
buffer: 875 ms
fps: 60 fps
frame-duration: 6.4 ms, 0% > 16ms
query-point: 0.63 ms
query-box: 38.70 ms
geojson-setdata-small: 10 ms
geojson-setdata-large: 95 ms