### PR TITLE
Update extrusion examples to use separate fill-extrusion type

### DIFF
--- a/docs/_posts/examples/3400-01-27-3d-extrusion-floorplan.html
+++ b/docs/_posts/examples/3400-01-27-3d-extrusion-floorplan.html
@@ -1,9 +1,9 @@
---- 
+---
 layout: example
 category: example
 title: Extrude polygons for 3D indoor mapping.
-description: Create a 3D indoor map with the fill-extrude-height paint property.
-tags: 
+description: Create a 3D indoor map with the fill-extrusion type.
+tags:
   - layers
 ---
 <div id='map'>
@@ -28,29 +28,29 @@ map.on('load', function() {
     });
 
     map.addLayer({
-        'id': 'room-extrude',
-        'type': 'fill',
+        'id': 'room-extrusion',
+        'type': 'fill-extrusion',
         'source': 'museumData',
         'paint': {
             // See the Mapbox Style Spec for details on property functions
             // https://www.mapbox.com/mapbox-gl-style-spec/#types-function
-            'fill-color': {
+            'fill-extrusion-color': {
                 // Get the fill-color from the source 'color' property.
                 'property': 'color',
                 'type': 'identity'
             },
-            'fill-extrude-height': {
+            'fill-extrusion-height': {
                 // Get fill-extrude-height from the source 'height' property.
                 'property': 'height',
                 'type': 'identity'
             },
-            'fill-extrude-base': {
+            'fill-extrusion-base': {
                 // Get fill-extrude-base from the source 'base_height' property.
                 'property': 'base_height',
                 'type': 'identity'
             },
             // Make extrusions slightly opaque for see through indoor walls.
-            'fill-opacity': 0.5
+            'fill-extrusion-opacity': 0.5
         }
     });
 });

--- a/docs/_posts/examples/3400-01-27-3d-extrusion-floorplan.html
+++ b/docs/_posts/examples/3400-01-27-3d-extrusion-floorplan.html
@@ -35,17 +35,17 @@ map.on('load', function() {
             // See the Mapbox Style Spec for details on property functions
             // https://www.mapbox.com/mapbox-gl-style-spec/#types-function
             'fill-extrusion-color': {
-                // Get the fill-color from the source 'color' property.
+                // Get the fill-extrusion-color from the source 'color' property.
                 'property': 'color',
                 'type': 'identity'
             },
             'fill-extrusion-height': {
-                // Get fill-extrude-height from the source 'height' property.
+                // Get fill-extrusion-height from the source 'height' property.
                 'property': 'height',
                 'type': 'identity'
             },
             'fill-extrusion-base': {
-                // Get fill-extrude-base from the source 'base_height' property.
+                // Get fill-extrusion-base from the source 'base_height' property.
                 'property': 'base_height',
                 'type': 'identity'
             },

--- a/docs/_posts/examples/3400-01-30-3d-buildings.html
+++ b/docs/_posts/examples/3400-01-30-3d-buildings.html
@@ -1,9 +1,9 @@
---- 
-layout: example 
-category: example 
-title: Display buildings in 3D 
-description: Use extrusions to display buildings' height in 3D 
-tags: 
+---
+layout: example
+category: example
+title: Display buildings in 3D
+description: Use extrusions to display buildings' heights in 3D.
+tags:
   - layers
 ---
 <div id='map'></div>
@@ -25,19 +25,19 @@ map.on('load', function() {
         'source': 'composite',
         'source-layer': 'building',
         'filter': ['==', 'extrude', 'true'],
-        'type': 'fill',
+        'type': 'fill-extrusion',
         'minzoom': 15,
         'paint': {
-            'fill-color': '#aaa',
-            'fill-extrude-height': {
+            'fill-extrusion-color': '#aaa',
+            'fill-extrusion-height': {
                 'type': 'identity',
                 'property': 'height'
             },
-            'fill-extrude-base': {
+            'fill-extrusion-base': {
                 'type': 'identity',
                 'property': 'min_height'
             },
-            'fill-opacity': .6
+            'fill-extrusion-opacity': .6
         }
     });
 });


### PR DESCRIPTION
Update extrusion-based examples (once https://github.com/mapbox/mapbox-gl-js/pull/3487 is merged). Refs https://github.com/mapbox/mapbox-gl-style-spec/issues/554.
