### PR TITLE
Check offset when determining if should anchor to top

### DIFF
--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -234,7 +234,7 @@ Popup.prototype = util.inherit(Evented, /** @lends Popup.prototype */{
             var width = this._container.offsetWidth,
                 height = this._container.offsetHeight;
 
-            if (pos.y < height) {
+            if (pos.y + offset.bottom.y < height) {
                 anchor = ['top'];
             } else if (pos.y > this._map.transform.height - height) {
                 anchor = ['bottom'];

--- a/test/js/ui/popup.test.js
+++ b/test/js/ui/popup.test.js
@@ -234,6 +234,28 @@ test('Popup anchors as specified by the anchor option', function (t) {
     });
 });
 
+test('Popup automatically anchors to top if its bottom offset would push it off-screen', function (t) {
+    var map = createMap();
+    var point = new Point(containerWidth / 2, containerHeight / 2);
+    var options = { offset: {
+        'bottom': [0, -25],
+        'top': [0, 0]
+    }};
+    var popup = new Popup(options)
+        .setLngLat([0, 0])
+        .setText('Test')
+        .addTo(map);
+
+    popup._container.offsetWidth = (containerWidth / 2);
+    popup._container.offsetHeight = (containerHeight / 2);
+
+    sinon.stub(map, 'project', function () { return point; });
+    popup.setLngLat([0, 0]);
+
+    t.ok(popup._container.classList.contains('mapboxgl-popup-anchor-top'));
+    t.end();
+});
+
 test('Popup is offset via a PointLike offset option', function (t) {
     var map = createMap();
     sinon.stub(map, 'project', function () { return new Point(0, 0); });


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

When auto determining the anchor for a popup, you were not checking the offset. I was using a negative bottom offset to place the popup _above_ the marker when anchored to the bottom. This means that when you checked `if (pos.y < height) {` to see if the popup would be off the viewport, your code would assume it is not, then the offset would put it off the screen. By adding the offset to the position when comparing, it prevents the offset from pushing the popup off the viewport.

The other conditions might benefit from checking the offset  as well (not positive) but this is the only one that affected me.

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page

