### PR TITLE
Simplify drawBackground & optimize patterns

### DIFF
--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -1,87 +1,43 @@
 'use strict';
 
-const pixelsToTileUnits = require('../source/pixels_to_tile_units');
-
-const tileSize = 512;
+const setPattern = require('./set_pattern');
 
 module.exports = drawBackground;
 
 function drawBackground(painter, sourceCache, layer) {
     const gl = painter.gl;
     const transform = painter.transform;
+    const tileSize = transform.tileSize;
     const color = layer.paint['background-color'];
     const image = layer.paint['background-pattern'];
     const opacity = layer.paint['background-opacity'];
-    let program;
 
-    const imagePosA = image ? painter.spriteAtlas.getPosition(image.from, true) : null;
-    const imagePosB = image ? painter.spriteAtlas.getPosition(image.to, true) : null;
-
-    painter.setDepthSublayer(0);
-    if (imagePosA && imagePosB) {
-
-        if (painter.isOpaquePass) return;
-
-        // Draw texture fill
-        program = painter.useProgram('fillPattern');
-        gl.uniform1i(program.u_image, 0);
-        gl.uniform2fv(program.u_pattern_tl_a, imagePosA.tl);
-        gl.uniform2fv(program.u_pattern_br_a, imagePosA.br);
-        gl.uniform2fv(program.u_pattern_tl_b, imagePosB.tl);
-        gl.uniform2fv(program.u_pattern_br_b, imagePosB.br);
-        gl.uniform1f(program.u_opacity, opacity);
-
-        gl.uniform1f(program.u_mix, image.t);
-
-        gl.uniform2fv(program.u_pattern_size_a, imagePosA.size);
-        gl.uniform2fv(program.u_pattern_size_b, imagePosB.size);
-        gl.uniform1f(program.u_scale_a, image.fromScale);
-        gl.uniform1f(program.u_scale_b, image.toScale);
-
-        gl.activeTexture(gl.TEXTURE0);
-        painter.spriteAtlas.bind(gl, true);
-
-        painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer);
-    } else {
-        // Draw filling rectangle.
-        if (painter.isOpaquePass !== (color[3] === 1)) return;
-
-        program = painter.useProgram('fill', painter.basicFillProgramConfiguration);
-
-        gl.uniform4fv(program.u_color, color);
-        gl.uniform1f(program.u_opacity, opacity);
-        painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer);
-    }
+    if (painter.isOpaquePass !== (!image && color[3] === 1)) return;
 
     gl.disable(gl.STENCIL_TEST);
 
-    // We need to draw the background in tiles in order to use calculatePosMatrix
-    // which applies the projection matrix (transform.projMatrix). Otherwise
-    // the depth and stencil buffers get into a bad state.
-    // This can be refactored into a single draw call once earcut lands and
-    // we don't have so much going on in the stencil buffer.
-    const coords = transform.coveringTiles({ tileSize: tileSize });
-    for (let c = 0; c < coords.length; c++) {
-        const coord = coords[c];
-        // var pixelsToTileUnitsBound = pixelsToTileUnits.bind({coord:coord, tileSize: tileSize});
-        if (imagePosA && imagePosB) {
-            const tile = {coord:coord, tileSize: tileSize};
+    painter.setDepthSublayer(0);
 
-            gl.uniform1f(program.u_tile_units_to_pixels, 1 / pixelsToTileUnits(tile, 1, painter.transform.tileZoom));
+    let program;
+    if (image) {
+        program = painter.useProgram('fillPattern');
+        setPattern(image, painter, program);
+        painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer);
+    } else {
+        program = painter.useProgram('fill', painter.basicFillProgramConfiguration);
+        gl.uniform4fv(program.u_color, color);
+        painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer);
+    }
 
-            const tileSizeAtNearestZoom = tile.tileSize * Math.pow(2, painter.transform.tileZoom - tile.coord.z);
+    gl.uniform1f(program.u_opacity, opacity);
 
-            const pixelX = tileSizeAtNearestZoom * (tile.coord.x + coord.w * Math.pow(2, tile.coord.z));
-            const pixelY = tileSizeAtNearestZoom * tile.coord.y;
-            // split the pixel coord into two pairs of 16 bit numbers. The glsl spec only guarantees 16 bits of precision.
-            gl.uniform2f(program.u_pixel_coord_upper, pixelX >> 16, pixelY >> 16);
-            gl.uniform2f(program.u_pixel_coord_lower, pixelX & 0xFFFF, pixelY & 0xFFFF);
+    const coords = transform.coveringTiles({tileSize});
+
+    for (const coord of coords) {
+        if (image) {
+            setPattern.setTile({coord, tileSize}, painter, program, true);
         }
-
         gl.uniformMatrix4fv(program.u_matrix, false, painter.transform.calculatePosMatrix(coord));
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.length);
     }
-
-    gl.stencilMask(0x00);
-    gl.stencilFunc(gl.EQUAL, 0x80, 0x80);
 }

--- a/js/render/draw_extrusion.js
+++ b/js/render/draw_extrusion.js
@@ -159,7 +159,8 @@ function drawExtrusion(painter, source, layer, coord) {
     programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
 
     if (image) {
-        setPattern(image, tile, coord, painter, program, true);
+        setPattern(image, painter, program);
+        setPattern.setTile(tile, painter, program, true);
     }
 
     setMatrix(program, painter, coord, tile, layer);

--- a/js/render/draw_fill.js
+++ b/js/render/draw_fill.js
@@ -91,7 +91,10 @@ function setFillProgram(programId, usePattern, painter, layerData, layer, tile, 
     } else {
         program = painter.useProgram(`${programId}Pattern`);
         painter.gl.uniform1f(program.u_opacity, layer.paint['fill-opacity']);
-        setPattern(layer.paint['fill-pattern'], tile, coord, painter, program, false);
+        if (firstTile || program !== prevProgram) {
+            setPattern(layer.paint['fill-pattern'], painter, program);
+        }
+        setPattern.setTile(tile, painter, program, false);
     }
     painter.gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
         coord.posMatrix, tile,


### PR DESCRIPTION
- Break `setPattern` into two phases (one is done once per layer and the other once per tile).
- Reuse `setPattern` in `drawBackground`, removing lots of duplicated code.

👀 @ansis @lucaswoj 