### PR TITLE
Include test for mapbox-gl module

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "lint": "eslint  --ignore-path .gitignore js test bench docs/_posts/examples/*.html",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "test-suite": "node test/render.test.js && node test/query.test.js",
-    "test": "npm run lint && tap --reporter dot test/js/*/*.js test/build/webpack.test.js"
+    "test": "npm run lint && tap --reporter dot test/js/*/*.js test/js/mapbox-gl.js test/build/webpack.test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "lint": "eslint  --ignore-path .gitignore js test bench docs/_posts/examples/*.html",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "test-suite": "node test/render.test.js && node test/query.test.js",
-    "test": "npm run lint && tap --reporter dot test/js/*/*.js test/js/mapbox-gl.js test/build/webpack.test.js"
+    "test": "npm run lint && tap --reporter dot test/js test/build/webpack.test.js"
   }
 }

--- a/test/js/mapbox-gl.js
+++ b/test/js/mapbox-gl.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tap').test;
-var mapboxgl = require('../../../js/mapbox-gl');
+var mapboxgl = require('../../js/mapbox-gl');
 
 test('mapboxgl', function(t) {
     t.test('version', function(t) {


### PR DESCRIPTION
<!--
Hello! Thanks for contributing. To help your PR be most easily reviewed, please complete
the following checklist:
-->

`test/js/mapbox-gl.js` is currently not being run by `npm test`, because it is targeting `test/js/*/*.js`.  This change adds that test file explicitly, and fixes a require path.

Note that the nature of this change is such that it will cause coveralls to report a test coverage regression.

 - [ ] get a PR review :+1: / :-1:
