### PR TITLE
indicate that LngLatBounds parameters are optional

### DIFF
--- a/js/geo/lng_lat_bounds.js
+++ b/js/geo/lng_lat_bounds.js
@@ -15,8 +15,8 @@ var LngLat = require('./lng_lat');
  * This flexible type is documented as [`LngLatBoundsLike`](#LngLatBoundsLike).
  *
  * @class LngLatBounds
- * @param {LngLatLike} sw The southwest corner of the bounding box.
- * @param {LngLatLike} ne The northeast corner of the bounding box.
+ * @param {LngLatLike} [sw] The southwest corner of the bounding box.
+ * @param {LngLatLike} [ne] The northeast corner of the bounding box.
  * @example
  * var sw = new mapboxgl.LngLat(-73.9876, 40.7661);
  * var ne = new mapboxgl.LngLat(-73.9397, 40.8002);


### PR DESCRIPTION
The docs state that:
> If no arguments are provided to the constructor, a null bounding box is created.

yet our documentation.js markup show them as optional. This fixes that! 
ref #3307 