### PR TITLE
Avoid unnecessary style validation

### DIFF
--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -42,6 +42,7 @@ StyleLayer.prototype = util.inherit(Evented, {
         this._layoutFunctions = {}; // {[propertyName]: Boolean}
 
         var paintName, layoutName;
+        var options = {validate: false};
 
         // Resolve paint declarations
         for (var key in layer) {
@@ -49,7 +50,7 @@ StyleLayer.prototype = util.inherit(Evented, {
             if (match) {
                 var klass = match[1] || '';
                 for (paintName in layer[key]) {
-                    this.setPaintProperty(paintName, layer[key][paintName], klass);
+                    this.setPaintProperty(paintName, layer[key][paintName], klass, options);
                 }
             }
         }
@@ -59,7 +60,7 @@ StyleLayer.prototype = util.inherit(Evented, {
             this._layoutDeclarations = refLayer._layoutDeclarations;
         } else {
             for (layoutName in layer.layout) {
-                this.setLayoutProperty(layoutName, layer.layout[layoutName]);
+                this.setLayoutProperty(layoutName, layer.layout[layoutName], options);
             }
         }
 
@@ -72,13 +73,13 @@ StyleLayer.prototype = util.inherit(Evented, {
         }
     },
 
-    setLayoutProperty: function(name, value) {
+    setLayoutProperty: function(name, value, options) {
 
         if (value == null) {
             delete this._layoutDeclarations[name];
         } else {
             var key = 'layers.' + this.id + '.layout.' + name;
-            if (this._handleErrors(validateStyle.layoutProperty, key, name, value)) return;
+            if (this._validate(validateStyle.layoutProperty, key, name, value, options)) return;
             this._layoutDeclarations[name] = new StyleDeclaration(this._layoutSpecifications[name], value);
         }
         this._updateLayoutValue(name);
@@ -102,7 +103,7 @@ StyleLayer.prototype = util.inherit(Evented, {
         }
     },
 
-    setPaintProperty: function(name, value, klass) {
+    setPaintProperty: function(name, value, klass, options) {
         var validateStyleKey = 'layers.' + this.id + (klass ? '["paint.' + klass + '"].' : '.paint.') + name;
 
         if (util.endsWith(name, TRANSITION_SUFFIX)) {
@@ -112,7 +113,7 @@ StyleLayer.prototype = util.inherit(Evented, {
             if (value === null || value === undefined) {
                 delete this._paintTransitionOptions[klass || ''][name];
             } else {
-                if (this._handleErrors(validateStyle.paintProperty, validateStyleKey, name, value)) return;
+                if (this._validate(validateStyle.paintProperty, validateStyleKey, name, value, options)) return;
                 this._paintTransitionOptions[klass || ''][name] = value;
             }
         } else {
@@ -122,7 +123,7 @@ StyleLayer.prototype = util.inherit(Evented, {
             if (value === null || value === undefined) {
                 delete this._paintDeclarations[klass || ''][name];
             } else {
-                if (this._handleErrors(validateStyle.paintProperty, validateStyleKey, name, value)) return;
+                if (this._validate(validateStyle.paintProperty, validateStyleKey, name, value, options)) return;
                 this._paintDeclarations[klass || ''][name] = new StyleDeclaration(this._paintSpecifications[name], value);
             }
         }
@@ -315,7 +316,10 @@ StyleLayer.prototype = util.inherit(Evented, {
         }
     },
 
-    _handleErrors: function(validate, key, name, value) {
+    _validate: function(validate, key, name, value, options) {
+        if (options && options.validate === false) {
+            return false;
+        }
         return validateStyle.emitErrors(this, validate.call(validateStyle, {
             key: key,
             layerType: this.type,

--- a/js/style/validate_style.js
+++ b/js/style/validate_style.js
@@ -2,7 +2,7 @@
 
 module.exports = require('mapbox-gl-style-spec/lib/validate_style.min');
 
-module.exports.emitErrors = function throwErrors(emitter, errors) {
+module.exports.emitErrors = function (emitter, errors) {
     if (errors && errors.length) {
         for (var i = 0; i < errors.length; i++) {
             emitter.fire('error', { error: new Error(errors[i].message) });
@@ -10,13 +10,5 @@ module.exports.emitErrors = function throwErrors(emitter, errors) {
         return true;
     } else {
         return false;
-    }
-};
-
-module.exports.throwErrors = function throwErrors(emitter, errors) {
-    if (errors) {
-        for (var i = 0; i < errors.length; i++) {
-            throw new Error(errors[i].message);
-        }
     }
 };

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -27,6 +27,10 @@ function makeAPIURL(path, query, accessToken) {
     return url;
 }
 
+module.exports.isMapboxURL = function(url) {
+    return URL.parse(url).protocol === 'mapbox:';
+};
+
 module.exports.normalizeStyleURL = function(url, accessToken) {
     var urlObject = URL.parse(url);
 


### PR DESCRIPTION
Avoid unnecessary style validation:

* Don't validate mapbox:// styles (fixes #3152)
* Don't validate data in the worker (fixes #3149)
* Don't revalidate previously-validated data (fixes #3151)

This PR does not expose a `validate` option at the API level yet.

# Benchmarks

## map-load

**master c0f1c7e:** 272 ms
**style-load-perf b2e5679:** 89 ms

## style-load

**master c0f1c7e:** 163 ms
**style-load-perf b2e5679:** 112 ms

## buffer

**master c0f1c7e:** 1,032 ms
**style-load-perf b2e5679:** 989 ms

## fps

**master c0f1c7e:** 60 fps
**style-load-perf b2e5679:** 60 fps

## frame-duration

**master c0f1c7e:** 7.3 ms, 0% > 16ms
**style-load-perf b2e5679:** 7.3 ms, 0% > 16ms

## query-point

**master c0f1c7e:** 1.01 ms
**style-load-perf b2e5679:** 1.33 ms

## query-box

**master c0f1c7e:** 64.97 ms
**style-load-perf b2e5679:** 68.48 ms

## geojson-setdata-small

**master c0f1c7e:** 12 ms
**style-load-perf b2e5679:** 13 ms

## geojson-setdata-large

**master c0f1c7e:** 121 ms
**style-load-perf b2e5679:** 113 ms

# Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page
