### PR TITLE
Program configuration optimizations

### DIFF
--- a/js/data/program_configuration.js
+++ b/js/data/program_configuration.js
@@ -106,6 +106,8 @@ class ProgramConfiguration {
             }
         }
 
+        self.cacheKey = JSON.stringify([self.vertexPragmas, self.fragmentPragmas]);
+
         return self;
     }
 
@@ -126,6 +128,8 @@ class ProgramConfiguration {
             pragmas.define[uniform.name.slice(2)] = `uniform ${type} ${uniform.name};\n`;
             pragmas.initialize[uniform.name.slice(2)] = `${type} ${uniform.name.slice(2)} = ${uniform.name};\n`;
         }
+
+        self.cacheKey = JSON.stringify(pragmas);
 
         return self;
     }
@@ -151,15 +155,6 @@ class ProgramConfiguration {
 
     paintVertexArrayType() {
         return new VertexArrayType(this.attributes);
-    }
-
-    programCacheKey(name, showOverdraw) {
-        return JSON.stringify({
-            name: name,
-            vertexPragmas: this.vertexPragmas,
-            fragmentPragmas: this.fragmentPragmas,
-            overdraw: showOverdraw
-        });
     }
 
     createProgram(name, showOverdraw, gl) {

--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
-const ProgramConfiguration = require('../data/program_configuration');
 
 const tileSize = 512;
 
@@ -47,10 +46,7 @@ function drawBackground(painter, sourceCache, layer) {
         // Draw filling rectangle.
         if (painter.isOpaquePass !== (color[3] === 1)) return;
 
-        program = painter.useProgram('fill', ProgramConfiguration.createStatic([
-            {name: 'u_color', components: 4},
-            {name: 'u_opacity', components: 1}
-        ]));
+        program = painter.useProgram('fill', painter.basicFillProgramConfiguration);
 
         gl.uniform4fv(program.u_color, color);
         gl.uniform1f(program.u_opacity, opacity);

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -369,7 +369,7 @@ class Painter {
 
     _createProgramCached(name, paintAttributeSet) {
         this.cache = this.cache || {};
-        const key = paintAttributeSet.programCacheKey(name, this._showOverdrawInspector);
+        const key = `${name}:${paintAttributeSet.cacheKey}:${this._showOverdrawInspector}`;
         if (!this.cache[key]) {
             this.cache[key] = paintAttributeSet.createProgram(name, this._showOverdrawInspector, this.gl);
         }

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -48,6 +48,11 @@ class Painter {
         this.depthEpsilon = 1 / Math.pow(2, 16);
 
         this.lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
+
+        this.basicFillProgramConfiguration = ProgramConfiguration.createStatic([
+            {name: 'u_color', components: 4},
+            {name: 'u_opacity', components: 1}
+        ]);
     }
 
     /*
@@ -152,16 +157,13 @@ class Painter {
 
         let idNext = 1;
         this._tileClippingMaskIDs = {};
-        for (let i = 0; i < coords.length; i++) {
-            const coord = coords[i];
+
+        for (const coord of coords) {
             const id = this._tileClippingMaskIDs[coord.id] = (idNext++) << 3;
 
             gl.stencilFunc(gl.ALWAYS, id, 0xF8);
 
-            const program = this.useProgram('fill', ProgramConfiguration.createStatic([
-                {name: 'u_color', components: 4},
-                {name: 'u_opacity', components: 1}
-            ]));
+            const program = this.useProgram('fill', this.basicFillProgramConfiguration);
             gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
             // Draw the clipping mask

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "coveralls": "^2.11.8",
     "documentation": "4.0.0-beta11",
     "envify": "^3.4.0",
-    "eslint": "^3.3.1",
+    "eslint": "^3.9.0",
     "eslint-config-mourner": "^2.0.0",
     "eslint-plugin-html": "^1.5.1",
     "github-slugger": "^1.1.1",

--- a/test/js/symbol/get_anchors.test.js
+++ b/test/js/symbol/get_anchors.test.js
@@ -31,18 +31,10 @@ test('getAnchors', (t) => {
     test('non-continued line with short labels', (t) => {
         const anchors = getAnchors(nonContinuedLine, bigSpacing, Math.PI, shapedText, shapedIcon, glyphSize, 1, 1, TILE_EXTENT);
 
-        t.deepEqual(anchors, [ { x: 1,
-            y: 2,
-            angle: 1.5707963267948966,
-            segment: 1 },
-            { x: 1,
-                y: 5,
-            angle: 1.5707963267948966,
-            segment: 4 },
-            { x: 1,
-                y: 8,
-            angle: 1.5707963267948966,
-            segment: 7 } ]);
+        t.deepEqual(anchors, [
+            { x: 1, y: 2, angle: 1.5707963267948966, segment: 1 },
+            { x: 1, y: 5, angle: 1.5707963267948966, segment: 4 },
+            { x: 1, y: 8, angle: 1.5707963267948966, segment: 7 } ]);
 
         t.ok(labelLength / 2 + 1 <= anchors[0].y && anchors[0].y < labelLength / 2 + 3 * glyphSize + 1,
                 'first label is placed as close to the beginning as possible');
@@ -53,18 +45,10 @@ test('getAnchors', (t) => {
     test('non-continued line with long labels', (t) => {
         const anchors = getAnchors(nonContinuedLine, smallSpacing, Math.PI, shapedText, shapedIcon, glyphSize, 1, 1, TILE_EXTENT);
 
-        t.deepEqual(anchors, [ { x: 1,
-            y: 2,
-            angle: 1.5707963267948966,
-            segment: 1 },
-            { x: 1,
-                y: 5,
-            angle: 1.5707963267948966,
-            segment: 3 },
-            { x: 1,
-                y: 7,
-            angle: 1.5707963267948966,
-            segment: 6 } ]);
+        t.deepEqual(anchors, [
+            { x: 1, y: 2, angle: 1.5707963267948966, segment: 1 },
+            { x: 1, y: 5, angle: 1.5707963267948966, segment: 3 },
+            { x: 1, y: 7, angle: 1.5707963267948966, segment: 6 } ]);
 
         t.end();
     });
@@ -72,18 +56,10 @@ test('getAnchors', (t) => {
     test('continued line with short labels', (t) => {
         const anchors = getAnchors(continuedLine, bigSpacing, Math.PI, shapedText, shapedIcon, glyphSize, 1, 1, TILE_EXTENT);
 
-        t.deepEqual(anchors, [ { x: 1,
-            y: 2,
-            angle: 1.5707963267948966,
-            segment: 1 },
-            { x: 1,
-                y: 5,
-            angle: 1.5707963267948966,
-            segment: 4 },
-            { x: 1,
-                y: 8,
-            angle: 1.5707963267948966,
-            segment: 7 } ]);
+        t.deepEqual(anchors, [
+            { x: 1, y: 2, angle: 1.5707963267948966, segment: 1 },
+            { x: 1, y: 5, angle: 1.5707963267948966, segment: 4 },
+            { x: 1, y: 8, angle: 1.5707963267948966, segment: 7 } ]);
 
         t.end();
     });
@@ -91,18 +67,10 @@ test('getAnchors', (t) => {
     test('continued line with long labels', (t) => {
         const anchors = getAnchors(continuedLine, smallSpacing, Math.PI, shapedText, shapedIcon, glyphSize, 1, 1, TILE_EXTENT);
 
-        t.deepEqual(anchors, [ { x: 1,
-            y: 1,
-            angle: 1.5707963267948966,
-            segment: 1 },
-            { x: 1,
-                y: 4,
-            angle: 1.5707963267948966,
-            segment: 3 },
-            { x: 1,
-                y: 6,
-            angle: 1.5707963267948966,
-            segment: 6 } ]);
+        t.deepEqual(anchors, [
+            { x: 1, y: 1, angle: 1.5707963267948966, segment: 1 },
+            { x: 1, y: 4, angle: 1.5707963267948966, segment: 3 },
+            { x: 1, y: 6, angle: 1.5707963267948966, segment: 6 } ]);
 
         t.end();
     });
@@ -129,10 +97,7 @@ test('getAnchors', (t) => {
         const line = [new Point(1, 1), new Point(1, 3.1)];
         const anchors = getAnchors(line, 2, Math.PI, shapedText, shapedIcon, glyphSize, 1, 1, TILE_EXTENT);
         t.deepEqual(anchors, [
-            { x: 1,
-            y: 2,
-            angle: 1.5707963267948966,
-            segment: 0 }]);
+            { x: 1, y: 2, angle: 1.5707963267948966, segment: 0 }]);
         t.end();
     });
     t.end();


### PR DESCRIPTION
Along with #3485, this PR brings the rendering performance with the Streets z13 benchmark to pre-DDS levels and closes #3342! 🎉🎉🎉 [Benchmark](http://jsfiddle.net/Mourner/2bzyLLp5/4/) results:

- v0.22: 8.8ms
- v0.25: 17.2ms
- master before #3485: 15.3ms
- master: 11.7ms
- after this PR: 8.3ms

Changes:

- Avoid repeatedly restringifying program configurations for caching.
- Avoid repeatedly recreating the same fill program for clipping masks and background.

Note that the failing build is due to changes in ESLint 3.9.0; fixed up the warnings in the third commit.

👀 @jfirebaugh @lucaswoj @ansis 