### PR TITLE
Tolerate hashes that don't refer to IDs. Fixes #2540

### DIFF
--- a/docs/_theme/assets/site.js
+++ b/docs/_theme/assets/site.js
@@ -39,6 +39,7 @@ function showHashTarget(hash) {
   var targetId = hash && hash.substring(1);
   if (!targetId) return;
   var hashTarget = document.getElementById(targetId);
+  if (!hashTarget) return;
   var toggleInside = hashTarget.querySelector('.hidden.toggle-target');
   var toggleSibling = hashTarget.querySelector('.toggle-sibling');
   if (toggleInside && toggleSibling) {


### PR DESCRIPTION
## Launch Checklist

This fixes #2540: it checks whether a hash resolves to an element before assuming that element's existence.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page

cc @lucaswoj