### PR TITLE
fix Popup docs so that the offset option is displayed, add offset option to example

### DIFF
--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -23,14 +23,25 @@ var Point = require('point-geometry');
  *   `'top-right'`, `'bottom-left'`, and `'bottom-right'`. If unset the anchor will be
  *   dynamically set to ensure the popup falls within the map container with a preference
  *   for `'bottom'`.
- * @param {number|PointLike|{[position: string]: PointLike}} [options.offset] -
+ * @param {number|PointLike|Object} [options.offset] -
  *  A pixel offset applied to the popup's location specified as:
  *   - a single number specifying a distance from the popup's location
  *   - a [`PointLike`](#PointLike) specifying a constant offset
  *   - an object of [`PointLike`](#PointLike)s specifing an offset for each anchor position
  *  Negative offsets indicate left and up.
  * @example
- * var popup = new mapboxgl.Popup()
+ * var markerHeight = 50, markerRadius = 10, linearOffset = 25;
+ * var popupOffsets = {
+ *  'top': [0, 0],
+ *  'top-left': [0,0],
+ *  'top-right': [0,0],
+ *  'bottom': [0, -markerHeight],
+ *  'bottom-left': [linearOffset, (markerHeight - markerRadius + linearOffset) * -1],
+ *  'bottom-right': [-linearOffset, (markerHeight - markerRadius + linearOffset) * -1],
+ *  'left': [markerRadius, (markerHeight - markerRadius) * -1],
+ *  'right': [-markerRadius, (markerHeight - markerRadius) * -1]
+ *  };
+ * var popup = new mapboxgl.Popup({offset:popupOffsets})
  *   .setLngLat(e.lngLat)
  *   .setHTML("<h1>Hello World!</h1>")
  *   .addTo(map);


### PR DESCRIPTION
documentation wasn't being generated bc the type wasn't recognize (I think)

![screen shot 2016-09-06 at 3 21 04 pm](https://cloud.githubusercontent.com/assets/2425307/18293085/9200328a-7445-11e6-95c0-b2c546d71185.png)


cc @lucaswoj @jfirebaugh 