### PR TITLE
Get rid of util inherit, extendAll, debounce, coalesce, startsWith

### DIFF
--- a/js/symbol/collision_box.js
+++ b/js/symbol/collision_box.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const StructArrayType = require('../util/struct_array');
-const util = require('../util/util');
 const Point = require('point-geometry');
 
 /**
@@ -72,8 +71,6 @@ const CollisionBoxArray = module.exports = new StructArrayType({
         { type: 'Float32', name: 'placementScale' }
     ]});
 
-util.extendAll(CollisionBoxArray.prototype.StructType.prototype, {
-    get anchorPoint() {
-        return new Point(this.anchorPointX, this.anchorPointY);
-    }
+Object.defineProperty(CollisionBoxArray.prototype.StructType.prototype, 'anchorPoint', {
+    get() { return new Point(this.anchorPointX, this.anchorPointY); }
 });

--- a/js/symbol/symbol_instances.js
+++ b/js/symbol/symbol_instances.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const StructArrayType = require('../util/struct_array');
-const util = require('../util/util');
 const Point = require('point-geometry');
 
 /*
@@ -34,10 +33,8 @@ const SymbolInstancesArray = module.exports = new StructArrayType({
     ]
 });
 
-util.extendAll(SymbolInstancesArray.prototype.StructType.prototype, {
-    get anchorPoint() {
-        return new Point(this.anchorPointX, this.anchorPointY);
-    }
+Object.defineProperty(SymbolInstancesArray.prototype.StructType.prototype, 'anchorPoint', {
+    get() { return new Point(this.anchorPointX, this.anchorPointY); }
 });
 
 

--- a/js/symbol/symbol_quads.js
+++ b/js/symbol/symbol_quads.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const StructArrayType = require('../util/struct_array');
-const util = require('../util/util');
 const Point = require('point-geometry');
 const SymbolQuad = require('./quads').SymbolQuad;
 
@@ -52,11 +51,12 @@ const SymbolQuadsArray = module.exports = new StructArrayType({
     ]
 });
 
-util.extendAll(SymbolQuadsArray.prototype.StructType.prototype, {
-    get anchorPoint() {
-        return new Point(this.anchorPointX, this.anchorPointY);
-    },
-    get SymbolQuad() {
+Object.defineProperty(SymbolQuadsArray.prototype.StructType.prototype, 'anchorPoint', {
+    get() { return new Point(this.anchorPointX, this.anchorPointY); }
+});
+
+Object.defineProperty(SymbolQuadsArray.prototype.StructType.prototype, 'SymbolQuad', {
+    get() {
         return new SymbolQuad(this.anchorPoint,
             new Point(this.tlX, this.tlY),
             new Point(this.trX, this.trY),
@@ -69,4 +69,3 @@ util.extendAll(SymbolQuadsArray.prototype.StructType.prototype, {
             this.maxScale);
     }
 });
-

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -168,21 +168,6 @@ exports.extend = function (dest) {
 };
 
 /**
- * Extend a destination object with all properties of the src object,
- * using defineProperty instead of simple assignment.
- * @param {Object} dest
- * @param {Object} src
- * @returns {Object} dest
- * @private
- */
-exports.extendAll = function (dest, src) {
-    for (const i in src) {
-        Object.defineProperty(dest, i, Object.getOwnPropertyDescriptor(src, i));
-    }
-    return dest;
-};
-
-/**
  * Given an object and a number of properties as strings, return version
  * of that object with only those properties.
  *

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -183,22 +183,6 @@ exports.extendAll = function (dest, src) {
 };
 
 /**
- * Extend a parent's prototype with all properties in a properties
- * object.
- *
- * @param {Object} parent
- * @param {Object} props
- * @returns {Object}
- * @private
- */
-exports.inherit = function (parent, props) {
-    const parentProto = typeof parent === 'function' ? parent.prototype : parent,
-        proto = Object.create(parentProto);
-    exports.extendAll(proto, props);
-    return proto;
-};
-
-/**
  * Given an object and a number of properties as strings, return version
  * of that object with only those properties.
  *

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -77,19 +77,6 @@ exports.wrap = function (n, min, max) {
 };
 
 /*
- * return the first non-null and non-undefined argument to this function.
- * @returns {*} argument
- * @private
- */
-exports.coalesce = function() {
-    for (let i = 0; i < arguments.length; i++) {
-        const arg = arguments[i];
-        if (arg !== null && arg !== undefined)
-            return arg;
-    }
-};
-
-/*
  * Call an asynchronous function on an array of arguments,
  * calling `callback` with the completed results of all calls.
  *
@@ -206,28 +193,6 @@ exports.uniqueId = function () {
 };
 
 /**
- * Create a version of `fn` that is only called `time` milliseconds
- * after its last invocation
- *
- * @param {Function} fn the function to be debounced
- * @param {number} time millseconds after which the function will be invoked
- * @returns {Function} debounced function
- * @private
- */
-exports.debounce = function(fn, time) {
-    let timer, args;
-
-    return function() {
-        args = arguments;
-        clearTimeout(timer);
-
-        timer = setTimeout(() => {
-            fn.apply(null, args);
-        }, time);
-    };
-};
-
-/**
  * Given an array of member function names as strings, replace all of them
  * with bound versions that will always refer to `context` as `this`. This
  * is useful for classes where otherwise event bindings would reassign
@@ -291,17 +256,6 @@ exports.getCoordinatesCenter = function(coords) {
  */
 exports.endsWith = function(string, suffix) {
     return string.indexOf(suffix, string.length - suffix.length) !== -1;
-};
-
-/**
- * Determine if a string starts with a particular substring
- * @param {string} string
- * @param {string} prefix
- * @returns {boolean}
- * @private
- */
-exports.startsWith = function(string, prefix) {
-    return string.indexOf(prefix) === 0;
 };
 
 /**

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -14,18 +14,22 @@ const util = require('../../../js/util/util');
 function MockSourceType(id, sourceOptions) {
     // allow tests to override mocked methods/properties by providing
     // them in the source definition object that's given to Source.create()
-    let source = util.extend({
-        id: id,
-        minzoom: 0,
-        maxzoom: 22,
-        loadTile: function (tile, callback) {
+    class SourceMock extends Evented {
+        constructor() {
+            super();
+            this.id = id;
+            this.minzoom = 0;
+            this.maxzoom = 22;
+            util.extend(this, sourceOptions);
+        }
+        loadTile(tile, callback) {
             setTimeout(callback, 0);
-        },
-        abortTile: function () {},
-        unloadTile: function () {},
-        serialize: function () {}
-    }, sourceOptions);
-    source = util.inherit(Evented, source);
+        }
+        abortTile() {}
+        unloadTile() {}
+        serialize() {}
+    }
+    const source = new SourceMock();
 
     if (sourceOptions.noLoad) { return source; }
     setTimeout(() => {

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -83,14 +83,6 @@ test('util', (t) => {
         t.end();
     });
 
-    t.test('coalesce', (t) => {
-        t.equal(util.coalesce(undefined, 1), 1);
-        t.equal(util.coalesce(2, 1), 2);
-        t.equal(util.coalesce(null, undefined, 4), 4);
-        t.equal(util.coalesce(), undefined);
-        t.end();
-    });
-
     t.test('clamp', (t) => {
         t.equal(util.clamp(0, 0, 1), 0);
         t.equal(util.clamp(1, 0, 1), 1);
@@ -128,25 +120,6 @@ test('util', (t) => {
         }, () => {
             t.end();
         });
-    });
-
-    t.test('debounce', (t) => {
-        const ender = function(number) {
-            t.equal(number, 3, 'passes argument');
-            t.pass('calls function');
-            t.end();
-        };
-        const debounced = util.debounce(ender, 100);
-        t.ok(debounced, 'creates function');
-        debounced(1);
-        debounced(2);
-        debounced(3);
-    });
-
-    t.test('startsWith', (t) => {
-        t.ok(util.startsWith('mapbox', 'map'));
-        t.notOk(util.startsWith('mapbox', 'box'));
-        t.end();
     });
 
     t.test('endsWith', (t) => {

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -17,21 +17,6 @@ test('util', (t) => {
     t.deepEqual(util.pick({a:1, b:2, c:3}, ['a', 'c', 'd']), {a:1, c:3}, 'pick');
     t.ok(typeof util.uniqueId() === 'number', 'uniqueId');
 
-    t.test('inherit', (t) => {
-        function Inheritance() { }
-        Inheritance.prototype.foo = function() { return 42; };
-        function Child() {}
-        Child.prototype = util.inherit(Inheritance, {
-            bar: function() {
-                return 20;
-            }
-        });
-        const c = new Child();
-        t.equal(c.foo(), 42);
-        t.equal(c.bar(), 20);
-        t.end();
-    });
-
     t.test('getCoordinatesCenter', (t) => {
         t.deepEqual(util.getCoordinatesCenter(
             [

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -12,7 +12,6 @@ test('util', (t) => {
     t.deepEqual(util.keysDifference({a:1}, {}), ['a'], 'keysDifference');
     t.deepEqual(util.keysDifference({a:1}, {a:1}), [], 'keysDifference');
     t.deepEqual(util.extend({a:1}, {b:2}), {a:1, b:2}, 'extend');
-    t.deepEqual(util.extendAll({a:1}, {b:2}), {a:1, b:2}, 'extend');
     t.deepEqual(util.pick({a:1, b:2, c:3}, ['a', 'c']), {a:1, c:3}, 'pick');
     t.deepEqual(util.pick({a:1, b:2, c:3}, ['a', 'c', 'd']), {a:1, c:3}, 'pick');
     t.ok(typeof util.uniqueId() === 'number', 'uniqueId');


### PR DESCRIPTION
Got rid of:

- `util.inherit`after @jfirebaugh mentioned it in https://github.com/mapbox/mapbox-gl-js/issues/1408#issuecomment-255560965. Not needed with ES6 classes.
- `util.extendAll` (not needed much without `inherit`).
- `util` `debounce`, `coalesce` and `startsWith` — they seem not to be used anymore.