### PR TITLE
Simplify and optimize drawFill

### DIFF
--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -2,30 +2,28 @@
 
 const setPattern = require('./set_pattern');
 
-module.exports = draw;
+module.exports = drawFill;
 
-function draw(painter, sourceCache, layer, coords) {
+function drawFill(painter, sourceCache, layer, coords) {
     const gl = painter.gl;
     gl.enable(gl.STENCIL_TEST);
 
-    const isOpaque = (
+    const isOpaque =
         !layer.paint['fill-pattern'] &&
         layer.isPaintValueFeatureConstant('fill-color') &&
         layer.isPaintValueFeatureConstant('fill-opacity') &&
         layer.paint['fill-color'][3] === 1 &&
-        layer.paint['fill-opacity'] === 1
-    );
+        layer.paint['fill-opacity'] === 1;
 
     // Draw fill
     if (painter.isOpaquePass === isOpaque) {
         // Once we switch to earcut drawing we can pull most of the WebGL setup
         // outside of this coords loop.
         painter.setDepthSublayer(1);
-        for (let i = 0; i < coords.length; i++) {
-            drawFill(painter, sourceCache, layer, coords[i]);
-        }
+        drawFillTiles(painter, sourceCache, layer, coords, drawFillTile);
     }
 
+    // Draw stroke
     if (!painter.isOpaquePass && layer.paint['fill-antialias']) {
         painter.lineWidth(2);
         painter.depthMask(false);
@@ -39,49 +37,27 @@ function draw(painter, sourceCache, layer, coords) {
         // the current shape, some pixels from the outline stroke overlapped
         // the (non-antialiased) fill.
         painter.setDepthSublayer(layer.getPaintProperty('fill-outline-color') ? 2 : 0);
-
-        for (let j = 0; j < coords.length; j++) {
-            drawStroke(painter, sourceCache, layer, coords[j]);
-        }
+        drawFillTiles(painter, sourceCache, layer, coords, drawStrokeTile);
     }
 }
 
-function drawFill(painter, sourceCache, layer, coord) {
-    const tile = sourceCache.getTile(coord);
-    const bucket = tile.getBucket(layer);
-    if (!bucket) return;
+function drawFillTiles(painter, sourceCache, layer, coords, drawFn) {
+    for (const coord of coords) {
+        const tile = sourceCache.getTile(coord);
+        const bucket = tile.getBucket(layer);
+        if (!bucket) continue;
 
-    const buffers = bucket.buffers;
+        painter.enableTileClippingMask(coord);
+
+        drawFn(painter, sourceCache, layer, tile, coord, bucket.buffers);
+    }
+}
+
+function drawFillTile(painter, sourceCache, layer, tile, coord, buffers) {
     const gl = painter.gl;
-
-    const image = layer.paint['fill-pattern'];
     const layerData = buffers.layerData[layer.id];
 
-    let program;
-
-    if (!image) {
-        const programConfiguration = layerData.programConfiguration;
-        program = painter.useProgram('fill', programConfiguration);
-        programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
-
-    } else {
-        // Draw texture fill
-        program = painter.useProgram('fillPattern');
-        setPattern(image, tile, coord, painter, program, false);
-        gl.uniform1f(program.u_opacity, layer.paint['fill-opacity']);
-
-        gl.activeTexture(gl.TEXTURE0);
-        painter.spriteAtlas.bind(gl, true);
-    }
-
-    gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
-        coord.posMatrix,
-        tile,
-        layer.paint['fill-translate'],
-        layer.paint['fill-translate-anchor']
-    ));
-
-    painter.enableTileClippingMask(coord);
+    const program = setFillProgram('fill', layer.paint['fill-pattern'], painter, layerData, layer, tile, coord);
 
     for (const segment of buffers.segments) {
         segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
@@ -89,47 +65,34 @@ function drawFill(painter, sourceCache, layer, coord) {
     }
 }
 
-function drawStroke(painter, sourceCache, layer, coord) {
-    const tile = sourceCache.getTile(coord);
-    const bucket = tile.getBucket(layer);
-    if (!bucket) return;
-
-    const buffers = bucket.buffers;
-    const layerData = buffers.layerData[layer.id];
+function drawStrokeTile(painter, sourceCache, layer, tile, coord, buffers) {
     const gl = painter.gl;
+    const layerData = buffers.layerData[layer.id];
+    const usePattern = layer.paint['fill-pattern'] && !layer.getPaintProperty('fill-outline-color');
 
-    const image = layer.paint['fill-pattern'];
-    const isOutlineColorDefined = layer.getPaintProperty('fill-outline-color');
-    let program;
-
-    if (image && !isOutlineColorDefined) {
-        program = painter.useProgram('fillOutlinePattern');
-        gl.uniform2f(program.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
-
-    } else {
-        const programConfiguration = layerData.programConfiguration;
-        program = painter.useProgram('fillOutline', programConfiguration);
-        programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
-        gl.uniform2f(program.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
-    }
-
-    gl.uniform1f(program.u_opacity, layer.paint['fill-opacity']);
-
-    gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
-        coord.posMatrix,
-        tile,
-        layer.paint['fill-translate'],
-        layer.paint['fill-translate-anchor']
-    ));
-
-    if (image) {
-        setPattern(image, tile, coord, painter, program, false);
-    }
-
-    painter.enableTileClippingMask(coord);
+    const program = setFillProgram('fillOutline', usePattern, painter, layerData, layer, tile, coord);
+    gl.uniform2f(program.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
     for (const segment of buffers.segments2) {
         segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer2, layerData.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);
     }
+}
+
+function setFillProgram(programId, usePattern, painter, layerData, layer, tile, coord) {
+    let program;
+    if (!usePattern) {
+        program = painter.useProgram(programId, layerData.programConfiguration);
+        layerData.programConfiguration.setUniforms(painter.gl, program, layer, {zoom: painter.transform.zoom});
+    } else {
+        program = painter.useProgram(`${programId}Pattern`);
+        painter.gl.uniform1f(program.u_opacity, layer.paint['fill-opacity']);
+        setPattern(layer.paint['fill-pattern'], tile, coord, painter, program, false);
+    }
+    painter.gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
+        coord.posMatrix, tile,
+        layer.paint['fill-translate'],
+        layer.paint['fill-translate-anchor']
+    ));
+    return program;
 }


### PR DESCRIPTION
Cleans up, simplifies and optimizes `drawFill`. Uses similar technique to #3485, avoiding redundant `setUniforms` calls between tiles. 👀 @lucaswoj 

[Mapbox Streets z13 bench](http://jsfiddle.net/Mourner/2bzyLLp5/4/):
**before**: 8.56ms
**after**: 7.15ms