### PR TITLE
Clone filter before returning in "Map#getFilter"

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -525,7 +525,7 @@ Style.prototype = util.inherit(Evented, {
      * @private
      */
     getFilter: function(layer) {
-        return this.getReferentLayer(layer).filter;
+        return util.clone(this.getReferentLayer(layer).filter);
     },
 
     setLayoutProperty: function(layerId, name, value) {
@@ -777,4 +777,3 @@ Style.prototype = util.inherit(Evented, {
         }
     }
 });
-

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -396,11 +396,11 @@ exports.filterObject = function(input, iterator, context) {
  * @returns {boolean}
  * @private
  */
-exports.deepEqual = function deepEqual(a, b) {
+exports.deepEqual = function(a, b) {
     if (Array.isArray(a)) {
         if (!Array.isArray(b) || a.length !== b.length) return false;
         for (var i = 0; i < a.length; i++) {
-            if (!deepEqual(a[i], b[i])) return false;
+            if (!exports.deepEqual(a[i], b[i])) return false;
         }
         return true;
     }
@@ -409,7 +409,7 @@ exports.deepEqual = function deepEqual(a, b) {
         var keys = Object.keys(a);
         if (keys.length !== Object.keys(b).length) return false;
         for (var key in a) {
-            if (!deepEqual(a[key], b[key])) return false;
+            if (!exports.deepEqual(a[key], b[key])) return false;
         }
         return true;
     }
@@ -423,7 +423,7 @@ exports.deepEqual = function deepEqual(a, b) {
  * @returns {boolean}
  * @private
  */
-exports.clone = function deepEqual(input) {
+exports.clone = function(input) {
     if (Array.isArray(input)) {
         return input.map(exports.clone);
     } else if (typeof input === 'object') {

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -801,6 +801,23 @@ test('Style#setFilter', function(t) {
         });
     });
 
+    t.test('gets a clone of the filter', function(t) {
+        var style = createStyle();
+
+        style.on('load', function() {
+            var filter1 = ['==', 'id', 1];
+            style.setFilter('symbol', filter1);
+            var filter2 = style.getFilter('symbol');
+            var filter3 = style.getLayer('symbol').filter;
+
+            t.notEqual(filter1, filter2);
+            t.notEqual(filter1, filter3);
+            t.notEqual(filter2, filter3);
+
+            t.end();
+        });
+    });
+
     t.test('sets again mutated filter', function(t) {
         var style = createStyle();
 


### PR DESCRIPTION
This PR fixes #3079 by cloning the filter before returning in `Map#getFilter`.

cc @tmcw @anvarik 

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [x] get a PR review :+1: / :-1:
