### PR TITLE
Support python-like token replacement and formatting

### DIFF
--- a/js/util/token.js
+++ b/js/util/token.js
@@ -2,6 +2,8 @@
 
 module.exports = resolveTokens;
 
+var stringFormat = require('string-format');
+
 /**
  * Replace tokens in a string template with values in an object
  *
@@ -11,7 +13,5 @@ module.exports = resolveTokens;
  * @private
  */
 function resolveTokens(properties, text) {
-    return text.replace(/{([^{}]+)}/g, function(match, key) {
-        return key in properties ? properties[key] : '';
-    });
+    return stringFormat(text, properties);
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "quickselect": "^1.0.0",
     "request": "^2.39.0",
     "shelf-pack": "^1.0.0",
+    "string-format": "^0.5.0",
     "supercluster": "^2.0.1",
     "tinyqueue": "^1.1.0",
     "unassertify": "^2.0.0",


### PR DESCRIPTION
## Launch Checklist

This PR introduces advanced (Python `str.format()`-like) token formatting when using `{fieldname}` string replacement.

The change is backwards compatible with existing syntax, we very conveniently (deliberately?) chose the curly-bracket syntax that is basically compatible with Python's `str.format()`.

The primary motivation for this change is number formatting: `float` and `double` fields encoded in vector tiles are currently unformatted.  Values like `0.1` encoded as a `float` currently end up as text labels like `0.100000005932`.  This change allows you to specify number formatting precision in the Python syntax, like: `{float_field::.2}` for 2 decimal places.

There is an alternatively library at https://github.com/xfix/python-format, which seems to have better test coverage, but does not support using dictionary keys as field names.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page

