### PR TITLE
Fix a bug preventing map.loaded() from returning true with raster tiles.

### DIFF
--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -54,10 +54,13 @@ class RasterTileSource extends Evented {
         function done(err, img) {
             delete tile.request;
 
-            if (tile.aborted)
-                return;
+            if (tile.aborted) {
+                this.state = 'unloaded';
+                return callback(null);
+            }
 
             if (err) {
+                this.state = 'errored';
                 return callback(err);
             }
 

--- a/test/js/util/ajax.test.js
+++ b/test/js/util/ajax.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const test = require('mapbox-gl-js-test').test;
+const ajax = require('../../../js/util/ajax');
+const window = require('../../../js/util/window');
+
+test('ajax', (t) => {
+    t.beforeEach(callback => {
+        window.useFakeXMLHttpRequest();
+        callback();
+    });
+
+    t.afterEach(callback => {
+        window.restore();
+        callback();
+    });
+    t.test('getArrayBuffer', (t) => {
+        const url = '/buffer-request';
+        window.server.respondWith(request => {
+            request.respond(200, {'Content-Type': 'image/png'}, '');
+        });
+        ajax.getArrayBuffer(url, (error) => {
+            t.pass('called getArrayBuffer');
+            t.ok(error, 'should error when the status is 200 without content.');
+            t.end();
+        });
+        window.server.respond();
+    });
+    t.end();
+});


### PR DESCRIPTION
## Launch Checklist

* Uses a transparent png when there's no content from raster tiles.
* Removes unused `return img;` because `getArrayBuffer` does nothing with the returned value from it's callback.
* properly sets the tile state when the request is aborted or errors.
