### PR TITLE
Add support for ideographic text breaking

### DIFF
--- a/debug/chinese.html
+++ b/debug/chinese.html
@@ -50,8 +50,8 @@ map.on('load', function () {
         "type": "symbol",
         "source": "points",
         "layout": {
+            "icon-image": "{icon}-15",
             "text-field": "{name}",
-            "text-max-width": 2,
             "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
             "text-offset": [0, 0.6],
             "text-anchor": "top",

--- a/debug/chinese.html
+++ b/debug/chinese.html
@@ -50,8 +50,8 @@ map.on('load', function () {
         "type": "symbol",
         "source": "points",
         "layout": {
-            "icon-image": "{icon}-15",
             "text-field": "{name}",
+            "text-max-width": 2,
             "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
             "text-offset": [0, 0.6],
             "text-anchor": "top",

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -118,8 +118,6 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
     const positionedGlyphs = shaping.positionedGlyphs;
 
     if (maxWidth) {
-        const wordLength = positionedGlyphs.length;
-
         if (allowsIdeographicBreaking) {
             const lastPositionedGlyph = positionedGlyphs[positionedGlyphs.length - 1];
             const estimatedLineCount = Math.max(1, Math.ceil(lastPositionedGlyph.x / maxWidth));
@@ -159,9 +157,7 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
                 line++;
             }
 
-            if (allowsIdeographicBreaking) {
-                lastSafeBreak = i
-            } else if (breakable[positionedGlyph.codePoint]) {
+            if (allowsIdeographicBreaking || breakable[positionedGlyph.codePoint]) {
                 lastSafeBreak = i;
             }
         }

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const scriptDetection = require('../util/script_detection');
+
 module.exports = {
     shapeText: shapeText,
     shapeIcon: shapeIcon
@@ -54,7 +56,7 @@ function shapeText(text, glyphs, maxWidth, lineHeight, horizontalAlign, vertical
 
     if (!positionedGlyphs.length) return false;
 
-    linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate);
+    linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, scriptDetection.allowsBalancedBreaking(text));
 
     return shaping;
 }
@@ -105,7 +107,7 @@ const breakable = {
 
 invisible[newLine] = breakable[newLine] = true;
 
-function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate) {
+function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, allowsBalancedBreaking) {
     let lastSafeBreak = null;
     let lengthBeforeCurrentLine = 0;
     let lineStartIndex = 0;
@@ -150,14 +152,7 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
                 line++;
             }
 
-            if (positionedGlyph.codePoint > 19968) {
-                if (breakable[positionedGlyph.codePoint]) {
-                    lastSafeBreak = i - 1;
-                }
-                if (!(breakable[positionedGlyph.codePoint])) {
-                    lastSafeBreak = Math.round(wordLength / 3);
-                }
-            }   else if (breakable[positionedGlyph.codePoint]) {
+            if (allowsBalancedBreaking || breakable[positionedGlyph.codePoint]) {
                 lastSafeBreak = i;
             }
         }

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -56,7 +56,7 @@ function shapeText(text, glyphs, maxWidth, lineHeight, horizontalAlign, vertical
 
     if (!positionedGlyphs.length) return false;
 
-    linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, scriptDetection.allowsIdeographicBreakingBreaking(text));
+    linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, scriptDetection.allowsIdeographicBreaking(text));
 
     return shaping;
 }
@@ -107,7 +107,7 @@ const breakable = {
 
 invisible[newLine] = breakable[newLine] = true;
 
-function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, allowsIdeographicBreakingBreaking) {
+function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, allowsIdeographicBreaking) {
     let lastSafeBreak = null;
     let lengthBeforeCurrentLine = 0;
     let lineStartIndex = 0;
@@ -119,6 +119,13 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
 
     if (maxWidth) {
         const wordLength = positionedGlyphs.length;
+
+        if (allowsIdeographicBreaking) {
+            const lastPositionedGlyph = positionedGlyphs[positionedGlyphs.length - 1];
+            const estimatedLineCount = Math.max(1, Math.ceil(lastPositionedGlyph.x / maxWidth));
+            maxWidth = lastPositionedGlyph.x / estimatedLineCount;
+        }
+
         for (let i = 0; i < positionedGlyphs.length; i++) {
             const positionedGlyph = positionedGlyphs[i];
 
@@ -152,7 +159,9 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
                 line++;
             }
 
-            if (allowsIdeographicBreakingBreaking || breakable[positionedGlyph.codePoint]) {
+            if (allowsIdeographicBreaking) {
+                lastSafeBreak = i
+            } else if (breakable[positionedGlyph.codePoint]) {
                 lastSafeBreak = i;
             }
         }

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -67,18 +67,16 @@ const invisible = {
 };
 
 const breakable = {
-    0x0020: true, // space
-    0x0022: true, // quotation mark
-    0x0026: true, // ampersand
-    0x0028: true, // left parenthesis
-    0x002b: true, // plus sign
-    0x002d: true, // hyphen-minus
-    0x00ad: true, // soft hyphen
-    0x00b7: true, // middle dot
+    0x20:   true, // space
+    0x26:   true, // ampersand
+    0x2b:   true, // plus sign
+    0x2d:   true, // hyphen-minus
+    0x2f:   true, // solidus
+    0xad:   true, // soft hyphen
+    0xb7:   true, // middle dot
     0x200b: true, // zero-width space
     0x2010: true, // hyphen
-    0x2013: true, // en dash
-    0x2018: true  // left single quotation mark
+    0x2013: true  // en dash
 };
 
 invisible[newLine] = breakable[newLine] = true;

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -69,40 +69,16 @@ const invisible = {
 const breakable = {
     0x0020: true, // space
     0x0022: true, // quotation mark
-    0x0024: true, // dollar sign
     0x0026: true, // ampersand
     0x0028: true, // left parenthesis
     0x002b: true, // plus sign
     0x002d: true, // hyphen-minus
-    0x002f: true, // solidus
-    0x00a3: true, // pound sign
-    0x00a5: true, // yen sign
     0x00ad: true, // soft hyphen
     0x00b7: true, // middle dot
     0x200b: true, // zero-width space
     0x2010: true, // hyphen
     0x2013: true, // en dash
-    0x2018: true, // left single quotation mark
-    0x3002: true, // ideographic full stop
-    0x3008: true, // left angle bracket
-    0x300a: true, // left double angle bracket
-    0x300c: true, // left corner bracket
-    0x300e: true, // left white corner bracket
-    0x3010: true, // left black lenticular bracket
-    0x3014: true, // left tortoise shell bracket
-    0x3016: true, // left white lenticular bracket
-    0x301d: true, // reversed double prime quotation mark
-    0x533a: true, // unknown
-    0xfe59: true, // small left parenthesis
-    0xfe5b: true, // small left curly bracket
-    0xff04: true, // fullwidth dollar sign
-    0xff08: true, // fullwidth left parenthesis
-    0xff0e: true, // fullwidth full stop
-    0xff3b: true, // fullwidth left square bracket
-    0xff5b: true, // fullwidth left curly bracket
-    0xff5e: true, // fullwidth tilde
-    0xffe1: true, // fullwidth pound sign
-    0xffe5: true  // fullwidth yen sign
+    0x2018: true  // left single quotation mark
 };
 
 invisible[newLine] = breakable[newLine] = true;

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -81,7 +81,7 @@ const breakable = {
 
 invisible[newLine] = breakable[newLine] = true;
 
-function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, allowsIdeographicBreaking) {
+function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, useBalancedIdeographicBreaking) {
     let lastSafeBreak = null;
     let lengthBeforeCurrentLine = 0;
     let lineStartIndex = 0;
@@ -92,7 +92,7 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
     const positionedGlyphs = shaping.positionedGlyphs;
 
     if (maxWidth) {
-        if (allowsIdeographicBreaking) {
+        if (useBalancedIdeographicBreaking) {
             const lastPositionedGlyph = positionedGlyphs[positionedGlyphs.length - 1];
             const estimatedLineCount = Math.max(1, Math.ceil(lastPositionedGlyph.x / maxWidth));
             maxWidth = lastPositionedGlyph.x / estimatedLineCount;
@@ -131,7 +131,7 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
                 line++;
             }
 
-            if (allowsIdeographicBreaking || breakable[positionedGlyph.codePoint]) {
+            if (useBalancedIdeographicBreaking || breakable[positionedGlyph.codePoint] || scriptDetection.charAllowsIdeographicBreaking(positionedGlyph.codePoint)) {
                 lastSafeBreak = i;
             }
         }

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -65,16 +65,42 @@ const invisible = {
 };
 
 const breakable = {
-    0x20:   true, // space
-    0x26:   true, // ampersand
-    0x2b:   true, // plus sign
-    0x2d:   true, // hyphen-minus
-    0x2f:   true, // solidus
-    0xad:   true, // soft hyphen
-    0xb7:   true, // middle dot
+    0x0020: true, // space
+    0x0022: true, // quotation mark
+    0x0024: true, // dollar sign
+    0x0026: true, // ampersand
+    0x0028: true, // left parenthesis
+    0x002b: true, // plus sign
+    0x002d: true, // hyphen-minus
+    0x002f: true, // solidus
+    0x00a3: true, // pound sign
+    0x00a5: true, // yen sign
+    0x00ad: true, // soft hyphen
+    0x00b7: true, // middle dot
     0x200b: true, // zero-width space
     0x2010: true, // hyphen
-    0x2013: true  // en dash
+    0x2013: true, // en dash
+    0x2018: true, // left single quotation mark
+    0x3002: true, // ideographic full stop
+    0x3008: true, // left angle bracket
+    0x300a: true, // left double angle bracket
+    0x300c: true, // left corner bracket
+    0x300e: true, // left white corner bracket
+    0x3010: true, // left black lenticular bracket
+    0x3014: true, // left tortoise shell bracket
+    0x3016: true, // left white lenticular bracket
+    0x301d: true, // reversed double prime quotation mark
+    0x533a: true, // unknown
+    0xfe59: true, // small left parenthesis
+    0xfe5b: true, // small left curly bracket
+    0xff04: true, // fullwidth dollar sign
+    0xff08: true, // fullwidth left parenthesis
+    0xff0e: true, // fullwidth full stop
+    0xff3b: true, // fullwidth left square bracket
+    0xff5b: true, // fullwidth left curly bracket
+    0xff5e: true, // fullwidth tilde
+    0xffe1: true, // fullwidth pound sign
+    0xffe5: true  // fullwidth yen sign
 };
 
 invisible[newLine] = breakable[newLine] = true;
@@ -90,6 +116,7 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
     const positionedGlyphs = shaping.positionedGlyphs;
 
     if (maxWidth) {
+        const wordLength = positionedGlyphs.length;
         for (let i = 0; i < positionedGlyphs.length; i++) {
             const positionedGlyph = positionedGlyphs[i];
 
@@ -123,7 +150,14 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
                 line++;
             }
 
-            if (breakable[positionedGlyph.codePoint]) {
+            if (positionedGlyph.codePoint > 19968) {
+                if (breakable[positionedGlyph.codePoint]) {
+                    lastSafeBreak = i - 1;
+                }
+                if (!(breakable[positionedGlyph.codePoint])) {
+                    lastSafeBreak = Math.round(wordLength / 3);
+                }
+            }   else if (breakable[positionedGlyph.codePoint]) {
                 lastSafeBreak = i;
             }
         }
@@ -164,7 +198,6 @@ function align(positionedGlyphs, justify, horizontalAlign, verticalAlign, maxLin
         positionedGlyphs[j].y += shiftY;
     }
 }
-
 
 function shapeIcon(image, layout) {
     if (!image || !image.rect) return null;

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -56,7 +56,7 @@ function shapeText(text, glyphs, maxWidth, lineHeight, horizontalAlign, vertical
 
     if (!positionedGlyphs.length) return false;
 
-    linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, scriptDetection.allowsBalancedBreaking(text));
+    linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, scriptDetection.allowsIdeographicBreakingBreaking(text));
 
     return shaping;
 }
@@ -107,7 +107,7 @@ const breakable = {
 
 invisible[newLine] = breakable[newLine] = true;
 
-function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, allowsBalancedBreaking) {
+function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify, translate, allowsIdeographicBreakingBreaking) {
     let lastSafeBreak = null;
     let lengthBeforeCurrentLine = 0;
     let lineStartIndex = 0;
@@ -152,7 +152,7 @@ function linewrap(shaping, glyphs, lineHeight, maxWidth, horizontalAlign, vertic
                 line++;
             }
 
-            if (allowsBalancedBreaking || breakable[positionedGlyph.codePoint]) {
+            if (allowsIdeographicBreakingBreaking || breakable[positionedGlyph.codePoint]) {
                 lastSafeBreak = i;
             }
         }

--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const balancedRegExp = new RegExp([
+    '[一-鿌]',
+    '[㐀-䶵]',
+    // eslint-disable-next-line no-irregular-whitespace
+    '[　-〿]',
+    '\uD840[\uDC00-\uFFFF]|[\uD841-\uD872]|\uD873[\u0000-\uDEAF]', // '[𠀀-𬺯]'
+    '[！-￮]',
+    '[ぁ-ゟ]',
+    '[゠-ヿ]',
+    '[ㇰ-ㇿ]',
+    '[ꀀ-꓆]'
+].join('|'));
+
+module.exports.allowsBalancedBreaking = function(input) {
+    return input.search(balancedRegExp) !== -1;
+};

--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const balancedRegExp = new RegExp([
+const ideographicBreakingRegExp = new RegExp([
     '[一-鿌]',
     '[㐀-䶵]',
     // eslint-disable-next-line no-irregular-whitespace
@@ -13,6 +13,6 @@ const balancedRegExp = new RegExp([
     '[ꀀ-꓆]'
 ].join('|'));
 
-module.exports.allowsBalancedBreaking = function(input) {
-    return input.search(balancedRegExp) !== -1;
+module.exports.allowsIdeographicBreakingBreaking = function(input) {
+    return input.search(ideographicBreakingRegExp) !== -1;
 };

--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -1,18 +1,45 @@
 'use strict';
 
-const ideographicBreakingRegExp = new RegExp(`^(${[
-    '[一-鿌]',
-    '[㐀-䶵]',
-    // eslint-disable-next-line no-irregular-whitespace
-    '[　-〿]',
-    '\uD840[\uDC00-\uFFFF]|[\uD841-\uD872]|\uD873[\u0000-\uDEAF]', // '[𠀀-𬺯]'
-    '[！-￮]',
-    '[ぁ-ゟ]',
-    '[゠-ヿ]',
-    '[ㇰ-ㇿ]',
-    '[ꀀ-꓆]'
-].join('|')})+$`);
-
 module.exports.allowsIdeographicBreaking = function(input) {
-    return input.search(ideographicBreakingRegExp) !== -1;
+    for (let i = 0; i < input.length; i++) {
+        if (!charAllowsIdeographicBreaking(input.charCodeAt(i), input.charCodeAt(i + 1))) {
+            return false;
+        }
+    }
+    return true;
 };
+
+
+function charAllowsIdeographicBreaking(char, nextChar) {
+    // "一" to "鿌"
+    if (char >= 0x4E00 && char <= 0x9FCC) return true;
+
+    // "㐀" to "䶵"
+    if (char >= 0x3400 && char <= 0x4DB5) return true;
+
+    // eslint-disable-next-line no-irregular-whitespace
+    // "　" to "〿"
+    if (char >= 0x3000 && char <= 0x303F) return true;
+
+    // "𠀀" to "𬺯"
+    if (char === 0xD840 && nextChar >= 0xDC00) return true;
+    if (char >= 0xD841 && char <= 0xD872) return true;
+    if (char === 0xD873 && nextChar <= 0xDEAF) return true;
+
+    // "！" to "￮"
+    if (char >= 0xFF01 && char <= 0xFFEE) return true;
+
+    // "ぁ" to "ゟ"
+    if (char >= 0x3041 && char <= 0x309F) return true;
+
+    // "゠" to "ヿ"
+    if (char >= 0x30A0 && char <= 0x30FF) return true;
+
+    // "ㇰ" to "ㇿ"
+    if (char >= 0x31F0 && char <= 0x31FF) return true;
+
+    // "ꀀ" to "꓆"
+    if (char >= 0xA000 && char <= 0xA4C6) return true;
+
+    return false;
+}

--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -1,8 +1,8 @@
 'use strict';
 
-module.exports.allowsIdeographicBreaking = function(input) {
-    for (let i = 0; i < input.length; i++) {
-        if (!exports.charAllowsIdeographicBreaking(input.charCodeAt(i), input.charCodeAt(i + 1))) {
+module.exports.allowsIdeographicBreaking = function(chars) {
+    for (const char of chars) {
+        if (!exports.charAllowsIdeographicBreaking(char.charCodeAt(0))) {
             return false;
         }
     }
@@ -10,7 +10,10 @@ module.exports.allowsIdeographicBreaking = function(input) {
 };
 
 
-module.exports.charAllowsIdeographicBreaking = function(char, nextChar) {
+module.exports.charAllowsIdeographicBreaking = function(char) {
+    // early termination for characters outside all ideographic ranges
+    if (char < 0x3000) return false;
+
     // "一" to "鿌"
     if (char >= 0x4E00 && char <= 0x9FCC) return true;
 
@@ -20,11 +23,6 @@ module.exports.charAllowsIdeographicBreaking = function(char, nextChar) {
     // eslint-disable-next-line no-irregular-whitespace
     // "　" to "〿"
     if (char >= 0x3000 && char <= 0x303F) return true;
-
-    // "𠀀" to "𬺯"
-    if (char === 0xD840 && nextChar >= 0xDC00) return true;
-    if (char >= 0xD841 && char <= 0xD872) return true;
-    if (char === 0xD873 && nextChar <= 0xDEAF) return true;
 
     // "！" to "￮"
     if (char >= 0xFF01 && char <= 0xFFEE) return true;

--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -13,6 +13,6 @@ const ideographicBreakingRegExp = new RegExp([
     '[ꀀ-꓆]'
 ].join('|'));
 
-module.exports.allowsIdeographicBreakingBreaking = function(input) {
+module.exports.allowsIdeographicBreaking = function(input) {
     return input.search(ideographicBreakingRegExp) !== -1;
 };

--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -2,7 +2,7 @@
 
 module.exports.allowsIdeographicBreaking = function(input) {
     for (let i = 0; i < input.length; i++) {
-        if (!charAllowsIdeographicBreaking(input.charCodeAt(i), input.charCodeAt(i + 1))) {
+        if (!exports.charAllowsIdeographicBreaking(input.charCodeAt(i), input.charCodeAt(i + 1))) {
             return false;
         }
     }
@@ -10,7 +10,7 @@ module.exports.allowsIdeographicBreaking = function(input) {
 };
 
 
-function charAllowsIdeographicBreaking(char, nextChar) {
+module.exports.charAllowsIdeographicBreaking = function(char, nextChar) {
     // "一" to "鿌"
     if (char >= 0x4E00 && char <= 0x9FCC) return true;
 
@@ -42,4 +42,4 @@ function charAllowsIdeographicBreaking(char, nextChar) {
     if (char >= 0xA000 && char <= 0xA4C6) return true;
 
     return false;
-}
+};

--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -11,33 +11,44 @@ module.exports.allowsIdeographicBreaking = function(chars) {
 
 
 module.exports.charAllowsIdeographicBreaking = function(char) {
-    // early termination for characters outside all ideographic ranges
-    if (char < 0x3000) return false;
+    // Return early for characters outside all ideographic ranges.
+    if (char < 0x2E80) return false;
 
-    // "一" to "鿌"
-    if (char >= 0x4E00 && char <= 0x9FCC) return true;
+    // CJK Radicals Supplement, Kangxi Radicals, Ideographic Description Characters, CJK Symbols and Punctuation: “⺀” to “〿”
+    if (char >= 0x2E80 && char <= 0x303F) return true;
 
-    // "㐀" to "䶵"
-    if (char >= 0x3400 && char <= 0x4DB5) return true;
+    // Hiragana: before “ぁ” to “ゟ”
+    if (char >= 0x3040 && char <= 0x309F) return true;
 
-    // eslint-disable-next-line no-irregular-whitespace
-    // "　" to "〿"
-    if (char >= 0x3000 && char <= 0x303F) return true;
-
-    // "！" to "￮"
-    if (char >= 0xFF01 && char <= 0xFFEE) return true;
-
-    // "ぁ" to "ゟ"
-    if (char >= 0x3041 && char <= 0x309F) return true;
-
-    // "゠" to "ヿ"
+    // Katakana: “゠” to “ヿ”
     if (char >= 0x30A0 && char <= 0x30FF) return true;
 
-    // "ㇰ" to "ㇿ"
+    // CJK Strokes: “㇀” to past “㇣”
+    if (char >= 0x31C0 && char <= 0x31EF) return true;
+
+    // Katakana Phonetic Extensions: “ㇰ” to “ㇿ”
     if (char >= 0x31F0 && char <= 0x31FF) return true;
 
-    // "ꀀ" to "꓆"
-    if (char >= 0xA000 && char <= 0xA4C6) return true;
+    // Enclosed CJK Letters and Months, CJK Compatibility: “㈀” to “㏿”
+    if (char >= 0x3200 && char <= 0x33FF) return true;
+
+    // CJK Unified Ideographs Extension A: “㐀” to past “䶵”
+    if (char >= 0x3400 && char <= 0x4DBF) return true;
+
+    // CJK Unified Ideographs: “一” to past “鿕”
+    if (char >= 0x4E00 && char <= 0x9FFF) return true;
+
+    // Yi Syllables, Yi Radicals: “ꀀ” to past “꓆”
+    if (char >= 0xA000 && char <= 0xA4CF) return true;
+
+    // CJK Compatibility Forms: “︰” to “﹏”
+    if (char >= 0xFE30 && char <= 0xFE4F) return true;
+
+    // CJK Compatibility Ideographs: “豈” to past “龎”
+    if (char >= 0xF900 && char <= 0xFAFF) return true;
+
+    // Halfwidth and Fullwidth Forms: before “！” to past “￮”
+    if (char >= 0xFF00 && char <= 0xFFEF) return true;
 
     return false;
 };

--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ideographicBreakingRegExp = new RegExp([
+const ideographicBreakingRegExp = new RegExp(`^(${[
     '[一-鿌]',
     '[㐀-䶵]',
     // eslint-disable-next-line no-irregular-whitespace
@@ -11,7 +11,7 @@ const ideographicBreakingRegExp = new RegExp([
     '[゠-ヿ]',
     '[ㇰ-ㇿ]',
     '[ꀀ-꓆]'
-].join('|'));
+].join('|')})+$`);
 
 module.exports.allowsIdeographicBreaking = function(input) {
     return input.search(ideographicBreakingRegExp) !== -1;

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#16f7e8cdb73512ac723b7f4943e8464c930de066",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#4a508b6da9bad0fe267b0ccd4440fa061da3b4f8",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#4a508b6da9bad0fe267b0ccd4440fa061da3b4f8",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#e3c236991ca1c6e3bd07491284b3b216d03cd285",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#77b281c9e6225471505f7daefa76806a8fbf22e2",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#cba8696e0c868dd0e1ee9c7b937c512e5fe0bd5c",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#107e22655a346e88d2525bdc8217d342208188c5",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#6f0d8a0f7428a70b6a7daa5a5980dfe6c56a1d88",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#6f0d8a0f7428a70b6a7daa5a5980dfe6c56a1d88",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#77b281c9e6225471505f7daefa76806a8fbf22e2",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#cba8696e0c868dd0e1ee9c7b937c512e5fe0bd5c",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#16f7e8cdb73512ac723b7f4943e8464c930de066",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
## Launch Checklist

Splitting out from https://github.com/mapbox/mapbox-gl-js/pull/3402 for clearer tracking of two separate issues. 

This PR adds support for:
- CJK line breaking
## Requirements
- GL JS must line break for point labels in CJK even if there are no spaces in the label
## Specifications
- we will use naïve "balanced" breaking 
- we will enable / disable naive breaking based on language detection
- we will use character ranges for language detection ([data](https://en.wiktionary.org/wiki/Module:scripts/data))
## Launch Checklist
- [x] fix failing unit tests 
- [x] write tests
- [x] remove whitespace & debug page changes from diff where appropriate
- [x] manually test the debug page
- [x] post benchmark scores
- [ ] merge https://github.com/mapbox/mapbox-gl-test-suite/pull/153
