### PR TITLE
Fix regression in querySourceFeatures

### DIFF
--- a/js/source/query_features.js
+++ b/js/source/query_features.js
@@ -23,7 +23,7 @@ exports.rendered = function(sourceCache, styleLayers, queryGeometry, params, zoo
 };
 
 exports.source = function(sourceCache, params) {
-    var tiles = sourceCache.renderedIDs().map(function(id) {
+    var tiles = sourceCache.getRenderableIds().map(function(id) {
         return sourceCache.getTileByID(id);
     });
 

--- a/test/js/source/query_features.test.js
+++ b/test/js/source/query_features.test.js
@@ -2,11 +2,28 @@
 
 var test = require('tap').test;
 var QueryFeatures = require('../../../js/source/query_features.js');
+var SourceCache = require('../../../js/source/source_cache.js');
 
 test('QueryFeatures#rendered', function (t) {
     t.test('returns empty object if source returns no tiles', function (t) {
         var mockSourceCache = { tilesIn: function () { return []; } };
         var result = QueryFeatures.rendered(mockSourceCache);
+        t.deepEqual(result, []);
+        t.end();
+    });
+
+    t.end();
+});
+
+test('QueryFeatures#source', function (t) {
+    t.test('returns empty result when source has no features', function (t) {
+        var sourceCache = new SourceCache('test', {
+            type: 'geojson',
+            data: { type: 'FeatureCollection', features: [] }
+        }, {
+            send: function (type, params, callback) { return callback(); }
+        });
+        var result = QueryFeatures.source(sourceCache, {});
         t.deepEqual(result, []);
         t.end();
     });


### PR DESCRIPTION
This fixes a regression due to an obsolete method name ('SourceCache#renderedIDs'), and adds a test that would have caught this regression.