### PR TITLE
Fix queryRenderedFeatures for symbol features

### DIFF
--- a/js/data/feature_index.js
+++ b/js/data/feature_index.js
@@ -146,7 +146,7 @@ class FeatureIndex {
         matching.sort(topDownFeatureComparator);
         this.filterMatching(result, matching, this.featureIndexArray, queryGeometry, filter, params.layers, styleLayers, args.bearing, pixelsToTileUnits);
 
-        const matchingSymbols = this.collisionTile.queryRenderedSymbols(minX, minY, maxX, maxY, args.scale);
+        const matchingSymbols = this.collisionTile.queryRenderedSymbols(queryGeometry, args.scale);
         matchingSymbols.sort();
         this.filterMatching(result, matchingSymbols, this.collisionTile.collisionBoxArray, queryGeometry, filter, params.layers, styleLayers, args.bearing, pixelsToTileUnits);
 

--- a/js/util/intersection_tests.js
+++ b/js/util/intersection_tests.js
@@ -6,8 +6,23 @@ module.exports = {
     multiPolygonIntersectsBufferedMultiPoint: multiPolygonIntersectsBufferedMultiPoint,
     multiPolygonIntersectsMultiPolygon: multiPolygonIntersectsMultiPolygon,
     multiPolygonIntersectsBufferedMultiLine: multiPolygonIntersectsBufferedMultiLine,
+    polygonIntersectsPolygon: polygonIntersectsPolygon,
     distToSegmentSquared: distToSegmentSquared
 };
+
+function polygonIntersectsPolygon(polygonA, polygonB) {
+    for (let i = 0; i < polygonA.length; i++) {
+        if (polygonContainsPoint(polygonB, polygonA[i])) return true;
+    }
+
+    for (let i = 0; i < polygonB.length; i++) {
+        if (polygonContainsPoint(polygonA, polygonB[i])) return true;
+    }
+
+    if (lineIntersectsLine(polygonA, polygonB)) return true;
+
+    return false;
+}
 
 function multiPolygonIntersectsBufferedMultiPoint(multiPolygon, rings, radius) {
     for (let j = 0; j < multiPolygon.length; j++) {
@@ -89,6 +104,7 @@ function lineIntersectsBufferedLine(lineA, lineB, radius) {
 }
 
 function lineIntersectsLine(lineA, lineB) {
+    if (lineA.length === 0 || lineB.length === 0) return false;
     for (let i = 0; i < lineA.length - 1; i++) {
         const a0 = lineA[i];
         const a1 = lineA[i + 1];

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#28c76c64e8cfcee8764c6c0f6d4fcc2d15a8d1e1",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2817eedfe76f38b63bb77cb58c3b691e47169a92",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
Use the query geometry as polygon for intersecting with symbol features collision box. Fixes situations where e.g. unseen features were returned or vice-versa.

This PR is a port from GL native (see https://github.com/mapbox/mapbox-gl-native/pull/6773). 

Query test `symbol-features-in/pitched-screen` (#3447) should be passing now, but because the feature order differs from GL native, the test fails. We should probably sort features by latitude/longitude prior to JSON comparison.

Benchmark reports are within standard deviation:
<img width="277" alt="screen shot 2016-10-25 at 4 51 33 pm" src="https://cloud.githubusercontent.com/assets/76133/19689100/e9b688e8-9ad4-11e6-9300-919929f7a5e0.png">

/cc @ansis @jfirebaugh @mourner 