### PR TITLE
Fix smooth zoom with mouse wheel

### DIFF
--- a/js/ui/handler/scroll_zoom.js
+++ b/js/ui/handler/scroll_zoom.js
@@ -88,8 +88,6 @@ ScrollZoomHandler.prototype = {
         if (value !== 0 && (value % 4.000244140625) === 0) {
             // This one is definitely a mouse wheel event.
             this._type = 'wheel';
-            // Normalize this value to match trackpad.
-            value = Math.floor(value / 4);
 
         } else if (value !== 0 && Math.abs(value) < 4) {
             // This one is definitely a trackpad event because it is so small.
@@ -143,9 +141,10 @@ ScrollZoomHandler.prototype = {
             targetZoom = map.transform.scaleZoom(fromScale * scale);
 
         map.zoomTo(targetZoom, {
-            duration: 0,
+            duration: this._type === 'wheel' ? 200 : 0,
             around: map.unproject(this._pos),
-            delayEndEvents: 200
+            delayEndEvents: 200,
+            smoothEasing: true
         }, { originalEvent: e });
     }
 };


### PR DESCRIPTION
Closes #1730. This turned out to be a pretty tricky issue. Here's how the regression happened:

1. As a part of #2128, @ansis rewrote `zoomTo` to use `easeTo` rather than a custom implementation; however, it accidentally removed [this line of code](https://github.com/mapbox/mapbox-gl-js/pull/2128/commits/9846a4f6d54bd09dfba5c655c56e11d4484458f9#diff-91ad654374133c7bf9558652da3838c1L141) that was there specifically to smooth out mousewheel zoom animation (see https://github.com/mapbox/mapbox-gl-js/commit/f9b61f043ffef4e6287cb27bbd3b97468d628ff5).
2. @tristen noticed that mousewheel zoom feels awkward, and submitted https://github.com/mapbox/mapbox-gl-js/pull/1060, which removed animation from mousewheel zooming altogether, which improved mousewheel experience a lot compared to previously regressed state but in expense of smooth zoom we had earlier.
3. As a result, [this `_updateEasing` code](https://github.com/mapbox/mapbox-gl-js/blob/2924b910d7a9a0a12e0d71bd0771f7529acfade8/js/ui/camera.js#L749-L776) was completely unused for 7 months and I only noticed this because it was highlighted red in test coverage. 😆 

cc @tristen @ansis @lucaswoj @nthtran — please test with your mouses to make sure it works well.

- [x] get a PR review
- [x] make sure it works OK across browsers