### PR TITLE
Disable drag rotate if touch detected

### DIFF
--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -61,6 +61,7 @@ class DragRotateHandler {
     enable() {
         if (this.isEnabled()) return;
         this._el.addEventListener('mousedown', this._onDown);
+        this._el.addEventListener('touchstart', this._onTouchStart);
         this._enabled = true;
     }
 
@@ -73,7 +74,12 @@ class DragRotateHandler {
     disable() {
         if (!this.isEnabled()) return;
         this._el.removeEventListener('mousedown', this._onDown);
+        this._el.removeEventListener('touchstart', this._onTouchStart);
         this._enabled = false;
+    }
+
+    _onTouchStart() {
+        this.disable();
     }
 
     _onDown(e) {


### PR DESCRIPTION
A long press touch is interpreted by the browser as a right click,
which causes the drag rotate to start a rotation. Subsequent touches
perform the rotation, which causes the map to erratically rotate
around. If a touch start event is detected, just disable the feature.

As recommended by @bhousel in https://github.com/mapbox/mapbox-gl-js/issues/2204
