### PR TITLE
Worker refactor

### DIFF
--- a/js/source/geojson_worker_source.js
+++ b/js/source/geojson_worker_source.js
@@ -17,15 +17,15 @@ module.exports = GeoJSONWorkerSource;
  * This class is designed to be easily reused to support custom source types
  * for data formats that can be parsed/converted into an in-memory GeoJSON
  * representation.  To do so, create it with
- * `new GeoJSONWorkerSource(actor, styleLayers, customLoadGeoJSONFunction)`.  For a full example, see [mapbox-gl-topojson](https://github.com/developmentseed/mapbox-gl-topojson).
+ * `new GeoJSONWorkerSource(actor, layerIndex, customLoadGeoJSONFunction)`.  For a full example, see [mapbox-gl-topojson](https://github.com/developmentseed/mapbox-gl-topojson).
  *
  * @class GeoJSONWorkerSource
  * @private
  * @param {Function} [loadGeoJSON] Optional method for custom loading/parsing of GeoJSON based on parameters passed from the main-thread Source.  See {@link GeoJSONWorkerSource#loadGeoJSON}.
  */
-function GeoJSONWorkerSource (actor, styleLayers, loadGeoJSON) {
+function GeoJSONWorkerSource (actor, layerIndex, loadGeoJSON) {
     if (loadGeoJSON) { this.loadGeoJSON = loadGeoJSON; }
-    VectorTileWorkerSource.call(this, actor, styleLayers);
+    VectorTileWorkerSource.call(this, actor, layerIndex);
 }
 
 GeoJSONWorkerSource.prototype = util.inherit(VectorTileWorkerSource, /** @lends GeoJSONWorkerSource.prototype */ {

--- a/js/source/source.js
+++ b/js/source/source.js
@@ -122,9 +122,7 @@ exports.setType = function (name, type) {
  *
  * @class WorkerSource
  * @param {Actor} actor
- * @param {object} styleLayers An accessor provided by the Worker to get the current style layers and layer families.
- * @param {Function} styleLayers.getLayers
- * @param {Function} styleLayers.getLayerFamilies
+ * @param {StyleLayerIndex} layerIndex
  */
 
 /**

--- a/js/source/vector_tile_worker_source.js
+++ b/js/source/vector_tile_worker_source.js
@@ -18,9 +18,9 @@ module.exports = VectorTileWorkerSource;
  * @private
  * @param {Function} [loadVectorData] Optional method for custom loading of a VectorTile object based on parameters passed from the main-thread Source.  See {@link VectorTileWorkerSource#loadTile}.  The default implementation simply loads the pbf at `params.url`.
  */
-function VectorTileWorkerSource (actor, styleLayers, loadVectorData) {
+function VectorTileWorkerSource (actor, layerIndex, loadVectorData) {
     this.actor = actor;
-    this.styleLayers = styleLayers;
+    this.layerIndex = layerIndex;
 
     if (loadVectorData) { this.loadVectorData = loadVectorData; }
 
@@ -59,7 +59,7 @@ VectorTileWorkerSource.prototype = {
             if (!vectorTile) return callback(null, null);
 
             workerTile.vectorTile = vectorTile;
-            workerTile.parse(vectorTile, this.styleLayers.getLayerFamilies(), this.actor, (err, result, transferrables) => {
+            workerTile.parse(vectorTile, this.layerIndex.families, this.actor, (err, result, transferrables) => {
                 if (err) return callback(err);
 
                 // Not transferring rawTileData because the worker needs to retain its copy.
@@ -85,7 +85,7 @@ VectorTileWorkerSource.prototype = {
             uid = params.uid;
         if (loaded && loaded[uid]) {
             const workerTile = loaded[uid];
-            workerTile.parse(workerTile.vectorTile, this.styleLayers.getLayerFamilies(), this.actor, callback);
+            workerTile.parse(workerTile.vectorTile, this.layerIndex.families, this.actor, callback);
         }
     },
 

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -47,8 +47,8 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, callback) {
 
     // Map non-ref layers to buckets.
     let bucketIndex = 0;
-    for (const layerId in layerFamilies) {
-        const layer = layerFamilies[layerId][0];
+    for (const family of layerFamilies) {
+        const layer = family[0];
         const sourceLayerId = layer.sourceLayer || '_geojsonTileLayer';
 
         assert(!layer.ref);
@@ -62,7 +62,7 @@ WorkerTile.prototype.parse = function(data, layerFamilies, actor, callback) {
         const bucket = Bucket.create({
             layer: layer,
             index: bucketIndex++,
-            childLayers: layerFamilies[layerId],
+            childLayers: family,
             zoom: this.zoom,
             overscaling: this.overscaling,
             showCollisionBoxes: this.showCollisionBoxes,

--- a/js/style/style_layer_index.js
+++ b/js/style/style_layer_index.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const StyleLayer = require('./style_layer');
+const featureFilter = require('feature-filter');
+
+class StyleLayerIndex {
+    constructor(layers) {
+        this.families = [];
+        if (layers) {
+            this.replace(layers);
+        }
+    }
+
+    replace(layers) {
+        this._layers = {};
+        this._order = [];
+        this.update(layers);
+    }
+
+    _updateLayer(layer) {
+        const refLayer = layer.ref && this._layers[layer.ref];
+
+        let styleLayer = this._layers[layer.id];
+        if (styleLayer) {
+            styleLayer.set(layer, refLayer);
+        } else {
+            styleLayer = this._layers[layer.id] = StyleLayer.create(layer, refLayer);
+        }
+
+        styleLayer.updatePaintTransitions({}, {transition: false});
+        styleLayer.filter = featureFilter(styleLayer.filter);
+    }
+
+    update(layers) {
+        for (const layer of layers) {
+            if (!this._layers[layer.id]) {
+                this._order.push(layer.id);
+            }
+        }
+
+        // Update ref parents
+        for (const layer of layers) {
+            if (!layer.ref) this._updateLayer(layer);
+        }
+
+        // Update ref children
+        for (const layer of layers) {
+            if (layer.ref) this._updateLayer(layer);
+        }
+
+        this.families = [];
+        const byParent = {};
+
+        for (const id of this._order) {
+            const layer = this._layers[id];
+            const parent = layer.ref ? this._layers[layer.ref] : layer;
+
+            if (parent.layout && parent.layout.visibility === 'none') {
+                continue;
+            }
+
+            let family = byParent[parent.id];
+            if (!family) {
+                family = [];
+                this.families.push(family);
+                byParent[parent.id] = family;
+            }
+
+            if (layer.ref) {
+                family.push(layer);
+            } else {
+                family.unshift(layer);
+            }
+        }
+    }
+}
+
+module.exports = StyleLayerIndex;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#8db35f9130bce27102c5867d6542c42c074d9bfc",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#119551708b3621fb1e7066347730b1ea449ff8d6",
     "memory-fs": "^0.3.0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",

--- a/test/js/source/vector_tile_worker_source.test.js
+++ b/test/js/source/vector_tile_worker_source.test.js
@@ -2,15 +2,11 @@
 
 const test = require('mapbox-gl-js-test').test;
 const VectorTileWorkerSource = require('../../../js/source/vector_tile_worker_source');
-
-const styleLayers = {
-    getLayers: function () {},
-    getLayerFamilies: function () {}
-};
+const StyleLayerIndex = require('../../../js/style/style_layer_index');
 
 test('abortTile', (t) => {
     t.test('aborts pending request', (t) => {
-        const source = new VectorTileWorkerSource(null, styleLayers);
+        const source = new VectorTileWorkerSource(null, new StyleLayerIndex());
 
         source.loadTile({
             source: 'source',
@@ -32,7 +28,7 @@ test('abortTile', (t) => {
 
 test('removeTile', (t) => {
     t.test('removes loaded tile', (t) => {
-        const source = new VectorTileWorkerSource(null, styleLayers);
+        const source = new VectorTileWorkerSource(null, new StyleLayerIndex());
 
         source.loaded = {
             source: {
@@ -55,7 +51,7 @@ test('removeTile', (t) => {
 test('redoPlacement', (t) => {
 
     t.test('on loaded tile', (t) => {
-        const source = new VectorTileWorkerSource(null, styleLayers);
+        const source = new VectorTileWorkerSource(null, new StyleLayerIndex());
         const tile = {
             redoPlacement: function(angle, pitch, showCollisionBoxes) {
                 t.equal(angle, 60);
@@ -84,7 +80,7 @@ test('redoPlacement', (t) => {
     });
 
     t.test('on loading tile', (t) => {
-        const source = new VectorTileWorkerSource(null, styleLayers);
+        const source = new VectorTileWorkerSource(null, new StyleLayerIndex());
         const tile = {};
         source.loading = {mapbox: {3: tile}};
 

--- a/test/js/source/worker.test.js
+++ b/test/js/source/worker.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* jshint -W079 */
-
 const test = require('mapbox-gl-js-test').test;
 const Worker = require('../../../js/source/worker');
 const window = require('../../../js/util/window');
@@ -30,55 +28,6 @@ test('load tile', (t) => {
     t.end();
 });
 
-test('set layers', (t) => {
-    const worker = new Worker(_self);
-
-    worker['set layers'](0, [
-        { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }  },
-        { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }  },
-        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
-    ]);
-
-    t.equal(worker.layers[0].one.id, 'one');
-    t.equal(worker.layers[0].two.id, 'two');
-    t.equal(worker.layers[0].three.id, 'three');
-
-    t.equal(worker.layers[0].one.getPaintProperty('circle-color'), 'red');
-    t.equal(worker.layers[0].two.getPaintProperty('circle-color'), 'green');
-    t.equal(worker.layers[0].three.getPaintProperty('circle-color'), 'blue');
-
-    t.equal(worker.layerFamilies[0].one.length, 1);
-    t.equal(worker.layerFamilies[0].one[0].id, 'one');
-    t.equal(worker.layerFamilies[0].two.length, 2);
-    t.equal(worker.layerFamilies[0].two[0].id, 'two');
-    t.equal(worker.layerFamilies[0].two[1].id, 'three');
-
-    t.end();
-});
-
-test('update layers', (t) => {
-    const worker = new Worker(_self);
-
-    worker['set layers'](0, [
-        { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }, 'source': 'foo' },
-        { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }, 'source': 'foo' },
-        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
-    ]);
-
-    worker['update layers'](0, [
-        { id: 'one', type: 'circle', paint: { 'circle-color': 'cyan' }, 'source': 'bar' },
-        { id: 'two', type: 'circle', paint: { 'circle-color': 'magenta' }, 'source': 'bar' },
-        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'yellow' } }
-    ]);
-
-    t.equal(worker.layers[0].one.getPaintProperty('circle-color'), 'cyan');
-    t.equal(worker.layers[0].two.getPaintProperty('circle-color'), 'magenta');
-    t.equal(worker.layers[0].three.getPaintProperty('circle-color'), 'yellow');
-    t.equal(worker.layers[0].three.source, 'bar');
-
-    t.end();
-});
-
 test('redo placement', (t) => {
     const worker = new Worker(_self);
     _self.registerWorkerSource('test', function() {
@@ -91,41 +40,20 @@ test('redo placement', (t) => {
     worker['redo placement'](0, {type: 'test', mapbox: true});
 });
 
-test('update layers isolates different instances\' data', (t) => {
+test('isolates different instances\' data', (t) => {
     const worker = new Worker(_self);
 
     worker['set layers'](0, [
-        { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }  },
-        { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }  },
-        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
+        { id: 'one', type: 'circle' }
     ]);
 
     worker['set layers'](1, [
-        { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }  },
-        { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }  },
-        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
+        { id: 'one', type: 'circle' },
+        { id: 'two', type: 'circle' },
     ]);
 
-    worker['update layers'](1, [
-        { id: 'one', type: 'circle', paint: { 'circle-color': 'cyan' }  },
-        { id: 'two', type: 'circle', paint: { 'circle-color': 'magenta' }  },
-        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'yellow' } }
-    ]);
-
-    t.equal(worker.layers[0].one.id, 'one');
-    t.equal(worker.layers[0].two.id, 'two');
-    t.equal(worker.layers[0].three.id, 'three');
-
-    t.equal(worker.layers[0].one.getPaintProperty('circle-color'), 'red');
-    t.equal(worker.layers[0].two.getPaintProperty('circle-color'), 'green');
-    t.equal(worker.layers[0].three.getPaintProperty('circle-color'), 'blue');
-
-    t.equal(worker.layerFamilies[0].one.length, 1);
-    t.equal(worker.layerFamilies[0].one[0].id, 'one');
-    t.equal(worker.layerFamilies[0].two.length, 2);
-    t.equal(worker.layerFamilies[0].two[0].id, 'two');
-    t.equal(worker.layerFamilies[0].two[1].id, 'three');
-
+    t.equal(worker.layerIndexes[0].families.length, 1);
+    t.equal(worker.layerIndexes[1].families.length, 2);
 
     t.end();
 });

--- a/test/js/style/style_layer_index.test.js
+++ b/test/js/style/style_layer_index.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const test = require('mapbox-gl-js-test').test;
+const StyleLayerIndex = require('../../../js/style/style_layer_index');
+
+test('StyleLayerIndex', (t) => {
+    const index = new StyleLayerIndex();
+    t.deepEqual(index.families, []);
+    t.end();
+});
+
+test('StyleLayerIndex#replace', (t) => {
+    const index = new StyleLayerIndex([
+        { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }  },
+        { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }  },
+        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
+    ]);
+
+    t.equal(index.families.length, 2);
+    t.equal(index.families[0].length, 1);
+    t.equal(index.families[0][0].id, 'one');
+    t.equal(index.families[1].length, 2);
+    t.equal(index.families[1][0].id, 'two');
+    t.equal(index.families[1][1].id, 'three');
+
+    index.replace([]);
+    t.deepEqual(index.families, []);
+
+    t.end();
+});
+
+test('StyleLayerIndex#update', (t) => {
+    const index = new StyleLayerIndex([
+        { id: 'one', type: 'circle', paint: { 'circle-color': 'red' }, 'source': 'foo' },
+        { id: 'two', type: 'circle', paint: { 'circle-color': 'green' }, 'source': 'foo' },
+        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'blue' } }
+    ]);
+
+    index.update([
+        { id: 'one', type: 'circle', paint: { 'circle-color': 'cyan' }, 'source': 'bar' },
+        { id: 'two', type: 'circle', paint: { 'circle-color': 'magenta' }, 'source': 'bar' },
+        { id: 'three', ref: 'two', type: 'circle', paint: { 'circle-color': 'yellow' } }
+    ]);
+
+    t.equal(index.families.length, 2);
+    t.equal(index.families[0].length, 1);
+    t.equal(index.families[0][0].getPaintProperty('circle-color'), 'cyan');
+    t.equal(index.families[1].length, 2);
+    t.equal(index.families[1][0].getPaintProperty('circle-color'), 'magenta');
+    t.equal(index.families[1][0].source, 'bar');
+    t.equal(index.families[1][1].getPaintProperty('circle-color'), 'yellow');
+    t.equal(index.families[1][1].source, 'bar');
+
+    t.end();
+});


### PR DESCRIPTION
Clean up and simplify `WorkerTile#parse`; retain correct layer order throughout the layout process.

Fixes #3394.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page

# Benchmarks

## map-load

**master 875edf2:** 116 ms
**worker-refactor 317c921:** 88 ms

## style-load

**master 875edf2:** 95 ms
**worker-refactor 317c921:** 98 ms

## buffer

**master 875edf2:** 1,065 ms
**worker-refactor 317c921:** 1,106 ms

## fps

**master 875edf2:** 60 fps
**worker-refactor 317c921:** 60 fps

## frame-duration

**master 875edf2:** 7.4 ms, 0% > 16ms
**worker-refactor 317c921:** 7.5 ms, 1% > 16ms

## query-point

**master 875edf2:** 1.03 ms
**worker-refactor 317c921:** 1.15 ms

## query-box

**master 875edf2:** 88.51 ms
**worker-refactor 317c921:** 90.13 ms

## geojson-setdata-small

**master 875edf2:** 8 ms
**worker-refactor 317c921:** 7 ms

## geojson-setdata-large

**master 875edf2:** 103 ms
**worker-refactor 317c921:** 96 ms
