### PR TITLE
Allow drag rotate handler to control pitch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ npm-debug.log
 *.sublime-*
 coverage
 .DS_Store
-.mason
 .nyc_output
 /debug/access-token-generated.js
 /bench/index-generated.js

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ npm-debug.log
 *.sublime-*
 coverage
 .DS_Store
+.mason
 .nyc_output
 /debug/access-token-generated.js
 /bench/index-generated.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-.mason
 _site
 bench
 coverage

--- a/debug/index.html
+++ b/debug/index.html
@@ -39,10 +39,11 @@
 <body>
 <div id='map'></div>
 <div id='checkboxes'>
-  <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
-  <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br />
-  <input id='show-overdraw-checkbox' name='show-overdraw' type='checkbox'> <label for='show-overdraw'>overdraw debug</label><br />
-  <input id='buffer-checkbox' name='buffer' type='checkbox'> <label for='buffer'>buffer stats</label>
+  <label><input id='show-tile-boundaries-checkbox' type='checkbox'> tile debug</label><br />
+  <label><input id='show-symbol-collision-boxes-checkbox' type='checkbox'> collision debug</label><br />
+  <label><input id='show-overdraw-checkbox' type='checkbox'> overdraw debug</label><br />
+  <label><input id='pitch-checkbox' type='checkbox' checked> pitch with rotate</label><br />
+  <label><input id='buffer-checkbox' type='checkbox'> buffer stats</label>
 </div>
 
 <div id='buffer' style="display:none">
@@ -135,6 +136,10 @@ document.getElementById('show-overdraw-checkbox').onclick = function() {
 
 document.getElementById('buffer-checkbox').onclick = function() {
     document.getElementById('buffer').style.display = this.checked ? 'block' : 'none';
+};
+
+document.getElementById('pitch-checkbox').onclick = function() {
+    map.dragRotate._pitchWithRotate = !!this.checked;
 };
 
 // keyboard shortcut for comparing rendering with Mapbox GL native

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -3,7 +3,7 @@
 var LngLat = require('./lng_lat'),
     Point = require('point-geometry'),
     Coordinate = require('./coordinate'),
-    wrap = require('../util/util').wrap,
+    util = require('../util/util'),
     interp = require('../util/interpolate'),
     TileCoord = require('../source/tile_coord'),
     EXTENT = require('../data/bucket').EXTENT,
@@ -72,7 +72,7 @@ Transform.prototype = {
         return -this.angle / Math.PI * 180;
     },
     set bearing(bearing) {
-        var b = -wrap(bearing, -180, 180) * Math.PI / 180;
+        var b = -util.wrap(bearing, -180, 180) * Math.PI / 180;
         if (this.angle === b) return;
         this._unmodified = false;
         this.angle = b;
@@ -87,7 +87,7 @@ Transform.prototype = {
         return this._pitch / Math.PI * 180;
     },
     set pitch(pitch) {
-        var p = Math.min(60, pitch) / 180 * Math.PI;
+        var p = util.clamp(pitch, 0, 60) / 180 * Math.PI;
         if (this._pitch === p) return;
         this._unmodified = false;
         this._pitch = p;

--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -194,6 +194,20 @@ test('transform', function(t) {
         t.end();
     });
 
+    t.test('clamps pitch', function(t) {
+        var transform = new Transform();
+
+        transform.pitch = 45;
+        t.equal(transform.pitch, 45);
+
+        transform.pitch = -10;
+        t.equal(transform.pitch, 0);
+
+        transform.pitch = 90;
+        t.equal(transform.pitch, 60);
+
+        t.end();
+    });
 
     t.end();
 });


### PR DESCRIPTION
Right-click and drag previously only controlled the bearing of the map.
Now it also controls the pitch along with bearing.

Dragging up and down controls the pitch. Dragging left and right controls
the bearing.

The pitch control is opt-out and can be disabled by passing `pitchWithRotate:
false` when initializing the Map. The experience can be demoed at
http://localhost:9966/debug/