### PR TITLE
Fix variable repurposing and out-of-order conditional

### DIFF
--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -39,14 +39,13 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, callback) {
     var bucketsById = {};
     var bucketsBySourceLayer = {};
     var i;
-    var layer;
     var sourceLayerId;
     var bucket;
 
     // Map non-ref layers to buckets.
     var bucketIndex = 0;
     for (var layerId in layerFamilies) {
-        layer = layerFamilies[layerId][0];
+        var layer = layerFamilies[layerId][0];
 
         if (layer.source !== this.source) continue;
         if (layer.ref) continue;
@@ -80,17 +79,15 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, callback) {
     // read each layer, and sort its features into buckets
     if (data.layers) { // vectortile
         for (sourceLayerId in bucketsBySourceLayer) {
-            if (layer.version === 1) {
+            var sourceLayer = data.layers[sourceLayerId];
+            if (sourceLayer.version === 1) {
                 util.warnOnce(
                     'Vector tile source "' + this.source + '" layer "' +
                     sourceLayerId + '" does not use vector tile spec v2 ' +
                     'and therefore may have some rendering errors.'
                 );
             }
-            layer = data.layers[sourceLayerId];
-            if (layer) {
-                sortLayerIntoBuckets(layer, bucketsBySourceLayer[sourceLayerId]);
-            }
+            sortLayerIntoBuckets(sourceLayer, bucketsBySourceLayer[sourceLayerId]);
         }
     } else { // geojson
         sortLayerIntoBuckets(data, bucketsById);


### PR DESCRIPTION
The `layer` variable was being used for both style layers and source layers. As a result, the fact that the `version === 1` conditional was being checked at the wrong point went unnoticed.

The `if (layer)` conditional was also misplaced, but fortunately it didn't matter because the prior loop already skips style layers whose source layer does not exist.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page

