### PR TITLE
When firing tile removal event, include tile and indicate it is being removed

### DIFF
--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -422,7 +422,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.uses--;
         delete this._tiles[id];
-        this._source.fire('data', {dataType: 'tile'});
+        this._source.fire('data', { tile: tile, dataType: 'tile', tileRemoved: true });
 
         if (tile.uses > 0)
             return;

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -422,7 +422,7 @@ SourceCache.prototype = util.inherit(Evented, {
 
         tile.uses--;
         delete this._tiles[id];
-        this._source.fire('data', { tile: tile, dataType: 'tile', tileRemoved: true });
+        this._source.fire('data', { tile: tile, dataType: 'tile' });
 
         if (tile.uses > 0)
             return;


### PR DESCRIPTION
When listening to the `data` event and a tile is removed, I want to know which tile is being removed. This PR adds the `tile` object back to the event payload.

The new property `tileRemoved` feels like a poor solution. I also thought of setting `tile.state = 'removed'` but I don't know what consequences that may have elsewhere. So here's `tileRemoved` for discussion.

This is the change where the `tile` object was removed from the payload (when `tile.remove` changed to `data`):

https://github.com/mapbox/mapbox-gl-js/commit/1d373b0596af42a6a5c5f7a5cc89ccc1e6076d95#diff-06cf24c5dc5d855571fe09af2b823b96R430

--

My use case is drawing a shading over tiles that are "loading" from my vector tile source. When zoom or viewport changes, I need to remove shading from tiles that won't ever be loaded.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page

… removed