### PR TITLE
Markdown table in benchmark clipboard results

### DIFF
--- a/bench/benchmarks_view.js
+++ b/bench/benchmarks_view.js
@@ -64,13 +64,28 @@ const BenchmarksView = React.createClass({
     },
 
     renderTextBenchmarks: function() {
-        let output = '# Benchmarks\n';
+        const versions = [];
         for (const name in this.state.results) {
-            output += `\n## ${name}\n\n`;
             for (const version in this.state.results[name]) {
-                const result = this.state.results[name][version];
-                output += `**${version}:** ${result.message || '...'}\n`;
+                if (versions.indexOf(version) < 0) {
+                    versions.push(version);
+                }
             }
+        }
+
+        let output = `benchmark | ${versions.join(' | ')}\n---`;
+        for (let i = 0; i < versions.length; i++) {
+            output += ' | ---';
+        }
+        output += '\n';
+
+        for (const name in this.state.results) {
+            output += `**${name}**`;
+            for (const version of versions) {
+                const result = this.state.results[name][version];
+                output += ` | ${result && result.message || 'n\/a'} `;
+            }
+            output += '\n';
         }
         return output;
     },


### PR DESCRIPTION
The clipboard benchmark results were a pain to read, so I made them a table. cc @lucaswoj 

benchmark | master 79e40c9 | bench-table cd70f94
--- | --- | ---
**map-load** | 312 ms  | 182 ms 
**style-load** | 207 ms  | 209 ms 
**buffer** | 1,208 ms  | 1,225 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 9.9 ms, 13% > 16ms  | 10 ms, 16% > 16ms 
**query-point** | 1.01 ms  | 1.18 ms 
**query-box** | 103.28 ms  | 103.12 ms 
**geojson-setdata-small** | 14 ms  | 7 ms 
**geojson-setdata-large** | 223 ms  | 203 ms 
