### PR TITLE
Implement symbol depth testing for symbols with pitch-alignment: map

### DIFF
--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -26,37 +26,33 @@ function drawSymbols(painter, sourceCache, layer, coords) {
         gl.enable(gl.STENCIL_TEST);
     }
 
-    painter.setDepthSublayer(0);
-    painter.depthMask(false);
-    gl.disable(gl.DEPTH_TEST);
-
     drawLayerSymbols(painter, sourceCache, layer, coords, false,
-            layer.paint['icon-translate'],
-            layer.paint['icon-translate-anchor'],
-            layer.layout['icon-rotation-alignment'],
-            // icon-pitch-alignment is not yet implemented
-            // and we simply inherit the rotation alignment
-            layer.layout['icon-rotation-alignment'],
-            layer.layout['icon-size'],
-            layer.paint['icon-halo-width'],
-            layer.paint['icon-halo-color'],
-            layer.paint['icon-halo-blur'],
-            layer.paint['icon-opacity'],
-            layer.paint['icon-color']);
+        layer.paint['icon-translate'],
+        layer.paint['icon-translate-anchor'],
+        layer.layout['icon-rotation-alignment'],
+        // icon-pitch-alignment is not yet implemented
+        // and we simply inherit the rotation alignment
+        layer.layout['icon-rotation-alignment'],
+        layer.layout['icon-size'],
+        layer.paint['icon-halo-width'],
+        layer.paint['icon-halo-color'],
+        layer.paint['icon-halo-blur'],
+        layer.paint['icon-opacity'],
+        layer.paint['icon-color']
+    );
 
     drawLayerSymbols(painter, sourceCache, layer, coords, true,
-            layer.paint['text-translate'],
-            layer.paint['text-translate-anchor'],
-            layer.layout['text-rotation-alignment'],
-            layer.layout['text-pitch-alignment'],
-            layer.layout['text-size'],
-            layer.paint['text-halo-width'],
-            layer.paint['text-halo-color'],
-            layer.paint['text-halo-blur'],
-            layer.paint['text-opacity'],
-            layer.paint['text-color']);
-
-    gl.enable(gl.DEPTH_TEST);
+        layer.paint['text-translate'],
+        layer.paint['text-translate-anchor'],
+        layer.layout['text-rotation-alignment'],
+        layer.layout['text-pitch-alignment'],
+        layer.layout['text-size'],
+        layer.paint['text-halo-width'],
+        layer.paint['text-halo-color'],
+        layer.paint['text-halo-blur'],
+        layer.paint['text-opacity'],
+        layer.paint['text-color']
+    );
 
     if (sourceCache.map.showCollisionBoxes) {
         drawCollisionDebug(painter, sourceCache, layer, coords);
@@ -74,6 +70,14 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText,
         haloBlur,
         opacity,
         color) {
+
+    var gl = painter.gl;
+    painter.depthMask(false);
+    if (pitchAlignment === 'map') {
+        gl.enable(gl.DEPTH_TEST);
+    } else {
+        gl.disable(gl.DEPTH_TEST);
+    }
 
     for (var j = 0; j < coords.length; j++) {
         var tile = sourceCache.getTile(coords[j]);
@@ -98,6 +102,8 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText,
                 opacity,
                 color);
     }
+
+    gl.enable(gl.DEPTH_TEST);
 }
 
 function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isText, sdf, iconsNeedLinear, adjustedSize, fontstack,
@@ -177,6 +183,8 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
 
         if (haloWidth) {
             // Draw halo underneath the text.
+            painter.setDepthSublayer(0);
+
             gl.uniform1f(program.u_gamma, (haloBlur * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
             gl.uniform4fv(program.u_color, haloColor);
             gl.uniform1f(program.u_opacity, opacity);
@@ -197,6 +205,7 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
         gl.uniform1f(program.u_bearing, tr.bearing / 360 * 2 * Math.PI);
         gl.uniform1f(program.u_aspect_ratio, tr.width / tr.height);
 
+        painter.setDepthSublayer(1);
         for (var i = 0; i < bufferGroups.length; i++) {
             group = bufferGroups[i];
             group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer);
@@ -204,6 +213,7 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
         }
 
     } else {
+        painter.setDepthSublayer(0);
         gl.uniform1f(program.u_opacity, opacity);
         for (var k = 0; k < bufferGroups.length; k++) {
             group = bufferGroups[k];

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -72,6 +72,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText,
         color) {
 
     var gl = painter.gl;
+    painter.setDepthSublayer(0);
     painter.depthMask(false);
     if (pitchAlignment === 'map') {
         gl.enable(gl.DEPTH_TEST);
@@ -183,8 +184,6 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
 
         if (haloWidth) {
             // Draw halo underneath the text.
-            painter.setDepthSublayer(0);
-
             gl.uniform1f(program.u_gamma, (haloBlur * blurOffset / fontScale / sdfPx + gamma) * gammaScale);
             gl.uniform4fv(program.u_color, haloColor);
             gl.uniform1f(program.u_opacity, opacity);
@@ -205,7 +204,6 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
         gl.uniform1f(program.u_bearing, tr.bearing / 360 * 2 * Math.PI);
         gl.uniform1f(program.u_aspect_ratio, tr.width / tr.height);
 
-        painter.setDepthSublayer(1);
         for (var i = 0; i < bufferGroups.length; i++) {
             group = bufferGroups[i];
             group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer);
@@ -213,7 +211,6 @@ function drawSymbol(painter, layer, posMatrix, tile, bucket, bufferGroups, isTex
         }
 
     } else {
-        painter.setDepthSublayer(0);
         gl.uniform1f(program.u_opacity, opacity);
         for (var k = 0; k < bufferGroups.length; k++) {
             group = bufferGroups[k];

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#bc28ffacb5e0e85f1948f157161952ecdb55d559",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f6e5b4576f2a1af1e5338a6915054492d99bd7cb",
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",


### PR DESCRIPTION
Implements symbol depth testing for symbols drawn on the map plane (`pitch-alignment: map`) per discussion on https://github.com/mapbox/mapbox-gl-js/issues/2074#issuecomment-180613190.

Broader discussion of the problem space/issue here: https://github.com/mapbox/mapbox-gl-test-suite/pull/147.

 - [x] briefly describe the changes in this PR
  - https://github.com/mapbox/mapbox-gl-js/issues/2074#issuecomment-180613190
  - https://github.com/mapbox/mapbox-gl-test-suite/pull/147
 - [x] write tests for all new functionality
  - https://github.com/mapbox/mapbox-gl-test-suite/pull/147
 - [x] document any changes to public APIs
  - n/a
 - [x] post benchmark scores
 - [x] manually test the debug page

Corresponding native PR (https://github.com/mapbox/mapbox-gl-native/pull/6404).

------

# Benchmarks

## map-load

**master 594248c:** 470 ms
**viewport-symbol-depth 38d4d97:** 228 ms

## style-load

**master 594248c:** 209 ms
**viewport-symbol-depth 38d4d97:** 220 ms

## buffer

**master 594248c:** 2,048 ms
**viewport-symbol-depth 38d4d97:** 2,012 ms

## fps

**master 594248c:** 60 fps
**viewport-symbol-depth 38d4d97:** 60 fps

## frame-duration

**master 594248c:** 16.7 ms, 44% > 16ms
**viewport-symbol-depth 38d4d97:** 16.5 ms, 47% > 16ms

## query-point

**master 594248c:** 1.79 ms
**viewport-symbol-depth 38d4d97:** 2.04 ms

## query-box

**master 594248c:** 129.13 ms
**viewport-symbol-depth 38d4d97:** 186.07 ms

## geojson-setdata-small

**master 594248c:** 23 ms
**viewport-symbol-depth 38d4d97:** 24 ms

## geojson-setdata-large

**master 594248c:** 278 ms
**viewport-symbol-depth 38d4d97:** 288 ms

cc @ansis 