### PR TITLE
add mapbox-gl-draw to plugins page

### DIFF
--- a/docs/_posts/plugins/0100-01-01-mapbox-gl-draw.html
+++ b/docs/_posts/plugins/0100-01-01-mapbox-gl-draw.html
@@ -1,0 +1,13 @@
+---
+layout: default
+categories: plugin
+title: mapbox-gl-draw
+prefix: mapbox-gl-draw
+description: Draw and edit features on Mapbox GL JS maps
+tags:
+  - isc
+code: https://github.com/mapbox/mapbox-gl-draw
+license: ISC
+---
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v0.11.15/mapbox-gl-draw.js'></script>
+<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v0.11.15/mapbox-gl-draw.css' type='text/css' />


### PR DESCRIPTION
Just set up a CDN link for mapbox-gl-draw, so I added the links to the plugin page. I still need to add an example before this PR is merged. 

cc @lucaswoj @mcwhittemore @davidtheclark @colleenmcginnis 
