### PR TITLE
Encapsulate SymbolBucket's unique requirements

### DIFF
--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -6,56 +6,54 @@ const ElementArrayType = require('../element_array_type');
 const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
 
-const circleInterfaces = {
-    circle: {
-        layoutVertexArrayType: new VertexArrayType([{
-            name: 'a_pos',
-            components: 2,
-            type: 'Int16'
-        }]),
-        elementArrayType: new ElementArrayType(),
+const circleInterface = {
+    layoutVertexArrayType: new VertexArrayType([{
+        name: 'a_pos',
+        components: 2,
+        type: 'Int16'
+    }]),
+    elementArrayType: new ElementArrayType(),
 
-        paintAttributes: [{
-            name: 'a_color',
-            components: 4,
-            type: 'Uint8',
-            getValue: (layer, globalProperties, featureProperties) => {
-                return layer.getPaintValue("circle-color", globalProperties, featureProperties);
-            },
-            multiplier: 255,
-            paintProperty: 'circle-color'
-        }, {
-            name: 'a_radius',
-            components: 1,
-            type: 'Uint16',
-            isLayerConstant: false,
-            getValue: (layer, globalProperties, featureProperties) => {
-                return [layer.getPaintValue("circle-radius", globalProperties, featureProperties)];
-            },
-            multiplier: 10,
-            paintProperty: 'circle-radius'
-        }, {
-            name: 'a_blur',
-            components: 1,
-            type: 'Uint16',
-            isLayerConstant: false,
-            getValue: (layer, globalProperties, featureProperties) => {
-                return [layer.getPaintValue("circle-blur", globalProperties, featureProperties)];
-            },
-            multiplier: 10,
-            paintProperty: 'circle-blur'
-        }, {
-            name: 'a_opacity',
-            components: 1,
-            type: 'Uint16',
-            isLayerConstant: false,
-            getValue: (layer, globalProperties, featureProperties) => {
-                return [layer.getPaintValue("circle-opacity", globalProperties, featureProperties)];
-            },
-            multiplier: 255,
-            paintProperty: 'circle-opacity'
-        }]
-    }
+    paintAttributes: [{
+        name: 'a_color',
+        components: 4,
+        type: 'Uint8',
+        getValue: (layer, globalProperties, featureProperties) => {
+            return layer.getPaintValue("circle-color", globalProperties, featureProperties);
+        },
+        multiplier: 255,
+        paintProperty: 'circle-color'
+    }, {
+        name: 'a_radius',
+        components: 1,
+        type: 'Uint16',
+        isLayerConstant: false,
+        getValue: (layer, globalProperties, featureProperties) => {
+            return [layer.getPaintValue("circle-radius", globalProperties, featureProperties)];
+        },
+        multiplier: 10,
+        paintProperty: 'circle-radius'
+    }, {
+        name: 'a_blur',
+        components: 1,
+        type: 'Uint16',
+        isLayerConstant: false,
+        getValue: (layer, globalProperties, featureProperties) => {
+            return [layer.getPaintValue("circle-blur", globalProperties, featureProperties)];
+        },
+        multiplier: 10,
+        paintProperty: 'circle-blur'
+    }, {
+        name: 'a_opacity',
+        components: 1,
+        type: 'Uint16',
+        isLayerConstant: false,
+        getValue: (layer, globalProperties, featureProperties) => {
+            return [layer.getPaintValue("circle-opacity", globalProperties, featureProperties)];
+        },
+        multiplier: 255,
+        paintProperty: 'circle-opacity'
+    }]
 };
 
 function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
@@ -72,13 +70,12 @@ function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
  * @private
  */
 class CircleBucket extends Bucket {
-
-    get programInterfaces() {
-        return circleInterfaces;
+    constructor(options) {
+        super(options, circleInterface);
     }
 
     addFeature(feature) {
-        const arrays = this.arrays.circle;
+        const arrays = this.arrays;
 
         for (const ring of loadGeometry(feature)) {
             for (const point of ring) {

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -113,7 +113,7 @@ class CircleBucket extends Bucket {
             }
         }
 
-        arrays.populatePaintArrays(this.layers, {zoom: this.zoom}, feature.properties);
+        arrays.populatePaintArrays(feature.properties);
     }
 }
 

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -9,54 +9,52 @@ const classifyRings = require('../../util/classify_rings');
 const assert = require('assert');
 const EARCUT_MAX_RINGS = 500;
 
-const fillInterfaces = {
-    fill: {
-        layoutVertexArrayType: new VertexArrayType([{
-            name: 'a_pos',
-            components: 2,
-            type: 'Int16'
-        }]),
-        elementArrayType: new ElementArrayType(3),
-        elementArrayType2: new ElementArrayType(2),
+const fillInterface = {
+    layoutVertexArrayType: new VertexArrayType([{
+        name: 'a_pos',
+        components: 2,
+        type: 'Int16'
+    }]),
+    elementArrayType: new ElementArrayType(3),
+    elementArrayType2: new ElementArrayType(2),
 
-        paintAttributes: [{
-            name: 'a_color',
-            components: 4,
-            type: 'Uint8',
-            getValue: (layer, globalProperties, featureProperties) => {
-                return layer.getPaintValue("fill-color", globalProperties, featureProperties);
-            },
-            multiplier: 255,
-            paintProperty: 'fill-color'
-        }, {
-            name: 'a_outline_color',
-            components: 4,
-            type: 'Uint8',
-            getValue: (layer, globalProperties, featureProperties) => {
-                return layer.getPaintValue("fill-outline-color", globalProperties, featureProperties);
-            },
-            multiplier: 255,
-            paintProperty: 'fill-outline-color'
-        }, {
-            name: 'a_opacity',
-            components: 1,
-            type: 'Uint8',
-            getValue: (layer, globalProperties, featureProperties) => {
-                return [layer.getPaintValue("fill-opacity", globalProperties, featureProperties)];
-            },
-            multiplier: 255,
-            paintProperty: 'fill-opacity'
-        }]
-    }
+    paintAttributes: [{
+        name: 'a_color',
+        components: 4,
+        type: 'Uint8',
+        getValue: (layer, globalProperties, featureProperties) => {
+            return layer.getPaintValue("fill-color", globalProperties, featureProperties);
+        },
+        multiplier: 255,
+        paintProperty: 'fill-color'
+    }, {
+        name: 'a_outline_color',
+        components: 4,
+        type: 'Uint8',
+        getValue: (layer, globalProperties, featureProperties) => {
+            return layer.getPaintValue("fill-outline-color", globalProperties, featureProperties);
+        },
+        multiplier: 255,
+        paintProperty: 'fill-outline-color'
+    }, {
+        name: 'a_opacity',
+        components: 1,
+        type: 'Uint8',
+        getValue: (layer, globalProperties, featureProperties) => {
+            return [layer.getPaintValue("fill-opacity", globalProperties, featureProperties)];
+        },
+        multiplier: 255,
+        paintProperty: 'fill-opacity'
+    }]
 };
 
 class FillBucket extends Bucket {
-    get programInterfaces() {
-        return fillInterfaces;
+    constructor(options) {
+        super(options, fillInterface);
     }
 
     addFeature(feature) {
-        const arrays = this.arrays.fill;
+        const arrays = this.arrays;
 
         for (const polygon of classifyRings(loadGeometry(feature), EARCUT_MAX_RINGS)) {
             let numVertices = 0;

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -112,7 +112,7 @@ class FillBucket extends Bucket {
             triangleSegment.primitiveLength += indices.length / 3;
         }
 
-        arrays.populatePaintArrays(this.layers, {zoom: this.zoom}, feature.properties);
+        arrays.populatePaintArrays(feature.properties);
     }
 }
 

--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -157,7 +157,7 @@ class FillExtrusionBucket extends Bucket {
             segment.primitiveLength += triangleIndices.length / 3;
         }
 
-        arrays.populatePaintArrays(this.layers, {zoom: this.zoom}, feature.properties);
+        arrays.populatePaintArrays(feature.properties);
     }
 }
 

--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -10,54 +10,52 @@ const classifyRings = require('../../util/classify_rings');
 const assert = require('assert');
 const EARCUT_MAX_RINGS = 500;
 
-const fillExtrusionInterfaces = {
-    fillextrusion: {
-        layoutVertexArrayType: new VertexArrayType([{
-            name: 'a_pos',
-            components: 2,
-            type: 'Int16'
-        }, {
-            name: 'a_normal',
-            components: 3,
-            type: 'Int16'
-        }, {
-            name: 'a_edgedistance',
-            components: 1,
-            type: 'Int16'
-        }]),
-        elementArrayType: new ElementArrayType(3),
+const fillExtrusionInterface = {
+    layoutVertexArrayType: new VertexArrayType([{
+        name: 'a_pos',
+        components: 2,
+        type: 'Int16'
+    }, {
+        name: 'a_normal',
+        components: 3,
+        type: 'Int16'
+    }, {
+        name: 'a_edgedistance',
+        components: 1,
+        type: 'Int16'
+    }]),
+    elementArrayType: new ElementArrayType(3),
 
-        paintAttributes: [{
-            name: 'a_minH',
-            components: 1,
-            type: 'Uint16',
-            getValue: (layer, globalProperties, featureProperties) => {
-                return [Math.max(layer.getPaintValue("fill-extrude-base", globalProperties, featureProperties), 0)];
-            },
-            multiplier: 1,
-            paintProperty: 'fill-extrude-base'
-        }, {
-            name: 'a_maxH',
-            components: 1,
-            type: 'Uint16',
-            getValue: (layer, globalProperties, featureProperties) => {
-                return [Math.max(layer.getPaintValue("fill-extrude-height", globalProperties, featureProperties), 0)];
-            },
-            multiplier: 1,
-            paintProperty: 'fill-extrude-height'
-        }, {
-            name: 'a_color',
-            components: 4,
-            type: 'Uint8',
-            getValue: (layer, globalProperties, featureProperties) => {
-                const color = layer.getPaintValue("fill-color", globalProperties, featureProperties);
-                color[3] = 1.0;
-                return color;
-            },
-            multiplier: 255,
-            paintProperty: 'fill-color'
-        }]
-    }
+    paintAttributes: [{
+        name: 'a_minH',
+        components: 1,
+        type: 'Uint16',
+        getValue: (layer, globalProperties, featureProperties) => {
+            return [Math.max(layer.getPaintValue("fill-extrude-base", globalProperties, featureProperties), 0)];
+        },
+        multiplier: 1,
+        paintProperty: 'fill-extrude-base'
+    }, {
+        name: 'a_maxH',
+        components: 1,
+        type: 'Uint16',
+        getValue: (layer, globalProperties, featureProperties) => {
+            return [Math.max(layer.getPaintValue("fill-extrude-height", globalProperties, featureProperties), 0)];
+        },
+        multiplier: 1,
+        paintProperty: 'fill-extrude-height'
+    }, {
+        name: 'a_color',
+        components: 4,
+        type: 'Uint8',
+        getValue: (layer, globalProperties, featureProperties) => {
+            const color = layer.getPaintValue("fill-color", globalProperties, featureProperties);
+            color[3] = 1.0;
+            return color;
+        },
+        multiplier: 255,
+        paintProperty: 'fill-color'
+    }]
 };
 
 const FACTOR = Math.pow(2, 13);
@@ -78,12 +76,12 @@ function addVertex(vertexArray, x, y, nx, ny, nz, t, e) {
 }
 
 class FillExtrusionBucket extends Bucket {
-    get programInterfaces() {
-        return fillExtrusionInterfaces;
+    constructor(options) {
+        super(options, fillExtrusionInterface);
     }
 
     addFeature(feature) {
-        const arrays = this.arrays.fillextrusion;
+        const arrays = this.arrays;
 
         for (const polygon of classifyRings(loadGeometry(feature), EARCUT_MAX_RINGS)) {
             let numVertices = 0;

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -356,7 +356,7 @@ class LineBucket extends Bucket {
             startOfLine = false;
         }
 
-        arrays.populatePaintArrays(this.layers, {zoom: this.zoom}, featureProperties);
+        arrays.populatePaintArrays(featureProperties);
     }
 
     /**

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -39,29 +39,27 @@ const LINE_DISTANCE_SCALE = 1 / 2;
 // The maximum line distance, in tile units, that fits in the buffer.
 const MAX_LINE_DISTANCE = Math.pow(2, LINE_DISTANCE_BUFFER_BITS - 1) / LINE_DISTANCE_SCALE;
 
-const lineInterfaces = {
-    line: {
-        layoutVertexArrayType: new VertexArrayType([{
-            name: 'a_pos',
-            components: 2,
-            type: 'Int16'
-        }, {
-            name: 'a_data',
-            components: 4,
-            type: 'Uint8'
-        }]),
-        paintAttributes: [{
-            name: 'a_color',
-            components: 4,
-            type: 'Uint8',
-            getValue: (layer, globalProperties, featureProperties) => {
-                return layer.getPaintValue("line-color", globalProperties, featureProperties);
-            },
-            multiplier: 255,
-            paintProperty: 'line-color'
-        }],
-        elementArrayType: new ElementArrayType()
-    }
+const lineInterface = {
+    layoutVertexArrayType: new VertexArrayType([{
+        name: 'a_pos',
+        components: 2,
+        type: 'Int16'
+    }, {
+        name: 'a_data',
+        components: 4,
+        type: 'Uint8'
+    }]),
+    paintAttributes: [{
+        name: 'a_color',
+        components: 4,
+        type: 'Uint8',
+        getValue: (layer, globalProperties, featureProperties) => {
+            return layer.getPaintValue("line-color", globalProperties, featureProperties);
+        },
+        multiplier: 255,
+        paintProperty: 'line-color'
+    }],
+    elementArrayType: new ElementArrayType()
 };
 
 function addLineVertex(layoutVertexBuffer, point, extrude, tx, ty, dir, linesofar) {
@@ -86,9 +84,8 @@ function addLineVertex(layoutVertexBuffer, point, extrude, tx, ty, dir, linesofa
  * @private
  */
 class LineBucket extends Bucket {
-
-    get programInterfaces() {
-        return lineInterfaces;
+    constructor(options) {
+        super(options, lineInterface);
     }
 
     addFeature(feature) {
@@ -122,7 +119,7 @@ class LineBucket extends Bucket {
             lastVertex = vertices[len - 1],
             closed = firstVertex.equals(lastVertex);
 
-        const arrays = this.arrays.line;
+        const arrays = this.arrays;
 
         // we could be more precise, but it would only save a negligible amount of space
         const segment = arrays.prepareSegment('line', len * 10);
@@ -372,7 +369,7 @@ class LineBucket extends Bucket {
     addCurrentVertex(currentVertex, distance, normal, endLeft, endRight, round, segment) {
         const tx = round ? 1 : 0;
         let extrude;
-        const arrays = this.arrays.line;
+        const arrays = this.arrays;
         const layoutVertexArray = arrays.layoutVertexArray;
         const elementArray = arrays.elementArray;
 
@@ -421,7 +418,7 @@ class LineBucket extends Bucket {
     addPieSliceVertex(currentVertex, distance, extrude, lineTurnsLeft, segment) {
         const ty = lineTurnsLeft ? 1 : 0;
         extrude = extrude.mult(lineTurnsLeft ? -1 : 1);
-        const arrays = this.arrays.line;
+        const arrays = this.arrays;
         const layoutVertexArray = arrays.layoutVertexArray;
         const elementArray = arrays.elementArray;
 

--- a/js/data/program_configuration.js
+++ b/js/data/program_configuration.js
@@ -22,7 +22,7 @@ const assert = require('assert');
  * @private
  */
 class ProgramConfiguration {
-    static createDynamic(attributes, layer, options) {
+    static createDynamic(attributes, layer, zoom) {
         const self = new ProgramConfiguration();
 
         self.attributes = [];
@@ -61,7 +61,7 @@ class ProgramConfiguration {
                 // Find the four closest stops, ideally with two on each side of the zoom level.
                 let numStops = 0;
                 const zoomLevels = layer.getPaintValueStopZoomLevels(attribute.paintProperty);
-                while (numStops < zoomLevels.length && zoomLevels[numStops] < options.zoom) numStops++;
+                while (numStops < zoomLevels.length && zoomLevels[numStops] < zoom) numStops++;
                 const stopOffset = Math.max(0, Math.min(zoomLevels.length - 4, numStops - 2));
 
                 const fourZoomLevels = [];

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -24,7 +24,8 @@ function drawCircles(painter, sourceCache, layer, coords) {
         if (!bucket) continue;
 
         const buffers = bucket.bufferGroups.circle;
-        const programConfiguration = bucket.programConfigurations.circle[layer.id];
+        const layerData = buffers.layerData[layer.id];
+        const programConfiguration = layerData.programConfiguration;
         const program = painter.useProgram('circle', programConfiguration);
         programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
 
@@ -48,7 +49,7 @@ function drawCircles(painter, sourceCache, layer, coords) {
         ));
 
         for (const segment of buffers.segments) {
-            segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+            segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
             gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
         }
     }

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -23,7 +23,7 @@ function drawCircles(painter, sourceCache, layer, coords) {
         const bucket = tile.getBucket(layer);
         if (!bucket) continue;
 
-        const buffers = bucket.bufferGroups.circle;
+        const buffers = bucket.buffers;
         const layerData = buffers.layerData[layer.id];
         const programConfiguration = layerData.programConfiguration;
         const program = painter.useProgram('circle', programConfiguration);

--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -22,7 +22,7 @@ function drawCollisionDebug(painter, sourceCache, layer, coords) {
         gl.uniform1f(program.u_zoom, painter.transform.zoom * 10);
         gl.uniform1f(program.u_maxzoom, (tile.coord.z + 1) * 10);
 
-        const buffers = bucket.bufferGroups.collisionBox;
+        const buffers = bucket.buffers.collisionBox;
         for (const segment of buffers.segments) {
             segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, null, segment.vertexOffset);
             gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);

--- a/js/render/draw_extrusion.js
+++ b/js/render/draw_extrusion.js
@@ -148,7 +148,7 @@ function drawExtrusion(painter, source, layer, coord) {
     const bucket = tile.getBucket(layer);
     if (!bucket) return;
 
-    const buffers = bucket.bufferGroups.fillextrusion;
+    const buffers = bucket.buffers;
     const gl = painter.gl;
 
     const image = layer.paint['fill-pattern'];

--- a/js/render/draw_extrusion.js
+++ b/js/render/draw_extrusion.js
@@ -153,7 +153,8 @@ function drawExtrusion(painter, source, layer, coord) {
 
     const image = layer.paint['fill-pattern'];
 
-    const programConfiguration = bucket.programConfigurations.fillextrusion[layer.id];
+    const layerData = buffers.layerData[layer.id];
+    const programConfiguration = layerData.programConfiguration;
     const program = painter.useProgram(image ? 'fillExtrudePattern' : 'fillExtrude', programConfiguration);
     programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
 
@@ -165,7 +166,7 @@ function drawExtrusion(painter, source, layer, coord) {
     setLight(program, painter);
 
     for (const segment of buffers.segments) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -51,7 +51,7 @@ function drawFill(painter, sourceCache, layer, coord) {
     const bucket = tile.getBucket(layer);
     if (!bucket) return;
 
-    const buffers = bucket.bufferGroups.fill;
+    const buffers = bucket.buffers;
     const gl = painter.gl;
 
     const image = layer.paint['fill-pattern'];
@@ -94,7 +94,7 @@ function drawStroke(painter, sourceCache, layer, coord) {
     const bucket = tile.getBucket(layer);
     if (!bucket) return;
 
-    const buffers = bucket.bufferGroups.fill;
+    const buffers = bucket.buffers;
     const layerData = buffers.layerData[layer.id];
     const gl = painter.gl;
 

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -55,11 +55,12 @@ function drawFill(painter, sourceCache, layer, coord) {
     const gl = painter.gl;
 
     const image = layer.paint['fill-pattern'];
+    const layerData = buffers.layerData[layer.id];
+
     let program;
 
     if (!image) {
-
-        const programConfiguration = bucket.programConfigurations.fill[layer.id];
+        const programConfiguration = layerData.programConfiguration;
         program = painter.useProgram('fill', programConfiguration);
         programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
 
@@ -83,7 +84,7 @@ function drawFill(painter, sourceCache, layer, coord) {
     painter.enableTileClippingMask(coord);
 
     for (const segment of buffers.segments) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }
@@ -94,6 +95,7 @@ function drawStroke(painter, sourceCache, layer, coord) {
     if (!bucket) return;
 
     const buffers = bucket.bufferGroups.fill;
+    const layerData = buffers.layerData[layer.id];
     const gl = painter.gl;
 
     const image = layer.paint['fill-pattern'];
@@ -105,7 +107,7 @@ function drawStroke(painter, sourceCache, layer, coord) {
         gl.uniform2f(program.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
     } else {
-        const programConfiguration = bucket.programConfigurations.fill[layer.id];
+        const programConfiguration = layerData.programConfiguration;
         program = painter.useProgram('fillOutline', programConfiguration);
         programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
         gl.uniform2f(program.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
@@ -127,7 +129,7 @@ function drawStroke(painter, sourceCache, layer, coord) {
     painter.enableTileClippingMask(coord);
 
     for (const segment of buffers.segments2) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer2, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer2, layerData.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);
     }
 }

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -35,12 +35,13 @@ function drawLineTile(painter, sourceCache, layer, coord) {
     if (!bucket) return;
 
     const buffers = bucket.bufferGroups.line;
+    const layerData = buffers.layerData[layer.id];
     const gl = painter.gl;
 
     const dasharray = layer.paint['line-dasharray'];
     const image = layer.paint['line-pattern'];
 
-    const programConfiguration = bucket.programConfigurations.line[layer.id];
+    const programConfiguration = layerData.programConfiguration;
     const program = painter.useProgram(dasharray ? 'lineSDF' : image ? 'linePattern' : 'line', programConfiguration);
     programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
 
@@ -121,7 +122,7 @@ function drawLineTile(painter, sourceCache, layer, coord) {
     gl.uniform1f(program.u_ratio, 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom));
 
     for (const segment of buffers.segments) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, buffers.paintVertexBuffers[layer.id], segment.vertexOffset);
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -34,7 +34,7 @@ function drawLineTile(painter, sourceCache, layer, coord) {
     const bucket = tile.getBucket(layer);
     if (!bucket) return;
 
-    const buffers = bucket.bufferGroups.line;
+    const buffers = bucket.buffers;
     const layerData = buffers.layerData[layer.id];
     const gl = painter.gl;
 

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -84,7 +84,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText,
         const tile = sourceCache.getTile(coords[j]);
         const bucket = tile.getBucket(layer);
         if (!bucket) continue;
-        const buffers = isText ? bucket.bufferGroups.glyph : bucket.bufferGroups.icon;
+        const buffers = isText ? bucket.buffers.glyph : bucket.buffers.icon;
         if (!buffers.segments.length) continue;
 
         painter.enableTileClippingMask(coords[j]);

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -63,7 +63,7 @@ test('Bucket', (t) => {
                 arrays.layoutVertexArray.emplaceBack(point.x * 2, point.y * 2);
                 arrays.elementArray.emplaceBack(1, 2, 3);
                 arrays.elementArray2.emplaceBack(point.x, point.y);
-                arrays.populatePaintArrays(this.layers, {}, feature.properties);
+                arrays.populatePaintArrays(feature.properties);
             }
         }
 
@@ -96,7 +96,7 @@ test('Bucket', (t) => {
         const v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        const paintVertex = bucket.arrays.test.paintVertexArrays.layerid;
+        const paintVertex = bucket.arrays.test.layerData.layerid.paintVertexArray;
         t.equal(paintVertex.length, 1);
         const p0 = paintVertex.get(0);
         t.equal(p0.a_map, 17);
@@ -126,8 +126,8 @@ test('Bucket', (t) => {
         bucket.populate([createFeature(17, 42)], createOptions());
 
         const v0 = bucket.arrays.test.layoutVertexArray.get(0);
-        const a0 = bucket.arrays.test.paintVertexArrays.one.get(0);
-        const b0 = bucket.arrays.test.paintVertexArrays.two.get(0);
+        const a0 = bucket.arrays.test.layerData.one.paintVertexArray.get(0);
+        const b0 = bucket.arrays.test.layerData.two.paintVertexArray.get(0);
         t.equal(a0.a_map, 17);
         t.equal(b0.a_map, 17);
         t.equal(v0.a_box0, 34);
@@ -154,7 +154,7 @@ test('Bucket', (t) => {
 
         t.equal(bucket.arrays.test.layoutVertexArray.bytesPerElement, 0);
         t.deepEqual(
-            bucket.programConfigurations.test.one.uniforms[0].getValue.call(bucket),
+            bucket.arrays.test.layerData.one.programConfiguration.uniforms[0].getValue.call(bucket),
             [5]
         );
 
@@ -214,7 +214,7 @@ test('Bucket', (t) => {
         t.equal(bucket.arrays.test.layoutVertexArray.arrayBuffer, transferables[0]);
         t.equal(bucket.arrays.test.elementArray.arrayBuffer, transferables[1]);
         t.equal(bucket.arrays.test.elementArray2.arrayBuffer, transferables[2]);
-        t.equal(bucket.arrays.test.paintVertexArrays.layerid.arrayBuffer, transferables[3]);
+        t.equal(bucket.arrays.test.layerData.layerid.paintVertexArray.arrayBuffer, transferables[3]);
 
         t.end();
     });
@@ -231,7 +231,7 @@ test('Bucket', (t) => {
         const v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        const testPaintVertex = bucket.arrays.test.paintVertexArrays.layerid;
+        const testPaintVertex = bucket.arrays.test.layerData.layerid.paintVertexArray;
         t.equal(testPaintVertex.length, 1);
         const p0 = testPaintVertex.get(0);
         t.equal(p0.a_map, 17);
@@ -268,7 +268,7 @@ test('Bucket', (t) => {
         const v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
-        const testPaintVertex = bucket.arrays.test.paintVertexArrays.layerid;
+        const testPaintVertex = bucket.arrays.test.layerData.layerid.paintVertexArray;
         t.equal(testPaintVertex.length, 1);
         const p0 = testPaintVertex.get(0);
         t.equal(p0.a_map, 17);

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -33,7 +33,6 @@ function createPolygon(numPoints) {
 test('FillBucket', (t) => {
     const layer = new StyleLayer({ id: 'test', type: 'fill', layout: {} });
     const bucket = new FillBucket({ layers: [layer] });
-    bucket.createArrays();
 
     bucket.addFeature(createFeature([[
         new Point(0, 0),
@@ -71,7 +70,6 @@ test('FillBucket segmentation', (t) => {
     layer.updatePaintTransition('fill-color', [], {});
 
     const bucket = new FillBucket({ layers: [layer] });
-    bucket.createArrays();
 
     // first add an initial, small feature to make sure the next one starts at
     // a non-zero offset
@@ -83,7 +81,7 @@ test('FillBucket segmentation', (t) => {
         createPolygon(128)
     ]));
 
-    const arrays = bucket.arrays.fill;
+    const arrays = bucket.arrays;
 
     // Each polygon must fit entirely within a segment, so we expect the
     // first segment to include the first feature and the first polygon

--- a/test/js/data/fill_bucket.test.js
+++ b/test/js/data/fill_bucket.test.js
@@ -103,9 +103,9 @@ test('FillBucket segmentation', (t) => {
         primitiveLength: 126
     });
 
-    t.equal(arrays.paintVertexArrays.test.length, 266);
-    for (let i = 0; i < arrays.paintVertexArrays.test.length; i++) {
-        const vertex = arrays.paintVertexArrays.test.get(i);
+    t.equal(arrays.layerData.test.paintVertexArray.length, 266);
+    for (let i = 0; i < arrays.layerData.test.paintVertexArray.length; i++) {
+        const vertex = arrays.layerData.test.paintVertexArray.get(i);
         t.deepEqual([
             vertex['a_color0'],
             vertex['a_color1'],

--- a/test/js/data/line_bucket.test.js
+++ b/test/js/data/line_bucket.test.js
@@ -16,7 +16,6 @@ const feature = vt.layers.road.feature(0);
 test('LineBucket', (t) => {
     const layer = new StyleLayer({ id: 'test', type: 'line', layout: {} });
     const bucket = new LineBucket({ layers: [layer] });
-    bucket.createArrays();
 
     const pointWithScale = new Point(0, 0);
     pointWithScale.scale = 10;

--- a/test/js/data/symbol_bucket.test.js
+++ b/test/js/data/symbol_bucket.test.js
@@ -92,3 +92,15 @@ test('SymbolBucket integer overflow', (t) => {
     t.ok(util.warnOnce.getCall(1).calledWithMatch(/Too many (symbols|glyphs) being rendered in a tile./));
     t.end();
 });
+
+test('SymbolBucket redo placement', (t) => {
+    const bucket = bucketSetup();
+    const options = {iconDependencies: {}, glyphDependencies: {}};
+
+    bucket.populate([feature], options);
+    bucket.prepare(stacks, {});
+    bucket.place(collision);
+    bucket.place(collision);
+
+    t.end();
+});

--- a/test/js/source/worker_tile.test.js
+++ b/test/js/source/worker_tile.test.js
@@ -44,10 +44,6 @@ test('WorkerTile#parse', (t) => {
 
 test('WorkerTile#parse skips hidden layers', (t) => {
     const layerIndex = new StyleLayerIndex([{
-        id: 'test',
-        source: 'source',
-        type: 'circle'
-    }, {
         id: 'test-hidden',
         source: 'source',
         type: 'fill',
@@ -57,7 +53,7 @@ test('WorkerTile#parse skips hidden layers', (t) => {
     const tile = createWorkerTile();
     tile.parse(createWrapper(), layerIndex, {}, (err, result) => {
         t.ifError(err);
-        t.equal(Object.keys(result.buckets[0].arrays).length, 1);
+        t.equal(result.buckets.length, 0);
         t.end();
     });
 });


### PR DESCRIPTION
`SymbolBucket` is in several ways the "odd bucket out":

* It's the only bucket type that works with multiple program interfaces -- one for glyphs, one for icons, and one for collision boxes.
* It's the only bucket type whose instances are reused to build buffers multiple times.

Previously, the `Bucket` base class was generalized such that it could support multiple program interfaces for any `Bucket` subtype, and re-create buffers at any time. However, this added complexity to all subtypes other than Symbol.

Now, `SymbolBucket` encapsulates its differences:

* It uses `ArrayGroup`/`BufferGroup` directly, creating one for each of its three interfaces. In turn, the other bucket types, their corresponding layer rendering functions, and the `Bucket` base class, can all assume a single program interface.
* It recreates these arrays when needed, while the `Bucket` base class creates them once, in the constructor.
