### PR TITLE
Clean up url normalization

### DIFF
--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -5,9 +5,12 @@ const browser = require('./browser');
 
 const help = 'See https://www.mapbox.com/developers/api/#access-tokens';
 
-function makeAPIURL(path, accessToken) {
-    const url = config.API_URL + path;
-    if (!config.REQUIRE_ACCESS_TOKEN) return url;
+function makeAPIURL(urlObject, accessToken) {
+    const apiUrlObject = parseUrl(config.API_URL);
+    urlObject.protocol = apiUrlObject.protocol;
+    urlObject.authority = apiUrlObject.authority;
+
+    if (!config.REQUIRE_ACCESS_TOKEN) return formatUrl(urlObject);
 
     accessToken = accessToken || config.ACCESS_TOKEN;
     if (!accessToken)
@@ -15,11 +18,8 @@ function makeAPIURL(path, accessToken) {
     if (accessToken[0] === 's')
         throw new Error(`Use a public access token (pk.*) with Mapbox GL, not a secret access token (sk.*). ${help}`);
 
-    return addParam(url, `access_token=${accessToken}`);
-}
-
-function addParam(url, param) {
-    return url + (url.indexOf('?') >= 0 ? '&' : '?') + param;
+    urlObject.params.push(`access_token=${accessToken}`);
+    return formatUrl(urlObject);
 }
 
 function isMapboxURL(url) {
@@ -30,48 +30,77 @@ exports.isMapboxURL = isMapboxURL;
 
 exports.normalizeStyleURL = function(url, accessToken) {
     if (!isMapboxURL(url)) return url;
-    return makeAPIURL(url.replace('mapbox://styles', '/styles/v1'), accessToken);
+    const urlObject = parseUrl(url);
+    urlObject.path = `/styles/v1${urlObject.path}`;
+    return makeAPIURL(urlObject, accessToken);
 };
 
 exports.normalizeGlyphsURL = function(url, accessToken) {
     if (!isMapboxURL(url)) return url;
-    return makeAPIURL(url.replace('mapbox://fonts', '/fonts/v1'), accessToken);
+    const urlObject = parseUrl(url);
+    urlObject.path = `/fonts/v1${urlObject.path}`;
+    return makeAPIURL(urlObject, accessToken);
 };
-
-const mapboxSourceRe = /mapbox:\/\/([^?]+)/;
 
 exports.normalizeSourceURL = function(url, accessToken) {
     if (!isMapboxURL(url)) return url;
-
-    url = makeAPIURL(url.replace(mapboxSourceRe, '/v4/$1.json'), accessToken);
+    const urlObject = parseUrl(url);
+    urlObject.path = `/v4/${urlObject.authority}.json`;
     // TileJSON requests need a secure flag appended to their URLs so
     // that the server knows to send SSL-ified resource references.
-    return addParam(url, 'secure');
+    urlObject.params.push('secure');
+    return makeAPIURL(urlObject, accessToken);
 };
-
-const beforeParamsRe = /([^?]+)/;
-const mapboxSpritesRe = /mapbox:\/\/sprites\/([^?]+)/;
 
 exports.normalizeSpriteURL = function(url, format, extension, accessToken) {
-    if (!isMapboxURL(url))
-        return url.replace(beforeParamsRe, `$1${format}${extension}`);
-
-    const path = url.replace(mapboxSpritesRe, `/styles/v1/$1/sprite${format}${extension}`);
-    return makeAPIURL(path, accessToken);
+    const urlObject = parseUrl(url);
+    if (!isMapboxURL(url)) {
+        urlObject.path += `${format}${extension}`;
+        return formatUrl(urlObject);
+    }
+    urlObject.path = `/styles/v1${urlObject.path}/sprite${format}${extension}`;
+    return makeAPIURL(urlObject, accessToken);
 };
 
-const imageExtensionRe = /(\.(png|jpg)\d*)(?=$|\?)/;
-const tempAccessTokenRe = /([?&]access_token=)tk\.[^&]+/;
+const imageExtensionRe = /(\.(png|jpg)\d*)(?=$)/;
 
 exports.normalizeTileURL = function(tileURL, sourceURL, tileSize) {
     if (!sourceURL || !isMapboxURL(sourceURL)) return tileURL;
+
+    const urlObject = parseUrl(tileURL);
 
     // The v4 mapbox tile API supports 512x512 image tiles only when @2x
     // is appended to the tile URL. If `tileSize: 512` is specified for
     // a Mapbox raster source force the @2x suffix even if a non hidpi device.
     const suffix = browser.devicePixelRatio >= 2 || tileSize === 512 ? '@2x' : '';
     const extension = browser.supportsWebp ? '.webp' : '$1';
-    return tileURL
-        .replace(imageExtensionRe, `${suffix}${extension}`)
-        .replace(tempAccessTokenRe, `$1${config.ACCESS_TOKEN}`);
+    urlObject.path = urlObject.path.replace(imageExtensionRe, `${suffix}${extension}`);
+
+    replaceTempAccessToken(urlObject.params);
+    return formatUrl(urlObject);
 };
+
+function replaceTempAccessToken(params) {
+    for (let i = 0; i < params.length; i++) {
+        if (params[i].indexOf('access_token=tk.') === 0) {
+            params[i] = `access_token=${config.ACCESS_TOKEN}`;
+        }
+    }
+}
+
+const urlRe = /^(\w+):\/\/([^/?]+)(\/[^?]+)?\??(.+)?/;
+
+function parseUrl(url) {
+    const parts = url.match(urlRe);
+    return {
+        protocol: parts[1],
+        authority: parts[2],
+        path: parts[3] || '/',
+        params: parts[4] ? parts[4].split('&') : []
+    };
+}
+
+function formatUrl(obj) {
+    const params = obj.params.length ? `?${obj.params.join('&')}` : '';
+    return `${obj.protocol}://${obj.authority}${obj.path}${params}`;
+}

--- a/js/util/mapbox.js
+++ b/js/util/mapbox.js
@@ -2,128 +2,76 @@
 
 const config = require('./config');
 const browser = require('./browser');
-const URL = require('url');
-const util = require('./util');
 
-function makeAPIURL(path, query, accessToken) {
+const help = 'See https://www.mapbox.com/developers/api/#access-tokens';
+
+function makeAPIURL(path, accessToken) {
+    const url = config.API_URL + path;
+    if (!config.REQUIRE_ACCESS_TOKEN) return url;
+
     accessToken = accessToken || config.ACCESS_TOKEN;
+    if (!accessToken)
+        throw new Error(`An API access token is required to use Mapbox GL. ${help}`);
+    if (accessToken[0] === 's')
+        throw new Error(`Use a public access token (pk.*) with Mapbox GL, not a secret access token (sk.*). ${help}`);
 
-    if (!accessToken && config.REQUIRE_ACCESS_TOKEN) {
-        throw new Error('An API access token is required to use Mapbox GL. ' +
-            'See https://www.mapbox.com/developers/api/#access-tokens');
-    }
-
-    let url = config.API_URL + path + (query ? `?${query}` : '');
-
-    if (config.REQUIRE_ACCESS_TOKEN) {
-        if (accessToken[0] === 's') {
-            throw new Error('Use a public access token (pk.*) with Mapbox GL JS, not a secret access token (sk.*). ' +
-                'See https://www.mapbox.com/developers/api/#access-tokens');
-        }
-
-        url += `${query ? '&' : '?'}access_token=${accessToken}`;
-    }
-
-    return url;
+    return addParam(url, `access_token=${accessToken}`);
 }
 
-module.exports.isMapboxURL = function(url) {
-    return URL.parse(url).protocol === 'mapbox:';
+function addParam(url, param) {
+    return url + (url.indexOf('?') >= 0 ? '&' : '?') + param;
+}
+
+function isMapboxURL(url) {
+    return url.indexOf('mapbox:') === 0;
+}
+
+exports.isMapboxURL = isMapboxURL;
+
+exports.normalizeStyleURL = function(url, accessToken) {
+    if (!isMapboxURL(url)) return url;
+    return makeAPIURL(url.replace('mapbox://styles', '/styles/v1'), accessToken);
 };
 
-module.exports.normalizeStyleURL = function(url, accessToken) {
-    const urlObject = URL.parse(url);
-
-    if (urlObject.protocol !== 'mapbox:') {
-        return url;
-    } else {
-        return makeAPIURL(
-            `/styles/v1${urlObject.pathname}`,
-            urlObject.query,
-            accessToken
-        );
-    }
+exports.normalizeGlyphsURL = function(url, accessToken) {
+    if (!isMapboxURL(url)) return url;
+    return makeAPIURL(url.replace('mapbox://fonts', '/fonts/v1'), accessToken);
 };
 
-module.exports.normalizeSourceURL = function(url, accessToken) {
-    const urlObject = URL.parse(url);
+const mapboxSourceRe = /mapbox:\/\/([^?]+)/;
 
-    if (urlObject.protocol !== 'mapbox:') {
-        return url;
-    } else {
-        // We parse the URL with a regex because the URL module does not handle
-        // URLs with commas in the hostname
-        const sources = url.match(/mapbox:\/\/([^?]+)/)[1];
+exports.normalizeSourceURL = function(url, accessToken) {
+    if (!isMapboxURL(url)) return url;
 
-        // TileJSON requests need a secure flag appended to their URLs so
-        // that the server knows to send SSL-ified resource references.
-        return `${makeAPIURL(
-            `/v4/${sources}.json`,
-            urlObject.query,
-            accessToken
-        )}&secure`;
-    }
-
+    url = makeAPIURL(url.replace(mapboxSourceRe, '/v4/$1.json'), accessToken);
+    // TileJSON requests need a secure flag appended to their URLs so
+    // that the server knows to send SSL-ified resource references.
+    return addParam(url, 'secure');
 };
 
-module.exports.normalizeGlyphsURL = function(url, accessToken) {
-    const urlObject = URL.parse(url);
+const beforeParamsRe = /([^?]+)/;
+const mapboxSpritesRe = /mapbox:\/\/sprites\/([^?]+)/;
 
-    if (urlObject.protocol !== 'mapbox:') {
-        return url;
-    } else {
-        const user = urlObject.pathname.split('/')[1];
-        return makeAPIURL(
-            `/fonts/v1/${user}/{fontstack}/{range}.pbf`,
-            urlObject.query,
-            accessToken
-        );
-    }
+exports.normalizeSpriteURL = function(url, format, extension, accessToken) {
+    if (!isMapboxURL(url))
+        return url.replace(beforeParamsRe, `$1${format}${extension}`);
+
+    const path = url.replace(mapboxSpritesRe, `/styles/v1/$1/sprite${format}${extension}`);
+    return makeAPIURL(path, accessToken);
 };
 
-module.exports.normalizeSpriteURL = function(url, format, extension, accessToken) {
-    const urlObject = URL.parse(url);
+const imageExtensionRe = /(\.(png|jpg)\d*)(?=$|\?)/;
+const tempAccessTokenRe = /([?&]access_token=)tk\.[^&]+/;
 
-    if (urlObject.protocol !== 'mapbox:') {
-        urlObject.pathname += format + extension;
-        return URL.format(urlObject);
-    } else {
-        return makeAPIURL(
-            `/styles/v1${urlObject.pathname}/sprite${format}${extension}`,
-            urlObject.query,
-            accessToken
-        );
-    }
-};
-
-module.exports.normalizeTileURL = function(tileURL, sourceURL, tileSize) {
-    const tileURLObject = URL.parse(tileURL, true);
-    if (!sourceURL) return tileURL;
-    const sourceURLObject = URL.parse(sourceURL);
-    if (sourceURLObject.protocol !== 'mapbox:') return tileURL;
+exports.normalizeTileURL = function(tileURL, sourceURL, tileSize) {
+    if (!sourceURL || !isMapboxURL(sourceURL)) return tileURL;
 
     // The v4 mapbox tile API supports 512x512 image tiles only when @2x
     // is appended to the tile URL. If `tileSize: 512` is specified for
-    // a Mapbox raster source force the @2x suffix even if a non hidpi
-    // device.
-
+    // a Mapbox raster source force the @2x suffix even if a non hidpi device.
+    const suffix = browser.devicePixelRatio >= 2 || tileSize === 512 ? '@2x' : '';
     const extension = browser.supportsWebp ? '.webp' : '$1';
-    const resolution = (browser.devicePixelRatio >= 2 || tileSize === 512) ? '@2x' : '';
-
-    return URL.format({
-        protocol: tileURLObject.protocol,
-        hostname: tileURLObject.hostname,
-        pathname: tileURLObject.pathname.replace(/(\.(?:png|jpg)\d*)/, resolution + extension),
-        query: replaceTempAccessToken(tileURLObject.query)
-    });
+    return tileURL
+        .replace(imageExtensionRe, `${suffix}${extension}`)
+        .replace(tempAccessTokenRe, `$1${config.ACCESS_TOKEN}`);
 };
-
-function replaceTempAccessToken(query) {
-    if (query.access_token && query.access_token.slice(0, 3) === 'tk.') {
-        return util.extend({}, query, {
-            'access_token': config.ACCESS_TOKEN
-        });
-    } else {
-        return query;
-    }
-}

--- a/test/js/util/mapbox.test.js
+++ b/test/js/util/mapbox.test.js
@@ -35,22 +35,22 @@ test("mapbox", (t) => {
 
     t.test('.normalizeSourceURL', (t) => {
         t.test('returns a v4 URL with access_token parameter', (t) => {
-            t.equal(mapbox.normalizeSourceURL(mapboxSource), 'https://api.mapbox.com/v4/user.map.json?access_token=key&secure');
+            t.equal(mapbox.normalizeSourceURL(mapboxSource), 'https://api.mapbox.com/v4/user.map.json?secure&access_token=key');
             t.end();
         });
 
         t.test('uses provided access token', (t) => {
-            t.equal(mapbox.normalizeSourceURL(mapboxSource, 'token'), 'https://api.mapbox.com/v4/user.map.json?access_token=token&secure');
+            t.equal(mapbox.normalizeSourceURL(mapboxSource, 'token'), 'https://api.mapbox.com/v4/user.map.json?secure&access_token=token');
             t.end();
         });
 
         t.test('uses provided query parameters', (t) => {
-            t.equal(mapbox.normalizeSourceURL(`${mapboxSource}?foo=bar`, 'token'), 'https://api.mapbox.com/v4/user.map.json?foo=bar&access_token=token&secure');
+            t.equal(mapbox.normalizeSourceURL(`${mapboxSource}?foo=bar`, 'token'), 'https://api.mapbox.com/v4/user.map.json?foo=bar&secure&access_token=token');
             t.end();
         });
 
         t.test('works with composite sources', (t) => {
-            t.equal(mapbox.normalizeSourceURL('mapbox://one.a,two.b,three.c'), 'https://api.mapbox.com/v4/one.a,two.b,three.c.json?access_token=key&secure');
+            t.equal(mapbox.normalizeSourceURL('mapbox://one.a,two.b,three.c'), 'https://api.mapbox.com/v4/one.a,two.b,three.c.json?secure&access_token=key');
             t.end();
         });
 


### PR DESCRIPTION
Partially reverts #2702 while retaining the fix, getting rid of Node `URL.parse` and getting back to regexps and string manipulation. Reasons:

- 40% less code
- the build is 3.6% lighter (gzipped) without `url` module
- it's 20x faster (`normalizeTileURL` on a typical `satellite` style profiling session would take ~60ms, now 2.5ms)
- consistency and readability (previously we mixed both regexps and URL parsing together)
- it feels hacky to use URL parsing on strings that are not really true urls

@lucaswoj @xrwang 