### PR TITLE
Fix #2827 and #2828 (fill zoom-and-property-fns)

### DIFF
--- a/js/style/style_layer/fill_style_layer.js
+++ b/js/style/style_layer/fill_style_layer.js
@@ -21,7 +21,7 @@ FillStyleLayer.prototype = util.inherit(StyleLayer, {
         if (name === 'fill-outline-color' && this.getPaintProperty('fill-outline-color') === undefined) {
             return StyleLayer.prototype.getPaintValueStopZoomLevels.call(this, 'fill-color');
         } else {
-            return StyleLayer.prototype.getPaintValueStopZoomLevels.call(this, arguments);
+            return StyleLayer.prototype.getPaintValueStopZoomLevels.call(this, name);
         }
     },
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#0e205e417484b763daa3b133644d1ebc46201040",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f6746fe4a0cafe5a6276f9455187b87c8263e3e4",
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",


### PR DESCRIPTION
Fixes #2827, #2828. Found while adding fill-extrude properties this bug wherein `getPaintValueStopZoomLevels` is being called with an array of its name (i.e. `getPaintValueStopZoomLevels(["fill-color"])`), the nature of `arguments`, and therefore always returning undefined.


fixes #2827 
fixes #2828

cc @lucaswoj 