### PR TITLE
Enforce LngLatLike param in LngLat.convert

### DIFF
--- a/js/geo/lng_lat.js
+++ b/js/geo/lng_lat.js
@@ -82,7 +82,7 @@ LngLat.prototype.toString = function () {
 LngLat.convert = function (input) {
     if (input instanceof LngLat) {
         return input;
-    } else if (typeof input !== 'undefined' && input.hasOwnProperty('lng') && input.hasOwnProperty('lat')) {
+    } else if (input && input.hasOwnProperty('lng') && input.hasOwnProperty('lat')) {
         return new LngLat(input.lng, input.lat);
     } else if (Array.isArray(input) && input.length === 2) {
         return new LngLat(input[0], input[1]);

--- a/js/geo/lng_lat.js
+++ b/js/geo/lng_lat.js
@@ -82,9 +82,11 @@ LngLat.prototype.toString = function () {
 LngLat.convert = function (input) {
     if (input instanceof LngLat) {
         return input;
-    }
-    if (Array.isArray(input)) {
+    } else if (input && input.lng && input.lat) {
+        return input;
+    } else if (Array.isArray(input) && input.length === 2) {
         return new LngLat(input[0], input[1]);
+    } else {
+        throw new Error("`LngLatLike` argument must be specified as a LngLat instance, an object {lng: <lng>, lat: <lat>}, or an array of [<lng>, <lat>]");
     }
-    return input;
 };

--- a/js/geo/lng_lat.js
+++ b/js/geo/lng_lat.js
@@ -82,8 +82,8 @@ LngLat.prototype.toString = function () {
 LngLat.convert = function (input) {
     if (input instanceof LngLat) {
         return input;
-    } else if (input && input.lng && input.lat) {
-        return input;
+    } else if (typeof input !== 'undefined' && input.hasOwnProperty('lng') && input.hasOwnProperty('lat')) {
+        return new LngLat(input.lng, input.lat);
     } else if (Array.isArray(input) && input.length === 2) {
         return new LngLat(input[0], input[1]);
     } else {

--- a/js/geo/lng_lat_bounds.js
+++ b/js/geo/lng_lat_bounds.js
@@ -81,9 +81,9 @@ LngLatBounds.prototype = {
 
         } else {
             if (Array.isArray(obj)) {
-                if (obj.every(function(i) { return Array.isArray(i); })) {
+                if (obj.every(Array.isArray)) {
                     return this.extend(LngLatBounds.convert(obj));
-                } else if (obj.every(function(i) { return !isNaN(i); })) {
+                } else {
                     return this.extend(LngLat.convert(obj));
                 }
             }

--- a/js/geo/lng_lat_bounds.js
+++ b/js/geo/lng_lat_bounds.js
@@ -80,7 +80,14 @@ LngLatBounds.prototype = {
             if (!sw2 || !ne2) return this;
 
         } else {
-            return obj ? this.extend(LngLat.convert(obj) || LngLatBounds.convert(obj)) : this;
+            if (Array.isArray(obj)) {
+                if (obj.every(function(i) { return Array.isArray(i); })) {
+                    return this.extend(LngLatBounds.convert(obj));
+                } else if (obj.every(function(i) { return !isNaN(i); })) {
+                    return this.extend(LngLat.convert(obj));
+                }
+            }
+            return this;
         }
 
         if (!sw && !ne) {

--- a/test/js/geo/lng_lat.test.js
+++ b/test/js/geo/lng_lat.test.js
@@ -24,7 +24,9 @@ test('LngLat', function(t) {
     t.test('#convert', function(t) {
         t.ok(LngLat.convert([0, 10]) instanceof LngLat, 'convert creates a LngLat instance');
         t.ok(LngLat.convert(new LngLat(0, 0)) instanceof LngLat, 'convert creates a LngLat instance');
-        t.equal(LngLat.convert('othervalue'), 'othervalue', 'passes through other values');
+        t.throws(function() {
+            LngLat.convert(0, 10);
+        }, "`LngLatLike` argument must be specified as a LngLat instance, an object {lng: <lng>, lat: <lat>}, or an array of [<lng>, <lat>]", 'detects and throws on invalid input');
         t.end();
     });
 

--- a/test/js/geo/lng_lat.test.js
+++ b/test/js/geo/lng_lat.test.js
@@ -23,6 +23,8 @@ test('LngLat', function(t) {
 
     t.test('#convert', function(t) {
         t.ok(LngLat.convert([0, 10]) instanceof LngLat, 'convert creates a LngLat instance');
+        t.ok(LngLat.convert({lng: 0, lat: 10}) instanceof LngLat, 'convert creates a LngLat instance');
+        t.ok(LngLat.convert({lng: 0, lat: 0}) instanceof LngLat, 'convert creates a LngLat instance');
         t.ok(LngLat.convert(new LngLat(0, 0)) instanceof LngLat, 'convert creates a LngLat instance');
         t.throws(function() {
             LngLat.convert(0, 10);

--- a/test/js/geo/lng_lat_bounds.test.js
+++ b/test/js/geo/lng_lat_bounds.test.js
@@ -55,6 +55,13 @@ test('LngLatBounds', function(t) {
         t.equal(bounds.getNorth(), 10);
         t.equal(bounds.getEast(), 10);
 
+        bounds.extend(new LngLat(-15, -15));
+
+        t.equal(bounds.getSouth(), -15);
+        t.equal(bounds.getWest(), -15);
+        t.equal(bounds.getNorth(), 10);
+        t.equal(bounds.getEast(), 10);
+
         t.end();
     });
 
@@ -67,6 +74,14 @@ test('LngLatBounds', function(t) {
         t.equal(bounds1.getWest(), -10);
         t.equal(bounds1.getNorth(), 10);
         t.equal(bounds1.getEast(), 10);
+
+        var bounds3 = [[-15, -15], [15, 15]];
+        bounds1.extend(bounds3);
+
+        t.equal(bounds1.getSouth(), -15);
+        t.equal(bounds1.getWest(), -15);
+        t.equal(bounds1.getNorth(), 15);
+        t.equal(bounds1.getEast(), 15);
 
         t.end();
     });

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -35,6 +35,13 @@ test('camera', function(t) {
             t.end();
         });
 
+        t.test('throws on invalid center argument', function(t) {
+            t.throws(function() {
+                camera.jumpTo({center: 1});
+            }, Error, 'throws with non-LngLatLike argument');
+            t.end();
+        });
+
         t.test('keeps current center if not specified', function(t) {
             camera.jumpTo({});
             t.deepEqual(camera.getCenter(), { lng: 1, lat: 2 });
@@ -141,6 +148,13 @@ test('camera', function(t) {
         t.test('sets center', function(t) {
             camera.setCenter([1, 2]);
             t.deepEqual(camera.getCenter(), { lng: 1, lat: 2 });
+            t.end();
+        });
+
+        t.test('throws on invalid center argument', function(t) {
+            t.throws(function() {
+                camera.jumpTo({center: 1});
+            }, Error, 'throws with non-LngLatLike argument');
             t.end();
         });
 
@@ -302,6 +316,14 @@ test('camera', function(t) {
             var camera = createCamera();
             camera.panTo([100, 0], { duration: 0 });
             t.deepEqual(camera.getCenter(), { lng: 100, lat: 0 });
+            t.end();
+        });
+
+        t.test('throws on invalid center argument', function(t) {
+            var camera = createCamera();
+            t.throws(function() {
+                camera.panTo({center: 1});
+            }, Error, 'throws with non-LngLatLike argument');
             t.end();
         });
 
@@ -703,6 +725,14 @@ test('camera', function(t) {
             var camera = createCamera();
             camera.flyTo({ center: [100, 0], animate: false });
             t.deepEqual(fixedLngLat(camera.getCenter()), { lng: 100, lat: 0 });
+            t.end();
+        });
+
+        t.test('throws on invalid center argument', function(t) {
+            var camera = createCamera();
+            t.throws(function() {
+                camera.flyTo({center: 1});
+            }, Error, 'throws with non-LngLatLike argument');
             t.end();
         });
 

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -430,6 +430,17 @@ test('Map', function(t) {
             t.end();
         });
 
+        t.test('throws on invalid bounds', function(t) {
+            var map = createMap({zoom:0});
+            t.throws(function() {
+                map.setMaxBounds([-130.4297, 50.0642], [-61.52344, 24.20688]);
+            }, Error, 'throws on two decoupled array coordinate arguments');
+            t.throws(function() {
+                map.setMaxBounds(-130.4297, 50.0642, -61.52344, 24.20688);
+            }, Error, 'throws on individual coordinate arguments');
+            t.end();
+        });
+
         function toFixed(bounds) {
             var n = 10;
             return [


### PR DESCRIPTION
This PR enforces `LngLatLike`-ness of the `LngLatLike` argument to `LngLat.convert`. 

Previously `LngLat.convert` passed through non-`LngLatLike` (as class instance or array) arguments unchanged. In updating tests I caught once instance where its arguments become `{lng: <lng>, lat: <lat>}` but _not_ a `LngLat` class instance, so I added that conditional to `LngLat.convert`. If its argument is none of those three types it now throws an error describing the nature of a `LngLatLike` argument. 

This method is used in the internals of methods like `setCenter`, `panTo`, etc etc and should stop error reports of the ever-cryptic ["failed to invert matrix"](https://github.com/mapbox/mapbox-gl-js/issues?utf8=%E2%9C%93&q=is%3Aissue%20failed%20to%20invert%20matrix).

@lucaswoj — there's not some special reason I'm missing why `LatLng.convert` may need to pass through non-LngLatLike arguments, is there? (I removed the one test that verified that worked: https://github.com/mapbox/mapbox-gl-js/commit/c3820aed73fde3737be767de13dfa342731e5845#diff-c6936a6d2842db2080af49f8c5dac23aL27)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
