### PR TITLE
Stringify layers for faster worker transfer

### DIFF
--- a/bench/benchmarks/buffer.js
+++ b/bench/benchmarks/buffer.js
@@ -186,7 +186,7 @@ var createLayerFamiliesCacheValue;
 function createLayerFamilies(layers) {
     if (layers !== createLayerFamiliesCacheKey) {
         var worker = new Worker({addEventListener: function() {} });
-        worker['set layers'](0, layers);
+        worker['set layers'](0, JSON.stringify(layers));
 
         createLayerFamiliesCacheKey = layers;
         createLayerFamiliesCacheValue = worker.layerFamilies[0];

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -35,8 +35,9 @@ function Worker(self) {
 }
 
 util.extend(Worker.prototype, {
-    'set layers': function(mapId, layerDefinitions) {
+    'set layers': function(mapId, data) {
         var layers = this.layers[mapId] = {};
+        var layerDefinitions = JSON.parse(data);
 
         // Filter layers and create an id -> layer map
         var childLayerIndicies = [];
@@ -68,11 +69,12 @@ util.extend(Worker.prototype, {
         this.layerFamilies[mapId] = createLayerFamilies(this.layers[mapId]);
     },
 
-    'update layers': function(mapId, layerDefinitions) {
+    'update layers': function(mapId, data) {
         var id;
         var layer;
 
         var layers = this.layers[mapId];
+        var layerDefinitions = JSON.parse(data);
 
         // Update ref parents
         for (id in layerDefinitions) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -189,7 +189,7 @@ Style.prototype = util.inherit(Evented, {
         for (var i = 0; i < ids.length; i++) {
             serialized.push(this._layers[ids[i]].serialize(options));
         }
-        return serialized;
+        return JSON.stringify(serialized);
     },
 
     _applyClasses: function(classes, options) {

--- a/test/js/source/worker.test.js
+++ b/test/js/source/worker.test.js
@@ -32,11 +32,11 @@ test('load tile', function(t) {
 test('set layers', function(t) {
     var worker = new Worker(_self);
 
-    worker['set layers'](0, [
+    worker['set layers'](0, JSON.stringify([
         { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }  },
         { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }  },
         { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
-    ]);
+    ]));
 
     t.equal(worker.layers[0].one.id, 'one');
     t.equal(worker.layers[0].two.id, 'two');
@@ -58,17 +58,17 @@ test('set layers', function(t) {
 test('update layers', function(t) {
     var worker = new Worker(_self);
 
-    worker['set layers'](0, [
+    worker['set layers'](0, JSON.stringify([
         { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }  },
         { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }  },
         { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
-    ]);
+    ]));
 
-    worker['update layers'](0, {
+    worker['update layers'](0, JSON.stringify({
         one: { id: 'one', type: 'circle', paint: { 'circle-color': 'cyan' }  },
         two: { id: 'two', type: 'circle', paint: { 'circle-color': 'magenta' }  },
         three: { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'yellow' } }
-    });
+    }));
 
     t.equal(worker.layers[0].one.getPaintProperty('circle-color'), 'cyan');
     t.equal(worker.layers[0].two.getPaintProperty('circle-color'), 'magenta');
@@ -92,23 +92,23 @@ test('redo placement', function(t) {
 test('update layers isolates different instances\' data', function(t) {
     var worker = new Worker(_self);
 
-    worker['set layers'](0, [
+    worker['set layers'](0, JSON.stringify([
         { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }  },
         { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }  },
         { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
-    ]);
+    ]));
 
-    worker['set layers'](1, [
+    worker['set layers'](1, JSON.stringify([
         { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }  },
         { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }  },
         { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
-    ]);
+    ]));
 
-    worker['update layers'](1, {
+    worker['update layers'](1, JSON.stringify({
         one: { id: 'one', type: 'circle', paint: { 'circle-color': 'cyan' }  },
         two: { id: 'two', type: 'circle', paint: { 'circle-color': 'magenta' }  },
         three: { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'yellow' } }
-    });
+    }));
 
     t.equal(worker.layers[0].one.id, 'one');
     t.equal(worker.layers[0].two.id, 'two');

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -155,7 +155,7 @@ test('Style#_updateWorkerLayers', function(t) {
 
         style.dispatcher.broadcast = function(key, value) {
             t.equal(key, 'set layers');
-            t.deepEqual(value.map(function(layer) { return layer.id; }), ['first', 'second', 'third']);
+            t.deepEqual(JSON.parse(value).map(function(layer) { return layer.id; }), ['first', 'second', 'third']);
             t.end();
         };
 
@@ -183,7 +183,7 @@ test('Style#_updateWorkerLayers with specific ids', function(t) {
     style.on('load', function() {
         style.dispatcher.broadcast = function(key, value) {
             t.equal(key, 'update layers');
-            t.deepEqual(value.map(function(layer) { return layer.id; }), ['second', 'third']);
+            t.deepEqual(JSON.parse(value).map(function(layer) { return layer.id; }), ['second', 'third']);
             t.end();
         };
 
@@ -785,7 +785,8 @@ test('Style#setFilter', function(t) {
         var style = createStyle();
 
         style.on('load', function() {
-            style.dispatcher.broadcast = function(key, value) {
+            style.dispatcher.broadcast = function(key, data) {
+                var value = JSON.parse(data);
                 t.equal(key, 'update layers');
                 t.deepEqual(value[0].id, 'symbol');
                 t.deepEqual(value[0].filter, ['==', 'id', 1]);
@@ -823,7 +824,8 @@ test('Style#setFilter', function(t) {
             style.setFilter('symbol', filter);
             style.update({}, {}); // flush pending operations
 
-            style.dispatcher.broadcast = function(key, value) {
+            style.dispatcher.broadcast = function(key, data) {
+                var value = JSON.parse(data);
                 t.equal(key, 'update layers');
                 t.deepEqual(value[0].id, 'symbol');
                 t.deepEqual(value[0].filter, ['==', 'id', 2]);
@@ -841,7 +843,7 @@ test('Style#setFilter', function(t) {
         style.on('load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
-                t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
+                t.deepEqual(JSON.parse(value).map(function(layer) { return layer.id; }), ['symbol']);
             };
 
             style.setFilter('symbol-child', ['==', 'id', 1]);
@@ -899,7 +901,7 @@ test('Style#setLayerZoomRange', function(t) {
         style.on('load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
-                t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
+                t.deepEqual(JSON.parse(value).map(function(layer) { return layer.id; }), ['symbol']);
             };
 
             style.setLayerZoomRange('symbol', 5, 12);
@@ -915,7 +917,7 @@ test('Style#setLayerZoomRange', function(t) {
         style.on('load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
-                t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
+                t.deepEqual(JSON.parse(value).map(function(layer) { return layer.id; }), ['symbol']);
             };
 
             style.setLayerZoomRange('symbol-child', 5, 12);

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -672,7 +672,7 @@ test('Map', function(t) {
             map.on('style.load', function () {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'update layers');
-                    t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
+                    t.deepEqual(JSON.parse(value).map(function(layer) { return layer.id; }), ['symbol']);
                 };
 
                 map.setLayoutProperty('symbol', 'text-transform', 'lowercase');
@@ -712,7 +712,7 @@ test('Map', function(t) {
             map.on('style.load', function () {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'update layers');
-                    t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
+                    t.deepEqual(JSON.parse(value).map(function(layer) { return layer.id; }), ['symbol']);
                 };
 
                 map.setLayoutProperty('symbol-ref', 'text-transform', 'lowercase');


### PR DESCRIPTION
Ref #3153, not the cleanest change but appears to reduce time-to-fist-render by ~150ms. 

Couldn’t run benchmarks yet because they seem to be broken at the moment (only run on master).

cc @jfirebaugh @lucaswoj 