### PR TITLE
[not ready] Better handling for undefined icon|text-rotation-alignment

### DIFF
--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -10,22 +10,20 @@ function SymbolStyleLayer() {
 module.exports = SymbolStyleLayer;
 
 SymbolStyleLayer.prototype = util.inherit(StyleLayer, {
-
     getLayoutValue: function(name, globalProperties, featureProperties) {
-        if (name === 'text-rotation-alignment' &&
-                this.getLayoutValue('symbol-placement', globalProperties, featureProperties) === 'line' &&
-                !this.getLayoutProperty('text-rotation-alignment')) {
-            return 'map';
-        } else if (name === 'icon-rotation-alignment' &&
-                this.getLayoutValue('symbol-placement', globalProperties, featureProperties) === 'line' &&
-                !this.getLayoutProperty('icon-rotation-alignment')) {
-            return 'map';
-        // If unspecified `text-pitch-alignment` inherits `text-rotation-alignment`
-        } else if (name === 'text-pitch-alignment' && !this.getLayoutProperty('text-pitch-alignment')) {
-            return this.getLayoutValue('text-rotation-alignment');
-        } else {
-            return StyleLayer.prototype.getLayoutValue.apply(this, arguments);
+        var value = StyleLayer.prototype.getLayoutValue.apply(this, arguments);
+        if (value !== 'auto') {
+            return value;
+        }
+
+        switch (name) {
+        case 'text-rotation-alignment':
+        case 'icon-rotation-alignment':
+            return this.getLayoutValue('symbol-placement', globalProperties, featureProperties) === 'line' ? 'map' : 'viewport';
+        case 'text-pitch-alignment':
+            return this.getLayoutValue('text-rotation-alignment', globalProperties, featureProperties);
+        default:
+            return value;
         }
     }
-
 });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "^1.2.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#df162476980d9ee2ab6f8d0cf5a06e27aac60472",
-    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#83b1a3e5837d785af582efd5ed1a212f2df6a4ae",
+    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#a6c95d33ff5ced2c0d7df995fd89eb557c0a353c",
     "mapbox-gl-supported": "^1.2.0",
     "package-json-versionify": "^1.0.2",
     "pbf": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#01c2e8d1e7bb7a6b2a58ec0df4816eee21dd8646",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#c736ea5acc1094488394f3fc5e5c1f6f94279c71",
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -604,6 +604,18 @@ test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
         assert.equal(layer.getLayoutValue('text-pitch-alignment'), 'viewport');
         assert.end();
     });
+    assert.test('text-pitch-alignment:auto defaults to text-rotation-alignment', function(assert) {
+        var layer = StyleLayer.create({
+            "type": "symbol",
+            "layout": {
+                "text-rotation-alignment": "map",
+                "text-pitch-alignment": "auto"
+            }
+        });
+        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
+        assert.equal(layer.getLayoutValue('text-pitch-alignment'), 'map');
+        assert.end();
+    });
     assert.test('text-pitch-alignment respected when set', function(assert) {
         var layer = StyleLayer.create({
             "type": "symbol",
@@ -614,6 +626,50 @@ test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
         });
         assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
         assert.equal(layer.getLayoutValue('text-pitch-alignment'), 'map');
+        assert.end();
+    });
+    assert.test('symbol-placement:point and text-rotation-alignment:auto  => text-rotation-alignment:viewport ', function(assert) {
+        var layer = StyleLayer.create({
+            "type": "symbol",
+            "layout": {
+                "symbol-placement": "point",
+                "text-rotation-alignment": "auto"
+            }
+        });
+        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
+        assert.end();
+    });
+    assert.test('symbol-placement:line and text-rotation-alignment:auto  => text-rotation-alignment:map ', function(assert) {
+        var layer = StyleLayer.create({
+            "type": "symbol",
+            "layout": {
+                "symbol-placement": "line",
+                "text-rotation-alignment": "auto"
+            }
+        });
+        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
+        assert.end();
+    });
+    assert.test('symbol-placement:point and icon-rotation-alignment:auto  => icon-rotation-alignment:viewport ', function(assert) {
+        var layer = StyleLayer.create({
+            "type": "symbol",
+            "layout": {
+                "symbol-placement": "point",
+                "icon-rotation-alignment": "auto"
+            }
+        });
+        assert.equal(layer.getLayoutValue('icon-rotation-alignment'), 'viewport');
+        assert.end();
+    });
+    assert.test('symbol-placement:line and icon-rotation-alignment:auto  => icon-rotation-alignment:map ', function(assert) {
+        var layer = StyleLayer.create({
+            "type": "symbol",
+            "layout": {
+                "symbol-placement": "line",
+                "icon-rotation-alignment": "auto"
+            }
+        });
+        assert.equal(layer.getLayoutValue('icon-rotation-alignment'), 'map');
         assert.end();
     });
     assert.end();

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -559,52 +559,56 @@ test('StyleLayer#serialize', function(t) {
     t.end();
 });
 
-test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
-    assert.test('symbol-placement:point => *-rotation-alignment:viewport', function(assert) {
+test('StyleLayer#getLayoutValue (default exceptions)', function(t) {
+    t.test('symbol-placement:point => *-rotation-alignment:viewport', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
                 "symbol-placement": "point"
             }
         });
-        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
-        assert.equal(layer.getLayoutValue('icon-rotation-alignment'), 'viewport');
-        assert.end();
+        t.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
+        t.equal(layer.getLayoutValue('icon-rotation-alignment'), 'viewport');
+        t.end();
     });
-    assert.test('symbol-placement:line => *-rotation-alignment:map', function(assert) {
+
+    t.test('symbol-placement:line => *-rotation-alignment:map', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
                 "symbol-placement": "line"
             }
         });
-        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
-        assert.equal(layer.getLayoutValue('icon-rotation-alignment'), 'map');
-        assert.end();
+        t.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
+        t.equal(layer.getLayoutValue('icon-rotation-alignment'), 'map');
+        t.end();
     });
-    assert.test('text-rotation-alignment:map => text-pitch-alignment:map', function(assert) {
+
+    t.test('text-rotation-alignment:map => text-pitch-alignment:map', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
                 "text-rotation-alignment": "map"
             }
         });
-        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
-        assert.equal(layer.getLayoutValue('text-pitch-alignment'), 'map');
-        assert.end();
+        t.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
+        t.equal(layer.getLayoutValue('text-pitch-alignment'), 'map');
+        t.end();
     });
-    assert.test('text-rotation-alignment:viewport => text-pitch-alignment:viewport', function(assert) {
+
+    t.test('text-rotation-alignment:viewport => text-pitch-alignment:viewport', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
                 "text-rotation-alignment": "viewport"
             }
         });
-        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
-        assert.equal(layer.getLayoutValue('text-pitch-alignment'), 'viewport');
-        assert.end();
+        t.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
+        t.equal(layer.getLayoutValue('text-pitch-alignment'), 'viewport');
+        t.end();
     });
-    assert.test('text-pitch-alignment:auto defaults to text-rotation-alignment', function(assert) {
+
+    t.test('text-pitch-alignment:auto defaults to text-rotation-alignment', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
@@ -612,11 +616,12 @@ test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
                 "text-pitch-alignment": "auto"
             }
         });
-        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
-        assert.equal(layer.getLayoutValue('text-pitch-alignment'), 'map');
-        assert.end();
+        t.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
+        t.equal(layer.getLayoutValue('text-pitch-alignment'), 'map');
+        t.end();
     });
-    assert.test('text-pitch-alignment respected when set', function(assert) {
+
+    t.test('text-pitch-alignment respected when set', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
@@ -624,11 +629,12 @@ test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
                 "text-pitch-alignment": "map"
             }
         });
-        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
-        assert.equal(layer.getLayoutValue('text-pitch-alignment'), 'map');
-        assert.end();
+        t.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
+        t.equal(layer.getLayoutValue('text-pitch-alignment'), 'map');
+        t.end();
     });
-    assert.test('symbol-placement:point and text-rotation-alignment:auto  => text-rotation-alignment:viewport ', function(assert) {
+
+    t.test('symbol-placement:point and text-rotation-alignment:auto  => text-rotation-alignment:viewport ', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
@@ -636,10 +642,11 @@ test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
                 "text-rotation-alignment": "auto"
             }
         });
-        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
-        assert.end();
+        t.equal(layer.getLayoutValue('text-rotation-alignment'), 'viewport');
+        t.end();
     });
-    assert.test('symbol-placement:line and text-rotation-alignment:auto  => text-rotation-alignment:map ', function(assert) {
+
+    t.test('symbol-placement:line and text-rotation-alignment:auto  => text-rotation-alignment:map ', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
@@ -647,10 +654,11 @@ test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
                 "text-rotation-alignment": "auto"
             }
         });
-        assert.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
-        assert.end();
+        t.equal(layer.getLayoutValue('text-rotation-alignment'), 'map');
+        t.end();
     });
-    assert.test('symbol-placement:point and icon-rotation-alignment:auto  => icon-rotation-alignment:viewport ', function(assert) {
+
+    t.test('symbol-placement:point and icon-rotation-alignment:auto  => icon-rotation-alignment:viewport ', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
@@ -658,10 +666,11 @@ test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
                 "icon-rotation-alignment": "auto"
             }
         });
-        assert.equal(layer.getLayoutValue('icon-rotation-alignment'), 'viewport');
-        assert.end();
+        t.equal(layer.getLayoutValue('icon-rotation-alignment'), 'viewport');
+        t.end();
     });
-    assert.test('symbol-placement:line and icon-rotation-alignment:auto  => icon-rotation-alignment:map ', function(assert) {
+
+    t.test('symbol-placement:line and icon-rotation-alignment:auto  => icon-rotation-alignment:map ', function(t) {
         var layer = StyleLayer.create({
             "type": "symbol",
             "layout": {
@@ -669,10 +678,11 @@ test('StyleLayer#getLayoutValue (default exceptions)', function(assert) {
                 "icon-rotation-alignment": "auto"
             }
         });
-        assert.equal(layer.getLayoutValue('icon-rotation-alignment'), 'map');
-        assert.end();
+        t.equal(layer.getLayoutValue('icon-rotation-alignment'), 'map');
+        t.end();
     });
-    assert.end();
+
+    t.end();
 });
 
 function createAnimationLoop() {


### PR DESCRIPTION
This updates the symbol style layer so that it uses the correct values (viewport or map) when the auto value is set explicitly or by default for the properties that support it.

`text-pitch-alignment` continues to parrot text-rotation-alignment but now also does so if its value is explicitly set to auto.

Companion to mapbox/mapbox-gl-style-spec#493, mapbox/mapbox-gl-native#6253, and https://github.com/mapbox/mapbox-gl-test-suite/pull/144.

Part of the federation of PRs to address https://github.com/mapbox/mapbox-gl-native/issues/5683

## Launch Checklist

 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] get a PR review

cc @jfirebaugh @lbud 

