### PR TITLE
Serialize 'tiles' in raster tile source

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -37,7 +37,8 @@ RasterTileSource.prototype = util.inherit(Evented, {
         return {
             type: 'raster',
             url: this.url,
-            tileSize: this.tileSize
+            tileSize: this.tileSize,
+            tiles: this.tiles
         };
     },
 


### PR DESCRIPTION
It seems like the raster tile source `serialize` method omits serializing the `tiles` field. I do not understand why this would be desirable, so my guess is it's a bug. If this is not intentional, this PR addresses the problem.

This popped up when I was trying to write save-and-restore functionality for debugging my application and I was losing my raster tiles each time.
