### PR TITLE
Fix NPEs in raster tile source when destroying map with tiles loading

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -66,6 +66,9 @@ RasterTileSource.prototype = util.inherit(Evented, {
                 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, img);
             } else {
                 tile.texture = gl.createTexture();
+                if (!tile.texture) {
+                    return callback(null);
+                }
                 gl.bindTexture(gl.TEXTURE_2D, tile.texture);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
@@ -78,7 +81,9 @@ RasterTileSource.prototype = util.inherit(Evented, {
             gl.generateMipmap(gl.TEXTURE_2D);
 
             tile.timeAdded = new Date().getTime();
-            this.map.animationLoop.set(this.style.rasterFadeDuration);
+            if (this.map.style != null) {
+                this.map.animationLoop.set(this.map.style.rasterFadeDuration);
+            }
 
             tile.source = this;
             tile.loaded = true;


### PR DESCRIPTION
Hi,

I've observed two different NPEs triggered from the `RasterTileSource` when I `map.remove` a map that is still loading.

The first npe occurs because `gl.createTexture()` can silently return `null` if the webgl context has been closed.

I am not sure why the second NPE occurs, but my change fixed it.

Neither of my fixes are great and I am sure that they can be obviated by someone with a better understanding of the teardown process for mapbox-gl-js, but they did solve my immediate problem so I figured I'd flag the issues.

Andy
