### PR TITLE
fix documentation anchors

### DIFF
--- a/docs/_theme/section_list.hbs
+++ b/docs/_theme/section_list.hbs
@@ -1,10 +1,10 @@
 <div class="clearfix">
   <% members.forEach(function(member) { %>
     <div class='keyline-bottom' id='<%- member.namespace %>'>
-      <div class="clearfix small pointer toggle-sibling">
+      <div class="clearfix small pointer toggle-sibling" data-href="#<%=member.namespace%>">
         <div class="pad1y contain">
             <a class='rcon pin-right pad1y dark-link caret-right'></a>
-            <span class='code strong strong truncate'><a href='#<%=member.namespace%>'><%= member.name%></a></span>
+            <span class='code strong strong truncate'><%= member.name%></span>
             <span class='quiet code space-right2'><%= shortSignature(member, false) %></span>
         </div>
       </div>

--- a/docs/_theme/section_list.hbs
+++ b/docs/_theme/section_list.hbs
@@ -4,7 +4,7 @@
       <div class="clearfix small pointer toggle-sibling">
         <div class="pad1y contain">
             <a class='rcon pin-right pad1y dark-link caret-right'></a>
-            <span class='code strong strong truncate'><%= member.name%></span>
+            <span class='code strong strong truncate'><a href='#<%=member.namespace%>'> <%= member.name%></a></span>
             <span class='quiet code space-right2'><%= shortSignature(member, false) %></span>
         </div>
       </div>
@@ -18,3 +18,4 @@
     </div>
   <% }) %>
 </div>
+

--- a/docs/_theme/section_list.hbs
+++ b/docs/_theme/section_list.hbs
@@ -4,7 +4,7 @@
       <div class="clearfix small pointer toggle-sibling">
         <div class="pad1y contain">
             <a class='rcon pin-right pad1y dark-link caret-right'></a>
-            <span class='code strong strong truncate'><a href='#<%=member.namespace%>'> <%= member.name%></a></span>
+            <span class='code strong strong truncate'><a href='#<%=member.namespace%>'><%= member.name%></a></span>
             <span class='quiet code space-right2'><%= shortSignature(member, false) %></span>
         </div>
       </div>
@@ -18,4 +18,3 @@
     </div>
   <% }) %>
 </div>
-

--- a/docs/js/site.js
+++ b/docs/js/site.js
@@ -30,6 +30,10 @@ function load() {
         $('a.action.signup').trigger('click');
         return false;
     });
+
+    $('[data-href]').on('click', function() {
+        window.location = $(this).data('href');
+    });
 }
 
 $(load);


### PR DESCRIPTION
<!--
Hello! Thanks for contributing. To help your PR be most easily reviewed, please complete
the following checklist:
-->

fixes #2581: fix documentation anchors so hashes update when clicked from within the main content section (not the sidebar)

re: checklist -- I didn't see tests for the documentation build, and the benchmarks do not apply here.

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] [document any changes or additions to public APIs](https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md)
 - [x] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks)
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [x] get a PR review :+1: / :-1:

