### PR TITLE
rawTileData cleanup

### DIFF
--- a/bench/benchmarks/buffer.js
+++ b/bench/benchmarks/buffer.js
@@ -157,7 +157,7 @@ function runSample(stylesheet, getGlyphs, getIcons, getTile, callback) {
 
         getTile(url, function(err, response) {
             if (err) throw err;
-            var data = new VT.VectorTile(new Protobuf(new Uint8Array(response)));
+            var data = new VT.VectorTile(new Protobuf(response));
             workerTile.parse(data, layerFamilies, actor, function(err) {
                 if (err) return callback(err);
                 eachCallback();

--- a/bench/benchmarks/buffer.js
+++ b/bench/benchmarks/buffer.js
@@ -158,7 +158,7 @@ function runSample(stylesheet, getGlyphs, getIcons, getTile, callback) {
         getTile(url, function(err, response) {
             if (err) throw err;
             var data = new VT.VectorTile(new Protobuf(new Uint8Array(response)));
-            workerTile.parse(data, layerFamilies, actor, null, function(err) {
+            workerTile.parse(data, layerFamilies, actor, function(err) {
                 if (err) return callback(err);
                 eachCallback();
             });

--- a/bin/point-in-polygon.js
+++ b/bin/point-in-polygon.js
@@ -22,7 +22,7 @@ var data = fs.readFileSync(process.argv[2]);
 zlib.inflate(data, function(err, data) {
 if (err) throw err;
 
-var tile = new VectorTile(new Protobuf(new Uint8Array(data)));
+var tile = new VectorTile(new Protobuf(data));
 
 
 var tree = rbush(9, ['.x1', '.y1', '.x2', '.y2']);

--- a/bin/show.js
+++ b/bin/show.js
@@ -29,7 +29,7 @@ var data = fs.readFileSync(process.argv[2]);
 zlib.inflate(data, function(err, data) {
     if (err) throw err;
 
-    var tile = new VectorTile(new Protobuf(new Uint8Array(data)));
+    var tile = new VectorTile(new Protobuf(data));
 
     for (var layer_name in tile.layers) {
         var layer = tile.layers[layer_name];

--- a/bin/stats-type.js
+++ b/bin/stats-type.js
@@ -18,7 +18,7 @@ var data = fs.readFileSync(process.argv[2]);
 zlib.inflate(data, function(err, data) {
     if (err) throw err;
 
-    var tile = new VectorTile(new Protobuf(new Uint8Array(data)));
+    var tile = new VectorTile(new Protobuf(data));
 
     var stats = {};
     for (var layer_name in tile.layers) {

--- a/bin/stats.js
+++ b/bin/stats.js
@@ -19,7 +19,7 @@ var data = fs.readFileSync(process.argv[2]);
 zlib.inflate(data, function(err, data) {
     if (err) throw err;
 
-    var tile = new VectorTile(new Protobuf(new Uint8Array(data)));
+    var tile = new VectorTile(new Protobuf(data));
 
     var omit = ['osm_id', 'name', 'name_en', 'name_de', 'name_es', 'name_fr', 'maki', 'website', 'address', 'reflen', 'len', 'area'];
 

--- a/js/data/feature_index.js
+++ b/js/data/feature_index.js
@@ -98,7 +98,7 @@ function translateDistance(translate) {
 // Finds features in this tile at a particular position.
 FeatureIndex.prototype.query = function(args, styleLayers) {
     if (!this.vtLayers) {
-        this.vtLayers = new vt.VectorTile(new Protobuf(new Uint8Array(this.rawTileData))).layers;
+        this.vtLayers = new vt.VectorTile(new Protobuf(this.rawTileData)).layers;
         this.sourceLayerCoder = new DictionaryCoder(this.vtLayers ? Object.keys(this.vtLayers).sort() : ['_geojsonTileLayer']);
     }
 

--- a/js/source/geojson_worker_source.js
+++ b/js/source/geojson_worker_source.js
@@ -39,22 +39,24 @@ GeoJSONWorkerSource.prototype = util.inherit(VectorTileWorkerSource, /** @lends 
         var source = params.source,
             coord = params.coord;
 
-        if (!this._geoJSONIndexes[source]) return callback(null, null); // we couldn't load the file
+        if (!this._geoJSONIndexes[source]) {
+            return callback(null, null);  // we couldn't load the file
+        }
 
         var geoJSONTile = this._geoJSONIndexes[source].getTile(Math.min(coord.z, params.maxZoom), coord.x, coord.y);
-        if (geoJSONTile) {
-            var geojsonWrapper = new GeoJSONWrapper(geoJSONTile.features);
-            geojsonWrapper.name = '_geojsonTileLayer';
-            var pbf = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
-            if (pbf.byteOffset !== 0 || pbf.byteLength !== pbf.buffer.byteLength) {
-                // Compatibility with node Buffer (https://github.com/mapbox/pbf/issues/35)
-                pbf = new Uint8Array(pbf);
-            }
-            callback(null, { tile: geojsonWrapper, rawTileData: pbf.buffer });
-            // tile.parse(geojsonWrapper, this.layerFamilies, this.actor, rawTileData, callback);
-        } else {
+        if (!geoJSONTile) {
             return callback(null, null); // nothing in the given tile
         }
+
+        var geojsonWrapper = new GeoJSONWrapper(geoJSONTile.features);
+        geojsonWrapper.name = '_geojsonTileLayer';
+        var pbf = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
+        if (pbf.byteOffset !== 0 || pbf.byteLength !== pbf.buffer.byteLength) {
+            // Compatibility with node Buffer (https://github.com/mapbox/pbf/issues/35)
+            pbf = new Uint8Array(pbf);
+        }
+        geojsonWrapper.rawData = pbf.buffer;
+        callback(null, geojsonWrapper);
     },
 
     /**

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -156,7 +156,7 @@ Tile.prototype = {
         if (!this.rawTileData) return;
 
         if (!this.vtLayers) {
-            this.vtLayers = new vt.VectorTile(new Protobuf(new Uint8Array(this.rawTileData))).layers;
+            this.vtLayers = new vt.VectorTile(new Protobuf(this.rawTileData)).layers;
         }
 
         var layer = this.vtLayers._geojsonTileLayer || this.vtLayers[params.sourceLayer];

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -57,12 +57,15 @@ Tile.prototype = {
         // empty GeoJSON tile
         if (!data) return;
 
+        if (data.rawTileData) {
+            this.rawTileData = data.rawTileData;
+        }
+
         this.collisionBoxArray = new CollisionBoxArray(data.collisionBoxArray);
         this.collisionTile = new CollisionTile(data.collisionTile, this.collisionBoxArray);
         this.symbolInstancesArray = new SymbolInstancesArray(data.symbolInstancesArray);
         this.symbolQuadsArray = new SymbolQuadsArray(data.symbolQuadsArray);
-        this.featureIndex = new FeatureIndex(data.featureIndex, data.rawTileData, this.collisionTile);
-        this.rawTileData = data.rawTileData;
+        this.featureIndex = new FeatureIndex(data.featureIndex, this.rawTileData, this.collisionTile);
         this.buckets = unserializeBuckets(data.buckets, style);
     },
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -58,16 +58,13 @@ VectorTileSource.prototype = util.inherit(Evented, {
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 
-        if (tile.workerID) {
-            if (tile.state === 'loading') {
-                // schedule tile reloading after it has been loaded
-                tile.reloadCallback = callback;
-            } else {
-                params.rawTileData = tile.rawTileData;
-                this.dispatcher.send('reload tile', params, done.bind(this), tile.workerID);
-            }
-        } else {
+        if (!tile.workerID) {
             tile.workerID = this.dispatcher.send('load tile', params, done.bind(this));
+        } else if (tile.state === 'loading') {
+            // schedule tile reloading after it has been loaded
+            tile.reloadCallback = callback;
+        } else {
+            this.dispatcher.send('reload tile', params, done.bind(this), tile.workerID);
         }
 
         function done(err, data) {

--- a/js/source/vector_tile_worker_source.js
+++ b/js/source/vector_tile_worker_source.js
@@ -3,6 +3,7 @@ var ajax = require('../util/ajax');
 var vt = require('vector-tile');
 var Protobuf = require('pbf');
 var WorkerTile = require('./worker_tile');
+var util = require('../util/util');
 
 module.exports = VectorTileWorkerSource;
 
@@ -58,7 +59,12 @@ VectorTileWorkerSource.prototype = {
             if (!data) return callback(null, null);
 
             tile.data = data.tile;
-            tile.parse(tile.data, this.styleLayers.getLayerFamilies(), this.actor, data.rawTileData, callback);
+            tile.parse(tile.data, this.styleLayers.getLayerFamilies(), this.actor, function (err, result, transferrables) {
+                if (err) return callback(err);
+                callback(null,
+                    util.extend({rawTileData: data.rawTileData}, result),
+                    transferrables.concat(data.rawTileData));
+            });
 
             this.loaded[source] = this.loaded[source] || {};
             this.loaded[source][uid] = tile;
@@ -77,7 +83,7 @@ VectorTileWorkerSource.prototype = {
             uid = params.uid;
         if (loaded && loaded[uid]) {
             var tile = loaded[uid];
-            tile.parse(tile.data, this.styleLayers.getLayerFamilies(), this.actor, params.rawTileData, callback);
+            tile.parse(tile.data, this.styleLayers.getLayerFamilies(), this.actor, callback);
         }
     },
 

--- a/js/source/vector_tile_worker_source.js
+++ b/js/source/vector_tile_worker_source.js
@@ -61,9 +61,11 @@ VectorTileWorkerSource.prototype = {
             tile.data = data.tile;
             tile.parse(tile.data, this.styleLayers.getLayerFamilies(), this.actor, function (err, result, transferrables) {
                 if (err) return callback(err);
+
+                // Not transferring rawTileData because the worker needs to retain its copy.
                 callback(null,
                     util.extend({rawTileData: data.rawTileData}, result),
-                    transferrables.concat(data.rawTileData));
+                    transferrables);
             });
 
             this.loaded[source] = this.loaded[source] || {};
@@ -127,7 +129,7 @@ VectorTileWorkerSource.prototype = {
         return function abort () { xhr.abort(); };
         function done(err, data) {
             if (err) { return callback(err); }
-            var tile =  new vt.VectorTile(new Protobuf(new Uint8Array(data)));
+            var tile = new vt.VectorTile(new Protobuf(data));
             callback(err, { tile: tile, rawTileData: data });
         }
     },

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -23,7 +23,7 @@ function WorkerTile(params) {
     this.showCollisionBoxes = params.showCollisionBoxes;
 }
 
-WorkerTile.prototype.parse = function(data, layerFamilies, actor, rawTileData, callback) {
+WorkerTile.prototype.parse = function(data, layerFamilies, actor, callback) {
 
     this.status = 'parsing';
     this.data = data;
@@ -208,7 +208,6 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, rawTileData, c
         var collisionBoxArray = tile.collisionBoxArray.serialize();
         var symbolInstancesArray = tile.symbolInstancesArray.serialize();
         var symbolQuadsArray = tile.symbolQuadsArray.serialize();
-        var transferables = [rawTileData].concat(featureIndex_.transferables).concat(collisionTile_.transferables);
         var nonEmptyBuckets = buckets.filter(isBucketNonEmpty);
 
         callback(null, {
@@ -217,9 +216,10 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, rawTileData, c
             collisionTile: collisionTile_.data,
             collisionBoxArray: collisionBoxArray,
             symbolInstancesArray: symbolInstancesArray,
-            symbolQuadsArray: symbolQuadsArray,
-            rawTileData: rawTileData
-        }, getTransferables(nonEmptyBuckets).concat(transferables));
+            symbolQuadsArray: symbolQuadsArray
+        }, getTransferables(nonEmptyBuckets)
+            .concat(featureIndex_.transferables)
+            .concat(collisionTile_.transferables));
     }
 };
 

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -106,7 +106,7 @@ GlyphSource.prototype.loadRange = function(fontstack, range, callback) {
         var url = glyphUrl(fontstack, rangeName, this.url);
 
         getArrayBuffer(url, function(err, data) {
-            var glyphs = !err && new Glyphs(new Protobuf(new Uint8Array(data)));
+            var glyphs = !err && new Glyphs(new Protobuf(data));
             for (var i = 0; i < loading[range].length; i++) {
                 loading[range][i](err, range, glyphs);
             }

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -11,7 +11,7 @@ var path = require('path');
 var StyleLayer = require('../../../js/style/style_layer');
 
 // Load a fill feature from fixture tile.
-var vt = new VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
+var vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
 var feature = vt.layers.water.feature(0);
 
 function createFeature(points) {

--- a/test/js/data/line_bucket.test.js
+++ b/test/js/data/line_bucket.test.js
@@ -10,7 +10,7 @@ var LineBucket = require('../../../js/data/bucket/line_bucket');
 var StyleLayer = require('../../../js/style/style_layer');
 
 // Load a line feature from fixture tile.
-var vt = new VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
+var vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
 var feature = vt.layers.road.feature(0);
 
 test('LineBucket', function(t) {

--- a/test/js/data/load_geometry.test.js
+++ b/test/js/data/load_geometry.test.js
@@ -8,7 +8,7 @@ var VectorTile = require('vector-tile').VectorTile;
 var loadGeometry = require('../../../js/data/load_geometry.js');
 
 // Load a line feature from fixture tile.
-var vt = new VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
+var vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
 
 test('loadGeometry', function(t) {
     var feature = vt.layers.road.feature(0);

--- a/test/js/data/symbol_bucket.test.js
+++ b/test/js/data/symbol_bucket.test.js
@@ -16,7 +16,7 @@ var StyleLayer = require('../../../js/style/style_layer');
 var util = require('../../../js/util/util');
 
 // Load a point feature from fixture tile.
-var vt = new VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
+var vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
 var feature = vt.layers.place_label.feature(10);
 var glyphs = JSON.parse(fs.readFileSync(path.join(__dirname, '/../../fixtures/fontstack-glyphs.json')));
 

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -34,7 +34,7 @@ test('basic', function(t) {
             })]
         };
 
-        tile.parse(new Wrapper(features), layerFamilies, {}, null, function(err, result) {
+        tile.parse(new Wrapper(features), layerFamilies, {}, function(err, result) {
             t.equal(err, null);
             t.ok(result.buckets[0]);
             t.end();
@@ -59,7 +59,7 @@ test('basic', function(t) {
             })]
         };
 
-        tile.parse(new Wrapper(features), layerFamilies, {}, null, function(err, result) {
+        tile.parse(new Wrapper(features), layerFamilies, {}, function(err, result) {
             t.equal(err, null);
             t.equal(Object.keys(result.buckets[0].arrays).length, 1, 'array groups exclude hidden layer');
             t.end();

--- a/test/js/util/classify_rings.test.js
+++ b/test/js/util/classify_rings.test.js
@@ -8,7 +8,7 @@ var VectorTile = require('vector-tile').VectorTile;
 var classifyRings = require('../../../js/util/classify_rings');
 
 // Load a fill feature from fixture tile.
-var vt = new VectorTile(new Protobuf(new Uint8Array(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf')))));
+var vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
 var feature = vt.layers.water.feature(0);
 
 test('classifyRings', function(assert) {


### PR DESCRIPTION
<!--
Hello! Thanks for contributing. To help your PR be most easily reviewed, please complete
the following checklist:
-->

In preparation for https://github.com/mapbox/mapbox-gl-native/issues/5701, I reviewed the GL JS implementation of tile reloading and noticed a few issues.

* Whenever a `VectorTile` is created, we were accidentally making an extra copy of the data.
* This was hiding a latent bug, where the worker thread was giving up ownership of raw data that it needed to retain.
* We were copying raw data _back_ to the worker on tile reload requests for no reason.
* The naming of tile and data related variables in `VectorTileWorkerSource` was vague and confusing.
* The contract of the semi-public `loadVectorData` extension point was underspecified.

This PR fixes those issues.

## Benchmarks

### `master`

**load-multiple-maps:** 150 ms, loaded 6 maps.
**buffer:** 854 ms
**fps:** 60 fps
**frame-duration:** 7.6 ms, 0% > 16ms
**query-point:** 0.63 ms
**query-box:** 51.76 ms
**geojson-setdata-small:** 11 ms
**geojson-setdata-large:** 97 ms

### Branch

**load-multiple-maps:** 151 ms, loaded 6 maps.
**buffer:** 863 ms
**fps:** 60 fps
**frame-duration:** 7.6 ms, 0% > 16ms
**query-point:** 0.65 ms
**query-box:** 49.49 ms
**geojson-setdata-small:** 10 ms
**geojson-setdata-large:** 104 ms

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks)
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [ ] get a PR review :+1: / :-1:
