### PR TITLE
Iterate array with for rather than for..in

### DIFF
--- a/js/style/light.js
+++ b/js/style/light.js
@@ -35,9 +35,7 @@ class Light extends Evented {
             intensity: this._specifications.intensity.default
         }, lightOpts);
 
-        for (let p = 0; p < this.properties.length; p++) {
-            const prop = this.properties[p];
-
+        for (const prop of this.properties) {
             this._declarations[prop] = new StyleDeclaration(this._specifications[prop], lightOpts[prop]);
         }
 

--- a/js/style/light.js
+++ b/js/style/light.js
@@ -35,7 +35,7 @@ class Light extends Evented {
             intensity: this._specifications.intensity.default
         }, lightOpts);
 
-        for (const p in this.properties) {
+        for (let p = 0; p < this.properties.length; p++) {
             const prop = this.properties[p];
 
             this._declarations[prop] = new StyleDeclaration(this._specifications[prop], lightOpts[prop]);


### PR DESCRIPTION
Reason: I just ran into a case where an ill-advised polyfill on a page I
don't fully control caused this loop to blow up, because the polyfill
attached enumerable properties to Array.prototype. (Ugh.)