### PR TITLE
Fix flicker when rendering image source

### DIFF
--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -36,8 +36,6 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     const tile = sourceCache.getTile(coord);
     const posMatrix = painter.transform.calculatePosMatrix(coord, sourceCache.getSource().maxzoom);
 
-    if (!tile.texture) return;
-
     const program = painter.useProgram('raster');
     gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
 
@@ -58,7 +56,7 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
 
     gl.activeTexture(gl.TEXTURE1);
 
-    if (parentTile && parentTile.texture) {
+    if (parentTile) {
         gl.bindTexture(gl.TEXTURE_2D, parentTile.texture);
         parentScaleBy = Math.pow(2, parentTile.coord.z - tile.coord.z);
         parentTL = [tile.coord.x * parentScaleBy % 1, tile.coord.y * parentScaleBy % 1];

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -36,6 +36,8 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     const tile = sourceCache.getTile(coord);
     const posMatrix = painter.transform.calculatePosMatrix(coord, sourceCache.getSource().maxzoom);
 
+    if (!tile.texture) return;
+
     const program = painter.useProgram('raster');
     gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
 
@@ -56,7 +58,7 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
 
     gl.activeTexture(gl.TEXTURE1);
 
-    if (parentTile) {
+    if (parentTile && parentTile.texture) {
         gl.bindTexture(gl.TEXTURE_2D, parentTile.texture);
         parentScaleBy = Math.pow(2, parentTile.coord.z - tile.coord.z);
         parentTL = [tile.coord.x * parentScaleBy % 1, tile.coord.y * parentScaleBy % 1];

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -224,12 +224,12 @@ class Painter {
             let j;
             let coords = [];
             if (sourceCache) {
+                if (sourceCache.prepare) sourceCache.prepare();
                 coords = sourceCache.getVisibleCoordinates();
                 for (j = 0; j < coords.length; j++) {
                     coords[j].posMatrix = this.transform.calculatePosMatrix(coords[j], sourceCache.getSource().maxzoom);
                 }
                 this.clearStencil();
-                if (sourceCache.prepare) sourceCache.prepare();
                 if (sourceCache.getSource().isTileClipped) {
                     this._renderTileClippingMasks(coords);
                 }

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('../util/util');
+const window = require('../util/window');
 const TileCoord = require('./tile_coord');
 const LngLat = require('../geo/lng_lat');
 const Point = require('point-geometry');
@@ -158,7 +159,7 @@ class ImageSource extends Evented {
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-        } else {
+        } else if (image instanceof window.HTMLVideoElement) {
             gl.bindTexture(gl.TEXTURE_2D, this.tile.texture);
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, image);
         }

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -67,7 +67,6 @@ class ImageSource extends Evented {
             if (err) return this.fire('error', {error: err});
 
             this.image = image;
-            this._loaded = true;
 
             this._finishLoading();
         });
@@ -128,7 +127,6 @@ class ImageSource extends Evented {
     }
 
     _setTile(tile) {
-        this._prepared = false;
         this.tile = tile;
         const maxInt16 = 32767;
         const array = new RasterBoundsArray();
@@ -141,17 +139,16 @@ class ImageSource extends Evented {
 
         this.tile.boundsBuffer = Buffer.fromStructArray(array, Buffer.BufferType.VERTEX);
         this.tile.boundsVAO = new VertexArrayObject();
-        this.tile.state = 'loaded';
     }
 
     prepare() {
-        if (!this.tile || !this._loaded || !this.image || !this.image.complete) return;
+        if (!this.tile || !this.image || !this.image.complete) return;
         this._prepareImage(this.map.painter.gl, this.image);
     }
 
     _prepareImage(gl, image) {
-        if (!this._prepared) {
-            this._prepared = true;
+        if (this.tile.state !== 'loaded') {
+            this.tile.state = 'loaded';
             this.tile.texture = gl.createTexture();
             gl.bindTexture(gl.TEXTURE_2D, this.tile.texture);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);


### PR DESCRIPTION
This PR fixes a flicker that occurs intermittently when rendering an image source. See https://github.com/mapbox/mapbox-gl-js/issues/3519 for more info about the bug. 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality (`image/default` has been failing on my machine since #3353, this PR fixes it)
 - [x] post benchmark scores
 - [x] manually test the debug page
