### PR TITLE
Add event propagation system to Evented

### DIFF
--- a/bench/benchmarks/buffer.js
+++ b/bench/benchmarks/buffer.js
@@ -90,7 +90,7 @@ function preloadAssets(stylesheet, callback) {
 
     var style = new Style(stylesheet);
 
-    style.on('load', function() {
+    style.on('style.load', function() {
         function getGlyphs(params, callback) {
             style['get glyphs'](0, params, function(err, glyphs) {
                 assets.glyphs[JSON.stringify(params)] = glyphs;

--- a/bench/benchmarks/style_load.js
+++ b/bench/benchmarks/style_load.js
@@ -28,7 +28,7 @@ module.exports = function() {
                 .on('error', function(err) {
                     evented.fire('error', { error: err });
                 })
-                .on('load', function() {
+                .on('style.load', function() {
                     var time = performance.now() - timeStart;
                     timeSum += time;
                     timeCount++;

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -85,7 +85,7 @@ function GeoJSONSource(id, options, dispatcher) {
 
     this._updateWorkerData(function done(err) {
         if (err) {
-            this.fire('source.error', {error: err});
+            this.fire('error', {error: err});
             return;
         }
         this.fire('source.load');
@@ -117,7 +117,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
 
         this._updateWorkerData(function (err) {
             if (err) {
-                return this.fire('source.error', { error: err });
+                return this.fire('error', { error: err });
             }
             this.fire('source.change');
         }.bind(this));

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -85,10 +85,10 @@ function GeoJSONSource(id, options, dispatcher) {
 
     this._updateWorkerData(function done(err) {
         if (err) {
-            this.fire('error', {error: err});
+            this.fire('source.error', {error: err});
             return;
         }
-        this.fire('load');
+        this.fire('source.load');
     }.bind(this));
 }
 
@@ -117,9 +117,9 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
 
         this._updateWorkerData(function (err) {
             if (err) {
-                return this.fire('error', { error: err });
+                return this.fire('source.error', { error: err });
             }
-            this.fire('change');
+            this.fire('source.change');
         }.bind(this));
 
         return this;

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -49,7 +49,7 @@ function ImageSource(id, options, dispatcher) {
     this.coordinates = options.coordinates;
 
     ajax.getImage(options.url, function(err, image) {
-        if (err) return this.fire('error', {error: err});
+        if (err) return this.fire('source.error', {error: err});
 
         this.image = image;
 
@@ -58,7 +58,7 @@ function ImageSource(id, options, dispatcher) {
         }.bind(this));
 
         this._loaded = true;
-        this.fire('load');
+        this.fire('source.load');
 
         if (this.map) {
             this.setCoordinates(options.coordinates);
@@ -111,7 +111,7 @@ ImageSource.prototype = util.inherit(Evented, /** @lends ImageSource.prototype *
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('change');
+        this.fire('source.change');
         return this;
     },
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -49,7 +49,7 @@ function ImageSource(id, options, dispatcher) {
     this.coordinates = options.coordinates;
 
     ajax.getImage(options.url, function(err, image) {
-        if (err) return this.fire('source.error', {error: err});
+        if (err) return this.fire('error', {error: err});
 
         this.image = image;
 

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -14,7 +14,7 @@ function RasterTileSource(id, options, dispatcher) {
     util.extend(this, util.pick(options, ['url', 'scheme', 'tileSize']));
     loadTileJSON(options, function (err, tileJSON) {
         if (err) {
-            return this.fire('source.error', err);
+            return this.fire('error', err);
         }
         util.extend(this, tileJSON);
         this.fire('source.load');

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -14,10 +14,10 @@ function RasterTileSource(id, options, dispatcher) {
     util.extend(this, util.pick(options, ['url', 'scheme', 'tileSize']));
     loadTileJSON(options, function (err, tileJSON) {
         if (err) {
-            return this.fire('error', err);
+            return this.fire('source.error', err);
         }
         util.extend(this, tileJSON);
-        this.fire('load');
+        this.fire('source.load');
     }.bind(this));
 }
 

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -30,7 +30,7 @@ function SourceCache(id, options, dispatcher) {
     var source = this._source = Source.create(id, options, dispatcher);
     source.forwardEvents(this);
 
-    this.on('load', function() {
+    this.on('source.load', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
 
         this._sourceLoaded = true;
@@ -46,11 +46,11 @@ function SourceCache(id, options, dispatcher) {
         this.vectorLayerIds = source.vectorLayerIds;
     });
 
-    this.on('error', function() {
+    this.on('source.error', function() {
         this._sourceErrored = true;
     });
 
-    this.on('change', function() {
+    this.on('source.change', function() {
         this.reload();
         if (this.transform) {
             this.update(this.transform, this.map && this.map.style.rasterFadeDuration);

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -28,7 +28,7 @@ function SourceCache(id, options, dispatcher) {
     this.dispatcher = dispatcher;
 
     var source = this._source = Source.create(id, options, dispatcher);
-    source.pipe(this);
+    source.forwardEvents(this);
 
     this.on('load', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -46,7 +46,7 @@ function SourceCache(id, options, dispatcher) {
         this.vectorLayerIds = source.vectorLayerIds;
     });
 
-    this.on('source.error', function() {
+    this.on('error', function() {
         this._sourceErrored = true;
     });
 
@@ -160,7 +160,7 @@ SourceCache.prototype = util.inherit(Evented, {
     _tileLoaded: function (tile, err) {
         if (err) {
             tile.state = 'errored';
-            this._source.fire('tile.error', {tile: tile, error: err});
+            this._source.fire('error', {tile: tile, error: err});
             return;
         }
 

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -28,7 +28,7 @@ function SourceCache(id, options, dispatcher) {
     this.dispatcher = dispatcher;
 
     var source = this._source = Source.create(id, options, dispatcher);
-    source.forwardEvents(this);
+    source.setEventedParent(this);
 
     this.on('source.load', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -27,8 +27,10 @@ function SourceCache(id, options, dispatcher) {
     this.id = id;
     this.dispatcher = dispatcher;
 
-    var source = this._source = Source.create(id, options, dispatcher)
-    .on('load', function () {
+    var source = this._source = Source.create(id, options, dispatcher);
+    source.pipe(this);
+
+    this.on('load', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
 
         this._sourceLoaded = true;
@@ -42,20 +44,18 @@ function SourceCache(id, options, dispatcher) {
         this.attribution = source.attribution;
 
         this.vectorLayerIds = source.vectorLayerIds;
+    });
 
-        this.fire('load');
-    }.bind(this))
-    .on('error', function (e) {
+    this.on('error', function() {
         this._sourceErrored = true;
-        this.fire('error', e);
-    }.bind(this))
-    .on('change', function () {
+    });
+
+    this.on('change', function() {
         this.reload();
         if (this.transform) {
             this.update(this.transform, this.map && this.map.style.rasterFadeDuration);
         }
-        this.fire('change');
-    }.bind(this));
+    });
 
     this._tiles = {};
     this._cache = new Cache(0, this.unloadTile.bind(this));
@@ -160,14 +160,12 @@ SourceCache.prototype = util.inherit(Evented, {
     _tileLoaded: function (tile, err) {
         if (err) {
             tile.state = 'errored';
-            this.fire('tile.error', {tile: tile, error: err});
             this._source.fire('tile.error', {tile: tile, error: err});
             return;
         }
 
         tile.source = this;
         tile.timeAdded = new Date().getTime();
-        this.fire('tile.load', {tile: tile});
         this._source.fire('tile.load', {tile: tile});
 
         // HACK this is nescessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
@@ -409,7 +407,6 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.uses++;
         this._tiles[coord.id] = tile;
-        this.fire('tile.add', {tile: tile});
         this._source.fire('tile.add', {tile: tile});
 
         return tile;
@@ -428,7 +425,6 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.uses--;
         delete this._tiles[id];
-        this.fire('tile.remove', {tile: tile});
         this._source.fire('tile.remove', {tile: tile});
 
         if (tile.uses > 0)

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -19,11 +19,11 @@ function VectorTileSource(id, options, dispatcher) {
 
     loadTileJSON(options, function (err, tileJSON) {
         if (err) {
-            this.fire('error', err);
+            this.fire('source.error', err);
             return;
         }
         util.extend(this, tileJSON);
-        this.fire('load');
+        this.fire('source.load');
     }.bind(this));
 }
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -19,7 +19,7 @@ function VectorTileSource(id, options, dispatcher) {
 
     loadTileJSON(options, function (err, tileJSON) {
         if (err) {
-            this.fire('source.error', err);
+            this.fire('error', err);
             return;
         }
         util.extend(this, tileJSON);

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -50,7 +50,7 @@ function VideoSource(id, options) {
     this.coordinates = options.coordinates;
 
     ajax.getVideo(options.urls, function(err, video) {
-        if (err) return this.fire('source.error', {error: err});
+        if (err) return this.fire('error', {error: err});
 
         this.video = video;
         this.video.loop = true;

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -50,7 +50,7 @@ function VideoSource(id, options) {
     this.coordinates = options.coordinates;
 
     ajax.getVideo(options.urls, function(err, video) {
-        if (err) return this.fire('error', {error: err});
+        if (err) return this.fire('source.error', {error: err});
 
         this.video = video;
         this.video.loop = true;
@@ -73,7 +73,7 @@ function VideoSource(id, options) {
             this.setCoordinates(options.coordinates);
         }
 
-        this.fire('load');
+        this.fire('source.load');
     }.bind(this));
 }
 
@@ -135,7 +135,7 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('change');
+        this.fire('source.change');
         return this;
     },
 

--- a/js/style/image_sprite.js
+++ b/js/style/image_sprite.js
@@ -41,7 +41,7 @@ function ImageSprite(base) {
         }
 
         this.img = img;
-        if (this.data) this.fire('load');
+        if (this.data) this.fire('style.change');
     }.bind(this));
 }
 

--- a/js/style/image_sprite.js
+++ b/js/style/image_sprite.js
@@ -20,7 +20,7 @@ function ImageSprite(base) {
         }
 
         this.data = data;
-        if (this.img) this.fire('load');
+        if (this.img) this.fire('style.change');
     }.bind(this));
 
     ajax.getImage(normalizeURL(base, format, '.png'), function(err, img) {
@@ -58,7 +58,7 @@ ImageSprite.prototype.loaded = function() {
 ImageSprite.prototype.resize = function(/*gl*/) {
     if (browser.devicePixelRatio > 1 !== this.retina) {
         var newSprite = new ImageSprite(this.base);
-        newSprite.on('load', function() {
+        newSprite.on('style.change', function() {
             this.img = newSprite.img;
             this.data = newSprite.data;
             this.retina = newSprite.retina;

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -62,7 +62,7 @@ function Style(stylesheet, animationLoop, options) {
 
         if (stylesheet.sprite) {
             this.sprite = new ImageSprite(stylesheet.sprite);
-            this.sprite.forwardEvents(this);
+            this.sprite.setEventedParent(this);
         }
 
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
@@ -141,7 +141,7 @@ Style.prototype = util.inherit(Evented, {
             if (layerJSON.ref) continue;
             layer = StyleLayer.create(layerJSON);
             this._layers[layer.id] = layer;
-            layer.forwardEvents(this, {layer: {id: layer.id}});
+            layer.setEventedParent(this, {layer: {id: layer.id}});
         }
 
         // resolve all layers WITH a ref
@@ -151,7 +151,7 @@ Style.prototype = util.inherit(Evented, {
             var refLayer = this.getLayer(layerJSON.ref);
             layer = StyleLayer.create(layerJSON, refLayer);
             this._layers[layer.id] = layer;
-            layer.forwardEvents(this, {layer: {id: layer.id}});
+            layer.setEventedParent(this, {layer: {id: layer.id}});
         }
 
         this._groupLayers();
@@ -335,7 +335,7 @@ Style.prototype = util.inherit(Evented, {
         source = new SourceCache(id, source, this.dispatcher);
         this.sources[id] = source;
         source.style = this;
-        source.forwardEvents(this, {source: source});
+        source.setEventedParent(this, {source: source});
 
         this._updates.events.push(['source.add', {source: source}]);
         this._updates.changed = true;
@@ -359,7 +359,7 @@ Style.prototype = util.inherit(Evented, {
         var source = this.sources[id];
         delete this.sources[id];
         delete this._updates.sources[id];
-        source.unforwardEvents(this);
+        source.setEventedParent(null);
 
         this._updates.events.push(['source.remove', {source: source}]);
         this._updates.changed = true;
@@ -399,7 +399,7 @@ Style.prototype = util.inherit(Evented, {
         }
         this._validateLayer(layer);
 
-        layer.forwardEvents(this, {layer: {id: layer.id}});
+        layer.setEventedParent(this, {layer: {id: layer.id}});
 
         this._layers[layer.id] = layer;
         this._order.splice(before ? this._order.indexOf(before) : Infinity, 0, layer.id);
@@ -433,7 +433,7 @@ Style.prototype = util.inherit(Evented, {
             }
         }
 
-        layer.unforwardEvents(this);
+        layer.setEventedParent(null);
 
         delete this._layers[id];
         delete this._updates.layers[id];

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -62,7 +62,7 @@ function Style(stylesheet, animationLoop, options) {
 
         if (stylesheet.sprite) {
             this.sprite = new ImageSprite(stylesheet.sprite);
-            this.sprite.forwardEvents(this, {style: this});
+            this.sprite.forwardEvents(this);
         }
 
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
@@ -337,7 +337,7 @@ Style.prototype = util.inherit(Evented, {
         source.style = this;
         source.forwardEvents(this, {source: source});
 
-        this._updates.events.push(['source.add', {source: source, style: this}]);
+        this._updates.events.push(['source.add', {source: source}]);
         this._updates.changed = true;
 
         return this;
@@ -361,7 +361,7 @@ Style.prototype = util.inherit(Evented, {
         delete this._updates.sources[id];
         source.unforwardEvents(this);
 
-        this._updates.events.push(['source.remove', {source: source, style: this}]);
+        this._updates.events.push(['source.remove', {source: source}]);
         this._updates.changed = true;
 
         return this;
@@ -408,7 +408,7 @@ Style.prototype = util.inherit(Evented, {
         if (layer.source) {
             this._updates.sources[layer.source] = true;
         }
-        this._updates.events.push(['layer.add', {layer: layer, style: this}]);
+        this._updates.events.push(['layer.add', {layer: layer}]);
 
         return this.updateClasses(layer.id);
     },
@@ -441,7 +441,7 @@ Style.prototype = util.inherit(Evented, {
         this._order.splice(this._order.indexOf(id), 1);
 
         this._updates.allLayers = true;
-        this._updates.events.push(['layer.remove', {layer: layer, style: this}]);
+        this._updates.events.push(['layer.remove', {layer: layer}]);
         this._updates.changed = true;
 
         return this;

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -62,7 +62,7 @@ function Style(stylesheet, animationLoop, options) {
 
         if (stylesheet.sprite) {
             this.sprite = new ImageSprite(stylesheet.sprite);
-            this.sprite.on('load', this.fire.bind(this, 'change'));
+            this.sprite.forwardEvents(this, {style: this});
         }
 
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
@@ -718,7 +718,7 @@ Style.prototype = util.inherit(Evented, {
             spriteAtlas.setSprite(sprite);
             spriteAtlas.addIcons(params.icons, callback);
         } else {
-            sprite.on('load', function() {
+            sprite.on('style.change', function() {
                 spriteAtlas.setSprite(sprite);
                 spriteAtlas.addIcons(params.icons, callback);
             });

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -340,15 +340,7 @@ Style.prototype = util.inherit(Evented, {
         source = new SourceCache(id, source, this.dispatcher);
         this.sources[id] = source;
         source.style = this;
-        source
-            .on('load', this._forwardSourceEvent)
-            .on('error', this._forwardSourceEvent)
-            .on('change', this._forwardSourceEvent)
-            .on('tile.add', this._forwardTileEvent)
-            .on('tile.load', this._forwardTileEvent)
-            .on('tile.error', this._forwardTileEvent)
-            .on('tile.remove', this._forwardTileEvent)
-            .on('tile.stats', this._forwardTileEvent);
+        source.forwardEvents(this, {source: source});
 
         this._updates.events.push(['source.add', {source: source}]);
         this._updates.changed = true;
@@ -372,15 +364,7 @@ Style.prototype = util.inherit(Evented, {
         var source = this.sources[id];
         delete this.sources[id];
         delete this._updates.sources[id];
-        source
-            .off('load', this._forwardSourceEvent)
-            .off('error', this._forwardSourceEvent)
-            .off('change', this._forwardSourceEvent)
-            .off('tile.add', this._forwardTileEvent)
-            .off('tile.load', this._forwardTileEvent)
-            .off('tile.error', this._forwardTileEvent)
-            .off('tile.remove', this._forwardTileEvent)
-            .off('tile.stats', this._forwardTileEvent);
+        source.unforwardEvents(this);
 
         this._updates.events.push(['source.remove', {source: source}]);
         this._updates.changed = true;
@@ -728,14 +712,6 @@ Style.prototype = util.inherit(Evented, {
         for (var id in this.sources) {
             if (this.sources[id].redoPlacement) this.sources[id].redoPlacement();
         }
-    },
-
-    _forwardSourceEvent: function(e) {
-        this.fire('source.' + e.type, util.extend({source: e.target.getSource()}, e));
-    },
-
-    _forwardTileEvent: function(e) {
-        this.fire(e.type, util.extend({source: e.target}, e));
     },
 
     _forwardLayerEvent: function(e) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -67,7 +67,7 @@ function Style(stylesheet, animationLoop, options) {
 
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
         this._resolve();
-        this.fire('load');
+        this.fire('style.load');
     }.bind(this);
 
     if (typeof stylesheet === 'string') {
@@ -300,7 +300,7 @@ Style.prototype = util.inherit(Evented, {
         this._applyClasses(classes, options);
 
         if (this._updates.changed) {
-            this.fire('change');
+            this.fire('style.change');
         }
 
         this._resetUpdates();
@@ -337,7 +337,7 @@ Style.prototype = util.inherit(Evented, {
         source.style = this;
         source.forwardEvents(this, {source: source});
 
-        this._updates.events.push(['source.add', {source: source}]);
+        this._updates.events.push(['source.add', {source: source, style: this}]);
         this._updates.changed = true;
 
         return this;
@@ -361,7 +361,7 @@ Style.prototype = util.inherit(Evented, {
         delete this._updates.sources[id];
         source.unforwardEvents(this);
 
-        this._updates.events.push(['source.remove', {source: source}]);
+        this._updates.events.push(['source.remove', {source: source, style: this}]);
         this._updates.changed = true;
 
         return this;
@@ -408,7 +408,7 @@ Style.prototype = util.inherit(Evented, {
         if (layer.source) {
             this._updates.sources[layer.source] = true;
         }
-        this._updates.events.push(['layer.add', {layer: layer}]);
+        this._updates.events.push(['layer.add', {layer: layer, style: this}]);
 
         return this.updateClasses(layer.id);
     },
@@ -441,7 +441,7 @@ Style.prototype = util.inherit(Evented, {
         this._order.splice(this._order.indexOf(id), 1);
 
         this._updates.allLayers = true;
-        this._updates.events.push(['layer.remove', {layer: layer}]);
+        this._updates.events.push(['layer.remove', {layer: layer, style: this}]);
         this._updates.changed = true;
 
         return this;

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -157,8 +157,8 @@ var Map = module.exports = function(options) {
     this._setupContainer();
     this._setupPainter();
 
-    this.on('move', this._update);
-    this.on('zoom', this._update);
+    this.on('move', this._update.bind(this, false));
+    this.on('zoom', this._update.bind(this, true));
     this.on('moveend', function() {
         this.animationLoop.set(300); // text fading
         this._rerender();

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -146,15 +146,6 @@ var Map = module.exports = function(options) {
     }
 
     util.bindAll([
-        '_forwardStyleEvent',
-        '_forwardSourceEvent',
-        '_forwardLayerEvent',
-        '_forwardTileEvent',
-        '_onStyleLoad',
-        '_onStyleChange',
-        '_onSourceAdd',
-        '_onSourceRemove',
-        '_onSourceUpdate',
         '_onWindowOnline',
         '_onWindowResize',
         '_contextLost',
@@ -166,8 +157,8 @@ var Map = module.exports = function(options) {
     this._setupContainer();
     this._setupPainter();
 
-    this.on('move', this._update.bind(this, false));
-    this.on('zoom', this._update.bind(this, true));
+    this.on('move', this._update);
+    this.on('zoom', this._update);
     this.on('moveend', function() {
         this.animationLoop.set(300); // text fading
         this._rerender();
@@ -200,9 +191,33 @@ var Map = module.exports = function(options) {
     if (options.attributionControl) this.addControl(new Attribution(options.attributionControl));
 
     var fireError = this.fire.bind(this, 'error');
-    this.on('style.error', fireError);
     this.on('source.error', fireError);
     this.on('tile.error', fireError);
+
+    this.on('style.load', function() {
+        if (this.transform.unmodified) {
+            this.jumpTo(this.style.stylesheet);
+        }
+        this.style.update(this._classes, {transition: false});
+    });
+
+    this.on('style.change', function() {
+        this._update(true);
+    });
+
+    this.on('source.add', function(event) {
+        var source = event.source;
+        if (source.onAdd) source.onAdd(this);
+    });
+
+    this.on('source.remove', function(event) {
+        var source = event.source;
+        if (source.onRemove) source.onRemove(this);
+    });
+
+    this.on('source.load', this._update);
+    this.on('source.change', this._update);
+    this.on('tile.load', this._update);
 };
 
 util.extend(Map.prototype, Evented);
@@ -604,23 +619,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      */
     setStyle: function(style) {
         if (this.style) {
-            this.style
-                .off('load', this._onStyleLoad)
-                .off('error', this._forwardStyleEvent)
-                .off('change', this._onStyleChange)
-                .off('source.add', this._onSourceAdd)
-                .off('source.remove', this._onSourceRemove)
-                .off('source.load', this._onSourceUpdate)
-                .off('source.error', this._forwardSourceEvent)
-                .off('source.change', this._onSourceUpdate)
-                .off('layer.add', this._forwardLayerEvent)
-                .off('layer.remove', this._forwardLayerEvent)
-                .off('tile.add', this._forwardTileEvent)
-                .off('tile.remove', this._forwardTileEvent)
-                .off('tile.load', this._update)
-                .off('tile.error', this._forwardTileEvent)
-                .off('tile.stats', this._forwardTileEvent)
-                ._remove();
+            this.style.unforwardEvents(this);
+            this.style._remove();
 
             this.off('rotate', this.style._redoPlacement);
             this.off('pitch', this.style._redoPlacement);
@@ -635,22 +635,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             this.style = new Style(style, this.animationLoop);
         }
 
-        this.style
-            .on('load', this._onStyleLoad)
-            .on('error', this._forwardStyleEvent)
-            .on('change', this._onStyleChange)
-            .on('source.add', this._onSourceAdd)
-            .on('source.remove', this._onSourceRemove)
-            .on('source.load', this._onSourceUpdate)
-            .on('source.error', this._forwardSourceEvent)
-            .on('source.change', this._onSourceUpdate)
-            .on('layer.add', this._forwardLayerEvent)
-            .on('layer.remove', this._forwardLayerEvent)
-            .on('tile.add', this._forwardTileEvent)
-            .on('tile.remove', this._forwardTileEvent)
-            .on('tile.load', this._update)
-            .on('tile.error', this._forwardTileEvent)
-            .on('tile.stats', this._forwardTileEvent);
+        this.style.forwardEvents(this, {style: this.style});
 
         this.on('rotate', this.style._redoPlacement);
         this.on('pitch', this.style._redoPlacement);
@@ -1111,54 +1096,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         if (this.style && !this._frameId) {
             this._frameId = browser.frame(this._render);
         }
-    },
-
-    _forwardStyleEvent: function(e) {
-        this.fire('style.' + e.type, util.extend({style: e.target}, e));
-    },
-
-    _forwardSourceEvent: function(e) {
-        this.fire(e.type, util.extend({style: e.target}, e));
-    },
-
-    _forwardLayerEvent: function(e) {
-        this.fire(e.type, util.extend({style: e.target}, e));
-    },
-
-    _forwardTileEvent: function(e) {
-        this.fire(e.type, util.extend({style: e.target}, e));
-    },
-
-    _onStyleLoad: function(e) {
-        if (this.transform.unmodified) {
-            this.jumpTo(this.style.stylesheet);
-        }
-        this.style.update(this._classes, {transition: false});
-        this._forwardStyleEvent(e);
-    },
-
-    _onStyleChange: function(e) {
-        this._update(true);
-        this._forwardStyleEvent(e);
-    },
-
-    _onSourceAdd: function(e) {
-        var source = e.source;
-        if (source.onAdd)
-            source.onAdd(this);
-        this._forwardSourceEvent(e);
-    },
-
-    _onSourceRemove: function(e) {
-        var source = e.source;
-        if (source.onRemove)
-            source.onRemove(this);
-        this._forwardSourceEvent(e);
-    },
-
-    _onSourceUpdate: function(e) {
-        this._update();
-        this._forwardSourceEvent(e);
     },
 
     _onWindowOnline: function() {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -203,7 +203,6 @@ var Map = module.exports = function(options) {
     this.on('style.error', fireError);
     this.on('source.error', fireError);
     this.on('tile.error', fireError);
-    this.on('layer.error', fireError);
 };
 
 util.extend(Map.prototype, Evented);
@@ -616,7 +615,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
                 .off('source.change', this._onSourceUpdate)
                 .off('layer.add', this._forwardLayerEvent)
                 .off('layer.remove', this._forwardLayerEvent)
-                .off('layer.error', this._forwardLayerEvent)
                 .off('tile.add', this._forwardTileEvent)
                 .off('tile.remove', this._forwardTileEvent)
                 .off('tile.load', this._update)
@@ -648,7 +646,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             .on('source.change', this._onSourceUpdate)
             .on('layer.add', this._forwardLayerEvent)
             .on('layer.remove', this._forwardLayerEvent)
-            .on('layer.error', this._forwardLayerEvent)
             .on('tile.add', this._forwardTileEvent)
             .on('tile.remove', this._forwardTileEvent)
             .on('tile.load', this._update)

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -615,7 +615,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      */
     setStyle: function(style) {
         if (this.style) {
-            this.style.unforwardEvents(this);
+            this.style.setEventedParent(null);
             this.style._remove();
 
             this.off('rotate', this.style._redoPlacement);
@@ -631,7 +631,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
             this.style = new Style(style, this.animationLoop);
         }
 
-        this.style.forwardEvents(this, {style: this.style});
+        this.style.setEventedParent(this, {style: this.style});
 
         this.on('rotate', this.style._redoPlacement);
         this.on('pitch', this.style._redoPlacement);

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -190,10 +190,6 @@ var Map = module.exports = function(options) {
     if (options.style) this.setStyle(options.style);
     if (options.attributionControl) this.addControl(new Attribution(options.attributionControl));
 
-    var fireError = this.fire.bind(this, 'error');
-    this.on('source.error', fireError);
-    this.on('tile.error', fireError);
-
     this.on('style.load', function() {
         if (this.transform.unmodified) {
             this.jumpTo(this.style.stylesheet);

--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -19,9 +19,9 @@ var Evented = {
      * @returns {Object} `this`
      */
     on: function(type, listener) {
-        this._events = this._events || {};
-        this._events[type] = this._events[type] || [];
-        this._events[type].push(listener);
+        this._listeners = this._listeners || {};
+        this._listeners[type] = this._listeners[type] || [];
+        this._listeners[type].push(listener);
 
         return this;
     },
@@ -38,22 +38,22 @@ var Evented = {
     off: function(type, listener) {
         if (!type) {
             // clear all listeners if no arguments specified
-            delete this._events;
+            delete this._listeners;
             return this;
         }
 
         if (!this.listens(type)) return this;
 
         if (listener) {
-            var idx = this._events[type].indexOf(listener);
-            if (idx >= 0) {
-                this._events[type].splice(idx, 1);
+            var index = this._listeners[type].indexOf(listener);
+            if (index >= 0) {
+                this._listeners[type].splice(index, 1);
             }
-            if (!this._events[type].length) {
-                delete this._events[type];
+            if (!this._listeners[type].length) {
+                delete this._listeners[type];
             }
         } else {
-            delete this._events[type];
+            delete this._listeners[type];
         }
 
         return this;
@@ -69,11 +69,11 @@ var Evented = {
      * @returns {Object} `this`
      */
     once: function(type, listener) {
-        var wrapper = function(data) {
-            this.off(type, wrapper);
+        var wrappedListener = function(data) {
+            this.off(type, wrappedListener);
             listener.call(this, data);
         }.bind(this);
-        this.on(type, wrapper);
+        this.on(type, wrappedListener);
         return this;
     },
 
@@ -98,7 +98,7 @@ var Evented = {
         util.extend(data, {type: type, target: this});
 
         // make sure adding/removing listeners inside other listeners won't cause infinite loop
-        var listeners = this._events[type].slice();
+        var listeners = this._listeners[type].slice();
 
         for (var i = 0; i < listeners.length; i++) {
             listeners[i].call(this, data);
@@ -114,7 +114,7 @@ var Evented = {
      * @returns {boolean} `true` if there is at least one registered listener for specified event type.
      */
     listens: function(type) {
-        return !!(this._events && this._events[type]);
+        return !!(this._listeners && this._listeners[type]);
     }
 };
 

--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -74,16 +74,17 @@ var Evented = {
 
             data = util.extend({}, data, {type: type, target: this});
 
-            // make sure adding listeners / forwardees inside other listeners won't cause an infinite loop
+            // make sure adding or removing listeners or forwardees inside other listeners won't cause an infinite loop
             var listeners = this._listeners && this._listeners[type] ? this._listeners[type].slice() : [];
             var forwardees = this._forwardees ? this._forwardees.slice() : [];
+            var forwardeeData = this._forwardees ? this._forwardeeData.slice() : [];
 
             for (var i = 0; i < listeners.length; i++) {
                 listeners[i].call(this, data);
             }
 
             for (var j = 0; j < forwardees.length; j++) {
-                forwardees[j].fire(type, data);
+                forwardees[j].fire(type, util.extend({}, data, forwardeeData[j]));
             }
 
         // To ensure that no error events are dropped, print them to the
@@ -119,9 +120,11 @@ var Evented = {
      * @param {forwardee}
      * @returns {Object} `this`
      */
-    forwardEvents: function(forwardee) {
+    forwardEvents: function(forwardee, data) {
         this._forwardees = this._forwardees || [];
+        this._forwardeeData = this._forwardeeData || [];
         this._forwardees.push(forwardee);
+        this._forwardeeData.push(data);
 
         return this;
     },
@@ -137,6 +140,7 @@ var Evented = {
             var index = this._forwardees.indexOf(forwardee);
             if (index !== -1) {
                 this._forwardees.splice(index, 1);
+                this._forwardeeData.splice(index, 1);
             }
         }
 

--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -74,16 +74,16 @@ var Evented = {
 
             data = util.extend({}, data, {type: type, target: this});
 
-            // make sure adding listeners / pipes inside other listeners won't cause an infinite loop
+            // make sure adding listeners / forwardees inside other listeners won't cause an infinite loop
             var listeners = this._listeners && this._listeners[type] ? this._listeners[type].slice() : [];
-            var pipes = this._pipes ? this._pipes.slice() : [];
+            var forwardees = this._forwardees ? this._forwardees.slice() : [];
 
             for (var i = 0; i < listeners.length; i++) {
                 listeners[i].call(this, data);
             }
 
-            for (var j = 0; j < pipes.length; j++) {
-                pipes[j].fire(type, data);
+            for (var j = 0; j < forwardees.length; j++) {
+                forwardees[j].fire(type, data);
             }
 
         // To ensure that no error events are dropped, print them to the
@@ -96,7 +96,7 @@ var Evented = {
     },
 
     /**
-     * Returns a true if this instance of Evented or any piped instances of Evented have a listener for the specified type.
+     * Returns a true if this instance of Evented or any forwardeed instances of Evented have a listener for the specified type.
      *
      * @param {string} type The event type
      * @returns {boolean} `true` if there is at least one registered listener for specified event type, `false` otherwise
@@ -104,9 +104,9 @@ var Evented = {
     listens: function(type) {
         if (this._listeners && this._listeners[type]) return true;
 
-        if (this._pipes) {
-            for (var i = 0; i < this._pipes.length; i++) {
-                if (this._pipes[i].listens(type)) return true;
+        if (this._forwardees) {
+            for (var i = 0; i < this._forwardees.length; i++) {
+                if (this._forwardees[i].listens(type)) return true;
             }
         }
 
@@ -114,30 +114,29 @@ var Evented = {
     },
 
     /**
-     * Pipes (forwards) all events fired by this instance of Evented to
-     * another instance of Evented.
+     * Forward all events fired by this instance of Evented to another instance of Evented.
      *
-     * @param {pipe}
+     * @param {forwardee}
      * @returns {Object} `this`
      */
-    pipe: function(pipe) {
-        this._pipes = this._pipes || [];
-        this._pipes.push(pipe);
+    forwardEvents: function(forwardee) {
+        this._forwardees = this._forwardees || [];
+        this._forwardees.push(forwardee);
 
         return this;
     },
 
     /**
-     * Removes a previously registered pipe.
+     * Removes a previously registered forwardee.
      *
-     * @param {pipe}
+     * @param {forwardee}
      * @returns {Object} `this`
      */
-    unpipe: function(pipe) {
-        if (this._pipes) {
-            var index = this._pipes.indexOf(pipe);
+    unforwardEvents: function(forwardee) {
+        if (this._forwardees) {
+            var index = this._forwardees.indexOf(forwardee);
             if (index !== -1) {
-                this._pipes.splice(index, 1);
+                this._forwardees.splice(index, 1);
             }
         }
 

--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -110,6 +110,7 @@ var Evented = {
     /**
      * Bubble all events fired by this instance of Evented to this parent instance of Evented.
      *
+     * @private
      * @param {parent}
      * @param {data}
      * @returns {Object} `this`

--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -54,11 +54,11 @@ var Evented = {
      * @returns {Object} `this`
      */
     once: function(type, listener) {
-        var wrappedListener = function(data) {
-            this.off(type, wrappedListener);
+        var wrapper = function(data) {
+            this.off(type, wrapper);
             listener.call(this, data);
         }.bind(this);
-        this.on(type, wrappedListener);
+        this.on(type, wrapper);
         return this;
     },
 

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -59,7 +59,7 @@ test('GeoJSONSource#setData', function(t) {
             }
         };
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
-        source.on('change', function() {
+        source.on('source.change', function() {
             t.end();
         });
         source.setData({});
@@ -119,7 +119,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('load', function() {
+        source.on('source.load', function() {
             t.end();
         });
     });
@@ -133,7 +133,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('error', function(err) {
+        source.on('source.error', function(err) {
             t.equal(err.error, 'error');
             t.end();
         });
@@ -148,11 +148,11 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('load', function() {
+        source.on('source.load', function() {
             // Note: we register this before calling setData because `change`
             // is fired synchronously within that method.  It may be worth
             // considering dezalgoing there.
-            source.on('change', function () {
+            source.on('source.change', function () {
                 t.end();
             });
             source.setData({});
@@ -175,7 +175,7 @@ test('GeoJSONSource#update', function(t) {
             transform: {}
         };
 
-        source.on('load', function () {
+        source.on('source.load', function () {
             source.setData({});
             source.loadTile(new Tile(new TileCoord(0, 0, 0), 512), function () {});
         });
@@ -216,4 +216,3 @@ test('GeoJSONSource#serialize', function(t) {
 
     t.end();
 });
-

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -133,7 +133,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('source.error', function(err) {
+        source.on('error', function(err) {
             t.equal(err.error, 'error');
             t.end();
         });

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -30,9 +30,9 @@ Source.setType('mock-source-type', function create (id, sourceOptions) {
     if (sourceOptions.noLoad) { return source; }
     setTimeout(function () {
         if (sourceOptions.error) {
-            source.fire('error', { error: sourceOptions.error });
+            source.fire('source.error', { error: sourceOptions.error });
         } else {
-            source.fire('load');
+            source.fire('source.load');
         }
     }, 0);
     return source;
@@ -53,7 +53,7 @@ test('SourceCache#attribution is set', function(t) {
     var sourceCache = createSourceCache({
         attribution: 'Mapbox Heavy Industries'
     });
-    sourceCache.on('load', function() {
+    sourceCache.on('source.load', function() {
         t.equal(sourceCache.attribution, 'Mapbox Heavy Industries');
         t.end();
     });
@@ -205,23 +205,23 @@ test('SourceCache#removeTile', function(t) {
 test('SourceCache / Source lifecycle', function (t) {
     t.test('does not fire load or change before source load event', function (t) {
         createSourceCache({noLoad: true})
-            .on('load', t.fail)
-            .on('change', t.fail);
+            .on('source.load', t.fail)
+            .on('source.change', t.fail);
         setTimeout(t.end, 1);
     });
 
     t.test('forward load event', function (t) {
-        createSourceCache({}).on('load', t.end);
+        createSourceCache({}).on('source.load', t.end);
     });
 
     t.test('forward change event', function (t) {
-        var sourceCache = createSourceCache().on('change', t.end);
-        sourceCache.getSource().fire('change');
+        var sourceCache = createSourceCache().on('source.change', t.end);
+        sourceCache.getSource().fire('source.change');
     });
 
     t.test('forward error event', function (t) {
         createSourceCache({ error: 'Error loading source' })
-        .on('error', function (err) {
+        .on('source.error', function (err) {
             t.equal(err.error, 'Error loading source');
             t.end();
         });
@@ -229,7 +229,7 @@ test('SourceCache / Source lifecycle', function (t) {
 
     t.test('loaded() true after error', function (t) {
         var sourceCache = createSourceCache({ error: 'Error loading source' })
-        .on('error', function () {
+        .on('source.error', function () {
             t.ok(sourceCache.loaded());
             t.end();
         });
@@ -251,9 +251,9 @@ test('SourceCache / Source lifecycle', function (t) {
             }
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
-            sourceCache.getSource().fire('change');
+            sourceCache.getSource().fire('source.change');
         });
     });
 
@@ -267,7 +267,7 @@ test('SourceCache#update', function(t) {
         transform.zoom = 0;
 
         var sourceCache = createSourceCache({}, false);
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getIds(), []);
@@ -281,7 +281,7 @@ test('SourceCache#update', function(t) {
         transform.zoom = 0;
 
         var sourceCache = createSourceCache({});
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
             t.end();
@@ -299,7 +299,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
@@ -330,7 +330,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
@@ -361,7 +361,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0, 1).id]);
 
@@ -392,7 +392,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform, 100);
             t.deepEqual(sourceCache.getIds(), [
                 new TileCoord(2, 1, 1).id,
@@ -422,7 +422,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform, 100);
 
             transform.zoom = 2;
@@ -452,7 +452,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             t.equal(sourceCache.maxzoom, 14);
 
             sourceCache.update(transform);
@@ -531,7 +531,7 @@ test('SourceCache#tilesIn', function (t) {
             }
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getIds(), [
@@ -572,7 +572,7 @@ test('SourceCache#tilesIn', function (t) {
             tileSize: 512
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             var transform = new Transform();
             transform.resize(512, 512);
             transform.zoom = 2.0;
@@ -616,7 +616,7 @@ test('SourceCache#tilesIn', function (t) {
             tileSize: 512
         });
 
-        sourceCache.on('load', function () {
+        sourceCache.on('source.load', function () {
             var transform = new Transform();
             transform.resize(512, 512);
             transform.zoom = 2.0;
@@ -638,7 +638,7 @@ test('SourceCache#loaded (no errors)', function (t) {
         }
     });
 
-    sourceCache.on('load', function () {
+    sourceCache.on('source.load', function () {
         var coord = new TileCoord(0, 0, 0);
         sourceCache.addTile(coord);
 
@@ -654,7 +654,7 @@ test('SourceCache#loaded (with errors)', function (t) {
         }
     });
 
-    sourceCache.on('load', function () {
+    sourceCache.on('source.load', function () {
         var coord = new TileCoord(0, 0, 0);
         sourceCache.addTile(coord);
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -30,7 +30,7 @@ Source.setType('mock-source-type', function create (id, sourceOptions) {
     if (sourceOptions.noLoad) { return source; }
     setTimeout(function () {
         if (sourceOptions.error) {
-            source.fire('source.error', { error: sourceOptions.error });
+            source.fire('error', { error: sourceOptions.error });
         } else {
             source.fire('source.load');
         }
@@ -221,7 +221,7 @@ test('SourceCache / Source lifecycle', function (t) {
 
     t.test('forward error event', function (t) {
         createSourceCache({ error: 'Error loading source' })
-        .on('source.error', function (err) {
+        .on('error', function (err) {
             t.equal(err.error, 'Error loading source');
             t.end();
         });
@@ -229,7 +229,7 @@ test('SourceCache / Source lifecycle', function (t) {
 
     t.test('loaded() true after error', function (t) {
         var sourceCache = createSourceCache({ error: 'Error loading source' })
-        .on('source.error', function () {
+        .on('error', function () {
             t.ok(sourceCache.loaded());
             t.end();
         });

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -8,7 +8,7 @@ var window = require('../../../js/util/window');
 function createSource(options) {
     var source = new VectorTileSource('id', options, { send: function() {} });
 
-    source.on('source.error', function(e) {
+    source.on('error', function(e) {
         throw e.error;
     });
 

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -8,7 +8,7 @@ var window = require('../../../js/util/window');
 function createSource(options) {
     var source = new VectorTileSource('id', options, { send: function() {} });
 
-    source.on('error', function(e) {
+    source.on('source.error', function(e) {
         throw e.error;
     });
 
@@ -38,7 +38,7 @@ test('VectorTileSource', function(t) {
             tiles: ["http://example.com/{z}/{x}/{y}.png"]
         });
 
-        source.on('load', function() {
+        source.on('source.load', function() {
             t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
@@ -52,7 +52,7 @@ test('VectorTileSource', function(t) {
 
         var source = createSource({ url: "/source.json" });
 
-        source.on('load', function() {
+        source.on('source.load', function() {
             t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
@@ -107,7 +107,7 @@ test('VectorTileSource', function(t) {
                 t.end();
             };
 
-            source.on('load', function() {
+            source.on('source.load', function() {
                 source.loadTile({coord: new TileCoord(10, 5, 5, 0)}, function () {});
             });
         });
@@ -127,7 +127,7 @@ test('VectorTileSource', function(t) {
             return 1;
         };
 
-        source.on('load', function () {
+        source.on('source.load', function () {
             var tile = {
                 coord: new TileCoord(10, 5, 5, 0),
                 state: 'loading',

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -156,7 +156,7 @@ test('Style', function(t) {
             }]
         }));
 
-        style.on('layer.error', function(e) {
+        style.on('error', function(e) {
             t.deepEqual(e.layer, {id: 'background'});
             t.ok(e.mapbox);
             t.end();
@@ -529,7 +529,7 @@ test('Style#addLayer', function(t) {
     t.test('sets up layer event forwarding', function(t) {
         var style = new Style(createStyleJSON());
 
-        style.on('layer.error', function(e) {
+        style.on('error', function(e) {
             t.deepEqual(e.layer, {id: 'background'});
             t.ok(e.mapbox);
             t.end();
@@ -637,7 +637,7 @@ test('Style#addLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('layer.error', function(e) {
+        style.on('error', function(e) {
             t.deepEqual(e.layer, {id: 'background'});
             t.notOk(/duplicate/.match(e.error.message));
             t.end();
@@ -739,7 +739,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('layer.error', function() {
+        style.on('error', function() {
             t.fail();
         });
 

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -394,8 +394,8 @@ test('Style#addSource', function(t) {
         style.on('load', function () {
             t.plan(7);
             style.addSource('source-id', source); // Fires load
-            style.sources['source-id'].fire('error');
-            style.sources['source-id'].fire('change');
+            style.sources['source-id'].fire('source.error');
+            style.sources['source-id'].fire('source.change');
             style.sources['source-id'].fire('tile.add');
             style.sources['source-id'].fire('tile.load');
             style.sources['source-id'].fire('tile.error');
@@ -487,12 +487,12 @@ test('Style#removeSource', function(t) {
             style.removeSource('source-id');
 
             // Bind a listener to prevent fallback Evented error reporting.
-            source.on('error',  function() {});
+            source.on('source.error',  function() {});
             source.on('tile.error',  function() {});
 
-            source.fire('load');
-            source.fire('error');
-            source.fire('change');
+            source.fire('source.load');
+            source.fire('source.error');
+            source.fire('source.change');
             source.fire('tile.add');
             source.fire('tile.load');
             source.fire('tile.error');

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -53,7 +53,7 @@ test('Style', function(t) {
         window.useFakeXMLHttpRequest();
         window.server.respondWith('/style.json', JSON.stringify(require('../../fixtures/style')));
         var style = new Style('/style.json');
-        style.on('load', function() {
+        style.on('style.load', function() {
             window.restore();
             t.end();
         });
@@ -69,7 +69,7 @@ test('Style', function(t) {
                 }
             }
         }));
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.ok(style.sources['mapbox'] instanceof SourceCache);
             t.end();
         });
@@ -105,7 +105,7 @@ test('Style', function(t) {
             .on('error', function() {
                 t.fail();
             })
-            .on('load', function() {
+            .on('style.load', function() {
                 window.restore();
                 t.end();
             });
@@ -127,7 +127,7 @@ test('Style', function(t) {
             }]
         }));
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.removeSource('-source-id-');
 
             var source = createSource();
@@ -162,7 +162,7 @@ test('Style', function(t) {
             t.end();
         });
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style._layers.background.fire('error', {mapbox: true});
         });
     });
@@ -188,7 +188,7 @@ test('Style#_updateWorkerLayers', function(t) {
 
     style.on('error', function(error) { t.error(error); });
 
-    style.on('load', function() {
+    style.on('style.load', function() {
         style.addLayer({id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer' }, 'second');
         style.addLayer({id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer' });
 
@@ -219,7 +219,7 @@ test('Style#_updateWorkerLayers with specific ids', function(t) {
 
     style.on('error', function(error) { t.error(error); });
 
-    style.on('load', function() {
+    style.on('style.load', function() {
         style.dispatcher.broadcast = function(key, value) {
             t.equal(key, 'update layers');
             t.deepEqual(value.map(function(layer) { return layer.id; }), ['second', 'third']);
@@ -249,7 +249,7 @@ test('Style#_resolve', function(t) {
 
         style.on('error', function(error) { t.error(error); });
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.ok(style.getLayer('fill') instanceof StyleLayer);
             t.end();
         });
@@ -277,7 +277,7 @@ test('Style#_resolve', function(t) {
 
         style.on('error', function(event) { t.error(event.error); });
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             var ref = style.getLayer('ref'),
                 referent = style.getLayer('referent');
             t.equal(ref.type, 'fill');
@@ -293,7 +293,7 @@ test('Style#addSource', function(t) {
     t.test('returns self', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('load', function () {
+        style.on('style.load', function () {
             t.equal(style.addSource('source-id', source), style);
             t.end();
         });
@@ -305,7 +305,7 @@ test('Style#addSource', function(t) {
         t.throws(function () {
             style.addSource('source-id', source);
         }, Error, /load/i);
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -316,7 +316,7 @@ test('Style#addSource', function(t) {
 
         delete source.type;
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.throws(function () {
                 style.addSource('source-id', source);
             }, Error, /type/i);
@@ -331,7 +331,7 @@ test('Style#addSource', function(t) {
             t.same(e.source.serialize(), source);
             t.end();
         });
-        style.on('load', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             style.update();
         });
@@ -340,7 +340,7 @@ test('Style#addSource', function(t) {
     t.test('throws on duplicates', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('load', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             t.throws(function() {
                 style.addSource('source-id', source);
@@ -351,7 +351,7 @@ test('Style#addSource', function(t) {
 
     t.test('emits on invalid source', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.on('error', function() {
                 t.notOk(style.sources['source-id']);
                 t.end();
@@ -391,7 +391,7 @@ test('Style#addSource', function(t) {
         style.on('tile.error',    tileEvent);
         style.on('tile.remove',   tileEvent);
 
-        style.on('load', function () {
+        style.on('style.load', function () {
             t.plan(7);
             style.addSource('source-id', source); // Fires load
             style.sources['source-id'].fire('source.error');
@@ -410,7 +410,7 @@ test('Style#removeSource', function(t) {
     t.test('returns self', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('load', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             t.equal(style.removeSource('source-id'), style);
             t.end();
@@ -429,7 +429,7 @@ test('Style#removeSource', function(t) {
         t.throws(function () {
             style.removeSource('source-id');
         }, Error, /load/i);
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -441,7 +441,7 @@ test('Style#removeSource', function(t) {
             t.same(e.source.serialize(), source);
             t.end();
         });
-        style.on('load', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             style.removeSource('source-id');
             style.update();
@@ -460,7 +460,7 @@ test('Style#removeSource', function(t) {
 
     t.test('throws on non-existence', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('load', function () {
+        style.on('style.load', function () {
             t.throws(function() {
                 style.removeSource('source-id');
             }, /There is no source with this ID/);
@@ -480,7 +480,7 @@ test('Style#removeSource', function(t) {
         style.on('tile.error',    t.fail);
         style.on('tile.remove',   t.fail);
 
-        style.on('load', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             source = style.sources['source-id'];
 
@@ -509,7 +509,7 @@ test('Style#addLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.equal(style.addLayer(layer), style);
             t.end();
         });
@@ -521,7 +521,7 @@ test('Style#addLayer', function(t) {
         t.throws(function () {
             style.addLayer(layer);
         }, Error, /load/i);
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -535,7 +535,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.addLayer({
                 id: 'background',
                 type: 'background'
@@ -552,7 +552,7 @@ test('Style#addLayer', function(t) {
             }
         }));
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             var source = createSource();
             source['vector_layers'] = [{id: 'green'}];
             style.addSource('-source-id-', source);
@@ -578,7 +578,7 @@ test('Style#addLayer', function(t) {
 
     t.test('emits error on invalid layer', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.on('error', function() {
                 t.notOk(style.getLayer('background'));
                 t.end();
@@ -610,7 +610,7 @@ test('Style#addLayer', function(t) {
             "filter": ["==", "id", 0]
         };
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.sources['mapbox'].reload = t.end;
 
             style.addLayer(layer);
@@ -627,7 +627,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             style.update();
         });
@@ -643,7 +643,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             style.addLayer(layer);
             t.end();
@@ -662,7 +662,7 @@ test('Style#addLayer', function(t) {
             })),
             layer = {id: 'c', type: 'background'};
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             t.deepEqual(style._order, ['a', 'b', 'c']);
             t.end();
@@ -681,7 +681,7 @@ test('Style#addLayer', function(t) {
             })),
             layer = {id: 'c', type: 'background'};
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.addLayer(layer, 'a');
             t.deepEqual(style._order, ['c', 'a', 'b']);
             t.end();
@@ -696,7 +696,7 @@ test('Style#removeLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             t.equal(style.removeLayer('background'), style);
             t.end();
@@ -710,7 +710,7 @@ test('Style#removeLayer', function(t) {
         t.throws(function () {
             style.removeLayer('background');
         }, Error, /load/i);
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -724,7 +724,7 @@ test('Style#removeLayer', function(t) {
             t.end();
         });
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             style.removeLayer('background');
             style.update();
@@ -743,7 +743,7 @@ test('Style#removeLayer', function(t) {
             t.fail();
         });
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             var layer = style._layers.background;
             style.removeLayer('background');
 
@@ -758,7 +758,7 @@ test('Style#removeLayer', function(t) {
     t.test('throws on non-existence', function(t) {
         var style = new Style(createStyleJSON());
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.throws(function () {
                 style.removeLayer('background');
             }, /There is no layer with this ID/);
@@ -777,7 +777,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.removeLayer('a');
             t.deepEqual(style._order, ['b']);
             t.end();
@@ -795,7 +795,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.removeLayer('a');
             t.deepEqual(style.getLayer('a'), undefined);
             t.deepEqual(style.getLayer('b'), undefined);
@@ -823,7 +823,7 @@ test('Style#setFilter', function(t) {
     t.test('sets filter', function(t) {
         var style = createStyle();
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value[0].id, 'symbol');
@@ -840,7 +840,7 @@ test('Style#setFilter', function(t) {
     t.test('gets a clone of the filter', function(t) {
         var style = createStyle();
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             var filter1 = ['==', 'id', 1];
             style.setFilter('symbol', filter1);
             var filter2 = style.getFilter('symbol');
@@ -857,7 +857,7 @@ test('Style#setFilter', function(t) {
     t.test('sets again mutated filter', function(t) {
         var style = createStyle();
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             var filter = ['==', 'id', 1];
             style.setFilter('symbol', filter);
             style.update({}, {}); // flush pending operations
@@ -877,7 +877,7 @@ test('Style#setFilter', function(t) {
     t.test('sets filter on parent', function(t) {
         var style = createStyle();
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -902,7 +902,7 @@ test('Style#setFilter', function(t) {
 
     t.test('emits if invalid', function(t) {
         var style = createStyle();
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.on('error', function() {
                 t.deepEqual(style.getLayer('symbol').serialize().filter, ['==', 'id', 0]);
                 t.end();
@@ -935,7 +935,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.test('sets zoom range', function(t) {
         var style = createStyle();
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -951,7 +951,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.test('sets zoom range on parent layer', function(t) {
         var style = createStyle();
 
-        style.on('load', function() {
+        style.on('style.load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -969,7 +969,7 @@ test('Style#setLayerZoomRange', function(t) {
         t.throws(function () {
             style.setLayerZoomRange('symbol', 5, 12);
         }, Error, /load/i);
-        style.on('load', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -1071,7 +1071,7 @@ test('Style#queryRenderedFeatures', function(t) {
         }]
     });
 
-    style.on('load', function() {
+    style.on('style.load', function() {
         style._applyClasses([]);
         style._recalculate(0);
 
@@ -1154,7 +1154,7 @@ test('Style defers expensive methods', function(t) {
         }
     }));
 
-    style.on('load', function() {
+    style.on('style.load', function() {
         style.update();
 
         // spies to track defered methods
@@ -1182,7 +1182,7 @@ test('Style defers expensive methods', function(t) {
         t.equal(style.fire.args[0][0], 'layer.add', 'fire was called with layer.add');
         t.equal(style.fire.args[1][0], 'layer.add', 'fire was called with layer.add');
         t.equal(style.fire.args[2][0], 'layer.add', 'fire was called with layer.add');
-        t.equal(style.fire.args[3][0], 'change', 'fire was called with change');
+        t.equal(style.fire.args[3][0], 'style.change', 'fire was called with style.change');
 
         // called per source
         t.ok(style._reloadSource.calledTwice, '_reloadSource is called per source');
@@ -1224,7 +1224,7 @@ test('Style#query*Features', function(t) {
         onError = sinon.spy();
 
         style.on('error', onError)
-            .on('load', function() {
+            .on('style.load', function() {
                 callback();
             });
     });

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -375,30 +375,24 @@ test('Style#addSource', function(t) {
         }));
         var source = createSource();
 
-        function sourceEvent(e) {
+        function checkEvent(e) {
             t.same(e.source.serialize(), source);
         }
 
-        function tileEvent(e) {
-            t.same(e.source.serialize(), source);
-        }
-
-        style.on('source.load',   sourceEvent);
-        style.on('source.error',  sourceEvent);
-        style.on('source.change', sourceEvent);
-        style.on('tile.add',      tileEvent);
-        style.on('tile.load',     tileEvent);
-        style.on('tile.error',    tileEvent);
-        style.on('tile.remove',   tileEvent);
+        style.on('error',         checkEvent);
+        style.on('source.load',   checkEvent);
+        style.on('source.change', checkEvent);
+        style.on('tile.add',      checkEvent);
+        style.on('tile.load',     checkEvent);
+        style.on('tile.remove',   checkEvent);
 
         style.on('style.load', function () {
-            t.plan(7);
+            t.plan(6);
             style.addSource('source-id', source); // Fires load
-            style.sources['source-id'].fire('source.error');
+            style.sources['source-id'].fire('error');
             style.sources['source-id'].fire('source.change');
             style.sources['source-id'].fire('tile.add');
             style.sources['source-id'].fire('tile.load');
-            style.sources['source-id'].fire('tile.error');
             style.sources['source-id'].fire('tile.remove');
         });
     });
@@ -473,11 +467,11 @@ test('Style#removeSource', function(t) {
             source = createSource();
 
         style.on('source.load',   t.fail);
-        style.on('source.error',  t.fail);
+        style.on('error',  t.fail);
         style.on('source.change', t.fail);
         style.on('tile.add',      t.fail);
         style.on('tile.load',     t.fail);
-        style.on('tile.error',    t.fail);
+        style.on('error',    t.fail);
         style.on('tile.remove',   t.fail);
 
         style.on('style.load', function () {
@@ -487,15 +481,15 @@ test('Style#removeSource', function(t) {
             style.removeSource('source-id');
 
             // Bind a listener to prevent fallback Evented error reporting.
-            source.on('source.error',  function() {});
-            source.on('tile.error',  function() {});
+            source.on('error',  function() {});
+            source.on('error',  function() {});
 
             source.fire('source.load');
-            source.fire('source.error');
+            source.fire('error');
             source.fire('source.change');
             source.fire('tile.add');
             source.fire('tile.load');
-            source.fire('tile.error');
+            source.fire('error');
             source.fire('tile.remove');
             t.end();
         });

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -130,37 +130,31 @@ test('Map', function(t) {
             createMap({}, function(error, map) {
                 t.error(error);
 
-                // Suppress error messages
-                map.on('error', function() {});
-
                 var events = [];
                 function recordEvent(event) {
                     events.push(event.type);
                 }
 
+                map.on('error',         recordEvent);
                 map.on('style.change',  recordEvent);
                 map.on('source.load',   recordEvent);
-                map.on('source.error',  recordEvent);
                 map.on('source.change', recordEvent);
                 map.on('tile.add',      recordEvent);
-                map.on('tile.error',    recordEvent);
                 map.on('tile.remove',   recordEvent);
 
+                map.style.fire('error');
                 map.style.fire('style.change');
                 map.style.fire('source.load');
-                map.style.fire('source.error');
                 map.style.fire('source.change');
                 map.style.fire('tile.add');
-                map.style.fire('tile.error');
                 map.style.fire('tile.remove');
 
                 t.deepEqual(events, [
+                    'error',
                     'style.change',
                     'source.load',
-                    'source.error',
                     'source.change',
                     'tile.add',
-                    'tile.error',
                     'tile.remove'
                 ]);
 

--- a/test/js/util/evented.test.js
+++ b/test/js/util/evented.test.js
@@ -16,18 +16,6 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('calls parent listeners added with "on"', function(t) {
-        var listener = sinon.spy();
-        var eventedSource = Object.create(Evented);
-        var eventedSink = Object.create(Evented);
-        eventedSource.setEventedParent(eventedSink);
-        eventedSink.on('a', listener);
-        eventedSource.fire('a');
-        eventedSource.fire('a');
-        t.ok(listener.calledTwice);
-        t.end();
-    });
-
     t.test('calls listeners added with "once" once', function(t) {
         var evented = Object.create(Evented);
         var listener = sinon.spy();
@@ -56,18 +44,6 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('passes original "target" to parent listeners', function(t) {
-        var eventedSource = Object.create(Evented);
-        var eventedSink = Object.create(Evented);
-        eventedSource.setEventedParent(eventedSink);
-        eventedSource.setEventedParent(null);
-        eventedSink.on('a', function(data) {
-            t.equal(data.target, eventedSource);
-        });
-        eventedSource.fire('a');
-        t.end();
-    });
-
     t.test('passes "type" to listeners', function(t) {
         var evented = Object.create(Evented);
         evented.on('a', function(data) {
@@ -87,32 +63,11 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('removes parents', function(t) {
-        var listener = sinon.spy();
-        var eventedSource = Object.create(Evented);
-        var eventedSink = Object.create(Evented);
-        eventedSink.on('a', listener);
-        eventedSource.setEventedParent(eventedSink);
-        eventedSource.setEventedParent(null);
-        eventedSource.fire('a');
-        t.ok(listener.notCalled);
-        t.end();
-    });
-
     t.test('reports if an event has listeners with "listens"', function(t) {
         var evented = Object.create(Evented);
         evented.on('a', function() {});
         t.ok(evented.listens('a'));
         t.notOk(evented.listens('b'));
-        t.end();
-    });
-
-    t.test('reports if an event has parent listeners with "listens"', function(t) {
-        var eventedSource = Object.create(Evented);
-        var eventedSink = Object.create(Evented);
-        eventedSink.on('a', function() {});
-        eventedSource.setEventedParent(eventedSink);
-        t.ok(eventedSink.listens('a'));
         t.end();
     });
 
@@ -125,6 +80,78 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.end();
+    t.test('evented parents', function(t) {
 
+        t.test('adds parents with "setEventedParent"', function(t) {
+            var listener = sinon.spy();
+            var eventedSource = Object.create(Evented);
+            var eventedSink = Object.create(Evented);
+            eventedSource.setEventedParent(eventedSink);
+            eventedSink.on('a', listener);
+            eventedSource.fire('a');
+            eventedSource.fire('a');
+            t.ok(listener.calledTwice);
+            t.end();
+        });
+
+        t.test('passes original data to parent listeners', function(t) {
+            var eventedSource = Object.create(Evented);
+            var eventedSink = Object.create(Evented);
+            eventedSource.setEventedParent(eventedSink);
+            eventedSink.on('a', function(data) {
+                t.equal(data.foo, 'bar');
+            });
+            eventedSource.fire('a', {foo: 'bar'});
+            t.end();
+        });
+
+        t.test('attaches parent data to parent listeners', function(t) {
+            var eventedSource = Object.create(Evented);
+            var eventedSink = Object.create(Evented);
+            eventedSource.setEventedParent(eventedSink, {foz: 'baz'});
+            eventedSink.on('a', function(data) {
+                t.equal(data.foz, 'baz');
+            });
+            eventedSource.fire('a', {foo: 'bar'});
+            t.end();
+        });
+
+        t.test('passes original "target" to parent listeners', function(t) {
+            var eventedSource = Object.create(Evented);
+            var eventedSink = Object.create(Evented);
+            eventedSource.setEventedParent(eventedSink);
+            eventedSource.setEventedParent(null);
+            eventedSink.on('a', function(data) {
+                t.equal(data.target, eventedSource);
+            });
+            eventedSource.fire('a');
+            t.end();
+        });
+
+        t.test('removes parents with "setEventedParent(null)"', function(t) {
+            var listener = sinon.spy();
+            var eventedSource = Object.create(Evented);
+            var eventedSink = Object.create(Evented);
+            eventedSink.on('a', listener);
+            eventedSource.setEventedParent(eventedSink);
+            eventedSource.setEventedParent(null);
+            eventedSource.fire('a');
+            t.ok(listener.notCalled);
+            t.end();
+        });
+
+        t.test('reports if an event has parent listeners with "listens"', function(t) {
+            var eventedSource = Object.create(Evented);
+            var eventedSink = Object.create(Evented);
+            eventedSink.on('a', function() {});
+            eventedSource.setEventedParent(eventedSink);
+            t.ok(eventedSink.listens('a'));
+            t.end();
+        });
+
+        t.end();
+
+    });
+
+    t.end();
 });

--- a/test/js/util/evented.test.js
+++ b/test/js/util/evented.test.js
@@ -16,11 +16,11 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('calls piped listeners added with "on"', function(t) {
+    t.test('calls forwarded listeners added with "on"', function(t) {
         var listener = sinon.spy();
         var eventedSource = Object.create(Evented);
         var eventedSink = Object.create(Evented);
-        eventedSource.pipe(eventedSink);
+        eventedSource.forwardEvents(eventedSink);
         eventedSink.on('a', listener);
         eventedSource.fire('a');
         eventedSource.fire('a');
@@ -75,13 +75,13 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('removes pipes with "unpipe"', function(t) {
+    t.test('removes forwardees with "unforwardEvents"', function(t) {
         var listener = sinon.spy();
         var eventedSource = Object.create(Evented);
         var eventedSink = Object.create(Evented);
         eventedSink.on('a', listener);
-        eventedSource.pipe(eventedSink);
-        eventedSource.unpipe(eventedSink);
+        eventedSource.forwardEvents(eventedSink);
+        eventedSource.unforwardEvents(eventedSink);
         eventedSource.fire('a');
         t.ok(listener.notCalled);
         t.end();
@@ -95,11 +95,11 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('reports if an event has piped listeners with "listens"', function(t) {
+    t.test('reports if an event has forwarded listeners with "listens"', function(t) {
         var eventedSource = Object.create(Evented);
         var eventedSink = Object.create(Evented);
         eventedSink.on('a', function() {});
-        eventedSource.pipe(eventedSink);
+        eventedSource.forwardEvents(eventedSink);
         t.ok(eventedSink.listens('a'));
         t.end();
     });

--- a/test/js/util/evented.test.js
+++ b/test/js/util/evented.test.js
@@ -2,69 +2,87 @@
 
 var test = require('tap').test;
 var Evented = require('../../../js/util/evented');
+var sinon = require('sinon');
 
-test('evented', function(t) {
-    var evented = Object.create(Evented);
-    var report = function(data) {
-        t.deepEqual(data, { a: 'a', type: 'a', target: evented });
-    };
-    t.equal(evented.on('a', report), evented);
-    t.equal(evented.listens('a'), true);
-    t.equal(evented.fire('a', { a: 'a' }), evented);
-    t.equal(evented.off('a', report), evented);
-    t.equal(evented.off('a', report), evented);
-    t.equal(evented.listens('a'), false);
-    t.end();
-});
+test('Evented', function(t) {
 
-test('evented-all', function(t) {
-    var report = function() {
-        t.fail();
-    };
-    var evented = Object.create(Evented);
-    t.equal(evented.on('a', report), evented);
-    t.equal(evented.on('b', report), evented);
-    t.equal(evented.on('c', report), evented);
-    t.equal(evented.off(), evented);
-    ['a', 'b', 'c'].forEach(function(e) {
-        t.equal(evented.fire(e, { a: 'a' }), evented);
-    });
-    t.end();
-});
-
-test('evented-one', function(t) {
-    var report1 = function() { t.fail(); };
-    var report2 = function() { t.fail(); };
-    var report3 = function() { t.fail(); };
-    var evented = Object.create(Evented);
-    t.equal(evented.on('a', report1), evented);
-    t.equal(evented.on('a', report2), evented);
-    t.equal(evented.on('a', report3), evented);
-    t.equal(evented.off('a'), evented);
-    t.equal(evented.fire('a', { a: 'a' }), evented);
-    t.end();
-});
-
-test('evented-once', function(t) {
-    var evented = Object.create(Evented);
-
-    function report(data) {
-        t.equal(data.type, 'a');
-        t.equal(data.n, 1);
+    t.test('calls listeners added with "on" when their event is fired', function(t) {
+        var evented = Object.create(Evented);
+        var listener = sinon.spy();
+        evented.on('a', listener);
+        evented.fire('a');
+        evented.fire('a');
+        evented.fire('b');
+        t.ok(listener.calledTwice);
         t.end();
-    }
+    });
 
-    t.equal(evented.once('a', report), evented);
+    t.test('calls listeners added with "once" once', function(t) {
+        var evented = Object.create(Evented);
+        var listener = sinon.spy();
+        evented.once('a', listener);
+        evented.fire('a');
+        evented.fire('a');
+        t.ok(listener.calledOnce);
+        t.end();
+    });
 
-    evented.fire('a', {n: 1});
-    evented.fire('a', {n: 2});
-});
+    t.test('passes data to listeners', function(t) {
+        var evented = Object.create(Evented);
+        evented.on('a', function(data) {
+            t.equal(data.foo, 'bar');
+        });
+        evented.fire('a', {foo: 'bar'});
+        t.end();
+    });
 
-test('evented-not-found', function(t) {
-    var report1 = function() { t.pass(); };
-    var evented = Object.create(Evented);
-    t.equal(evented.on('a', report1), evented);
-    t.equal(evented.off('a', function() {}), evented);
-    t.equal(evented.fire('a', { a: 'a' }), evented);
+    t.test('passes "target" to listeners', function(t) {
+        var evented = Object.create(Evented);
+        evented.on('a', function(data) {
+            t.equal(data.target, evented);
+        });
+        evented.fire('a');
+        t.end();
+    });
+
+    t.test('passes "type" to listeners', function(t) {
+        var evented = Object.create(Evented);
+        evented.on('a', function(data) {
+            t.deepEqual(data.type, 'a');
+        });
+        evented.fire('a');
+        t.end();
+    });
+
+    t.test('removes listeners with "off"', function(t) {
+        var evented = Object.create(Evented);
+        var listener = sinon.spy();
+        evented.on('a', listener);
+        evented.off('a', listener);
+        evented.fire('a');
+        t.ok(listener.notCalled);
+        t.end();
+    });
+
+    t.test('reports if an event has listeners with "listens"', function(t) {
+        var evented = Object.create(Evented);
+        evented.on('a', function() {});
+        t.ok(evented.listens('a'));
+        t.notOk(evented.listens('b'));
+        t.end();
+    });
+
+    t.test('does not immediately call listeners added within another listener', function(t) {
+        var evented = Object.create(Evented);
+        evented.on('a', function() {
+            evented.on('a', function() {
+                assert.fail();
+            })
+        });
+        evented.fire('a');
+        t.end();
+    });
+
     t.end();
+
 });

--- a/test/js/util/evented.test.js
+++ b/test/js/util/evented.test.js
@@ -16,11 +16,11 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('calls forwarded listeners added with "on"', function(t) {
+    t.test('calls parent listeners added with "on"', function(t) {
         var listener = sinon.spy();
         var eventedSource = Object.create(Evented);
         var eventedSink = Object.create(Evented);
-        eventedSource.forwardEvents(eventedSink);
+        eventedSource.setEventedParent(eventedSink);
         eventedSink.on('a', listener);
         eventedSource.fire('a');
         eventedSource.fire('a');
@@ -56,11 +56,11 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('passes original "target" to forwarded listeners', function(t) {
+    t.test('passes original "target" to parent listeners', function(t) {
         var eventedSource = Object.create(Evented);
         var eventedSink = Object.create(Evented);
-        eventedSource.forwardEvents(eventedSink);
-        eventedSource.unforwardEvents(eventedSink);
+        eventedSource.setEventedParent(eventedSink);
+        eventedSource.setEventedParent(null);
         eventedSink.on('a', function(data) {
             t.equal(data.target, eventedSource);
         });
@@ -87,13 +87,13 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('removes forwardees with "unforwardEvents"', function(t) {
+    t.test('removes parents', function(t) {
         var listener = sinon.spy();
         var eventedSource = Object.create(Evented);
         var eventedSink = Object.create(Evented);
         eventedSink.on('a', listener);
-        eventedSource.forwardEvents(eventedSink);
-        eventedSource.unforwardEvents(eventedSink);
+        eventedSource.setEventedParent(eventedSink);
+        eventedSource.setEventedParent(null);
         eventedSource.fire('a');
         t.ok(listener.notCalled);
         t.end();
@@ -107,11 +107,11 @@ test('Evented', function(t) {
         t.end();
     });
 
-    t.test('reports if an event has forwarded listeners with "listens"', function(t) {
+    t.test('reports if an event has parent listeners with "listens"', function(t) {
         var eventedSource = Object.create(Evented);
         var eventedSink = Object.create(Evented);
         eventedSink.on('a', function() {});
-        eventedSource.forwardEvents(eventedSink);
+        eventedSource.setEventedParent(eventedSink);
         t.ok(eventedSink.listens('a'));
         t.end();
     });

--- a/test/js/util/evented.test.js
+++ b/test/js/util/evented.test.js
@@ -56,6 +56,18 @@ test('Evented', function(t) {
         t.end();
     });
 
+    t.test('passes original "target" to forwarded listeners', function(t) {
+        var eventedSource = Object.create(Evented);
+        var eventedSink = Object.create(Evented);
+        eventedSource.forwardEvents(eventedSink);
+        eventedSource.unforwardEvents(eventedSink);
+        eventedSink.on('a', function(data) {
+            t.equal(data.target, eventedSource);
+        });
+        eventedSource.fire('a');
+        t.end();
+    });
+
     t.test('passes "type" to listeners', function(t) {
         var evented = Object.create(Evented);
         evented.on('a', function(data) {

--- a/test/js/util/evented.test.js
+++ b/test/js/util/evented.test.js
@@ -6,13 +6,24 @@ var sinon = require('sinon');
 
 test('Evented', function(t) {
 
-    t.test('calls listeners added with "on" when their event is fired', function(t) {
+    t.test('calls listeners added with "on"', function(t) {
         var evented = Object.create(Evented);
         var listener = sinon.spy();
         evented.on('a', listener);
         evented.fire('a');
         evented.fire('a');
-        evented.fire('b');
+        t.ok(listener.calledTwice);
+        t.end();
+    });
+
+    t.test('calls piped listeners added with "on"', function(t) {
+        var listener = sinon.spy();
+        var eventedSource = Object.create(Evented);
+        var eventedSink = Object.create(Evented);
+        eventedSource.pipe(eventedSink);
+        eventedSink.on('a', listener);
+        eventedSource.fire('a');
+        eventedSource.fire('a');
         t.ok(listener.calledTwice);
         t.end();
     });
@@ -64,6 +75,18 @@ test('Evented', function(t) {
         t.end();
     });
 
+    t.test('removes pipes with "unpipe"', function(t) {
+        var listener = sinon.spy();
+        var eventedSource = Object.create(Evented);
+        var eventedSink = Object.create(Evented);
+        eventedSink.on('a', listener);
+        eventedSource.pipe(eventedSink);
+        eventedSource.unpipe(eventedSink);
+        eventedSource.fire('a');
+        t.ok(listener.notCalled);
+        t.end();
+    });
+
     t.test('reports if an event has listeners with "listens"', function(t) {
         var evented = Object.create(Evented);
         evented.on('a', function() {});
@@ -72,12 +95,19 @@ test('Evented', function(t) {
         t.end();
     });
 
+    t.test('reports if an event has piped listeners with "listens"', function(t) {
+        var eventedSource = Object.create(Evented);
+        var eventedSink = Object.create(Evented);
+        eventedSink.on('a', function() {});
+        eventedSource.pipe(eventedSink);
+        t.ok(eventedSink.listens('a'));
+        t.end();
+    });
+
     t.test('does not immediately call listeners added within another listener', function(t) {
         var evented = Object.create(Evented);
         evented.on('a', function() {
-            evented.on('a', function() {
-                assert.fail();
-            })
+            evented.on('a', t.fail.bind(t));
         });
         evented.fire('a');
         t.end();


### PR DESCRIPTION
Adding a new `Map` event that needs to be fired from another class requires a lot of GL JS boilerplate. Before tackling https://github.com/mapbox/mapbox-gl-js/issues/1715, I built an event propogation system that...

 - adds a `Evented#setEventedParent` method which propagates events 
 - uses `Evented#setEventedParent` to eliminate repetitive binding / unbinding of `_forward*Event` methods 
 - uses `Evented#setEventedParent` allow event names to remain constant from `Evented#fire` to `Map` listeners, making it easier to add new events and follow the path of existing events
 - improves test coverage of `Evented`
 - eliminates the ability to call `Evented#off` with less than two arguments, removing all listeners (this could break GL JS core)
 - eliminates lines of code

I'm still not 💯 on the name `Evented#setEventedParent`. Any other ideas?

cc @jfirebaugh @mourner @mollymerp @lbud @mapsam 

# Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page

# Benchmarks

## map-load

**master 594248c:** 132 ms
**datastart 102807b:** 114 ms

## style-load

**master 594248c:** 113 ms
**datastart 102807b:** 110 ms

## buffer

**master 594248c:** 984 ms
**datastart 102807b:** 1,092 ms

## fps

**master 594248c:** 60 fps
**datastart 102807b:** 60 fps

## frame-duration

**master 594248c:** 8.1 ms, 1% > 16ms
**datastart 102807b:** 8 ms, 4% > 16ms

## query-point

**master 594248c:** 1.15 ms
**datastart 102807b:** 1.23 ms

## query-box

**master 594248c:** 92.81 ms
**datastart 102807b:** 92.15 ms

## geojson-setdata-small

**master 594248c:** 15 ms
**datastart 102807b:** 13 ms

## geojson-setdata-large

**master 594248c:** 131 ms
**datastart 102807b:** 133 ms
