### PR TITLE
add scale control to docs

### DIFF
--- a/documentation.yml
+++ b/documentation.yml
@@ -16,6 +16,7 @@ toc:
   - Navigation
   - Geolocate
   - Attribution
+  - Scale
   - Control
   - name: Handlers
     description: |


### PR DESCRIPTION
`Scale` needed to be added to `documentation.yml` to be included in the `Control` docs. 


![screen shot 2016-09-06 at 6 43 40 pm](https://cloud.githubusercontent.com/assets/2425307/18296967/2a6a09f8-7462-11e6-93fb-c8494c4a1f31.png)
