### PR TITLE
Fix tagged builds on CircleCI 

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -13,6 +13,6 @@ else
     source ./nvm/nvm.sh && nvm use ${NODE_VERSION} && npm install && npm ls
 fi
 
-if [ "$CIRCLE_BRANCH" == "master" ] || [ -z "$CIRCLE_TAG" ]; then
+if [ "$CIRCLE_BRANCH" == "master" ] || [ -n "$CIRCLE_TAG" ]; then
     pip install --user --upgrade awscli
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -27,7 +27,7 @@ npm run test-cov
 
 # send coverage report to coveralls
 nyc report --reporter=lcov
-# there is a Coveralls / Circle bug triggered by tagged builds
+# this code works around a Coveralls / CircleCI bug triggered by tagged builds
 if [ -z "$CIRCLE_TAG" ]; then
     (node ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info) || true
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,7 +3,7 @@
 source ./nvm/nvm.sh
 nvm use ${NODE_VERSION}
 
-set -eu
+set -e
 set -o pipefail
 
 # add npm packages to $PATH
@@ -27,7 +27,10 @@ npm run test-cov
 
 # send coverage report to coveralls
 nyc report --reporter=lcov
-(node ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info) || true
+# there is a Coveralls / Circle bug triggered by tagged builds
+if [ -z "$CIRCLE_TAG" ]; then
+    (node ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info) || true
+fi
 
 # upload benchmarks
 if [ "$CIRCLE_BRANCH" == "master" ]; then


### PR DESCRIPTION
Coveralls causes tagged builds to [fail](https://circleci.com/gh/mapbox/mapbox-gl-js/5027) because of some missing git metadata.

This PR skips coverage measurements and fixes `awscli` installation on tagged builds 