### PR TITLE
ensure no subpixel transforms on marker elements

### DIFF
--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -43,9 +43,9 @@ Marker.prototype = {
         this.remove();
         this._map = map;
         map.getCanvasContainer().appendChild(this._element);
-        map.on('move', this._update);
-        map.on('moveend', this._update);
-        this._update();
+        map.on('move', this._update.bind(this));
+        map.on('moveend', this._update.bind(this, {roundPos: true}));
+        this._update({roundPos: true});
 
         // If we attached the `click` listener to the marker element, the popup
         // would close once the event propogated to `map` due to the
@@ -149,9 +149,10 @@ Marker.prototype = {
         else popup.addTo(this._map);
     },
 
-    _update: function (e) {
+    _update: function (options) {
         if (!this._map) return;
-        var pos =  (e && e.type === "move") ? this._map.project(this._lngLat)._add(this._offset) : this._map.project(this._lngLat)._add(this._offset).round();
+        var pos = this._map.project(this._lngLat)._add(this._offset);
+        if (options.roundPos) pos = pos.round();
         DOM.setTransform(this._element, 'translate(' + pos.x + 'px,' + pos.y + 'px)');
     }
 };

--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -150,7 +150,7 @@ Marker.prototype = {
 
     _update: function () {
         if (!this._map) return;
-        var pos = this._map.project(this._lngLat)._add(this._offset);
+        var pos = this._map.project(this._lngLat)._add(this._offset).round();
         DOM.setTransform(this._element, 'translate(' + pos.x + 'px,' + pos.y + 'px)');
     }
 };

--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -44,6 +44,7 @@ Marker.prototype = {
         this._map = map;
         map.getCanvasContainer().appendChild(this._element);
         map.on('move', this._update);
+        map.on('moveend', this._update);
         this._update();
 
         // If we attached the `click` listener to the marker element, the popup
@@ -148,9 +149,9 @@ Marker.prototype = {
         else popup.addTo(this._map);
     },
 
-    _update: function () {
+    _update: function (e) {
         if (!this._map) return;
-        var pos = this._map.project(this._lngLat)._add(this._offset).round();
+        var pos =  (e && e.type === "move") ? this._map.project(this._lngLat)._add(this._offset) : this._map.project(this._lngLat)._add(this._offset).round();
         DOM.setTransform(this._element, 'translate(' + pos.x + 'px,' + pos.y + 'px)');
     }
 };


### PR DESCRIPTION
## Launch Checklist

While subpixel transforms turned out not to be the issue on popups (#3249 ), they are an issue with markers. Here I just round the `Point` pos for the marker (like we do with [`Popup`](https://github.com/mapbox/mapbox-gl-js/blob/master/js/ui/popup.js#L231) to prevent the blurriness it causes. 

_subpixel transform_
![screen shot 2016-09-28 at 5 16 27 pm](https://cloud.githubusercontent.com/assets/2425307/18936812/7887edc8-859f-11e6-8f0a-b5e071f71f33.png)

_rounded pixel transform_
![screen shot 2016-09-28 at 5 17 03 pm](https://cloud.githubusercontent.com/assets/2425307/18936821/8af9e966-859f-11e6-8804-17525c48d2fc.png)

cc @jfirebaugh @lucaswoj 
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

