### PR TITLE
Minor fix for 3386 (provide empty object for lookup)

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -282,7 +282,7 @@ Bucket.create = function(options) {
     let type = options.layer.type;
     if (type === 'fill' && (!options.layer.isPaintValueFeatureConstant('fill-extrude-height') ||
         !options.layer.isPaintValueZoomConstant('fill-extrude-height') ||
-        options.layer.getPaintValue('fill-extrude-height', {}) !== 0)) {
+        options.layer.getPaintValue('fill-extrude-height', {zoom: this.zoom}) !== 0)) {
         type = 'fillextrusion';
     }
     return new subclasses[type](options);

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -282,7 +282,7 @@ Bucket.create = function(options) {
     let type = options.layer.type;
     if (type === 'fill' && (!options.layer.isPaintValueFeatureConstant('fill-extrude-height') ||
         !options.layer.isPaintValueZoomConstant('fill-extrude-height') ||
-        options.layer.getPaintValue('fill-extrude-height') !== 0)) {
+        options.layer.getPaintValue('fill-extrude-height', {}) !== 0)) {
         type = 'fillextrusion';
     }
     return new subclasses[type](options);

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -279,7 +279,7 @@ class Painter {
         if (type === 'fill' &&
             (!layer.isPaintValueFeatureConstant('fill-extrude-height') ||
             !layer.isPaintValueZoomConstant('fill-extrude-height') ||
-            layer.getPaintValue('fill-extrude-height') !== 0)) {
+            layer.getPaintValue('fill-extrude-height', {}) !== 0)) {
             type = 'extrusion';
         }
 

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -279,7 +279,7 @@ class Painter {
         if (type === 'fill' &&
             (!layer.isPaintValueFeatureConstant('fill-extrude-height') ||
             !layer.isPaintValueZoomConstant('fill-extrude-height') ||
-            layer.getPaintValue('fill-extrude-height', {}) !== 0)) {
+            layer.getPaintValue('fill-extrude-height', {zoom: this.transform.zoom}) !== 0)) {
             type = 'extrusion';
         }
 


### PR DESCRIPTION
This is only a small part of the fix for #3386 (more details on that ticket) — `getPaintValue` does an object lookup on `globalProperties`, so without providing an object for lookup this was sometimes throwing.