### PR TITLE
use aria-label on control buttons

### DIFF
--- a/js/ui/control/geolocate_control.js
+++ b/js/ui/control/geolocate_control.js
@@ -33,6 +33,7 @@ class GeolocateControl extends Control {
 
         this._geolocateButton = DOM.create('button', (`${className}-icon ${className}-geolocate`), this._container);
         this._geolocateButton.type = 'button';
+        this._geolocateButton.setAttribute('aria-label', 'Geolocate');
         this._geolocateButton.addEventListener('click', this._onClickGeolocate.bind(this));
         return container;
     }

--- a/js/ui/control/navigation_control.js
+++ b/js/ui/control/navigation_control.js
@@ -28,9 +28,9 @@ class NavigationControl extends Control {
         const container = this._container = DOM.create('div', `${className}-group`, map.getContainer());
         this._container.addEventListener('contextmenu', this._onContextMenu.bind(this));
 
-        this._zoomInButton = this._createButton(`${className}-icon ${className}-zoom-in`, map.zoomIn.bind(map));
-        this._zoomOutButton = this._createButton(`${className}-icon ${className}-zoom-out`, map.zoomOut.bind(map));
-        this._compass = this._createButton(`${className}-icon ${className}-compass`, map.resetNorth.bind(map));
+        this._zoomInButton = this._createButton(`${className}-icon ${className}-zoom-in`, 'Zoom In', map.zoomIn.bind(map));
+        this._zoomOutButton = this._createButton(`${className}-icon ${className}-zoom-out`, 'Zoom Out', map.zoomOut.bind(map));
+        this._compass = this._createButton(`${className}-icon ${className}-compass`, 'Reset North', map.resetNorth.bind(map));
 
         this._compassArrow = DOM.create('span', 'arrow', this._compass);
 
@@ -79,9 +79,10 @@ class NavigationControl extends Control {
         e.stopPropagation();
     }
 
-    _createButton(className, fn) {
+    _createButton(className, ariaLabel, fn) {
         const a = DOM.create('button', className, this._container);
         a.type = 'button';
+        a.setAttribute('aria-label', ariaLabel);
         a.addEventListener('click', () => { fn(); });
         return a;
     }


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

As far as I can tell it doesn't seem like the navigation controls (zoom, rotate, geolocate) are accessible. As per https://www.w3.org/TR/wai-aria/states_and_properties#aria-label and general advice at http://getbootstrap.com/components/#glyphicons-how-to-use I believe by adding the `aria-label` attribute to these buttons screen readers etc will be able to provide users more information about what these buttons do.

 - [ ] write tests for all new functionality

Not sure this is really applicable here?

 - [x] document any changes to public APIs

No public API changes.

 - [x] post benchmark scores

Shouldn't affect performance.

 - [x] manually test the debug page

Manually tested.