### PR TITLE
Add "data" event

### DIFF
--- a/bench/benchmarks/geojson_setdata_large.js
+++ b/bench/benchmarks/geojson_setdata_large.js
@@ -30,9 +30,8 @@ module.exports = function() {
 
         map.on('load', function() {
             map = setupGeoJSONMap(map);
-            var source = map.getSource('geojson');
 
-            setDataPerf(source, 50, data, function(err, ms) {
+            setDataPerf(map.style.sources['geojson'], data, function(err, ms) {
                 if (err) return evented.fire('error', {error: err});
                 map.remove();
                 evented.fire('end', {message: formatNumber(ms) + ' ms', score: ms});

--- a/bench/benchmarks/geojson_setdata_small.js
+++ b/bench/benchmarks/geojson_setdata_small.js
@@ -33,9 +33,7 @@ module.exports = function() {
     map.on('load', function() {
         map = setupGeoJSONMap(map);
 
-        var source = map.getSource('geojson');
-
-        setDataPerf(source, 50, featureCollection, function(err, ms) {
+        setDataPerf(map.style.sources['geojson'], featureCollection, function(err, ms) {
             map.remove();
             if (err) return evented.fire('error', {error: err});
             evented.fire('end', {message: formatNumber(ms) + ' ms', score: ms});

--- a/bench/lib/set_data_perf.js
+++ b/bench/lib/set_data_perf.js
@@ -7,7 +7,9 @@ module.exports = function(source, numCalls, geojson, cb) {
     var startTime = null;
     var times = [];
 
-    source.on('tile.load', function tileCounter() {
+    source.on('data', function tileCounter(event) {
+        if (event.dataType !== 'tile') return;
+
         tileCount++;
         if (tileCount === NUM_TILES) {
             tileCount = 0;
@@ -20,7 +22,7 @@ module.exports = function(source, numCalls, geojson, cb) {
                 var avgTileTime = times.reduce(function (v, t) {
                     return v + t;
                 }, 0) / times.length;
-                source.off('tile.load', tileCounter);
+                source.off('data', tileCounter);
                 cb(null, avgTileTime);
             }
         }

--- a/bench/lib/set_data_perf.js
+++ b/bench/lib/set_data_perf.js
@@ -1,33 +1,29 @@
 'use strict';
 
-var NUM_TILES = 6;
-
-module.exports = function(source, numCalls, geojson, cb) {
-    var tileCount = 0;
+module.exports = function(sourceCache, data, callback) {
+    var sampleCount = 50;
     var startTime = null;
-    var times = [];
+    var samples = [];
 
-    source.on('data', function tileCounter(event) {
-        if (event.dataType !== 'tile') return;
-
-        tileCount++;
-        if (tileCount === NUM_TILES) {
-            tileCount = 0;
-            times.push(performance.now() - startTime);
-
-            if (times.length < numCalls) {
+    sourceCache.on('data', function onData() {
+        if (sourceCache.loaded()) {
+            samples.push(performance.now() - startTime);
+            sourceCache.off('data', onData);
+            if (samples.length < sampleCount) {
                 startTime = performance.now();
-                source.setData(geojson);
+                sourceCache.clearTiles();
+                sourceCache.on('data', onData);
+                sourceCache.getSource().setData(data);
             } else {
-                var avgTileTime = times.reduce(function (v, t) {
-                    return v + t;
-                }, 0) / times.length;
-                source.off('data', tileCounter);
-                cb(null, avgTileTime);
+                callback(null, average(samples));
             }
         }
     });
 
     startTime = performance.now();
-    source.setData(geojson);
+    sourceCache.getSource().setData(data);
 };
+
+function average(array) {
+    return array.reduce(function (sum, value) { return sum + value; }, 0) / array.length;
+}

--- a/documentation.yml
+++ b/documentation.yml
@@ -56,6 +56,7 @@ toc:
   - MapMouseEvent
   - MapTouchEvent
   - MapBoxZoomEvent
+  - MapDataEvent
   - name: Types
     description: |
       These are types used in the documentation above to describe arguments,

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -88,7 +88,8 @@ function GeoJSONSource(id, options, dispatcher) {
             this.fire('error', {error: err});
             return;
         }
-        this.fire('source.load');
+        this.fire('data', {dataType: 'geojson'});
+        this.fire('sourceload');
     }.bind(this));
 }
 

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -119,7 +119,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             if (err) {
                 return this.fire('error', { error: err });
             }
-            this.fire('source.change');
+            this.fire('data', {dataType: 'geoJSON'});
         }.bind(this));
 
         return this;

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -89,7 +89,7 @@ function GeoJSONSource(id, options, dispatcher) {
             return;
         }
         this.fire('data', {dataType: 'geojson'});
-        this.fire('sourceload');
+        this.fire('source.load');
     }.bind(this));
 }
 

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -88,7 +88,7 @@ function GeoJSONSource(id, options, dispatcher) {
             this.fire('error', {error: err});
             return;
         }
-        this.fire('data', {dataType: 'geojson'});
+        this.fire('data', {dataType: 'source'});
         this.fire('source.load');
     }.bind(this));
 }
@@ -120,7 +120,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             if (err) {
                 return this.fire('error', { error: err });
             }
-            this.fire('data', {dataType: 'geoJSON'});
+            this.fire('data', {dataType: 'source'});
         }.bind(this));
 
         return this;

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -106,7 +106,7 @@ ImageSource.prototype = util.inherit(Evented, /** @lends ImageSource.prototype *
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('source.change');
+        this.fire('data', {dataType: 'image'});
         return this;
     },
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -53,7 +53,8 @@ function ImageSource(id, options, dispatcher) {
 
         this.image = image;
         this._loaded = true;
-        this.fire('source.load');
+        this.fire('data', {type: 'image'});
+        this.fire('sourceload');
 
         if (this.map) {
             this.setCoordinates(options.coordinates);

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -54,7 +54,7 @@ function ImageSource(id, options, dispatcher) {
         this.image = image;
         this._loaded = true;
         this.fire('data', {type: 'image'});
-        this.fire('sourceload');
+        this.fire('source.load');
 
         if (this.map) {
             this.setCoordinates(options.coordinates);

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -53,7 +53,7 @@ function ImageSource(id, options, dispatcher) {
 
         this.image = image;
         this._loaded = true;
-        this.fire('data', {type: 'image'});
+        this.fire('data', {dataType: 'source'});
         this.fire('source.load');
 
         if (this.map) {
@@ -107,7 +107,7 @@ ImageSource.prototype = util.inherit(Evented, /** @lends ImageSource.prototype *
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('data', {dataType: 'image'});
+        this.fire('data', {dataType: 'source'});
         return this;
     },
 

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -17,7 +17,8 @@ function RasterTileSource(id, options, dispatcher) {
             return this.fire('error', err);
         }
         util.extend(this, tileJSON);
-        this.fire('source.load');
+        this.fire('data', {type: 'tileJSON'});
+        this.fire('sourceload');
     }.bind(this));
 }
 

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -17,7 +17,7 @@ function RasterTileSource(id, options, dispatcher) {
             return this.fire('error', err);
         }
         util.extend(this, tileJSON);
-        this.fire('data', {type: 'tileJSON'});
+        this.fire('data', {dataType: 'source'});
         this.fire('source.load');
     }.bind(this));
 }

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -18,7 +18,7 @@ function RasterTileSource(id, options, dispatcher) {
         }
         util.extend(this, tileJSON);
         this.fire('data', {type: 'tileJSON'});
-        this.fire('sourceload');
+        this.fire('source.load');
     }.bind(this));
 }
 

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -50,10 +50,12 @@ function SourceCache(id, options, dispatcher) {
         this._sourceErrored = true;
     });
 
-    this.on('source.change', function() {
-        this.reload();
-        if (this.transform) {
-            this.update(this.transform, this.map && this.map.style.rasterFadeDuration);
+    this.on('data', function(event) {
+        if (this._sourceLoaded && ['image', 'video', 'geoJSON'].indexOf(event.dataType) !== -1) {
+            this.reload();
+            if (this.transform) {
+                this.update(this.transform, this.map && this.map.style.rasterFadeDuration);
+            }
         }
     });
 

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -427,7 +427,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.uses--;
         delete this._tiles[id];
-        this._source.fire('tile.remove', {tile: tile});
+        this._source.fire('data', {tile: tile, dataType: 'tile', isDataRemoved: true});
 
         if (tile.uses > 0)
             return;

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -30,7 +30,7 @@ function SourceCache(id, options, dispatcher) {
     var source = this._source = Source.create(id, options, dispatcher);
     source.setEventedParent(this);
 
-    this.on('source.load', function() {
+    this.on('sourceload', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
 
         this._sourceLoaded = true;

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -168,7 +168,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.source = this;
         tile.timeAdded = new Date().getTime();
-        this._source.fire('tile.load', {tile: tile});
+        this._source.fire('data', {tile: tile, dataType: 'tile'});
 
         // HACK this is nescessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
         if (this.map) this.map.painter.tileExtentVAO.vao = null;

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -409,7 +409,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.uses++;
         this._tiles[coord.id] = tile;
-        this._source.fire('tile.add', {tile: tile});
+        this._source.fire('dataloading', {tile: tile, dataType: 'tile'});
 
         return tile;
     },

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -427,7 +427,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.uses--;
         delete this._tiles[id];
-        this._source.fire('data', {tile: tile, dataType: 'tile', isDataRemoved: true});
+        this._source.fire('data', {dataType: 'tile'});
 
         if (tile.uses > 0)
             return;

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -51,7 +51,7 @@ function SourceCache(id, options, dispatcher) {
     });
 
     this.on('data', function(event) {
-        if (this._sourceLoaded && ['image', 'video', 'geoJSON'].indexOf(event.dataType) !== -1) {
+        if (this._sourceLoaded && event.dataType === 'source') {
             this.reload();
             if (this.transform) {
                 this.update(this.transform, this.map && this.map.style.rasterFadeDuration);

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -30,7 +30,7 @@ function SourceCache(id, options, dispatcher) {
     var source = this._source = Source.create(id, options, dispatcher);
     source.setEventedParent(this);
 
-    this.on('sourceload', function() {
+    this.on('source.load', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
 
         this._sourceLoaded = true;

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -144,7 +144,7 @@ Tile.prototype = {
 
         function done(_, data) {
             this.reloadSymbolData(data, source.map.painter, source.map.style);
-            source.fire('tile.load', {tile: this});
+            source.fire('data', {tile: this, dataType: 'tile'});
 
             // HACK this is nescessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
             if (source.map) source.map.painter.tileExtentVAO.vao = null;

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -23,7 +23,8 @@ function VectorTileSource(id, options, dispatcher) {
             return;
         }
         util.extend(this, tileJSON);
-        this.fire('source.load');
+        this.fire('data', {dataType: 'tileJSON'});
+        this.fire('sourceload');
     }.bind(this));
 }
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -24,7 +24,7 @@ function VectorTileSource(id, options, dispatcher) {
         }
         util.extend(this, tileJSON);
         this.fire('data', {dataType: 'tileJSON'});
-        this.fire('sourceload');
+        this.fire('source.load');
     }.bind(this));
 }
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -23,7 +23,7 @@ function VectorTileSource(id, options, dispatcher) {
             return;
         }
         util.extend(this, tileJSON);
-        this.fire('data', {dataType: 'tileJSON'});
+        this.fire('data', {dataType: 'source'});
         this.fire('source.load');
     }.bind(this));
 }

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -135,7 +135,7 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('source.change');
+        this.fire('data', {dataType: 'video'});
         return this;
     },
 

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -73,7 +73,8 @@ function VideoSource(id, options) {
             this.setCoordinates(options.coordinates);
         }
 
-        this.fire('source.load');
+        this.fire('data', {dataType: 'video'});
+        this.fire('sourceload');
     }.bind(this));
 }
 

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -73,7 +73,7 @@ function VideoSource(id, options) {
             this.setCoordinates(options.coordinates);
         }
 
-        this.fire('data', {dataType: 'video'});
+        this.fire('data', {dataType: 'source'});
         this.fire('source.load');
     }.bind(this));
 }
@@ -136,7 +136,7 @@ VideoSource.prototype = util.inherit(Evented, /** @lends VideoSource.prototype *
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('data', {dataType: 'video'});
+        this.fire('data', {dataType: 'source'});
         return this;
     },
 

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -74,7 +74,7 @@ function VideoSource(id, options) {
         }
 
         this.fire('data', {dataType: 'video'});
-        this.fire('sourceload');
+        this.fire('source.load');
     }.bind(this));
 }
 

--- a/js/style/image_sprite.js
+++ b/js/style/image_sprite.js
@@ -20,7 +20,7 @@ function ImageSprite(base) {
         }
 
         this.data = data;
-        if (this.img) this.fire('style.change');
+        if (this.img) this.fire('data', {dataType: 'sprite'});
     }.bind(this));
 
     ajax.getImage(normalizeURL(base, format, '.png'), function(err, img) {
@@ -41,7 +41,7 @@ function ImageSprite(base) {
         }
 
         this.img = img;
-        if (this.data) this.fire('style.change');
+        if (this.data) this.fire('data', {dataType: 'sprite'});
     }.bind(this));
 }
 
@@ -58,7 +58,7 @@ ImageSprite.prototype.loaded = function() {
 ImageSprite.prototype.resize = function(/*gl*/) {
     if (browser.devicePixelRatio > 1 !== this.retina) {
         var newSprite = new ImageSprite(this.base);
-        newSprite.on('style.change', function() {
+        newSprite.on('data', function() {
             this.img = newSprite.img;
             this.data = newSprite.data;
             this.retina = newSprite.retina;

--- a/js/style/image_sprite.js
+++ b/js/style/image_sprite.js
@@ -20,7 +20,7 @@ function ImageSprite(base) {
         }
 
         this.data = data;
-        if (this.img) this.fire('data', {dataType: 'sprite'});
+        if (this.img) this.fire('data', {dataType: 'style'});
     }.bind(this));
 
     ajax.getImage(normalizeURL(base, format, '.png'), function(err, img) {
@@ -41,7 +41,7 @@ function ImageSprite(base) {
         }
 
         this.img = img;
-        if (this.data) this.fire('data', {dataType: 'sprite'});
+        if (this.data) this.fire('data', {dataType: 'style'});
     }.bind(this));
 }
 

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -67,7 +67,8 @@ function Style(stylesheet, animationLoop, options) {
 
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
         this._resolve();
-        this.fire('style.load');
+        this.fire('data', {dataType: 'style'});
+        this.fire('styleload');
     }.bind(this);
 
     if (typeof stylesheet === 'string') {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -76,7 +76,7 @@ function Style(stylesheet, animationLoop, options) {
         browser.frame(stylesheetLoaded.bind(this, null, stylesheet));
     }
 
-    this.on('source.load', function(event) {
+    this.on('sourceload', function(event) {
         var source = event.source;
         if (source && source.vectorLayerIds) {
             for (var layerId in this._layers) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -300,7 +300,7 @@ Style.prototype = util.inherit(Evented, {
         this._applyClasses(classes, options);
 
         if (this._updates.changed) {
-            this.fire('style.change');
+            this.fire('data', {dataType: 'style'});
         }
 
         this._resetUpdates();
@@ -718,7 +718,7 @@ Style.prototype = util.inherit(Evented, {
             spriteAtlas.setSprite(sprite);
             spriteAtlas.addIcons(params.icons, callback);
         } else {
-            sprite.on('style.change', function() {
+            sprite.on('data', function() {
                 spriteAtlas.setSprite(sprite);
                 spriteAtlas.addIcons(params.icons, callback);
             });

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -68,7 +68,7 @@ function Style(stylesheet, animationLoop, options) {
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
         this._resolve();
         this.fire('data', {dataType: 'style'});
-        this.fire('styleload');
+        this.fire('style.load');
     }.bind(this);
 
     if (typeof stylesheet === 'string') {
@@ -77,7 +77,7 @@ function Style(stylesheet, animationLoop, options) {
         browser.frame(stylesheetLoaded.bind(this, null, stylesheet));
     }
 
-    this.on('sourceload', function(event) {
+    this.on('source.load', function(event) {
         var source = event.source;
         if (source && source.vectorLayerIds) {
             for (var layerId in this._layers) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -22,8 +22,9 @@ var getWorkerPool = require('../global_worker_pool');
 
 module.exports = Style;
 
-function Style(stylesheet, animationLoop, options) {
-    this.animationLoop = animationLoop || new AnimationLoop();
+function Style(stylesheet, map, options) {
+    this.map = map;
+    this.animationLoop = (map && map.animationLoop) || new AnimationLoop();
     this.dispatcher = new Dispatcher(getWorkerPool(), this);
     this.spriteAtlas = new SpriteAtlas(1024, 1024);
     this.lineAtlas = new LineAtlas(256, 512);
@@ -338,7 +339,7 @@ Style.prototype = util.inherit(Evented, {
         source.style = this;
         source.setEventedParent(this, {source: source});
 
-        this._updates.events.push(['source.add', {source: source}]);
+        if (source.onAdd) source.onAdd(this.map);
         this._updates.changed = true;
 
         return this;
@@ -362,7 +363,7 @@ Style.prototype = util.inherit(Evented, {
         delete this._updates.sources[id];
         source.setEventedParent(null);
 
-        this._updates.events.push(['source.remove', {source: source}]);
+        if (source.onRemove) source.onRemove(this.map);
         this._updates.changed = true;
 
         return this;

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -337,7 +337,7 @@ Style.prototype = util.inherit(Evented, {
         source = new SourceCache(id, source, this.dispatcher);
         this.sources[id] = source;
         source.style = this;
-        source.setEventedParent(this, {source: source});
+        source.setEventedParent(this, {source: source.getSource()});
 
         if (source.onAdd) source.onAdd(this.map);
         this._updates.changed = true;

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -384,7 +384,6 @@ Style.prototype = util.inherit(Evented, {
      * ID `before`, or appended if `before` is omitted.
      * @param {StyleLayer|Object} layer
      * @param {string=} before  ID of an existing layer to insert before
-     * @fires layer.add
      * @returns {Style} `this`
      * @private
      */
@@ -410,7 +409,6 @@ Style.prototype = util.inherit(Evented, {
         if (layer.source) {
             this._updates.sources[layer.source] = true;
         }
-        this._updates.events.push(['layer.add', {layer: layer}]);
 
         return this.updateClasses(layer.id);
     },
@@ -443,7 +441,6 @@ Style.prototype = util.inherit(Evented, {
         this._order.splice(this._order.indexOf(id), 1);
 
         this._updates.allLayers = true;
-        this._updates.events.push(['layer.remove', {layer: layer}]);
         this._updates.changed = true;
 
         return this;

--- a/js/ui/control/attribution.js
+++ b/js/ui/control/attribution.js
@@ -54,7 +54,6 @@ Attribution.prototype = util.inherit(Control, {
             container = this._container = DOM.create('div', className, map.getContainer());
 
         this._update();
-        map.on('source.load', this._update.bind(this));
         map.on('data', this._update.bind(this));
         map.on('source.remove', this._update.bind(this));
         map.on('moveend', this._updateEditLink.bind(this));

--- a/js/ui/control/attribution.js
+++ b/js/ui/control/attribution.js
@@ -55,7 +55,7 @@ Attribution.prototype = util.inherit(Control, {
 
         this._update();
         map.on('source.load', this._update.bind(this));
-        map.on('source.change', this._update.bind(this));
+        map.on('data', this._update.bind(this));
         map.on('source.remove', this._update.bind(this));
         map.on('moveend', this._updateEditLink.bind(this));
 

--- a/js/ui/control/attribution.js
+++ b/js/ui/control/attribution.js
@@ -54,7 +54,11 @@ Attribution.prototype = util.inherit(Control, {
             container = this._container = DOM.create('div', className, map.getContainer());
 
         this._update();
-        map.on('data', this._update.bind(this));
+        map.on('data', function(event) {
+            if (event.dataType === 'source') {
+                this._update();
+            }
+        }.bind(this));
         map.on('moveend', this._updateEditLink.bind(this));
 
         return container;

--- a/js/ui/control/attribution.js
+++ b/js/ui/control/attribution.js
@@ -55,7 +55,6 @@ Attribution.prototype = util.inherit(Control, {
 
         this._update();
         map.on('data', this._update.bind(this));
-        map.on('source.remove', this._update.bind(this));
         map.on('moveend', this._updateEditLink.bind(this));
 
         return container;

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -190,7 +190,7 @@ var Map = module.exports = function(options) {
     if (options.style) this.setStyle(options.style);
     if (options.attributionControl) this.addControl(new Attribution(options.attributionControl));
 
-    this.on('style.load', function() {
+    this.on('styleload', function() {
         if (this.transform.unmodified) {
             this.jumpTo(this.style.stylesheet);
         }

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -212,7 +212,6 @@ var Map = module.exports = function(options) {
     });
 
     this.on('data', this._update);
-    this.on('tile.load', this._update);
 };
 
 util.extend(Map.prototype, Evented);

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -212,7 +212,7 @@ var Map = module.exports = function(options) {
     });
 
     this.on('source.load', this._update);
-    this.on('source.change', this._update);
+    this.on('data', this._update);
     this.on('tile.load', this._update);
 };
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -197,7 +197,7 @@ var Map = module.exports = function(options) {
         this.style.update(this._classes, {transition: false});
     });
 
-    this.on('style.change', function() {
+    this.on('data', function() {
         this._update(true);
     });
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -211,7 +211,6 @@ var Map = module.exports = function(options) {
         if (source.onRemove) source.onRemove(this);
     });
 
-    this.on('source.load', this._update);
     this.on('data', this._update);
     this.on('tile.load', this._update);
 };

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -699,7 +699,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      *   [layer definition](https://www.mapbox.com/mapbox-gl-style-spec/#layers).
      * @param {string} [before] The ID of an existing layer to insert the new layer before.
      *   If this argument is omitted, the layer will be appended to the end of the layers array.
-     * @fires layer.add
      * @returns {Map} `this`
      */
     addLayer: function(layer, before) {
@@ -716,7 +715,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      *
      * @param {string} id The ID of the layer to remove.
      * @throws {Error} if no layer with the specified `id` exists.
-     * @fires layer.remove
      * @returns {Map} `this`
      */
     removeLayer: function(id) {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -201,16 +201,6 @@ var Map = module.exports = function(options) {
         this._update(true);
     });
 
-    this.on('source.add', function(event) {
-        var source = event.source;
-        if (source.onAdd) source.onAdd(this);
-    });
-
-    this.on('source.remove', function(event) {
-        var source = event.source;
-        if (source.onRemove) source.onRemove(this);
-    });
-
     this.on('data', this._update);
 };
 
@@ -626,7 +616,7 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
         } else if (style instanceof Style) {
             this.style = style;
         } else {
-            this.style = new Style(style, this.animationLoop);
+            this.style = new Style(style, this);
         }
 
         this.style.setEventedParent(this, {style: this.style});
@@ -680,7 +670,6 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
      * Removes a source from the map's style.
      *
      * @param {string} id The ID of the source to remove.
-     * @fires source.remove
      * @returns {Map} `this`
      */
     removeSource: function(id) {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1396,8 +1396,8 @@ function removeNode(node) {
   * The `Map#data` event is fired when any map data loads or changes. The types
   * of map data are:
   *
-  * - `'GeoJSON'`: [GeoJSON](http://geojson.org/) data associated with a `geojson` source.
-  * - `'TileJSON'`: [TileJSON](https://github.com/mapbox/tilejson-spec) metadata associated with a `vector` or `raster` source.
+  * - `'geoJSON'`: [GeoJSON](http://geojson.org/) data associated with a `geojson` source.
+  * - `'tileJSON'`: [TileJSON](https://github.com/mapbox/tilejson-spec) metadata associated with a `vector` or `raster` source.
   * - `'style'`: The [style](https://www.mapbox.com/mapbox-gl-style-spec/) used by the map
   * - `'sprite'`: The icons and patterns used by the style
   * - `'image'`: A `image` source's image and coordinates

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1370,7 +1370,7 @@ function removeNode(node) {
  */
 
  /**
-  * Fired if any error occurs. This is GL JS's primary error reporting
+  * Fired when an error occurs. This is GL JS's primary error reporting
   * mechanism. We use an event instead of `throw` to better accommodate
   * asyncronous operations. If no listeners are bound to the `error` event, the
   * error will be printed to the console.
@@ -1379,4 +1379,32 @@ function removeNode(node) {
   * @memberof Map
   * @instance
   * @property {{error: {message: string}}} data
+  */
+
+/**
+ * Fired when any map data (style, source, tile, etc) loads or changes. See
+ * [`MapDataEvent`](#MapDataEvent) for more information.
+ *
+ * @event data
+ * @memberof Map
+ * @instance
+ * @property {MapDataEvent} data
+ */
+
+ /**
+  * A `MapDataEvent` object is attached to the [`Map#data`](#Map.event:data) event.
+  * The `Map#data` event is fired when any map data loads or changes. The types
+  * of map data are:
+  *
+  * - `'GeoJSON'`: [GeoJSON](http://geojson.org/) data associated with a `geojson` source.
+  * - `'TileJSON'`: [TileJSON](https://github.com/mapbox/tilejson-spec) metadata associated with a `vector` or `raster` source.
+  * - `'style'`: The [style](https://www.mapbox.com/mapbox-gl-style-spec/) used by the map
+  * - `'sprite'`: The icons and patterns used by the style
+  * - `'image'`: A `image` source's image and coordinates
+  * - `'video'`: A `video` source's video and coordinates
+  * - `'tile'`: A vector or raster tile
+  *
+  * @typedef {Object} MapDataEvent
+  * @property {string} type The event type.
+  * @property {string} dataType The type of data that has changed. One of `'geoJSON'`, `'tileJSON'`, `'style'`, `'sprite'`, `'image'`, `'video'`, or `'tile'`.
   */

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1407,15 +1407,11 @@ function removeNode(node) {
   * and [`Map#data`](#Map.event:dataloading) events. Possible values for
   * `dataType`s are:
   *
-  * - `'geoJSON'`: [GeoJSON](http://geojson.org/) data associated with a `geojson` source.
-  * - `'tileJSON'`: [TileJSON](https://github.com/mapbox/tilejson-spec) metadata associated with a `vector` or `raster` source.
+  * - `'source'`: The non-tile data associated with any source
   * - `'style'`: The [style](https://www.mapbox.com/mapbox-gl-style-spec/) used by the map
-  * - `'sprite'`: The icons and patterns used by the style
-  * - `'image'`: A `image` source's image and coordinates
-  * - `'video'`: A `video` source's video and coordinates
   * - `'tile'`: A vector or raster tile
   *
   * @typedef {Object} MapDataEvent
   * @property {string} type The event type.
-  * @property {string} dataType The type of data that has changed. One of `'geoJSON'`, `'tileJSON'`, `'style'`, `'sprite'`, `'image'`, `'video'`, or `'tile'`.
+  * @property {string} dataType The type of data that has changed. One of `'source'`, `'style'`, or `'tile'`.
   */

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1392,9 +1392,20 @@ function removeNode(node) {
  */
 
  /**
-  * A `MapDataEvent` object is attached to the [`Map#data`](#Map.event:data) event.
-  * The `Map#data` event is fired when any map data loads or changes. The types
-  * of map data are:
+  * Fired when any map data (style, source, tile, etc) begins loading or
+  * changing asyncronously. All `dataloading` events are followed by a `data`
+  * or `error` event. See [`MapDataEvent`](#MapDataEvent) for more information.
+  *
+  * @event dataloading
+  * @memberof Map
+  * @instance
+  * @property {MapDataEvent} data
+  */
+
+ /**
+  * A `MapDataEvent` object is emitted with the [`Map#data`](#Map.event:data)
+  * and [`Map#data`](#Map.event:dataloading) events. Possible values for
+  * `dataType`s are:
   *
   * - `'geoJSON'`: [GeoJSON](http://geojson.org/) data associated with a `geojson` source.
   * - `'tileJSON'`: [TileJSON](https://github.com/mapbox/tilejson-spec) metadata associated with a `vector` or `raster` source.

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -190,7 +190,7 @@ var Map = module.exports = function(options) {
     if (options.style) this.setStyle(options.style);
     if (options.attributionControl) this.addControl(new Attribution(options.attributionControl));
 
-    this.on('styleload', function() {
+    this.on('style.load', function() {
         if (this.transform.unmodified) {
             this.jumpTo(this.style.stylesheet);
         }

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -197,11 +197,13 @@ var Map = module.exports = function(options) {
         this.style.update(this._classes, {transition: false});
     });
 
-    this.on('data', function() {
-        this._update(true);
+    this.on('data', function(event) {
+        if (event.dataType === 'style') {
+            this._update(true);
+        } else {
+            this._update();
+        }
     });
-
-    this.on('data', this._update);
 };
 
 util.extend(Map.prototype, Evented);

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -119,7 +119,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('source.load', function() {
+        source.on('sourceload', function() {
             t.end();
         });
     });
@@ -148,7 +148,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('source.load', function() {
+        source.on('sourceload', function() {
             // Note: we register this before calling setData because `change`
             // is fired synchronously within that method.  It may be worth
             // considering dezalgoing there.
@@ -175,7 +175,7 @@ test('GeoJSONSource#update', function(t) {
             transform: {}
         };
 
-        source.on('source.load', function () {
+        source.on('sourceload', function () {
             source.setData({});
             source.loadTile(new Tile(new TileCoord(0, 0, 0), 512), function () {});
         });

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -59,7 +59,7 @@ test('GeoJSONSource#setData', function(t) {
             }
         };
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
-        source.on('source.change', function() {
+        source.on('data', function() {
             t.end();
         });
         source.setData({});
@@ -152,7 +152,7 @@ test('GeoJSONSource#update', function(t) {
             // Note: we register this before calling setData because `change`
             // is fired synchronously within that method.  It may be worth
             // considering dezalgoing there.
-            source.on('source.change', function () {
+            source.on('data', function () {
                 t.end();
             });
             source.setData({});

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -119,7 +119,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('sourceload', function() {
+        source.on('source.load', function() {
             t.end();
         });
     });
@@ -148,7 +148,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('sourceload', function() {
+        source.on('source.load', function() {
             // Note: we register this before calling setData because `change`
             // is fired synchronously within that method.  It may be worth
             // considering dezalgoing there.
@@ -175,7 +175,7 @@ test('GeoJSONSource#update', function(t) {
             transform: {}
         };
 
-        source.on('sourceload', function () {
+        source.on('source.load', function () {
             source.setData({});
             source.loadTile(new Tile(new TileCoord(0, 0, 0), 512), function () {});
         });

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -206,7 +206,7 @@ test('SourceCache / Source lifecycle', function (t) {
     t.test('does not fire load or change before source load event', function (t) {
         createSourceCache({noLoad: true})
             .on('source.load', t.fail)
-            .on('source.change', t.fail);
+            .on('data', t.fail);
         setTimeout(t.end, 1);
     });
 
@@ -215,8 +215,8 @@ test('SourceCache / Source lifecycle', function (t) {
     });
 
     t.test('forward change event', function (t) {
-        var sourceCache = createSourceCache().on('source.change', t.end);
-        sourceCache.getSource().fire('source.change');
+        var sourceCache = createSourceCache().on('data', t.end);
+        sourceCache.getSource().fire('data');
     });
 
     t.test('forward error event', function (t) {
@@ -235,7 +235,7 @@ test('SourceCache / Source lifecycle', function (t) {
         });
     });
 
-    t.test('reloads tiles after source change event', function (t) {
+    t.test('reloads tiles after a geoJSON data event', function (t) {
         var transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -253,7 +253,7 @@ test('SourceCache / Source lifecycle', function (t) {
 
         sourceCache.on('source.load', function () {
             sourceCache.update(transform);
-            sourceCache.getSource().fire('source.change');
+            sourceCache.getSource().fire('data', {dataType: 'geoJSON'});
         });
     });
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -75,7 +75,7 @@ test('SourceCache#addTile', function(t) {
     t.test('adds tile when uncached', function(t) {
         var coord = new TileCoord(0, 0, 0);
         var sourceCache = createSourceCache({})
-        .on('tile.add', function (data) {
+        .on('dataloading', function (data) {
             t.deepEqual(data.tile.coord, coord);
             t.equal(data.tile.uses, 1);
             t.end();
@@ -95,7 +95,7 @@ test('SourceCache#addTile', function(t) {
                 callback();
             }
         })
-        .on('tile.add', function () { add++; });
+        .on('dataloading', function () { add++; });
 
         var tr = new Transform();
         tr.width = 512;
@@ -123,7 +123,7 @@ test('SourceCache#addTile', function(t) {
                 callback();
             }
         })
-        .on('tile.add', function () { add++; });
+        .on('dataloading', function () { add++; });
 
         var t1 = sourceCache.addTile(coord);
         var t2 = sourceCache.addTile(new TileCoord(0, 0, 0, 1));

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -32,7 +32,7 @@ Source.setType('mock-source-type', function create (id, sourceOptions) {
         if (sourceOptions.error) {
             source.fire('error', { error: sourceOptions.error });
         } else {
-            source.fire('source.load');
+            source.fire('sourceload');
         }
     }, 0);
     return source;
@@ -53,7 +53,7 @@ test('SourceCache#attribution is set', function(t) {
     var sourceCache = createSourceCache({
         attribution: 'Mapbox Heavy Industries'
     });
-    sourceCache.on('source.load', function() {
+    sourceCache.on('sourceload', function() {
         t.equal(sourceCache.attribution, 'Mapbox Heavy Industries');
         t.end();
     });
@@ -205,13 +205,13 @@ test('SourceCache#removeTile', function(t) {
 test('SourceCache / Source lifecycle', function (t) {
     t.test('does not fire load or change before source load event', function (t) {
         createSourceCache({noLoad: true})
-            .on('source.load', t.fail)
+            .on('sourceload', t.fail)
             .on('data', t.fail);
         setTimeout(t.end, 1);
     });
 
     t.test('forward load event', function (t) {
-        createSourceCache({}).on('source.load', t.end);
+        createSourceCache({}).on('sourceload', t.end);
     });
 
     t.test('forward change event', function (t) {
@@ -251,7 +251,7 @@ test('SourceCache / Source lifecycle', function (t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform);
             sourceCache.getSource().fire('data', {dataType: 'geoJSON'});
         });
@@ -267,7 +267,7 @@ test('SourceCache#update', function(t) {
         transform.zoom = 0;
 
         var sourceCache = createSourceCache({}, false);
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getIds(), []);
@@ -281,7 +281,7 @@ test('SourceCache#update', function(t) {
         transform.zoom = 0;
 
         var sourceCache = createSourceCache({});
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
             t.end();
@@ -299,7 +299,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
@@ -330,7 +330,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
@@ -361,7 +361,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0, 1).id]);
 
@@ -392,7 +392,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform, 100);
             t.deepEqual(sourceCache.getIds(), [
                 new TileCoord(2, 1, 1).id,
@@ -422,7 +422,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform, 100);
 
             transform.zoom = 2;
@@ -452,7 +452,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             t.equal(sourceCache.maxzoom, 14);
 
             sourceCache.update(transform);
@@ -531,7 +531,7 @@ test('SourceCache#tilesIn', function (t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getIds(), [
@@ -572,7 +572,7 @@ test('SourceCache#tilesIn', function (t) {
             tileSize: 512
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             var transform = new Transform();
             transform.resize(512, 512);
             transform.zoom = 2.0;
@@ -616,7 +616,7 @@ test('SourceCache#tilesIn', function (t) {
             tileSize: 512
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.on('sourceload', function () {
             var transform = new Transform();
             transform.resize(512, 512);
             transform.zoom = 2.0;
@@ -638,7 +638,7 @@ test('SourceCache#loaded (no errors)', function (t) {
         }
     });
 
-    sourceCache.on('source.load', function () {
+    sourceCache.on('sourceload', function () {
         var coord = new TileCoord(0, 0, 0);
         sourceCache.addTile(coord);
 
@@ -654,7 +654,7 @@ test('SourceCache#loaded (with errors)', function (t) {
         }
     });
 
-    sourceCache.on('source.load', function () {
+    sourceCache.on('sourceload', function () {
         var coord = new TileCoord(0, 0, 0);
         sourceCache.addTile(coord);
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -141,12 +141,14 @@ test('SourceCache#addTile', function(t) {
 test('SourceCache#removeTile', function(t) {
     t.test('removes tile', function(t) {
         var coord = new TileCoord(0, 0, 0);
-        var sourceCache = createSourceCache({})
-        .on('tile.remove', function (data) {
-            var tile = data.tile;
-            t.deepEqual(tile.coord, coord);
-            t.equal(tile.uses, 0);
-            t.end();
+        var sourceCache = createSourceCache({});
+        sourceCache.on('data', function (event) {
+            if (event.isDataRemoved) {
+                var tile = event.tile;
+                t.deepEqual(tile.coord, coord);
+                t.equal(tile.uses, 0);
+                t.end();
+            }
         });
         sourceCache.addTile(coord);
         sourceCache.removeTile(coord.id);

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -142,11 +142,8 @@ test('SourceCache#removeTile', function(t) {
     t.test('removes tile', function(t) {
         var coord = new TileCoord(0, 0, 0);
         var sourceCache = createSourceCache({});
-        sourceCache.on('data', function (event) {
-            if (event.isDataRemoved) {
-                var tile = event.tile;
-                t.deepEqual(tile.coord, coord);
-                t.equal(tile.uses, 0);
+        sourceCache.once('data', function (event) {
+            if (event.dataType === 'tile') {
                 t.end();
             }
         });

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -234,7 +234,7 @@ test('SourceCache / Source lifecycle', function (t) {
         });
     });
 
-    t.test('reloads tiles after a geoJSON data event', function (t) {
+    t.test('reloads tiles after a "source" data event', function (t) {
         var transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -252,7 +252,7 @@ test('SourceCache / Source lifecycle', function (t) {
 
         sourceCache.on('source.load', function () {
             sourceCache.update(transform);
-            sourceCache.getSource().fire('data', {dataType: 'geoJSON'});
+            sourceCache.getSource().fire('data', {dataType: 'source'});
         });
     });
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -32,7 +32,7 @@ Source.setType('mock-source-type', function create (id, sourceOptions) {
         if (sourceOptions.error) {
             source.fire('error', { error: sourceOptions.error });
         } else {
-            source.fire('sourceload');
+            source.fire('source.load');
         }
     }, 0);
     return source;
@@ -53,7 +53,7 @@ test('SourceCache#attribution is set', function(t) {
     var sourceCache = createSourceCache({
         attribution: 'Mapbox Heavy Industries'
     });
-    sourceCache.on('sourceload', function() {
+    sourceCache.on('source.load', function() {
         t.equal(sourceCache.attribution, 'Mapbox Heavy Industries');
         t.end();
     });
@@ -207,13 +207,13 @@ test('SourceCache#removeTile', function(t) {
 test('SourceCache / Source lifecycle', function (t) {
     t.test('does not fire load or change before source load event', function (t) {
         createSourceCache({noLoad: true})
-            .on('sourceload', t.fail)
+            .on('source.load', t.fail)
             .on('data', t.fail);
         setTimeout(t.end, 1);
     });
 
     t.test('forward load event', function (t) {
-        createSourceCache({}).on('sourceload', t.end);
+        createSourceCache({}).on('source.load', t.end);
     });
 
     t.test('forward change event', function (t) {
@@ -253,7 +253,7 @@ test('SourceCache / Source lifecycle', function (t) {
             }
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             sourceCache.getSource().fire('data', {dataType: 'geoJSON'});
         });
@@ -269,7 +269,7 @@ test('SourceCache#update', function(t) {
         transform.zoom = 0;
 
         var sourceCache = createSourceCache({}, false);
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getIds(), []);
@@ -283,7 +283,7 @@ test('SourceCache#update', function(t) {
         transform.zoom = 0;
 
         var sourceCache = createSourceCache({});
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
             t.end();
@@ -301,7 +301,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
@@ -332,7 +332,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
@@ -363,7 +363,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0, 1).id]);
 
@@ -394,7 +394,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform, 100);
             t.deepEqual(sourceCache.getIds(), [
                 new TileCoord(2, 1, 1).id,
@@ -424,7 +424,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform, 100);
 
             transform.zoom = 2;
@@ -454,7 +454,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             t.equal(sourceCache.maxzoom, 14);
 
             sourceCache.update(transform);
@@ -533,7 +533,7 @@ test('SourceCache#tilesIn', function (t) {
             }
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getIds(), [
@@ -574,7 +574,7 @@ test('SourceCache#tilesIn', function (t) {
             tileSize: 512
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             var transform = new Transform();
             transform.resize(512, 512);
             transform.zoom = 2.0;
@@ -618,7 +618,7 @@ test('SourceCache#tilesIn', function (t) {
             tileSize: 512
         });
 
-        sourceCache.on('sourceload', function () {
+        sourceCache.on('source.load', function () {
             var transform = new Transform();
             transform.resize(512, 512);
             transform.zoom = 2.0;
@@ -640,7 +640,7 @@ test('SourceCache#loaded (no errors)', function (t) {
         }
     });
 
-    sourceCache.on('sourceload', function () {
+    sourceCache.on('source.load', function () {
         var coord = new TileCoord(0, 0, 0);
         sourceCache.addTile(coord);
 
@@ -656,7 +656,7 @@ test('SourceCache#loaded (with errors)', function (t) {
         }
     });
 
-    sourceCache.on('sourceload', function () {
+    sourceCache.on('source.load', function () {
         var coord = new TileCoord(0, 0, 0);
         sourceCache.addTile(coord);
 

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -38,7 +38,7 @@ test('VectorTileSource', function(t) {
             tiles: ["http://example.com/{z}/{x}/{y}.png"]
         });
 
-        source.on('source.load', function() {
+        source.on('sourceload', function() {
             t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
@@ -52,7 +52,7 @@ test('VectorTileSource', function(t) {
 
         var source = createSource({ url: "/source.json" });
 
-        source.on('source.load', function() {
+        source.on('sourceload', function() {
             t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
@@ -107,7 +107,7 @@ test('VectorTileSource', function(t) {
                 t.end();
             };
 
-            source.on('source.load', function() {
+            source.on('sourceload', function() {
                 source.loadTile({coord: new TileCoord(10, 5, 5, 0)}, function () {});
             });
         });
@@ -127,7 +127,7 @@ test('VectorTileSource', function(t) {
             return 1;
         };
 
-        source.on('source.load', function () {
+        source.on('sourceload', function () {
             var tile = {
                 coord: new TileCoord(10, 5, 5, 0),
                 state: 'loading',

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -38,7 +38,7 @@ test('VectorTileSource', function(t) {
             tiles: ["http://example.com/{z}/{x}/{y}.png"]
         });
 
-        source.on('sourceload', function() {
+        source.on('source.load', function() {
             t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
@@ -52,7 +52,7 @@ test('VectorTileSource', function(t) {
 
         var source = createSource({ url: "/source.json" });
 
-        source.on('sourceload', function() {
+        source.on('source.load', function() {
             t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
@@ -107,7 +107,7 @@ test('VectorTileSource', function(t) {
                 t.end();
             };
 
-            source.on('sourceload', function() {
+            source.on('source.load', function() {
                 source.loadTile({coord: new TileCoord(10, 5, 5, 0)}, function () {});
             });
         });
@@ -127,7 +127,7 @@ test('VectorTileSource', function(t) {
             return 1;
         };
 
-        source.on('sourceload', function () {
+        source.on('source.load', function () {
             var tile = {
                 coord: new TileCoord(10, 5, 5, 0),
                 state: 'loading',

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -381,7 +381,7 @@ test('Style#addSource', function(t) {
 
         style.on('error',         checkEvent);
         style.on('source.load',   checkEvent);
-        style.on('source.change', checkEvent);
+        style.on('data', checkEvent);
         style.on('tile.add',      checkEvent);
         style.on('tile.load',     checkEvent);
         style.on('tile.remove',   checkEvent);
@@ -390,7 +390,7 @@ test('Style#addSource', function(t) {
             t.plan(6);
             style.addSource('source-id', source); // Fires load
             style.sources['source-id'].fire('error');
-            style.sources['source-id'].fire('source.change');
+            style.sources['source-id'].fire('data');
             style.sources['source-id'].fire('tile.add');
             style.sources['source-id'].fire('tile.load');
             style.sources['source-id'].fire('tile.remove');
@@ -468,7 +468,7 @@ test('Style#removeSource', function(t) {
 
         style.on('source.load',   t.fail);
         style.on('error',  t.fail);
-        style.on('source.change', t.fail);
+        style.on('data', t.fail);
         style.on('tile.add',      t.fail);
         style.on('tile.load',     t.fail);
         style.on('error',    t.fail);
@@ -486,7 +486,7 @@ test('Style#removeSource', function(t) {
 
             source.fire('source.load');
             source.fire('error');
-            source.fire('source.change');
+            source.fire('data');
             source.fire('tile.add');
             source.fire('tile.load');
             source.fire('error');

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -53,7 +53,7 @@ test('Style', function(t) {
         window.useFakeXMLHttpRequest();
         window.server.respondWith('/style.json', JSON.stringify(require('../../fixtures/style')));
         var style = new Style('/style.json');
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             window.restore();
             t.end();
         });
@@ -69,7 +69,7 @@ test('Style', function(t) {
                 }
             }
         }));
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.ok(style.sources['mapbox'] instanceof SourceCache);
             t.end();
         });
@@ -105,7 +105,7 @@ test('Style', function(t) {
             .on('error', function() {
                 t.fail();
             })
-            .on('style.load', function() {
+            .on('styleload', function() {
                 window.restore();
                 t.end();
             });
@@ -127,7 +127,7 @@ test('Style', function(t) {
             }]
         }));
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.removeSource('-source-id-');
 
             var source = createSource();
@@ -162,7 +162,7 @@ test('Style', function(t) {
             t.end();
         });
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style._layers.background.fire('error', {mapbox: true});
         });
     });
@@ -188,7 +188,7 @@ test('Style#_updateWorkerLayers', function(t) {
 
     style.on('error', function(error) { t.error(error); });
 
-    style.on('style.load', function() {
+    style.on('styleload', function() {
         style.addLayer({id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer' }, 'second');
         style.addLayer({id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer' });
 
@@ -219,7 +219,7 @@ test('Style#_updateWorkerLayers with specific ids', function(t) {
 
     style.on('error', function(error) { t.error(error); });
 
-    style.on('style.load', function() {
+    style.on('styleload', function() {
         style.dispatcher.broadcast = function(key, value) {
             t.equal(key, 'update layers');
             t.deepEqual(value.map(function(layer) { return layer.id; }), ['second', 'third']);
@@ -249,7 +249,7 @@ test('Style#_resolve', function(t) {
 
         style.on('error', function(error) { t.error(error); });
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.ok(style.getLayer('fill') instanceof StyleLayer);
             t.end();
         });
@@ -277,7 +277,7 @@ test('Style#_resolve', function(t) {
 
         style.on('error', function(event) { t.error(event.error); });
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             var ref = style.getLayer('ref'),
                 referent = style.getLayer('referent');
             t.equal(ref.type, 'fill');
@@ -293,7 +293,7 @@ test('Style#addSource', function(t) {
     t.test('returns self', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('style.load', function () {
+        style.on('styleload', function () {
             t.equal(style.addSource('source-id', source), style);
             t.end();
         });
@@ -305,7 +305,7 @@ test('Style#addSource', function(t) {
         t.throws(function () {
             style.addSource('source-id', source);
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.end();
         });
     });
@@ -316,7 +316,7 @@ test('Style#addSource', function(t) {
 
         delete source.type;
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.throws(function () {
                 style.addSource('source-id', source);
             }, Error, /type/i);
@@ -331,7 +331,7 @@ test('Style#addSource', function(t) {
             t.same(e.source.serialize(), source);
             t.end();
         });
-        style.on('style.load', function () {
+        style.on('styleload', function () {
             style.addSource('source-id', source);
             style.update();
         });
@@ -340,7 +340,7 @@ test('Style#addSource', function(t) {
     t.test('throws on duplicates', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('style.load', function () {
+        style.on('styleload', function () {
             style.addSource('source-id', source);
             t.throws(function() {
                 style.addSource('source-id', source);
@@ -351,7 +351,7 @@ test('Style#addSource', function(t) {
 
     t.test('emits on invalid source', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.on('error', function() {
                 t.notOk(style.sources['source-id']);
                 t.end();
@@ -375,25 +375,16 @@ test('Style#addSource', function(t) {
         }));
         var source = createSource();
 
-        function checkEvent(e) {
-            t.same(e.source.serialize(), source);
-        }
+        style.on('styleload', function () {
+            t.plan(4);
 
-        style.on('error',         checkEvent);
-        style.on('sourceload',    checkEvent);
-        style.on('data',          checkEvent);
-        style.on('tile.add',      checkEvent);
-        style.on('tile.load',     checkEvent);
-        style.on('tile.remove',   checkEvent);
+            style.on('error', function() { t.ok(true); });
+            style.on('data', function() { t.ok(true); });
+            style.on('sourceload', function() { t.ok(true); });
 
-        style.on('style.load', function () {
-            t.plan(7);
-            style.addSource('source-id', source); // Fires load
+            style.addSource('source-id', source); // Fires 'sourceload' and 'data'
             style.sources['source-id'].fire('error');
             style.sources['source-id'].fire('data');
-            style.sources['source-id'].fire('tile.add');
-            style.sources['source-id'].fire('tile.load');
-            style.sources['source-id'].fire('tile.remove');
         });
     });
 
@@ -404,7 +395,7 @@ test('Style#removeSource', function(t) {
     t.test('returns self', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('style.load', function () {
+        style.on('styleload', function () {
             style.addSource('source-id', source);
             t.equal(style.removeSource('source-id'), style);
             t.end();
@@ -423,7 +414,7 @@ test('Style#removeSource', function(t) {
         t.throws(function () {
             style.removeSource('source-id');
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.end();
         });
     });
@@ -435,7 +426,7 @@ test('Style#removeSource', function(t) {
             t.same(e.source.serialize(), source);
             t.end();
         });
-        style.on('style.load', function () {
+        style.on('styleload', function () {
             style.addSource('source-id', source);
             style.removeSource('source-id');
             style.update();
@@ -454,7 +445,7 @@ test('Style#removeSource', function(t) {
 
     t.test('throws on non-existence', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('style.load', function () {
+        style.on('styleload', function () {
             t.throws(function() {
                 style.removeSource('source-id');
             }, /There is no source with this ID/);
@@ -466,31 +457,20 @@ test('Style#removeSource', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
 
-        style.on('sourceload',   t.fail);
-        style.on('error',  t.fail);
-        style.on('data', t.fail);
-        style.on('tile.add',      t.fail);
-        style.on('tile.load',     t.fail);
-        style.on('error',    t.fail);
-        style.on('tile.remove',   t.fail);
-
-        style.on('style.load', function () {
+        style.on('styleload', function () {
             style.addSource('source-id', source);
             source = style.sources['source-id'];
 
             style.removeSource('source-id');
 
-            // Bind a listener to prevent fallback Evented error reporting.
-            source.on('error',  function() {});
-            source.on('error',  function() {});
+            // Suppress error reporting
+            source.on('error', function() {});
 
-            source.fire('sourceload');
-            source.fire('error');
+            style.on('data', function() { t.ok(false); });
+            style.on('error', function() { t.ok(false); });
             source.fire('data');
-            source.fire('tile.add');
-            source.fire('tile.load');
             source.fire('error');
-            source.fire('tile.remove');
+
             t.end();
         });
     });
@@ -503,7 +483,7 @@ test('Style#addLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.equal(style.addLayer(layer), style);
             t.end();
         });
@@ -515,7 +495,7 @@ test('Style#addLayer', function(t) {
         t.throws(function () {
             style.addLayer(layer);
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.end();
         });
     });
@@ -529,7 +509,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.addLayer({
                 id: 'background',
                 type: 'background'
@@ -546,7 +526,7 @@ test('Style#addLayer', function(t) {
             }
         }));
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             var source = createSource();
             source['vector_layers'] = [{id: 'green'}];
             style.addSource('-source-id-', source);
@@ -572,7 +552,7 @@ test('Style#addLayer', function(t) {
 
     t.test('emits error on invalid layer', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.on('error', function() {
                 t.notOk(style.getLayer('background'));
                 t.end();
@@ -604,7 +584,7 @@ test('Style#addLayer', function(t) {
             "filter": ["==", "id", 0]
         };
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.sources['mapbox'].reload = t.end;
 
             style.addLayer(layer);
@@ -621,7 +601,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.addLayer(layer);
             style.update();
         });
@@ -637,7 +617,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.addLayer(layer);
             style.addLayer(layer);
             t.end();
@@ -656,7 +636,7 @@ test('Style#addLayer', function(t) {
             })),
             layer = {id: 'c', type: 'background'};
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.addLayer(layer);
             t.deepEqual(style._order, ['a', 'b', 'c']);
             t.end();
@@ -675,7 +655,7 @@ test('Style#addLayer', function(t) {
             })),
             layer = {id: 'c', type: 'background'};
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.addLayer(layer, 'a');
             t.deepEqual(style._order, ['c', 'a', 'b']);
             t.end();
@@ -690,7 +670,7 @@ test('Style#removeLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.addLayer(layer);
             t.equal(style.removeLayer('background'), style);
             t.end();
@@ -704,7 +684,7 @@ test('Style#removeLayer', function(t) {
         t.throws(function () {
             style.removeLayer('background');
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.end();
         });
     });
@@ -718,7 +698,7 @@ test('Style#removeLayer', function(t) {
             t.end();
         });
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.addLayer(layer);
             style.removeLayer('background');
             style.update();
@@ -737,7 +717,7 @@ test('Style#removeLayer', function(t) {
             t.fail();
         });
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             var layer = style._layers.background;
             style.removeLayer('background');
 
@@ -752,7 +732,7 @@ test('Style#removeLayer', function(t) {
     t.test('throws on non-existence', function(t) {
         var style = new Style(createStyleJSON());
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.throws(function () {
                 style.removeLayer('background');
             }, /There is no layer with this ID/);
@@ -771,7 +751,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.removeLayer('a');
             t.deepEqual(style._order, ['b']);
             t.end();
@@ -789,7 +769,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.removeLayer('a');
             t.deepEqual(style.getLayer('a'), undefined);
             t.deepEqual(style.getLayer('b'), undefined);
@@ -817,7 +797,7 @@ test('Style#setFilter', function(t) {
     t.test('sets filter', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value[0].id, 'symbol');
@@ -834,7 +814,7 @@ test('Style#setFilter', function(t) {
     t.test('gets a clone of the filter', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             var filter1 = ['==', 'id', 1];
             style.setFilter('symbol', filter1);
             var filter2 = style.getFilter('symbol');
@@ -851,7 +831,7 @@ test('Style#setFilter', function(t) {
     t.test('sets again mutated filter', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             var filter = ['==', 'id', 1];
             style.setFilter('symbol', filter);
             style.update({}, {}); // flush pending operations
@@ -871,7 +851,7 @@ test('Style#setFilter', function(t) {
     t.test('sets filter on parent', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -896,7 +876,7 @@ test('Style#setFilter', function(t) {
 
     t.test('emits if invalid', function(t) {
         var style = createStyle();
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.on('error', function() {
                 t.deepEqual(style.getLayer('symbol').serialize().filter, ['==', 'id', 0]);
                 t.end();
@@ -929,7 +909,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.test('sets zoom range', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -945,7 +925,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.test('sets zoom range on parent layer', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -963,7 +943,7 @@ test('Style#setLayerZoomRange', function(t) {
         t.throws(function () {
             style.setLayerZoomRange('symbol', 5, 12);
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.on('styleload', function() {
             t.end();
         });
     });
@@ -1065,7 +1045,7 @@ test('Style#queryRenderedFeatures', function(t) {
         }]
     });
 
-    style.on('style.load', function() {
+    style.on('styleload', function() {
         style._applyClasses([]);
         style._recalculate(0);
 
@@ -1148,7 +1128,7 @@ test('Style defers expensive methods', function(t) {
         }
     }));
 
-    style.on('style.load', function() {
+    style.on('styleload', function() {
         style.update();
 
         // spies to track defered methods
@@ -1213,7 +1193,7 @@ test('Style#query*Features', function(t) {
         onError = sinon.spy();
 
         style.on('error', onError)
-            .on('style.load', function() {
+            .on('styleload', function() {
                 callback();
             });
     });

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -380,14 +380,14 @@ test('Style#addSource', function(t) {
         }
 
         style.on('error',         checkEvent);
-        style.on('source.load',   checkEvent);
-        style.on('data', checkEvent);
+        style.on('sourceload',    checkEvent);
+        style.on('data',          checkEvent);
         style.on('tile.add',      checkEvent);
         style.on('tile.load',     checkEvent);
         style.on('tile.remove',   checkEvent);
 
         style.on('style.load', function () {
-            t.plan(6);
+            t.plan(7);
             style.addSource('source-id', source); // Fires load
             style.sources['source-id'].fire('error');
             style.sources['source-id'].fire('data');
@@ -466,7 +466,7 @@ test('Style#removeSource', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
 
-        style.on('source.load',   t.fail);
+        style.on('sourceload',   t.fail);
         style.on('error',  t.fail);
         style.on('data', t.fail);
         style.on('tile.add',      t.fail);
@@ -484,7 +484,7 @@ test('Style#removeSource', function(t) {
             source.on('error',  function() {});
             source.on('error',  function() {});
 
-            source.fire('source.load');
+            source.fire('sourceload');
             source.fire('error');
             source.fire('data');
             source.fire('tile.add');

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -1171,12 +1171,7 @@ test('Style defers expensive methods', function(t) {
 
         style.update();
 
-        // called per added layer, conflating 'change' events
-        t.equal(style.fire.callCount, 4, 'fire is called per action');
-        t.equal(style.fire.args[0][0], 'layer.add', 'fire was called with layer.add');
-        t.equal(style.fire.args[1][0], 'layer.add', 'fire was called with layer.add');
-        t.equal(style.fire.args[2][0], 'layer.add', 'fire was called with layer.add');
-        t.equal(style.fire.args[3][0], 'style.change', 'fire was called with style.change');
+        t.ok(style.fire.calledWith('data'), 'a data event was fired');
 
         // called per source
         t.ok(style._reloadSource.calledTwice, '_reloadSource is called per source');

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -586,14 +586,11 @@ test('Style#addLayer', function(t) {
         });
     });
 
-    t.test('fires layer.add', function(t) {
+    t.test('fires "data" event', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('layer.add', function (e) {
-            t.equal(e.layer.id, 'background');
-            t.end();
-        });
+        style.once('data', t.end);
 
         style.on('style.load', function() {
             style.addLayer(layer);
@@ -683,14 +680,11 @@ test('Style#removeLayer', function(t) {
         });
     });
 
-    t.test('fires layer.remove', function(t) {
+    t.test('fires "data" event', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('layer.remove', function(e) {
-            t.equal(e.layer.id, 'background');
-            t.end();
-        });
+        style.once('data', t.end);
 
         style.on('style.load', function() {
             style.addLayer(layer);

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -53,7 +53,7 @@ test('Style', function(t) {
         window.useFakeXMLHttpRequest();
         window.server.respondWith('/style.json', JSON.stringify(require('../../fixtures/style')));
         var style = new Style('/style.json');
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             window.restore();
             t.end();
         });
@@ -69,7 +69,7 @@ test('Style', function(t) {
                 }
             }
         }));
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.ok(style.sources['mapbox'] instanceof SourceCache);
             t.end();
         });
@@ -105,7 +105,7 @@ test('Style', function(t) {
             .on('error', function() {
                 t.fail();
             })
-            .on('styleload', function() {
+            .on('style.load', function() {
                 window.restore();
                 t.end();
             });
@@ -127,7 +127,7 @@ test('Style', function(t) {
             }]
         }));
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.removeSource('-source-id-');
 
             var source = createSource();
@@ -162,7 +162,7 @@ test('Style', function(t) {
             t.end();
         });
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style._layers.background.fire('error', {mapbox: true});
         });
     });
@@ -188,7 +188,7 @@ test('Style#_updateWorkerLayers', function(t) {
 
     style.on('error', function(error) { t.error(error); });
 
-    style.on('styleload', function() {
+    style.on('style.load', function() {
         style.addLayer({id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer' }, 'second');
         style.addLayer({id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer' });
 
@@ -219,7 +219,7 @@ test('Style#_updateWorkerLayers with specific ids', function(t) {
 
     style.on('error', function(error) { t.error(error); });
 
-    style.on('styleload', function() {
+    style.on('style.load', function() {
         style.dispatcher.broadcast = function(key, value) {
             t.equal(key, 'update layers');
             t.deepEqual(value.map(function(layer) { return layer.id; }), ['second', 'third']);
@@ -249,7 +249,7 @@ test('Style#_resolve', function(t) {
 
         style.on('error', function(error) { t.error(error); });
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.ok(style.getLayer('fill') instanceof StyleLayer);
             t.end();
         });
@@ -277,7 +277,7 @@ test('Style#_resolve', function(t) {
 
         style.on('error', function(event) { t.error(event.error); });
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             var ref = style.getLayer('ref'),
                 referent = style.getLayer('referent');
             t.equal(ref.type, 'fill');
@@ -293,7 +293,7 @@ test('Style#addSource', function(t) {
     t.test('returns self', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('styleload', function () {
+        style.on('style.load', function () {
             t.equal(style.addSource('source-id', source), style);
             t.end();
         });
@@ -305,7 +305,7 @@ test('Style#addSource', function(t) {
         t.throws(function () {
             style.addSource('source-id', source);
         }, Error, /load/i);
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -316,7 +316,7 @@ test('Style#addSource', function(t) {
 
         delete source.type;
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.throws(function () {
                 style.addSource('source-id', source);
             }, Error, /type/i);
@@ -331,7 +331,7 @@ test('Style#addSource', function(t) {
             t.same(e.source.serialize(), source);
             t.end();
         });
-        style.on('styleload', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             style.update();
         });
@@ -340,7 +340,7 @@ test('Style#addSource', function(t) {
     t.test('throws on duplicates', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('styleload', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             t.throws(function() {
                 style.addSource('source-id', source);
@@ -351,7 +351,7 @@ test('Style#addSource', function(t) {
 
     t.test('emits on invalid source', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.on('error', function() {
                 t.notOk(style.sources['source-id']);
                 t.end();
@@ -375,14 +375,14 @@ test('Style#addSource', function(t) {
         }));
         var source = createSource();
 
-        style.on('styleload', function () {
+        style.on('style.load', function () {
             t.plan(4);
 
             style.on('error', function() { t.ok(true); });
             style.on('data', function() { t.ok(true); });
-            style.on('sourceload', function() { t.ok(true); });
+            style.on('source.load', function() { t.ok(true); });
 
-            style.addSource('source-id', source); // Fires 'sourceload' and 'data'
+            style.addSource('source-id', source); // Fires 'source.load' and 'data'
             style.sources['source-id'].fire('error');
             style.sources['source-id'].fire('data');
         });
@@ -395,7 +395,7 @@ test('Style#removeSource', function(t) {
     t.test('returns self', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('styleload', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             t.equal(style.removeSource('source-id'), style);
             t.end();
@@ -414,7 +414,7 @@ test('Style#removeSource', function(t) {
         t.throws(function () {
             style.removeSource('source-id');
         }, Error, /load/i);
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -426,7 +426,7 @@ test('Style#removeSource', function(t) {
             t.same(e.source.serialize(), source);
             t.end();
         });
-        style.on('styleload', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             style.removeSource('source-id');
             style.update();
@@ -445,7 +445,7 @@ test('Style#removeSource', function(t) {
 
     t.test('throws on non-existence', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('styleload', function () {
+        style.on('style.load', function () {
             t.throws(function() {
                 style.removeSource('source-id');
             }, /There is no source with this ID/);
@@ -457,7 +457,7 @@ test('Style#removeSource', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
 
-        style.on('styleload', function () {
+        style.on('style.load', function () {
             style.addSource('source-id', source);
             source = style.sources['source-id'];
 
@@ -483,7 +483,7 @@ test('Style#addLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.equal(style.addLayer(layer), style);
             t.end();
         });
@@ -495,7 +495,7 @@ test('Style#addLayer', function(t) {
         t.throws(function () {
             style.addLayer(layer);
         }, Error, /load/i);
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -509,7 +509,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.addLayer({
                 id: 'background',
                 type: 'background'
@@ -526,7 +526,7 @@ test('Style#addLayer', function(t) {
             }
         }));
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             var source = createSource();
             source['vector_layers'] = [{id: 'green'}];
             style.addSource('-source-id-', source);
@@ -552,7 +552,7 @@ test('Style#addLayer', function(t) {
 
     t.test('emits error on invalid layer', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.on('error', function() {
                 t.notOk(style.getLayer('background'));
                 t.end();
@@ -584,7 +584,7 @@ test('Style#addLayer', function(t) {
             "filter": ["==", "id", 0]
         };
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.sources['mapbox'].reload = t.end;
 
             style.addLayer(layer);
@@ -601,7 +601,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             style.update();
         });
@@ -617,7 +617,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             style.addLayer(layer);
             t.end();
@@ -636,7 +636,7 @@ test('Style#addLayer', function(t) {
             })),
             layer = {id: 'c', type: 'background'};
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             t.deepEqual(style._order, ['a', 'b', 'c']);
             t.end();
@@ -655,7 +655,7 @@ test('Style#addLayer', function(t) {
             })),
             layer = {id: 'c', type: 'background'};
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.addLayer(layer, 'a');
             t.deepEqual(style._order, ['c', 'a', 'b']);
             t.end();
@@ -670,7 +670,7 @@ test('Style#removeLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             t.equal(style.removeLayer('background'), style);
             t.end();
@@ -684,7 +684,7 @@ test('Style#removeLayer', function(t) {
         t.throws(function () {
             style.removeLayer('background');
         }, Error, /load/i);
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -698,7 +698,7 @@ test('Style#removeLayer', function(t) {
             t.end();
         });
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.addLayer(layer);
             style.removeLayer('background');
             style.update();
@@ -717,7 +717,7 @@ test('Style#removeLayer', function(t) {
             t.fail();
         });
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             var layer = style._layers.background;
             style.removeLayer('background');
 
@@ -732,7 +732,7 @@ test('Style#removeLayer', function(t) {
     t.test('throws on non-existence', function(t) {
         var style = new Style(createStyleJSON());
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.throws(function () {
                 style.removeLayer('background');
             }, /There is no layer with this ID/);
@@ -751,7 +751,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.removeLayer('a');
             t.deepEqual(style._order, ['b']);
             t.end();
@@ -769,7 +769,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.removeLayer('a');
             t.deepEqual(style.getLayer('a'), undefined);
             t.deepEqual(style.getLayer('b'), undefined);
@@ -797,7 +797,7 @@ test('Style#setFilter', function(t) {
     t.test('sets filter', function(t) {
         var style = createStyle();
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value[0].id, 'symbol');
@@ -814,7 +814,7 @@ test('Style#setFilter', function(t) {
     t.test('gets a clone of the filter', function(t) {
         var style = createStyle();
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             var filter1 = ['==', 'id', 1];
             style.setFilter('symbol', filter1);
             var filter2 = style.getFilter('symbol');
@@ -831,7 +831,7 @@ test('Style#setFilter', function(t) {
     t.test('sets again mutated filter', function(t) {
         var style = createStyle();
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             var filter = ['==', 'id', 1];
             style.setFilter('symbol', filter);
             style.update({}, {}); // flush pending operations
@@ -851,7 +851,7 @@ test('Style#setFilter', function(t) {
     t.test('sets filter on parent', function(t) {
         var style = createStyle();
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -876,7 +876,7 @@ test('Style#setFilter', function(t) {
 
     t.test('emits if invalid', function(t) {
         var style = createStyle();
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.on('error', function() {
                 t.deepEqual(style.getLayer('symbol').serialize().filter, ['==', 'id', 0]);
                 t.end();
@@ -909,7 +909,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.test('sets zoom range', function(t) {
         var style = createStyle();
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -925,7 +925,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.test('sets zoom range on parent layer', function(t) {
         var style = createStyle();
 
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -943,7 +943,7 @@ test('Style#setLayerZoomRange', function(t) {
         t.throws(function () {
             style.setLayerZoomRange('symbol', 5, 12);
         }, Error, /load/i);
-        style.on('styleload', function() {
+        style.on('style.load', function() {
             t.end();
         });
     });
@@ -1045,7 +1045,7 @@ test('Style#queryRenderedFeatures', function(t) {
         }]
     });
 
-    style.on('styleload', function() {
+    style.on('style.load', function() {
         style._applyClasses([]);
         style._recalculate(0);
 
@@ -1128,7 +1128,7 @@ test('Style defers expensive methods', function(t) {
         }
     }));
 
-    style.on('styleload', function() {
+    style.on('style.load', function() {
         style.update();
 
         // spies to track defered methods
@@ -1193,7 +1193,7 @@ test('Style#query*Features', function(t) {
         onError = sinon.spy();
 
         style.on('error', onError)
-            .on('styleload', function() {
+            .on('style.load', function() {
                 callback();
             });
     });

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -324,13 +324,10 @@ test('Style#addSource', function(t) {
         });
     });
 
-    t.test('fires source.add', function(t) {
+    t.test('fires "data" event', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('source.add', function(e) {
-            t.same(e.source.serialize(), source);
-            t.end();
-        });
+        style.once('data', t.end);
         style.on('style.load', function () {
             style.addSource('source-id', source);
             style.update();
@@ -419,13 +416,10 @@ test('Style#removeSource', function(t) {
         });
     });
 
-    t.test('fires source.remove', function(t) {
+    t.test('fires "data" event', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('source.remove', function(e) {
-            t.same(e.source.serialize(), source);
-            t.end();
-        });
+        style.once('data', t.end);
         style.on('style.load', function () {
             style.addSource('source-id', source);
             style.removeSource('source-id');

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -136,14 +136,12 @@ test('Map', function(t) {
                 }
 
                 map.on('error',         recordEvent);
-                map.on('style.change',  recordEvent);
                 map.on('sourceload',   recordEvent);
                 map.on('data', recordEvent);
                 map.on('tile.add',      recordEvent);
                 map.on('tile.remove',   recordEvent);
 
                 map.style.fire('error');
-                map.style.fire('style.change');
                 map.style.fire('sourceload');
                 map.style.fire('data');
                 map.style.fire('tile.add');
@@ -151,7 +149,6 @@ test('Map', function(t) {
 
                 t.deepEqual(events, [
                     'error',
-                    'style.change',
                     'sourceload',
                     'data',
                     'tile.add',
@@ -744,7 +741,7 @@ test('Map', function(t) {
             t.end();
         });
 
-        t.test('fires a style.change event', function (t) {
+        t.test('fires a data event', function (t) {
             // background layers do not have a source
             var map = createMap({
                 style: {
@@ -760,10 +757,11 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
-                map.once('style.change', function (e) {
-                    t.ok(e, 'change event');
-                    t.end();
+            map.once('style.load', function () {
+                map.once('data', function (e) {
+                    if (e.dataType === 'style') {
+                        t.end();
+                    }
                 });
 
                 map.setLayoutProperty('background', 'visibility', 'visible');

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -137,14 +137,14 @@ test('Map', function(t) {
 
                 map.on('error',         recordEvent);
                 map.on('style.change',  recordEvent);
-                map.on('source.load',   recordEvent);
+                map.on('sourceload',   recordEvent);
                 map.on('data', recordEvent);
                 map.on('tile.add',      recordEvent);
                 map.on('tile.remove',   recordEvent);
 
                 map.style.fire('error');
                 map.style.fire('style.change');
-                map.style.fire('source.load');
+                map.style.fire('sourceload');
                 map.style.fire('data');
                 map.style.fire('tile.add');
                 map.style.fire('tile.remove');
@@ -152,7 +152,7 @@ test('Map', function(t) {
                 t.deepEqual(events, [
                     'error',
                     'style.change',
-                    'source.load',
+                    'sourceload',
                     'data',
                     'tile.add',
                     'tile.remove'

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -138,20 +138,20 @@ test('Map', function(t) {
                 map.on('error',         recordEvent);
                 map.on('sourceload',   recordEvent);
                 map.on('data', recordEvent);
-                map.on('tile.add',      recordEvent);
+                map.on('dataloading',      recordEvent);
                 map.on('tile.remove',   recordEvent);
 
                 map.style.fire('error');
                 map.style.fire('sourceload');
                 map.style.fire('data');
-                map.style.fire('tile.add');
+                map.style.fire('dataloading');
                 map.style.fire('tile.remove');
 
                 t.deepEqual(events, [
                     'error',
                     'sourceload',
                     'data',
-                    'tile.add',
+                    'dataloading',
                     'tile.remove'
                 ]);
 

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -138,14 +138,14 @@ test('Map', function(t) {
                 map.on('error',         recordEvent);
                 map.on('style.change',  recordEvent);
                 map.on('source.load',   recordEvent);
-                map.on('source.change', recordEvent);
+                map.on('data', recordEvent);
                 map.on('tile.add',      recordEvent);
                 map.on('tile.remove',   recordEvent);
 
                 map.style.fire('error');
                 map.style.fire('style.change');
                 map.style.fire('source.load');
-                map.style.fire('source.change');
+                map.style.fire('data');
                 map.style.fire('tile.add');
                 map.style.fire('tile.remove');
 
@@ -153,7 +153,7 @@ test('Map', function(t) {
                     'error',
                     'style.change',
                     'source.load',
-                    'source.change',
+                    'data',
                     'tile.add',
                     'tile.remove'
                 ]);

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -176,7 +176,7 @@ test('Map', function(t) {
             t.equal(map.transform.zoom, 0.6983039737971012, 'map transform is constrained');
             t.ok(map.transform.unmodified, 'map transform is not modified');
             map.setStyle(createStyle());
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -73.9749, lat: 40.7736 }));
                 t.equal(fixedNum(map.transform.zoom), 12.5);
                 t.equal(fixedNum(map.transform.bearing), 29);
@@ -189,7 +189,7 @@ test('Map', function(t) {
             var map = createMap({zoom: 10, center: [-77.0186, 38.8888]});
             t.notOk(map.transform.unmodified, 'map transform is modified by options');
             map.setStyle(createStyle());
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -77.0186, lat: 38.8888 }));
                 t.equal(fixedNum(map.transform.zoom), 10);
                 t.equal(fixedNum(map.transform.bearing), 0);
@@ -205,7 +205,7 @@ test('Map', function(t) {
             map.setCenter([-77.0186, 38.8888]);
             t.notOk(map.transform.unmodified, 'map transform is modified via setters');
             map.setStyle(createStyle());
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -77.0186, lat: 38.8888 }));
                 t.equal(fixedNum(map.transform.zoom), 10);
                 t.equal(fixedNum(map.transform.bearing), 0);
@@ -672,7 +672,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'update layers');
                     t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -712,7 +712,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'update layers');
                     t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -757,7 +757,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.once('style.load', function () {
+            map.once('styleload', function () {
                 map.once('data', function (e) {
                     if (e.dataType === 'style') {
                         t.end();
@@ -784,7 +784,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 map.setLayoutProperty('background', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('background', 'visibility'), 'visible');
                 t.end();
@@ -815,7 +815,7 @@ test('Map', function(t) {
             // Suppress errors because we're not loading tiles from a real URL.
             map.on('error', function() {});
 
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 map.setLayoutProperty('satellite', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('satellite', 'visibility'), 'visible');
                 t.end();
@@ -849,7 +849,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 map.setLayoutProperty('shore', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('shore', 'visibility'), 'visible');
                 t.end();
@@ -883,7 +883,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 map.setLayoutProperty('image', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('image', 'visibility'), 'visible');
                 t.end();
@@ -906,7 +906,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.on('styleload', function () {
                 map.setPaintProperty('background', 'background-color', 'red');
                 t.deepEqual(map.getPaintProperty('background', 'background-color'), 'red');
                 t.end();

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -131,28 +131,23 @@ test('Map', function(t) {
                 t.error(error);
 
                 var events = [];
-                function recordEvent(event) {
-                    events.push(event.type);
-                }
+                function recordEvent(event) { events.push(event.type); }
 
-                map.on('error',         recordEvent);
-                map.on('sourceload',   recordEvent);
+                map.on('error', recordEvent);
+                map.on('sourceload', recordEvent);
                 map.on('data', recordEvent);
-                map.on('dataloading',      recordEvent);
-                map.on('tile.remove',   recordEvent);
+                map.on('dataloading', recordEvent);
 
                 map.style.fire('error');
                 map.style.fire('sourceload');
                 map.style.fire('data');
                 map.style.fire('dataloading');
-                map.style.fire('tile.remove');
 
                 t.deepEqual(events, [
                     'error',
                     'sourceload',
                     'data',
                     'dataloading',
-                    'tile.remove'
                 ]);
 
                 t.end();

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -134,18 +134,18 @@ test('Map', function(t) {
                 function recordEvent(event) { events.push(event.type); }
 
                 map.on('error', recordEvent);
-                map.on('sourceload', recordEvent);
+                map.on('source.load', recordEvent);
                 map.on('data', recordEvent);
                 map.on('dataloading', recordEvent);
 
                 map.style.fire('error');
-                map.style.fire('sourceload');
+                map.style.fire('source.load');
                 map.style.fire('data');
                 map.style.fire('dataloading');
 
                 t.deepEqual(events, [
                     'error',
-                    'sourceload',
+                    'source.load',
                     'data',
                     'dataloading',
                 ]);
@@ -171,7 +171,7 @@ test('Map', function(t) {
             t.equal(map.transform.zoom, 0.6983039737971012, 'map transform is constrained');
             t.ok(map.transform.unmodified, 'map transform is not modified');
             map.setStyle(createStyle());
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -73.9749, lat: 40.7736 }));
                 t.equal(fixedNum(map.transform.zoom), 12.5);
                 t.equal(fixedNum(map.transform.bearing), 29);
@@ -184,7 +184,7 @@ test('Map', function(t) {
             var map = createMap({zoom: 10, center: [-77.0186, 38.8888]});
             t.notOk(map.transform.unmodified, 'map transform is modified by options');
             map.setStyle(createStyle());
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -77.0186, lat: 38.8888 }));
                 t.equal(fixedNum(map.transform.zoom), 10);
                 t.equal(fixedNum(map.transform.bearing), 0);
@@ -200,7 +200,7 @@ test('Map', function(t) {
             map.setCenter([-77.0186, 38.8888]);
             t.notOk(map.transform.unmodified, 'map transform is modified via setters');
             map.setStyle(createStyle());
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -77.0186, lat: 38.8888 }));
                 t.equal(fixedNum(map.transform.zoom), 10);
                 t.equal(fixedNum(map.transform.bearing), 0);
@@ -667,7 +667,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'update layers');
                     t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -707,7 +707,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'update layers');
                     t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -752,7 +752,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.once('styleload', function () {
+            map.once('style.load', function () {
                 map.once('data', function (e) {
                     if (e.dataType === 'style') {
                         t.end();
@@ -779,7 +779,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 map.setLayoutProperty('background', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('background', 'visibility'), 'visible');
                 t.end();
@@ -810,7 +810,7 @@ test('Map', function(t) {
             // Suppress errors because we're not loading tiles from a real URL.
             map.on('error', function() {});
 
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 map.setLayoutProperty('satellite', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('satellite', 'visibility'), 'visible');
                 t.end();
@@ -844,7 +844,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 map.setLayoutProperty('shore', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('shore', 'visibility'), 'visible');
                 t.end();
@@ -878,7 +878,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 map.setLayoutProperty('image', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('image', 'visibility'), 'visible');
                 t.end();
@@ -901,7 +901,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('styleload', function () {
+            map.on('style.load', function () {
                 map.setPaintProperty('background', 'background-color', 'red');
                 t.deepEqual(map.getPaintProperty('background', 'background-color'), 'red');
                 t.end();


### PR DESCRIPTION
This PR consolidates various undocumented data lifecycle events into the new `data` and `dataloading` events. 

 - [x] replace `source.change` with `data`
 - [x] augment `source.load` with `data`
 - [x] replace `style.change` with `data` 
 - [x] augment `style.load` with `data`
 - [x] replace `tile.add` with `dataloading`
 - [x] replace `tile.load` with `data`
 - [x] replace `tile.remove`with `data`
 - [x] replace `source.add` with `data`
 - [x] replace `source.remove` with `data`
 - [x] replace `layer.add` with `data`
 - [x] replace `layer.remove` with `data`
 - [x] document `data` event
 - [x] document `dataloading` event
 - [x] merge `geoJSON`, `tileJSON`, `image`, and `video` types into a `source` type
 - [x] merge `sprite` into the `style` type

Having an event per resource type per possible mutation produced a complex taxonomy of events. Understanding, documenting, and using these events was difficult. Most users did not require the level of granularity exposed by this taxonomy. Some use cases required listening to many different events. 

The unified `data` event is easy to understand, document, and use. Users who require more granularity may inspect the `MapDataEvent` object. 

> A `MapDataEvent` object is attached to the [`Map#data`](#Map.event:data) event.
> The `Map#data` event is fired when any map data loads or changes. The types
> of map data are:
> 
> - `'geoJSON'`: [GeoJSON](http://geojson.org/) data associated with a `geojson` source.
> - `'tileJSON'`: [TileJSON](https://github.com/mapbox/tilejson-spec) metadata associated with a `vector` or `raster` source.
> - `'style'`: The [style](https://www.mapbox.com/mapbox-gl-style-spec/) used by the map
> - `'sprite'`: The icons and patterns used by the style
> - `'image'`: A `image` source's image and coordinates
> - `'video'`: A `video` source's video and coordinates
> - `'tile'`: A vector or raster tile

cc @jfirebaugh @lbud @mollymerp @mapsam @mourner 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
