### PR TITLE
Fix exception when running geoJSONSetData benchmarks

### DIFF
--- a/bench/benchmarks/geojson_setdata_large.js
+++ b/bench/benchmarks/geojson_setdata_large.js
@@ -31,7 +31,7 @@ module.exports = function() {
         map.on('load', function() {
             map = setupGeoJSONMap(map);
 
-            setDataPerf(map.style.sources['geojson'], data, function(err, ms) {
+            setDataPerf(map.style.sourceCaches.geojson, data, function(err, ms) {
                 if (err) return evented.fire('error', {error: err});
                 map.remove();
                 evented.fire('end', {message: formatNumber(ms) + ' ms', score: ms});

--- a/bench/benchmarks/geojson_setdata_small.js
+++ b/bench/benchmarks/geojson_setdata_small.js
@@ -33,7 +33,7 @@ module.exports = function() {
     map.on('load', function() {
         map = setupGeoJSONMap(map);
 
-        setDataPerf(map.style.sources['geojson'], featureCollection, function(err, ms) {
+        setDataPerf(map.style.sourceCaches.geojson, featureCollection, function(err, ms) {
             map.remove();
             if (err) return evented.fire('error', {error: err});
             evented.fire('end', {message: formatNumber(ms) + ' ms', score: ms});

--- a/bench/index.html
+++ b/bench/index.html
@@ -14,7 +14,7 @@
     <div id="benchmarks"></div>
     <script src="https://npmcdn.com/react@15.3.0/dist/react.js"></script>
     <script src="https://npmcdn.com/react-dom@15.3.0/dist/react-dom.js"></script>
-    <script src="https://s3.amazonaws.com/mapbox-gl-js/master/benchmarks.js"></script>
+    <!-- <script src="https://s3.amazonaws.com/mapbox-gl-js/master/benchmarks.js"></script> -->
     <script src="/bench/benchmarks_generated.js"></script>
     <script src="/bench/benchmarks_view_generated.js"></script>
 </body>


### PR DESCRIPTION
I introduced a bug in the benchmarks in https://github.com/mapbox/mapbox-gl-js/pull/3278. I renamed `Style#sources` to `Style#sourceCaches` and did not update the benchmarks use of this property. 

We can catch bugs like this in the future by running the benchmarks during unit tests and doing some sanity checks. This could be done within the scope of https://github.com/mapbox/mapbox-gl-js/issues/3166. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the benchmarks page

