### PR TITLE
Simplify draw_line.js

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -468,5 +468,16 @@ Transform.prototype = {
         m = mat4.invert(new Float64Array(16), this.pixelMatrix);
         if (!m) throw new Error("failed to invert matrix");
         this.pixelMatrixInverse = m;
+
+        // line antialiasing matrix
+        m = mat2.create();
+        mat2.scale(m, m, [1, Math.cos(this._pitch)]);
+        mat2.rotate(m, m, this.angle);
+        this.lineAntialiasingMatrix = m;
+
+        // calculate how much longer the real world distance is at the top of the screen
+        // than at the middle of the screen.
+        var topedgelength = Math.sqrt(this.height * this.height / 4  * (1 + this.altitude * this.altitude));
+        this.lineStretch = (topedgelength + (this.height / 2 * Math.tan(this._pitch))) / topedgelength - 1;
     }
 };

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -25,35 +25,11 @@ module.exports = function drawLine(painter, sourceCache, layer, coords) {
     // don't draw zero-width lines
     if (layer.paint['line-width'] <= 0) return;
 
-    for (var k = 0; k < coords.length; k++) {
-        drawLineTile(painter, sourceCache, layer, coords[k]);
-    }
-
-};
-
-function drawLineTile(painter, sourceCache, layer, coord) {
-    var tile = sourceCache.getTile(coord);
-    var bucket = tile.getBucket(layer);
-    if (!bucket) return;
-    var bufferGroups = bucket.bufferGroups.line;
-    if (!bufferGroups) return;
-
-    var gl = painter.gl;
-
-    var programOptions = bucket.paintAttributes.line[layer.id];
-
-    // the distance over which the line edge fades out.
-    // Retina devices need a smaller distance to avoid aliasing.
-    var antialiasing = 1 / browser.devicePixelRatio;
-
-    var blur = layer.paint['line-blur'] + antialiasing;
-    var color = layer.paint['line-color'];
-
     var tr = painter.transform;
 
     var antialiasingMatrix = mat2.create();
     mat2.scale(antialiasingMatrix, antialiasingMatrix, [1, Math.cos(tr._pitch)]);
-    mat2.rotate(antialiasingMatrix, antialiasingMatrix, painter.transform.angle);
+    mat2.rotate(antialiasingMatrix, antialiasingMatrix, tr.angle);
 
     // calculate how much longer the real world distance is at the top of the screen
     // than at the middle of the screen.
@@ -61,25 +37,32 @@ function drawLineTile(painter, sourceCache, layer, coord) {
     var x = tr.height / 2 * Math.tan(tr._pitch);
     var extra = (topedgelength + x) / topedgelength - 1;
 
+    for (var k = 0; k < coords.length; k++) {
+        drawLineTile(painter, sourceCache, layer, coords[k], antialiasingMatrix, extra);
+    }
+};
+
+function drawLineTile(painter, sourceCache, layer, coord, antialiasingMatrix, extra) {
+    var tile = sourceCache.getTile(coord);
+    var bucket = tile.getBucket(layer);
+    if (!bucket) return;
+    var bufferGroups = bucket.bufferGroups.line;
+    if (!bufferGroups) return;
+
+    var gl = painter.gl;
     var dasharray = layer.paint['line-dasharray'];
     var image = layer.paint['line-pattern'];
-    var program, posA, posB, imagePosA, imagePosB;
+    var programOptions = bucket.paintAttributes.line[layer.id];
 
+    var program = painter.useProgram(dasharray ? 'lineSDF' : image ? 'linePattern' : 'line',
+            programOptions.defines, programOptions.vertexPragmas, programOptions.fragmentPragmas);
+
+    if (!image) {
+        gl.uniform4fv(program.u_color, layer.paint['line-color']);
+    }
+
+    var posA, posB, imagePosA, imagePosB;
     if (dasharray) {
-        program = painter.useProgram(
-            'lineSDF',
-            programOptions.defines,
-            programOptions.vertexPragmas,
-            programOptions.fragmentPragmas
-        );
-
-        gl.uniform1f(program.u_linewidth, layer.paint['line-width'] / 2);
-        gl.uniform1f(program.u_gapwidth, layer.paint['line-gap-width'] / 2);
-        gl.uniform1f(program.u_antialiasing, antialiasing / 2);
-        gl.uniform1f(program.u_blur, blur);
-        gl.uniform4fv(program.u_color, color);
-        gl.uniform1f(program.u_opacity, layer.paint['line-opacity']);
-
         posA = painter.lineAtlas.getDash(dasharray.from, layer.layout['line-cap'] === 'round');
         posB = painter.lineAtlas.getDash(dasharray.to, layer.layout['line-cap'] === 'round');
 
@@ -90,58 +73,35 @@ function drawLineTile(painter, sourceCache, layer, coord) {
         gl.uniform1f(program.u_tex_y_a, posA.y);
         gl.uniform1f(program.u_tex_y_b, posB.y);
         gl.uniform1f(program.u_mix, dasharray.t);
-        gl.uniform1f(program.u_extra, extra);
-        gl.uniform1f(program.u_offset, -layer.paint['line-offset']);
-        gl.uniformMatrix2fv(program.u_antialiasingmatrix, false, antialiasingMatrix);
 
     } else if (image) {
         imagePosA = painter.spriteAtlas.getPosition(image.from, true);
         imagePosB = painter.spriteAtlas.getPosition(image.to, true);
         if (!imagePosA || !imagePosB) return;
 
-        program = painter.useProgram(
-            'linePattern',
-            programOptions.defines,
-            programOptions.vertexPragmas,
-            programOptions.fragmentPragmas
-        );
-
         gl.uniform1i(program.u_image, 0);
         gl.activeTexture(gl.TEXTURE0);
         painter.spriteAtlas.bind(gl, true);
 
-        gl.uniform1f(program.u_linewidth, layer.paint['line-width'] / 2);
-        gl.uniform1f(program.u_gapwidth, layer.paint['line-gap-width'] / 2);
-        gl.uniform1f(program.u_antialiasing, antialiasing / 2);
-        gl.uniform1f(program.u_blur, blur);
         gl.uniform2fv(program.u_pattern_tl_a, imagePosA.tl);
         gl.uniform2fv(program.u_pattern_br_a, imagePosA.br);
         gl.uniform2fv(program.u_pattern_tl_b, imagePosB.tl);
         gl.uniform2fv(program.u_pattern_br_b, imagePosB.br);
         gl.uniform1f(program.u_fade, image.t);
-        gl.uniform1f(program.u_opacity, layer.paint['line-opacity']);
-        gl.uniform1f(program.u_extra, extra);
-        gl.uniform1f(program.u_offset, -layer.paint['line-offset']);
-        gl.uniformMatrix2fv(program.u_antialiasingmatrix, false, antialiasingMatrix);
-
-    } else {
-        program = painter.useProgram(
-            'line',
-            programOptions.defines,
-            programOptions.vertexPragmas,
-            programOptions.fragmentPragmas
-        );
-
-        gl.uniform1f(program.u_linewidth, layer.paint['line-width'] / 2);
-        gl.uniform1f(program.u_gapwidth, layer.paint['line-gap-width'] / 2);
-        gl.uniform1f(program.u_antialiasing, antialiasing / 2);
-        gl.uniform1f(program.u_blur, blur);
-        gl.uniform1f(program.u_extra, extra);
-        gl.uniform1f(program.u_offset, -layer.paint['line-offset']);
-        gl.uniformMatrix2fv(program.u_antialiasingmatrix, false, antialiasingMatrix);
-        gl.uniform4fv(program.u_color, color);
-        gl.uniform1f(program.u_opacity, layer.paint['line-opacity']);
     }
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    var antialiasing = 1 / browser.devicePixelRatio;
+
+    gl.uniform1f(program.u_linewidth, layer.paint['line-width'] / 2);
+    gl.uniform1f(program.u_gapwidth, layer.paint['line-gap-width'] / 2);
+    gl.uniform1f(program.u_antialiasing, antialiasing / 2);
+    gl.uniform1f(program.u_blur, layer.paint['line-blur'] + antialiasing);
+    gl.uniform1f(program.u_opacity, layer.paint['line-opacity']);
+    gl.uniformMatrix2fv(program.u_antialiasingmatrix, false, antialiasingMatrix);
+    gl.uniform1f(program.u_offset, -layer.paint['line-offset']);
+    gl.uniform1f(program.u_extra, extra);
 
     painter.enableTileClippingMask(coord);
 
@@ -149,21 +109,18 @@ function drawLineTile(painter, sourceCache, layer, coord) {
     var posMatrix = painter.translatePosMatrix(coord.posMatrix, tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
     gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
 
-    var ratio = 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom);
-
     if (dasharray) {
         var widthA = posA.width * dasharray.fromScale;
         var widthB = posB.width * dasharray.toScale;
         var scaleA = [1 / pixelsToTileUnits(tile, widthA, painter.transform.tileZoom), -posA.height / 2];
         var scaleB = [1 / pixelsToTileUnits(tile, widthB, painter.transform.tileZoom), -posB.height / 2];
         var gamma = painter.lineAtlas.width / (Math.min(widthA, widthB) * 256 * browser.devicePixelRatio) / 2;
-        gl.uniform1f(program.u_ratio, ratio);
+
         gl.uniform2fv(program.u_patternscale_a, scaleA);
         gl.uniform2fv(program.u_patternscale_b, scaleB);
         gl.uniform1f(program.u_sdfgamma, gamma);
 
     } else if (image) {
-        gl.uniform1f(program.u_ratio, ratio);
         gl.uniform2fv(program.u_pattern_size_a, [
             pixelsToTileUnits(tile, imagePosA.size[0] * image.fromScale, painter.transform.tileZoom),
             imagePosB.size[1]
@@ -172,10 +129,9 @@ function drawLineTile(painter, sourceCache, layer, coord) {
             pixelsToTileUnits(tile, imagePosB.size[0] * image.toScale, painter.transform.tileZoom),
             imagePosB.size[1]
         ]);
-
-    } else {
-        gl.uniform1f(program.u_ratio, ratio);
     }
+
+    gl.uniform1f(program.u_ratio, 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom));
 
     bucket.setUniforms(gl, 'line', program, layer, {zoom: painter.transform.zoom});
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -27,22 +27,12 @@ module.exports = function drawLine(painter, sourceCache, layer, coords) {
 
     var tr = painter.transform;
 
-    var antialiasingMatrix = mat2.create();
-    mat2.scale(antialiasingMatrix, antialiasingMatrix, [1, Math.cos(tr._pitch)]);
-    mat2.rotate(antialiasingMatrix, antialiasingMatrix, tr.angle);
-
-    // calculate how much longer the real world distance is at the top of the screen
-    // than at the middle of the screen.
-    var topedgelength = Math.sqrt(tr.height * tr.height / 4  * (1 + tr.altitude * tr.altitude));
-    var x = tr.height / 2 * Math.tan(tr._pitch);
-    var extra = (topedgelength + x) / topedgelength - 1;
-
     for (var k = 0; k < coords.length; k++) {
-        drawLineTile(painter, sourceCache, layer, coords[k], antialiasingMatrix, extra);
+        drawLineTile(painter, sourceCache, layer, coords[k]);
     }
 };
 
-function drawLineTile(painter, sourceCache, layer, coord, antialiasingMatrix, extra) {
+function drawLineTile(painter, sourceCache, layer, coord) {
     var tile = sourceCache.getTile(coord);
     var bucket = tile.getBucket(layer);
     if (!bucket) return;
@@ -99,9 +89,9 @@ function drawLineTile(painter, sourceCache, layer, coord, antialiasingMatrix, ex
     gl.uniform1f(program.u_antialiasing, antialiasing / 2);
     gl.uniform1f(program.u_blur, layer.paint['line-blur'] + antialiasing);
     gl.uniform1f(program.u_opacity, layer.paint['line-opacity']);
-    gl.uniformMatrix2fv(program.u_antialiasingmatrix, false, antialiasingMatrix);
+    gl.uniformMatrix2fv(program.u_antialiasingmatrix, false, painter.transform.lineAntialiasingMatrix);
     gl.uniform1f(program.u_offset, -layer.paint['line-offset']);
-    gl.uniform1f(program.u_extra, extra);
+    gl.uniform1f(program.u_extra, painter.transform.lineStretch);
 
     painter.enableTileClippingMask(coord);
 

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var browser = require('../util/browser');
-var mat2 = require('gl-matrix').mat2;
 var pixelsToTileUnits = require('../source/pixels_to_tile_units');
 
 /**
@@ -24,8 +23,6 @@ module.exports = function drawLine(painter, sourceCache, layer, coords) {
 
     // don't draw zero-width lines
     if (layer.paint['line-width'] <= 0) return;
-
-    var tr = painter.transform;
 
     for (var k = 0; k < coords.length; k++) {
         drawLineTile(painter, sourceCache, layer, coords[k]);


### PR DESCRIPTION
- Removed lots of repetition in `draw_line.js`
- Moved calculation of line antialiasing matrix and stretch coefficient to transform so that it’s not repeated

👀 @lucaswoj @ansis