### PR TITLE
Add a hack to fix Map#setFilter and rotation on iOS 10

### DIFF
--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -169,6 +169,9 @@ SourceCache.prototype = util.inherit(Evented, {
         tile.timeAdded = new Date().getTime();
         this.fire('tile.load', {tile: tile});
         this._source.fire('tile.load', {tile: tile});
+
+        // HACK this is nescessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
+        if (this.map) this.map.painter.tileExtentVAO.vao = null;
     },
 
     /**

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -144,6 +144,9 @@ Tile.prototype = {
             this.reloadSymbolData(data, source.map.painter, source.map.style);
             source.fire('tile.load', {tile: this});
 
+            // HACK this is nescessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
+            if (source.map) source.map.painter.tileExtentVAO.vao = null;
+
             this.state = 'loaded';
             if (this.redoWhenDone) {
                 this.redoPlacement(source);


### PR DESCRIPTION
This PR adds some hack code to work around #2986. I have been unable to identify a root cause of the bug or a minimal test case that reproduces the bug. We can view this hack as 

 - a starting point for more discussion
 - a temporary fix
 - a long-term fix (there are no significant perf implications AFIK)

cc @jfirebaugh @mourner @mollymerp  

# Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page

# Benchmarks

## map-load

**master dbd0f90:** 145 ms
**2986 b66e8cc:** 98 ms

## style-load

**master dbd0f90:** 177 ms
**2986 b66e8cc:** 180 ms

## buffer

**master dbd0f90:** 1,031 ms
**2986 b66e8cc:** 1,034 ms

## fps

**master dbd0f90:** 60 fps
**2986 b66e8cc:** 60 fps

## frame-duration

**master dbd0f90:** 6.7 ms, 2% > 16ms
**2986 b66e8cc:** 6.5 ms, 1% > 16ms

## query-point

**master dbd0f90:** 0.97 ms
**2986 b66e8cc:** 1.07 ms

## query-box

**master dbd0f90:** 66.35 ms
**2986 b66e8cc:** 83.66 ms

## geojson-setdata-small

**master dbd0f90:** 15 ms
**2986 b66e8cc:** 19 ms

## geojson-setdata-large

**master dbd0f90:** 149 ms
**2986 b66e8cc:** 137 ms
