### PR TITLE
map#isMoving

### DIFF
--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -434,6 +434,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
         this.zooming = (zoom !== startZoom);
         this.rotating = (startBearing !== bearing);
         this.pitching = (pitch !== startPitch);
+        this.easing = true;
 
         if (!options.noMoveStart) {
             this.fire('movestart', eventData);
@@ -485,6 +486,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
         this.zooming = false;
         this.rotating = false;
         this.pitching = false;
+        this.easing = false;
 
         if (wasZooming) {
             this.fire('zoomend', eventData);
@@ -703,6 +705,22 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
 
     isEasing: function() {
         return !!this._abortFn;
+    },
+
+    /**
+     * Returns a Boolean indicating whether the map is currently in a "moving" state.
+     * Returns `false` if zooming, rotating, pitching, and dragging are all inactive.
+     *
+     * @returns {boolean} A Boolean indicating whether the map is moving.
+     */
+    isMoving: function() {
+        if (this.zooming ||
+            this.rotating ||
+            this.pitching ||
+            this.easing ||
+            this.dragPan.isActive() ||
+            this.dragRotate.isActive() ) return true;
+        return false;
     },
 
     /**

--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -434,7 +434,6 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
         this.zooming = (zoom !== startZoom);
         this.rotating = (startBearing !== bearing);
         this.pitching = (pitch !== startPitch);
-        this.easing = true;
 
         if (!options.noMoveStart) {
             this.fire('movestart', eventData);
@@ -486,7 +485,6 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
         this.zooming = false;
         this.rotating = false;
         this.pitching = false;
-        this.easing = false;
 
         if (wasZooming) {
             this.fire('zoomend', eventData);
@@ -664,7 +662,6 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
         this.zooming = true;
         if (startBearing !== bearing) this.rotating = true;
         if (startPitch !== pitch) this.pitching = true;
-        this.easing = true;
 
         this.fire('movestart', eventData);
         this.fire('zoomstart', eventData);
@@ -696,7 +693,6 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
             this.zooming = false;
             this.rotating = false;
             this.pitching = false;
-            this.easing = false;
 
             this.fire('zoomend', eventData);
             this.fire('moveend', eventData);
@@ -716,10 +712,8 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
      * @returns {boolean} A Boolean indicating whether the map is moving.
      */
     isMoving: function() {
-        if (this.zooming ||
-            this.rotating ||
-            this.pitching ||
-            this.easing ||
+        if (this.isEasing() ||
+            this.zooming ||
             this.dragPan.isActive() ||
             this.dragRotate.isActive()) return true;
         return false;

--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -721,7 +721,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
             this.pitching ||
             this.easing ||
             this.dragPan.isActive() ||
-            this.dragRotate.isActive() ) return true;
+            this.dragRotate.isActive()) return true;
         return false;
     },
 

--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -664,6 +664,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
         this.zooming = true;
         if (startBearing !== bearing) this.rotating = true;
         if (startPitch !== pitch) this.pitching = true;
+        this.easing = true;
 
         this.fire('movestart', eventData);
         this.fire('zoomstart', eventData);
@@ -695,6 +696,7 @@ util.extend(Camera.prototype, /** @lends Map.prototype */{
             this.zooming = false;
             this.rotating = false;
             this.pitching = false;
+            this.easing = false;
 
             this.fire('zoomend', eventData);
             this.fire('moveend', eventData);

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -985,7 +985,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     /**
-     * Returns a Boolean indicating whether the map is currently in a "moving" state. 
+     * Returns a Boolean indicating whether the map is currently in a "moving" state.
      * Returns `false` if zooming, rotating, pitching, and dragging are all inactive.
      *
      * @returns {boolean} A Boolean indicating whether the map is moving.
@@ -994,8 +994,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         if (this.zooming ||
             this.rotating ||
             this.pitching ||
-            map.dragPan._active ||
-            map.dragRotate._active) return true;
+            this.dragPan._active ||
+            this.dragRotate._active) return true;
         return false;
     },
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -985,6 +985,24 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     /**
+     * Returns a Boolean indicating whether the map currently in a "moving" state.
+     *
+     * Returns `false` if the style is not yet fully loaded,
+     * or if there has been a change to the sources or style that
+     * has not yet fully loaded.
+     *
+     * @returns {boolean} A Boolean indicating whether the map is fully loaded.
+     */
+    isMoving: function() {
+        if (this.zooming ||
+            this.rotating ||
+            this.pitching ||
+            map.dragPan._active ||
+            map.dragRotate._active) return true;
+        return false;
+    },
+
+    /**
      * Update this map's style and sources, and re-render the map.
      *
      * @param {boolean} updateStyle mark the map's style for reprocessing as

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -985,13 +985,10 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     /**
-     * Returns a Boolean indicating whether the map currently in a "moving" state.
+     * Returns a Boolean indicating whether the map is currently in a "moving" state. 
+     * Returns `false` if zooming, rotating, pitching, and dragging are all inactive.
      *
-     * Returns `false` if the style is not yet fully loaded,
-     * or if there has been a change to the sources or style that
-     * has not yet fully loaded.
-     *
-     * @returns {boolean} A Boolean indicating whether the map is fully loaded.
+     * @returns {boolean} A Boolean indicating whether the map is moving.
      */
     isMoving: function() {
         if (this.zooming ||

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -985,21 +985,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     },
 
     /**
-     * Returns a Boolean indicating whether the map is currently in a "moving" state.
-     * Returns `false` if zooming, rotating, pitching, and dragging are all inactive.
-     *
-     * @returns {boolean} A Boolean indicating whether the map is moving.
-     */
-    isMoving: function() {
-        if (this.zooming ||
-            this.rotating ||
-            this.pitching ||
-            this.dragPan._active ||
-            this.dragRotate._active) return true;
-        return false;
-    },
-
-    /**
      * Update this map's style and sources, and re-render the map.
      *
      * @param {boolean} updateStyle mark the map's style for reprocessing as

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -486,6 +486,23 @@ test('Map', function(t) {
         t.end();
     });
 
+    t.test('#isMoving', function(t) {
+        var map = createMap();
+
+        map.on('load', function() {
+            // map is not moving
+            t.notOk(map.isMoving());
+            map.flyTo({center: [1, 1], zoom: 8, duration: 10});
+            // synchronously check if map is moving, it should be!
+            t.ok(map.isMoving());
+            // wait 200 ms, assert the map is not moving after the 100ms flyTo
+            setTimeout(function() {
+                t.notOk(map.isMoving());
+                t.end();
+            }, 20);
+        });
+    });
+
     t.test('#remove', function(t) {
         var map = createMap(),
             removedCanvas,


### PR DESCRIPTION
Adds a method `Map#isMoving` that checks for the states of `this.zooming`, `this.rotating`, `this.pitching`, `map.dragPan._active`, and `map.dragRotate._active`. If any of them is `true`, the map is considered "moving" and the method returns `true`.

![mapbox-gl-jsismoving](https://cloud.githubusercontent.com/assets/1943001/17984812/92e8cbe2-6ad8-11e6-9858-d71680f1adae.gif)

refs: #2792 

TODO
- [ ] add tests, @lucaswoj I was thinking a test that looks something like this:

``` javascript
test('Map#isMoving returns expected results', function (t) {
    var map = createMap();
    var moving = false;
    var notMoving = false;

    function check () {
        if (map.isMoving()) moving = true;
        if (!map.isMoving()) notMoving = true;
    }

    map.on('load', function() {
        map.flyTo({center: [0, 0], zoom: 9});
    });

    map.on('render', check);

    map.on('moveend', function() {
        t.ok(moving, 'map was considered moving at one point');
        t.ok(notMoving, 'map was considered not moving at one point');
        t.end();
    });
});
```

But not having any luck with it so far.

cc @mollymerp @jfirebaugh 
