### PR TITLE
Add bindPopup API to the Marker class 

### DIFF
--- a/debug/markers.html
+++ b/debug/markers.html
@@ -37,7 +37,7 @@ var map = window.map = new mapboxgl.Map({
     hash: true
 });
 
-function addRandomMarker() {
+function addRandomMarker(i) {
     var bounds = map.getBounds();
     var s = bounds.getSouth();
     var n = bounds.getNorth();
@@ -47,13 +47,14 @@ function addRandomMarker() {
     var lng = w + (e - w) * Math.random();
     var lat = s + (n - s) * Math.random();
 
+    var popupHtml = "<h1>hi html</h1>";
     var marker = new mapboxgl.Marker()
         .setLngLat([lng, lat])
+        .bindPopup(popupHtml)
         .addTo(map);
 
     marker.getElement().onclick = function(e) {
-        alert('Hello world');
-        e.stopPropagation();
+        alert('clicked me');
     };
 }
 

--- a/debug/markers.html
+++ b/debug/markers.html
@@ -37,7 +37,7 @@ var map = window.map = new mapboxgl.Map({
     hash: true
 });
 
-function addRandomMarker(i) {
+function addRandomMarker() {
     var bounds = map.getBounds();
     var s = bounds.getSouth();
     var n = bounds.getNorth();
@@ -46,11 +46,11 @@ function addRandomMarker(i) {
 
     var lng = w + (e - w) * Math.random();
     var lat = s + (n - s) * Math.random();
+    var popup = new mapboxgl.Popup().setText('hello hi');
 
-    var popupHtml = "<h1>hi html</h1>";
     var marker = new mapboxgl.Marker()
         .setLngLat([lng, lat])
-        .bindPopup(popupHtml)
+        .setPopup(popup)
         .addTo(map);
 
     marker.getElement().onclick = function(e) {
@@ -61,6 +61,7 @@ function addRandomMarker(i) {
 for (var i = 0; i < 100; i++) addRandomMarker();
 
 map.addControl(new mapboxgl.Navigation());
+
 </script>
 
 </body>

--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -5,7 +5,6 @@ module.exports = Marker;
 
 var DOM = require('../util/dom');
 var util = require('../util/util');
-var Evented = require('../util/evented');
 var LngLat = require('../geo/lng_lat');
 var Point = require('point-geometry');
 var Popup = require('./popup');
@@ -33,7 +32,7 @@ function Marker(element, options) {
     this._update = this._update.bind(this);
 }
 
-Marker.prototype = util.inherit(Evented, {
+Marker.prototype = {
     /**
      * Attaches the marker to a map
      * @param {Map} map
@@ -151,7 +150,7 @@ Marker.prototype = util.inherit(Evented, {
 
     _openPopup: function(e) {
         // prevent event from bubbling up to the map canvas
-        // e.stopPropagation();
+        e.stopPropagation();
         if (!this._popup || !this._map) return;
 
         if (!this._popup._map) {
@@ -174,4 +173,4 @@ Marker.prototype = util.inherit(Evented, {
         var pos = this._map.project(this._lngLat)._add(this._offset);
         DOM.setTransform(this._el, 'translate(' + pos.x + 'px,' + pos.y + 'px)');
     }
-});
+};

--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -4,8 +4,11 @@
 module.exports = Marker;
 
 var DOM = require('../util/dom');
+var util = require('../util/util');
+var Evented = require('../util/evented');
 var LngLat = require('../geo/lng_lat');
 var Point = require('point-geometry');
+var Popup = require('./popup');
 
 /**
  * Creates a marker component
@@ -30,7 +33,7 @@ function Marker(element, options) {
     this._update = this._update.bind(this);
 }
 
-Marker.prototype = {
+Marker.prototype = util.inherit(Evented, {
     /**
      * Attaches the marker to a map
      * @param {Map} map
@@ -59,6 +62,7 @@ Marker.prototype = {
         }
         var parent = this._el.parentNode;
         if (parent) parent.removeChild(this._el);
+        if (this._popup) this._closePopup();
         return this;
     },
 
@@ -77,6 +81,7 @@ Marker.prototype = {
      */
     setLngLat: function(lnglat) {
         this._lngLat = LngLat.convert(lnglat);
+        if (this._popup) this._popup.setLngLat(this._lngLat);
         this._update();
         return this;
     },
@@ -85,9 +90,88 @@ Marker.prototype = {
         return this._el;
     },
 
+    /**
+     * Binds a Popup to the Marker
+     * @param {HTMLElement|String|Popup} content the DOM content to appear in the popup, or 
+     *  an instance of the Popup class
+     * @param {Object} [options] options for the Popup class
+     * @param {boolean} [options.closeButton=true] If `true`, a close button will appear in the
+     *   top right corner of the popup.
+     * @param {boolean} [options.closeOnClick=true] If `true`, the popup will closed when the
+     *   map is clicked.
+     * @param {string} options.anchor - A string indicating the popup's location relative to
+     *   the coordinate set via [Popup#setLngLat](#Popup#setLngLat).
+     *   Options are `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
+     * `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
+     * @returns {Marker} `this`
+     */
+
+    bindPopup: function(content, options){
+        if (content instanceof Popup) {
+            this._popup = content;
+        } else {
+            if (!this._popup || options) {
+                this._popup = new Popup(options);
+            }
+            content instanceof HTMLElement ? this._popup.setDOMContent(content) : this._popup.setHTML(content);
+        }
+            
+        if (this._popup && this._lngLat) this._popup.setLngLat(this._lngLat);
+
+        if (!this._popupHandlersAdded) {
+            this.getElement().addEventListener('click', this._openPopup.bind(this));
+            this._popupHandlersAdded = true;
+        }
+        return this;
+    },
+
+    /**
+     * Opens or closes the bound popup, depending on the current state
+     * @returns {Marker} `this`
+     */
+    togglePopup: function(){
+        if (this._popup) {
+            if (this._popup._map){
+                this._closePopup();
+            } else {
+                this._openPopup();
+            }
+        }
+    },
+
+    /**
+     * Returns the Popup instance that is bound to the Marker
+     * @returns {Popup} popup
+     */
+    getPopup: function(){
+        if (this._popup) {
+            return this._popup;
+        }
+    },
+
+    _openPopup: function(e) {
+        // prevent event from bubbling up to the map canvas
+        // e.stopPropagation();
+        if (!this._popup || !this._map) return;
+
+        if (!this._popup._map) {
+            this._popup.addTo(this._map);
+        }
+
+        return this;
+    },
+
+    _closePopup: function(){
+        if (this._popup) {
+            this._popup.remove();
+        }
+
+        return this;
+    },
+
     _update: function() {
         if (!this._map) return;
         var pos = this._map.project(this._lngLat)._add(this._offset);
         DOM.setTransform(this._el, 'translate(' + pos.x + 'px,' + pos.y + 'px)');
     }
-};
+});

--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -38,7 +38,7 @@ Marker.prototype = {
      * @param {Map} map
      * @returns {Marker} `this`
      */
-    addTo: function(map) {
+    addTo: function (map) {
         this.remove();
         this._map = map;
         map.getCanvasContainer().appendChild(this._el);
@@ -54,7 +54,7 @@ Marker.prototype = {
      * marker.remove();
      * @returns {Marker} `this`
      */
-    remove: function() {
+    remove: function () {
         if (this._map) {
             this._map.off('move', this._update);
             this._map = null;
@@ -69,7 +69,7 @@ Marker.prototype = {
      * Get the marker's geographical location
      * @returns {LngLat}
      */
-    getLngLat: function() {
+    getLngLat: function () {
         return this._lngLat;
     },
 
@@ -78,43 +78,35 @@ Marker.prototype = {
      * @param {LngLat} lnglat
      * @returns {Marker} `this`
      */
-    setLngLat: function(lnglat) {
+    setLngLat: function (lnglat) {
         this._lngLat = LngLat.convert(lnglat);
         if (this._popup) this._popup.setLngLat(this._lngLat);
         this._update();
         return this;
     },
 
-    getElement: function() {
+    getElement: function () {
         return this._el;
     },
 
     /**
      * Binds a Popup to the Marker
-     * @param {HTMLElement|String|Popup} content the DOM content to appear in the popup, or 
-     *  an instance of the Popup class
-     * @param {Object} [options] options for the Popup class
-     * @param {boolean} [options.closeButton=true] If `true`, a close button will appear in the
-     *   top right corner of the popup.
-     * @param {boolean} [options.closeOnClick=true] If `true`, the popup will closed when the
-     *   map is clicked.
-     * @param {string} options.anchor - A string indicating the popup's location relative to
-     *   the coordinate set via [Popup#setLngLat](#Popup#setLngLat).
-     *   Options are `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
-     * `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
+     * @param {Popup=} popup an instance of the `Popup` class. If undefined or null, any popup 
+     * set on this `Marker` instance is unset
      * @returns {Marker} `this`
      */
 
-    bindPopup: function(content, options){
-        if (content instanceof Popup) {
-            this._popup = content;
+    setPopup: function (popup) {
+        if (popup == null) {
+            this._closePopup();
+            delete this._popupHandlersAdded;
+            delete this._popup;
+        } else if (popup instanceof Popup) {
+            this._popup = popup;
         } else {
-            if (!this._popup || options) {
-                this._popup = new Popup(options);
-            }
-            content instanceof HTMLElement ? this._popup.setDOMContent(content) : this._popup.setHTML(content);
+            util.warnOnce('Marker.setPopup only accepts an instance of the Popup class as an argument. If no argument is provided, the popup is unset from this Marker instance');
         }
-            
+
         if (this._popup && this._lngLat) this._popup.setLngLat(this._lngLat);
 
         if (!this._popupHandlersAdded) {
@@ -125,12 +117,20 @@ Marker.prototype = {
     },
 
     /**
+     * Returns the Popup instance that is bound to the Marker
+     * @returns {Popup} popup
+     */
+    getPopup: function () {
+        return this._popup;
+    },
+
+    /**
      * Opens or closes the bound popup, depending on the current state
      * @returns {Marker} `this`
      */
-    togglePopup: function(){
+    togglePopup: function () {
         if (this._popup) {
-            if (this._popup._map){
+            if (this._popup._map) {
                 this._closePopup();
             } else {
                 this._openPopup();
@@ -138,32 +138,10 @@ Marker.prototype = {
         }
     },
 
-    /**
-     * Returns the Popup instance that is bound to the Marker
-     * @returns {Popup} popup
-     */
-    getPopup: function(){
-        if (this._popup) {
-            return this._popup;
-        }
-    },
-
-    /**
-     * Unbinds a Popup from the Marker instance
-     * Returns the Popup instance that was bound to the Marker
-     * @returns {Popup} popup
-     */
-    unbindPopup: function(){
-        this._closePopup();
-        var popup = this._popup;
-        delete this._popupHandlersAdded;
-        delete this._popup;
-        return popup;
-    },
-
-    _openPopup: function(e) {
+    _openPopup: function (e) {
         // prevent event from bubbling up to the map canvas
         e.stopPropagation();
+
         if (!this._popup || !this._map) return;
 
         if (!this._popup._map) {
@@ -173,7 +151,7 @@ Marker.prototype = {
         return this;
     },
 
-    _closePopup: function(){
+    _closePopup: function () {
         if (this._popup) {
             this._popup.remove();
         }
@@ -181,9 +159,10 @@ Marker.prototype = {
         return this;
     },
 
-    _update: function() {
+    _update: function () {
         if (!this._map) return;
         var pos = this._map.project(this._lngLat)._add(this._offset);
         DOM.setTransform(this._el, 'translate(' + pos.x + 'px,' + pos.y + 'px)');
     }
 };
+

--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -148,6 +148,19 @@ Marker.prototype = {
         }
     },
 
+    /**
+     * Unbinds a Popup from the Marker instance
+     * Returns the Popup instance that was bound to the Marker
+     * @returns {Popup} popup
+     */
+    unbindPopup: function(){
+        this._closePopup();
+        var popup = this._popup;
+        delete this._popupHandlersAdded;
+        delete this._popup;
+        return popup;
+    },
+
     _openPopup: function(e) {
         // prevent event from bubbling up to the map canvas
         e.stopPropagation();

--- a/js/util/dom.js
+++ b/js/util/dom.js
@@ -2,12 +2,15 @@
 
 exports.create = function (tagName, className, container) {
     return {
-        offsetWidth: container.offsetWidth,
-        offsetHeight: container.offsetHeight,
+        offsetWidth: container ? container.offsetWidth : null,
+        offsetHeight: container ? container.offsetHeight : null,
         remove: function () {},
         addEventListener: function() {},
         classList: {
             add: function () {}
-        }
+        },
+        appendChild: function () {}
     };
 };
+
+exports.setTransform = function() {};

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "highlight.js": "9.3.0",
     "istanbul": "^0.4.2",
     "jsdom": "^9.4.2",
+    "jsdom-global": "^2.1.0",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3e36b193a0c442a3fd863119f101afa6db97b32d",
@@ -94,15 +95,12 @@
     "build-token": "browserify debug/access-token.js --debug --transform envify > debug/access-token-generated.js",
     "watch-bench": "node bench/download-data.js && watchify bench/index.js --plugin [minifyify --no-map] --transform [babelify --presets react] --transform unassertify --transform envify --outfile bench/index-generated.js --verbose",
     "start-server": "st --no-cache --localhost --port 9966 --index index.html .",
-
     "start": "run-p build-token watch-dev watch-bench start-server",
     "start-debug": "run-p build-token watch-dev start-server",
     "start-bench": "run-p build-token watch-bench start-server",
-
     "build-docs": "documentation build --github --format html --config documentation.yml --theme ./docs/_theme --output docs/api/",
     "build": "npm run build-docs # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve --watch",
-    
     "lint": "eslint  --ignore-path .gitignore js test bench docs/_posts/examples/*.html",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "test-suite": "node test/render.test.js && node test/query.test.js",

--- a/package.json
+++ b/package.json
@@ -94,12 +94,15 @@
     "build-token": "browserify debug/access-token.js --debug --transform envify > debug/access-token-generated.js",
     "watch-bench": "node bench/download-data.js && watchify bench/index.js --plugin [minifyify --no-map] --transform [babelify --presets react] --transform unassertify --transform envify --outfile bench/index-generated.js --verbose",
     "start-server": "st --no-cache --localhost --port 9966 --index index.html .",
+
     "start": "run-p build-token watch-dev watch-bench start-server",
     "start-debug": "run-p build-token watch-dev start-server",
     "start-bench": "run-p build-token watch-bench start-server",
+
     "build-docs": "documentation build --github --format html --config documentation.yml --theme ./docs/_theme --output docs/api/",
     "build": "npm run build-docs # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve --watch",
+    
     "lint": "eslint  --ignore-path .gitignore js test bench docs/_posts/examples/*.html",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "test-suite": "node test/render.test.js && node test/query.test.js",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "handlebars": "4.0.5",
     "highlight.js": "9.3.0",
     "istanbul": "^0.4.2",
+    "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3e36b193a0c442a3fd863119f101afa6db97b32d",
@@ -93,15 +94,12 @@
     "build-token": "browserify debug/access-token.js --debug --transform envify > debug/access-token-generated.js",
     "watch-bench": "node bench/download-data.js && watchify bench/index.js --plugin [minifyify --no-map] --transform [babelify --presets react] --transform unassertify --transform envify --outfile bench/index-generated.js --verbose",
     "start-server": "st --no-cache --localhost --port 9966 --index index.html .",
-
     "start": "run-p build-token watch-dev watch-bench start-server",
     "start-debug": "run-p build-token watch-dev start-server",
     "start-bench": "run-p build-token watch-bench start-server",
-
     "build-docs": "documentation build --github --format html --config documentation.yml --theme ./docs/_theme --output docs/api/",
     "build": "npm run build-docs # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve --watch",
-
     "lint": "eslint  --ignore-path .gitignore js test bench docs/_posts/examples/*.html",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "test-suite": "node test/render.test.js && node test/query.test.js",

--- a/test/js/ui/marker.test.js
+++ b/test/js/ui/marker.test.js
@@ -75,14 +75,28 @@ test('Marker', function (t) {
         var marker = new Marker(el).setLngLat([-77.01866, 38.888]).addTo(map);
         marker.bindPopup(popup);
         t.ok(marker.getPopup() instanceof Popup, 'popup created with Popup instance');
+        marker.unbindPopup();
 
         marker.bindPopup('<h1>pop</h1>');
         t.ok(marker.getPopup() instanceof Popup, 'popup created with HTML string');
+        marker.unbindPopup();
 
         el.text = 'pop pop';
         marker.bindPopup(el);
         t.ok(marker.getPopup() instanceof Popup, 'popup created with HTMLElement');
 
+        t.end();
+    });
+
+    t.test('popups can be unbound from a marker instance', function (t) {
+        prepareDOM();
+        var map = createMap();
+        var el = document.createElement('div');
+        var marker = new Marker(el).setLngLat([-77.01866, 38.888]).addTo(map);
+        marker.bindPopup('<h1>pop</h1>');
+        t.ok(marker.getPopup() instanceof Popup);
+        t.deepEqual(marker.getPopup(), marker.unbindPopup(), 'Marker.unbindPopup returns previously bound popup');
+        t.ok(!marker.getPopup(), 'Marker.unbindPopup successfully removes Popup instance from Marker instance');
         t.end();
     });
 

--- a/test/js/ui/marker.test.js
+++ b/test/js/ui/marker.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var test = require('tap').test;
+var jsdom = require('jsdom');
+
+var extend = require('../../../js/util/util').extend;
+var Map = require('../../../js/ui/map');
+var Marker = require('../../../js/ui/marker');
+var Popup = require('../../../js/ui/popup');
+
+function prepareDOM(html) {
+    html = html || '<!doctype html><html><body><div id="map"></div></body></html>';
+    if (typeof document !== 'undefined') {
+        return;
+    }
+    global.document = jsdom.jsdom(html);
+    global.window = global.document.defaultView;
+    global.navigator = {
+        userAgent: 'JSDOM'
+    };
+    global.HTMLElement = global.window.HTMLElement;
+
+}
+
+function createMap(options, callback) {
+    var map = new Map(extend({
+        container: 'map',
+        attributionControl: false,
+        trackResize: true,
+        style: {
+            "version": 8,
+            "sources": {},
+            "layers": []
+        }
+    }, options));
+
+    if (callback) map.on('load', function () {
+        callback(null, map);
+    });
+
+    return map;
+}
+
+
+
+test('Marker', function (t) {
+    t.test('constructor', function (t) {
+        prepareDOM();
+        var el = document.createElement('div');
+        var marker = new Marker(el);
+        t.ok(marker.getElement(), 'marker element is created');
+        t.end();
+    });
+
+    t.test('marker is added to map', function (t) {
+        prepareDOM();
+        var map = createMap();
+        var el = document.createElement('div');
+
+        map.on('load', function () {
+            var marker = new Marker(el).setLngLat([-77.01866, 38.888]);
+            t.ok(marker.addTo(map) instanceof Marker, 'marker.addTo(map) returns Marker instance');
+            t.ok(marker._map, 'marker instance is bound to map instance');
+            t.end();
+        });
+
+
+    });
+
+    t.test('popups can be bound to marker instance', function (t) {
+        prepareDOM();
+        var map = createMap();
+        var el = document.createElement('div');
+        var popup = new Popup();
+        var marker = new Marker(el).setLngLat([-77.01866, 38.888]).addTo(map);
+        marker.bindPopup(popup);
+        t.ok(marker.getPopup() instanceof Popup, 'popup created with Popup instance');
+
+        marker.bindPopup('<h1>pop</h1>');
+        t.ok(marker.getPopup() instanceof Popup, 'popup created with HTML string');
+
+        el.text = 'pop pop';
+        marker.bindPopup(el);
+        t.ok(marker.getPopup() instanceof Popup, 'popup created with HTMLElement');
+
+        t.end();
+    });
+
+    t.end();
+});
+


### PR DESCRIPTION
<!--
Hello! Thanks for contributing. To help your PR be most easily reviewed, please complete
the following checklist:
-->

This PR introduces methods for using `Popup`s in conjunction with `Marker`s and is not-so-loosely based on [Leaflet's API of the same name](http://leafletjs.com/reference.html#marker-bindpopup). 

Also includes the first DOM tests in the gl-js unit test suite using [`jsdom`](https://github.com/tmpvar/jsdom). I had to make some changes to `js/util/dom` in order for the tests to complete without errors, but there might be other workarounds using jsdom that I'm not aware of. 

Provides a fix for the problem of adding a `Popup`on a `click` event to a `Marker` with the current API -- the Popup is created and then immediately destroyed unless you have `Popup.closeOnClick: false` because the click event bubbles up to the map canvas. Related discussion at #2931 

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] [document any changes or additions to public APIs](https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md)
 - [ ] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks)
 - [ ] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [ ] get a PR review :+1: / :-1:
