### PR TITLE
Ensure removing style or source releases tile resources

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -724,10 +724,10 @@ Style.prototype = util.inherit(Evented, {
     },
 
     _remove: function() {
-        this.dispatcher.remove();
         for (var id in this.sourceCaches) {
             this.sourceCaches[id].clearTiles();
         }
+        this.dispatcher.remove();
     },
 
     _reloadSource: function(id) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -372,6 +372,7 @@ Style.prototype = util.inherit(Evented, {
         delete this.sourceCaches[id];
         delete this._updates.sources[id];
         sourceCache.setEventedParent(null);
+        sourceCache.clearTiles();
 
         if (sourceCache.onRemove) sourceCache.onRemove(this.map);
         this._updates.changed = true;
@@ -724,6 +725,9 @@ Style.prototype = util.inherit(Evented, {
 
     _remove: function() {
         this.dispatcher.remove();
+        for (var id in this.sourceCaches) {
+            this.sourceCaches[id].clearTiles();
+        }
     },
 
     _reloadSource: function(id) {

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -177,6 +177,26 @@ test('Style', function(t) {
     t.end();
 });
 
+test('Style#_remove', function(t) {
+
+    t.test('clears tiles', function(t) {
+        var style = new Style(createStyleJSON({
+            sources: {'source-id': createGeoJSONSource()}
+        }));
+
+        style.on('style.load', function () {
+            var sourceCache = style.sourceCaches['source-id'];
+            sinon.spy(sourceCache, 'clearTiles');
+            style._remove();
+            t.ok(sourceCache.clearTiles.calledOnce);
+            t.end();
+        });
+    });
+
+    t.end();
+
+});
+
 test('Style#_updateWorkerLayers', function(t) {
     var style = new Style({
         'version': 8,
@@ -431,6 +451,20 @@ test('Style#removeSource', function(t) {
             style.addSource('source-id', source);
             style.removeSource('source-id');
             style.update();
+        });
+    });
+
+    t.test('clears tiles', function(t) {
+        var style = new Style(createStyleJSON({
+            sources: {'source-id': createGeoJSONSource()}
+        }));
+
+        style.on('style.load', function () {
+            var sourceCache = style.sourceCaches['source-id'];
+            sinon.spy(sourceCache, 'clearTiles');
+            style.removeSource('source-id');
+            t.ok(sourceCache.clearTiles.calledOnce);
+            t.end();
         });
     });
 


### PR DESCRIPTION
This PR modifies `Style` such that removing a source or removing the style itself clears all tiles in the `SourceCache`.

fixes #3116

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
