### PR TITLE
Ensure fills with transparent colors and patterns are rendered as expected

### DIFF
--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -218,8 +218,6 @@ StyleLayer.prototype = util.inherit(Evented, {
         if (this.minzoom && zoom < this.minzoom) return true;
         if (this.maxzoom && zoom >= this.maxzoom) return true;
         if (this.layout['visibility'] === 'none') return true;
-        if (this.isPaintValueFeatureConstant(this.type + '-opacity') && this.paint[this.type + '-opacity'] === 0) return true;
-        if (this.isPaintValueFeatureConstant(this.type + '-color') && this.paint[this.type + '-color'] && this.paint[this.type + '-color'][3] === 0) return true;
 
         return false;
     },

--- a/js/style/style_layer/fill_style_layer.js
+++ b/js/style/style_layer/fill_style_layer.js
@@ -64,7 +64,12 @@ FillStyleLayer.prototype = util.inherit(StyleLayer, {
             this.paint['fill-outline-color'][3] === 0
         );
 
-        return isFillHidden && isOutlineHidden;
+        var isPatternHidden = (
+            this.isPaintValueFeatureConstant('fill-pattern') &&
+            !this.paint['fill-pattern']
+        );
+
+        return isFillHidden && isOutlineHidden && isPatternHidden;
     }
 
 });

--- a/js/style/style_layer/fill_style_layer.js
+++ b/js/style/style_layer/fill_style_layer.js
@@ -47,29 +47,6 @@ FillStyleLayer.prototype = util.inherit(StyleLayer, {
         } else {
             return StyleLayer.prototype.isPaintValueZoomConstant.call(this, name);
         }
-    },
-
-    isHidden: function(zoom) {
-        if (this.minzoom && zoom < this.minzoom) return true;
-        if (this.maxzoom && zoom >= this.maxzoom) return true;
-        if (this.layout['visibility'] === 'none') return true;
-
-        var isFillHidden = (
-            (this.isPaintValueFeatureConstant('fill-opacity') && this.paint['fill-opacity'] === 0) ||
-            (this.isPaintValueFeatureConstant('fill-color') && this.paint['fill-color'][3] === 0)
-        );
-
-        var isOutlineHidden = (
-            this.isPaintValueFeatureConstant('fill-outline-color') &&
-            this.paint['fill-outline-color'][3] === 0
-        );
-
-        var isPatternHidden = (
-            this.isPaintValueFeatureConstant('fill-pattern') &&
-            !this.paint['fill-pattern']
-        );
-
-        return isFillHidden && isOutlineHidden && isPatternHidden;
     }
 
 });

--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -11,16 +11,6 @@ module.exports = SymbolStyleLayer;
 
 SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
 
-    isHidden: function() {
-        if (StyleLayer.prototype.isHidden.apply(this, arguments)) return true;
-
-        var isTextHidden = this.paint['text-opacity'] === 0 || !this.layout['text-field'];
-        var isIconHidden = this.paint['icon-opacity'] === 0 || !this.layout['icon-image'];
-        if (isTextHidden && isIconHidden) return true;
-
-        return false;
-    },
-
     getLayoutValue: function(name, globalProperties, featureProperties) {
         if (name === 'text-rotation-alignment' &&
                 this.getLayoutValue('symbol-placement', globalProperties, featureProperties) === 'line' &&

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#35efbce663a0f13d37d34afac799e33178ee610a",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#333cf135f5358f48abd608a62787045a5f6fac0c",
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",


### PR DESCRIPTION
This PR fixes #3107 by making `FillStyleLayer#isHidden` aware of `fill-pattern`. 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality https://github.com/mapbox/mapbox-gl-test-suite/pull/140
 - [x] manually test the debug page
 - [ ] get a PR review
