### PR TITLE
Switch from physical to logical segmentation of buffers

### DIFF
--- a/js/data/array_group.js
+++ b/js/data/array_group.js
@@ -2,39 +2,84 @@
 
 const util = require('../util/util');
 
+class Segment {
+    constructor(vertexOffset, primitiveOffset) {
+        this.vertexOffset = vertexOffset;
+        this.primitiveOffset = primitiveOffset;
+        this.vertexLength = 0;
+        this.primitiveLength = 0;
+    }
+}
+
 /**
- * A class that manages vertex and element arrays for a range of features. It handles initialization,
+ * A class that manages vertex and element arrays for a bucket. It handles initialization,
  * serialization for transfer to the main thread, and certain intervening mutations.
  *
- * Array elements are broken into array groups based on inherent limits of WebGL. Within a group is:
+ * A group has:
  *
- * * A "layout" vertex array, with fixed layout, containing values calculated from layout properties.
- * * Zero, one, or two element arrays, with fixed layout, typically for eventual use in
- *   `gl.drawElements(gl.TRIANGLES, ...)`.
+ * * A "layout" vertex array, with fixed attributes, containing values calculated from layout properties.
+ * * Zero, one, or two element arrays, with fixed layout, for eventual `gl.drawElements` use.
  * * Zero or more "paint" vertex arrays keyed by layer ID, each with a dynamic layout which depends
  *   on which paint properties of that layer use data-driven-functions (property functions or
  *   property-and-zoom functions). Values are calculated by evaluating those functions.
  *
+ * Because indexed rendering is best done with 16 bit indices (and in fact, in WebGL, 16 bit
+ * indices are the only choice), a form of segmented addressing is used. Each group
+ * contains an `Array` of `Segment`s. A segment contains a vertex array offset, which forms
+ * the "base address" of indices within this segment. Each segment is drawn separately.
+ *
  * @private
  */
 class ArrayGroup {
-    constructor(arrayTypes) {
-        const LayoutVertexArrayType = arrayTypes.layoutVertexArrayType;
+    constructor(programInterface, programConfigurations) {
+        const LayoutVertexArrayType = programInterface.layoutVertexArrayType;
         this.layoutVertexArray = new LayoutVertexArrayType();
 
-        const ElementArrayType = arrayTypes.elementArrayType;
+        const ElementArrayType = programInterface.elementArrayType;
         if (ElementArrayType) this.elementArray = new ElementArrayType();
 
-        const ElementArrayType2 = arrayTypes.elementArrayType2;
+        const ElementArrayType2 = programInterface.elementArrayType2;
         if (ElementArrayType2) this.elementArray2 = new ElementArrayType2();
 
-        this.paintVertexArrays = util.mapObject(arrayTypes.paintVertexArrayTypes, (PaintVertexArrayType) => {
-            return new PaintVertexArrayType();
+        this.paintVertexArrays = util.mapObject(programConfigurations, (programConfiguration) => {
+            const PaintVertexArrayType = programConfiguration.paintVertexArrayType();
+            const paintVertexArray = new PaintVertexArrayType();
+            paintVertexArray.programConfiguration = programConfiguration;
+            return paintVertexArray;
         });
+
+        this.segments = [];
+        this.segments2 = [];
     }
 
-    hasCapacityFor(numVertices) {
-        return this.layoutVertexArray.length + numVertices <= ArrayGroup.MAX_VERTEX_ARRAY_LENGTH;
+    prepareSegment(numVertices) {
+        let segment = this.segments[this.segments.length - 1];
+        if (!segment || segment.vertexLength + numVertices > ArrayGroup.MAX_VERTEX_ARRAY_LENGTH) {
+            segment = new Segment(this.layoutVertexArray.length, this.elementArray.length);
+            this.segments.push(segment);
+        }
+        return segment;
+    }
+
+    prepareSegment2(numVertices) {
+        let segment = this.segments2[this.segments2.length - 1];
+        if (!segment || segment.vertexLength + numVertices > ArrayGroup.MAX_VERTEX_ARRAY_LENGTH) {
+            segment = new Segment(this.layoutVertexArray.length, this.elementArray2.length);
+            this.segments2.push(segment);
+        }
+        return segment;
+    }
+
+    populatePaintArrays(layers, globalProperties, featureProperties) {
+        for (const layer of layers) {
+            const paintArray = this.paintVertexArrays[layer.id];
+            paintArray.programConfiguration.populatePaintArray(
+                layer,
+                paintArray,
+                this.layoutVertexArray.length,
+                globalProperties,
+                featureProperties);
+        }
     }
 
     isEmpty() {
@@ -63,8 +108,13 @@ class ArrayGroup {
             elementArray: this.elementArray && this.elementArray.serialize(),
             elementArray2: this.elementArray2 && this.elementArray2.serialize(),
             paintVertexArrays: util.mapObject(this.paintVertexArrays, (array) => {
-                return array.serialize();
-            })
+                return {
+                    array: array.serialize(),
+                    type: array.constructor.serialize()
+                };
+            }),
+            segments: this.segments,
+            segments2: this.segments2
         };
     }
 

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -30,30 +30,20 @@ class Bucket {
     constructor (options) {
         this.zoom = options.zoom;
         this.overscaling = options.overscaling;
-        this.layer = options.layer;
-        this.childLayers = options.childLayers;
-
+        this.layers = options.layers;
         this.index = options.index;
+
         this.programConfigurations = util.mapObject(this.programInterfaces, (programInterface) => {
             const result = {};
-            for (const layer of options.childLayers) {
+            for (const layer of this.layers) {
                 result[layer.id] = ProgramConfiguration.createDynamic(programInterface.paintAttributes || [], layer, options);
             }
             return result;
         });
 
         if (options.arrays) {
-            this.bufferGroups = util.mapObject(options.arrays, (programArrayGroups, programName) => {
-                const programInterface = this.programInterfaces[programName];
-                const paintVertexArrayTypes = options.paintVertexArrayTypes[programName];
-                return programArrayGroups.map((arrayGroup) => {
-                    return new BufferGroup(arrayGroup, {
-                        layoutVertexArrayType: programInterface.layoutVertexArrayType.serialize(),
-                        elementArrayType: programInterface.elementArrayType && programInterface.elementArrayType.serialize(),
-                        elementArrayType2: programInterface.elementArrayType2 && programInterface.elementArrayType2.serialize(),
-                        paintVertexArrayTypes: paintVertexArrayTypes
-                    });
-                });
+            this.bufferGroups = util.mapObject(options.arrays, (arrayGroup, programName) => {
+                return new BufferGroup(arrayGroup, this.programInterfaces[programName]);
             });
         }
     }
@@ -63,7 +53,7 @@ class Bucket {
         this.recalculateStyleLayers();
 
         for (const feature of features) {
-            if (this.layer.filter(feature)) {
+            if (this.layers[0].filter(feature)) {
                 this.addFeature(feature);
                 options.featureIndex.insert(feature, this.index);
             }
@@ -72,143 +62,53 @@ class Bucket {
         this.trimArrays();
     }
 
-    /**
-     * Check if there is enough space available in the current array group for
-     * `vertexLength` vertices. If not, append a new array group. Should be called
-     * by `populateArrays` and its callees.
-     *
-     * Array groups are added to this.arrayGroups[programName].
-     *
-     * @param {string} programName the name of the program associated with the buffer that will receive the vertices
-     * @param {number} vertexLength The number of vertices that will be inserted to the buffer.
-     * @returns The current array group
-     */
-    prepareArrayGroup(programName, numVertices) {
-        const groups = this.arrayGroups[programName];
-        let currentGroup = groups.length && groups[groups.length - 1];
-
-        if (!currentGroup || !currentGroup.hasCapacityFor(numVertices)) {
-            currentGroup = new ArrayGroup({
-                layoutVertexArrayType: this.programInterfaces[programName].layoutVertexArrayType,
-                elementArrayType: this.programInterfaces[programName].elementArrayType,
-                elementArrayType2: this.programInterfaces[programName].elementArrayType2,
-                paintVertexArrayTypes: this.paintVertexArrayTypes[programName]
-            });
-
-            currentGroup.index = groups.length;
-
-            groups.push(currentGroup);
-        }
-
-        return currentGroup;
-    }
-
-    /**
-     * Sets up `this.paintVertexArrayTypes` as { [programName]: { [layerName]: PaintArrayType, ... }, ... }
-     *
-     * And `this.arrayGroups` as { [programName]: [], ... }; these get populated
-     * with array group structure over in `prepareArrayGroup`.
-     */
     createArrays() {
-        this.arrayGroups = {};
-        this.paintVertexArrayTypes = {};
-
+        this.arrays = {};
         for (const programName in this.programInterfaces) {
-            this.arrayGroups[programName] = [];
-            this.paintVertexArrayTypes[programName] = util.mapObject(
-                this.programConfigurations[programName], (programConfiguration) => {
-                    return programConfiguration.paintVertexArrayType();
-                });
+            this.arrays[programName] = new ArrayGroup(
+                this.programInterfaces[programName],
+                this.programConfigurations[programName]);
         }
     }
 
     destroy() {
         for (const programName in this.bufferGroups) {
-            const programBufferGroups = this.bufferGroups[programName];
-            for (let i = 0; i < programBufferGroups.length; i++) {
-                programBufferGroups[i].destroy();
-            }
+            this.bufferGroups[programName].destroy();
         }
     }
 
     trimArrays() {
-        for (const programName in this.arrayGroups) {
-            const arrayGroups = this.arrayGroups[programName];
-            for (let i = 0; i < arrayGroups.length; i++) {
-                arrayGroups[i].trim();
-            }
+        for (const programName in this.arrays) {
+            this.arrays[programName].trim();
         }
     }
 
     isEmpty() {
-        for (const programName in this.arrayGroups) {
-            const arrayGroups = this.arrayGroups[programName];
-            for (let i = 0; i < arrayGroups.length; i++) {
-                if (!arrayGroups[i].isEmpty()) {
-                    return false;
-                }
+        for (const programName in this.arrays) {
+            if (!this.arrays[programName].isEmpty()) {
+                return false;
             }
         }
         return true;
     }
 
     getTransferables(transferables) {
-        for (const programName in this.arrayGroups) {
-            const arrayGroups = this.arrayGroups[programName];
-            for (let i = 0; i < arrayGroups.length; i++) {
-                arrayGroups[i].getTransferables(transferables);
-            }
+        for (const programName in this.arrays) {
+            this.arrays[programName].getTransferables(transferables);
         }
     }
 
     serialize() {
         return {
-            layerId: this.layer.id,
             zoom: this.zoom,
-            arrays: util.mapObject(this.arrayGroups, (programArrayGroups) => {
-                return programArrayGroups.map((arrayGroup) => {
-                    return arrayGroup.serialize();
-                });
-            }),
-            paintVertexArrayTypes: util.mapObject(this.paintVertexArrayTypes, (arrayTypes) => {
-                return util.mapObject(arrayTypes, (arrayType) => {
-                    return arrayType.serialize();
-                });
-            }),
-
-            childLayerIds: this.childLayers.map((layer) => {
-                return layer.id;
-            })
+            layerIds: this.layers.map((l) => l.id),
+            arrays: util.mapObject(this.arrays, (a) => a.serialize())
         };
     }
 
     recalculateStyleLayers() {
-        for (let i = 0; i < this.childLayers.length; i++) {
-            this.childLayers[i].recalculate(this.zoom, FAKE_ZOOM_HISTORY);
-        }
-    }
-
-    populatePaintArrays(interfaceName, globalProperties, featureProperties, startGroup, startIndex) {
-        const groups = this.arrayGroups[interfaceName];
-        const programConfiguration = this.programConfigurations[interfaceName];
-
-        for (const layer of this.childLayers) {
-            for (let g = startGroup.index; g < groups.length; g++) {
-                const group = groups[g];
-                const start = g === startGroup.index ? startIndex : 0;
-                const length = group.layoutVertexArray.length;
-
-                const paintArray = group.paintVertexArrays[layer.id];
-                paintArray.resize(length);
-
-                programConfiguration[layer.id].populatePaintArray(
-                    layer,
-                    paintArray,
-                    start,
-                    length,
-                    globalProperties,
-                    featureProperties);
-            }
+        for (const layer of this.layers) {
+            layer.recalculate(this.zoom, FAKE_ZOOM_HISTORY);
         }
     }
 }
@@ -229,11 +129,32 @@ const subclasses = {
  * @returns {Bucket}
  */
 Bucket.create = function(options) {
-    let type = options.layer.type;
-    if (type === 'fill' && (!options.layer.isPaintValueFeatureConstant('fill-extrude-height') ||
-        !options.layer.isPaintValueZoomConstant('fill-extrude-height') ||
-        options.layer.getPaintValue('fill-extrude-height', {zoom: options.zoom}) !== 0)) {
+    const layer = options.layers[0];
+    let type = layer.type;
+    if (type === 'fill' && (!layer.isPaintValueFeatureConstant('fill-extrude-height') ||
+        !layer.isPaintValueZoomConstant('fill-extrude-height') ||
+        layer.getPaintValue('fill-extrude-height', {zoom: options.zoom}) !== 0)) {
         type = 'fillextrusion';
     }
     return new subclasses[type](options);
+};
+
+Bucket.deserialize = function(input, style) {
+    // Guard against the case where the map's style has been set to null while
+    // this bucket has been parsing.
+    if (!style) return;
+
+    const output = {};
+    for (const serialized of input) {
+        const layers = serialized.layerIds
+            .map((id) => style.getLayer(id))
+            .filter(Boolean);
+
+        if (layers.length === 0) {
+            continue;
+        }
+
+        output[layers[0].id] = Bucket.create(util.extend({layers}, serialized));
+    }
+    return output;
 };

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -59,7 +59,7 @@ const circleInterfaces = {
 };
 
 function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
-    return layoutVertexArray.emplaceBack(
+    layoutVertexArray.emplaceBack(
         (x * 2) + ((extrudeX + 1) / 2),
         (y * 2) + ((extrudeY + 1) / 2));
 }
@@ -78,8 +78,7 @@ class CircleBucket extends Bucket {
     }
 
     addFeature(feature) {
-        const startGroup = this.prepareArrayGroup('circle', 0);
-        const startIndex = startGroup.layoutVertexArray.length;
+        const arrays = this.arrays.circle;
 
         for (const ring of loadGeometry(feature)) {
             for (const point of ring) {
@@ -98,20 +97,23 @@ class CircleBucket extends Bucket {
                 // │ 0     1 │
                 // └─────────┘
 
-                const group = this.prepareArrayGroup('circle', 4);
-                const layoutVertexArray = group.layoutVertexArray;
+                const segment = arrays.prepareSegment(4);
+                const index = segment.vertexLength;
 
-                const index = addCircleVertex(layoutVertexArray, x, y, -1, -1);
-                addCircleVertex(layoutVertexArray, x, y, 1, -1);
-                addCircleVertex(layoutVertexArray, x, y, 1, 1);
-                addCircleVertex(layoutVertexArray, x, y, -1, 1);
+                addCircleVertex(arrays.layoutVertexArray, x, y, -1, -1);
+                addCircleVertex(arrays.layoutVertexArray, x, y, 1, -1);
+                addCircleVertex(arrays.layoutVertexArray, x, y, 1, 1);
+                addCircleVertex(arrays.layoutVertexArray, x, y, -1, 1);
 
-                group.elementArray.emplaceBack(index, index + 1, index + 2);
-                group.elementArray.emplaceBack(index, index + 3, index + 2);
+                arrays.elementArray.emplaceBack(index, index + 1, index + 2);
+                arrays.elementArray.emplaceBack(index, index + 3, index + 2);
+
+                segment.vertexLength += 4;
+                segment.primitiveLength += 2;
             }
         }
 
-        this.populatePaintArrays('circle', {zoom: this.zoom}, feature.properties, startGroup, startIndex);
+        arrays.populatePaintArrays(this.layers, {zoom: this.zoom}, feature.properties);
     }
 }
 

--- a/js/data/buffer.js
+++ b/js/data/buffer.js
@@ -56,8 +56,9 @@ class Buffer {
      * Set the attribute pointers in a WebGL context
      * @param gl The WebGL context
      * @param program The active WebGL program
+     * @param vertexOffset Index of the starting vertex of the segment
      */
-    setVertexAttribPointers(gl, program) {
+    setVertexAttribPointers(gl, program, vertexOffset) {
         for (let j = 0; j < this.attributes.length; j++) {
             const member = this.attributes[j];
             const attribIndex = program[member.name];
@@ -69,7 +70,7 @@ class Buffer {
                     gl[AttributeType[member.type]],
                     false,
                     this.arrayType.bytesPerElement,
-                    member.offset
+                    member.offset + (this.arrayType.bytesPerElement * vertexOffset || 0)
                 );
             }
         }

--- a/js/data/program_configuration.js
+++ b/js/data/program_configuration.js
@@ -132,7 +132,10 @@ class ProgramConfiguration {
         return self;
     }
 
-    populatePaintArray(layer, paintArray, start, length, globalProperties, featureProperties) {
+    populatePaintArray(layer, paintArray, length, globalProperties, featureProperties) {
+        const start = paintArray.length;
+        paintArray.resize(length);
+
         for (const attribute of this.attributes) {
             const value = attribute.getValue(layer, globalProperties, featureProperties);
             const multiplier = attribute.multiplier || 1;

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -22,9 +22,8 @@ function drawCircles(painter, sourceCache, layer, coords) {
         const tile = sourceCache.getTile(coord);
         const bucket = tile.getBucket(layer);
         if (!bucket) continue;
-        const bufferGroups = bucket.bufferGroups.circle;
-        if (!bufferGroups) continue;
 
+        const buffers = bucket.bufferGroups.circle;
         const programConfiguration = bucket.programConfigurations.circle[layer.id];
         const program = painter.useProgram('circle', programConfiguration);
         programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
@@ -48,10 +47,9 @@ function drawCircles(painter, sourceCache, layer, coords) {
             layer.paint['circle-translate-anchor']
         ));
 
-        for (let k = 0; k < bufferGroups.length; k++) {
-            const group = bufferGroups[k];
-            group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer, group.paintVertexBuffers[layer.id]);
-            gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
+        for (const segment of buffers.segments) {
+            segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+            gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
         }
     }
 }

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -12,11 +12,6 @@ function drawCollisionDebug(painter, sourceCache, layer, coords) {
         const tile = sourceCache.getTile(coord);
         const bucket = tile.getBucket(layer);
         if (!bucket) continue;
-        const bufferGroups = bucket.bufferGroups.collisionBox;
-
-        if (!bufferGroups || !bufferGroups.length) continue;
-        const group = bufferGroups[0];
-        if (group.layoutVertexBuffer.length === 0) continue;
 
         gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
@@ -27,7 +22,10 @@ function drawCollisionDebug(painter, sourceCache, layer, coords) {
         gl.uniform1f(program.u_zoom, painter.transform.zoom * 10);
         gl.uniform1f(program.u_maxzoom, (tile.coord.z + 1) * 10);
 
-        group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer);
-        gl.drawArrays(gl.LINES, 0, group.layoutVertexBuffer.length);
+        const buffers = bucket.bufferGroups.collisionBox;
+        for (const segment of buffers.segments) {
+            segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, null, segment.vertexOffset);
+            gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);
+        }
     }
 }

--- a/js/render/draw_extrusion.js
+++ b/js/render/draw_extrusion.js
@@ -142,14 +142,13 @@ ExtrusionTexture.prototype.renderToMap = function() {
 };
 
 function drawExtrusion(painter, source, layer, coord) {
+    if (painter.isOpaquePass) return;
+
     const tile = source.getTile(coord);
     const bucket = tile.getBucket(layer);
     if (!bucket) return;
-    const bufferGroups = bucket.bufferGroups.fillextrusion;
-    if (!bufferGroups) return;
 
-    if (painter.isOpaquePass) return;
-
+    const buffers = bucket.bufferGroups.fillextrusion;
     const gl = painter.gl;
 
     const image = layer.paint['fill-pattern'];
@@ -165,10 +164,9 @@ function drawExtrusion(painter, source, layer, coord) {
     setMatrix(program, painter, coord, tile, layer);
     setLight(program, painter);
 
-    for (let i = 0; i < bufferGroups.length; i++) {
-        const group = bufferGroups[i];
-        group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer, group.paintVertexBuffers[layer.id]);
-        gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
+    for (const segment of buffers.segments) {
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+        gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -50,9 +50,8 @@ function drawFill(painter, sourceCache, layer, coord) {
     const tile = sourceCache.getTile(coord);
     const bucket = tile.getBucket(layer);
     if (!bucket) return;
-    const bufferGroups = bucket.bufferGroups.fill;
-    if (!bufferGroups) return;
 
+    const buffers = bucket.bufferGroups.fill;
     const gl = painter.gl;
 
     const image = layer.paint['fill-pattern'];
@@ -83,10 +82,9 @@ function drawFill(painter, sourceCache, layer, coord) {
 
     painter.enableTileClippingMask(coord);
 
-    for (let i = 0; i < bufferGroups.length; i++) {
-        const group = bufferGroups[i];
-        group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer, group.paintVertexBuffers[layer.id]);
-        gl.drawElements(gl.TRIANGLES, group.elementBuffer.length, gl.UNSIGNED_SHORT, 0);
+    for (const segment of buffers.segments) {
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+        gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }
 
@@ -94,9 +92,8 @@ function drawStroke(painter, sourceCache, layer, coord) {
     const tile = sourceCache.getTile(coord);
     const bucket = tile.getBucket(layer);
     if (!bucket) return;
-    const bufferGroups = bucket.bufferGroups.fill;
-    if (!bufferGroups) return;
 
+    const buffers = bucket.bufferGroups.fill;
     const gl = painter.gl;
 
     const image = layer.paint['fill-pattern'];
@@ -129,9 +126,8 @@ function drawStroke(painter, sourceCache, layer, coord) {
 
     painter.enableTileClippingMask(coord);
 
-    for (let k = 0; k < bufferGroups.length; k++) {
-        const group = bufferGroups[k];
-        group.secondVaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer2, group.paintVertexBuffers[layer.id]);
-        gl.drawElements(gl.LINES, group.elementBuffer2.length * 2, gl.UNSIGNED_SHORT, 0);
+    for (const segment of buffers.segments2) {
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer2, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+        gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);
     }
 }

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -33,10 +33,10 @@ function drawLineTile(painter, sourceCache, layer, coord) {
     const tile = sourceCache.getTile(coord);
     const bucket = tile.getBucket(layer);
     if (!bucket) return;
-    const bufferGroups = bucket.bufferGroups.line;
-    if (!bufferGroups) return;
 
+    const buffers = bucket.bufferGroups.line;
     const gl = painter.gl;
+
     const dasharray = layer.paint['line-dasharray'];
     const image = layer.paint['line-pattern'];
 
@@ -120,9 +120,8 @@ function drawLineTile(painter, sourceCache, layer, coord) {
 
     gl.uniform1f(program.u_ratio, 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom));
 
-    for (let i = 0; i < bufferGroups.length; i++) {
-        const group = bufferGroups[i];
-        group.vaos[layer.id].bind(gl, program, group.layoutVertexBuffer, group.elementBuffer, group.paintVertexBuffers[layer.id]);
-        gl.drawElements(gl.TRIANGLES, group.elementBuffer.length * 3, gl.UNSIGNED_SHORT, 0);
+    for (const segment of buffers.segments) {
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+        gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }

--- a/js/render/vertex_array_object.js
+++ b/js/render/vertex_array_object.js
@@ -8,10 +8,11 @@ class VertexArrayObject {
         this.boundVertexBuffer = null;
         this.boundVertexBuffer2 = null;
         this.boundElementBuffer = null;
+        this.boundVertexOffset = null;
         this.vao = null;
     }
 
-    bind(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2) {
+    bind(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2, vertexOffset) {
 
         if (gl.extVertexArrayObject === undefined) {
             gl.extVertexArrayObject = gl.getExtension("OES_vertex_array_object");
@@ -22,18 +23,19 @@ class VertexArrayObject {
             this.boundProgram !== program ||
             this.boundVertexBuffer !== layoutVertexBuffer ||
             this.boundVertexBuffer2 !== vertexBuffer2 ||
-            this.boundElementBuffer !== elementBuffer
+            this.boundElementBuffer !== elementBuffer ||
+            this.boundVertexOffset !== vertexOffset
         );
 
         if (!gl.extVertexArrayObject || isFreshBindRequired) {
-            this.freshBind(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2);
+            this.freshBind(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2, vertexOffset);
             this.gl = gl;
         } else {
             gl.extVertexArrayObject.bindVertexArrayOES(this.vao);
         }
     }
 
-    freshBind(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2) {
+    freshBind(gl, program, layoutVertexBuffer, elementBuffer, vertexBuffer2, vertexOffset) {
         let numPrevAttributes;
         const numNextAttributes = program.numAttributes;
 
@@ -48,6 +50,7 @@ class VertexArrayObject {
             this.boundVertexBuffer = layoutVertexBuffer;
             this.boundVertexBuffer2 = vertexBuffer2;
             this.boundElementBuffer = elementBuffer;
+            this.boundVertexOffset = vertexOffset;
 
         } else {
             numPrevAttributes = gl.currentNumAttributes || 0;
@@ -68,10 +71,10 @@ class VertexArrayObject {
         }
 
         layoutVertexBuffer.bind(gl);
-        layoutVertexBuffer.setVertexAttribPointers(gl, program);
+        layoutVertexBuffer.setVertexAttribPointers(gl, program, vertexOffset);
         if (vertexBuffer2) {
             vertexBuffer2.bind(gl);
-            vertexBuffer2.setVertexAttribPointers(gl, program);
+            vertexBuffer2.setVertexAttribPointers(gl, program, vertexOffset);
         }
         if (elementBuffer) {
             elementBuffer.bind(gl);

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -72,7 +72,7 @@ class Tile {
         this.symbolInstancesArray = new SymbolInstancesArray(data.symbolInstancesArray);
         this.symbolQuadsArray = new SymbolQuadsArray(data.symbolQuadsArray);
         this.featureIndex = new FeatureIndex(data.featureIndex, this.rawTileData, this.collisionTile);
-        this.buckets = unserializeBuckets(data.buckets, painter.style);
+        this.buckets = Bucket.deserialize(data.buckets, painter.style);
     }
 
     /**
@@ -97,7 +97,7 @@ class Tile {
         }
 
         // Add new symbol buckets
-        util.extend(this.buckets, unserializeBuckets(data.buckets, style));
+        util.extend(this.buckets, Bucket.deserialize(data.buckets, style));
     }
 
     /**
@@ -182,27 +182,6 @@ class Tile {
     hasData() {
         return this.state === 'loaded' || this.state === 'reloading';
     }
-}
-
-function unserializeBuckets(input, style) {
-    // Guard against the case where the map's style has been set to null while
-    // this bucket has been parsing.
-    if (!style) return;
-
-    const output = {};
-    for (let i = 0; i < input.length; i++) {
-        const layer = style.getLayer(input[i].layerId);
-        if (!layer) continue;
-
-        const bucket = Bucket.create(util.extend({
-            layer: layer,
-            childLayers: input[i].childLayerIds
-                .map(style.getLayer.bind(style))
-                .filter((layer) => { return layer; })
-        }, input[i]));
-        output[layer.id] = bucket;
-    }
-    return output;
 }
 
 module.exports = Tile;

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -84,9 +84,8 @@ class WorkerTile {
                 if (layer.layout && layer.layout.visibility === 'none') continue;
 
                 const bucket = buckets[layer.id] = Bucket.create({
-                    layer: layer,
                     index: bucketIndex++,
-                    childLayers: family,
+                    layers: family,
                     zoom: this.zoom,
                     overscaling: this.overscaling,
                     collisionBoxArray: this.collisionBoxArray,
@@ -131,7 +130,7 @@ class WorkerTile {
         for (let i = layerIndex.order.length - 1; i >= 0; i--) {
             const id = layerIndex.order[i];
             const bucket = buckets[id];
-            if (bucket && bucket.layer.type === 'symbol') {
+            if (bucket && bucket.layers[0].type === 'symbol') {
                 this.symbolBuckets.push(bucket);
             }
         }

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -58,13 +58,12 @@ test('Bucket', (t) => {
             }
 
             addFeature(feature) {
-                const group = this.prepareArrayGroup('test', 1);
+                const arrays = this.arrays.test;
                 const point = feature.loadGeometry()[0][0];
-                const startIndex = group.layoutVertexArray.length;
-                group.layoutVertexArray.emplaceBack(point.x * 2, point.y * 2);
-                group.elementArray.emplaceBack(1, 2, 3);
-                group.elementArray2.emplaceBack(point.x, point.y);
-                this.populatePaintArrays('test', {}, feature.properties, group, startIndex);
+                arrays.layoutVertexArray.emplaceBack(point.x * 2, point.y * 2);
+                arrays.elementArray.emplaceBack(1, 2, 3);
+                arrays.elementArray2.emplaceBack(point.x, point.y);
+                arrays.populatePaintArrays(this.layers, {}, feature.properties);
             }
         }
 
@@ -80,10 +79,7 @@ test('Bucket', (t) => {
             return styleLayer;
         });
 
-        return new Class({
-            layer: layers[0],
-            childLayers: layers
-        });
+        return new Class({layers});
     }
 
     function createOptions() {
@@ -95,24 +91,24 @@ test('Bucket', (t) => {
 
         bucket.populate([createFeature(17, 42)], createOptions());
 
-        const testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
+        const testVertex = bucket.arrays.test.layoutVertexArray;
         t.equal(testVertex.length, 1);
         const v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        const paintVertex = bucket.arrayGroups.test[0].paintVertexArrays.layerid;
+        const paintVertex = bucket.arrays.test.paintVertexArrays.layerid;
         t.equal(paintVertex.length, 1);
         const p0 = paintVertex.get(0);
         t.equal(p0.a_map, 17);
 
-        const testElement = bucket.arrayGroups.test[0].elementArray;
+        const testElement = bucket.arrays.test.elementArray;
         t.equal(testElement.length, 1);
         const e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        const testElement2 = bucket.arrayGroups.test[0].elementArray2;
+        const testElement2 = bucket.arrays.test.elementArray2;
         t.equal(testElement2.length, 1);
         const e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);
@@ -129,9 +125,9 @@ test('Bucket', (t) => {
 
         bucket.populate([createFeature(17, 42)], createOptions());
 
-        const v0 = bucket.arrayGroups.test[0].layoutVertexArray.get(0);
-        const a0 = bucket.arrayGroups.test[0].paintVertexArrays.one.get(0);
-        const b0 = bucket.arrayGroups.test[0].paintVertexArrays.two.get(0);
+        const v0 = bucket.arrays.test.layoutVertexArray.get(0);
+        const a0 = bucket.arrays.test.paintVertexArrays.one.get(0);
+        const b0 = bucket.arrays.test.paintVertexArrays.two.get(0);
         t.equal(a0.a_map, 17);
         t.equal(b0.a_map, 17);
         t.equal(v0.a_box0, 34);
@@ -156,7 +152,7 @@ test('Bucket', (t) => {
 
         bucket.populate([createFeature(17, 42)], createOptions());
 
-        t.equal(bucket.arrayGroups.test[0].layoutVertexArray.bytesPerElement, 0);
+        t.equal(bucket.arrays.test.layoutVertexArray.bytesPerElement, 0);
         t.deepEqual(
             bucket.programConfigurations.test.one.uniforms[0].getValue.call(bucket),
             [5]
@@ -176,7 +172,7 @@ test('Bucket', (t) => {
 
         bucket.populate([createFeature(17, 42)], createOptions());
 
-        const v0 = bucket.arrayGroups.test[0].layoutVertexArray.get(0);
+        const v0 = bucket.arrays.test.layoutVertexArray.get(0);
         t.equal(v0.a_map, 34);
 
         t.end();
@@ -187,9 +183,9 @@ test('Bucket', (t) => {
 
         bucket.populate([createFeature(17, 42)], createOptions());
 
-        t.equal(bucket.arrayGroups.test.length, 1);
+        t.notEqual(bucket.arrays.test.layoutVertexArray.length, 0);
         bucket.createArrays();
-        t.equal(bucket.arrayGroups.test.length, 0);
+        t.equal(bucket.arrays.test.layoutVertexArray.length, 0);
 
         t.end();
     });
@@ -198,13 +194,13 @@ test('Bucket', (t) => {
         const bucket = create();
 
         bucket.createArrays();
-        bucket.prepareArrayGroup('test', 10);
-        t.equal(0, bucket.arrayGroups.test[0].layoutVertexArray.length);
-        t.notEqual(0, bucket.arrayGroups.test[0].layoutVertexArray.capacity);
+        bucket.arrays.test.prepareSegment(10);
+        t.equal(0, bucket.arrays.test.layoutVertexArray.length);
+        t.notEqual(0, bucket.arrays.test.layoutVertexArray.capacity);
 
         bucket.trimArrays();
-        t.equal(0, bucket.arrayGroups.test[0].layoutVertexArray.length);
-        t.equal(0, bucket.arrayGroups.test[0].layoutVertexArray.capacity);
+        t.equal(0, bucket.arrays.test.layoutVertexArray.length);
+        t.equal(0, bucket.arrays.test.layoutVertexArray.capacity);
 
         t.end();
     });
@@ -230,10 +226,10 @@ test('Bucket', (t) => {
         bucket.getTransferables(transferables);
 
         t.equal(4, transferables.length);
-        t.equal(bucket.arrayGroups.test[0].layoutVertexArray.arrayBuffer, transferables[0]);
-        t.equal(bucket.arrayGroups.test[0].elementArray.arrayBuffer, transferables[1]);
-        t.equal(bucket.arrayGroups.test[0].elementArray2.arrayBuffer, transferables[2]);
-        t.equal(bucket.arrayGroups.test[0].paintVertexArrays.layerid.arrayBuffer, transferables[3]);
+        t.equal(bucket.arrays.test.layoutVertexArray.arrayBuffer, transferables[0]);
+        t.equal(bucket.arrays.test.elementArray.arrayBuffer, transferables[1]);
+        t.equal(bucket.arrays.test.elementArray2.arrayBuffer, transferables[2]);
+        t.equal(bucket.arrays.test.paintVertexArrays.layerid.arrayBuffer, transferables[3]);
 
         t.end();
     });
@@ -245,24 +241,24 @@ test('Bucket', (t) => {
         bucket.createArrays();
         bucket.populate([createFeature(17, 42)], createOptions());
 
-        const testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
+        const testVertex = bucket.arrays.test.layoutVertexArray;
         t.equal(testVertex.length, 1);
         const v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        const testPaintVertex = bucket.arrayGroups.test[0].paintVertexArrays.layerid;
+        const testPaintVertex = bucket.arrays.test.paintVertexArrays.layerid;
         t.equal(testPaintVertex.length, 1);
         const p0 = testPaintVertex.get(0);
         t.equal(p0.a_map, 17);
 
-        const testElement = bucket.arrayGroups.test[0].elementArray;
+        const testElement = bucket.arrays.test.elementArray;
         t.equal(testElement.length, 1);
         const e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        const testElement2 = bucket.arrayGroups.test[0].elementArray2;
+        const testElement2 = bucket.arrays.test.elementArray2;
         t.equal(testElement2.length, 1);
         const e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);
@@ -273,7 +269,7 @@ test('Bucket', (t) => {
 
     t.test('layout properties', (t) => {
         const bucket = create();
-        t.equal(bucket.layer.layout.visibility, 'visible');
+        t.equal(bucket.layers[0].layout.visibility, 'visible');
         t.end();
     });
 
@@ -282,24 +278,24 @@ test('Bucket', (t) => {
 
         bucket.populate([createFeature(17, 42)], createOptions());
 
-        const testVertex = bucket.arrayGroups.test[0].layoutVertexArray;
+        const testVertex = bucket.arrays.test.layoutVertexArray;
         t.equal(testVertex.length, 1);
         const v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        const testPaintVertex = bucket.arrayGroups.test[0].paintVertexArrays.layerid;
+        const testPaintVertex = bucket.arrays.test.paintVertexArrays.layerid;
         t.equal(testPaintVertex.length, 1);
         const p0 = testPaintVertex.get(0);
         t.equal(p0.a_map, 17);
 
-        const testElement = bucket.arrayGroups.test[0].elementArray;
+        const testElement = bucket.arrays.test.elementArray;
         t.equal(testElement.length, 1);
         const e1 = testElement.get(0);
         t.equal(e1.vertices0, 1);
         t.equal(e1.vertices1, 2);
         t.equal(e1.vertices2, 3);
 
-        const testElement2 = bucket.arrayGroups.test[0].elementArray2;
+        const testElement2 = bucket.arrays.test.elementArray2;
         t.equal(testElement2.length, 1);
         const e2 = testElement2.get(0);
         t.equal(e2.vertices0, 17);

--- a/test/js/data/line_bucket.test.js
+++ b/test/js/data/line_bucket.test.js
@@ -15,42 +15,38 @@ const feature = vt.layers.road.feature(0);
 
 test('LineBucket', (t) => {
     const layer = new StyleLayer({ id: 'test', type: 'line', layout: {} });
-    const bucket = new LineBucket({
-        buffers: {},
-        layer: layer,
-        childLayers: [layer]
-    });
+    const bucket = new LineBucket({ layers: [layer] });
     bucket.createArrays();
 
     const pointWithScale = new Point(0, 0);
     pointWithScale.scale = 10;
 
     // should throw in the future?
-    t.equal(bucket.addLine([
+    bucket.addLine([
         new Point(0, 0)
-    ], {}), undefined);
+    ], {});
 
     // should also throw in the future?
     // this is a closed single-segment line
-    t.equal(bucket.addLine([
+    bucket.addLine([
         new Point(0, 0),
         new Point(0, 0)
-    ], {}), undefined);
+    ], {});
 
-    t.equal(bucket.addLine([
+    bucket.addLine([
         new Point(0, 0),
         new Point(10, 10),
         new Point(10, 20)
-    ], {}), undefined);
+    ], {});
 
-    t.equal(bucket.addLine([
+    bucket.addLine([
         new Point(0, 0),
         new Point(10, 10),
         new Point(10, 20),
         new Point(0, 0)
-    ], {}), undefined);
+    ], {});
 
-    t.equal(bucket.addFeature(feature), undefined);
+    bucket.addFeature(feature);
 
     t.end();
 });

--- a/test/js/data/symbol_bucket.test.js
+++ b/test/js/data/symbol_bucket.test.js
@@ -47,8 +47,7 @@ function bucketSetup() {
         collisionBoxArray: collisionBoxArray,
         symbolInstancesArray: symbolInstancesArray,
         symbolQuadsArray: symbolQuadsArray,
-        layer: layer,
-        childLayers: [layer]
+        layers: [layer]
     });
 }
 


### PR DESCRIPTION
Fixes #207. 

And while here, switch to indexed rendering for collision boxes. Fixes #2038.

Physical segmentation: each vertex buffer holds a maximum of 2¹⁶-1 vertices. When a layer requires more than that, create a new vertex buffer and index buffer.

Logical segmentation: no limit to the size of a vertex buffer. When reaching 2¹⁶-1 vertices, record the vertex and primitive offsets, then reset the indexing, starting a new "segment". Use the offsets when rendering each segment.

Logical segmentation has the following advantages:

* It uses a smaller number of larger buffer objects. In theory this is more efficient for WebGL/OpenGL. However in this case the performance difference is likely negligible. We already use VAOs, which largely eliminate the cost of switching between buffers, which leaves the cost of creating them. And buffers larger than 2¹⁶ vertices are relatively rare.
* It's what gl-native does. Having the two codebases work the same way is an advantage, as we frequently need to port changes back and forth.
* It simplifies `populatePaintArrays`. With physical segmentation, `populatePaintArrays` needs to track both a buffer index and an index into the first buffer, and might need to populate multiple buffer segments. With logical segmentation, it just fills the single paint vertex buffer until it's the same length as the layout vertex buffer.

benchmark | master e03a7b1 | logical-buffer-segmentation 59f39b7
--- | --- | ---
**map-load** | 150 ms  | 104 ms 
**style-load** | 100 ms  | 104 ms 
**buffer** | 1,030 ms  | 993 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 7.3 ms, 1% > 16ms  | 7.3 ms, 1% > 16ms 
**query-point** | 1.05 ms  | 1.16 ms 
**query-box** | 84.95 ms  | 88.68 ms 
**geojson-setdata-small** | 8 ms  | 10 ms 
**geojson-setdata-large** | 117 ms  | 99 ms 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page

