### PR TITLE
Resolve Z units to meters 

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -453,6 +453,10 @@ class Transform {
         mat4.rotateX(m, m, this._pitch);
         mat4.rotateZ(m, m, this.angle);
         mat4.translate(m, m, [-this.x, -this.y, 0]);
+        mat4.scale(m, m, [1, 1,
+            // scale vertically to meters per pixel (inverse of ground resolution)
+            (Math.pow(2, this.zoom) * 512) / (2 * Math.PI * 6378137 * Math.abs(Math.cos(this.center.lat * (Math.PI / 180)))),
+        1]);
 
         this.projMatrix = m;
 

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -456,7 +456,7 @@ class Transform {
         mat4.scale(m, m, [1, 1,
             // scale vertically to meters per pixel (inverse of ground resolution)
             (Math.pow(2, this.zoom) * 512) / (2 * Math.PI * 6378137 * Math.abs(Math.cos(this.center.lat * (Math.PI / 180)))),
-        1]);
+            1]);
 
         this.projMatrix = m;
 

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -453,9 +453,14 @@ class Transform {
         mat4.rotateX(m, m, this._pitch);
         mat4.rotateZ(m, m, this.angle);
         mat4.translate(m, m, [-this.x, -this.y, 0]);
+
+        const circumferenceOfEarth = 2 * Math.PI * 6378137;
+
         mat4.scale(m, m, [1, 1,
-            // scale vertically to meters per pixel (inverse of ground resolution)
-            (Math.pow(2, this.zoom) * 512) / (2 * Math.PI * 6378137 * Math.abs(Math.cos(this.center.lat * (Math.PI / 180)))),
+            // scale vertically to meters per pixel (inverse of ground resolution):
+            // (2^z * tileSize) / (circumferenceOfEarth * cos(lat * π / 180))
+            (Math.pow(2, this.zoom) * this.tileSize) /
+            (circumferenceOfEarth * Math.abs(Math.cos(this.center.lat * (Math.PI / 180)))),
             1]);
 
         this.projMatrix = m;

--- a/js/render/draw_fill_extrusion.js
+++ b/js/render/draw_fill_extrusion.js
@@ -162,28 +162,19 @@ function drawExtrusion(painter, source, layer, coord) {
         setPattern(image, tile, coord, painter, program, true);
     }
 
-    setMatrix(program, painter, coord, tile, layer);
+    painter.gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
+        coord.posMatrix,
+        tile,
+        layer.paint['fill-extrusion-translate'],
+        layer.paint['fill-extrusion-translate-anchor']
+    ));
+
     setLight(program, painter);
 
     for (const segment of buffers.segments) {
         segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
-}
-
-function setMatrix(program, painter, coord, tile, layer) {
-    const zScale = Math.pow(2, painter.transform.zoom) / 50000;
-
-    painter.gl.uniformMatrix4fv(program.u_matrix, false, mat4.scale(
-        mat4.create(),
-        painter.translatePosMatrix(
-            coord.posMatrix,
-            tile,
-            layer.paint['fill-extrusion-translate'],
-            layer.paint['fill-extrusion-translate-anchor']
-        ),
-        [1, 1, zScale, 1])
-    );
 }
 
 function setLight(program, painter) {

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -382,9 +382,14 @@ test('Map', (t) => {
         function toFixed(bounds) {
             const n = 10;
             return [
-                [bounds[0][0].toFixed(n), bounds[0][1].toFixed(n)],
-                [bounds[1][0].toFixed(n), bounds[1][1].toFixed(n)]
+                [normalizeFixed(bounds[0][0], n), normalizeFixed(bounds[0][1], n)],
+                [normalizeFixed(bounds[1][0], n), normalizeFixed(bounds[1][1], n)]
             ];
+        }
+
+        function normalizeFixed(num, n) {
+            // workaround for "-0.0000000000" ≠ "0.0000000000"
+            return parseFloat(num.toFixed(n)).toFixed(n);
         }
     });
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/3385.

I branched off the fill extrusion separate type branch and would like to merge this back into there. Lint tests are passing because of the new ESLint formatting — @mourner fixed this on master. I'd like to merge this (not passing) into the fill-extrusion-type branch and then just rebase once there.

My question is this: [this line](https://github.com/mapbox/mapbox-gl-js/blob/0f01a4ee45bcf79fdd716d53e00fe02e7dfbf0b5/js/geo/transform.js#L454) is affected when the map bearing is non-zero. Then here I'm introducing a z scaling in the same matrix. Effectively this means there is a single test in map.test.js failing [here](https://github.com/mapbox/mapbox-gl-js/blob/0f01a4ee45bcf79fdd716d53e00fe02e7dfbf0b5/test/js/ui/map.test.js#L372-L378), as 
```
      Error: should be equivalent
      + expected - actual

       [
         [
           "-49.7184455522"
      -    "0.0000000000"
      +    "-0.0000000000"
         ]
         [
           "49.7184455522"
      -    "0.0000000000"
      +    "-0.0000000000"
         ]
       ]
```
— before `toFixed` that number is something like -2<sup>-13</sup>, so it introduces a miniscule change. That's the only test that fails, and all non-extrusion render tests pass; is it okay to just update this test to parse/round a bit differently to make this test pass? Or should the matrix scaling happen elsewhere/will there be unintended consequences of scaling here (after the `rotateZ`)?

@ansis @jfirebaugh @lucaswoj 