### PR TITLE
Do not require passing WebGL context in order to destroy buffers/VAOs

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -172,11 +172,11 @@ Bucket.prototype.createArrays = function() {
     }
 };
 
-Bucket.prototype.destroy = function(gl) {
+Bucket.prototype.destroy = function() {
     for (var programName in this.bufferGroups) {
         var programBufferGroups = this.bufferGroups[programName];
         for (var i = 0; i < programBufferGroups.length; i++) {
-            programBufferGroups[i].destroy(gl);
+            programBufferGroups[i].destroy();
         }
     }
 };

--- a/js/data/buffer.js
+++ b/js/data/buffer.js
@@ -30,6 +30,7 @@ Buffer.prototype.bind = function(gl) {
     var type = gl[this.type];
 
     if (!this.buffer) {
+        this.gl = gl;
         this.buffer = gl.createBuffer();
         gl.bindBuffer(type, this.buffer);
         gl.bufferData(type, this.arrayBuffer, gl.STATIC_DRAW);
@@ -82,9 +83,9 @@ Buffer.prototype.setVertexAttribPointers = function(gl, program) {
  * @private
  * @param gl The WebGL context
  */
-Buffer.prototype.destroy = function(gl) {
+Buffer.prototype.destroy = function() {
     if (this.buffer) {
-        gl.deleteBuffer(this.buffer);
+        this.gl.deleteBuffer(this.buffer);
     }
 };
 

--- a/js/data/buffer_group.js
+++ b/js/data/buffer_group.js
@@ -33,21 +33,21 @@ function BufferGroup(arrayGroup, arrayTypes) {
     });
 }
 
-BufferGroup.prototype.destroy = function(gl) {
-    this.layoutVertexBuffer.destroy(gl);
+BufferGroup.prototype.destroy = function() {
+    this.layoutVertexBuffer.destroy();
     if (this.elementBuffer) {
-        this.elementBuffer.destroy(gl);
+        this.elementBuffer.destroy();
     }
     if (this.elementBuffer2) {
-        this.elementBuffer2.destroy(gl);
+        this.elementBuffer2.destroy();
     }
     for (var n in this.paintVertexBuffers) {
-        this.paintVertexBuffers[n].destroy(gl);
+        this.paintVertexBuffers[n].destroy();
     }
     for (var j in this.vaos) {
-        this.vaos[j].destroy(gl);
+        this.vaos[j].destroy();
     }
     for (var k in this.secondVaos) {
-        this.secondVaos[k].destroy(gl);
+        this.secondVaos[k].destroy();
     }
 };

--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -28,6 +28,7 @@ VertexArrayObject.prototype.bind = function(gl, program, layoutVertexBuffer, ele
 
     if (!gl.extVertexArrayObject || isFreshBindRequired) {
         this.freshBind(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2);
+        this.gl = gl;
     } else {
         gl.extVertexArrayObject.bindVertexArrayOES(this.vao);
     }
@@ -38,7 +39,7 @@ VertexArrayObject.prototype.freshBind = function(gl, program, layoutVertexBuffer
     var numNextAttributes = program.numAttributes;
 
     if (gl.extVertexArrayObject) {
-        if (this.vao) this.destroy(gl);
+        if (this.vao) this.destroy();
         this.vao = gl.extVertexArrayObject.createVertexArrayOES();
         gl.extVertexArrayObject.bindVertexArrayOES(this.vao);
         numPrevAttributes = 0;
@@ -80,10 +81,9 @@ VertexArrayObject.prototype.freshBind = function(gl, program, layoutVertexBuffer
     gl.currentNumAttributes = numNextAttributes;
 };
 
-VertexArrayObject.prototype.destroy = function(gl) {
-    var ext = gl.extVertexArrayObject;
-    if (ext && this.vao) {
-        ext.deleteVertexArrayOES(this.vao);
+VertexArrayObject.prototype.destroy = function() {
+    if (this.vao) {
+        this.gl.extVertexArrayObject.deleteVertexArrayOES(this.vao);
         this.vao = null;
     }
 };

--- a/js/source/geojson_source.js
+++ b/js/source/geojson_source.js
@@ -168,7 +168,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
 
         tile.workerID = this.dispatcher.send('load tile', params, function(err, data) {
 
-            tile.unloadVectorData(this.map.painter);
+            tile.unloadVectorData();
 
             if (tile.aborted)
                 return;
@@ -194,7 +194,7 @@ GeoJSONSource.prototype = util.inherit(Evented, /** @lends GeoJSONSource.prototy
     },
 
     unloadTile: function(tile) {
-        tile.unloadVectorData(this.map.painter);
+        tile.unloadVectorData();
         this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, function() {}, tile.workerID);
     },
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -97,7 +97,7 @@ VectorTileSource.prototype = util.inherit(Evented, {
     },
 
     unloadTile: function(tile) {
-        tile.unloadVectorData(this.map.painter);
+        tile.unloadVectorData();
         this.dispatcher.send('remove tile', { uid: tile.uid, source: this.id }, null, tile.workerID);
     }
 });


### PR DESCRIPTION
This mirrors `Unique{Buffer,VAO}` in native: a reference to the context is necessary to create, but the resulting object knows how to destroy itself without additional arguments.

It also reduces the number of places where `Source` objects need a painter or map reference (#3350).