### PR TITLE
Delegate Bucket creation to StyleLayer

### DIFF
--- a/js/data/bucket.js
+++ b/js/data/bucket.js
@@ -11,9 +11,8 @@ const FAKE_ZOOM_HISTORY = { lastIntegerZoom: Infinity, lastIntegerZoomTime: 0, l
  * The `Bucket` class is the single point of knowledge about turning vector
  * tiles into WebGL buffers.
  *
- * `Bucket` is an abstract class. A subclass exists for each Mapbox GL
- * style spec layer type. Because `Bucket` is an abstract class,
- * instances should be created via the `Bucket.create` method.
+ * `Bucket` is an abstract class. A subclass exists for each style layer type.
+ * Create a bucket via the `StyleLayer#createBucket` method.
  *
  * @private
  */
@@ -101,30 +100,6 @@ class Bucket {
 
 module.exports = Bucket;
 
-const subclasses = {
-    fill: require('./bucket/fill_bucket'),
-    fillextrusion: require('./bucket/fill_extrusion_bucket'),
-    line: require('./bucket/line_bucket'),
-    circle: require('./bucket/circle_bucket'),
-    symbol: require('./bucket/symbol_bucket')
-};
-
-/**
- * Instantiate the appropriate subclass of `Bucket` for `options`.
- * @param options See `Bucket` constructor options
- * @returns {Bucket}
- */
-Bucket.create = function(options) {
-    const layer = options.layers[0];
-    let type = layer.type;
-    if (type === 'fill' && (!layer.isPaintValueFeatureConstant('fill-extrude-height') ||
-        !layer.isPaintValueZoomConstant('fill-extrude-height') ||
-        layer.getPaintValue('fill-extrude-height', {zoom: options.zoom}) !== 0)) {
-        type = 'fillextrusion';
-    }
-    return new subclasses[type](options);
-};
-
 Bucket.deserialize = function(input, style) {
     // Guard against the case where the map's style has been set to null while
     // this bucket has been parsing.
@@ -140,7 +115,7 @@ Bucket.deserialize = function(input, style) {
             continue;
         }
 
-        output[layers[0].id] = Bucket.create(util.extend({layers}, serialized));
+        output[layers[0].id] = layers[0].createBucket(util.extend({layers}, serialized));
     }
     return output;
 };

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -2,7 +2,6 @@
 
 const FeatureIndex = require('../data/feature_index');
 const CollisionTile = require('../symbol/collision_tile');
-const Bucket = require('../data/bucket');
 const CollisionBoxArray = require('../symbol/collision_box');
 const DictionaryCoder = require('../util/dictionary_coder');
 const util = require('../util/util');
@@ -83,7 +82,7 @@ class WorkerTile {
                 if (layer.maxzoom && this.zoom >= layer.maxzoom) continue;
                 if (layer.layout && layer.layout.visibility === 'none') continue;
 
-                const bucket = buckets[layer.id] = Bucket.create({
+                const bucket = buckets[layer.id] = layer.createBucket({
                     index: bucketIndex++,
                     layers: family,
                     zoom: this.zoom,

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -332,6 +332,7 @@ class StyleLayer extends Evented {
 module.exports = StyleLayer;
 
 const subclasses = {
+    'circle': require('./style_layer/circle_style_layer'),
     'fill': require('./style_layer/fill_style_layer'),
     'line': require('./style_layer/line_style_layer'),
     'symbol': require('./style_layer/symbol_style_layer')

--- a/js/style/style_layer/circle_style_layer.js
+++ b/js/style/style_layer/circle_style_layer.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const StyleLayer = require('../style_layer');
+
+class CircleStyleLayer extends StyleLayer {
+}
+
+module.exports = CircleStyleLayer;

--- a/js/style/style_layer/circle_style_layer.js
+++ b/js/style/style_layer/circle_style_layer.js
@@ -1,8 +1,12 @@
 'use strict';
 
 const StyleLayer = require('../style_layer');
+const CircleBucket = require('../../data/bucket/circle_bucket');
 
 class CircleStyleLayer extends StyleLayer {
+    createBucket(options) {
+        return new CircleBucket(options);
+    }
 }
 
 module.exports = CircleStyleLayer;

--- a/js/style/style_layer/fill_style_layer.js
+++ b/js/style/style_layer/fill_style_layer.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const StyleLayer = require('../style_layer');
+const FillBucket = require('../../data/bucket/fill_bucket');
+const FillExtrusionBucket = require('../../data/bucket/fill_extrusion_bucket');
 
 class FillStyleLayer extends StyleLayer {
 
@@ -42,6 +44,15 @@ class FillStyleLayer extends StyleLayer {
         } else {
             return super.isPaintValueZoomConstant(name);
         }
+    }
+
+    createBucket(options) {
+        if (!this.isPaintValueFeatureConstant('fill-extrude-height') ||
+            !this.isPaintValueZoomConstant('fill-extrude-height') ||
+            this.getPaintValue('fill-extrude-height', {zoom: options.zoom}) !== 0) {
+            return new FillExtrusionBucket(options);
+        }
+        return new FillBucket(options);
     }
 }
 

--- a/js/style/style_layer/line_style_layer.js
+++ b/js/style/style_layer/line_style_layer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const StyleLayer = require('../style_layer');
+const LineBucket = require('../../data/bucket/line_bucket');
 const util = require('../../util/util');
 
 class LineStyleLayer extends StyleLayer {
@@ -18,6 +19,10 @@ class LineStyleLayer extends StyleLayer {
         }
 
         return value;
+    }
+
+    createBucket(options) {
+        return new LineBucket(options);
     }
 }
 

--- a/js/style/style_layer/symbol_style_layer.js
+++ b/js/style/style_layer/symbol_style_layer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const StyleLayer = require('../style_layer');
+const SymbolBucket = require('../../data/bucket/symbol_bucket');
 
 class SymbolStyleLayer extends StyleLayer {
 
@@ -19,6 +20,10 @@ class SymbolStyleLayer extends StyleLayer {
         default:
             return value;
         }
+    }
+
+    createBucket(options) {
+        return new SymbolBucket(options);
     }
 }
 


### PR DESCRIPTION
This allows an already-existing polymorphic class hierarchy to handle bucket creation, so that we don't have to maintain a second registry of layer types in `bucket.js`. Also, layer-specific logic like for fill layers can live with the other layer-specific code.

This'll conflict with #3468 but shouldn't be too much work to resolve either way the merge order happens.