### PR TITLE
Remove "style.load" event in favor of "data" event

### DIFF
--- a/bench/benchmarks/buffer.js
+++ b/bench/benchmarks/buffer.js
@@ -90,7 +90,7 @@ function preloadAssets(stylesheet, callback) {
 
     var style = new Style(stylesheet);
 
-    style.on('style.load', function() {
+    style.once('data', function() {
         function getGlyphs(params, callback) {
             style['get glyphs'](0, params, function(err, glyphs) {
                 assets.glyphs[JSON.stringify(params)] = glyphs;

--- a/bench/benchmarks/style_load.js
+++ b/bench/benchmarks/style_load.js
@@ -28,7 +28,7 @@ module.exports = function() {
                 .on('error', function(err) {
                     evented.fire('error', { error: err });
                 })
-                .on('style.load', function() {
+                .once('data', function() {
                     var time = performance.now() - timeStart;
                     timeSum += time;
                     timeCount++;

--- a/debug/query_features.html
+++ b/debug/query_features.html
@@ -30,7 +30,7 @@ map.addControl(new mapboxgl.Navigation());
 
 var emptyFc = { type: 'FeatureCollection', features: [] }
 
-map.on('style.load', function() {
+map.on('load', function() {
     map.addSource('queried', { type: 'geojson', data: emptyFc });
     map.addLayer({
         "id": "query",

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -157,7 +157,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.sourceCache = this;
         tile.timeAdded = new Date().getTime();
-        this._source.fire('data', {tile: tile, dataType: 'tile'});
+        this._source.fire('data', {tile: tile, dataType: 'tile', isFirst: true});
 
         // HACK this is nescessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
         if (this.map) this.map.painter.tileExtentVAO.vao = null;

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -67,7 +67,7 @@ function Style(stylesheet, map, options) {
 
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
         this._resolve();
-        this.fire('data', {dataType: 'style', isFirst: true});
+        this.update(map && map.getClasses(), {transition: false, isFirstData: true});
     }.bind(this);
 
     if (typeof stylesheet === 'string') {
@@ -301,7 +301,7 @@ Style.prototype = util.inherit(Evented, {
         this._applyClasses(classes, options);
 
         if (this._updates.changed) {
-            this.fire('data', {dataType: 'style'});
+            this.fire('data', {dataType: 'style', isFirst: options && options.isFirstData});
         }
 
         this._resetUpdates();

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -67,8 +67,7 @@ function Style(stylesheet, map, options) {
 
         this.glyphSource = new GlyphSource(stylesheet.glyphs);
         this._resolve();
-        this.fire('data', {dataType: 'style'});
-        this.fire('style.load');
+        this.fire('data', {dataType: 'style', isFirst: true});
     }.bind(this);
 
     if (typeof stylesheet === 'string') {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -196,7 +196,6 @@ var Map = module.exports = function(options) {
                 if (this.transform.unmodified) {
                     this.jumpTo(this.style.stylesheet);
                 }
-                this.style.update(this._classes, {transition: false});
             }
             this._update(true);
         } else {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1033,8 +1033,8 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
 
             this.fire('render');
 
-            if (this.loaded() && !this._loaded) {
-                this._loaded = true;
+            if (this.loaded() && !this._firedLoadEvent) {
+                this._firedLoadEvent = true;
                 this.fire('load');
             }
 

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -190,15 +190,14 @@ var Map = module.exports = function(options) {
     if (options.style) this.setStyle(options.style);
     if (options.attributionControl) this.addControl(new Attribution(options.attributionControl));
 
-    this.on('style.load', function() {
-        if (this.transform.unmodified) {
-            this.jumpTo(this.style.stylesheet);
-        }
-        this.style.update(this._classes, {transition: false});
-    });
-
     this.on('data', function(event) {
         if (event.dataType === 'style') {
+            if (event.isFirst) {
+                if (this.transform.unmodified) {
+                    this.jumpTo(this.style.stylesheet);
+                }
+                this.style.update(this._classes, {transition: false});
+            }
             this._update(true);
         } else {
             this._update();
@@ -1416,4 +1415,5 @@ function removeNode(node) {
   * @typedef {Object} MapDataEvent
   * @property {string} type The event type.
   * @property {string} dataType The type of data that has changed. One of `'source'`, `'style'`, or `'tile'`.
+  * @property {boolean} isFirst `true` if this is the first `data` event for this resource, `false` otherwise. Always `false` for `dataloading` events.
   */

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -53,7 +53,7 @@ test('Style', function(t) {
         window.useFakeXMLHttpRequest();
         window.server.respondWith('/style.json', JSON.stringify(require('../../fixtures/style')));
         var style = new Style('/style.json');
-        style.on('style.load', function() {
+        style.once('data', function() {
             window.restore();
             t.end();
         });
@@ -69,7 +69,7 @@ test('Style', function(t) {
                 }
             }
         }));
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.ok(style.sourceCaches['mapbox'] instanceof SourceCache);
             t.end();
         });
@@ -105,7 +105,7 @@ test('Style', function(t) {
             .on('error', function() {
                 t.fail();
             })
-            .on('style.load', function() {
+            .once('data', function() {
                 window.restore();
                 t.end();
             });
@@ -127,7 +127,7 @@ test('Style', function(t) {
             }]
         }));
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.removeSource('-source-id-');
 
             var source = createSource();
@@ -162,7 +162,7 @@ test('Style', function(t) {
             t.end();
         });
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style._layers.background.fire('error', {mapbox: true});
         });
     });
@@ -188,7 +188,7 @@ test('Style#_updateWorkerLayers', function(t) {
 
     style.on('error', function(error) { t.error(error); });
 
-    style.on('style.load', function() {
+    style.once('data', function() {
         style.addLayer({id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer' }, 'second');
         style.addLayer({id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer' });
 
@@ -219,7 +219,7 @@ test('Style#_updateWorkerLayers with specific ids', function(t) {
 
     style.on('error', function(error) { t.error(error); });
 
-    style.on('style.load', function() {
+    style.once('data', function() {
         style.dispatcher.broadcast = function(key, value) {
             t.equal(key, 'update layers');
             t.deepEqual(value.map(function(layer) { return layer.id; }), ['second', 'third']);
@@ -249,7 +249,7 @@ test('Style#_resolve', function(t) {
 
         style.on('error', function(error) { t.error(error); });
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.ok(style.getLayer('fill') instanceof StyleLayer);
             t.end();
         });
@@ -277,7 +277,7 @@ test('Style#_resolve', function(t) {
 
         style.on('error', function(event) { t.error(event.error); });
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             var ref = style.getLayer('ref'),
                 referent = style.getLayer('referent');
             t.equal(ref.type, 'fill');
@@ -293,7 +293,7 @@ test('Style#addSource', function(t) {
     t.test('returns self', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('style.load', function () {
+        style.once('data', function () {
             t.equal(style.addSource('source-id', source), style);
             t.end();
         });
@@ -305,7 +305,7 @@ test('Style#addSource', function(t) {
         t.throws(function () {
             style.addSource('source-id', source);
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.end();
         });
     });
@@ -316,7 +316,7 @@ test('Style#addSource', function(t) {
 
         delete source.type;
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.throws(function () {
                 style.addSource('source-id', source);
             }, Error, /type/i);
@@ -328,7 +328,7 @@ test('Style#addSource', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
         style.once('data', t.end);
-        style.on('style.load', function () {
+        style.once('data', function () {
             style.addSource('source-id', source);
             style.update();
         });
@@ -337,7 +337,7 @@ test('Style#addSource', function(t) {
     t.test('throws on duplicates', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('style.load', function () {
+        style.once('data', function () {
             style.addSource('source-id', source);
             t.throws(function() {
                 style.addSource('source-id', source);
@@ -348,7 +348,7 @@ test('Style#addSource', function(t) {
 
     t.test('emits on invalid source', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.on('error', function() {
                 t.notOk(style.sourceCaches['source-id']);
                 t.end();
@@ -372,7 +372,7 @@ test('Style#addSource', function(t) {
         }));
         var source = createSource();
 
-        style.on('style.load', function () {
+        style.once('data', function () {
             t.plan(4);
 
             style.on('error', function() { t.ok(true); });
@@ -392,7 +392,7 @@ test('Style#removeSource', function(t) {
     t.test('returns self', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
-        style.on('style.load', function () {
+        style.once('data', function () {
             style.addSource('source-id', source);
             t.equal(style.removeSource('source-id'), style);
             t.end();
@@ -411,7 +411,7 @@ test('Style#removeSource', function(t) {
         t.throws(function () {
             style.removeSource('source-id');
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.end();
         });
     });
@@ -420,7 +420,7 @@ test('Style#removeSource', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
         style.once('data', t.end);
-        style.on('style.load', function () {
+        style.once('data', function () {
             style.addSource('source-id', source);
             style.removeSource('source-id');
             style.update();
@@ -439,7 +439,7 @@ test('Style#removeSource', function(t) {
 
     t.test('throws on non-existence', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('style.load', function () {
+        style.once('data', function () {
             t.throws(function() {
                 style.removeSource('source-id');
             }, /There is no source with this ID/);
@@ -451,7 +451,7 @@ test('Style#removeSource', function(t) {
         var style = new Style(createStyleJSON()),
             source = createSource();
 
-        style.on('style.load', function () {
+        style.once('data', function () {
             style.addSource('source-id', source);
             source = style.sourceCaches['source-id'];
 
@@ -477,7 +477,7 @@ test('Style#addLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.equal(style.addLayer(layer), style);
             t.end();
         });
@@ -489,7 +489,7 @@ test('Style#addLayer', function(t) {
         t.throws(function () {
             style.addLayer(layer);
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.end();
         });
     });
@@ -503,7 +503,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.addLayer({
                 id: 'background',
                 type: 'background'
@@ -520,7 +520,7 @@ test('Style#addLayer', function(t) {
             }
         }));
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             var source = createSource();
             source['vector_layers'] = [{id: 'green'}];
             style.addSource('-source-id-', source);
@@ -546,7 +546,7 @@ test('Style#addLayer', function(t) {
 
     t.test('emits error on invalid layer', function(t) {
         var style = new Style(createStyleJSON());
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.on('error', function() {
                 t.notOk(style.getLayer('background'));
                 t.end();
@@ -578,7 +578,7 @@ test('Style#addLayer', function(t) {
             "filter": ["==", "id", 0]
         };
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.sourceCaches['mapbox'].reload = t.end;
 
             style.addLayer(layer);
@@ -592,7 +592,7 @@ test('Style#addLayer', function(t) {
 
         style.once('data', t.end);
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.addLayer(layer);
             style.update();
         });
@@ -608,7 +608,7 @@ test('Style#addLayer', function(t) {
             t.end();
         });
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.addLayer(layer);
             style.addLayer(layer);
             t.end();
@@ -627,7 +627,7 @@ test('Style#addLayer', function(t) {
             })),
             layer = {id: 'c', type: 'background'};
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.addLayer(layer);
             t.deepEqual(style._order, ['a', 'b', 'c']);
             t.end();
@@ -646,7 +646,7 @@ test('Style#addLayer', function(t) {
             })),
             layer = {id: 'c', type: 'background'};
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.addLayer(layer, 'a');
             t.deepEqual(style._order, ['c', 'a', 'b']);
             t.end();
@@ -661,7 +661,7 @@ test('Style#removeLayer', function(t) {
         var style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.addLayer(layer);
             t.equal(style.removeLayer('background'), style);
             t.end();
@@ -675,7 +675,7 @@ test('Style#removeLayer', function(t) {
         t.throws(function () {
             style.removeLayer('background');
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.end();
         });
     });
@@ -686,7 +686,7 @@ test('Style#removeLayer', function(t) {
 
         style.once('data', t.end);
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.addLayer(layer);
             style.removeLayer('background');
             style.update();
@@ -705,7 +705,7 @@ test('Style#removeLayer', function(t) {
             t.fail();
         });
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             var layer = style._layers.background;
             style.removeLayer('background');
 
@@ -720,7 +720,7 @@ test('Style#removeLayer', function(t) {
     t.test('throws on non-existence', function(t) {
         var style = new Style(createStyleJSON());
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.throws(function () {
                 style.removeLayer('background');
             }, /There is no layer with this ID/);
@@ -739,7 +739,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.removeLayer('a');
             t.deepEqual(style._order, ['b']);
             t.end();
@@ -757,7 +757,7 @@ test('Style#removeLayer', function(t) {
             }]
         }));
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.removeLayer('a');
             t.deepEqual(style.getLayer('a'), undefined);
             t.deepEqual(style.getLayer('b'), undefined);
@@ -785,7 +785,7 @@ test('Style#setFilter', function(t) {
     t.test('sets filter', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value[0].id, 'symbol');
@@ -802,7 +802,7 @@ test('Style#setFilter', function(t) {
     t.test('gets a clone of the filter', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             var filter1 = ['==', 'id', 1];
             style.setFilter('symbol', filter1);
             var filter2 = style.getFilter('symbol');
@@ -819,7 +819,7 @@ test('Style#setFilter', function(t) {
     t.test('sets again mutated filter', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             var filter = ['==', 'id', 1];
             style.setFilter('symbol', filter);
             style.update({}, {}); // flush pending operations
@@ -839,7 +839,7 @@ test('Style#setFilter', function(t) {
     t.test('sets filter on parent', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -864,7 +864,7 @@ test('Style#setFilter', function(t) {
 
     t.test('emits if invalid', function(t) {
         var style = createStyle();
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.on('error', function() {
                 t.deepEqual(style.getLayer('symbol').serialize().filter, ['==', 'id', 0]);
                 t.end();
@@ -897,7 +897,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.test('sets zoom range', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -913,7 +913,7 @@ test('Style#setLayerZoomRange', function(t) {
     t.test('sets zoom range on parent layer', function(t) {
         var style = createStyle();
 
-        style.on('style.load', function() {
+        style.once('data', function() {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'update layers');
                 t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -931,7 +931,7 @@ test('Style#setLayerZoomRange', function(t) {
         t.throws(function () {
             style.setLayerZoomRange('symbol', 5, 12);
         }, Error, /load/i);
-        style.on('style.load', function() {
+        style.once('data', function() {
             t.end();
         });
     });
@@ -1033,7 +1033,7 @@ test('Style#queryRenderedFeatures', function(t) {
         }]
     });
 
-    style.on('style.load', function() {
+    style.once('data', function() {
         style._applyClasses([]);
         style._recalculate(0);
 
@@ -1095,13 +1095,11 @@ test('Style#queryRenderedFeatures', function(t) {
         });
 
         t.test('fires an error if layer included in params does not exist on the style', function(t) {
-            var errors = 0;
-            sinon.stub(style, 'fire', function(type, data) {
-                if (data.error && data.error.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
+            style.on('error', function(event) {
+                t.ok(event.error.includes('does not exist in the map\'s style and cannot be queried for features.'));
+                t.end();
             });
             style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']});
-            t.equals(errors, 1);
-            t.end();
         });
 
         t.end();
@@ -1116,7 +1114,7 @@ test('Style defers expensive methods', function(t) {
         }
     }));
 
-    style.on('style.load', function() {
+    style.once('data', function() {
         style.update();
 
         // spies to track defered methods
@@ -1181,7 +1179,7 @@ test('Style#query*Features', function(t) {
         onError = sinon.spy();
 
         style.on('error', onError)
-            .on('style.load', function() {
+            .once('data', function() {
                 callback();
             });
     });

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -171,7 +171,7 @@ test('Map', function(t) {
             t.equal(map.transform.zoom, 0.6983039737971012, 'map transform is constrained');
             t.ok(map.transform.unmodified, 'map transform is not modified');
             map.setStyle(createStyle());
-            map.on('style.load', function () {
+            map.once('load', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -73.9749, lat: 40.7736 }));
                 t.equal(fixedNum(map.transform.zoom), 12.5);
                 t.equal(fixedNum(map.transform.bearing), 29);
@@ -184,7 +184,7 @@ test('Map', function(t) {
             var map = createMap({zoom: 10, center: [-77.0186, 38.8888]});
             t.notOk(map.transform.unmodified, 'map transform is modified by options');
             map.setStyle(createStyle());
-            map.on('style.load', function () {
+            map.once('load', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -77.0186, lat: 38.8888 }));
                 t.equal(fixedNum(map.transform.zoom), 10);
                 t.equal(fixedNum(map.transform.bearing), 0);
@@ -200,7 +200,7 @@ test('Map', function(t) {
             map.setCenter([-77.0186, 38.8888]);
             t.notOk(map.transform.unmodified, 'map transform is modified via setters');
             map.setStyle(createStyle());
-            map.on('style.load', function () {
+            map.once('load', function () {
                 t.deepEqual(fixedLngLat(map.transform.center), fixedLngLat({ lng: -77.0186, lat: 38.8888 }));
                 t.equal(fixedNum(map.transform.zoom), 10);
                 t.equal(fixedNum(map.transform.bearing), 0);
@@ -667,7 +667,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.once('load', function () {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'update layers');
                     t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -707,7 +707,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.once('load', function () {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'update layers');
                     t.deepEqual(value.map(function(layer) { return layer.id; }), ['symbol']);
@@ -752,7 +752,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.once('style.load', function () {
+            map.once('load', function () {
                 map.once('data', function (e) {
                     if (e.dataType === 'style') {
                         t.end();
@@ -779,7 +779,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.once('load', function () {
                 map.setLayoutProperty('background', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('background', 'visibility'), 'visible');
                 t.end();
@@ -810,7 +810,7 @@ test('Map', function(t) {
             // Suppress errors because we're not loading tiles from a real URL.
             map.on('error', function() {});
 
-            map.on('style.load', function () {
+            map.once('load', function () {
                 map.setLayoutProperty('satellite', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('satellite', 'visibility'), 'visible');
                 t.end();
@@ -844,7 +844,8 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            // The first 'data' event is always from the style
+            map.once('data', function () {
                 map.setLayoutProperty('shore', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('shore', 'visibility'), 'visible');
                 t.end();
@@ -878,7 +879,8 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            // The first 'data' event is always from the style
+            map.once('data', function () {
                 map.setLayoutProperty('image', 'visibility', 'visible');
                 t.deepEqual(map.getLayoutProperty('image', 'visibility'), 'visible');
                 t.end();
@@ -901,7 +903,7 @@ test('Map', function(t) {
                 }
             });
 
-            map.on('style.load', function () {
+            map.once('load', function () {
                 map.setPaintProperty('background', 'background-color', 'red');
                 t.deepEqual(map.getPaintProperty('background', 'background-color'), 'red');
                 t.end();

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -845,10 +845,12 @@ test('Map', function(t) {
             });
 
             // The first 'data' event is always from the style
-            map.once('data', function () {
-                map.setLayoutProperty('shore', 'visibility', 'visible');
-                t.deepEqual(map.getLayoutProperty('shore', 'visibility'), 'visible');
-                t.end();
+            map.on('data', function (event) {
+                if (event.dataType === 'style' && event.isFirst) {
+                    map.setLayoutProperty('shore', 'visibility', 'visible');
+                    t.deepEqual(map.getLayoutProperty('shore', 'visibility'), 'visible');
+                    t.end();
+                }
             });
         });
 
@@ -880,10 +882,12 @@ test('Map', function(t) {
             });
 
             // The first 'data' event is always from the style
-            map.once('data', function () {
-                map.setLayoutProperty('image', 'visibility', 'visible');
-                t.deepEqual(map.getLayoutProperty('image', 'visibility'), 'visible');
-                t.end();
+            map.on('data', function (event) {
+                if (event.dataType === 'style' && event.isFirst) {
+                    map.setLayoutProperty('image', 'visibility', 'visible');
+                    t.deepEqual(map.getLayoutProperty('image', 'visibility'), 'visible');
+                    t.end();
+                }
             });
         });
 

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -844,7 +844,6 @@ test('Map', function(t) {
                 }
             });
 
-            // The first 'data' event is always from the style
             map.on('data', function (event) {
                 if (event.dataType === 'style' && event.isFirst) {
                     map.setLayoutProperty('shore', 'visibility', 'visible');
@@ -881,7 +880,6 @@ test('Map', function(t) {
                 }
             });
 
-            // The first 'data' event is always from the style
             map.on('data', function (event) {
                 if (event.dataType === 'style' && event.isFirst) {
                     map.setLayoutProperty('image', 'visibility', 'visible');


### PR DESCRIPTION
This PR removes the `Style#style.load` event in favor of the `Style#data` event.

Why? We expose a smaller API surface. `style.load` is (err -- should have been) redundant with the `data` event. We wish the `Map#load` event had been this way all along. There's little precedent for `.` namespaced events therefore we should try to keep them out of our public API. 

ref #1715 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] manually test the benchmarks (blocked on https://github.com/mapbox/mapbox-gl-js/pull/3310)
 - [x] manually test the debug page
