### PR TITLE
Add instructions to issue template requiring issue titles be a verb phrase

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,6 +2,7 @@
 Hello! Thanks for contributing. 
 
 If you are reporting a bug, please:
+ - Make the issue an actionable verb phrase such as "Fix bug causing exception to thrown when rotating the map" (rather than "Map rotation is broken" or "Map rotation bug")
  - Include a link to a minimal demonstration of the bug. We recommend using https://jsbin.com
  - Ensure you can reproduce the bug using the latest release.
  - Check the console for relevant errors and warnings

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 Hello! Thanks for contributing. 
 
 If you are reporting a bug, please:
- - Make the issue an actionable verb phrase such as "Fix bug causing exception to thrown when rotating the map" (rather than "Map rotation is broken" or "Map rotation bug")
+ - Make the issue title a succinct but specific description of the problem you encountered. Bad: "Map rotation is broken". Good: "map.setBearing(...) throws a TypeError for negative values"
  - Include a link to a minimal demonstration of the bug. We recommend using https://jsbin.com
  - Ensure you can reproduce the bug using the latest release.
  - Check the console for relevant errors and warnings
@@ -10,6 +10,7 @@ If you are reporting a bug, please:
  
 If you are requesting a new feature or suggesting a big change, please:
  - Copy the Mapbox GL RFC template into this ticket and fill out as much as you can https://raw.githubusercontent.com/mapbox/mapbox-gl/master/RFC_TEMPLATE.md
+  - Make the issue title a succinct but specific description of your use case or the desired functionality. Bad: "More clustering options". Good: "Compute and expose aggregated values when clustering GeoJSON".
 -->
 
 **mapbox-gl-js version**:

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 Hello! Thanks for contributing. 
 
 If you are reporting a bug, please:
- - Make the issue title a succinct but specific description of the problem you encountered. Bad: "Map rotation is broken". Good: "map.setBearing(...) throws a TypeError for negative values"
+ - Make the issue title a succinct but specific description of the unexpected behavior. Bad: "Map rotation is broken". Good: "map.setBearing(...) throws a TypeError for negative values"
  - Include a link to a minimal demonstration of the bug. We recommend using https://jsbin.com
  - Ensure you can reproduce the bug using the latest release.
  - Check the console for relevant errors and warnings


### PR DESCRIPTION
Apologies for jumping the gun by committing 3e7e422b498c9d01b566a0dac24eeff57cb89742 directly to `master`.

Requiring that all issue titles be a verb phrase means that

 - there is more standardization of issue title formatting
 - there is a higher bar for summarizing the body of an issue in its title
 - there is more likelihood that an issue has a clear "success criterion" defining when it can be closed
 - there is less likelihood of issues being opened that do not request a new feature or report a bug
 - there is more likelihood of an issue having a clear [next action](https://zenhabits.net/why-whats-the-next-action-is-the-most-important-question/)

----

@jfirebaugh raised a concern about this new standard in Slack:

 > In my opinion, this approach adds redundancy to label titles, and in some cases leads people to presuppose particular solutions or approaches, where what's needed is a good problem statement rather than a particular remedy.

I think that this is a valid but mostly orthogonal concern. An issue title may presuppose a particular solution whether it is a verb phrase or not. There are valid cases to open Issues that are specifications only, requirements only, and that blend the two. 

 ----

cc @jfirebaugh @mourner @tmcw @1ec5 