### PR TITLE
Layout property proposal: numeric-precision

### DIFF
--- a/js/symbol/resolve_text.js
+++ b/js/symbol/resolve_text.js
@@ -13,16 +13,18 @@ module.exports = resolveText;
  */
 function resolveText(features, layoutProperties, codepoints) {
     var textFeatures = [];
+    var textField = layoutProperties['text-field'];
+    var transform = layoutProperties['text-transform'];
+    var numericMultiplier = Math.pow(10, layoutProperties['numeric-precision']);
 
     for (var i = 0, fl = features.length; i < fl; i++) {
-        var text = resolveTokens(features[i].properties, layoutProperties['text-field']);
+        var text = resolveTokens(features[i].properties, textField, numericMultiplier);
         if (!text) {
             textFeatures[i] = null;
             continue;
         }
         text = text.toString();
 
-        var transform = layoutProperties['text-transform'];
         if (transform === 'uppercase') {
             text = text.toLocaleUpperCase();
         } else if (transform === 'lowercase') {

--- a/js/symbol/resolve_text.js
+++ b/js/symbol/resolve_text.js
@@ -15,7 +15,8 @@ function resolveText(features, layoutProperties, codepoints) {
     var textFeatures = [];
     var textField = layoutProperties['text-field'];
     var transform = layoutProperties['text-transform'];
-    var numericMultiplier = Math.pow(10, layoutProperties['numeric-precision']);
+    var numericPrecision = layoutProperties['numeric-precision'];
+    var numericMultiplier = numericPrecision ? Math.pow(10, numericPrecision) : null;
 
     for (var i = 0, fl = features.length; i < fl; i++) {
         var text = resolveTokens(features[i].properties, textField, numericMultiplier);

--- a/js/symbol/resolve_text.js
+++ b/js/symbol/resolve_text.js
@@ -16,7 +16,8 @@ function resolveText(features, layoutProperties, codepoints) {
     var textField = layoutProperties['text-field'];
     var transform = layoutProperties['text-transform'];
     var numericPrecision = layoutProperties['numeric-precision'];
-    var numericMultiplier = numericPrecision ? Math.pow(10, numericPrecision) : null;
+    if (numericPrecision === undefined) numericPrecision = 8; // to be replaced with spec default
+    var numericMultiplier = Math.pow(10, numericPrecision);
 
     for (var i = 0, fl = features.length; i < fl; i++) {
         var text = resolveTokens(features[i].properties, textField, numericMultiplier);

--- a/js/util/token.js
+++ b/js/util/token.js
@@ -13,7 +13,7 @@ module.exports = resolveTokens;
 function resolveTokens(properties, text, numericMultiplier) {
     return text.replace(/{([^{}]+)}/g, function(match, key) {
         var value = key in properties ? properties[key] : '';
-        if (typeof value === 'number' && numericMultiplier !== undefined) {
+        if (typeof value === 'number' && numericMultiplier != null) {
             value = Math.round(value * numericMultiplier) / numericMultiplier;
         }
         return value;

--- a/js/util/token.js
+++ b/js/util/token.js
@@ -10,8 +10,12 @@ module.exports = resolveTokens;
  * @returns {string} the template with tokens replaced
  * @private
  */
-function resolveTokens(properties, text) {
+function resolveTokens(properties, text, numericMultiplier) {
     return text.replace(/{([^{}]+)}/g, function(match, key) {
-        return key in properties ? properties[key] : '';
+        var value = key in properties ? properties[key] : '';
+        if (typeof value === 'number' && numericMultiplier !== undefined) {
+            value = Math.round(value * numericMultiplier) / numericMultiplier;
+        }
+        return value;
     });
 }

--- a/test/js/util/token.test.js
+++ b/test/js/util/token.test.js
@@ -14,6 +14,7 @@ test('token', function(t) {
     t.equal('dashed', resolveTokens({'dashed-property': 'dashed'}, '{dashed-property}'));
     t.equal('150 m', resolveTokens({'HØYDE': 150}, '{HØYDE} m'));
     t.equal('mapbox', resolveTokens({'$special:characters;': 'mapbox'}, '{$special:characters;}'));
+    t.equal('12.345 m', resolveTokens({foo: 12.345178911111}, '{foo} m', 1e3));
 
     t.end();
 });


### PR DESCRIPTION
An alternative solution for https://github.com/mapbox/mapbox-gl-js/pull/3358. Introduces `numeric-precision` layout property that affects how numbers are interpolated in text fields. If set, 
numbers in resolved text fields of a layer will have the specified precision (e.g. `"numeric-precision": 2` will make `123.45678` appear s `123.46`).

This is just a proof of concept; a proper implementation would require corresponding style-spec changes, including settling on a default value there.

cc @danpat @jfirebaugh 
