### PR TITLE
Clean up struct array usage

### DIFF
--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -1,18 +1,18 @@
 'use strict';
 
 const Bucket = require('../bucket');
-const VertexArrayType = require('../vertex_array_type');
-const ElementArrayType = require('../element_array_type');
+const createVertexArrayType = require('../vertex_array_type');
+const createElementArrayType = require('../element_array_type');
 const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
 
 const circleInterface = {
-    layoutVertexArrayType: new VertexArrayType([{
+    layoutVertexArrayType: createVertexArrayType([{
         name: 'a_pos',
         components: 2,
         type: 'Int16'
     }]),
-    elementArrayType: new ElementArrayType(),
+    elementArrayType: createElementArrayType(),
 
     paintAttributes: [{
         name: 'a_color',

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Bucket = require('../bucket');
-const VertexArrayType = require('../vertex_array_type');
-const ElementArrayType = require('../element_array_type');
+const createVertexArrayType = require('../vertex_array_type');
+const createElementArrayType = require('../element_array_type');
 const loadGeometry = require('../load_geometry');
 const earcut = require('earcut');
 const classifyRings = require('../../util/classify_rings');
@@ -10,13 +10,13 @@ const assert = require('assert');
 const EARCUT_MAX_RINGS = 500;
 
 const fillInterface = {
-    layoutVertexArrayType: new VertexArrayType([{
+    layoutVertexArrayType: createVertexArrayType([{
         name: 'a_pos',
         components: 2,
         type: 'Int16'
     }]),
-    elementArrayType: new ElementArrayType(3),
-    elementArrayType2: new ElementArrayType(2),
+    elementArrayType: createElementArrayType(3),
+    elementArrayType2: createElementArrayType(2),
 
     paintAttributes: [{
         name: 'a_color',

--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Bucket = require('../bucket');
-const VertexArrayType = require('../vertex_array_type');
-const ElementArrayType = require('../element_array_type');
+const createVertexArrayType = require('../vertex_array_type');
+const createElementArrayType = require('../element_array_type');
 const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
 const earcut = require('earcut');
@@ -11,7 +11,7 @@ const assert = require('assert');
 const EARCUT_MAX_RINGS = 500;
 
 const fillExtrusionInterface = {
-    layoutVertexArrayType: new VertexArrayType([{
+    layoutVertexArrayType: createVertexArrayType([{
         name: 'a_pos',
         components: 2,
         type: 'Int16'
@@ -24,7 +24,7 @@ const fillExtrusionInterface = {
         components: 1,
         type: 'Int16'
     }]),
-    elementArrayType: new ElementArrayType(3),
+    elementArrayType: createElementArrayType(3),
 
     paintAttributes: [{
         name: 'a_minH',

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Bucket = require('../bucket');
-const VertexArrayType = require('../vertex_array_type');
-const ElementArrayType = require('../element_array_type');
+const createVertexArrayType = require('../vertex_array_type');
+const createElementArrayType = require('../element_array_type');
 const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
 
@@ -40,7 +40,7 @@ const LINE_DISTANCE_SCALE = 1 / 2;
 const MAX_LINE_DISTANCE = Math.pow(2, LINE_DISTANCE_BUFFER_BITS - 1) / LINE_DISTANCE_SCALE;
 
 const lineInterface = {
-    layoutVertexArrayType: new VertexArrayType([{
+    layoutVertexArrayType: createVertexArrayType([{
         name: 'a_pos',
         components: 2,
         type: 'Int16'
@@ -59,7 +59,7 @@ const lineInterface = {
         multiplier: 255,
         paintProperty: 'line-color'
     }],
-    elementArrayType: new ElementArrayType()
+    elementArrayType: createElementArrayType()
 };
 
 function addLineVertex(layoutVertexBuffer, point, extrude, tx, ty, dir, linesofar) {

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -3,8 +3,8 @@
 const Point = require('point-geometry');
 const ArrayGroup = require('../array_group');
 const BufferGroup = require('../buffer_group');
-const VertexArrayType = require('../vertex_array_type');
-const ElementArrayType = require('../element_array_type');
+const createVertexArrayType = require('../vertex_array_type');
+const createElementArrayType = require('../element_array_type');
 const EXTENT = require('../extent');
 const Anchor = require('../../symbol/anchor');
 const getAnchors = require('../../symbol/get_anchors');
@@ -25,8 +25,9 @@ const shapeIcon = Shaping.shapeIcon;
 const getGlyphQuads = Quads.getGlyphQuads;
 const getIconQuads = Quads.getIconQuads;
 
-const elementArrayType = new ElementArrayType();
-const layoutVertexArrayType = new VertexArrayType([{
+const elementArrayType = createElementArrayType();
+
+const layoutVertexArrayType = createVertexArrayType([{
     name: 'a_pos',
     components: 2,
     type: 'Int16'
@@ -54,7 +55,7 @@ const symbolInterfaces = {
         elementArrayType: elementArrayType
     },
     collisionBox: {
-        layoutVertexArrayType: new VertexArrayType([{
+        layoutVertexArrayType: createVertexArrayType([{
             name: 'a_pos',
             components: 2,
             type: 'Int16'
@@ -67,7 +68,7 @@ const symbolInterfaces = {
             components: 2,
             type: 'Uint8'
         }]),
-        elementArrayType: new ElementArrayType(2)
+        elementArrayType: createElementArrayType(2)
     }
 };
 

--- a/js/data/buffer.js
+++ b/js/data/buffer.js
@@ -32,6 +32,10 @@ class Buffer {
         this.arrayType = arrayType;
     }
 
+    static fromStructArray(array, type) {
+        return new Buffer(array.serialize(), array.constructor.serialize(), type);
+    }
+
     /**
      * Bind this buffer to a WebGL context.
      * @param gl The WebGL context

--- a/js/data/element_array_type.js
+++ b/js/data/element_array_type.js
@@ -1,18 +1,20 @@
 'use strict';
 
-const StructArrayType = require('../util/struct_array');
+const createStructArrayType = require('../util/struct_array');
+
+module.exports = createElementArrayType;
 
 /**
  * An element array stores Uint16 indicies of vertexes in a corresponding vertex array. With no
  * arguments, it defaults to three components per element, forming triangles.
  * @private
  */
-module.exports = function ElementArrayType(components) {
-    return new StructArrayType({
+function createElementArrayType(components) {
+    return createStructArrayType({
         members: [{
             type: 'Uint16',
             name: 'vertices',
             components: components || 3
         }]
     });
-};
+}

--- a/js/data/feature_index.js
+++ b/js/data/feature_index.js
@@ -4,7 +4,7 @@ const Point = require('point-geometry');
 const loadGeometry = require('./load_geometry');
 const EXTENT = require('./extent');
 const featureFilter = require('feature-filter');
-const StructArrayType = require('../util/struct_array');
+const createStructArrayType = require('../util/struct_array');
 const Grid = require('grid-index');
 const DictionaryCoder = require('../util/dictionary_coder');
 const vt = require('vector-tile');
@@ -17,7 +17,7 @@ const multiPolygonIntersectsBufferedMultiPoint = intersection.multiPolygonInters
 const multiPolygonIntersectsMultiPolygon = intersection.multiPolygonIntersectsMultiPolygon;
 const multiPolygonIntersectsBufferedMultiLine = intersection.multiPolygonIntersectsBufferedMultiLine;
 
-const FeatureIndexArray = new StructArrayType({
+const FeatureIndexArray = createStructArrayType({
     members: [
         // the index of the feature in the original vectortile
         { type: 'Uint32', name: 'featureIndex' },
@@ -25,7 +25,8 @@ const FeatureIndexArray = new StructArrayType({
         { type: 'Uint16', name: 'sourceLayerIndex' },
         // the bucket the feature appears in
         { type: 'Uint16', name: 'bucketIndex' }
-    ]});
+    ]
+});
 
 class FeatureIndex {
     constructor(coord, overscaling, collisionTile) {

--- a/js/data/pos_array.js
+++ b/js/data/pos_array.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const StructArrayType = require('../util/struct_array');
+
+const PosArray = new StructArrayType({
+    members: [{ name: 'a_pos', type: 'Int16', components: 2 }]
+});
+
+module.exports = PosArray;

--- a/js/data/pos_array.js
+++ b/js/data/pos_array.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const StructArrayType = require('../util/struct_array');
+const createStructArrayType = require('../util/struct_array');
 
-const PosArray = new StructArrayType({
+const PosArray = createStructArrayType({
     members: [{ name: 'a_pos', type: 'Int16', components: 2 }]
 });
 

--- a/js/data/program_configuration.js
+++ b/js/data/program_configuration.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const VertexArrayType = require('./vertex_array_type');
+const createVertexArrayType = require('./vertex_array_type');
 const util = require('../util/util');
 const shaders = require('mapbox-gl-shaders');
 const assert = require('assert');
@@ -154,7 +154,7 @@ class ProgramConfiguration {
     }
 
     paintVertexArrayType() {
-        return new VertexArrayType(this.attributes);
+        return createVertexArrayType(this.attributes);
     }
 
     createProgram(name, showOverdraw, gl) {

--- a/js/data/raster_bounds_array.js
+++ b/js/data/raster_bounds_array.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const StructArrayType = require('../util/struct_array');
+
+const RasterBoundsArray = new StructArrayType({
+    members: [
+        { name: 'a_pos', type: 'Int16', components: 2 },
+        { name: 'a_texture_pos', type: 'Int16', components: 2 }
+    ]
+});
+
+module.exports = RasterBoundsArray;

--- a/js/data/raster_bounds_array.js
+++ b/js/data/raster_bounds_array.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const StructArrayType = require('../util/struct_array');
+const createStructArrayType = require('../util/struct_array');
 
-const RasterBoundsArray = new StructArrayType({
+const RasterBoundsArray = createStructArrayType({
     members: [
         { name: 'a_pos', type: 'Int16', components: 2 },
         { name: 'a_texture_pos', type: 'Int16', components: 2 }

--- a/js/data/vertex_array_type.js
+++ b/js/data/vertex_array_type.js
@@ -1,15 +1,17 @@
 'use strict';
 
-const StructArrayType = require('../util/struct_array');
+const createStructArrayType = require('../util/struct_array');
+
+module.exports = createVertexArrayType;
 
 /**
  * A vertex array stores data for each vertex in a geometry. Elements are aligned to 4 byte
  * boundaries for best performance in WebGL.
  * @private
  */
-module.exports = function VertexArrayType(members) {
-    return new StructArrayType({
+function createVertexArrayType(members) {
+    return createStructArrayType({
         members: members,
         alignment: 4
     });
-};
+}

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -6,6 +6,7 @@ const mat4 = require('gl-matrix').mat4;
 const EXTENT = require('../data/extent');
 const Buffer = require('../data/buffer');
 const VertexArrayObject = require('./vertex_array_object');
+const PosArray = require('../data/pos_array');
 
 module.exports = drawDebug;
 
@@ -33,11 +34,11 @@ function drawDebugTile(painter, sourceCache, coord) {
     gl.drawArrays(gl.LINE_STRIP, 0, painter.debugBuffer.length);
 
     const vertices = textVertices(coord.toString(), 50, 200, 5);
-    const debugTextArray = new painter.PosArray();
+    const debugTextArray = new PosArray();
     for (let v = 0; v < vertices.length; v += 2) {
         debugTextArray.emplaceBack(vertices[v], vertices[v + 1]);
     }
-    const debugTextBuffer = new Buffer(debugTextArray.serialize(), painter.PosArray.serialize(), Buffer.BufferType.VERTEX);
+    const debugTextBuffer = new Buffer(debugTextArray.serialize(), PosArray.serialize(), Buffer.BufferType.VERTEX);
     const debugTextVAO = new VertexArrayObject();
     debugTextVAO.bind(gl, program, debugTextBuffer);
     gl.uniform4f(program.u_color, 1, 1, 1, 1);

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -38,7 +38,7 @@ function drawDebugTile(painter, sourceCache, coord) {
     for (let v = 0; v < vertices.length; v += 2) {
         debugTextArray.emplaceBack(vertices[v], vertices[v + 1]);
     }
-    const debugTextBuffer = new Buffer(debugTextArray.serialize(), PosArray.serialize(), Buffer.BufferType.VERTEX);
+    const debugTextBuffer = Buffer.fromStructArray(debugTextArray, Buffer.BufferType.VERTEX);
     const debugTextVAO = new VertexArrayObject();
     debugTextVAO.bind(gl, program, debugTextBuffer);
     gl.uniform4f(program.u_color, 1, 1, 1, 1);

--- a/js/render/draw_fill_extrusion.js
+++ b/js/render/draw_fill_extrusion.js
@@ -5,7 +5,7 @@ const mat4 = require('gl-matrix').mat4;
 const vec3 = require('gl-matrix').vec3;
 const Buffer = require('../data/buffer');
 const VertexArrayObject = require('./vertex_array_object');
-const StructArrayType = require('../util/struct_array');
+const PosArray = require('../data/pos_array');
 const pattern = require('./pattern');
 
 module.exports = draw;
@@ -96,12 +96,6 @@ ExtrusionTexture.prototype.unbindFramebuffer = function() {
     this.painter.saveViewportTexture(this.texture);
 };
 
-ExtrusionTexture.prototype.TextureBoundsArray = new StructArrayType({
-    members: [
-        { name: 'a_pos', type: 'Int16', components: 2 }
-    ]
-});
-
 ExtrusionTexture.prototype.renderToMap = function() {
     const gl = this.gl;
     const painter = this.painter;
@@ -128,12 +122,12 @@ ExtrusionTexture.prototype.renderToMap = function() {
     gl.uniform1i(program.u_xdim, painter.width);
     gl.uniform1i(program.u_ydim, painter.height);
 
-    const array = new this.TextureBoundsArray();
+    const array = new PosArray();
     array.emplaceBack(0, 0);
     array.emplaceBack(painter.width, 0);
     array.emplaceBack(0, painter.height);
     array.emplaceBack(painter.width, painter.height);
-    const buffer = new Buffer(array.serialize(), this.TextureBoundsArray.serialize(), Buffer.BufferType.VERTEX);
+    const buffer = new Buffer(array.serialize(), PosArray.serialize(), Buffer.BufferType.VERTEX);
 
     const vao = new VertexArrayObject();
     vao.bind(gl, program, buffer);

--- a/js/render/draw_fill_extrusion.js
+++ b/js/render/draw_fill_extrusion.js
@@ -127,7 +127,7 @@ ExtrusionTexture.prototype.renderToMap = function() {
     array.emplaceBack(painter.width, 0);
     array.emplaceBack(0, painter.height);
     array.emplaceBack(painter.width, painter.height);
-    const buffer = new Buffer(array.serialize(), PosArray.serialize(), Buffer.BufferType.VERTEX);
+    const buffer = Buffer.fromStructArray(array, Buffer.BufferType.VERTEX);
 
     const vao = new VertexArrayObject();
     vao.bind(gl, program, buffer);

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const util = require('../util/util');
-const StructArrayType = require('../util/struct_array');
 
 module.exports = drawRaster;
 
@@ -27,13 +26,6 @@ function drawRaster(painter, sourceCache, layer, coords) {
 
     gl.depthFunc(gl.LEQUAL);
 }
-
-drawRaster.RasterBoundsArray = new StructArrayType({
-    members: [
-        { name: 'a_pos', type: 'Int16', components: 2 },
-        { name: 'a_texture_pos', type: 'Int16', components: 2 }
-    ]
-});
 
 function drawRasterTile(painter, sourceCache, layer, coord) {
 

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -7,10 +7,10 @@ const SourceCache = require('../source/source_cache');
 const EXTENT = require('../data/extent');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 const util = require('../util/util');
-const StructArrayType = require('../util/struct_array');
 const Buffer = require('../data/buffer');
 const VertexArrayObject = require('./vertex_array_object');
-const RasterBoundsArray = require('./draw_raster').RasterBoundsArray;
+const RasterBoundsArray = require('../data/raster_bounds_array');
+const PosArray = require('../data/pos_array');
 const ProgramConfiguration = require('../data/program_configuration');
 
 const draw = {
@@ -85,10 +85,6 @@ class Painter {
 
         this._depthMask = false;
         gl.depthMask(false);
-
-        const PosArray = this.PosArray = new StructArrayType({
-            members: [{ name: 'a_pos', type: 'Int16', components: 2 }]
-        });
 
         const tileExtentArray = new PosArray();
         tileExtentArray.emplaceBack(0, 0);

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -91,7 +91,7 @@ class Painter {
         tileExtentArray.emplaceBack(EXTENT, 0);
         tileExtentArray.emplaceBack(0, EXTENT);
         tileExtentArray.emplaceBack(EXTENT, EXTENT);
-        this.tileExtentBuffer = new Buffer(tileExtentArray.serialize(), PosArray.serialize(), Buffer.BufferType.VERTEX);
+        this.tileExtentBuffer = Buffer.fromStructArray(tileExtentArray, Buffer.BufferType.VERTEX);
         this.tileExtentVAO = new VertexArrayObject();
         this.tileExtentPatternVAO = new VertexArrayObject();
 
@@ -101,7 +101,7 @@ class Painter {
         debugArray.emplaceBack(EXTENT, EXTENT);
         debugArray.emplaceBack(0, EXTENT);
         debugArray.emplaceBack(0, 0);
-        this.debugBuffer = new Buffer(debugArray.serialize(), PosArray.serialize(), Buffer.BufferType.VERTEX);
+        this.debugBuffer = Buffer.fromStructArray(debugArray, Buffer.BufferType.VERTEX);
         this.debugVAO = new VertexArrayObject();
 
         const rasterBoundsArray = new RasterBoundsArray();
@@ -109,7 +109,7 @@ class Painter {
         rasterBoundsArray.emplaceBack(EXTENT, 0, 32767, 0);
         rasterBoundsArray.emplaceBack(0, EXTENT, 0, 32767);
         rasterBoundsArray.emplaceBack(EXTENT, EXTENT, 32767, 32767);
-        this.rasterBoundsBuffer = new Buffer(rasterBoundsArray.serialize(), RasterBoundsArray.serialize(), Buffer.BufferType.VERTEX);
+        this.rasterBoundsBuffer = Buffer.fromStructArray(rasterBoundsArray, Buffer.BufferType.VERTEX);
         this.rasterBoundsVAO = new VertexArrayObject();
     }
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -7,7 +7,7 @@ const Point = require('point-geometry');
 const Evented = require('../util/evented');
 const ajax = require('../util/ajax');
 const EXTENT = require('../data/extent');
-const RasterBoundsArray = require('../render/draw_raster').RasterBoundsArray;
+const RasterBoundsArray = require('../data/raster_bounds_array');
 const Buffer = require('../data/buffer');
 const VertexArrayObject = require('../render/vertex_array_object');
 

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -138,7 +138,7 @@ class ImageSource extends Evented {
 
         this.tile.buckets = {};
 
-        this.tile.boundsBuffer = new Buffer(array.serialize(), RasterBoundsArray.serialize(), Buffer.BufferType.VERTEX);
+        this.tile.boundsBuffer = Buffer.fromStructArray(array, Buffer.BufferType.VERTEX);
         this.tile.boundsVAO = new VertexArrayObject();
         this.tile.state = 'loaded';
     }

--- a/js/symbol/collision_box.js
+++ b/js/symbol/collision_box.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const StructArrayType = require('../util/struct_array');
+const createStructArrayType = require('../util/struct_array');
 const Point = require('point-geometry');
 
 /**
@@ -39,7 +39,7 @@ const Point = require('point-geometry');
  * @private
  */
 
-const CollisionBoxArray = module.exports = new StructArrayType({
+const CollisionBoxArray = createStructArrayType({
     members: [
         // the box is centered around the anchor point
         { type: 'Int16', name: 'anchorPointX' },
@@ -69,8 +69,11 @@ const CollisionBoxArray = module.exports = new StructArrayType({
         { type: 'Int16', name: 'bbox3' },
 
         { type: 'Float32', name: 'placementScale' }
-    ]});
+    ]
+});
 
 Object.defineProperty(CollisionBoxArray.prototype.StructType.prototype, 'anchorPoint', {
     get() { return new Point(this.anchorPointX, this.anchorPointY); }
 });
+
+module.exports = CollisionBoxArray;

--- a/js/symbol/symbol_instances.js
+++ b/js/symbol/symbol_instances.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const StructArrayType = require('../util/struct_array');
+const createStructArrayType = require('../util/struct_array');
 const Point = require('point-geometry');
 
 /*
@@ -12,7 +12,7 @@ const Point = require('point-geometry');
  * @private
  */
 
-const SymbolInstancesArray = module.exports = new StructArrayType({
+const SymbolInstancesArray = createStructArrayType({
     members: [
 
         { type: 'Uint16', name: 'textBoxStartIndex' },
@@ -37,4 +37,4 @@ Object.defineProperty(SymbolInstancesArray.prototype.StructType.prototype, 'anch
     get() { return new Point(this.anchorPointX, this.anchorPointY); }
 });
 
-
+module.exports = SymbolInstancesArray;

--- a/js/symbol/symbol_quads.js
+++ b/js/symbol/symbol_quads.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const StructArrayType = require('../util/struct_array');
+const createStructArrayType = require('../util/struct_array');
 const Point = require('point-geometry');
 const SymbolQuad = require('./quads').SymbolQuad;
 
@@ -17,7 +17,7 @@ const SymbolQuad = require('./quads').SymbolQuad;
  * @private
  */
 
-const SymbolQuadsArray = module.exports = new StructArrayType({
+const SymbolQuadsArray = createStructArrayType({
     members: [
         // the quad is centered around the anchor point
         { type: 'Int16', name: 'anchorPointX' },
@@ -69,3 +69,5 @@ Object.defineProperty(SymbolQuadsArray.prototype.StructType.prototype, 'SymbolQu
             this.maxScale);
     }
 });
+
+module.exports = SymbolQuadsArray;

--- a/js/util/struct_array.js
+++ b/js/util/struct_array.js
@@ -4,7 +4,7 @@
 
 const assert = require('assert');
 
-module.exports = StructArrayType;
+module.exports = createStructArrayType;
 
 const viewTypes = {
     'Int8': Int8Array,
@@ -49,7 +49,7 @@ const RESIZE_MULTIPLIER = 5;
 
 /**
  * The StructArray class is inherited by the custom StructArrayType classes created with
- * `new StructArrayType(members, options)`.
+ * `createStructArrayType(members, options)`.
  * @private
  */
 class StructArray {
@@ -159,7 +159,7 @@ class StructArray {
 const structArrayTypeCache = {};
 
 /**
- * `StructArrayType` is used to create new `StructArray` types.
+ * `createStructArrayType` is used to create new `StructArray` types.
  *
  * `StructArray` provides an abstraction over `ArrayBuffer` and `TypedArray` making it behave like
  * an array of typed structs. A StructArray is comprised of elements. Each element has a set of
@@ -177,7 +177,7 @@ const structArrayTypeCache = {};
  * @param {Array<StructMember>} options.members
  * @example
  *
- * var PointArrayType = new StructArrayType({
+ * var PointArrayType = createStructArrayType({
  *  members: [
  *      { type: 'Int16', name: 'x' },
  *      { type: 'Int16', name: 'y' }
@@ -193,7 +193,7 @@ const structArrayTypeCache = {};
  *
  * @private
  */
-function StructArrayType(options) {
+function createStructArrayType(options) {
 
     const key = JSON.stringify(options);
 

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -2,8 +2,8 @@
 
 const test = require('mapbox-gl-js-test').test;
 const Bucket = require('../../../js/data/bucket');
-const VertexArrayType = require('../../../js/data/vertex_array_type');
-const ElementArrayType = require('../../../js/data/element_array_type');
+const createVertexArrayType = require('../../../js/data/vertex_array_type');
+const createElementArrayType = require('../../../js/data/element_array_type');
 const FeatureIndex = require('../../../js/data/feature_index');
 const StyleLayer = require('../../../js/style/style_layer');
 const featureFilter = require('feature-filter');
@@ -34,13 +34,13 @@ test('Bucket', (t) => {
         options = options || {};
 
         const programInterface = {
-            layoutVertexArrayType: new VertexArrayType(options.layoutAttributes || [{
+            layoutVertexArrayType: createVertexArrayType(options.layoutAttributes || [{
                 name: 'a_box',
                 components: 2,
                 type: 'Int16'
             }]),
-            elementArrayType: new ElementArrayType(),
-            elementArrayType2: new ElementArrayType(2),
+            elementArrayType: createElementArrayType(),
+            elementArrayType2: createElementArrayType(2),
 
             paintAttributes: options.paintAttributes || [{
                 name: 'a_map',

--- a/test/js/data/buffer.test.js
+++ b/test/js/data/buffer.test.js
@@ -21,7 +21,7 @@ test('Buffer', (t) => {
         array.emplaceBack(1, 1, 1);
         array.emplaceBack(1, 1, 1);
 
-        const buffer = new Buffer(array.serialize(), TestArray.serialize(), Buffer.BufferType.VERTEX);
+        const buffer = Buffer.fromStructArray(array, Buffer.BufferType.VERTEX);
 
         t.deepEqual(buffer.attributes, [
             {

--- a/test/js/util/struct_array.test.js
+++ b/test/js/util/struct_array.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const test = require('mapbox-gl-js-test').test;
-const StructArrayType = require('../../../js/util/struct_array');
+const createStructArrayType = require('../../../js/util/struct_array');
 
 test('StructArray', (t) => {
 
-    const TestArray = new StructArrayType({
+    const TestArray = createStructArrayType({
         members: [
             { type: 'Int16', name: 'map' },
             { type: 'Int16', name: 'box', components: 2 }


### PR DESCRIPTION
Fixing a few minor points of confusion in struct array types usage. 👀 @lucaswoj @ansis 

- Extracted a few common StructArray types (`PosArray` and `RasterBoundsArray`) into separate files.
- Added `Buffer.fromStructArray` shortcut to make buffer creation less intimidating.
- Converted all `new StructArrayType(...)` and similar calls to `createStructArrayType(...)`, because they are all really factories, not classes (`new` doesn't do anything), and we would probably have to do this anyway when flowifying code.

benchmark | master 6fd85d0 | simplify-struct-arrays 3eb42be
--- | --- | ---
**buffer** | 983 ms  | 983 ms 
