### PR TITLE
Stop firing obsolete Style 'zoom' event

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -237,7 +237,6 @@ Style.prototype = util.inherit(Evented, {
         }
 
         this.z = z;
-        this.fire('zoom');
     },
 
     _updateZoomHistory: function(z) {


### PR DESCRIPTION
This event is ancient (added in f3c7e7177c4226073eb955af37b578daf83976f7) and nothing now listens for it.