### PR TITLE
Make our CI tests fast again

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
-    "nyc": "^8.1.0",
+    "nyc": "mourner/nyc#fast",
     "proxyquire": "^1.7.9",
     "remark": "4.2.2",
     "remark-html": "3.0.0",


### PR DESCRIPTION
Closes #2366. A temporary change that gets our total CI build under 10m again (with test.sh taking under 6m, compared to 12-14m previously). We can either merge this now and enjoy smaller times, or wait a few weeks until the change propagates to `nyc@latest`. I think there's no harm temporarily switching to a fork — the only change compared to nyc master is a bumped `istanbul-lib-instrument` version.

cc @lucaswoj @jfirebaugh 