### PR TITLE
Bump Circle to Node v6 and NPM v3

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -8,9 +8,9 @@ fi
 source ./nvm/nvm.sh && nvm install ${NODE_VERSION}
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then
-    source ./nvm/nvm.sh && nvm use ${NODE_VERSION} && npm update
+    source ./nvm/nvm.sh && nvm use ${NODE_VERSION} && npm update && npm ls
 else
-    source ./nvm/nvm.sh && nvm use ${NODE_VERSION} && npm install
+    source ./nvm/nvm.sh && nvm use ${NODE_VERSION} && npm install && npm ls
 fi
 
 if [ "$CIRCLE_BRANCH" == "master"] || [ -z "$CIRCLE_TAG" ]; then

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   environment:
     XCODE_SCHEME: "no"
     XCODE_WORKSPACE: "no"
-    NODE_VERSION: 4
+    NODE_VERSION: 6
 
 dependencies:
   cache_directories:


### PR DESCRIPTION
Fiddling further with build optimization, it turns out that if we switch to Node v6 (and NPM v3), it cuts down total Circle build running time to 6m20s (!!!), down from 9m40s in #3162. This comes from several things:

- faster cache restore because of flat node_modules (4x less files)
- faster `npm install` after restored cache
- faster cache save (4x less files)
- faster test execution because of newer V8 — 5m vs 6m

I think the benefits (cutting down another 3m20s) are worth the risk of switching, and those versions will [become Active LTS in 3 weeks](https://github.com/nodejs/LTS) anyway. Also, NPM 3 seems to be much more stable than the last time we had problems with it in Circle.

cc @jfirebaugh @lucaswoj 