### PR TITLE
make sure popup container is an even number of pixels wide

### DIFF
--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -254,7 +254,6 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
                 anchor = anchor.join('-');
             }
         }
-
         var offsetedPos = pos.add(offset[anchor]);
 
         var anchorTranslate = {
@@ -274,7 +273,12 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
         }
         classList.add('mapboxgl-popup-anchor-' + anchor);
 
+
+
         DOM.setTransform(this._container, anchorTranslate[anchor] + ' translate(' + offsetedPos.x + 'px,' + offsetedPos.y + 'px)');
+        if (this._container.offsetWidth % 2 !== 0) {
+            this._container.style.width = this._container.offsetWidth + 1 + "px";
+        }
     },
 
     _onClickClose: function() {


### PR DESCRIPTION
Popups with a width of an odd number of pixels appear blurry on non-retina screens. This PR ensures that the containers are an even number of pixels. At first I thought this might be related to odd-pixel transforms in placing the popup element, but ensuring even dimensions did not fix the blurriness problem.

Right now I have this code in `popup.js`, but I can definitely move to a separate `util/dom.js` function.

Here's a gif that demonstrates the behavior

![blurry-popup](https://cloud.githubusercontent.com/assets/2425307/18854661/d0ff95ea-8401-11e6-9568-b5d64538d50b.gif)

ref #3249 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

