### PR TITLE
Clamp fill-extrude-height and fill-extrude-base to min 0

### DIFF
--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -32,7 +32,7 @@ const fillExtrusionInterfaces = {
             components: 1,
             type: 'Uint16',
             getValue: (layer, globalProperties, featureProperties) => {
-                return [layer.getPaintValue("fill-extrude-base", globalProperties, featureProperties)];
+                return [Math.max(layer.getPaintValue("fill-extrude-base", globalProperties, featureProperties), 0)];
             },
             multiplier: 1,
             paintProperty: 'fill-extrude-base'
@@ -41,7 +41,7 @@ const fillExtrusionInterfaces = {
             components: 1,
             type: 'Uint16',
             getValue: (layer, globalProperties, featureProperties) => {
-                return [layer.getPaintValue("fill-extrude-height", globalProperties, featureProperties)];
+                return [Math.max(layer.getPaintValue("fill-extrude-height", globalProperties, featureProperties), 0)];
             },
             multiplier: 1,
             paintProperty: 'fill-extrude-height'

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "highlight.js": "9.3.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2817eedfe76f38b63bb77cb58c3b691e47169a92",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#c71bd415a7f83518890c60c1473398072be2677b",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/3456 by clamping negative fill-extrude-height and fill-extrude-base values to 0. (They already specify `minimum=0` in the style spec.)

cc @lucaswoj 