### PR TITLE
Simplify Bucket

### DIFF
--- a/js/data/array_group.js
+++ b/js/data/array_group.js
@@ -102,36 +102,20 @@ class ArrayGroup {
         }
     }
 
-    serialize() {
+    serialize(transferables) {
         return {
-            layoutVertexArray: this.layoutVertexArray.serialize(),
-            elementArray: this.elementArray && this.elementArray.serialize(),
-            elementArray2: this.elementArray2 && this.elementArray2.serialize(),
+            layoutVertexArray: this.layoutVertexArray.serialize(transferables),
+            elementArray: this.elementArray && this.elementArray.serialize(transferables),
+            elementArray2: this.elementArray2 && this.elementArray2.serialize(transferables),
             paintVertexArrays: util.mapObject(this.paintVertexArrays, (array) => {
                 return {
-                    array: array.serialize(),
+                    array: array.serialize(transferables),
                     type: array.constructor.serialize()
                 };
             }),
             segments: this.segments,
             segments2: this.segments2
         };
-    }
-
-    getTransferables(transferables) {
-        transferables.push(this.layoutVertexArray.arrayBuffer);
-
-        if (this.elementArray) {
-            transferables.push(this.elementArray.arrayBuffer);
-        }
-
-        if (this.elementArray2) {
-            transferables.push(this.elementArray2.arrayBuffer);
-        }
-
-        for (const layerName in this.paintVertexArrays) {
-            transferables.push(this.paintVertexArrays[layerName].arrayBuffer);
-        }
     }
 }
 

--- a/js/data/array_group.js
+++ b/js/data/array_group.js
@@ -86,22 +86,6 @@ class ArrayGroup {
         return this.layoutVertexArray.length === 0;
     }
 
-    trim() {
-        this.layoutVertexArray.trim();
-
-        if (this.elementArray) {
-            this.elementArray.trim();
-        }
-
-        if (this.elementArray2) {
-            this.elementArray2.trim();
-        }
-
-        for (const layerName in this.paintVertexArrays) {
-            this.paintVertexArrays[layerName].trim();
-        }
-    }
-
     serialize(transferables) {
         return {
             layoutVertexArray: this.layoutVertexArray.serialize(transferables),

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -92,17 +92,11 @@ class Bucket {
         return true;
     }
 
-    getTransferables(transferables) {
-        for (const programName in this.arrays) {
-            this.arrays[programName].getTransferables(transferables);
-        }
-    }
-
-    serialize() {
+    serialize(transferables) {
         return {
             zoom: this.zoom,
             layerIds: this.layers.map((l) => l.id),
-            arrays: util.mapObject(this.arrays, (a) => a.serialize())
+            arrays: util.mapObject(this.arrays, (a) => a.serialize(transferables))
         };
     }
 

--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -58,8 +58,6 @@ class Bucket {
                 options.featureIndex.insert(feature, this.index);
             }
         }
-
-        this.trimArrays();
     }
 
     createArrays() {
@@ -74,12 +72,6 @@ class Bucket {
     destroy() {
         for (const programName in this.bufferGroups) {
             this.bufferGroups[programName].destroy();
-        }
-    }
-
-    trimArrays() {
-        for (const programName in this.arrays) {
-            this.arrays[programName].trim();
         }
     }
 

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -521,8 +521,6 @@ class SymbolBucket extends Bucket {
         }
 
         if (showCollisionBoxes) this.addToDebugBuffers(collisionTile);
-
-        this.trimArrays();
     }
 
     addSymbols(programName, quadsStart, quadsEnd, scale, keepUpright, alongLine, placementAngle) {

--- a/js/data/feature_index.js
+++ b/js/data/feature_index.js
@@ -75,17 +75,17 @@ class FeatureIndex {
         this.collisionTile = collisionTile;
     }
 
-    serialize() {
-        const data = {
+    serialize(transferables) {
+        const grid = this.grid.toArrayBuffer();
+        if (transferables) {
+            transferables.push(grid);
+        }
+        return {
             coord: this.coord,
             overscaling: this.overscaling,
-            grid: this.grid.toArrayBuffer(),
-            featureIndexArray: this.featureIndexArray.serialize(),
+            grid: grid,
+            featureIndexArray: this.featureIndexArray.serialize(transferables),
             bucketLayerIDs: this.bucketLayerIDs
-        };
-        return {
-            data: data,
-            transferables: [data.grid, data.featureIndexArray.arrayBuffer]
         };
     }
 

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -108,9 +108,7 @@ class WorkerTile {
 
             const transferables = [];
             callback(null, {
-                buckets: util.values(buckets)
-                    .filter((b) => !b.isEmpty())
-                    .map((b) => b.serialize(transferables)),
+                buckets: serializeBuckets(util.values(buckets), transferables),
                 featureIndex: featureIndex.serialize(transferables),
                 collisionTile: collisionTile.serialize(transferables),
                 collisionBoxArray: this.collisionBoxArray.serialize(),
@@ -183,14 +181,18 @@ class WorkerTile {
         const transferables = [];
         return {
             result: {
-                buckets: this.symbolBuckets
-                    .filter((b) => !b.isEmpty())
-                    .map((b) => b.serialize(transferables)),
+                buckets: serializeBuckets(this.symbolBuckets, transferables),
                 collisionTile: collisionTile.serialize(transferables)
             },
             transferables: transferables
         };
     }
+}
+
+function serializeBuckets(buckets, transferables) {
+    return buckets
+        .filter((b) => !b.isEmpty())
+        .map((b) => b.serialize(transferables));
 }
 
 module.exports = WorkerTile;

--- a/js/symbol/collision_tile.js
+++ b/js/symbol/collision_tile.js
@@ -80,16 +80,18 @@ class CollisionTile {
         ];
     }
 
-    serialize() {
-        const data = {
+    serialize(transferables) {
+        const grid = this.grid.toArrayBuffer();
+        const ignoredGrid = this.ignoredGrid.toArrayBuffer();
+        if (transferables) {
+            transferables.push(grid);
+            transferables.push(ignoredGrid);
+        }
+        return {
             angle: this.angle,
             pitch: this.pitch,
-            grid: this.grid.toArrayBuffer(),
-            ignoredGrid: this.ignoredGrid.toArrayBuffer()
-        };
-        return {
-            data: data,
-            transferables: [data.grid, data.ignoredGrid]
+            grid: grid,
+            ignoredGrid: ignoredGrid
         };
     }
 

--- a/js/util/struct_array.js
+++ b/js/util/struct_array.js
@@ -82,8 +82,11 @@ class StructArray {
     /**
      * Serialize this StructArray instance
      */
-    serialize() {
+    serialize(transferables) {
         this.trim();
+        if (transferables) {
+            transferables.push(this.arrayBuffer);
+        }
         return {
             length: this.length,
             arrayBuffer: this.arrayBuffer

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -218,12 +218,12 @@ test('Bucket', (t) => {
         t.end();
     });
 
-    t.test('getTransferables', (t) => {
+    t.test('serialize', (t) => {
         const bucket = create();
         bucket.populate([createFeature(17, 42)], createOptions());
 
         const transferables = [];
-        bucket.getTransferables(transferables);
+        bucket.serialize(transferables);
 
         t.equal(4, transferables.length);
         t.equal(bucket.arrays.test.layoutVertexArray.arrayBuffer, transferables[0]);

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -190,21 +190,6 @@ test('Bucket', (t) => {
         t.end();
     });
 
-    t.test('trimArrays', (t) => {
-        const bucket = create();
-
-        bucket.createArrays();
-        bucket.arrays.test.prepareSegment(10);
-        t.equal(0, bucket.arrays.test.layoutVertexArray.length);
-        t.notEqual(0, bucket.arrays.test.layoutVertexArray.capacity);
-
-        bucket.trimArrays();
-        t.equal(0, bucket.arrays.test.layoutVertexArray.length);
-        t.equal(0, bucket.arrays.test.layoutVertexArray.capacity);
-
-        t.end();
-    });
-
     t.test('isEmpty', (t) => {
         const bucket = create();
         t.ok(bucket.isEmpty());


### PR DESCRIPTION
Some relatively straightforward API simplifications for `Bucket`:

* Combine `getTransferables` and `serialize` into a single method.
* Eliminate explicit array trimming -- this [happens automatically](https://github.com/mapbox/mapbox-gl-js/blob/b9d95095c63a8e0193b6ee391ab308e75e1ecea3/js/util/struct_array.js#L86) as part of serialization.

benchmark | master b9d9509 | simplify-bucket b75bbf4
--- | --- | ---
**map-load** | 164 ms  | 96 ms 
**style-load** | 106 ms  | 102 ms 
**buffer** | 1,058 ms  | 1,080 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 7 ms, 0% > 16ms  | 7.1 ms, 0% > 16ms 
**query-point** | 1.06 ms  | 1.41 ms 
**query-box** | 68.11 ms  | 72.10 ms 
**geojson-setdata-small** | 9 ms  | 8 ms 
**geojson-setdata-large** | 304 ms  | 286 ms 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
