### PR TITLE
Add clearer error message for map.queryRenderedFeatures...

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -115,7 +115,6 @@ map.on('load', function() {
 });
 
 map.on('click', function(e) {
-    var features = map.queryRenderedFeatures(e.point, {layers:['derp']});
     if (e.originalEvent.shiftKey) return;
     (new mapboxgl.Popup())
         .setLngLat(map.unproject(e.point))

--- a/debug/index.html
+++ b/debug/index.html
@@ -115,6 +115,7 @@ map.on('load', function() {
 });
 
 map.on('click', function(e) {
+    var features = map.queryRenderedFeatures(e.point, {layers:['derp']});
     if (e.originalEvent.shiftKey) return;
     (new mapboxgl.Popup())
         .setLngLat(map.unproject(e.point))

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -646,12 +646,12 @@ Style.prototype = util.inherit(Evented, {
         var includedSources = {};
         if (params && params.layers) {
             for (var i = 0; i < params.layers.length; i++) {
-                var layerId = params.layers[i];
-                if (!(this._layers[layerId] instanceof StyleLayer)) {
+                var layer = this._layers[params.layers[i]];
+                if (!(layer instanceof StyleLayer)) {
                     // this layer is not in the style.layers array
-                    return this.fire('error', {error: 'The layer \'' + layerId + '\' does not exist in the map\'s style and cannot be queried for features.'});
+                    return this.fire('error', {error: 'The layer \'' + params.layers[i] + '\' does not exist in the map\'s style and cannot be queried for features.'});
                 }
-                includedSources[this._layers[layerId].source] = true;
+                includedSources[layer.source] = true;
             }
         }
 

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -649,7 +649,8 @@ Style.prototype = util.inherit(Evented, {
                 var layer = this._layers[params.layers[i]];
                 if (!(layer instanceof StyleLayer)) {
                     // this layer is not in the style.layers array
-                    return this.fire('error', {error: 'The layer \'' + params.layers[i] + '\' does not exist in the map\'s style and cannot be queried for features.'});
+                    return this.fire('error', {error: 'The layer \'' + params.layers[i] +
+                        '\' does not exist in the map\'s style and cannot be queried for features.'});
                 }
                 includedSources[layer.source] = true;
             }

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -648,9 +648,8 @@ Style.prototype = util.inherit(Evented, {
             for (var i = 0; i < params.layers.length; i++) {
                 var layerId = params.layers[i];
                 if (!(this._layers[layerId] instanceof StyleLayer)) {
-                    // this layer is not in the style.layers array, so we pass an impossible array index
-                    this._handleErrors(validateStyle.layer, 'layers.' + layer.id, layer, false, {arrayIndex: -1});
-                    return;
+                    // this layer is not in the style.layers array
+                    return this.fire('error', {error: 'The layer \'' + layerId + '\' does not exist in the map\'s style and cannot be queried for features'});
                 }
                 includedSources[this._layers[layerId].source] = true;
             }

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -649,7 +649,7 @@ Style.prototype = util.inherit(Evented, {
                 var layerId = params.layers[i];
                 if (!(this._layers[layerId] instanceof StyleLayer)) {
                     // this layer is not in the style.layers array
-                    return this.fire('error', {error: 'The layer \'' + layerId + '\' does not exist in the map\'s style and cannot be queried for features'});
+                    return this.fire('error', {error: 'The layer \'' + layerId + '\' does not exist in the map\'s style and cannot be queried for features.'});
                 }
                 includedSources[this._layers[layerId].source] = true;
             }

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -647,6 +647,11 @@ Style.prototype = util.inherit(Evented, {
         if (params && params.layers) {
             for (var i = 0; i < params.layers.length; i++) {
                 var layerId = params.layers[i];
+                if (!(this._layers[layerId] instanceof StyleLayer)) {
+                    // this layer is not in the style.layers array, so we pass an impossible array index
+                    this._handleErrors(validateStyle.layer, 'layers.' + layer.id, layer, false, {arrayIndex: -1});
+                    return;
+                }
                 includedSources[this._layers[layerId].source] = true;
             }
         }
@@ -685,7 +690,6 @@ Style.prototype = util.inherit(Evented, {
             url: SourceType.workerSourceURL
         }, callback);
     },
-
     _handleErrors: function(validate, key, value, throws, props) {
         var action = throws ? validateStyle.throwErrors : validateStyle.emitErrors;
         var result = validate.call(validateStyle, util.extend({

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -1093,6 +1093,16 @@ test('Style#queryRenderedFeatures', function(t) {
             t.end();
         });
 
+        t.test('fires an error if layer included in params does not exist on the style', function(t) {
+            var errors = 0;
+            sinon.stub(style, 'fire', function() {
+                if (arguments[1].error && arguments[1].error.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
+            });
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']});
+            t.equals(errors, 1);
+            t.end();
+        });
+
         t.end();
     });
 });

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -1095,8 +1095,8 @@ test('Style#queryRenderedFeatures', function(t) {
 
         t.test('fires an error if layer included in params does not exist on the style', function(t) {
             var errors = 0;
-            sinon.stub(style, 'fire', function() {
-                if (arguments[1].error && arguments[1].error.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
+            sinon.stub(style, 'fire', function(type, data) {
+                if (data.error && data.error.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
             });
             style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']});
             t.equals(errors, 1);


### PR DESCRIPTION
when called with a layer that does not exist in the map's style.
#3084 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs n/a
 - [ ] post benchmark scores n/a
 - [x] manually test the debug page 
 - [ ] get a PR review
