### PR TITLE
Remove dead code from ImageSource

### DIFF
--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -52,11 +52,6 @@ function ImageSource(id, options, dispatcher) {
         if (err) return this.fire('error', {error: err});
 
         this.image = image;
-
-        this.image.addEventListener('load', function() {
-            this.map._rerender();
-        }.bind(this));
-
         this._loaded = true;
         this.fire('load');
 

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -106,7 +106,6 @@ function fakeImage(png) {
         height: png.height,
         data: png.data.slice(),
         complete: true,
-        addEventListener: function() {},
         getData: function() { return this.data; }
     };
 }


### PR DESCRIPTION
The image that's passed to the callback has already been loaded; this event binding will never be triggered.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the image example