### PR TITLE
Run nyc with cache on

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "test-unit": "tap --reporter dot --no-coverage test/js test/build/webpack.test.js",
     "test-render": "node test/render.test.js",
     "test-query": "node test/query.test.js",
-    "test-cov": "nyc --reporter=text-summary run-s test-unit test-render test-query"
+    "test-cov": "nyc --reporter=text-summary --cache run-s test-unit test-render test-query"
   }
 }


### PR DESCRIPTION
Cuts down the CI build by ~2 minutes. Doesn't affect render/query tests but brings down unit test coverage from 3m to 1m — apparently the same files were instrumented over and over before without this setting. 

`--cache` used to be enabled in `nyc` by default, but it was turned off (https://github.com/istanbuljs/nyc/pull/303) because of some weird ava+babel+nyc conflicts.

cc @jfirebaugh @lucaswoj 