### PR TITLE
Share a single blob URL between all workers

### DIFF
--- a/js/util/browser/web_worker.js
+++ b/js/util/browser/web_worker.js
@@ -1,6 +1,9 @@
 'use strict';
+
 var WebWorkify = require('webworkify');
+var window = require('../window');
+var workerURL = window.URL.createObjectURL(new WebWorkify(require('../../source/worker'), {bare: true}));
 
 module.exports = function () {
-    return new WebWorkify(require('../../source/worker'));
+    return new window.Worker(workerURL);
 };

--- a/js/util/worker_pool.js
+++ b/js/util/worker_pool.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert');
 var WebWorker = require('./web_worker');
-var URL = require('./window').URL;
 
 module.exports = WorkerPool;
 
@@ -37,7 +36,6 @@ WorkerPool.prototype = {
         delete this.active[mapId];
         if (Object.keys(this.active).length === 0) {
             this.workers.forEach(function (w) {
-                URL.revokeObjectURL(w.objectURL);
                 w.terminate();
             });
             this.workers = null;

--- a/test/js/util/worker_pool.test.js
+++ b/test/js/util/worker_pool.test.js
@@ -24,22 +24,15 @@ test('WorkerPool', function (t) {
 
     t.test('#release', function (t) {
         var workersTerminated = 0;
-        var objectUrlsRevoked = {};
         var WorkerPool = proxyquire('../../../js/util/worker_pool', {
-            '../mapbox-gl': { workerCount: 4 },
-            './window': {
-                URL: {
-                    revokeObjectURL: function (url) { objectUrlsRevoked[url] = true; }
-                }
-            }
+            '../mapbox-gl': { workerCount: 4 }
         });
 
         var pool = new WorkerPool();
         pool.acquire('map-1');
         var workers = pool.acquire('map-2');
-        workers.forEach(function (w, i) {
+        workers.forEach(function (w) {
             w.terminate = function () { workersTerminated += 1; };
-            w.objectURL = 'blob:worker-' + i;
         });
 
         pool.release('map-2');
@@ -50,7 +43,6 @@ test('WorkerPool', function (t) {
         t.comment('terminates workers if no dispatchers are active');
         pool.release('map-1');
         t.equal(workersTerminated, 4);
-        t.equal(Object.keys(objectUrlsRevoked).length, 4);
         t.notOk(pool.workers);
 
         t.end();


### PR DESCRIPTION
Share a single blob URL between all workers (refs #3153). Turns out this is easy to do, so we might as well, even if the performance benefit is not significant.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page

# Benchmarks

## map-load

**master 56e9761:** 212 ms
**share-blob 9a7af59:** 71 ms

## style-load

**master 56e9761:** 102 ms
**share-blob 9a7af59:** 112 ms

## buffer

**master 56e9761:** 995 ms
**share-blob 9a7af59:** 991 ms

## fps

**master 56e9761:** 60 fps
**share-blob 9a7af59:** 60 fps

## frame-duration

**master 56e9761:** 7.3 ms, 0% > 16ms
**share-blob 9a7af59:** 7.4 ms, 0% > 16ms

## query-point

**master 56e9761:** 0.98 ms
**share-blob 9a7af59:** 1.12 ms

## query-box

**master 56e9761:** 70.14 ms
**share-blob 9a7af59:** 86.60 ms

## geojson-setdata-small

**master 56e9761:** 14 ms
**share-blob 9a7af59:** 14 ms

## geojson-setdata-large

**master 56e9761:** 121 ms
**share-blob 9a7af59:** 119 ms
