### PR TITLE
fix dash lengths

### DIFF
--- a/js/style/style_layer/line_style_layer.js
+++ b/js/style/style_layer/line_style_layer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const StyleLayer = require('../style_layer');
+const util = require('../../util/util');
 
 class LineStyleLayer extends StyleLayer {
 
@@ -13,7 +14,9 @@ class LineStyleLayer extends StyleLayer {
             const flooredZoom = Math.floor(globalProperties.zoom);
             if (this._flooredZoom !== flooredZoom) {
                 this._flooredZoom = flooredZoom;
-                this._flooredLineWidth = this.getPaintValue('line-width', globalProperties, featureProperties);
+                const flooredGlobalProperties = util.clone(globalProperties);
+                flooredGlobalProperties.zoom = flooredZoom;
+                this._flooredLineWidth = this.getPaintValue('line-width', flooredGlobalProperties, featureProperties);
             }
 
             value.fromScale *= this._flooredLineWidth;

--- a/js/style/style_layer/line_style_layer.js
+++ b/js/style/style_layer/line_style_layer.js
@@ -11,16 +11,10 @@ class LineStyleLayer extends StyleLayer {
         // If the line is dashed, scale the dash lengths by the line
         // width at the previous round zoom level.
         if (value && name === 'line-dasharray') {
-            const flooredZoom = Math.floor(globalProperties.zoom);
-            if (this._flooredZoom !== flooredZoom) {
-                this._flooredZoom = flooredZoom;
-                const flooredGlobalProperties = util.clone(globalProperties);
-                flooredGlobalProperties.zoom = flooredZoom;
-                this._flooredLineWidth = this.getPaintValue('line-width', flooredGlobalProperties, featureProperties);
-            }
-
-            value.fromScale *= this._flooredLineWidth;
-            value.toScale *= this._flooredLineWidth;
+            const width = this.getPaintValue('line-width',
+                    util.extend({}, globalProperties, {zoom: Math.floor(globalProperties.zoom)}), featureProperties);
+            value.fromScale *= width;
+            value.toScale *= width;
         }
 
         return value;

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#031ec5fde2a8b4b47603f9bb808705d4f0f8edb4",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#28c76c64e8cfcee8764c6c0f6d4fcc2d15a8d1e1",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f306dfc970d489b3e516677bac8a1040c0b8503f",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#031ec5fde2a8b4b47603f9bb808705d4f0f8edb4",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
First commit fixes a regression where the dash length was based on the first fractional zoom reached instead of the integer zoom level. [I added a new render test](https://github.com/mapbox/mapbox-gl-test-suite/commit/031ec5fde2a8b4b47603f9bb808705d4f0f8edb4). See commit message for details.

The second commit fixes #3426 (dash length when line width changes at runtime).

:eyes: @lucaswoj 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page

benchmark | master adf0df8 | master bfe3b2b
--- | --- | ---
**map-load** | 245 ms  | 139 ms 
**style-load** | 146 ms  | 143 ms 
**buffer** | 1,195 ms  | 1,227 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 7.7 ms, 1% > 16ms  | 7.9 ms, 3% > 16ms 
**query-point** | 1.11 ms  | 1.20 ms 
**query-box** | 89.36 ms  | 93.97 ms 
**geojson-setdata-small** | 7 ms  | 7 ms 
**geojson-setdata-large** | 124 ms  | 111 ms 

