### PR TITLE
Use package-json-versionify to trim package.json in min bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "mourner/nyc#fast",
+    "package-json-versionify": "^1.0.2",
     "proxyquire": "^1.7.9",
     "remark": "4.2.2",
     "remark-html": "3.0.0",
@@ -85,7 +86,7 @@
   "scripts": {
     "build-dev": "browserify js/mapbox-gl.js --debug --standalone mapboxgl > dist/mapbox-gl-dev.js && tap --no-coverage test/build/dev.test.js",
     "watch-dev": "watchify js/mapbox-gl.js --debug --standalone mapboxgl --outfile dist/mapbox-gl-dev.js --verbose",
-    "build-min": "browserify js/mapbox-gl.js --debug --transform unassertify --plugin [minifyify --map mapbox-gl.js.map --output dist/mapbox-gl.js.map] --standalone mapboxgl > dist/mapbox-gl.js && tap --no-coverage test/build/min.test.js",
+    "build-min": "browserify js/mapbox-gl.js --debug --transform unassertify --transform package-json-versionify --plugin [minifyify --map mapbox-gl.js.map --output dist/mapbox-gl.js.map] --standalone mapboxgl > dist/mapbox-gl.js && tap --no-coverage test/build/min.test.js",
     "build-token": "browserify debug/access_token.js --debug --transform envify > debug/access_token_generated.js",
     "build-benchmarks": "BENCHMARK_VERSION=\"$(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short=7 HEAD)\" browserify bench/benchmarks.js --plugin [minifyify --no-map] --transform unassertify --transform envify --outfile bench/benchmarks_generated.js --verbose",
     "watch-benchmarks": "BENCHMARK_VERSION=\"$(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short=7 HEAD)\" watchify bench/benchmarks.js --plugin [minifyify --no-map] --transform unassertify --transform envify --outfile bench/benchmarks_generated.js --verbose",

--- a/test/build/min.test.js
+++ b/test/build/min.test.js
@@ -2,8 +2,16 @@
 
 var test = require('tap').test;
 var fs = require('fs');
+var pkg = require('../../package.json');
+
+var minBundle = fs.readFileSync('dist/mapbox-gl.js', 'utf8');
 
 test('production build removes asserts', function(t) {
-    t.assert(fs.readFileSync('dist/mapbox-gl.js', 'utf8').indexOf('assert(') === -1);
+    t.assert(minBundle.indexOf('assert(') === -1);
+    t.end();
+});
+
+test('trims package.json assets', function(t) {
+    t.assert(minBundle.indexOf('module.exports={"version":"' + pkg.version + '"}') !== -1);
     t.end();
 });


### PR DESCRIPTION
This PR adds the [`package-json.versionify`](https://github.com/nolanlawson/package-json-versionify) transform to the `npm run build-min` tasks and add one `test/build/min.test.js` test case.

This change reduces the size of the resulting `dist/mapbox-gl.js` bundle by `5K` (and even more on `npm` consumer builds where the README.md data is pasted into the package.json).
