### PR TITLE
Add support for line property functions

### DIFF
--- a/js/data/array_group.js
+++ b/js/data/array_group.js
@@ -33,6 +33,7 @@ class Segment {
 class ArrayGroup {
     constructor(programInterface, layers, zoom) {
         this.globalProperties = {zoom};
+
         const LayoutVertexArrayType = programInterface.layoutVertexArrayType;
         this.layoutVertexArray = new LayoutVertexArrayType();
 

--- a/js/data/array_group.js
+++ b/js/data/array_group.js
@@ -33,7 +33,6 @@ class Segment {
 class ArrayGroup {
     constructor(programInterface, layers, zoom) {
         this.globalProperties = {zoom};
-
         const LayoutVertexArrayType = programInterface.layoutVertexArrayType;
         this.layoutVertexArray = new LayoutVertexArrayType();
 

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -5,6 +5,7 @@ const createVertexArrayType = require('../vertex_array_type');
 const createElementArrayType = require('../element_array_type');
 const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
+
 // NOTE ON EXTRUDE SCALE:
 // scale the extrusion vector so that the normal length is this value.
 // contains the "texture" normals (-1..1). this is distinct from the extrude
@@ -45,11 +46,11 @@ const lineInterface = {
     ]),
     paintAttributes: [
         {property: 'line-color', type: 'Uint8'},
-		{property: 'line-blur', multiplier:10, type: 'Uint8', },
-		{property: 'line-opacity', multiplier:10, type: 'Uint8', },
-		{property: 'line-width', multiplier:10, type: 'Uint8', },
-		{property: 'line-gap-width', multiplier:10, type: 'Uint8', name: 'a_gapwidth', },
-		{property: 'line-offset', multiplier:1, type: 'Int8', },
+		{property: 'line-blur', multiplier: 10, type: 'Uint8', },
+		{property: 'line-opacity', multiplier: 10, type: 'Uint8', },
+		{property: 'line-width', multiplier: 10, type: 'Uint8', },
+		{property: 'line-gap-width', multiplier: 10, type: 'Uint8', name: 'a_gapwidth', },
+		{property: 'line-offset', multiplier: 1, type: 'Int8', },
     ],
     elementArrayType: createElementArrayType()
 };
@@ -110,6 +111,7 @@ class LineBucket extends Bucket {
         const firstVertex = vertices[0],
             lastVertex = vertices[len - 1],
             closed = firstVertex.equals(lastVertex);
+
         const arrays = this.arrays;
 
         // we could be more precise, but it would only save a negligible amount of space
@@ -119,6 +121,7 @@ class LineBucket extends Bucket {
         if (len === 2 && closed) return;
 
         this.distance = 0;
+
         const beginCap = cap,
             endCap = closed ? 'butt' : cap;
         let startOfLine = true;
@@ -253,12 +256,13 @@ class LineBucket extends Bucket {
                 }
 
                 if (currentJoin === 'fakeround') {
-                        // The join angle is sharp enough that a round join would be visible.
-                        // Bevel joins fill the gap between segments with a single pie slice triangle.
-                        // Create a round join by adding multiple pie slices. The join isn't actually round, but
-                        // it looks like it is at the sizes we render lines at.
-                        // Add more triangles for sharper angles.
-                        // This math is just a good enough approximation. It isn't "correct".
+                    // The join angle is sharp enough that a round join would be visible.
+                    // Bevel joins fill the gap between segments with a single pie slice triangle.
+                    // Create a round join by adding multiple pie slices. The join isn't actually round, but
+                    // it looks like it is at the sizes we render lines at.
+
+                    // Add more triangles for sharper angles.
+                    // This math is just a good enough approximation. It isn't "correct".
                     const n = Math.floor((0.5 - (cosHalfAngle - 0.5)) * 8);
                     let approxFractionalJoinNormal;
 

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -49,7 +49,7 @@ const lineInterface = {
 		{property: 'line-opacity', multiplier:10, type: 'Uint8', },
 		{property: 'line-width', multiplier:10, type: 'Uint8', },
 		{property: 'line-gap-width', multiplier:10, type: 'Uint8', name: 'a_gapwidth', },
-		{property: 'line-offset', multiplier:10, type: 'Uint8', },
+		{property: 'line-offset', multiplier:1, type: 'Int8', },
     ],
     elementArrayType: createElementArrayType()
 };

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -5,7 +5,6 @@ const createVertexArrayType = require('../vertex_array_type');
 const createElementArrayType = require('../element_array_type');
 const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
-
 // NOTE ON EXTRUDE SCALE:
 // scale the extrusion vector so that the normal length is this value.
 // contains the "texture" normals (-1..1). this is distinct from the extrude
@@ -111,7 +110,6 @@ class LineBucket extends Bucket {
         const firstVertex = vertices[0],
             lastVertex = vertices[len - 1],
             closed = firstVertex.equals(lastVertex);
-
         const arrays = this.arrays;
 
         // we could be more precise, but it would only save a negligible amount of space
@@ -121,7 +119,6 @@ class LineBucket extends Bucket {
         if (len === 2 && closed) return;
 
         this.distance = 0;
-
         const beginCap = cap,
             endCap = closed ? 'butt' : cap;
         let startOfLine = true;
@@ -256,13 +253,12 @@ class LineBucket extends Bucket {
                 }
 
                 if (currentJoin === 'fakeround') {
-                    // The join angle is sharp enough that a round join would be visible.
-                    // Bevel joins fill the gap between segments with a single pie slice triangle.
-                    // Create a round join by adding multiple pie slices. The join isn't actually round, but
-                    // it looks like it is at the sizes we render lines at.
-
-                    // Add more triangles for sharper angles.
-                    // This math is just a good enough approximation. It isn't "correct".
+                        // The join angle is sharp enough that a round join would be visible.
+                        // Bevel joins fill the gap between segments with a single pie slice triangle.
+                        // Create a round join by adding multiple pie slices. The join isn't actually round, but
+                        // it looks like it is at the sizes we render lines at.
+                        // Add more triangles for sharper angles.
+                        // This math is just a good enough approximation. It isn't "correct".
                     const n = Math.floor((0.5 - (cosHalfAngle - 0.5)) * 8);
                     let approxFractionalJoinNormal;
 

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -45,7 +45,12 @@ const lineInterface = {
         {name: 'a_data', components: 4, type: 'Uint8'}
     ]),
     paintAttributes: [
-        {property: 'line-color', type: 'Uint8'}
+        {property: 'line-color', type: 'Uint8'},
+		{property: 'line-blur', type: 'Uint8'},
+		{property: 'line-opacity', type: 'Uint8'},
+		{property: 'line-width', type: 'Uint8'},
+		{property: 'line-gap-width', type: 'Uint8'},
+		{property: 'line-offset', type: 'Uint8'},
     ],
     elementArrayType: createElementArrayType()
 };

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -46,11 +46,11 @@ const lineInterface = {
     ]),
     paintAttributes: [
         {property: 'line-color', type: 'Uint8'},
-		{property: 'line-blur', multiplier: 10, type: 'Uint8', },
-		{property: 'line-opacity', multiplier: 10, type: 'Uint8', },
-		{property: 'line-width', multiplier: 10, type: 'Uint8', },
-		{property: 'line-gap-width', multiplier: 10, type: 'Uint8', name: 'a_gapwidth', },
-		{property: 'line-offset', multiplier: 1, type: 'Int8', },
+        {property: 'line-blur', multiplier: 10, type: 'Uint8'},
+        {property: 'line-opacity', multiplier: 10, type: 'Uint8'},
+        {property: 'line-width', multiplier: 10, type: 'Uint8'},
+        {property: 'line-gap-width', multiplier: 10, type: 'Uint8', name: 'a_gapwidth'},
+        {property: 'line-offset', multiplier: 1, type: 'Int8'},
     ],
     elementArrayType: createElementArrayType()
 };

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -45,11 +45,11 @@ const lineInterface = {
     ]),
     paintAttributes: [
         {property: 'line-color', type: 'Uint8'},
-		{property: 'line-blur', type: 'Uint8'},
-		{property: 'line-opacity', type: 'Uint8'},
-		{property: 'line-width', type: 'Uint8'},
-		{property: 'line-gap-width', type: 'Uint8'},
-		{property: 'line-offset', type: 'Uint8'},
+		{property: 'line-blur', multiplier:10, type: 'Uint8', },
+		{property: 'line-opacity', multiplier:10, type: 'Uint8', },
+		{property: 'line-width', multiplier:10, type: 'Uint8', },
+		{property: 'line-gap-width', multiplier:10, type: 'Uint8', name: 'a_gapwidth', },
+		{property: 'line-offset', multiplier:10, type: 'Uint8', },
     ],
     elementArrayType: createElementArrayType()
 };

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -105,17 +105,8 @@ function drawLineTile(program, painter, tile, buffers, layer, coord, layerData, 
             gl.uniform1f(program.u_fade, image.t);
         }
 
-        // the distance over which the line edge fades out.
-        // Retina devices need a smaller distance to avoid aliasing.
-        const antialiasing = 1 / browser.devicePixelRatio;
 
-        gl.uniform1f(program.u_linewidth, layer.paint['line-width'] / 2);
-        gl.uniform1f(program.u_gapwidth, layer.paint['line-gap-width'] / 2);
-        gl.uniform1f(program.u_antialiasing, antialiasing / 2);
-        gl.uniform1f(program.u_blur, layer.paint['line-blur'] + antialiasing);
-        gl.uniform1f(program.u_opacity, layer.paint['line-opacity']);
         gl.uniformMatrix2fv(program.u_antialiasingmatrix, false, painter.transform.lineAntialiasingMatrix);
-        gl.uniform1f(program.u_offset, -layer.paint['line-offset']);
         gl.uniform1f(program.u_extra, painter.transform.lineStretch);
     }
 

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -362,7 +362,7 @@ class Painter {
         const program = gl.createProgram();
         const definition = shaders[name];
 
-        let definesSource = '#define MAPBOX_GL_JS;\n';
+        let definesSource = `#define MAPBOX_GL_JS\n#define DEVICE_PIXEL_RATIO ${browser.devicePixelRatio.toFixed(1)}\n`;
         if (this._showOverdrawInspector) {
             definesSource += '#define OVERDRAW_INSPECTOR;\n';
         }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#0de59a02c1585ed7d2144c168961f77231793d06",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#5c89044bef42e8b557f60162b515f689e455de75",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gl-matrix": "^2.3.1",
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#5d7b99a4fd286e8b58a219a4247ca446746a462b",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#b13fc6818b647ac0b6a2255045291544ef324ade",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#512126c802dbb8f282e9826b181f0d53da00daf2",
     "mapbox-gl-supported": "^1.2.0",
     "package-json-versionify": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#066afa88372ad3882c15ad5ef2435bb526971190",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#0de59a02c1585ed7d2144c168961f77231793d06",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gl-matrix": "^2.3.1",
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#b2ba4c8299777582ae9f2df61560efc89cc15e23",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#597115a1e1bd982944b068f8accde34eada74fc2",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#512126c802dbb8f282e9826b181f0d53da00daf2",
     "mapbox-gl-supported": "^1.2.0",
     "package-json-versionify": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gl-matrix": "^2.3.1",
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#4d4ab3813274b0d2e9113f06d819e66a471df457",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#b2ba4c8299777582ae9f2df61560efc89cc15e23",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#512126c802dbb8f282e9826b181f0d53da00daf2",
     "mapbox-gl-supported": "^1.2.0",
     "package-json-versionify": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gl-matrix": "^2.3.1",
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#b13fc6818b647ac0b6a2255045291544ef324ade",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#4d4ab3813274b0d2e9113f06d819e66a471df457",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#512126c802dbb8f282e9826b181f0d53da00daf2",
     "mapbox-gl-supported": "^1.2.0",
     "package-json-versionify": "^1.0.2",


### PR DESCRIPTION
This PR adds support for line property functions

fixes #2729
## Checklist
- [x] briefly describe the changes in this PR
- [x] add support for `line-opacity` property functions
- [x] add support for `line-color` property functions
- [x] add support for `line-width` property functions
- [x] add support for `line-gap-width` property functions
- [x] add support for `line-offset` property functions
- [x] add support for `line-blur` property functions
- [x] ~~add support for `line-dasharray` property functions~~ https://github.com/mapbox/mapbox-gl-js/issues/3045
- [x] write test-suite tests for all new functionality
- [x] add `DEVICE_PIXEL_RATIO` constant to shaders on GL Native
- [x] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks)
- [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
- [ ] get a PR review :+1: / :-1:
## Related PRs
- https://github.com/mapbox/mapbox-gl-test-suite/pull/136
- https://github.com/mapbox/mapbox-gl-shaders/pull/24
