### PR TITLE
Only filter on keyup when the input field exists

### DIFF
--- a/docs/js/site.js
+++ b/docs/js/site.js
@@ -43,35 +43,37 @@ var filterInput = document.getElementById('filter-input');
 var headings = document.getElementsByClassName('heading');
 var tocElements = document.getElementsByClassName('example-names');
 
-filterInput.addEventListener('keyup', function (e) {
-    var value = this.value.toLowerCase();
-    var element;
-    for (i=0; i < headings.length; i++) {
-        if (!value || value == undefined || value == "" || value.length == 0) {
-            headings[i].style.display = 'block';
-        } else { 
-            headings[i].style.display = 'none';
+if (filterInput) {
+    filterInput.addEventListener('keyup', function (e) {
+        var value = this.value.toLowerCase();
+        var element;
+        for (i=0; i < headings.length; i++) {
+            if (!value || value == undefined || value == "" || value.length == 0) {
+                headings[i].style.display = 'block';
+            } else { 
+                headings[i].style.display = 'none';
+            }
         }
-    }
-    for (i=0; i < tocElements.length; i++) {
-        element = tocElements[i];
-    }
-    var match = function () {
-        return true;
-    };
-    var value = this.value.toLowerCase();
-    if (!value.match(/^\s*$/)) {
-        match = function (element) {
-            return element.innerHTML.toLowerCase().indexOf(value) !== -1;
+        for (i=0; i < tocElements.length; i++) {
+            element = tocElements[i];
+        }
+        var match = function () {
+            return true;
         };
-    }
-    for (i = 0; i < tocElements.length; i++) {
-        element = tocElements[i];
-        children = Array.from(element.getElementsByTagName('li'));
-        if (match(element) || children.some(match)) {
-            element.style.display = 'block';
-        } else {
-            element.style.display = 'none';
+        var value = this.value.toLowerCase();
+        if (!value.match(/^\s*$/)) {
+            match = function (element) {
+                return element.innerHTML.toLowerCase().indexOf(value) !== -1;
+            };
         }
-    }
-});
+        for (i = 0; i < tocElements.length; i++) {
+            element = tocElements[i];
+            children = Array.from(element.getElementsByTagName('li'));
+            if (match(element) || children.some(match)) {
+                element.style.display = 'block';
+            } else {
+                element.style.display = 'none';
+            }
+        }
+    });
+}


### PR DESCRIPTION
Minor regression on mb-pages:

![2016-10-06 at 5 54 pm](https://cloud.githubusercontent.com/assets/32314/19172071/f73125c8-8bed-11e6-8819-8186d98e900e.png)

Occurs on API pages, for all pageloads. Regressed in dd6b7626698eeee402b21fcafebc1229da99d815

This checks that there's a filter input before binding to it.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page

