### PR TITLE
Ensure "Tile#loadVectorData" preserves the most recent "rawTileData"

### DIFF
--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -61,6 +61,9 @@ Tile.prototype = {
         // empty GeoJSON tile
         if (!data) return;
 
+        // If we are redoing placement for the same tile, we will not recieve
+        // a new "rawTileData" object. If we are loading a new tile, we will
+        // recieve a new "rawTileData" object.
         if (data.rawTileData) {
             this.rawTileData = data.rawTileData;
         }
@@ -119,7 +122,6 @@ Tile.prototype = {
         this.symbolInstancesArray = null;
         this.collisionTile = null;
         this.featureIndex = null;
-        this.rawTileData = null;
         this.buckets = null;
         this.state = 'unloaded';
     },

--- a/test/js/source/tile.test.js
+++ b/test/js/source/tile.test.js
@@ -8,6 +8,12 @@ var fs = require('fs');
 var path = require('path');
 var vtpbf = require('vt-pbf');
 var sinon = require('sinon');
+var FeatureIndex = require('../../../js/data/feature_index');
+var CollisionTile = require('../../../js/symbol/collision_tile');
+var CollisionBoxArray = require('../../../js/symbol/collision_box');
+var SymbolInstancesArray = require('../../../js/symbol/symbol_instances');
+var SymbolQuadsArray = require('../../../js/symbol/symbol_quads');
+var util = require('../../../js/util/util');
 
 test('querySourceFeatures', function(t) {
     var features = [{
@@ -50,7 +56,10 @@ test('querySourceFeatures', function(t) {
         tile.querySourceFeatures(result, {});
         t.equal(result.length, 0);
 
-        tile.rawTileData = fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'));
+        tile.loadVectorData(
+            createVectorData({rawTileData: createRawTileData()}),
+            createPainter()
+        );
 
         result = [];
         tile.querySourceFeatures(result, { 'sourceLayer': 'does-not-exist'});
@@ -82,5 +91,45 @@ test('querySourceFeatures', function(t) {
         t.end();
     });
 
+    t.test('loadVectorData preserves the most recent rawTileData', function(t) {
+        var tile = new Tile(new TileCoord(1, 1, 1));
+        tile.state = 'loaded';
+
+        tile.loadVectorData(
+            createVectorData({rawTileData: createRawTileData()}),
+            createPainter()
+        );
+        tile.loadVectorData(
+            createVectorData(),
+            createPainter()
+        );
+
+        var features = [];
+        tile.querySourceFeatures(features, { 'sourceLayer': 'road' });
+        t.equal(features.length, 3);
+
+        t.end();
+    });
+
     t.end();
 });
+
+function createRawTileData() {
+    return fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'));
+}
+
+function createVectorData(options) {
+    var collisionBoxArray = new CollisionBoxArray();
+    return util.extend({
+        collisionBoxArray: collisionBoxArray.serialize(),
+        collisionTile: (new CollisionTile(0, 0, collisionBoxArray)).serialize(),
+        symbolInstancesArray: (new SymbolInstancesArray()).serialize(),
+        symbolQuadsArray: (new SymbolQuadsArray()).serialize(),
+        featureIndex: (new FeatureIndex(new TileCoord(1, 1, 1))).serialize(),
+        buckets: []
+    }, options);
+}
+
+function createPainter() {
+    return { style: {} };
+}


### PR DESCRIPTION
This PR ensures that `Tile#rawTileData` is not set to `null` after a "redo placement" operation. 

fixes #3221

# Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page

# Benchmarks

## map-load

**master 07feb8d:** 129 ms
**raw-tile-data-3221 9f07ba5:** 89 ms

## style-load

**master 07feb8d:** 107 ms
**raw-tile-data-3221 9f07ba5:** 107 ms

## buffer

**master 07feb8d:** 975 ms
**raw-tile-data-3221 9f07ba5:** 933 ms

## fps

**master 07feb8d:** 60 fps
**raw-tile-data-3221 9f07ba5:** 60 fps

## frame-duration

**master 07feb8d:** 6.6 ms, 1% > 16ms
**raw-tile-data-3221 9f07ba5:** 6.6 ms, 1% > 16ms

## query-point

**master 07feb8d:** 1.07 ms
**raw-tile-data-3221 9f07ba5:** 1.16 ms

## query-box

**master 07feb8d:** 85.02 ms
**raw-tile-data-3221 9f07ba5:** 88.38 ms

## geojson-setdata-small

**master 07feb8d:** 14 ms
**raw-tile-data-3221 9f07ba5:** 13 ms

## geojson-setdata-large

**master 07feb8d:** 144 ms
**raw-tile-data-3221 9f07ba5:** 134 ms
