### PR TITLE
Calculate matrices after constraining

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -112,8 +112,8 @@ class Transform {
         this.scale = this.zoomScale(z);
         this.tileZoom = Math.floor(z);
         this.zoomFraction = z - this.tileZoom;
-        this._calcMatrices();
         this._constrain();
+        this._calcMatrices();
     }
 
     get center() { return this._center; }
@@ -121,8 +121,8 @@ class Transform {
         if (center.lat === this._center.lat && center.lng === this._center.lng) return;
         this._unmodified = false;
         this._center = center;
-        this._calcMatrices();
         this._constrain();
+        this._calcMatrices();
     }
 
     /**
@@ -177,8 +177,8 @@ class Transform {
         this.height = height;
 
         this.pixelsToGLUnits = [2 / width, -2 / height];
-        this._calcMatrices();
         this._constrain();
+        this._calcMatrices();
     }
 
     get unmodified() { return this._unmodified; }

--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -45,6 +45,13 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test('does not throw on bad center', (t) => {
+        const transform = new Transform();
+        transform.resize(500, 500);
+        transform.center = {lng: 50, lat: -90};
+        t.end();
+    });
+
     t.test('panBy', (t) => {
         const transform = new Transform();
         transform.resize(500, 500);


### PR DESCRIPTION
Fixes #3474 by putting of calculating matrices until the view has been constrained to valid bounds. cc @nrako