### PR TITLE
Always unload vector tile data before overwriting it

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -192,7 +192,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
                 return callback(err);
             }
 
-            tile.loadVectorData(data, this.map.style);
+            tile.loadVectorData(data, this.map.painter);
 
             if (tile.redoWhenDone) {
                 tile.redoWhenDone = false;

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -137,7 +137,7 @@ SourceCache.prototype = util.inherit(Evented, {
     },
 
     _isIdRenderable: function(id) {
-        return this._tiles[id].hasVectorData() && !this._coveredTiles[id];
+        return this._tiles[id].hasData() && !this._coveredTiles[id];
     },
 
     reload: function() {
@@ -218,7 +218,7 @@ SourceCache.prototype = util.inherit(Evented, {
             var tile = this._tiles[id];
 
             // only consider renderable tiles on higher zoom levels (up to maxCoveringZoom)
-            if (retain[id] || !tile.hasVectorData() || tile.coord.z <= coord.z || tile.coord.z > maxCoveringZoom) continue;
+            if (retain[id] || !tile.hasData() || tile.coord.z <= coord.z || tile.coord.z > maxCoveringZoom) continue;
 
             // disregard tiles that are not descendants of the given tile coordinate
             var z2 = Math.pow(2, Math.min(tile.coord.z, this.maxzoom) - Math.min(coord.z, this.maxzoom));
@@ -235,7 +235,7 @@ SourceCache.prototype = util.inherit(Evented, {
                 var parentId = tile.coord.parent(this.maxzoom).id;
                 tile = this._tiles[parentId];
 
-                if (tile && tile.hasVectorData()) {
+                if (tile && tile.hasData()) {
                     delete retain[id];
                     retain[parentId] = true;
                 }
@@ -258,7 +258,7 @@ SourceCache.prototype = util.inherit(Evented, {
         for (var z = coord.z - 1; z >= minCoveringZoom; z--) {
             coord = coord.parent(this.maxzoom);
             var tile = this._tiles[coord.id];
-            if (tile && tile.hasVectorData()) {
+            if (tile && tile.hasData()) {
                 retain[coord.id] = true;
                 return tile;
             }
@@ -322,7 +322,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
             retain[coord.id] = true;
 
-            if (tile.hasVectorData())
+            if (tile.hasData())
                 continue;
 
             // The tile we require is not yet loaded.
@@ -423,7 +423,7 @@ SourceCache.prototype = util.inherit(Evented, {
         if (tile.uses > 0)
             return;
 
-        if (tile.hasVectorData()) {
+        if (tile.hasData()) {
             this._cache.add(tile.coord.wrapped().id, tile);
         } else {
             tile.aborted = true;

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -137,7 +137,7 @@ SourceCache.prototype = util.inherit(Evented, {
     },
 
     _isIdRenderable: function(id) {
-        return this._tiles[id].isRenderable() && !this._coveredTiles[id];
+        return this._tiles[id].hasVectorData() && !this._coveredTiles[id];
     },
 
     reload: function() {
@@ -218,7 +218,7 @@ SourceCache.prototype = util.inherit(Evented, {
             var tile = this._tiles[id];
 
             // only consider renderable tiles on higher zoom levels (up to maxCoveringZoom)
-            if (retain[id] || !tile.isRenderable() || tile.coord.z <= coord.z || tile.coord.z > maxCoveringZoom) continue;
+            if (retain[id] || !tile.hasVectorData() || tile.coord.z <= coord.z || tile.coord.z > maxCoveringZoom) continue;
 
             // disregard tiles that are not descendants of the given tile coordinate
             var z2 = Math.pow(2, Math.min(tile.coord.z, this.maxzoom) - Math.min(coord.z, this.maxzoom));
@@ -235,7 +235,7 @@ SourceCache.prototype = util.inherit(Evented, {
                 var parentId = tile.coord.parent(this.maxzoom).id;
                 tile = this._tiles[parentId];
 
-                if (tile && tile.isRenderable()) {
+                if (tile && tile.hasVectorData()) {
                     delete retain[id];
                     retain[parentId] = true;
                 }
@@ -258,7 +258,7 @@ SourceCache.prototype = util.inherit(Evented, {
         for (var z = coord.z - 1; z >= minCoveringZoom; z--) {
             coord = coord.parent(this.maxzoom);
             var tile = this._tiles[coord.id];
-            if (tile && tile.isRenderable()) {
+            if (tile && tile.hasVectorData()) {
                 retain[coord.id] = true;
                 return tile;
             }
@@ -322,7 +322,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
             retain[coord.id] = true;
 
-            if (tile.isRenderable())
+            if (tile.hasVectorData())
                 continue;
 
             // The tile we require is not yet loaded.
@@ -423,7 +423,7 @@ SourceCache.prototype = util.inherit(Evented, {
         if (tile.uses > 0)
             return;
 
-        if (tile.isRenderable()) {
+        if (tile.hasVectorData()) {
             this._cache.add(tile.coord.wrapped().id, tile);
         } else {
             tile.aborted = true;

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -180,7 +180,7 @@ Tile.prototype = {
         }
     },
 
-    isRenderable: function() {
+    hasVectorData: function() {
         return this.state === 'loaded' || this.state === 'reloading';
     }
 };

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -51,7 +51,11 @@ Tile.prototype = {
      * @returns {undefined}
      * @private
      */
-    loadVectorData: function(data, style) {
+    loadVectorData: function(data, painter) {
+        if (this.hasVectorData()) {
+            this.unloadVectorData(painter);
+        }
+
         this.state = 'loaded';
 
         // empty GeoJSON tile
@@ -65,8 +69,8 @@ Tile.prototype = {
         this.collisionTile = new CollisionTile(data.collisionTile, this.collisionBoxArray);
         this.symbolInstancesArray = new SymbolInstancesArray(data.symbolInstancesArray);
         this.symbolQuadsArray = new SymbolQuadsArray(data.symbolQuadsArray);
-        this.featureIndex = new FeatureIndex(data.featureIndex, this.rawTileData, this.collisionTile);
-        this.buckets = unserializeBuckets(data.buckets, style);
+        this.featureIndex = new FeatureIndex(data.featureIndex, data.rawTileData, this.collisionTile);
+        this.buckets = unserializeBuckets(data.buckets, painter.style);
     },
 
     /**

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -69,7 +69,7 @@ Tile.prototype = {
         this.collisionTile = new CollisionTile(data.collisionTile, this.collisionBoxArray);
         this.symbolInstancesArray = new SymbolInstancesArray(data.symbolInstancesArray);
         this.symbolQuadsArray = new SymbolQuadsArray(data.symbolQuadsArray);
-        this.featureIndex = new FeatureIndex(data.featureIndex, data.rawTileData, this.collisionTile);
+        this.featureIndex = new FeatureIndex(data.featureIndex, this.rawTileData, this.collisionTile);
         this.buckets = unserializeBuckets(data.buckets, painter.style);
     },
 

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -52,7 +52,7 @@ Tile.prototype = {
      * @private
      */
     loadVectorData: function(data, painter) {
-        if (this.hasVectorData()) {
+        if (this.hasData()) {
             this.unloadVectorData(painter);
         }
 
@@ -180,7 +180,7 @@ Tile.prototype = {
         }
     },
 
-    hasVectorData: function() {
+    hasData: function() {
         return this.state === 'loaded' || this.state === 'reloading';
     }
 };

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -75,7 +75,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
                 return callback(err);
             }
 
-            tile.loadVectorData(data, this.map.style);
+            tile.loadVectorData(data, this.map.painter);
 
             if (tile.redoWhenDone) {
                 tile.redoWhenDone = false;

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -696,7 +696,7 @@ test('SourceCache#findLoadedParent', function(t) {
 
         var tile = {
             coord: new TileCoord(1, 0, 0),
-            hasVectorData: function() { return true; }
+            hasData: function() { return true; }
         };
 
         sourceCache._tiles[tile.coord.id] = tile;

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -696,7 +696,7 @@ test('SourceCache#findLoadedParent', function(t) {
 
         var tile = {
             coord: new TileCoord(1, 0, 0),
-            isRenderable: function() { return true; }
+            hasVectorData: function() { return true; }
         };
 
         sourceCache._tiles[tile.coord.id] = tile;

--- a/test/js/source/tile.test.js
+++ b/test/js/source/tile.test.js
@@ -7,6 +7,7 @@ var TileCoord = require('../../../js/source/tile_coord');
 var fs = require('fs');
 var path = require('path');
 var vtpbf = require('vt-pbf');
+var sinon = require('sinon');
 
 test('querySourceFeatures', function(t) {
     var features = [{
@@ -69,6 +70,17 @@ test('querySourceFeatures', function(t) {
         t.end();
     });
 
+    t.test('loadVectorData unloads existing data before overwriting it', function(t) {
+        var tile = new Tile(new TileCoord(1, 1, 1));
+        tile.state = 'loaded';
+        sinon.stub(tile, 'unloadVectorData');
+        var painter = {};
+
+        tile.loadVectorData(null, painter);
+
+        t.ok(tile.unloadVectorData.calledWith(painter));
+        t.end();
+    });
 
     t.end();
 });


### PR DESCRIPTION
This PR fixes #2266 by ensuring a tile's vector data is always unloaded before being overwritten with new data in 3b01cad. 

This PR also includes 8157378 which renames `Tile#isRenderable` to `Tile#hasVectorData` in order to conceptually simplify `Tile` by removing the idea of "renderability" and expanding the primitives for working with a tile's "vector data."

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] [post scores for all benchmarks on your branch and `master`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench/README.md#running-benchmarks)
 - [x] [do a quick sanity check on the debug page](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md#serving-the-debug-page)
 - [x] get a PR review :+1: / :-1:
