### PR TITLE
Fix error in unit tests

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -225,6 +225,8 @@ Style.prototype = util.inherit(Evented, {
     },
 
     _recalculate: function(z) {
+        if (!this._loaded) return;
+
         for (var sourceId in this.sourceCaches)
             this.sourceCaches[sourceId].used = false;
 


### PR DESCRIPTION
Closes #3345 but not recalculating the style if it's not yet loaded. It wasn't throwing before the light/extrude changes by a lucky coincidence.

cc @jfirebaugh @lucaswoj 