### PR TITLE
Remove source.load

### DIFF
--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -88,8 +88,7 @@ function GeoJSONSource(id, options, dispatcher) {
             this.fire('error', {error: err});
             return;
         }
-        this.fire('data', {dataType: 'source'});
-        this.fire('source.load');
+        this.fire('data', {dataType: 'source', isFirst: true});
     }.bind(this));
 }
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -53,8 +53,7 @@ function ImageSource(id, options, dispatcher) {
 
         this.image = image;
         this._loaded = true;
-        this.fire('data', {dataType: 'source'});
-        this.fire('source.load');
+        this.fire('data', {dataType: 'source', isFirst: true});
 
         if (this.map) {
             this.setCoordinates(options.coordinates);

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -17,8 +17,7 @@ function RasterTileSource(id, options, dispatcher) {
             return this.fire('error', err);
         }
         util.extend(this, tileJSON);
-        this.fire('data', {dataType: 'source'});
-        this.fire('source.load');
+        this.fire('data', {dataType: 'source', isFirst: true});
     }.bind(this));
 }
 

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -29,8 +29,8 @@ function SourceCache(id, options, dispatcher) {
 
     var source = this._source = Source.create(id, options, dispatcher);
     source.setEventedParent(this);
-
-    this.on('source.load', function() {
+    
+    this.once('data', function() {
         if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
         this._sourceLoaded = true;
     });

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -30,19 +30,16 @@ function SourceCache(id, options, dispatcher) {
     var source = this._source = Source.create(id, options, dispatcher);
     source.setEventedParent(this);
 
-    this.on('data', function(event) {
-        if (event.dataType === 'source' && event.isFirst) {
-            if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
-            this._sourceLoaded = true;
-        }
-    });
-
     this.on('error', function() {
         this._sourceErrored = true;
     });
 
     this.on('data', function(event) {
-        if (this._sourceLoaded && event.dataType === 'source') {
+        if (event.dataType === 'source' && event.isFirst) {
+            if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
+            this._sourceLoaded = true;
+
+        } else if (this._sourceLoaded && event.dataType === 'source') {
             this.reload();
             if (this.transform) {
                 this.update(this.transform, this.map && this.map.style.rasterFadeDuration);

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -29,10 +29,12 @@ function SourceCache(id, options, dispatcher) {
 
     var source = this._source = Source.create(id, options, dispatcher);
     source.setEventedParent(this);
-    
-    this.once('data', function() {
-        if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
-        this._sourceLoaded = true;
+
+    this.on('data', function(event) {
+        if (event.dataType === 'source' && event.isFirst) {
+            if (this.map && this._source.onAdd) { this._source.onAdd(this.map); }
+            this._sourceLoaded = true;
+        }
     });
 
     this.on('error', function() {

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -23,8 +23,7 @@ function VectorTileSource(id, options, dispatcher) {
             return;
         }
         util.extend(this, tileJSON);
-        this.fire('data', {dataType: 'source'});
-        this.fire('source.load');
+        this.fire('data', {dataType: 'source', isFirst: true});
     }.bind(this));
 }
 

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -73,8 +73,7 @@ function VideoSource(id, options) {
             this.setCoordinates(options.coordinates);
         }
 
-        this.fire('data', {dataType: 'source'});
-        this.fire('source.load');
+        this.fire('data', {dataType: 'source', isFirst: true});
     }.bind(this));
 }
 

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -77,9 +77,9 @@ function Style(stylesheet, map, options) {
         browser.frame(stylesheetLoaded.bind(this, null, stylesheet));
     }
 
-    this.on('source.load', function(event) {
+    this.on('data', function(event) {
         var source = event.source;
-        if (source && source.vectorLayerIds) {
+        if (event.isFirst && source && source.vectorLayerIds) {
             for (var layerId in this._layers) {
                 var layer = this._layers[layerId];
                 if (layer.source === source.id) {

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -119,7 +119,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('source.load', function() {
+        source.once('data', function() {
             t.end();
         });
     });
@@ -148,7 +148,7 @@ test('GeoJSONSource#update', function(t) {
 
         var source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('source.load', function() {
+        source.once('data', function() {
             // Note: we register this before calling setData because `change`
             // is fired synchronously within that method.  It may be worth
             // considering dezalgoing there.
@@ -175,7 +175,7 @@ test('GeoJSONSource#update', function(t) {
             transform: {}
         };
 
-        source.on('source.load', function () {
+        source.once('data', function () {
             source.setData({});
             source.loadTile(new Tile(new TileCoord(0, 0, 0), 512), function () {});
         });

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -32,7 +32,7 @@ Source.setType('mock-source-type', function create (id, sourceOptions) {
         if (sourceOptions.error) {
             source.fire('error', { error: sourceOptions.error });
         } else {
-            source.fire('data');
+            source.fire('data', {dataType: 'source', isFirst: true});
         }
     }, 0);
     return source;

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -32,7 +32,7 @@ Source.setType('mock-source-type', function create (id, sourceOptions) {
         if (sourceOptions.error) {
             source.fire('error', { error: sourceOptions.error });
         } else {
-            source.fire('source.load');
+            source.fire('data');
         }
     }, 0);
     return source;
@@ -194,21 +194,15 @@ test('SourceCache#removeTile', function(t) {
 test('SourceCache / Source lifecycle', function (t) {
     t.test('does not fire load or change before source load event', function (t) {
         createSourceCache({noLoad: true})
-            .on('source.load', t.fail)
             .on('data', t.fail);
         setTimeout(t.end, 1);
     });
 
-    t.test('forward load event', function (t) {
-        createSourceCache({}).on('source.load', t.end);
+    t.test('forward "data" event', function (t) {
+        createSourceCache({}).on('data', t.end);
     });
 
-    t.test('forward change event', function (t) {
-        var sourceCache = createSourceCache().on('data', t.end);
-        sourceCache.getSource().fire('data');
-    });
-
-    t.test('forward error event', function (t) {
+    t.test('forward "error" event', function (t) {
         createSourceCache({ error: 'Error loading source' })
         .on('error', function (err) {
             t.equal(err.error, 'Error loading source');
@@ -240,7 +234,7 @@ test('SourceCache / Source lifecycle', function (t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform);
             sourceCache.getSource().fire('data', {dataType: 'source'});
         });
@@ -256,7 +250,7 @@ test('SourceCache#update', function(t) {
         transform.zoom = 0;
 
         var sourceCache = createSourceCache({}, false);
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getIds(), []);
@@ -270,7 +264,7 @@ test('SourceCache#update', function(t) {
         transform.zoom = 0;
 
         var sourceCache = createSourceCache({});
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
             t.end();
@@ -288,7 +282,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
@@ -319,7 +313,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
@@ -350,7 +344,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0, 1).id]);
 
@@ -381,7 +375,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform, 100);
             t.deepEqual(sourceCache.getIds(), [
                 new TileCoord(2, 1, 1).id,
@@ -411,7 +405,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform, 100);
 
             transform.zoom = 2;
@@ -441,7 +435,7 @@ test('SourceCache#update', function(t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform);
             t.deepEqual(sourceCache.getRenderableIds(), [
                 new TileCoord(16, 8191, 8191, 0).id,
@@ -518,7 +512,7 @@ test('SourceCache#tilesIn', function (t) {
             }
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getIds(), [
@@ -559,7 +553,7 @@ test('SourceCache#tilesIn', function (t) {
             tileSize: 512
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             var transform = new Transform();
             transform.resize(512, 512);
             transform.zoom = 2.0;
@@ -603,7 +597,7 @@ test('SourceCache#tilesIn', function (t) {
             tileSize: 512
         });
 
-        sourceCache.on('source.load', function () {
+        sourceCache.once('data', function () {
             var transform = new Transform();
             transform.resize(512, 512);
             transform.zoom = 2.0;
@@ -625,7 +619,7 @@ test('SourceCache#loaded (no errors)', function (t) {
         }
     });
 
-    sourceCache.on('source.load', function () {
+    sourceCache.once('data', function () {
         var coord = new TileCoord(0, 0, 0);
         sourceCache.addTile(coord);
 
@@ -641,7 +635,7 @@ test('SourceCache#loaded (with errors)', function (t) {
         }
     });
 
-    sourceCache.on('source.load', function () {
+    sourceCache.once('data', function () {
         var coord = new TileCoord(0, 0, 0);
         sourceCache.addTile(coord);
 

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -38,7 +38,7 @@ test('VectorTileSource', function(t) {
             tiles: ["http://example.com/{z}/{x}/{y}.png"]
         });
 
-        source.on('source.load', function() {
+        source.once('data', function() {
             t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
@@ -52,7 +52,7 @@ test('VectorTileSource', function(t) {
 
         var source = createSource({ url: "/source.json" });
 
-        source.on('source.load', function() {
+        source.once('data', function() {
             t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
             t.deepEqual(source.minzoom, 1);
             t.deepEqual(source.maxzoom, 10);
@@ -107,7 +107,7 @@ test('VectorTileSource', function(t) {
                 t.end();
             };
 
-            source.on('source.load', function() {
+            source.once('data', function() {
                 source.loadTile({coord: new TileCoord(10, 5, 5, 0)}, function () {});
             });
         });
@@ -127,7 +127,7 @@ test('VectorTileSource', function(t) {
             return 1;
         };
 
-        source.on('source.load', function () {
+        source.once('data', function () {
             var tile = {
                 coord: new TileCoord(10, 5, 5, 0),
                 state: 'loading',

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -576,11 +576,12 @@ test('Style#addLayer', function(t) {
             "filter": ["==", "id", 0]
         };
 
-        style.on('style.load', function() {
-            style.sourceCaches['mapbox'].reload = t.end;
-
+        style.once('style.load', function() {
+            sinon.spy(style.sourceCaches['mapbox'], 'reload');
             style.addLayer(layer);
             style.update();
+            t.ok(style.sourceCaches['mapbox'].reload.calledOnce);
+            t.end();
         });
     });
 

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -373,15 +373,13 @@ test('Style#addSource', function(t) {
         var source = createSource();
 
         style.on('style.load', function () {
-            t.plan(4);
+            t.plan(2);
 
             style.on('error', function() { t.ok(true); });
             style.on('data', function() { t.ok(true); });
-            style.on('source.load', function() { t.ok(true); });
 
-            style.addSource('source-id', source); // Fires 'source.load' and 'data'
+            style.addSource('source-id', source); // Fires 'data'
             style.sourceCaches['source-id'].fire('error');
-            style.sourceCaches['source-id'].fire('data');
         });
     });
 

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -134,18 +134,15 @@ test('Map', function(t) {
                 function recordEvent(event) { events.push(event.type); }
 
                 map.on('error', recordEvent);
-                map.on('source.load', recordEvent);
                 map.on('data', recordEvent);
                 map.on('dataloading', recordEvent);
 
                 map.style.fire('error');
-                map.style.fire('source.load');
                 map.style.fire('data');
                 map.style.fire('dataloading');
 
                 t.deepEqual(events, [
                     'error',
-                    'source.load',
                     'data',
                     'dataloading',
                 ]);


### PR DESCRIPTION
As a sister PR to https://github.com/mapbox/mapbox-gl-js/pull/3308, this PR removes the `Source#source.load` event in favor of the `Source#data` event.

Why? We expose a smaller API surface. `source.load` is redundant with the `data` event. We wish the `Map#load` event had been this way all along. There's little precedent for `.` namespaced events therefore we should try to keep them out of our public API. 

ref #1715 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
