### PR TITLE
Fix error when running dependencies.ci

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -13,6 +13,6 @@ else
     source ./nvm/nvm.sh && nvm use ${NODE_VERSION} && npm install && npm ls
 fi
 
-if [ "$CIRCLE_BRANCH" == "master"] || [ -z "$CIRCLE_TAG" ]; then
+if [ "$CIRCLE_BRANCH" == "master" ] || [ -z "$CIRCLE_TAG" ]; then
     pip install --user --upgrade awscli
 fi


### PR DESCRIPTION
This PR fixes the error that occurs when `dependencies.ci` is run and causes `awscli` to be installed on all builds. The error was caused by a bash syntax error. 

This bug was logged by @mourner at https://github.com/mapbox/mapbox-gl-js/pull/3100#r79139732

## Launch Checklist

 - [x] briefly describe the changes in this PR
