### PR TITLE
Fire "dataloading" events from all resources that fire "data" events

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -50,7 +50,7 @@ module.exports = GeoJSONSource;
  *   }]
  * });
  */
-function GeoJSONSource(id, options, dispatcher) {
+function GeoJSONSource(id, options, dispatcher, eventedParent) {
     options = options || {};
     this.id = id;
     this.dispatcher = dispatcher;
@@ -83,7 +83,8 @@ function GeoJSONSource(id, options, dispatcher) {
         }
     }, options.workerOptions);
 
-    this.asyncFire('dataloading', {dataType: 'source'});
+    this.setEventedParent(eventedParent);
+    this.fire('dataloading', {dataType: 'source'});
     this._updateWorkerData(function done(err) {
         if (err) {
             this.fire('error', {error: err});
@@ -117,7 +118,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     setData: function(data) {
         this._data = data;
 
-        this.asyncFire('dataloading', {dataType: 'source'});
+        this.fire('dataloading', {dataType: 'source'});
         this._updateWorkerData(function (err) {
             if (err) {
                 return this.fire('error', { error: err });

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -88,7 +88,6 @@ function GeoJSONSource(id, options, dispatcher) {
             this.fire('error', {error: err});
             return;
         }
-        this.fire('data', {dataType: 'source'});
         this.fire('source.load');
     }.bind(this));
 }
@@ -120,7 +119,6 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             if (err) {
                 return this.fire('error', { error: err });
             }
-            this.fire('data', {dataType: 'source'});
         }.bind(this));
 
         return this;
@@ -140,11 +138,14 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             options.data = JSON.stringify(data);
         }
 
+        this.asyncFire('dataloading', {dataType: 'source'});
+
         // target {this.type}.loadData rather than literally geojson.loadData,
         // so that other geojson-like source types can easily reuse this
         // implementation
         this.workerID = this.dispatcher.send(this.type + '.loadData', options, function(err) {
             this._loaded = true;
+            this.fire('data', {dataType: 'source'});
             callback(err);
 
         }.bind(this));

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -83,11 +83,13 @@ function GeoJSONSource(id, options, dispatcher) {
         }
     }, options.workerOptions);
 
+    this.asyncFire('dataloading', {dataType: 'source'});
     this._updateWorkerData(function done(err) {
         if (err) {
             this.fire('error', {error: err});
             return;
         }
+        this.fire('data', {dataType: 'source'});
         this.fire('source.load');
     }.bind(this));
 }
@@ -115,10 +117,12 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     setData: function(data) {
         this._data = data;
 
+        this.asyncFire('dataloading', {dataType: 'source'});
         this._updateWorkerData(function (err) {
             if (err) {
                 return this.fire('error', { error: err });
             }
+            this.fire('data', {dataType: 'source'});
         }.bind(this));
 
         return this;
@@ -138,14 +142,11 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
             options.data = JSON.stringify(data);
         }
 
-        this.asyncFire('dataloading', {dataType: 'source'});
-
         // target {this.type}.loadData rather than literally geojson.loadData,
         // so that other geojson-like source types can easily reuse this
         // implementation
         this.workerID = this.dispatcher.send(this.type + '.loadData', options, function(err) {
             this._loaded = true;
-            this.fire('data', {dataType: 'source'});
             callback(err);
 
         }.bind(this));

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -42,13 +42,14 @@ module.exports = ImageSource;
  *
  * map.removeSource('some id');  // remove
  */
-function ImageSource(id, options, dispatcher) {
+function ImageSource(id, options, dispatcher, eventedParent) {
     this.id = id;
     this.dispatcher = dispatcher;
     this.url = options.url;
     this.coordinates = options.coordinates;
 
-    this.asyncFire('dataloading', {dataType: 'source'});
+    this.setEventedParent(eventedParent);
+    this.fire('dataloading', {dataType: 'source'});
     ajax.getImage(options.url, function(err, image) {
         if (err) return this.fire('error', {error: err});
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -48,6 +48,7 @@ function ImageSource(id, options, dispatcher) {
     this.url = options.url;
     this.coordinates = options.coordinates;
 
+    this.asyncFire('dataloading', {dataType: 'source'});
     ajax.getImage(options.url, function(err, image) {
         if (err) return this.fire('error', {error: err});
 

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -12,6 +12,7 @@ function RasterTileSource(id, options, dispatcher) {
     this.id = id;
     this.dispatcher = dispatcher;
     util.extend(this, util.pick(options, ['url', 'scheme', 'tileSize']));
+    this.asyncFire('dataloading', {dataType: 'source'});
     loadTileJSON(options, function (err, tileJSON) {
         if (err) {
             return this.fire('error', err);

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -8,11 +8,13 @@ var normalizeURL = require('../util/mapbox').normalizeTileURL;
 
 module.exports = RasterTileSource;
 
-function RasterTileSource(id, options, dispatcher) {
+function RasterTileSource(id, options, dispatcher, eventedParent) {
     this.id = id;
     this.dispatcher = dispatcher;
     util.extend(this, util.pick(options, ['url', 'scheme', 'tileSize']));
-    this.asyncFire('dataloading', {dataType: 'source'});
+
+    this.setEventedParent(eventedParent);
+    this.fire('dataloading', {dataType: 'source'});
     loadTileJSON(options, function (err, tileJSON) {
         if (err) {
             return this.fire('error', err);

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -19,8 +19,9 @@ var sourceTypes = {
  * @param {Dispatcher} dispatcher
  * @returns {Source}
  */
-exports.create = function(id, source, dispatcher) {
-    source = new sourceTypes[source.type](id, source, dispatcher);
+exports.create = function(id, source, dispatcher, eventedParent) {
+    source = new sourceTypes[source.type](id, source, dispatcher, eventedParent);
+    source.setEventedParent(eventedParent);
 
     if (source.id !== id) {
         throw new Error('Expected Source id to be ' + id + ' instead of ' + source.id);

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -27,7 +27,7 @@ function SourceCache(id, options, dispatcher) {
     this.id = id;
     this.dispatcher = dispatcher;
 
-    var source = this._source = Source.create(id, options, dispatcher, this);
+    this._source = Source.create(id, options, dispatcher, this);
 
     this.on('source.load', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -27,8 +27,7 @@ function SourceCache(id, options, dispatcher) {
     this.id = id;
     this.dispatcher = dispatcher;
 
-    var source = this._source = Source.create(id, options, dispatcher);
-    source.setEventedParent(this);
+    var source = this._source = Source.create(id, options, dispatcher, this);
 
     this.on('source.load', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -17,6 +17,8 @@ function VectorTileSource(id, options, dispatcher) {
         throw new Error('vector tile sources must have a tileSize of 512');
     }
 
+    this.asyncFire('dataloading', {dataType: 'source'});
+
     loadTileJSON(options, function (err, tileJSON) {
         if (err) {
             this.fire('error', err);

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -7,7 +7,7 @@ var normalizeURL = require('../util/mapbox').normalizeTileURL;
 
 module.exports = VectorTileSource;
 
-function VectorTileSource(id, options, dispatcher) {
+function VectorTileSource(id, options, dispatcher, eventedParent) {
     this.id = id;
     this.dispatcher = dispatcher;
     util.extend(this, util.pick(options, ['url', 'scheme', 'tileSize']));
@@ -17,7 +17,8 @@ function VectorTileSource(id, options, dispatcher) {
         throw new Error('vector tile sources must have a tileSize of 512');
     }
 
-    this.asyncFire('dataloading', {dataType: 'source'});
+    this.setEventedParent(eventedParent);
+    this.fire('dataloading', {dataType: 'source'});
 
     loadTileJSON(options, function (err, tileJSON) {
         if (err) {

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -49,6 +49,7 @@ function VideoSource(id, options) {
     this.urls = options.urls;
     this.coordinates = options.coordinates;
 
+    this.asyncFire('dataloading', {dataType: 'source'});
     ajax.getVideo(options.urls, function(err, video) {
         if (err) return this.fire('error', {error: err});
 

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -44,12 +44,13 @@ module.exports = VideoSource;
  *
  * map.removeSource('some id');  // remove
  */
-function VideoSource(id, options) {
+function VideoSource(id, options, dispatcher, eventedParent) {
     this.id = id;
     this.urls = options.urls;
     this.coordinates = options.coordinates;
 
-    this.asyncFire('dataloading', {dataType: 'source'});
+    this.setEventedParent(eventedParent);
+    this.fire('dataloading', {dataType: 'source'});
     ajax.getVideo(options.urls, function(err, video) {
         if (err) return this.fire('error', {error: err});
 

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -43,7 +43,8 @@ function Style(stylesheet, map, options) {
         validate: typeof stylesheet === 'string' ? !mapbox.isMapboxURL(stylesheet) : true
     }, options);
 
-    this.asyncFire('dataloading', {dataType: 'style'});
+    this.setEventedParent(map);
+    this.fire('dataloading', {dataType: 'style'});
 
     var stylesheetLoaded = function(err, stylesheet) {
         if (err) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -43,6 +43,8 @@ function Style(stylesheet, map, options) {
         validate: typeof stylesheet === 'string' ? !mapbox.isMapboxURL(stylesheet) : true
     }, options);
 
+    this.asyncFire('dataloading', {dataType: 'style'});
+
     var stylesheetLoaded = function(err, stylesheet) {
         if (err) {
             this.fire('error', {error: err});

--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var util = require('./util');
-var window = require('./window');
 
 /**
  * Methods mixed in to other classes for event capabilities.
@@ -93,18 +92,6 @@ var Evented = {
         }
 
         return this;
-    },
-
-    /**
-     * Asyncronously fires an event of the specified type. The event will be
-     * fired within a "setTimeout(..., 0)" callback.
-     *
-     * @param {string} type The type of event to fire.
-     * @param {Object} [data] Data to be passed to any listeners.
-     * @returns {Object} `this`
-     */
-    asyncFire: function(type, data) {
-        window.setTimeout(this.fire.bind(this, type, data), 0);
     },
 
     /**

--- a/js/util/evented.js
+++ b/js/util/evented.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var util = require('./util');
+var window = require('./window');
 
 /**
  * Methods mixed in to other classes for event capabilities.
@@ -92,6 +93,18 @@ var Evented = {
         }
 
         return this;
+    },
+
+    /**
+     * Asyncronously fires an event of the specified type. The event will be
+     * fired within a "setTimeout(..., 0)" callback.
+     *
+     * @param {string} type The type of event to fire.
+     * @param {Object} [data] Data to be passed to any listeners.
+     * @returns {Object} `this`
+     */
+    asyncFire: function(type, data) {
+        window.setTimeout(this.fire.bind(this, type, data), 0);
     },
 
     /**

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -63,6 +63,20 @@ test('VectorTileSource', function(t) {
         window.server.respond();
     });
 
+    t.test('fires "data" event', function(t) {
+        window.server.respondWith('/source.json', JSON.stringify(require('../../fixtures/source')));
+        var source = createSource({ url: "/source.json" });
+        source.on('data', t.end);
+        window.server.respond();
+    });
+
+    t.test('fires "dataloading" event', function(t) {
+        window.server.respondWith('/source.json', JSON.stringify(require('../../fixtures/source')));
+        var source = createSource({ url: "/source.json" });
+        source.on('dataloading', t.end);
+        window.server.respond();
+    });
+
     t.test('serialize URL', function(t) {
         var source = createSource({
             url: "http://localhost:2900/source.json"

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -4,9 +4,10 @@ var test = require('tap').test;
 var VectorTileSource = require('../../../js/source/vector_tile_source');
 var TileCoord = require('../../../js/source/tile_coord');
 var window = require('../../../js/util/window');
+var Evented = require('../../../js/util/evented');
 
 function createSource(options) {
-    var source = new VectorTileSource('id', options, { send: function() {} });
+    var source = new VectorTileSource('id', options, { send: function() {} }, options.eventedParent);
 
     source.on('error', function(e) {
         throw e.error;
@@ -72,8 +73,9 @@ test('VectorTileSource', function(t) {
 
     t.test('fires "dataloading" event', function(t) {
         window.server.respondWith('/source.json', JSON.stringify(require('../../fixtures/source')));
-        var source = createSource({ url: "/source.json" });
-        source.on('dataloading', t.end);
+        var evented = Object.create(Evented);
+        evented.on('dataloading', t.end);
+        createSource({ url: "/source.json", eventedParent: evented });
         window.server.respond();
     });
 

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -7,6 +7,7 @@ var Style = require('../../../js/style/style');
 var SourceCache = require('../../../js/source/source_cache');
 var StyleLayer = require('../../../js/style/style_layer');
 var util = require('../../../js/util/util');
+var Evented = require('../../../js/util/evented');
 var window = require('../../../js/util/window');
 
 function createStyleJSON(properties) {
@@ -50,8 +51,9 @@ test('Style', function(t) {
     });
 
     t.test('fires "dataloading"', function(t) {
-        var style = new Style(createStyleJSON());
-        style.on('dataloading', t.end);
+        var eventedParent = Object.create(Evented);
+        eventedParent.on('dataloading', t.end);
+        new Style(createStyleJSON(), eventedParent);
     });
 
     t.test('can be constructed from a URL', function(t) {

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -49,6 +49,11 @@ test('Style', function(t) {
         t.end();
     });
 
+    t.test('fires "dataloading"', function(t) {
+        var style = new Style(createStyleJSON());
+        style.on('dataloading', t.end);
+    });
+
     t.test('can be constructed from a URL', function(t) {
         window.useFakeXMLHttpRequest();
         window.server.respondWith('/style.json', JSON.stringify(require('../../fixtures/style')));


### PR DESCRIPTION
This PR completes our support for "dataloading" events, ensuring they are fired from all resources that fire "data" events.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
