### PR TITLE
Add WorkerTile tests

### DIFF
--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -5,16 +5,11 @@ var WorkerTile = require('../../../js/source/worker_tile');
 var Wrapper = require('../../../js/source/geojson_wrapper');
 var TileCoord = require('../../../js/source/tile_coord');
 var StyleLayer = require('../../../js/style/style_layer');
+var util = require('../../../js/util/util');
 var featureFilter = require('feature-filter');
 
-test('basic', function(t) {
-    var features = [{
-        type: 1,
-        geometry: [0, 0],
-        tags: {}
-    }];
-
-    var tile = new WorkerTile({
+function createWorkerTile() {
+    return new WorkerTile({
         uid: '',
         zoom: 0,
         maxZoom: 20,
@@ -23,52 +18,112 @@ test('basic', function(t) {
         coord: new TileCoord(1, 1, 1),
         overscaling: 1
     });
+}
 
-    t.test('basic worker tile', function(t) {
-        var layerFamilies = {
-            test: [new StyleLayer({
-                id: 'test',
-                source: 'source',
-                type: 'circle',
-                layout: {},
-                compare: function () { return true; },
-                filter: featureFilter()
-            })]
-        };
+function createWrapper() {
+    return new Wrapper([{
+        type: 1,
+        geometry: [0, 0],
+        tags: {}
+    }]);
+}
 
-        tile.parse(new Wrapper(features), layerFamilies, {}, function(err, result) {
-            t.equal(err, null);
-            t.ok(result.buckets[0]);
-            t.end();
-        });
+test('WorkerTile#parse', function(t) {
+    var layerFamilies = {
+        test: [new StyleLayer({
+            id: 'test',
+            source: 'source',
+            type: 'circle',
+            layout: {},
+            compare: function () { return true; },
+            filter: featureFilter()
+        })]
+    };
+
+    var tile = createWorkerTile();
+    tile.parse(createWrapper(), layerFamilies, {}, function(err, result) {
+        t.ifError(err);
+        t.ok(result.buckets[0]);
+        t.end();
     });
+});
 
-    t.test('hidden layers', function(t) {
-        var layerFamilies = {
-            'test': [new StyleLayer({
-                id: 'test',
-                source: 'source',
-                type: 'circle',
-                layout: {},
-                compare: function () { return true; },
-                filter: featureFilter()
-            })],
-            'test-hidden': [new StyleLayer({
-                id: 'test-hidden',
-                source: 'source',
-                type: 'fill',
-                layout: { visibility: 'none' },
-                compare: function () { return true; },
-                filter: featureFilter()
-            })]
-        };
+test('WorkerTile#parse skips hidden layers', function(t) {
+    var layerFamilies = {
+        'test': [new StyleLayer({
+            id: 'test',
+            source: 'source',
+            type: 'circle',
+            layout: {},
+            compare: function () { return true; },
+            filter: featureFilter()
+        })],
+        'test-hidden': [new StyleLayer({
+            id: 'test-hidden',
+            source: 'source',
+            type: 'fill',
+            layout: { visibility: 'none' },
+            compare: function () { return true; },
+            filter: featureFilter()
+        })]
+    };
 
-        tile.parse(new Wrapper(features), layerFamilies, {}, function(err, result) {
-            t.equal(err, null);
-            t.equal(Object.keys(result.buckets[0].arrays).length, 1, 'array groups exclude hidden layer');
-            t.end();
-        });
+    var tile = createWorkerTile();
+    tile.parse(createWrapper(), layerFamilies, {}, function(err, result) {
+        t.ifError(err);
+        t.equal(Object.keys(result.buckets[0].arrays).length, 1);
+        t.end();
     });
+});
 
-    t.end();
+test('WorkerTile#parse skips layers without a corresponding source layer', function(t) {
+    var layerFamilies = {
+        'test-sourceless': [new StyleLayer({
+            id: 'test',
+            source: 'source',
+            'source-layer': 'nonesuch',
+            type: 'fill',
+            layout: {},
+            compare: function () { return true; },
+            filter: featureFilter()
+        })]
+    };
+
+    var tile = createWorkerTile();
+    tile.parse({layers: {}}, layerFamilies, {}, function(err, result) {
+        t.ifError(err);
+        t.equal(result.buckets.length, 0);
+        t.end();
+    });
+});
+
+test('WorkerTile#parse warns once when encountering a v1 vector tile layer', function(t) {
+    var layerFamilies = {
+        'test': [new StyleLayer({
+            id: 'test',
+            source: 'source',
+            'source-layer': 'test',
+            type: 'fill',
+            layout: {},
+            compare: function () { return true; },
+            filter: featureFilter()
+        })]
+    };
+
+    var data = {
+        layers: {
+            test: {
+                version: 1
+            }
+        }
+    };
+
+    t.stub(util, 'warnOnce');
+
+    var tile = createWorkerTile();
+    tile.parse(data, layerFamilies, {}, function(err) {
+        t.ifError(err);
+        t.ok(util.warnOnce.calledWithMatch(/does not use vector tile spec v2/));
+        t.end();
+    });
 });


### PR DESCRIPTION
Depends on #3375. Adds tests for #3369.

* WorkerTile#parse skips layers without a corresponding source layer
* WorkerTile#parse warns once when encountering a v1 vector tile layer

While here, rewrite the existing tests to conform more closely with our test guidelines. (Though technically they still mock domain objects.)