### PR TITLE
Add a zoom to linestring bounds example

### DIFF
--- a/docs/_posts/examples/3400-01-28-zoomto-linestring.html
+++ b/docs/_posts/examples/3400-01-28-zoomto-linestring.html
@@ -1,0 +1,107 @@
+---
+layout: example
+category: example
+title: Fit to the bounds of a LineString
+description: "Get the bounds of a LineString by passing it's first coordinates to <a href='https://www.mapbox.com/mapbox-gl-js/api/#LngLatBounds'>mapboxgl.LngLatBounds</a> and chaining <a href='https://www.mapbox.com/mapbox-gl-js/api/#LngLatBounds#extend'>extend</a> to include the last coordinates."
+tags:
+  - user-interaction
+---
+<style>
+.btn-control {
+    font:bold 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    background-color: #3386c0;
+    color: #fff;
+    position: absolute;
+    top: 20px;
+    left: 50%;
+    z-index: 1;
+    border: none;
+    width: 200px;
+    margin-left:-100px;
+    display: block;
+    cursor: pointer;
+    padding: 10px 20px;
+    border-radius: 3px;
+}
+
+.btn-control:hover {
+    background-color: #4ea0da;
+}
+</style>
+<div id='map'></div>
+<button id='zoomto' class='btn-control'>Zoom to bounds</nav>
+
+<script>
+// A GeoJSON object with a LineString route from the White House to Capitol Hill
+var geojson = {
+    "type": "FeatureCollection",
+    "features": [{
+        "type": "Feature",
+        "geometry": {
+            "type": "LineString",
+            "properties": {},
+            "coordinates": [
+                [-77.0366048812866, 38.89873175227713],
+                [-77.03364372253417, 38.89876515143842],
+                [-77.03364372253417, 38.89549195896866],
+                [-77.02982425689697, 38.89549195896866],
+                [-77.02400922775269, 38.89387200688839],
+                [-77.01519012451172, 38.891416957534204],
+                [-77.01521158218382, 38.892068305429156],
+                [-77.00813055038452, 38.892051604275686],
+                [-77.00832366943358, 38.89143365883688],
+                [-77.00818419456482, 38.89082405874451],
+                [-77.00815200805664, 38.88989712255097]
+            ]
+        }
+    }]
+};
+
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/light-v9',
+    center: [-77.0214, 38.8970],
+    zoom: 12
+});
+
+map.on('load', function() {
+    // Add a GeoJSON source containing place coordinates and information.
+    map.addSource("LineString", {
+        "type": "geojson",
+        "data": geojson
+    });
+
+    map.addLayer({
+        "id": "LineString",
+        "type": "line",
+        "source": "LineString",
+        "layout": {
+            "line-join": "round",
+            "line-cap": "round"
+        },
+        "paint": {
+            "line-color": "#BF93E4",
+            "line-width": 5
+        }
+    });
+
+    document.getElementById('zoomto').addEventListener('click', function() {
+
+        // Geographic coordinates of the LineString
+        var coordinates = geojson.features[0].geometry.coordinates;
+
+        // Pass the first coordinates in the LineString to `lngLatBounds` &
+        // wrap each coordinate pair in `extend` to include them in the bounds
+        // result. A variation of this technique could be applied to zooming
+        // to the bounds of multiple Points or Polygon geomteries - it just
+        // requires wrapping all the coordinates with the extend method.
+        var bounds = coordinates.reduce(function(bounds, coord) {
+            return bounds.extend(coord);
+        }, new mapboxgl.LngLatBounds(coordinates[0], coordinates[0]));
+
+        map.fitBounds(bounds, {
+            padding: 20
+        });
+    });
+});
+</script>


### PR DESCRIPTION
Demonstrates chaining [extend](https://www.mapbox.com/mapbox-gl-js/api/#LngLatBounds#extend) to [LngLatBounds](https://www.mapbox.com/mapbox-gl-js/api/#LngLatBounds) as a cheap alternative to using Turf to determine a features bounds

![fit-to-bounds](https://cloud.githubusercontent.com/assets/61150/19490148/016d3020-953c-11e6-9439-4db96c0d26d2.gif)

