### PR TITLE
Hash pitch

### DIFF
--- a/js/ui/hash.js
+++ b/js/ui/hash.js
@@ -51,7 +51,8 @@ Hash.prototype = {
             this._map.jumpTo({
                 center: [+loc[2], +loc[1]],
                 zoom: +loc[0],
-                bearing: +(loc[3] || 0)
+                bearing: +(loc[3] || 0),
+                pitch: +(loc[4] || 0)
             });
             return true;
         }
@@ -62,12 +63,15 @@ Hash.prototype = {
         var center = this._map.getCenter(),
             zoom = this._map.getZoom(),
             bearing = this._map.getBearing(),
+            pitch = this._map.getPitch(),
             precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2)),
 
             hash = '#' + (Math.round(zoom * 100) / 100) +
                 '/' + center.lat.toFixed(precision) +
-                '/' + center.lng.toFixed(precision) +
-                (bearing ? '/' + (Math.round(bearing * 10) / 10) : '');
+                '/' + center.lng.toFixed(precision);
+
+        if (bearing || pitch) hash += ('/' + (Math.round(bearing * 10) / 10));
+        if (pitch) hash += ('/' + Math.round(pitch));
 
         window.history.replaceState('', '', hash);
     }

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -86,8 +86,8 @@ var defaultOptions = {
  *  * `mapbox://styles/mapbox/satellite-v9`
  *  * `mapbox://styles/mapbox/satellite-streets-v9`
  *
- * @param {boolean} [options.hash=false] If `true`, the map's position (zoom, center latitude, center longitude, and bearing) will be synced with the hash fragment of the page's URL.
- *   For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1`.
+ * @param {boolean} [options.hash=false] If `true`, the map's position (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL.
+ *   For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
  * @param {boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners will be attached to the map, so it will not respond to interaction.
  * @param {number} [options.bearingSnap=7] The threshold, measured in degrees, that determines when the map's
  *   bearing (rotation) will snap to north. For example, with a `bearingSnap` of 7, if the user rotates

--- a/test/js/ui/hash.test.js
+++ b/test/js/ui/hash.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+var test = require('tap').test;
+var Hash = require('../../../js/ui/hash');
+var window = require('../../../js/util/window');
+var Map = require('../../../js/ui/map');
+
+test('hash', function(t) {
+    function createHash() {
+        return new Hash();
+    }
+
+    function createMap() {
+        var container = window.document.createElement('div');
+        container.offsetWidth = 512;
+        container.offsetHeight = 512;
+        return new Map({container: container});
+    }
+
+
+    t.test('#addTo', function(t) {
+        var map = createMap();
+        var hash = createHash();
+
+        t.notok(hash._map);
+
+        hash.addTo(map);
+
+        t.ok(hash._map);
+        t.end();
+    });
+
+    t.test('#remove', function(t) {
+        var map = createMap();
+        var hash = createHash()
+            .addTo(map);
+
+        t.ok(hash._map);
+
+        hash.remove();
+
+        t.notok(hash._map);
+        t.end();
+    });
+
+    t.test('#_onHashChange', function(t) {
+        var map = createMap();
+        var hash = createHash()
+            .addTo(map);
+
+        window.location.hash = '#10/3.00/-1.00';
+
+        hash._onHashChange();
+
+        t.equal(map.getCenter().lng, -1);
+        t.equal(map.getCenter().lat, 3);
+        t.equal(map.getZoom(), 10);
+        t.equal(map.getBearing(), 0);
+        t.equal(map.getPitch(), 0);
+
+        window.location.hash = '#5/1.00/0.50/30/60';
+
+        hash._onHashChange();
+
+        t.equal(map.getCenter().lng, 0.5);
+        t.equal(map.getCenter().lat, 1);
+        t.equal(map.getZoom(), 5);
+        t.equal(map.getBearing(), 30);
+        t.equal(map.getPitch(), 60);
+
+        window.location.hash = '';
+
+        t.end();
+    });
+
+    t.test('#_updateHash', function(t) {
+        function getHash() {
+            return window.location.hash.split('/');
+        }
+
+        var map = createMap();
+        createHash()
+            .addTo(map);
+
+        t.notok(window.location.hash);
+
+        map.setZoom(3);
+        map.setCenter([2.0, 1.0]);
+
+        t.ok(window.location.hash);
+
+        var newHash = getHash();
+
+        t.equal(newHash.length, 3);
+        t.equal(newHash[0], '#3');
+        t.equal(newHash[1], '1.00');
+        t.equal(newHash[2], '2.00');
+
+        map.setPitch(60);
+
+        newHash = getHash();
+
+        t.equal(newHash.length, 5);
+        t.equal(newHash[0], '#3');
+        t.equal(newHash[1], '1.00');
+        t.equal(newHash[2], '2.00');
+        t.equal(newHash[3], '0');
+        t.equal(newHash[4], '60');
+
+        map.setBearing(135);
+
+        newHash = getHash();
+
+        t.equal(newHash.length, 5);
+        t.equal(newHash[0], '#3');
+        t.equal(newHash[1], '1.00');
+        t.equal(newHash[2], '2.00');
+        t.equal(newHash[3], '135');
+        t.equal(newHash[4], '60');
+
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/3198.

This adds an additional parameter to the hash, so that in addition to hash options
```
#zoom/lat/lng
#zoom/lat/lng/bearing
```
it also allows for 
```
#zoom/lat/lng/bearing/pitch
```
if the map is pitched.

This PR also adds a test file for `js/ui/hash.js`, previously untested.

cc @mourner @jfirebaugh  

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] get a PR review



# Benchmarks

## map-load

**master 691f3fe:** 509 ms
**hash-pitch d45b810:** 179 ms

## style-load

**master 691f3fe:** 232 ms
**hash-pitch d45b810:** 168 ms

## buffer

**master 691f3fe:** 1,094 ms
**hash-pitch d45b810:** 1,393 ms

## fps

**master 691f3fe:** 60 fps
**hash-pitch d45b810:** 60 fps

## frame-duration

**master 691f3fe:** 7.9 ms, 0% > 16ms
**hash-pitch d45b810:** 8.3 ms, 3% > 16ms

## query-point

**master 691f3fe:** 1.38 ms
**hash-pitch d45b810:** 1.26 ms

## query-box

**master 691f3fe:** 81.20 ms
**hash-pitch d45b810:** 76.27 ms

## geojson-setdata-small

**master 691f3fe:** 17 ms
**hash-pitch d45b810:** 23 ms

## geojson-setdata-large

**master 691f3fe:** 146 ms
**hash-pitch d45b810:** 161 ms
