### PR TITLE
Fix wrong reported coordinates on Android Chrome

### DIFF
--- a/js/util/dom.js
+++ b/js/util/dom.js
@@ -65,7 +65,7 @@ exports.mousePos = function (el, e) {
 exports.touchPos = function (el, e) {
     var rect = el.getBoundingClientRect(),
         points = [];
-    var touches = e.type === 'touchend'?e.changedTouches:e.touches;
+    var touches = (e.type === 'touchend')? e.changedTouches : e.touches;
     for (var i = 0; i < touches.length; i++) {
         points.push(new Point(
             touches[i].clientX - rect.left - el.clientLeft,

--- a/js/util/dom.js
+++ b/js/util/dom.js
@@ -65,10 +65,11 @@ exports.mousePos = function (el, e) {
 exports.touchPos = function (el, e) {
     var rect = el.getBoundingClientRect(),
         points = [];
-    for (var i = 0; i < e.touches.length; i++) {
+    var touches = e.type === 'touchend'?e.changedTouches:e.touches;
+    for (var i = 0; i < touches.length; i++) {
         points.push(new Point(
-            e.touches[i].clientX - rect.left - el.clientLeft,
-            e.touches[i].clientY - rect.top - el.clientTop
+            touches[i].clientX - rect.left - el.clientLeft,
+            touches[i].clientY - rect.top - el.clientTop
         ));
     }
     return points;

--- a/js/util/dom.js
+++ b/js/util/dom.js
@@ -65,7 +65,7 @@ exports.mousePos = function (el, e) {
 exports.touchPos = function (el, e) {
     var rect = el.getBoundingClientRect(),
         points = [];
-    var touches = (e.type === 'touchend')? e.changedTouches : e.touches;
+    var touches = (e.type === 'touchend') ? e.changedTouches : e.touches;
     for (var i = 0; i < touches.length; i++) {
         points.push(new Point(
             touches[i].clientX - rect.left - el.clientLeft,


### PR DESCRIPTION
Closes #3304.

 - [x] Changed the util/dom.js/ touchPos function to consider changedTouches on touchend event as touches is empty on such event
 - [x] Tested only on android tablet (from the docs the fix shoud work on ios too)
 
