### PR TITLE
fix bug causing error when Marker#setLngLat is called on a marker that's already on the map

### DIFF
--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -43,9 +43,9 @@ Marker.prototype = {
         this.remove();
         this._map = map;
         map.getCanvasContainer().appendChild(this._element);
-        map.on('move', this._update.bind(this));
-        map.on('moveend', this._update.bind(this, {roundPos: true}));
-        this._update({roundPos: true});
+        map.on('move', this._update);
+        map.on('moveend', this._update);
+        this._update();
 
         // If we attached the `click` listener to the marker element, the popup
         // would close once the event propogated to `map` due to the
@@ -66,6 +66,7 @@ Marker.prototype = {
         if (this._map) {
             this._map.off('click', this._onMapClick);
             this._map.off('move', this._update);
+            this._map.on('moveend', this._update);
             this._map = null;
         }
         DOM.remove(this._element);
@@ -149,10 +150,13 @@ Marker.prototype = {
         else popup.addTo(this._map);
     },
 
-    _update: function (options) {
+    _update: function (e) {
         if (!this._map) return;
         var pos = this._map.project(this._lngLat)._add(this._offset);
-        if (options.roundPos) pos = pos.round();
+        // because rouding the coordinates at every `move` event causes stuttered zooming
+        // we only round them when _update is called with `moveend` or when its called with 
+        // no arguments (when the Marker is initialized or Marker#setLngLat is invoked).
+        if (!e || e.type === "moveend") pos = pos.round();
         DOM.setTransform(this._element, 'translate(' + pos.x + 'px,' + pos.y + 'px)');
     }
 };

--- a/js/ui/marker.js
+++ b/js/ui/marker.js
@@ -66,7 +66,7 @@ Marker.prototype = {
         if (this._map) {
             this._map.off('click', this._onMapClick);
             this._map.off('move', this._update);
-            this._map.on('moveend', this._update);
+            this._map.off('moveend', this._update);
             this._map = null;
         }
         DOM.remove(this._element);

--- a/test/js/ui/marker.test.js
+++ b/test/js/ui/marker.test.js
@@ -29,6 +29,14 @@ test('Marker', function (t) {
         t.end();
     });
 
+    t.test('marker\'s lngLat can be changed', function (t) {
+        var map = createMap();
+        var marker = new Marker(window.document.createElement('div')).setLngLat([-77.01866, 38.888]).addTo(map);
+        t.ok(marker.setLngLat([-76,39]) instanceof Marker, 'marker.setLngLat() returns Marker instance');
+        t.ok(marker._lngLat.lng === -76 &&  marker._lngLat.lat === 39, 'marker\'s position can be updated');
+        t.end();
+    })
+
     t.test('popups can be bound to marker instance', function (t) {
         var map = createMap();
         var popup = new Popup();

--- a/test/js/ui/marker.test.js
+++ b/test/js/ui/marker.test.js
@@ -32,10 +32,11 @@ test('Marker', function (t) {
     t.test('marker\'s lngLat can be changed', function (t) {
         var map = createMap();
         var marker = new Marker(window.document.createElement('div')).setLngLat([-77.01866, 38.888]).addTo(map);
-        t.ok(marker.setLngLat([-76,39]) instanceof Marker, 'marker.setLngLat() returns Marker instance');
-        t.ok(marker._lngLat.lng === -76 &&  marker._lngLat.lat === 39, 'marker\'s position can be updated');
+        t.ok(marker.setLngLat([-76, 39]) instanceof Marker, 'marker.setLngLat() returns Marker instance');
+        var markerLngLat = marker.getLngLat();
+        t.ok(markerLngLat.lng === -76 &&  markerLngLat.lat === 39, 'marker\'s position can be updated');
         t.end();
-    })
+    });
 
     t.test('popups can be bound to marker instance', function (t) {
         var map = createMap();


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

also adds a test that would have caught the bug.

I decided to go back to the approach where we don't add in an extra function argument to the `_update` function. IMO this reduces unnecessary complexity bc the `Evented` object that gets passed gives us all the information we need to produce the desired functionality. This code is less explicit than with `roundedPos`, but I added a detailed comment to compensate for this. 

Thanks @runetvilum for catching this bug!  ref #3283

cc @jfirebaugh @lucaswoj 
