### PR TITLE
Change light spec path as follow-up to mapbox-gl-style-spec#542

### DIFF
--- a/js/style/light.js
+++ b/js/style/light.js
@@ -17,7 +17,7 @@ class Light extends Evented {
     constructor(lightOptions) {
         super();
         this.properties = ['anchor', 'color', 'position', 'intensity'];
-        this._specifications = styleSpec.$root.light;
+        this._specifications = styleSpec.light;
         this.set(lightOptions);
     }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#44b65f8090a74cbb0319664d010b8d8a8a1512b0",
-    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#0683ea99c971e24c52db1e60aaafd8b9997c0103",
+    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#f5e88adb911b992494169541e17045bf6596a2f7",
     "mapbox-gl-supported": "^1.2.0",
     "package-json-versionify": "^1.0.2",
     "pbf": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#44b65f8090a74cbb0319664d010b8d8a8a1512b0",
-    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#7d330d2abf1775abc95ab8b889089cf5ff579357",
+    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#0683ea99c971e24c52db1e60aaafd8b9997c0103",
     "mapbox-gl-supported": "^1.2.0",
     "package-json-versionify": "^1.0.2",
     "pbf": "^1.3.2",

--- a/test/js/style/light.test.js
+++ b/test/js/style/light.test.js
@@ -2,7 +2,7 @@
 
 const test = require('mapbox-gl-js-test').test;
 const Light = require('../../../js/style/light');
-const spec = require('../../../js/style/style_spec').$root.light;
+const spec = require('../../../js/style/style_spec').light;
 
 test('Light', (t) => {
     t.test('creates default light with no options', (t) => {


### PR DESCRIPTION
When updating the style spec pin after https://github.com/mapbox/mapbox-gl-style-spec/commit/630ede585e39c5fbfa4ce41d4f5cfbe995d18ff5 `light.js` breaks. When we pin that to a more recent commit this needs to be merged as well.