### PR TITLE
Remove unused sprite callback

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -731,17 +731,6 @@ Style.prototype = util.inherit(Evented, {
 
     // Callbacks from web workers
 
-    'get sprite json': function(mapId, params, callback) {
-        var sprite = this.sprite;
-        if (sprite.loaded()) {
-            callback(null, { sprite: sprite.data, retina: sprite.retina });
-        } else {
-            sprite.on('load', function() {
-                callback(null, { sprite: sprite.data, retina: sprite.retina });
-            });
-        }
-    },
-
     'get icons': function(mapId, params, callback) {
         var sprite = this.sprite;
         var spriteAtlas = this.spriteAtlas;


### PR DESCRIPTION
It became unused 2 years ago (after @kkaefer https://github.com/mapbox/mapbox-gl-js/commit/0822b9fcbec215c4474d7acd94732c3e8638163e) and no one noticed! Free test coverage boost, yay :)