### PR TITLE
Get rid of async dependency

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -4,7 +4,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var util = require('../js/util/util');
-var async = require('async');
 var mapboxgl = require('../js/mapbox-gl');
 var Clipboard = require('clipboard');
 var URL = require('url');
@@ -116,15 +115,16 @@ var BenchmarksView = React.createClass({
 
     componentDidMount: function() {
         var that = this;
-        setTimeout(function() {
-            async.eachSeries(
-                Object.keys(that.props.benchmarks),
-                that.runBenchmark,
-                function() {
-                    that.setState({state: 'ended'});
-                    that.scrollToBenchmark(Object.keys(that.props.benchmarks)[0]);
-                }
-            );
+        var benchmarks = Object.keys(that.props.benchmarks);
+
+        setTimeout(function next() {
+            var bench = benchmarks.shift();
+            if (!bench) return;
+            that.scrollToBenchmark(bench);
+            that.runBenchmark(bench, function () {
+                that.setState({state: 'ended'});
+                next();
+            });
         }, 500);
     },
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "whoots-js": "^2.0.0"
   },
   "devDependencies": {
-    "async": "^2.0.1",
     "babel-preset-react": "^6.11.1",
     "babelify": "^7.3.0",
     "benchmark": "~2.1.0",
@@ -74,7 +73,6 @@
     "sinon": "^1.15.4",
     "st": "^1.0.0",
     "tap": "^5.7.0",
-    "through": "^2.3.7",
     "transform-loader": "^0.2.3",
     "unist-util-visit": "1.1.0",
     "vinyl": "1.1.1",


### PR DESCRIPTION
Just a minor change to make `async` dependency unnecessary. Also removes `through` dependency because it doesn’t appear to be used anywhere anymore.

Same amount of code + less dependencies = good!

cc @lucaswoj 