### PR TITLE
POC: bypass Protobuf to supply GeoJSON IDs

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -56,6 +56,7 @@ module.exports = GeoJSONSource;
  *     data: {
  *        "type": "FeatureCollection",
  *        "features": [{
+ *            "id": 65342,
  *            "type": "Feature",
  *            "properties": { "name": "Null Island" },
  *            "geometry": {

--- a/js/source/geojson_wrapper.js
+++ b/js/source/geojson_wrapper.js
@@ -14,10 +14,10 @@ function GeoJSONWrapper(features) {
 }
 
 GeoJSONWrapper.prototype.feature = function(i) {
-    return new FeatureWrapper(this.features[i]);
+    return new FeatureWrapper(this.features[i], i);
 };
 
-function FeatureWrapper(feature) {
+function FeatureWrapper(feature, id) {
     this.type = feature.type;
     if (feature.type === 1) {
         this.rawGeometry = [];
@@ -27,6 +27,8 @@ function FeatureWrapper(feature) {
     } else {
         this.rawGeometry = feature.geometry;
     }
+
+    this.id = id;
     this.properties = feature.tags;
     this.extent = EXTENT;
 }

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -19,6 +19,7 @@ var SourceCache = require('../source/source_cache');
 var styleSpec = require('./style_spec');
 var StyleFunction = require('./style_function');
 var getWorkerPool = require('../global_worker_pool');
+var GeoJSONSource = require('../source/geojson_source');
 
 module.exports = Style;
 
@@ -626,11 +627,18 @@ Style.prototype = util.inherit(Evented, {
         var features = [];
         for (var l = this._order.length - 1; l >= 0; l--) {
             var layerID = this._order[l];
+            var source = this.sources[this._layers[layerID].source];
             for (var s = 0; s < sourceResults.length; s++) {
                 var layerFeatures = sourceResults[s][layerID];
                 if (layerFeatures) {
                     for (var f = 0; f < layerFeatures.length; f++) {
-                        features.push(layerFeatures[f]);
+                        if (source && source._source instanceof GeoJSONSource) {
+                            features.push(Object.create(layerFeatures[f], {
+                                id: {value: source._source._data.features[layerFeatures[f].id].id || null}
+                            }));
+                        } else {
+                            features.push(layerFeatures[f]);
+                        }
                     }
                 }
             }

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -459,6 +459,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * @returns {Array<Object>} An array of [GeoJSON](http://geojson.org/)
      * [feature objects](http://geojson.org/geojson-spec.html#feature-objects).
      *
+     * The `id` value of each returned feature object contains the `id` specified on its source feature, or `null` if no id was specified.
+     *
      * The `properties` value of each returned feature object contains the properties of its source feature. For GeoJSON sources, only
      * string and numeric property values are supported (i.e. `null`, `Array`, and `Object` values are not supported).
      *


### PR DESCRIPTION
See issue #3210. This is just a proof of concept, and likely NOT the cleanest way to implement this feature.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] get a PR review

