### PR TITLE
Refactor WorkerTile/Bucket interface

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -35,11 +35,11 @@ class Bucket {
         this.childLayers = options.childLayers;
 
         this.type = this.layer.type;
-        this.features = [];
         this.id = this.layer.id;
         this.index = options.index;
         this.sourceLayer = this.layer.sourceLayer;
         this.sourceLayerIndex = options.sourceLayerIndex;
+        this.featureIndex = options.featureIndex;
         this.minZoom = this.layer.minzoom;
         this.maxZoom = this.layer.maxzoom;
 
@@ -86,15 +86,15 @@ class Bucket {
         return new Classes[type](options);
     }
 
-    /**
-     * Build the arrays! Features are set directly to the `features` property.
-     */
-    populateArrays() {
+    populate(features) {
         this.createArrays();
         this.recalculateStyleLayers();
 
-        for (let i = 0; i < this.features.length; i++) {
-            this.addFeature(this.features[i]);
+        for (const feature of features) {
+            if (this.layer.filter(feature)) {
+                this.addFeature(feature);
+                this.featureIndex.insert(feature, feature.index, this.sourceLayerIndex, this.index);
+            }
         }
 
         this.trimArrays();

--- a/js/symbol/resolve_text.js
+++ b/js/symbol/resolve_text.js
@@ -2,40 +2,19 @@
 
 const resolveTokens = require('../util/token');
 
-module.exports = resolveText;
+module.exports = function resolveText(feature, layout) {
+    let text = resolveTokens(feature.properties, layout['text-field']);
+    if (!text) {
+        return;
+    }
+    text = text.toString();
 
-/**
- * For an array of features determine what glyphs need to be loaded
- * and apply any text preprocessing. The remaining users of text should
- * use the `textFeatures` key returned by this function rather than accessing
- * feature text directly.
- * @private
- */
-function resolveText(features, layoutProperties, codepoints) {
-    const textFeatures = [];
-
-    for (let i = 0, fl = features.length; i < fl; i++) {
-        let text = resolveTokens(features[i].properties, layoutProperties['text-field']);
-        if (!text) {
-            textFeatures[i] = null;
-            continue;
-        }
-        text = text.toString();
-
-        const transform = layoutProperties['text-transform'];
-        if (transform === 'uppercase') {
-            text = text.toLocaleUpperCase();
-        } else if (transform === 'lowercase') {
-            text = text.toLocaleLowerCase();
-        }
-
-        for (let j = 0; j < text.length; j++) {
-            codepoints[text.charCodeAt(j)] = true;
-        }
-
-        // Track indexes of features with text.
-        textFeatures[i] = text;
+    const transform = layout['text-transform'];
+    if (transform === 'uppercase') {
+        text = text.toLocaleUpperCase();
+    } else if (transform === 'lowercase') {
+        text = text.toLocaleLowerCase();
     }
 
-    return textFeatures;
-}
+    return text;
+};

--- a/test/js/symbol/mergelines.test.js
+++ b/test/js/symbol/mergelines.test.js
@@ -4,42 +4,35 @@ const test = require('mapbox-gl-js-test').test;
 const mergeLines = require('../../../js/symbol/mergelines');
 const Point = require('point-geometry');
 
-function testLines(coords) {
-    const lines = [];
-    for (let i = 0; i < coords.length; i++) {
+function makeFeatures(lines) {
+    const features = [];
+    for (const line of lines) {
         const points = [];
-        for (let j = 0; j < coords[i].length; j++) {
-            points.push(new Point(coords[i][j], 0));
+        for (let j = 1; j < line.length; j++) {
+            points.push(new Point(line[j], 0));
         }
-        lines.push([points]);
+        features.push({text: line[0], geometry: [points]});
     }
-    return lines;
+    return features;
 }
-
-function merge(lines, letters) {
-    const features = new Array(lines.length);
-    letters = letters || `${features.join('a')}a`;
-    return mergeLines(features, letters.split(''), lines).geometries.filter((a) => { return a !== null; });
-}
-
 
 test('mergeLines merges lines with the same text', (t) => {
     t.deepEqual(
-        merge(testLines([[0, 1, 2], [4, 5, 6], [8, 9], [2, 3, 4], [6, 7, 8], [5, 6]]), 'abaaaa'),
-        testLines([[0, 1, 2, 3, 4], [4, 5, 6], [5, 6, 7, 8, 9]]));
+        mergeLines(makeFeatures([['a', 0, 1, 2], ['b', 4, 5, 6], ['a', 8, 9], ['a', 2, 3, 4], ['a', 6, 7, 8], ['a', 5, 6]])),
+        makeFeatures([['a', 0, 1, 2, 3, 4], ['b', 4, 5, 6], ['a', 5, 6, 7, 8, 9]]));
     t.end();
 });
 
 test('mergeLines handles merge from both ends', (t) => {
     t.deepEqual(
-        merge(testLines([[0, 1, 2], [4, 5, 6], [2, 3, 4]])),
-        testLines([[0, 1, 2, 3, 4, 5, 6]]));
+        mergeLines(makeFeatures([['a', 0, 1, 2], ['a', 4, 5, 6], ['a', 2, 3, 4]])),
+        makeFeatures([['a', 0, 1, 2, 3, 4, 5, 6]]));
     t.end();
 });
 
 test('mergeLines handles circular lines', (t) => {
     t.deepEqual(
-        merge(testLines([[0, 1, 2], [2, 3, 4], [4, 0]])),
-        testLines([[0, 1, 2, 3, 4, 0]]));
+        mergeLines(makeFeatures([['a', 0, 1, 2], ['a', 2, 3, 4], ['a', 4, 0]])),
+        makeFeatures([['a', 0, 1, 2, 3, 4, 0]]));
     t.end();
 });

--- a/test/js/symbol/resolve_text.test.js
+++ b/test/js/symbol/resolve_text.test.js
@@ -3,118 +3,57 @@
 const test = require('mapbox-gl-js-test').test;
 const resolveText = require('../../../js/symbol/resolve_text');
 
-function mockFeature(obj) {
-    const f = {};
-    f.loadGeometry = function() { return {}; };
-    f.properties = obj;
-    return f;
-}
-
-function compareResolve(t, expected, features, props) {
-    const stack = {};
-    t.deepEqual(resolveText(features, props, stack), expected.textFeatures);
-    t.deepEqual(Object.keys(stack).map(Number).sort(compareNum), expected.codepoints);
-}
-
-function compareNum(a, b) {
-    return a - b;
-}
-
 test('resolveText', (t) => {
-    // Latin ranges.
-    // Skips feature without text field.
-    compareResolve(t, {
-        textFeatures: [
-            'Pennsylvania Ave NW DC',
-            'Baker St',
-            null,
-            '14 St NW'
-        ],
-        codepoints: [ 32, 49, 52, 65, 66, 67, 68, 78, 80, 83, 87, 97, 101, 105, 107, 108, 110, 114, 115, 116, 118, 121 ]
-    }, [
-        mockFeature({ 'name': 'Pennsylvania Ave NW DC' }),
-        mockFeature({ 'name': 'Baker St' }),
-        mockFeature({}),
-        mockFeature({ 'name': '14 St NW' })
-    ], {
-        'text-field': '{name}'
-    });
+    // Basic.
+    t.deepEqual(
+        resolveText({properties: {name: 'Test'}}, {'text-field': '{name}'}),
+        'Test');
+    t.deepEqual(
+        resolveText({properties: {name: 'Test'}}, {'text-field': '{name}-suffix'}),
+        'Test-suffix');
 
-    // Token replacement.
-    compareResolve(t, {
-        textFeatures: [
-            'Pennsylvania Ave NW DC-suffixed',
-            'Baker St-suffixed',
-            '-suffixed',
-            '14 St NW-suffixed'
-        ],
-        codepoints: [ 32, 45, 49, 52, 65, 66, 67, 68, 78, 80, 83, 87, 97, 100, 101, 102, 105, 107, 108, 110, 114, 115, 116, 117, 118, 120, 121 ]
-    }, [
-        mockFeature({ 'name': 'Pennsylvania Ave NW DC' }),
-        mockFeature({ 'name': 'Baker St' }),
-        mockFeature({}),
-        mockFeature({ 'name': '14 St NW' })
-    ], {
-        'text-field': '{name}-suffixed'
-    });
+    // Undefined property.
+    t.deepEqual(
+        resolveText({properties: {}}, {'text-field': '{name}'}),
+        undefined);
+    t.deepEqual(
+        resolveText({properties: {}}, {'text-field': '{name}-suffix'}),
+        '-suffix');
 
-    // Non-latin ranges.
-    compareResolve(t, {
-        textFeatures: [
-            '서울특별시'
-        ],
-        codepoints: [ 48324, 49436, 49884, 50872, 53945 ]
-    }, [
-        mockFeature({ 'city': '서울특별시' })
-    ], {
-        'text-field': '{city}'
-    });
+    // Non-latin.
+    t.deepEqual(
+        resolveText({properties: {city: '서울특별시'}}, {'text-field': '{city}'}),
+        '서울특별시');
 
-    // Includes unicode up to 65535.
-    compareResolve(t, {
-        textFeatures: [
-            '\ufff0',
-            '\uffff'
-        ],
-        codepoints: [ 65520, 65535 ]
-    }, [
-        mockFeature({ 'text': '\ufff0' }),
-        mockFeature({ 'text': '\uffff' })
-    ], {
-        'text-field': '{text}'
-    });
+    // Unicode up to 65535.
+    t.deepEqual(
+        resolveText({properties: {text: '\ufff0'}}, {'text-field': '{text}'}),
+        '\ufff0');
+    t.deepEqual(
+        resolveText({properties: {text: '\uffff'}}, {'text-field': '{text}'}),
+        '\uffff');
 
     // Non-string values cast to strings.
-    compareResolve(t, {
-        textFeatures: [
-            '5000',
-            '-15.5',
-            'true'
-        ],
-        codepoints: [ 45, 46, 48, 49, 53, 101, 114, 116, 117 ]
-    }, [
-        mockFeature({ 'name': 5000 }),
-        mockFeature({ 'name': -15.5 }),
-        mockFeature({ 'name': true })
-    ], {
-        'text-field': '{name}'
-    });
+    t.deepEqual(
+        resolveText({properties: {name: 5000}}, {'text-field': '{name}'}),
+        '5000');
+    t.deepEqual(
+        resolveText({properties: {name: -15.5}}, {'text-field': '{name}'}),
+        '-15.5');
+    t.deepEqual(
+        resolveText({properties: {name: true}}, {'text-field': '{name}'}),
+        'true');
 
     // Non-string values cast to strings, with token replacement.
-    compareResolve(t, {
-        textFeatures: [
-            '5000-suffix',
-            '-15.5-suffix',
-            'true-suffix'
-        ],
-        codepoints: [ 45, 46, 48, 49, 53, 101, 102, 105, 114, 115, 116, 117, 120 ]
-    }, [
-        mockFeature({ 'name': 5000 }),
-        mockFeature({ 'name': -15.5 }),
-        mockFeature({ 'name': true })
-    ], {
-        'text-field': '{name}-suffix'
-    });
+    t.deepEqual(
+        resolveText({properties: {name: 5000}}, {'text-field': '{name}-suffix'}),
+        '5000-suffix');
+    t.deepEqual(
+        resolveText({properties: {name: -15.5}}, {'text-field': '{name}-suffix'}),
+        '-15.5-suffix');
+    t.deepEqual(
+        resolveText({properties: {name: true}}, {'text-field': '{name}-suffix'}),
+        'true-suffix');
 
     t.end();
 });


### PR DESCRIPTION
* Buckets no longer have a temporary `features` property
* SymbolBucket has three distinct layout steps, analogous to the gl-native implementation: population, preparation, and placement
* mergeLines and resolveText are simplified

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page

# Benchmarks

## map-load

**master 85097c3:** 143 ms
**worker-refactor 3be561c:** 99 ms

## style-load

**master 85097c3:** 123 ms
**worker-refactor 3be561c:** 114 ms

## buffer

**master 85097c3:** 1,064 ms
**worker-refactor 3be561c:** 1,091 ms

## fps

**master 85097c3:** 60 fps
**worker-refactor 3be561c:** 60 fps

## frame-duration

**master 85097c3:** 7.1 ms, 0% > 16ms
**worker-refactor 3be561c:** 7.2 ms, 1% > 16ms

## query-point

**master 85097c3:** 1.02 ms
**worker-refactor 3be561c:** 1.14 ms

## query-box

**master 85097c3:** 85.44 ms
**worker-refactor 3be561c:** 87.30 ms

## geojson-setdata-small

**master 85097c3:** 7 ms
**worker-refactor 3be561c:** 7 ms

## geojson-setdata-large

**master 85097c3:** 91 ms
**worker-refactor 3be561c:** 102 ms
