### PR TITLE
Eliminate use of browser globals, introduce jsdom in test environment

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "space-before-function-paren": "off",
   },
   "env": {
-    "es6": true
+    "es6": true,
+    "browser": false
   }
 }

--- a/bench/.eslintrc
+++ b/bench/.eslintrc
@@ -7,5 +7,8 @@
   "globals": {
     "React": false,
     "ReactDOM": false
+  },
+  "env": {
+    "browser": true
   }
 }

--- a/docs/_posts/examples/.eslintrc
+++ b/docs/_posts/examples/.eslintrc
@@ -1,13 +1,16 @@
 {
-    "plugins": ["html"],
-    "globals": {
-        "mapboxgl": true,
-        "turf": true,
-        "d3": true
-    },
-    "rules": {
-        "strict": "off",
-        "no-unused-vars": ["error", {varsIgnorePattern: "map|popup"}],
-        "no-loop-func": "off"
-    }
+  "plugins": ["html"],
+  "globals": {
+    "mapboxgl": true,
+    "turf": true,
+    "d3": true
+  },
+  "rules": {
+    "strict": "off",
+    "no-unused-vars": ["error", {varsIgnorePattern: "map|popup"}],
+    "no-loop-func": "off"
+  },
+  "env": {
+    "browser": true
+  }
 }

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -2,7 +2,7 @@
 
 var Evented = require('../util/evented');
 var util = require('../util/util');
-var urlResolve = require('resolve-url');
+var window = require('../util/window');
 var EXTENT = require('../data/bucket').EXTENT;
 
 module.exports = GeoJSONSource;
@@ -150,7 +150,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
         var options = util.extend({}, this.workerOptions);
         var data = this._data;
         if (typeof data === 'string') {
-            options.url = typeof window != 'undefined' ? urlResolve(window.location.href, data) : data;
+            options.url = resolveURL(data);
         } else {
             options.data = JSON.stringify(data);
         }
@@ -220,3 +220,9 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
         };
     }
 });
+
+function resolveURL(url) {
+    var a = window.document.createElement('a');
+    a.href = url;
+    return a.href;
+}

--- a/js/ui/control/geolocate.js
+++ b/js/ui/control/geolocate.js
@@ -4,6 +4,7 @@ var Control = require('./control');
 var browser = require('../../util/browser');
 var DOM = require('../../util/dom');
 var util = require('../../util/util');
+var window = require('../../util/window');
 
 module.exports = Geolocate;
 
@@ -48,7 +49,7 @@ Geolocate.prototype = util.inherit(Control, {
     },
 
     _onClickGeolocate: function() {
-        navigator.geolocation.getCurrentPosition(this._success.bind(this), this._error.bind(this), geoOptions);
+        window.navigator.geolocation.getCurrentPosition(this._success.bind(this), this._error.bind(this), geoOptions);
 
         // This timeout ensures that we still call finish() even if
         // the user declines to share their location in Firefox

--- a/js/ui/control/navigation.js
+++ b/js/ui/control/navigation.js
@@ -3,6 +3,7 @@
 var Control = require('./control');
 var DOM = require('../../util/dom');
 var util = require('../../util/util');
+var window = require('../../util/window');
 
 module.exports = Navigation;
 
@@ -58,8 +59,8 @@ Navigation.prototype = util.inherit(Control, {
         if (e.button !== 0) return;
 
         DOM.disableDrag();
-        document.addEventListener('mousemove', this._onCompassMove);
-        document.addEventListener('mouseup', this._onCompassUp);
+        window.document.addEventListener('mousemove', this._onCompassMove);
+        window.document.addEventListener('mouseup', this._onCompassUp);
 
         this._el.dispatchEvent(copyMouseEvent(e));
         e.stopPropagation();
@@ -75,8 +76,8 @@ Navigation.prototype = util.inherit(Control, {
     _onCompassUp: function(e) {
         if (e.button !== 0) return;
 
-        document.removeEventListener('mousemove', this._onCompassMove);
-        document.removeEventListener('mouseup', this._onCompassUp);
+        window.document.removeEventListener('mousemove', this._onCompassMove);
+        window.document.removeEventListener('mouseup', this._onCompassUp);
         DOM.enableDrag();
 
         this._el.dispatchEvent(copyMouseEvent(e));
@@ -98,7 +99,7 @@ Navigation.prototype = util.inherit(Control, {
 
 
 function copyMouseEvent(e) {
-    return new MouseEvent(e.type, {
+    return new window.MouseEvent(e.type, {
         button: 2,    // right click
         buttons: 2,   // right click
         bubbles: true,

--- a/js/ui/handler/box_zoom.js
+++ b/js/ui/handler/box_zoom.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var DOM = require('../../util/dom'),
-    LngLatBounds = require('../../geo/lng_lat_bounds'),
-    util = require('../../util/util');
+var DOM = require('../../util/dom');
+var LngLatBounds = require('../../geo/lng_lat_bounds');
+var util = require('../../util/util');
+var window = require('../../util/window');
 
 module.exports = BoxZoomHandler;
 
@@ -71,9 +72,9 @@ BoxZoomHandler.prototype = {
     _onMouseDown: function (e) {
         if (!(e.shiftKey && e.button === 0)) return;
 
-        document.addEventListener('mousemove', this._onMouseMove, false);
-        document.addEventListener('keydown', this._onKeyDown, false);
-        document.addEventListener('mouseup', this._onMouseUp, false);
+        window.document.addEventListener('mousemove', this._onMouseMove, false);
+        window.document.addEventListener('keydown', this._onKeyDown, false);
+        window.document.addEventListener('mouseup', this._onMouseUp, false);
 
         DOM.disableDrag();
         this._startPos = DOM.mousePos(this._el, e);
@@ -129,9 +130,9 @@ BoxZoomHandler.prototype = {
     _finish: function () {
         this._active = false;
 
-        document.removeEventListener('mousemove', this._onMouseMove, false);
-        document.removeEventListener('keydown', this._onKeyDown, false);
-        document.removeEventListener('mouseup', this._onMouseUp, false);
+        window.document.removeEventListener('mousemove', this._onMouseMove, false);
+        window.document.removeEventListener('keydown', this._onKeyDown, false);
+        window.document.removeEventListener('mouseup', this._onMouseUp, false);
 
         this._container.classList.remove('mapboxgl-crosshair');
 

--- a/js/ui/handler/drag_pan.js
+++ b/js/ui/handler/drag_pan.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var DOM = require('../../util/dom'),
-    util = require('../../util/util');
+var DOM = require('../../util/dom');
+var util = require('../../util/util');
+var window = require('../../util/window');
 
 module.exports = DragPanHandler;
 
@@ -79,11 +80,11 @@ DragPanHandler.prototype = {
         if (this.isActive()) return;
 
         if (e.touches) {
-            document.addEventListener('touchmove', this._onMove);
-            document.addEventListener('touchend', this._onTouchEnd);
+            window.document.addEventListener('touchmove', this._onMove);
+            window.document.addEventListener('touchend', this._onTouchEnd);
         } else {
-            document.addEventListener('mousemove', this._onMove);
-            document.addEventListener('mouseup', this._onMouseUp);
+            window.document.addEventListener('mousemove', this._onMove);
+            window.document.addEventListener('mouseup', this._onMouseUp);
         }
 
         this._active = false;
@@ -166,15 +167,15 @@ DragPanHandler.prototype = {
     _onMouseUp: function (e) {
         if (this._ignoreEvent(e)) return;
         this._onUp(e);
-        document.removeEventListener('mousemove', this._onMove);
-        document.removeEventListener('mouseup', this._onMouseUp);
+        window.document.removeEventListener('mousemove', this._onMove);
+        window.document.removeEventListener('mouseup', this._onMouseUp);
     },
 
     _onTouchEnd: function (e) {
         if (this._ignoreEvent(e)) return;
         this._onUp(e);
-        document.removeEventListener('touchmove', this._onMove);
-        document.removeEventListener('touchend', this._onTouchEnd);
+        window.document.removeEventListener('touchmove', this._onMove);
+        window.document.removeEventListener('touchend', this._onTouchEnd);
     },
 
     _fireEvent: function (type, e) {

--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var DOM = require('../../util/dom'),
-    Point = require('point-geometry'),
-    util = require('../../util/util');
+var DOM = require('../../util/dom');
+var Point = require('point-geometry');
+var util = require('../../util/util');
+var window = require('../../util/window');
 
 module.exports = DragRotateHandler;
 
@@ -81,8 +82,8 @@ DragRotateHandler.prototype = {
         if (this._ignoreEvent(e)) return;
         if (this.isActive()) return;
 
-        document.addEventListener('mousemove', this._onMove);
-        document.addEventListener('mouseup', this._onUp);
+        window.document.addEventListener('mousemove', this._onMove);
+        window.document.addEventListener('mouseup', this._onUp);
 
         this._active = false;
         this._inertia = [[Date.now(), this._map.getBearing()]];
@@ -134,8 +135,8 @@ DragRotateHandler.prototype = {
 
     _onUp: function (e) {
         if (this._ignoreEvent(e)) return;
-        document.removeEventListener('mousemove', this._onMove);
-        document.removeEventListener('mouseup', this._onUp);
+        window.document.removeEventListener('mousemove', this._onMove);
+        window.document.removeEventListener('mouseup', this._onUp);
 
         if (!this.isActive()) return;
 

--- a/js/ui/handler/scroll_zoom.js
+++ b/js/ui/handler/scroll_zoom.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var DOM = require('../../util/dom'),
-    browser = require('../../util/browser'),
-    util = require('../../util/util');
+var DOM = require('../../util/dom');
+var util = require('../../util/util');
+var browser = require('../../util/browser');
+var window = require('../../util/window');
 
 module.exports = ScrollZoomHandler;
 
 
-var ua = typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : '',
+var ua = window.navigator.userAgent.toLowerCase(),
     firefox = ua.indexOf('firefox') !== -1,
     safari = ua.indexOf('safari') !== -1 && ua.indexOf('chrom') === -1;
 

--- a/js/ui/handler/touch_zoom_rotate.js
+++ b/js/ui/handler/touch_zoom_rotate.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var DOM = require('../../util/dom'),
-    util = require('../../util/util');
+var DOM = require('../../util/dom');
+var util = require('../../util/util');
+var window = require('../../util/window');
 
 module.exports = TouchZoomRotateHandler;
 
@@ -98,8 +99,8 @@ TouchZoomRotateHandler.prototype = {
         this._gestureIntent = undefined;
         this._inertia = [];
 
-        document.addEventListener('touchmove', this._onMove, false);
-        document.addEventListener('touchend', this._onEnd, false);
+        window.document.addEventListener('touchmove', this._onMove, false);
+        window.document.addEventListener('touchend', this._onEnd, false);
     },
 
     _onMove: function (e) {
@@ -152,8 +153,8 @@ TouchZoomRotateHandler.prototype = {
     },
 
     _onEnd: function (e) {
-        document.removeEventListener('touchmove', this._onMove);
-        document.removeEventListener('touchend', this._onEnd);
+        window.document.removeEventListener('touchmove', this._onMove);
+        window.document.removeEventListener('touchend', this._onEnd);
         this._drainInertiaBuffer();
 
         var inertia = this._inertia,

--- a/js/ui/hash.js
+++ b/js/ui/hash.js
@@ -10,6 +10,7 @@
 module.exports = Hash;
 
 var util = require('../util/util');
+var window = require('../util/window');
 
 function Hash() {
     util.bindAll([
@@ -45,7 +46,7 @@ Hash.prototype = {
     },
 
     _onHashChange: function() {
-        var loc = location.hash.replace('#', '').split('/');
+        var loc = window.location.hash.replace('#', '').split('/');
         if (loc.length >= 3) {
             this._map.jumpTo({
                 center: [+loc[2], +loc[1]],

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -133,7 +133,7 @@ var Map = module.exports = function(options) {
     this._bearingSnap = options.bearingSnap;
 
     if (typeof options.container === 'string') {
-        this._container = document.getElementById(options.container);
+        this._container = window.document.getElementById(options.container);
     } else {
         this._container = options.container;
     }

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -7,6 +7,7 @@ var Evented = require('../util/evented');
 var DOM = require('../util/dom');
 var LngLat = require('../geo/lng_lat');
 var Point = require('point-geometry');
+var window = require('../util/window');
 
 /**
  * A popup component.
@@ -140,7 +141,7 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
      *   .addTo(map);
      */
     setText: function(text) {
-        return this.setDOMContent(document.createTextNode(text));
+        return this.setDOMContent(window.document.createTextNode(text));
     },
 
     /**
@@ -150,8 +151,8 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
      * @returns {Popup} `this`
      */
     setHTML: function(html) {
-        var frag = document.createDocumentFragment();
-        var temp = document.createElement('body'), child;
+        var frag = window.document.createDocumentFragment();
+        var temp = window.document.createElement('body'), child;
         temp.innerHTML = html;
         while (true) {
             child = temp.firstChild;
@@ -169,7 +170,7 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
      * @returns {Popup} `this`
      * @example
      * // create an element with the popup content
-     * var div = document.createElement('div');
+     * var div = window.document.createElement('div');
      * div.innerHTML = 'Hello, world!';
      * var popup = new mapboxgl.Popup()
      *   .setLngLat(e.lngLat)

--- a/js/util/browser.js
+++ b/js/util/browser.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var window = require('./window');
+
+exports.window = window;
+exports.document = window.document;
 /*
  * When browserify builds Mapbox GL JS, it redirects all require() statements
  * from this file, js/util/browser.js, to js/util/browser/browser.js.
@@ -8,13 +12,6 @@
  * is comfortable running under node.js, which is why it's the default require:
  * it's used for tests.
  */
-
-var window = {
-    addEventListener: function() {},
-    removeEventListener: function() {}
-};
-
-exports.window = window;
 
 exports.frame = function(fn) {
     return setImmediate(fn);

--- a/js/util/browser/ajax.js
+++ b/js/util/browser/ajax.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var window = require('./window');
+
 exports.getJSON = function(url, callback) {
-    var xhr = new XMLHttpRequest();
+    var xhr = new window.XMLHttpRequest();
     xhr.open('GET', url, true);
     xhr.setRequestHeader('Accept', 'application/json');
     xhr.onerror = function(e) {
@@ -25,7 +27,7 @@ exports.getJSON = function(url, callback) {
 };
 
 exports.getArrayBuffer = function(url, callback) {
-    var xhr = new XMLHttpRequest();
+    var xhr = new window.XMLHttpRequest();
     xhr.open('GET', url, true);
     xhr.responseType = 'arraybuffer';
     xhr.onerror = function(e) {
@@ -43,23 +45,23 @@ exports.getArrayBuffer = function(url, callback) {
 };
 
 function sameOrigin(url) {
-    var a = document.createElement('a');
+    var a = window.document.createElement('a');
     a.href = url;
-    return a.protocol === document.location.protocol && a.host === document.location.host;
+    return a.protocol === window.document.location.protocol && a.host === window.document.location.host;
 }
 
 exports.getImage = function(url, callback) {
     return exports.getArrayBuffer(url, function(err, imgData) {
         if (err) return callback(err);
-        var img = new Image();
+        var img = new window.Image();
         img.onload = function() {
             callback(null, img);
             (window.URL || window.webkitURL).revokeObjectURL(img.src);
         };
-        var blob = new Blob([new Uint8Array(imgData)], { type: 'image/png' });
+        var blob = new window.Blob([new Uint8Array(imgData)], { type: 'image/png' });
         img.src = (window.URL || window.webkitURL).createObjectURL(blob);
         img.getData = function() {
-            var canvas = document.createElement('canvas');
+            var canvas = window.document.createElement('canvas');
             var context = canvas.getContext('2d');
             canvas.width = img.width;
             canvas.height = img.height;
@@ -71,12 +73,12 @@ exports.getImage = function(url, callback) {
 };
 
 exports.getVideo = function(urls, callback) {
-    var video = document.createElement('video');
+    var video = window.document.createElement('video');
     video.onloadstart = function() {
         callback(null, video);
     };
     for (var i = 0; i < urls.length; i++) {
-        var s = document.createElement('source');
+        var s = window.document.createElement('source');
         if (!sameOrigin(urls[i])) {
             video.crossOrigin = 'Anonymous';
         }

--- a/js/util/browser/browser.js
+++ b/js/util/browser/browser.js
@@ -7,7 +7,10 @@
  * @private
  */
 
+var window = require('./window');
+
 exports.window = window;
+exports.document = window.document;
 
 /**
  * Provides a function that outputs milliseconds: either performance.now()
@@ -76,7 +79,7 @@ exports.timed = function (fn, dur, ctx) {
  */
 exports.supported = require('mapbox-gl-supported');
 
-exports.hardwareConcurrency = navigator.hardwareConcurrency || 4;
+exports.hardwareConcurrency = window.navigator.hardwareConcurrency || 4;
 
 Object.defineProperty(exports, 'devicePixelRatio', {
     get: function() { return window.devicePixelRatio; }
@@ -84,10 +87,10 @@ Object.defineProperty(exports, 'devicePixelRatio', {
 
 exports.supportsWebp = false;
 
-var webpImgTest = document.createElement('img');
+var webpImgTest = window.document.createElement('img');
 webpImgTest.onload = function() {
     exports.supportsWebp = true;
 };
 webpImgTest.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';
 
-exports.supportsGeolocation = !!navigator.geolocation;
+exports.supportsGeolocation = !!window.navigator.geolocation;

--- a/js/util/browser/canvas.js
+++ b/js/util/browser/canvas.js
@@ -2,11 +2,12 @@
 
 var util = require('../util');
 var isSupported = require('mapbox-gl-supported');
+var window = require('./window');
 
 module.exports = Canvas;
 
 function Canvas(parent, container) {
-    this.canvas = document.createElement('canvas');
+    this.canvas = window.document.createElement('canvas');
 
     if (parent && container) {
         this.canvas.style.position = 'absolute';

--- a/js/util/browser/dom.js
+++ b/js/util/browser/dom.js
@@ -1,15 +1,16 @@
 'use strict';
 
 var Point = require('point-geometry');
+var window = require('./window');
 
 exports.create = function (tagName, className, container) {
-    var el = document.createElement(tagName);
+    var el = window.document.createElement(tagName);
     if (className) el.className = className;
     if (container) container.appendChild(el);
     return el;
 };
 
-var docStyle = document.documentElement.style;
+var docStyle = window.document.documentElement.style;
 
 function testProp(props) {
     for (var i = 0; i < props.length; i++) {

--- a/js/util/browser/window.js
+++ b/js/util/browser/window.js
@@ -1,0 +1,4 @@
+'use strict';
+
+/* eslint-env browser */
+module.exports = window;

--- a/js/util/window.js
+++ b/js/util/window.js
@@ -1,0 +1,4 @@
+'use strict';
+
+var jsdom = require('jsdom');
+module.exports = jsdom.jsdom().defaultView;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "point-geometry": "^0.0.0",
     "quickselect": "^1.0.0",
     "request": "^2.39.0",
-    "resolve-url": "^0.2.1",
     "shelf-pack": "^1.0.0",
     "supercluster": "^2.0.1",
     "tinyqueue": "^1.1.0",
@@ -59,7 +58,6 @@
     "highlight.js": "9.3.0",
     "istanbul": "^0.4.2",
     "jsdom": "^9.4.2",
-    "jsdom-global": "^2.1.0",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3e36b193a0c442a3fd863119f101afa6db97b32d",
@@ -84,6 +82,7 @@
   "browser": {
     "./js/util/ajax.js": "./js/util/browser/ajax.js",
     "./js/util/browser.js": "./js/util/browser/browser.js",
+    "./js/util/window.js": "./js/util/browser/window.js",
     "./js/util/canvas.js": "./js/util/browser/canvas.js",
     "./js/util/dom.js": "./js/util/browser/dom.js",
     "./js/util/web_worker.js": "./js/util/browser/web_worker.js"

--- a/test/js/ui/marker.test.js
+++ b/test/js/ui/marker.test.js
@@ -1,24 +1,22 @@
 'use strict';
 
 var test = require('tap').test;
-var jsdomGlobal = require('jsdom-global');
-
 var extend = require('../../../js/util/util').extend;
+var window = require('../../../js/util/window');
 var Map = require('../../../js/ui/map');
 var Marker = require('../../../js/ui/marker');
 var Popup = require('../../../js/ui/popup');
 
-function prepareDOM() {
-    var cleanup = jsdomGlobal();
-    var mapdiv = document.createElement('div');
-    mapdiv.id = "map";
-    document.body.appendChild(mapdiv);
-    return cleanup;
-}
-
 function createMap(options, callback) {
     var map = new Map(extend({
-        container: 'map',
+        container: {
+            offsetWidth: 200,
+            offsetHeight: 200,
+            classList: {
+                add: function() {},
+                remove: function() {}
+            }
+        },
         attributionControl: false,
         trackResize: true,
         style: {
@@ -35,56 +33,45 @@ function createMap(options, callback) {
     return map;
 }
 
-
-
 test('Marker', function (t) {
     t.test('constructor', function (t) {
-        var cleanup = prepareDOM();
-        var el = document.createElement('div');
+        var el = window.document.createElement('div');
         var marker = new Marker(el);
         t.ok(marker.getElement(), 'marker element is created');
-        cleanup();
         t.end();
     });
 
     t.test('marker is added to map', function (t) {
-        var cleanup = prepareDOM();
         var map = createMap();
-        var el = document.createElement('div');
+        var el = window.document.createElement('div');
         map.on('load', function () {
             var marker = new Marker(el).setLngLat([-77.01866, 38.888]);
             t.ok(marker.addTo(map) instanceof Marker, 'marker.addTo(map) returns Marker instance');
             t.ok(marker._map, 'marker instance is bound to map instance');
-            cleanup();
             t.end();
         });
     });
 
     t.test('popups can be bound to marker instance', function (t) {
-        var cleanup = prepareDOM();
         var map = createMap();
-        var el = document.createElement('div');
+        var el = window.document.createElement('div');
         var popup = new Popup();
         var marker = new Marker(el).setLngLat([-77.01866, 38.888]).addTo(map);
         marker.setPopup(popup);
         t.ok(marker.getPopup() instanceof Popup, 'popup created with Popup instance');
-        cleanup();
         t.end();
     });
 
     t.test('popups can be unbound from a marker instance', function (t) {
-        var cleanup = prepareDOM();
         var map = createMap();
-        var el = document.createElement('div');
+        var el = window.document.createElement('div');
         var marker = new Marker(el).setLngLat([-77.01866, 38.888]).addTo(map);
         marker.setPopup(new Popup());
         t.ok(marker.getPopup() instanceof Popup);
         t.ok(marker.setPopup() instanceof Marker, 'passing no argument to Marker.setPopup() is valid');
         t.ok(!marker.getPopup(), 'Calling setPopup with no argument successfully removes Popup instance from Marker instance');
         t.end();
-        cleanup();
     });
 
     t.end();
 });
-


### PR DESCRIPTION
This PR proxies all access to browser globals through a new `js/util/window` module. In the browser this module exports `window` normally. In the testing environment `window` is provided by jsdom. 

jsdom is a lightweight solution for DOM testing compared to Selenium. I have used it on other projects at Mapbox and found it to be stable, complete, and only slightly quirky. 

With this change we will be able to begin writing tests for interaction handlers, UI controls and `js/util/browser`. #1550 

Related to #3056 

cc @mollymerp @jfirebaugh @mourner @mapsam 