### PR TITLE
Render raster loop

### DIFF
--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -254,9 +254,8 @@ class SourceCache extends Evented {
                 return tile;
             }
             if (this._cache.has(coord.id)) {
-                this.addTile(coord);
                 retain[coord.id] = true;
-                return this._tiles[coord.id];
+                return this._cache.get(coord.id);
             }
         }
     }
@@ -332,7 +331,10 @@ class SourceCache extends Evented {
             // The tile we require is not yet loaded.
             // Retain child or parent tiles that cover the same area.
             if (!this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
-                this.findLoadedParent(coord, minCoveringZoom, retain);
+                var parent = this.findLoadedParent(coord, minCoveringZoom, retain);
+                if (parent) {
+                  this.addTile(parent.coord);
+                }
             }
         }
 
@@ -348,7 +350,10 @@ class SourceCache extends Evented {
                 if (this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
                     retain[id] = true;
                 }
-                this.findLoadedParent(coord, minCoveringZoom, parentsForFading);
+                var parent = this.findLoadedParent(coord, minCoveringZoom, parentsForFading);
+                if (parent) {
+                  this.addTile(parent.coord);
+                }
             }
         }
 

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -287,6 +287,7 @@ class SourceCache extends Evented {
         let i;
         let coord;
         let tile;
+        let parentTile;
 
         this.updateCacheSize(transform);
 
@@ -331,9 +332,9 @@ class SourceCache extends Evented {
             // The tile we require is not yet loaded.
             // Retain child or parent tiles that cover the same area.
             if (!this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
-                var parent = this.findLoadedParent(coord, minCoveringZoom, retain);
-                if (parent) {
-                  this.addTile(parent.coord);
+                parentTile = this.findLoadedParent(coord, minCoveringZoom, retain);
+                if (parentTile) {
+                    this.addTile(parentTile.coord);
                 }
             }
         }
@@ -350,9 +351,9 @@ class SourceCache extends Evented {
                 if (this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
                     retain[id] = true;
                 }
-                var parent = this.findLoadedParent(coord, minCoveringZoom, parentsForFading);
-                if (parent) {
-                  this.addTile(parent.coord);
+                parentTile = this.findLoadedParent(coord, minCoveringZoom, parentsForFading);
+                if (parentTile) {
+                    this.addTile(parentTile.coord);
                 }
             }
         }

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -737,7 +737,7 @@ test('SourceCache#findLoadedParent', (t) => {
         t.end();
     });
 
-    t.test('adds from cache', (t) => {
+    t.test('retains parents', (t) => {
         const sourceCache = createSourceCache({});
         sourceCache.onAdd();
         const tr = new Transform();
@@ -756,7 +756,6 @@ test('SourceCache#findLoadedParent', (t) => {
         t.equal(sourceCache.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
         t.deepEqual(retain, expectedRetain);
         t.equal(sourceCache._cache.order.length, 0);
-        t.equal(sourceCache._tiles[tile.coord.id], tile);
 
         t.end();
     });


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-gl-js/issues/3398

Tested this using a modified "debug" page.

The issue is somewhat complex but here's a pseudo code description of the looping behavior:

```
map: _render()
  if _sourcesDirty?
    this._sourcesDirty = false;
    this.style._updateSources(this.transform)
      source_cache: update()
        recompute `visibleCoords` without parent id.
        source_cache: removeTile(someParent)
          triggers 'data' event with { tile: tile, dataType: 'tile' }
            maps: _update()
              maps._sourcesDirty = true;
               maps: _rerender
                 sets up reqAnimFrame listener on next render.
  painter: Painter.render()
    painter: Painter.renderLayer()
      draw_raster: drawRaster()
        draw_raster: drawRasterTile()
          source_cache: findLoadedParent()
            source_cache: addTile()
              adds the tile back to source_cache._tiles
```

To break out of this loop, I avoid adding the tile back inside of `drawRasterTile()`
