### PR TITLE
Fully switch to Nyc instead of Istanbul

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -19,12 +19,8 @@ npm run lint
 npm run build-min
 npm run build-dev
 
-# run unit tests
-tap --reporter dot --coverage --no-coverage-report test/js test/build/webpack.test.js
-
-# run render tests
-istanbul cover --dir .nyc_output --include-pid --report none --print none test/render.test.js
-istanbul cover --dir .nyc_output --include-pid --report none --print none test/query.test.js
+# run unit, render & query tests with coverage
+npm run test-cov
 
 # send coverage report to coveralls
 nyc report --reporter=lcov

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "gl": "^4.0.1",
     "handlebars": "4.0.5",
     "highlight.js": "9.3.0",
-    "istanbul": "^0.4.2",
     "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
@@ -99,7 +98,10 @@
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve --watch",
     "lint": "eslint  --ignore-path .gitignore js test bench docs/_posts/examples/*.html",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
-    "test-suite": "node test/render.test.js && node test/query.test.js",
-    "test": "npm run lint && tap --reporter dot test/js test/build/webpack.test.js"
+    "test": "run-s lint test-unit",
+    "test-unit": "tap --reporter dot --no-coverage test/js test/build/webpack.test.js",
+    "test-render": "node test/render.test.js",
+    "test-query": "node test/query.test.js",
+    "test-cov": "nyc --reporter=text-summary run-s test-unit test-render test-query"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
-    "nyc": "6.4.0",
+    "nyc": "^8.1.0",
     "proxyquire": "^1.7.9",
     "remark": "4.2.2",
     "remark-html": "3.0.0",


### PR DESCRIPTION
Instead of an Istanbul/Nyc mix, switches to Nyc fully for test coverage. Reasons:

1. Ensures all coverage code is run with the same tool/version (instead of a mix of Tap Nyc subdependency + standalone Istanbul).
2. Istanbul NPM module is getting deprecated soon — it's been rewritten as a set of independent modules in https://github.com/istanbuljs that Nyc now uses under the hood.
3. We'll be able to get the full benefit once my [performance patch](https://github.com/istanbuljs/istanbul-lib-instrument/pull/22) lands into Nyc.

cc @lucaswoj @jfirebaugh 