### PR TITLE
Use sinon's sandbox API

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -16,3 +16,9 @@ There are two test suites associated with Mapbox GL JS
  - **You should only test the return values and global side effects of methods.** You should not not test internal behavior, such as that another method is called with particular arguments. This ensures that method implementations may change without causing test failures.
  - **You must not make network requests in test cases.** This rule holds in cases when result isn't used or is expected to fail. You may use `window.useFakeXMLHttpRequest` and `window.server` per the [Sinon API](http://sinonjs.org/docs/#server) to simulate network requests. This ensures that tests are reliable, able to be run in an isolated environment, and performant.
  - **You should use clear [input space partitioning](http://crystal.uta.edu/~ylei/cse4321/data/isp.pdf) schemes.** Look for edge cases! This ensures that tests suites are comprehensive and easy to understand.
+
+## Spies, Stubs, and Mocks
+
+The test object is augmented with methods from Sinon.js for [spies](http://sinonjs.org/docs/#spies), [stubs](http://sinonjs.org/docs/#stubs), and [mocks](http://sinonjs.org/docs/#mocks). For example, to use Sinon's spy API, call `t.spy(...)` within a test.
+
+The test framework is set up such that spies, stubs, and mocks on global objects are restored at the end of each test.

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Bucket = require('../../../js/data/bucket');
 var util = require('../../../js/util/util');
 var StyleLayer = require('../../../js/style/style_layer');

--- a/test/js/data/buffer.test.js
+++ b/test/js/data/buffer.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Buffer = require('../../../js/data/buffer');
 var StructArrayType = require('../../../js/util/struct_array');
 

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var fs = require('fs');
 var Protobuf = require('pbf');
 var VectorTile = require('vector-tile').VectorTile;

--- a/test/js/data/line_bucket.test.js
+++ b/test/js/data/line_bucket.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var fs = require('fs');
 var path = require('path');
 var Protobuf = require('pbf');

--- a/test/js/data/load_geometry.test.js
+++ b/test/js/data/load_geometry.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var fs = require('fs');
 var path = require('path');
 var Protobuf = require('pbf');

--- a/test/js/data/symbol_bucket.test.js
+++ b/test/js/data/symbol_bucket.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
-var sinon = require('sinon');
+var test = require('mapbox-gl-js-test').test;
 var fs = require('fs');
 var path = require('path');
 var Protobuf = require('pbf');
@@ -81,7 +80,7 @@ test('SymbolBucket', function(t) {
 test('SymbolBucket integer overflow', function(t) {
     var bucket = bucketSetup();
     var numWarnings = 0;
-    sinon.stub(util, 'warnOnce', function(warning) {
+    t.stub(util, 'warnOnce', function(warning) {
         if (warning.includes('Too many symbols being rendered in a tile.') || warning.includes('Too many glyphs being rendered in a tile.')) numWarnings++;
     });
     // save correct value of MAX_QUADS

--- a/test/js/geo/coordinate.test.js
+++ b/test/js/geo/coordinate.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Coordinate = require('../../../js/geo/coordinate');
 
 test('Coordinate', function(t) {

--- a/test/js/geo/lng_lat.test.js
+++ b/test/js/geo/lng_lat.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var LngLat = require('../../../js/geo/lng_lat');
 
 test('LngLat', function(t) {

--- a/test/js/geo/lng_lat_bounds.test.js
+++ b/test/js/geo/lng_lat_bounds.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var LngLat = require('../../../js/geo/lng_lat');
 var LngLatBounds = require('../../../js/geo/lng_lat_bounds');
 

--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Point = require('point-geometry');
 var Transform = require('../../../js/geo/transform');
 var TileCoord = require('../../../js/source/tile_coord');

--- a/test/js/mapbox-gl.js
+++ b/test/js/mapbox-gl.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var proxyquire = require('proxyquire');
 var mapboxgl = require('../../js/mapbox-gl');
 

--- a/test/js/source/geojson_source.test.js
+++ b/test/js/source/geojson_source.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Tile = require('../../../js/source/tile');
 var TileCoord = require('../../../js/source/tile_coord');
 var GeoJSONSource = require('../../../js/source/geojson_source');

--- a/test/js/source/geojson_wrapper.test.js
+++ b/test/js/source/geojson_wrapper.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Wrapper = require('../../../js/source/geojson_wrapper');
 
 test('geojsonwrapper', function(t) {

--- a/test/js/source/query_features.test.js
+++ b/test/js/source/query_features.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var QueryFeatures = require('../../../js/source/query_features.js');
 var SourceCache = require('../../../js/source/source_cache.js');
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var SourceCache = require('../../../js/source/source_cache');
 var Source = require('../../../js/source/source');
 var TileCoord = require('../../../js/source/tile_coord');

--- a/test/js/source/tile.test.js
+++ b/test/js/source/tile.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Tile = require('../../../js/source/tile');
 var GeoJSONWrapper = require('../../../js/source/geojson_wrapper');
 var TileCoord = require('../../../js/source/tile_coord');
 var fs = require('fs');
 var path = require('path');
 var vtpbf = require('vt-pbf');
-var sinon = require('sinon');
 var FeatureIndex = require('../../../js/data/feature_index');
 var CollisionTile = require('../../../js/symbol/collision_tile');
 var CollisionBoxArray = require('../../../js/symbol/collision_box');
@@ -82,7 +81,7 @@ test('querySourceFeatures', function(t) {
     t.test('loadVectorData unloads existing data before overwriting it', function(t) {
         var tile = new Tile(new TileCoord(1, 1, 1));
         tile.state = 'loaded';
-        sinon.stub(tile, 'unloadVectorData');
+        t.stub(tile, 'unloadVectorData');
         var painter = {};
 
         tile.loadVectorData(null, painter);

--- a/test/js/source/tile_coord.test.js
+++ b/test/js/source/tile_coord.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var TileCoord = require('../../../js/source/tile_coord');
 
 test('TileCoord', function(t) {

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var VectorTileSource = require('../../../js/source/vector_tile_source');
 var TileCoord = require('../../../js/source/tile_coord');
 var window = require('../../../js/util/window');

--- a/test/js/source/vector_tile_worker_source.test.js
+++ b/test/js/source/vector_tile_worker_source.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var VectorTileWorkerSource = require('../../../js/source/vector_tile_worker_source');
 
 var styleLayers = {

--- a/test/js/source/worker.test.js
+++ b/test/js/source/worker.test.js
@@ -2,7 +2,7 @@
 
 /* jshint -W079 */
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Worker = require('../../../js/source/worker');
 var window = require('../../../js/util/window');
 

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var WorkerTile = require('../../../js/source/worker_tile');
 var Wrapper = require('../../../js/source/geojson_wrapper');
 var TileCoord = require('../../../js/source/tile_coord');

--- a/test/js/style/animation_loop.test.js
+++ b/test/js/style/animation_loop.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var AnimationLoop = require('../../../js/style/animation_loop');
 
 test('animationloop', function(t) {

--- a/test/js/style/light.test.js
+++ b/test/js/style/light.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Light = require('../../../js/style/light');
 var spec = require('../../../js/style/style_spec').$root.light;
 

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
-var sinon = require('sinon');
+var test = require('mapbox-gl-js-test').test;
 var proxyquire = require('proxyquire');
 var Style = require('../../../js/style/style');
 var SourceCache = require('../../../js/source/source_cache');
@@ -186,7 +185,7 @@ test('Style#_remove', function(t) {
 
         style.on('style.load', function () {
             var sourceCache = style.sourceCaches['source-id'];
-            sinon.spy(sourceCache, 'clearTiles');
+            t.spy(sourceCache, 'clearTiles');
             style._remove();
             t.ok(sourceCache.clearTiles.calledOnce);
             t.end();
@@ -461,7 +460,7 @@ test('Style#removeSource', function(t) {
 
         style.on('style.load', function () {
             var sourceCache = style.sourceCaches['source-id'];
-            sinon.spy(sourceCache, 'clearTiles');
+            t.spy(sourceCache, 'clearTiles');
             style.removeSource('source-id');
             t.ok(sourceCache.clearTiles.calledOnce);
             t.end();
@@ -1137,7 +1136,7 @@ test('Style#queryRenderedFeatures', function(t) {
 
         t.test('fires an error if layer included in params does not exist on the style', function(t) {
             var errors = 0;
-            sinon.stub(style, 'fire', function(type, data) {
+            t.stub(style, 'fire', function(type, data) {
                 if (data.error && data.error.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
             });
             style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']});
@@ -1161,10 +1160,10 @@ test('Style defers expensive methods', function(t) {
         style.update();
 
         // spies to track defered methods
-        sinon.spy(style, 'fire');
-        sinon.spy(style, '_reloadSource');
-        sinon.spy(style, '_updateWorkerLayers');
-        sinon.spy(style, '_groupLayers');
+        t.spy(style, 'fire');
+        t.spy(style, '_reloadSource');
+        t.spy(style, '_updateWorkerLayers');
+        t.spy(style, '_groupLayers');
 
         style.addLayer({ id: 'first', type: 'symbol', source: 'streets' });
         style.addLayer({ id: 'second', type: 'symbol', source: 'streets' });
@@ -1219,7 +1218,7 @@ test('Style#query*Features', function(t) {
             }]
         });
 
-        onError = sinon.spy();
+        onError = t.spy();
 
         style.on('error', onError)
             .on('style.load', function() {

--- a/test/js/style/style_declaration.test.js
+++ b/test/js/style/style_declaration.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var StyleDeclaration = require('../../../js/style/style_declaration');
 
 test('StyleDeclaration', function(t) {

--- a/test/js/style/style_layer.test.js
+++ b/test/js/style/style_layer.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var StyleLayer = require('../../../js/style/style_layer');
 var FillStyleLayer = require('../../../js/style/style_layer/fill_style_layer');
 var util = require('../../../js/util/util');

--- a/test/js/symbol/anchor.test.js
+++ b/test/js/symbol/anchor.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Anchor = require('../../../js/symbol/anchor');
 
 test('Anchor', function(t) {

--- a/test/js/symbol/check_max_angle.test.js
+++ b/test/js/symbol/check_max_angle.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Point = require('point-geometry');
 var checkMaxAngle = require('../../../js/symbol/check_max_angle');
 var Anchor = require('../../../js/symbol/anchor');

--- a/test/js/symbol/collision_feature.js
+++ b/test/js/symbol/collision_feature.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var CollisionFeature = require('../../../js/symbol/collision_feature');
 var Anchor = require('../../../js/symbol/anchor');
 var Point = require('point-geometry');

--- a/test/js/symbol/get_anchors.test.js
+++ b/test/js/symbol/get_anchors.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Point = require('point-geometry');
 var getAnchors = require('../../../js/symbol/get_anchors');
 

--- a/test/js/symbol/mergelines.test.js
+++ b/test/js/symbol/mergelines.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var mergeLines = require('../../../js/symbol/mergelines');
 var Point = require('point-geometry');
 

--- a/test/js/symbol/quads.test.js
+++ b/test/js/symbol/quads.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 
 var getIconQuads = require('../../../js/symbol/quads').getIconQuads;
 var Anchor = require('../../../js/symbol/anchor');

--- a/test/js/symbol/resolve_text.test.js
+++ b/test/js/symbol/resolve_text.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var resolveText = require('../../../js/symbol/resolve_text');
 
 function mockFeature(obj) {

--- a/test/js/symbol/shaping.test.js
+++ b/test/js/symbol/shaping.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var fs = require('fs');
 var path = require('path');
 var shaping = require('../../../js/symbol/shaping');

--- a/test/js/ui/camera.test.js
+++ b/test/js/ui/camera.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Camera = require('../../../js/ui/camera');
 var Evented = require('../../../js/util/evented');
 var Transform = require('../../../js/geo/transform');

--- a/test/js/ui/control/attribution.test.js
+++ b/test/js/ui/control/attribution.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var window = require('../../../../js/util/window');
 var Map = require('../../../../js/ui/map');
 var AttributionControl = require('../../../../js/ui/control/attribution_control');

--- a/test/js/ui/hash.test.js
+++ b/test/js/ui/hash.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Hash = require('../../../js/ui/hash');
 var window = require('../../../js/util/window');
 var Map = require('../../../js/ui/map');

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -1,11 +1,10 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var util = require('../../../js/util/util');
 var window = require('../../../js/util/window');
 var Map = require('../../../js/ui/map');
 var LngLat = require('../../../js/geo/lng_lat');
-var sinon = require('sinon');
 
 var fixed = require('../../testutil/fixed');
 var fixedNum = fixed.Num;
@@ -329,9 +328,9 @@ test('Map', function(t) {
         t.test('do not resize if trackResize is false', function (t) {
             var map = createMap({trackResize: false});
 
-            sinon.spy(map, 'stop');
-            sinon.spy(map, '_update');
-            sinon.spy(map, 'resize');
+            t.spy(map, 'stop');
+            t.spy(map, '_update');
+            t.spy(map, 'resize');
 
             map._onWindowResize();
 
@@ -345,9 +344,9 @@ test('Map', function(t) {
         t.test('do resize if trackResize is true (default)', function (t) {
             var map = createMap();
 
-            sinon.spy(map, 'stop');
-            sinon.spy(map, '_update');
-            sinon.spy(map, 'resize');
+            t.spy(map, 'stop');
+            t.spy(map, '_update');
+            t.spy(map, 'resize');
 
             map._onWindowResize();
 
@@ -560,7 +559,7 @@ test('Map', function(t) {
         t.test('if no arguments provided', function(t) {
             createMap({}, function(err, map) {
                 t.error(err);
-                sinon.spy(map.style, 'queryRenderedFeatures');
+                t.spy(map.style, 'queryRenderedFeatures');
 
                 var output = map.queryRenderedFeatures();
 
@@ -576,7 +575,7 @@ test('Map', function(t) {
         t.test('if only "geometry" provided', function(t) {
             createMap({}, function(err, map) {
                 t.error(err);
-                sinon.spy(map.style, 'queryRenderedFeatures');
+                t.spy(map.style, 'queryRenderedFeatures');
 
                 var output = map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
 
@@ -594,7 +593,7 @@ test('Map', function(t) {
         t.test('if only "params" provided', function(t) {
             createMap({}, function(err, map) {
                 t.error(err);
-                sinon.spy(map.style, 'queryRenderedFeatures');
+                t.spy(map.style, 'queryRenderedFeatures');
 
                 var output = map.queryRenderedFeatures({filter: ['all']});
 
@@ -610,7 +609,7 @@ test('Map', function(t) {
         t.test('if both "geometry" and "params" provided', function(t) {
             createMap({}, function(err, map) {
                 t.error(err);
-                sinon.spy(map.style, 'queryRenderedFeatures');
+                t.spy(map.style, 'queryRenderedFeatures');
 
                 var output = map.queryRenderedFeatures({filter: ['all']});
 
@@ -626,7 +625,7 @@ test('Map', function(t) {
         t.test('if "geometry" with unwrapped coords provided', function(t) {
             createMap({}, function(err, map) {
                 t.error(err);
-                sinon.spy(map.style, 'queryRenderedFeatures');
+                t.spy(map.style, 'queryRenderedFeatures');
 
                 map.queryRenderedFeatures(map.project(new LngLat(360, 0)));
 
@@ -931,8 +930,8 @@ test('Map', function(t) {
         t.test('logs errors to console when it has NO listeners', function (t) {
             var map = createMap({ style: { version: 8, sources: {}, layers: [] } });
 
-            sinon.spy(map, 'fire');
-            sinon.stub(console, 'error', function(error) {
+            t.spy(map, 'fire');
+            t.stub(console, 'error', function(error) {
                 if (error.message === 'version: expected one of [8], 7 found') {
                     t.notOk(map.fire.calledWith('error'));
                     console.error.restore();
@@ -949,7 +948,7 @@ test('Map', function(t) {
         t.test('calls listeners', function (t) {
             var map = createMap({ style: { version: 8, sources: {}, layers: [] } });
 
-            sinon.spy(console, 'error');
+            t.spy(console, 'error');
             map.on('error', function(event) {
                 t.equal(event.error.message, 'version: expected one of [8], 7 found');
                 t.notOk(console.error.calledWith('version: expected one of [8], 7 found'));

--- a/test/js/ui/marker.test.js
+++ b/test/js/ui/marker.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var window = require('../../../js/util/window');
 var Map = require('../../../js/ui/map');
 var Marker = require('../../../js/ui/marker');

--- a/test/js/ui/popup.test.js
+++ b/test/js/ui/popup.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
-var sinon = require('sinon');
+var test = require('mapbox-gl-js-test').test;
 var window = require('../../../js/util/window');
 var Map = require('../../../js/ui/map');
 var Popup = require('../../../js/ui/popup');
@@ -84,7 +83,7 @@ test('Popup has no close button if closeButton option is false', function (t) {
 
 test('Popup fires close event when removed', function (t) {
     var map = createMap();
-    var onClose = sinon.spy();
+    var onClose = t.spy();
 
     new Popup()
         .setText("Test")
@@ -213,7 +212,7 @@ test('Popup anchors as specified by the anchor option', function (t) {
         popup._container.offsetWidth = 100;
         popup._container.offsetHeight = 100;
 
-        sinon.stub(map, 'project', function () { return point; });
+        t.stub(map, 'project', function () { return point; });
         popup.setLngLat([0, 0]);
 
         t.ok(popup._container.classList.contains(`mapboxgl-popup-anchor-${anchor}`));
@@ -222,7 +221,7 @@ test('Popup anchors as specified by the anchor option', function (t) {
 
     test(`Popup translation reflects offset and ${anchor} anchor`, function (t) {
         var map = createMap();
-        sinon.stub(map, 'project', function () { return new Point(0, 0); });
+        t.stub(map, 'project', function () { return new Point(0, 0); });
 
         var popup = new Popup({anchor: anchor, offset: 10})
             .setLngLat([0, 0])
@@ -249,7 +248,7 @@ test('Popup automatically anchors to top if its bottom offset would push it off-
     popup._container.offsetWidth = (containerWidth / 2);
     popup._container.offsetHeight = (containerHeight / 2);
 
-    sinon.stub(map, 'project', function () { return point; });
+    t.stub(map, 'project', function () { return point; });
     popup.setLngLat([0, 0]);
 
     t.ok(popup._container.classList.contains('mapboxgl-popup-anchor-top'));
@@ -258,7 +257,7 @@ test('Popup automatically anchors to top if its bottom offset would push it off-
 
 test('Popup is offset via a PointLike offset option', function (t) {
     var map = createMap();
-    sinon.stub(map, 'project', function () { return new Point(0, 0); });
+    t.stub(map, 'project', function () { return new Point(0, 0); });
 
     var popup = new Popup({anchor: 'top-left', offset: [5, 10]})
         .setLngLat([0, 0])
@@ -271,7 +270,7 @@ test('Popup is offset via a PointLike offset option', function (t) {
 
 test('Popup is offset via an object offset option', function (t) {
     var map = createMap();
-    sinon.stub(map, 'project', function () { return new Point(0, 0); });
+    t.stub(map, 'project', function () { return new Point(0, 0); });
 
     var popup = new Popup({anchor: 'top-left', offset: {'top-left': [5, 10]}})
         .setLngLat([0, 0])

--- a/test/js/util/actor.test.js
+++ b/test/js/util/actor.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var proxyquire = require('proxyquire');
 var Actor = require('../../../js/util/actor');
 

--- a/test/js/util/browser.test.js
+++ b/test/js/util/browser.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var browser = require('../../../js/util/browser');
 
 test('browser', function(t) {

--- a/test/js/util/classify_rings.test.js
+++ b/test/js/util/classify_rings.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var fs = require('fs');
 var path = require('path');
 var Protobuf = require('pbf');

--- a/test/js/util/dispatcher.test.js
+++ b/test/js/util/dispatcher.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var proxyquire = require('proxyquire');
 var Dispatcher = require('../../../js/util/dispatcher');
 var WebWorker = require('../../../js/util/web_worker');

--- a/test/js/util/evented.test.js
+++ b/test/js/util/evented.test.js
@@ -1,14 +1,13 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Evented = require('../../../js/util/evented');
-var sinon = require('sinon');
 
 test('Evented', function(t) {
 
     t.test('calls listeners added with "on"', function(t) {
         var evented = Object.create(Evented);
-        var listener = sinon.spy();
+        var listener = t.spy();
         evented.on('a', listener);
         evented.fire('a');
         evented.fire('a');
@@ -18,7 +17,7 @@ test('Evented', function(t) {
 
     t.test('calls listeners added with "once" once', function(t) {
         var evented = Object.create(Evented);
-        var listener = sinon.spy();
+        var listener = t.spy();
         evented.once('a', listener);
         evented.fire('a');
         evented.fire('a');
@@ -55,7 +54,7 @@ test('Evented', function(t) {
 
     t.test('removes listeners with "off"', function(t) {
         var evented = Object.create(Evented);
-        var listener = sinon.spy();
+        var listener = t.spy();
         evented.on('a', listener);
         evented.off('a', listener);
         evented.fire('a');
@@ -83,7 +82,7 @@ test('Evented', function(t) {
     t.test('evented parents', function(t) {
 
         t.test('adds parents with "setEventedParent"', function(t) {
-            var listener = sinon.spy();
+            var listener = t.spy();
             var eventedSource = Object.create(Evented);
             var eventedSink = Object.create(Evented);
             eventedSource.setEventedParent(eventedSink);
@@ -129,7 +128,7 @@ test('Evented', function(t) {
         });
 
         t.test('removes parents with "setEventedParent(null)"', function(t) {
-            var listener = sinon.spy();
+            var listener = t.spy();
             var eventedSource = Object.create(Evented);
             var eventedSink = Object.create(Evented);
             eventedSink.on('a', listener);

--- a/test/js/util/find_pole_of_inaccessibility.test.js
+++ b/test/js/util/find_pole_of_inaccessibility.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Point = require('point-geometry');
 var findPoleOfInaccessibility = require('../../../js/util/find_pole_of_inaccessibility');
 

--- a/test/js/util/interpolate.test.js
+++ b/test/js/util/interpolate.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var interpolate = require('../../../js/util/interpolate');
 
 test('interpolate.number', function(t) {

--- a/test/js/util/lru_cache.test.js
+++ b/test/js/util/lru_cache.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var LRUCache = require('../../../js/util/lru_cache');
 
 test('LRUCache', function(t) {

--- a/test/js/util/mapbox.test.js
+++ b/test/js/util/mapbox.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var mapbox = require('../../../js/util/mapbox');
 var config = require('../../../js/util/config');
 var browser = require('../../../js/util/browser');

--- a/test/js/util/struct_array.test.js
+++ b/test/js/util/struct_array.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var StructArrayType = require('../../../js/util/struct_array');
 
 test('StructArray', function(t) {

--- a/test/js/util/token.test.js
+++ b/test/js/util/token.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var resolveTokens = require('../../../js/util/token');
 
 test('token', function(t) {

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var Coordinate = require('../../../js/geo/coordinate');
 var util = require('../../../js/util/util');
 

--- a/test/js/util/worker_pool.test.js
+++ b/test/js/util/worker_pool.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require('tap').test;
+var test = require('mapbox-gl-js-test').test;
 var proxyquire = require('proxyquire');
 
 test('WorkerPool', function (t) {

--- a/test/node_modules/mapbox-gl-js-test.js
+++ b/test/node_modules/mapbox-gl-js-test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var tap = module.exports = require('tap');
+var sinon = require('sinon');
+
+tap.beforeEach(function (done) {
+    this.sandbox = sinon.sandbox.create({
+        injectInto: this,
+        properties: ['spy', 'stub', 'mock']
+    });
+    done();
+});
+
+tap.afterEach(function (done) {
+    this.sandbox.restore();
+    done();
+});


### PR DESCRIPTION
Create a sandbox in a global `beforeEach` callback, and restore it in a global `afterEach` callback. Inject the methods into the tap `Test` object so that they are accessible via `t.spy`, `t.stub`, etc., and use those exclusively.

This ensures that a stubbed or spied global method (e.g. `util.warnOnce`) does not linger beyond a single test case.