### PR TITLE
pass tile sourceMaxZoom value to tile url

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -42,7 +42,7 @@ RasterTileSource.prototype = util.inherit(Evented, {
     },
 
     loadTile: function(tile, callback) {
-        var url = normalizeURL(tile.coord.url(this.tiles, tile.sourceMaxZoom, this.scheme), this.url, this.tileSize);
+        var url = normalizeURL(tile.coord.url(this.tiles, this.maxzoom, this.scheme), this.url, this.tileSize);
 
         tile.request = ajax.getImage(url, done.bind(this));
 

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -42,7 +42,7 @@ RasterTileSource.prototype = util.inherit(Evented, {
     },
 
     loadTile: function(tile, callback) {
-        var url = normalizeURL(tile.coord.url(this.tiles, null, this.scheme), this.url, this.tileSize);
+        var url = normalizeURL(tile.coord.url(this.tiles, tile.sourceMaxZoom, this.scheme), this.url, this.tileSize);
 
         tile.request = ajax.getImage(url, done.bind(this));
 


### PR DESCRIPTION
This fixes an issue when using a maxzoom level above the tile source's available maxzoom level (over-zooming).  Currently when over-zooming a (raster) tile source all tiles at the over zoom levels disappear. As well as requests are made to the tile source server that results in 404 errors