### PR TITLE
Fewer bucket members

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -34,7 +34,6 @@ class Bucket {
         this.childLayers = options.childLayers;
 
         this.index = options.index;
-        this.sourceLayerIndex = options.sourceLayerIndex;
         this.featureIndex = options.featureIndex;
         this.programConfigurations = util.mapObject(this.programInterfaces, (programInterface) => {
             const result = {};
@@ -67,7 +66,7 @@ class Bucket {
         for (const feature of features) {
             if (this.layer.filter(feature)) {
                 this.addFeature(feature);
-                this.featureIndex.insert(feature, feature.index, this.sourceLayerIndex, this.index);
+                this.featureIndex.insert(feature, this.index);
             }
         }
 

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -34,7 +34,6 @@ class Bucket {
         this.childLayers = options.childLayers;
 
         this.index = options.index;
-        this.featureIndex = options.featureIndex;
         this.programConfigurations = util.mapObject(this.programInterfaces, (programInterface) => {
             const result = {};
             for (const layer of options.childLayers) {
@@ -59,14 +58,14 @@ class Bucket {
         }
     }
 
-    populate(features) {
+    populate(features, options) {
         this.createArrays();
         this.recalculateStyleLayers();
 
         for (const feature of features) {
             if (this.layer.filter(feature)) {
                 this.addFeature(feature);
-                this.featureIndex.insert(feature, this.index);
+                options.featureIndex.insert(feature, this.index);
             }
         }
 

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -33,15 +33,9 @@ class Bucket {
         this.layer = options.layer;
         this.childLayers = options.childLayers;
 
-        this.type = this.layer.type;
-        this.id = this.layer.id;
         this.index = options.index;
-        this.sourceLayer = this.layer.sourceLayer;
         this.sourceLayerIndex = options.sourceLayerIndex;
         this.featureIndex = options.featureIndex;
-        this.minZoom = this.layer.minzoom;
-        this.maxZoom = this.layer.maxzoom;
-
         this.programConfigurations = util.mapObject(this.programInterfaces, (programInterface) => {
             const result = {};
             for (const layer of options.childLayers) {
@@ -51,9 +45,8 @@ class Bucket {
         });
 
         if (options.arrays) {
-            const programInterfaces = this.programInterfaces;
             this.bufferGroups = util.mapObject(options.arrays, (programArrayGroups, programName) => {
-                const programInterface = programInterfaces[programName];
+                const programInterface = this.programInterfaces[programName];
                 const paintVertexArrayTypes = options.paintVertexArrayTypes[programName];
                 return programArrayGroups.map((arrayGroup) => {
                     return new BufferGroup(arrayGroup, {

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -179,6 +179,7 @@ class SymbolBucket extends Bucket {
                 text,
                 icon,
                 index: this.features.length,
+                sourceLayerIndex: feature.sourceLayerIndex,
                 geometry: loadGeometry(feature),
                 properties: feature.properties
             });
@@ -378,7 +379,7 @@ class SymbolBucket extends Bucket {
                 // the buffers for both tiles and clipped to tile boundaries at draw time.
                 const addToBuffers = inside || mayOverlap;
                 this.addSymbolInstance(anchor, line, shapedText, shapedIcon, this.layer,
-                    addToBuffers, this.symbolInstancesArray.length, this.collisionBoxArray, feature.index, this.sourceLayerIndex, this.index,
+                    addToBuffers, this.symbolInstancesArray.length, this.collisionBoxArray, feature.index, feature.sourceLayerIndex, this.index,
                     textBoxScale, textPadding, textAlongLine,
                     iconBoxScale, iconPadding, iconAlongLine, {zoom: this.zoom}, feature.properties);
             }

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -95,8 +95,6 @@ class SymbolBucket extends Bucket {
     constructor(options) {
         super(options);
 
-        this.showCollisionBoxes = options.showCollisionBoxes;
-        this.overscaling = options.overscaling;
         this.collisionBoxArray = options.collisionBoxArray;
         this.symbolQuadsArray = options.symbolQuadsArray;
         this.symbolInstancesArray = options.symbolInstancesArray;
@@ -135,7 +133,7 @@ class SymbolBucket extends Bucket {
                 placementZoom * 10);
     }
 
-    populate(features, dependencies) {
+    populate(features, options) {
         this.recalculateStyleLayers();
 
         const layout = this.layer.layout;
@@ -152,8 +150,8 @@ class SymbolBucket extends Bucket {
             return;
         }
 
-        const icons = dependencies.icons;
-        const stacks = dependencies.stacks;
+        const icons = options.iconDependencies;
+        const stacks = options.glyphDependencies;
         const stack = stacks[textFont] = stacks[textFont] || {};
 
         for (const feature of features) {

--- a/js/data/feature_index.js
+++ b/js/data/feature_index.js
@@ -50,9 +50,9 @@ class FeatureIndex {
         this.setCollisionTile(collisionTile);
     }
 
-    insert(feature, featureIndex, sourceLayerIndex, bucketIndex) {
+    insert(feature, bucketIndex) {
         const key = this.featureIndexArray.length;
-        this.featureIndexArray.emplaceBack(featureIndex, sourceLayerIndex, bucketIndex);
+        this.featureIndexArray.emplaceBack(feature.index, feature.sourceLayerIndex, bucketIndex);
         const geometry = loadGeometry(feature);
 
         for (let r = 0; r < geometry.length; r++) {

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -200,7 +200,7 @@ function unserializeBuckets(input, style) {
                 .map(style.getLayer.bind(style))
                 .filter((layer) => { return layer; })
         }, input[i]));
-        output[bucket.id] = bucket;
+        output[layer.id] = bucket;
     }
     return output;
 }

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -130,7 +130,7 @@ class WorkerTile {
         for (let i = layerIndex.order.length - 1; i >= 0; i--) {
             const id = layerIndex.order[i];
             const bucket = buckets[id];
-            if (bucket && bucket.type === 'symbol') {
+            if (bucket && bucket.layer.type === 'symbol') {
                 this.symbolBuckets.push(bucket);
             }
         }

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -63,10 +63,12 @@ class WorkerTile {
                 );
             }
 
+            const sourceLayerIndex = sourceLayerCoder.encode(sourceLayerId);
             const features = [];
             for (let i = 0; i < sourceLayer.length; i++) {
                 const feature = sourceLayer.feature(i);
                 feature.index = i;
+                feature.sourceLayerIndex = sourceLayerIndex;
                 features.push(feature);
             }
 
@@ -89,7 +91,6 @@ class WorkerTile {
                     collisionBoxArray: this.collisionBoxArray,
                     symbolQuadsArray: this.symbolQuadsArray,
                     symbolInstancesArray: this.symbolInstancesArray,
-                    sourceLayerIndex: sourceLayerCoder.encode(sourceLayerId),
                     featureIndex: featureIndex
                 });
 

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -82,16 +82,18 @@ test('Bucket', (t) => {
 
         return new Class({
             layer: layers[0],
-            childLayers: layers,
-            buffers: {},
-            featureIndex: new FeatureIndex(new TileCoord(0, 0, 0), 0, null)
+            childLayers: layers
         });
+    }
+
+    function createOptions() {
+        return {featureIndex: new FeatureIndex(new TileCoord(0, 0, 0), 0, null)};
     }
 
     t.test('add features', (t) => {
         const bucket = create();
 
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
 
         const testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
         t.equal(testVertex.length, 1);
@@ -125,7 +127,7 @@ test('Bucket', (t) => {
             { id: 'two', type: 'circle', paint: dataDrivenPaint }
         ]});
 
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
 
         const v0 = bucket.arrayGroups.test[0].layoutVertexArray.get(0);
         const a0 = bucket.arrayGroups.test[0].paintVertexArrays.one.get(0);
@@ -152,7 +154,7 @@ test('Bucket', (t) => {
             ]
         });
 
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
 
         t.equal(bucket.arrayGroups.test[0].layoutVertexArray.bytesPerElement, 0);
         t.deepEqual(
@@ -172,7 +174,7 @@ test('Bucket', (t) => {
             }]
         });
 
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
 
         const v0 = bucket.arrayGroups.test[0].layoutVertexArray.get(0);
         t.equal(v0.a_map, 34);
@@ -183,7 +185,7 @@ test('Bucket', (t) => {
     t.test('reset buffers', (t) => {
         const bucket = create();
 
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
 
         t.equal(bucket.arrayGroups.test.length, 1);
         bucket.createArrays();
@@ -214,7 +216,7 @@ test('Bucket', (t) => {
         bucket.createArrays();
         t.ok(bucket.isEmpty());
 
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
         t.ok(!bucket.isEmpty());
 
         t.end();
@@ -222,7 +224,7 @@ test('Bucket', (t) => {
 
     t.test('getTransferables', (t) => {
         const bucket = create();
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
 
         const transferables = [];
         bucket.getTransferables(transferables);
@@ -239,9 +241,9 @@ test('Bucket', (t) => {
     t.test('add features after resetting buffers', (t) => {
         const bucket = create();
 
-        bucket.populate([createFeature(1, 5)]);
+        bucket.populate([createFeature(1, 5)], createOptions());
         bucket.createArrays();
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
 
         const testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
         t.equal(testVertex.length, 1);
@@ -278,7 +280,7 @@ test('Bucket', (t) => {
     t.test('add features', (t) => {
         const bucket = create();
 
-        bucket.populate([createFeature(17, 42)]);
+        bucket.populate([createFeature(17, 42)], createOptions());
 
         const testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
         t.equal(testVertex.length, 1);

--- a/test/js/data/symbol_bucket.test.js
+++ b/test/js/data/symbol_bucket.test.js
@@ -21,7 +21,6 @@ const feature = vt.layers.place_label.feature(10);
 const glyphs = JSON.parse(fs.readFileSync(path.join(__dirname, '/../../fixtures/fontstack-glyphs.json')));
 
 /*eslint new-cap: 0*/
-const buffers = {};
 const collisionBoxArray = new CollisionBoxArray();
 const symbolQuadsArray = new SymbolQuadsArray();
 const symbolInstancesArray = new SymbolInstancesArray();
@@ -43,26 +42,24 @@ function bucketSetup() {
     });
 
     return new SymbolBucket({
-        buffers: buffers,
         overscaling: 1,
         zoom: 0,
         collisionBoxArray: collisionBoxArray,
         symbolInstancesArray: symbolInstancesArray,
         symbolQuadsArray: symbolQuadsArray,
         layer: layer,
-        childLayers: [layer],
-        tileExtent: 4096
+        childLayers: [layer]
     });
 }
 
 test('SymbolBucket', (t) => {
     const bucketA = bucketSetup();
     const bucketB = bucketSetup();
-    const dependencies = {icons: {}, stacks: {}};
+    const options = {iconDependencies: {}, glyphDependencies: {}};
 
     // add feature from bucket A
     const a = collision.grid.keys.length;
-    bucketA.populate([feature], dependencies);
+    bucketA.populate([feature], options);
     bucketA.prepare(stacks, {});
     bucketA.place(collision);
 
@@ -71,7 +68,7 @@ test('SymbolBucket', (t) => {
 
     // add same feature from bucket B
     const a2 = collision.grid.keys.length;
-    bucketB.populate([feature], dependencies);
+    bucketB.populate([feature], options);
     bucketB.prepare(stacks, {});
     bucketB.place(collision);
     const b2 = collision.grid.keys.length;
@@ -85,9 +82,9 @@ test('SymbolBucket integer overflow', (t) => {
     t.stub(SymbolBucket, 'MAX_QUADS', 5);
 
     const bucket = bucketSetup();
-    const dependencies = {icons: {}, stacks: {}};
+    const options = {iconDependencies: {}, glyphDependencies: {}};
 
-    bucket.populate([feature], dependencies);
+    bucket.populate([feature], options);
     bucket.prepare(stacks, {});
     bucket.place(collision);
 


### PR DESCRIPTION
Various changes that reduce the amount of state held by `Bucket`.

benchmark | master c9c564f | fewer-bucket-members 9a1e4c5
--- | --- | ---
**map-load** | 232 ms  | 103 ms 
**style-load** | 119 ms  | 113 ms 
**buffer** | 1,046 ms  | 993 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 7.2 ms, 0% > 16ms  | 7.2 ms, 0% > 16ms 
**query-point** | 0.96 ms  | 1.12 ms 
**query-box** | 80.69 ms  | 85.99 ms 
**geojson-setdata-small** | 8 ms  | 7 ms 
**geojson-setdata-large** | 93 ms  | 98 ms 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
