### PR TITLE
Fix incomplete transferring in worker tile

### DIFF
--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -118,9 +118,9 @@ class WorkerTile {
                 buckets: serializeBuckets(util.values(buckets), transferables),
                 featureIndex: featureIndex.serialize(transferables),
                 collisionTile: collisionTile.serialize(transferables),
-                collisionBoxArray: this.collisionBoxArray.serialize(),
-                symbolInstancesArray: this.symbolInstancesArray.serialize(),
-                symbolQuadsArray: this.symbolQuadsArray.serialize()
+                collisionBoxArray: this.collisionBoxArray.serialize(transferables),
+                symbolInstancesArray: this.symbolInstancesArray.serialize(transferables),
+                symbolQuadsArray: this.symbolQuadsArray.serialize(transferables)
             }, transferables);
         };
 


### PR DESCRIPTION
Ref https://github.com/mapbox/mapbox-gl-js/pull/3465#discussion_r85550155, 👀 @jfirebaugh 

This is not really captured by any benchmarks, but I believe there will be a bit less stuttering on tile loads after the fix.