### PR TITLE
Simplify data-driven paint attributes implementation

### DIFF
--- a/js/data/array_group.js
+++ b/js/data/array_group.js
@@ -48,11 +48,10 @@ class ArrayGroup {
         for (const layer of layers) {
             const programConfiguration = ProgramConfiguration.createDynamic(
                 programInterface.paintAttributes || [], layer, zoom);
-            const PaintVertexArrayType = programConfiguration.paintVertexArrayType();
             this.layerData[layer.id] = {
                 layer: layer,
                 programConfiguration: programConfiguration,
-                paintVertexArray: new PaintVertexArrayType()
+                paintVertexArray: new programConfiguration.PaintVertexArray()
             };
         }
 

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -7,33 +7,17 @@ const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
 
 const circleInterface = {
-    layoutVertexArrayType: createVertexArrayType([{
-        name: 'a_pos',
-        components: 2,
-        type: 'Int16'
-    }]),
+    layoutVertexArrayType: createVertexArrayType([
+        {name: 'a_pos', components: 2, type: 'Int16'}
+    ]),
     elementArrayType: createElementArrayType(),
 
-    paintAttributes: [{
-        name: 'a_color',
-        type: 'Uint8',
-        paintProperty: 'circle-color'
-    }, {
-        name: 'a_radius',
-        type: 'Uint16',
-        multiplier: 10,
-        paintProperty: 'circle-radius'
-    }, {
-        name: 'a_blur',
-        type: 'Uint16',
-        multiplier: 10,
-        paintProperty: 'circle-blur'
-    }, {
-        name: 'a_opacity',
-        type: 'Uint16',
-        multiplier: 255,
-        paintProperty: 'circle-opacity'
-    }]
+    paintAttributes: [
+        {name: 'a_color',   paintProperty: 'circle-color',   type: 'Uint8'},
+        {name: 'a_radius',  paintProperty: 'circle-radius',  type: 'Uint16', multiplier: 10},
+        {name: 'a_blur',    paintProperty: 'circle-blur',    type: 'Uint16', multiplier: 10},
+        {name: 'a_opacity', paintProperty: 'circle-opacity', type: 'Uint16', multiplier: 255}
+    ]
 };
 
 function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -13,10 +13,10 @@ const circleInterface = {
     elementArrayType: createElementArrayType(),
 
     paintAttributes: [
-        {name: 'a_color',   paintProperty: 'circle-color',   type: 'Uint8'},
-        {name: 'a_radius',  paintProperty: 'circle-radius',  type: 'Uint16', multiplier: 10},
-        {name: 'a_blur',    paintProperty: 'circle-blur',    type: 'Uint16', multiplier: 10},
-        {name: 'a_opacity', paintProperty: 'circle-opacity', type: 'Uint8',  multiplier: 255}
+        {property: 'circle-color',   type: 'Uint8'},
+        {property: 'circle-radius',  type: 'Uint16', multiplier: 10},
+        {property: 'circle-blur',    type: 'Uint16', multiplier: 10},
+        {property: 'circle-opacity', type: 'Uint8',  multiplier: 255}
     ]
 };
 

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -16,7 +16,6 @@ const circleInterface = {
 
     paintAttributes: [{
         name: 'a_color',
-        components: 4,
         type: 'Uint8',
         getValue: (layer, globalProperties, featureProperties) => {
             return layer.getPaintValue("circle-color", globalProperties, featureProperties);
@@ -25,9 +24,7 @@ const circleInterface = {
         paintProperty: 'circle-color'
     }, {
         name: 'a_radius',
-        components: 1,
         type: 'Uint16',
-        isLayerConstant: false,
         getValue: (layer, globalProperties, featureProperties) => {
             return [layer.getPaintValue("circle-radius", globalProperties, featureProperties)];
         },
@@ -35,9 +32,7 @@ const circleInterface = {
         paintProperty: 'circle-radius'
     }, {
         name: 'a_blur',
-        components: 1,
         type: 'Uint16',
-        isLayerConstant: false,
         getValue: (layer, globalProperties, featureProperties) => {
             return [layer.getPaintValue("circle-blur", globalProperties, featureProperties)];
         },
@@ -45,9 +40,7 @@ const circleInterface = {
         paintProperty: 'circle-blur'
     }, {
         name: 'a_opacity',
-        components: 1,
         type: 'Uint16',
-        isLayerConstant: false,
         getValue: (layer, globalProperties, featureProperties) => {
             return [layer.getPaintValue("circle-opacity", globalProperties, featureProperties)];
         },

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -16,7 +16,7 @@ const circleInterface = {
         {name: 'a_color',   paintProperty: 'circle-color',   type: 'Uint8'},
         {name: 'a_radius',  paintProperty: 'circle-radius',  type: 'Uint16', multiplier: 10},
         {name: 'a_blur',    paintProperty: 'circle-blur',    type: 'Uint16', multiplier: 10},
-        {name: 'a_opacity', paintProperty: 'circle-opacity', type: 'Uint16', multiplier: 255}
+        {name: 'a_opacity', paintProperty: 'circle-opacity', type: 'Uint8',  multiplier: 255}
     ]
 };
 

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -17,7 +17,6 @@ const circleInterface = {
     paintAttributes: [{
         name: 'a_color',
         type: 'Uint8',
-        multiplier: 255,
         paintProperty: 'circle-color'
     }, {
         name: 'a_radius',

--- a/js/data/bucket/circle_bucket.js
+++ b/js/data/bucket/circle_bucket.js
@@ -17,33 +17,21 @@ const circleInterface = {
     paintAttributes: [{
         name: 'a_color',
         type: 'Uint8',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return layer.getPaintValue("circle-color", globalProperties, featureProperties);
-        },
         multiplier: 255,
         paintProperty: 'circle-color'
     }, {
         name: 'a_radius',
         type: 'Uint16',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return [layer.getPaintValue("circle-radius", globalProperties, featureProperties)];
-        },
         multiplier: 10,
         paintProperty: 'circle-radius'
     }, {
         name: 'a_blur',
         type: 'Uint16',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return [layer.getPaintValue("circle-blur", globalProperties, featureProperties)];
-        },
         multiplier: 10,
         paintProperty: 'circle-blur'
     }, {
         name: 'a_opacity',
         type: 'Uint16',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return [layer.getPaintValue("circle-opacity", globalProperties, featureProperties)];
-        },
         multiplier: 255,
         paintProperty: 'circle-opacity'
     }]

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -17,9 +17,9 @@ const fillInterface = {
     elementArrayType2: createElementArrayType(2),
 
     paintAttributes: [
-        {name: 'a_color',         paintProperty: 'fill-color',         type: 'Uint8'},
-        {name: 'a_outline_color', paintProperty: 'fill-outline-color', type: 'Uint8'},
-        {name: 'a_opacity',       paintProperty: 'fill-opacity',       type: 'Uint8', multiplier: 255}
+        {property: 'fill-color',         type: 'Uint8'},
+        {property: 'fill-outline-color', type: 'Uint8'},
+        {property: 'fill-opacity',       type: 'Uint8', multiplier: 255}
     ]
 };
 

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -21,12 +21,10 @@ const fillInterface = {
     paintAttributes: [{
         name: 'a_color',
         type: 'Uint8',
-        multiplier: 255,
         paintProperty: 'fill-color'
     }, {
         name: 'a_outline_color',
         type: 'Uint8',
-        multiplier: 255,
         paintProperty: 'fill-outline-color'
     }, {
         name: 'a_opacity',

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -20,7 +20,6 @@ const fillInterface = {
 
     paintAttributes: [{
         name: 'a_color',
-        components: 4,
         type: 'Uint8',
         getValue: (layer, globalProperties, featureProperties) => {
             return layer.getPaintValue("fill-color", globalProperties, featureProperties);
@@ -29,7 +28,6 @@ const fillInterface = {
         paintProperty: 'fill-color'
     }, {
         name: 'a_outline_color',
-        components: 4,
         type: 'Uint8',
         getValue: (layer, globalProperties, featureProperties) => {
             return layer.getPaintValue("fill-outline-color", globalProperties, featureProperties);
@@ -38,7 +36,6 @@ const fillInterface = {
         paintProperty: 'fill-outline-color'
     }, {
         name: 'a_opacity',
-        components: 1,
         type: 'Uint8',
         getValue: (layer, globalProperties, featureProperties) => {
             return [layer.getPaintValue("fill-opacity", globalProperties, featureProperties)];

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -21,25 +21,16 @@ const fillInterface = {
     paintAttributes: [{
         name: 'a_color',
         type: 'Uint8',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return layer.getPaintValue("fill-color", globalProperties, featureProperties);
-        },
         multiplier: 255,
         paintProperty: 'fill-color'
     }, {
         name: 'a_outline_color',
         type: 'Uint8',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return layer.getPaintValue("fill-outline-color", globalProperties, featureProperties);
-        },
         multiplier: 255,
         paintProperty: 'fill-outline-color'
     }, {
         name: 'a_opacity',
         type: 'Uint8',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return [layer.getPaintValue("fill-opacity", globalProperties, featureProperties)];
-        },
         multiplier: 255,
         paintProperty: 'fill-opacity'
     }]

--- a/js/data/bucket/fill_bucket.js
+++ b/js/data/bucket/fill_bucket.js
@@ -10,28 +10,17 @@ const assert = require('assert');
 const EARCUT_MAX_RINGS = 500;
 
 const fillInterface = {
-    layoutVertexArrayType: createVertexArrayType([{
-        name: 'a_pos',
-        components: 2,
-        type: 'Int16'
-    }]),
+    layoutVertexArrayType: createVertexArrayType([
+        {name: 'a_pos', components: 2, type: 'Int16'}
+    ]),
     elementArrayType: createElementArrayType(3),
     elementArrayType2: createElementArrayType(2),
 
-    paintAttributes: [{
-        name: 'a_color',
-        type: 'Uint8',
-        paintProperty: 'fill-color'
-    }, {
-        name: 'a_outline_color',
-        type: 'Uint8',
-        paintProperty: 'fill-outline-color'
-    }, {
-        name: 'a_opacity',
-        type: 'Uint8',
-        multiplier: 255,
-        paintProperty: 'fill-opacity'
-    }]
+    paintAttributes: [
+        {name: 'a_color',         paintProperty: 'fill-color',         type: 'Uint8'},
+        {name: 'a_outline_color', paintProperty: 'fill-outline-color', type: 'Uint8'},
+        {name: 'a_opacity',       paintProperty: 'fill-opacity',       type: 'Uint8', multiplier: 255}
+    ]
 };
 
 class FillBucket extends Bucket {

--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -19,9 +19,9 @@ const fillExtrusionInterface = {
     elementArrayType: createElementArrayType(3),
 
     paintAttributes: [
-        {name: 'a_base',   paintProperty: 'fill-extrusion-base',   type: 'Uint16'},
-        {name: 'a_height', paintProperty: 'fill-extrusion-height', type: 'Uint16'},
-        {name: 'a_color',  paintProperty: 'fill-extrusion-color',  type: 'Uint8'}
+        {property: 'fill-extrusion-base',   type: 'Uint16'},
+        {property: 'fill-extrusion-height', type: 'Uint16'},
+        {property: 'fill-extrusion-color',  type: 'Uint8'}
     ]
 };
 

--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -28,7 +28,6 @@ const fillExtrusionInterface = {
 
     paintAttributes: [{
         name: 'a_base',
-        components: 1,
         type: 'Uint16',
         getValue: (layer, globalProperties, featureProperties) => {
             return [Math.max(layer.getPaintValue("fill-extrusion-base", globalProperties, featureProperties), 0)];
@@ -37,7 +36,6 @@ const fillExtrusionInterface = {
         paintProperty: 'fill-extrusion-base'
     }, {
         name: 'a_height',
-        components: 1,
         type: 'Uint16',
         getValue: (layer, globalProperties, featureProperties) => {
             return [Math.max(layer.getPaintValue("fill-extrusion-height", globalProperties, featureProperties), 0)];
@@ -46,7 +44,6 @@ const fillExtrusionInterface = {
         paintProperty: 'fill-extrusion-height'
     }, {
         name: 'a_color',
-        components: 4,
         type: 'Uint8',
         getValue: (layer, globalProperties, featureProperties) => {
             const color = layer.getPaintValue("fill-extrusion-color", globalProperties, featureProperties);

--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -29,27 +29,16 @@ const fillExtrusionInterface = {
     paintAttributes: [{
         name: 'a_base',
         type: 'Uint16',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return [Math.max(layer.getPaintValue("fill-extrusion-base", globalProperties, featureProperties), 0)];
-        },
         multiplier: 1,
         paintProperty: 'fill-extrusion-base'
     }, {
         name: 'a_height',
         type: 'Uint16',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return [Math.max(layer.getPaintValue("fill-extrusion-height", globalProperties, featureProperties), 0)];
-        },
         multiplier: 1,
         paintProperty: 'fill-extrusion-height'
     }, {
         name: 'a_color',
         type: 'Uint8',
-        getValue: (layer, globalProperties, featureProperties) => {
-            const color = layer.getPaintValue("fill-extrusion-color", globalProperties, featureProperties);
-            color[3] = 1.0;
-            return color;
-        },
         multiplier: 255,
         paintProperty: 'fill-extrusion-color'
     }]

--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -29,17 +29,14 @@ const fillExtrusionInterface = {
     paintAttributes: [{
         name: 'a_base',
         type: 'Uint16',
-        multiplier: 1,
         paintProperty: 'fill-extrusion-base'
     }, {
         name: 'a_height',
         type: 'Uint16',
-        multiplier: 1,
         paintProperty: 'fill-extrusion-height'
     }, {
         name: 'a_color',
         type: 'Uint8',
-        multiplier: 255,
         paintProperty: 'fill-extrusion-color'
     }]
 };

--- a/js/data/bucket/fill_extrusion_bucket.js
+++ b/js/data/bucket/fill_extrusion_bucket.js
@@ -11,34 +11,18 @@ const assert = require('assert');
 const EARCUT_MAX_RINGS = 500;
 
 const fillExtrusionInterface = {
-    layoutVertexArrayType: createVertexArrayType([{
-        name: 'a_pos',
-        components: 2,
-        type: 'Int16'
-    }, {
-        name: 'a_normal',
-        components: 3,
-        type: 'Int16'
-    }, {
-        name: 'a_edgedistance',
-        components: 1,
-        type: 'Int16'
-    }]),
+    layoutVertexArrayType: createVertexArrayType([
+        {name: 'a_pos',          components: 2, type: 'Int16'},
+        {name: 'a_normal',       components: 3, type: 'Int16'},
+        {name: 'a_edgedistance', components: 1, type: 'Int16'}
+    ]),
     elementArrayType: createElementArrayType(3),
 
-    paintAttributes: [{
-        name: 'a_base',
-        type: 'Uint16',
-        paintProperty: 'fill-extrusion-base'
-    }, {
-        name: 'a_height',
-        type: 'Uint16',
-        paintProperty: 'fill-extrusion-height'
-    }, {
-        name: 'a_color',
-        type: 'Uint8',
-        paintProperty: 'fill-extrusion-color'
-    }]
+    paintAttributes: [
+        {name: 'a_base',   paintProperty: 'fill-extrusion-base',   type: 'Uint16'},
+        {name: 'a_height', paintProperty: 'fill-extrusion-height', type: 'Uint16'},
+        {name: 'a_color',  paintProperty: 'fill-extrusion-color',  type: 'Uint8'}
+    ]
 };
 
 const FACTOR = Math.pow(2, 13);

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -51,7 +51,6 @@ const lineInterface = {
     }]),
     paintAttributes: [{
         name: 'a_color',
-        components: 4,
         type: 'Uint8',
         getValue: (layer, globalProperties, featureProperties) => {
             return layer.getPaintValue("line-color", globalProperties, featureProperties);

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -52,7 +52,6 @@ const lineInterface = {
     paintAttributes: [{
         name: 'a_color',
         type: 'Uint8',
-        multiplier: 255,
         paintProperty: 'line-color'
     }],
     elementArrayType: createElementArrayType()

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -52,9 +52,6 @@ const lineInterface = {
     paintAttributes: [{
         name: 'a_color',
         type: 'Uint8',
-        getValue: (layer, globalProperties, featureProperties) => {
-            return layer.getPaintValue("line-color", globalProperties, featureProperties);
-        },
         multiplier: 255,
         paintProperty: 'line-color'
     }],

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -40,20 +40,13 @@ const LINE_DISTANCE_SCALE = 1 / 2;
 const MAX_LINE_DISTANCE = Math.pow(2, LINE_DISTANCE_BUFFER_BITS - 1) / LINE_DISTANCE_SCALE;
 
 const lineInterface = {
-    layoutVertexArrayType: createVertexArrayType([{
-        name: 'a_pos',
-        components: 2,
-        type: 'Int16'
-    }, {
-        name: 'a_data',
-        components: 4,
-        type: 'Uint8'
-    }]),
-    paintAttributes: [{
-        name: 'a_color',
-        type: 'Uint8',
-        paintProperty: 'line-color'
-    }],
+    layoutVertexArrayType: createVertexArrayType([
+        {name: 'a_pos',  components: 2, type: 'Int16'},
+        {name: 'a_data', components: 4, type: 'Uint8'}
+    ]),
+    paintAttributes: [
+        {name: 'a_color', paintProperty: 'line-color', type: 'Uint8'}
+    ],
     elementArrayType: createElementArrayType()
 };
 

--- a/js/data/bucket/line_bucket.js
+++ b/js/data/bucket/line_bucket.js
@@ -45,7 +45,7 @@ const lineInterface = {
         {name: 'a_data', components: 4, type: 'Uint8'}
     ]),
     paintAttributes: [
-        {name: 'a_color', paintProperty: 'line-color', type: 'Uint8'}
+        {property: 'line-color', type: 'Uint8'}
     ],
     elementArrayType: createElementArrayType()
 };

--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -27,23 +27,12 @@ const getIconQuads = Quads.getIconQuads;
 
 const elementArrayType = createElementArrayType();
 
-const layoutVertexArrayType = createVertexArrayType([{
-    name: 'a_pos',
-    components: 2,
-    type: 'Int16'
-}, {
-    name: 'a_offset',
-    components: 2,
-    type: 'Int16'
-}, {
-    name: 'a_texture_pos',
-    components: 2,
-    type: 'Uint16'
-}, {
-    name: 'a_data',
-    components: 4,
-    type: 'Uint8'
-}]);
+const layoutVertexArrayType = createVertexArrayType([
+    {name: 'a_pos',         components: 2, type: 'Int16'},
+    {name: 'a_offset',      components: 2, type: 'Int16'},
+    {name: 'a_texture_pos', components: 2, type: 'Uint16'},
+    {name: 'a_data',        components: 4, type: 'Uint8'}
+]);
 
 const symbolInterfaces = {
     glyph: {
@@ -55,19 +44,11 @@ const symbolInterfaces = {
         elementArrayType: elementArrayType
     },
     collisionBox: {
-        layoutVertexArrayType: createVertexArrayType([{
-            name: 'a_pos',
-            components: 2,
-            type: 'Int16'
-        }, {
-            name: 'a_extrude',
-            components: 2,
-            type: 'Int16'
-        }, {
-            name: 'a_data',
-            components: 2,
-            type: 'Uint8'
-        }]),
+        layoutVertexArrayType: createVertexArrayType([
+            {name: 'a_pos',     components: 2, type: 'Int16'},
+            {name: 'a_extrude', components: 2, type: 'Int16'},
+            {name: 'a_data',    components: 2, type: 'Uint8'}
+        ]),
         elementArrayType: createElementArrayType(2)
     }
 };

--- a/js/data/program_configuration.js
+++ b/js/data/program_configuration.js
@@ -205,26 +205,19 @@ class ProgramConfiguration {
         gl.linkProgram(program);
         assert(gl.getProgramParameter(program, gl.LINK_STATUS), gl.getProgramInfoLog(program));
 
-        const attributes = {};
         const numAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
+        const result = {program, numAttributes};
+
         for (let i = 0; i < numAttributes; i++) {
             const attribute = gl.getActiveAttrib(program, i);
-            attributes[attribute.name] = gl.getAttribLocation(program, attribute.name);
+            result[attribute.name] = gl.getAttribLocation(program, attribute.name);
         }
-
-        const uniforms = {};
         const numUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
-        for (let ui = 0; ui < numUniforms; ui++) {
-            const uniform = gl.getActiveUniform(program, ui);
-            uniforms[uniform.name] = gl.getUniformLocation(program, uniform.name);
+        for (let i = 0; i < numUniforms; i++) {
+            const uniform = gl.getActiveUniform(program, i);
+            result[uniform.name] = gl.getUniformLocation(program, uniform.name);
         }
-
-        return util.extend({
-            program: program,
-            definition: definition,
-            attributes: attributes,
-            numAttributes: numAttributes
-        }, attributes, uniforms);
+        return result;
     }
 
     setUniforms(gl, program, layer, globalProperties) {

--- a/js/data/program_configuration.js
+++ b/js/data/program_configuration.js
@@ -37,11 +37,11 @@ class ProgramConfiguration {
             const name = attribute.name.slice(2);
 
             if (layer.isPaintValueFeatureConstant(attribute.property)) {
-                self.addZoomDrivenAttribute(name, attribute);
+                self.addZoomAttribute(name, attribute);
             } else if (layer.isPaintValueZoomConstant(attribute.property)) {
-                self.addDataDrivenAttribute(name, attribute);
+                self.addPropertyAttribute(name, attribute);
             } else {
-                self.addDataAndZoomDrivenAttribute(name, attribute, layer, zoom);
+                self.addZoomAndPropertyAttribute(name, attribute, layer, zoom);
             }
         }
         self.PaintVertexArray = createVertexArrayType(self.attributes);
@@ -67,12 +67,12 @@ class ProgramConfiguration {
         this.cacheKey += `/u_${name}`;
     }
 
-    addZoomDrivenAttribute(name, attribute) {
+    addZoomAttribute(name, attribute) {
         this.uniforms.push(attribute);
         this.addUniform(name, attribute.name);
     }
 
-    addDataDrivenAttribute(name, attribute) {
+    addPropertyAttribute(name, attribute) {
         const pragmas = this.getPragmas(name);
 
         this.attributes.push(attribute);
@@ -85,7 +85,7 @@ class ProgramConfiguration {
         this.cacheKey += `/a_${name}`;
     }
 
-    addDataAndZoomDrivenAttribute(name, attribute, layer, zoom) {
+    addZoomAndPropertyAttribute(name, attribute, layer, zoom) {
         const pragmas = this.getPragmas(name);
 
         pragmas.define.push(`varying {precision} {type} ${name};`);

--- a/js/data/program_configuration.js
+++ b/js/data/program_configuration.js
@@ -41,7 +41,6 @@ class ProgramConfiguration {
             const name = attribute.name.slice(2);
             const multiplier = attribute.multiplier || (isColor ? 255 : 1);
 
-            const frag = self.getFragmentPragmas(name);
             const vert = self.getVertexPragmas(name);
 
             if (layer.isPaintValueFeatureConstant(attribute.paintProperty)) {
@@ -50,12 +49,9 @@ class ProgramConfiguration {
 
             } else if (layer.isPaintValueZoomConstant(attribute.paintProperty)) {
                 self.attributes.push(util.extend({}, attribute, {components: isColor ? 4 : 1, multiplier}));
-
-                frag.define.push(`varying {precision} {type} ${name};`);
-                vert.define.push(`varying {precision} {type} ${name};`);
+                self.addVarying(name);
 
                 vert.define.push(`attribute {precision} {type} ${inputName};`);
-
                 vert.initialize.push(`${name} = ${inputName} / ${multiplier}.0;`);
 
             } else {
@@ -73,8 +69,7 @@ class ProgramConfiguration {
 
                 const tName = `u_${name}_t`;
 
-                frag.define.push(`varying {precision} {type} ${name};`);
-                vert.define.push(`varying {precision} {type} ${name};`);
+                self.addVarying(name);
 
                 vert.define.push(`uniform lowp float ${tName};`);
 
@@ -136,6 +131,14 @@ class ProgramConfiguration {
 
         frag.initialize.push(`{precision} {type} ${name} = ${inputName};`);
         vert.initialize.push(`{precision} {type} ${name} = ${inputName};`);
+    }
+
+    addVarying(name) {
+        const frag = this.getFragmentPragmas(name);
+        const vert = this.getVertexPragmas(name);
+
+        frag.define.push(`varying {precision} {type} ${name};`);
+        vert.define.push(`varying {precision} {type} ${name};`);
     }
 
     getFragmentPragmas(name) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -49,10 +49,7 @@ class Painter {
 
         this.lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
 
-        this.basicFillProgramConfiguration = ProgramConfiguration.createStatic([
-            {name: 'u_color', components: 4},
-            {name: 'u_opacity', components: 1}
-        ]);
+        this.basicFillProgramConfiguration = ProgramConfiguration.createStatic(['color', 'opacity']);
         this.emptyProgramConfiguration = ProgramConfiguration.createStatic([]);
     }
 
@@ -359,20 +356,19 @@ class Painter {
         }
     }
 
-    _createProgramCached(name, paintAttributeSet) {
+    _createProgramCached(name, programConfiguration) {
         this.cache = this.cache || {};
-        const key = `${name}${paintAttributeSet.cacheKey}${!!this._showOverdrawInspector}`;
+        const key = `${name}${programConfiguration.cacheKey}${!!this._showOverdrawInspector}`;
         if (!this.cache[key]) {
-            this.cache[key] = paintAttributeSet.createProgram(name, this._showOverdrawInspector, this.gl);
+            this.cache[key] = programConfiguration.createProgram(name, this._showOverdrawInspector, this.gl);
         }
         return this.cache[key];
     }
 
-    useProgram(name, paintAttributeSet) {
+    useProgram(name, programConfiguration) {
         const gl = this.gl;
 
-        const nextProgram = this._createProgramCached(name,
-            paintAttributeSet || this.emptyProgramConfiguration);
+        const nextProgram = this._createProgramCached(name, programConfiguration || this.emptyProgramConfiguration);
         const previousProgram = this.currentProgram;
 
         if (previousProgram !== nextProgram) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -357,12 +357,13 @@ class Painter {
         }
     }
 
-    createProgram(name, showOverdraw, gl, configuration) {
+    createProgram(name, configuration) {
+        const gl = this.gl;
         const program = gl.createProgram();
         const definition = shaders[name];
 
         let definesSource = '#define MAPBOX_GL_JS;\n';
-        if (showOverdraw) {
+        if (this._showOverdrawInspector) {
             definesSource += '#define OVERDRAW_INSPECTOR;\n';
         }
 
@@ -398,9 +399,9 @@ class Painter {
 
     _createProgramCached(name, programConfiguration) {
         this.cache = this.cache || {};
-        const key = `${name}${programConfiguration.cacheKey || ''}/${!!this._showOverdrawInspector}`;
+        const key = `${name}${programConfiguration.cacheKey || ''}${this._showOverdrawInspector ? '/overdraw' : ''}`;
         if (!this.cache[key]) {
-            this.cache[key] = this.createProgram(name, this._showOverdrawInspector, this.gl, programConfiguration);
+            this.cache[key] = this.createProgram(name, programConfiguration);
         }
         return this.cache[key];
     }

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -12,6 +12,8 @@ const VertexArrayObject = require('./vertex_array_object');
 const RasterBoundsArray = require('../data/raster_bounds_array');
 const PosArray = require('../data/pos_array');
 const ProgramConfiguration = require('../data/program_configuration');
+const shaders = require('mapbox-gl-shaders');
+const assert = require('assert');
 
 const draw = {
     symbol: require('./draw_symbol'),
@@ -50,7 +52,6 @@ class Painter {
         this.lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
 
         this.basicFillProgramConfiguration = ProgramConfiguration.createStatic(['color', 'opacity']);
-        this.emptyProgramConfiguration = ProgramConfiguration.createStatic([]);
     }
 
     /*
@@ -356,18 +357,57 @@ class Painter {
         }
     }
 
+    createProgram(name, showOverdraw, gl, configuration) {
+        const program = gl.createProgram();
+        const definition = shaders[name];
+
+        let definesSource = '#define MAPBOX_GL_JS;\n';
+        if (showOverdraw) {
+            definesSource += '#define OVERDRAW_INSPECTOR;\n';
+        }
+
+        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(fragmentShader, applyPragmas(definesSource + definition.fragmentSource, configuration.fragmentPragmas));
+        gl.compileShader(fragmentShader);
+        assert(gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(fragmentShader));
+        gl.attachShader(program, fragmentShader);
+
+        const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vertexShader, applyPragmas(definesSource + shaders.util + definition.vertexSource, configuration.vertexPragmas));
+        gl.compileShader(vertexShader);
+        assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(vertexShader));
+        gl.attachShader(program, vertexShader);
+
+        gl.linkProgram(program);
+        assert(gl.getProgramParameter(program, gl.LINK_STATUS), gl.getProgramInfoLog(program));
+
+        const numAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
+        const result = {program, numAttributes};
+
+        for (let i = 0; i < numAttributes; i++) {
+            const attribute = gl.getActiveAttrib(program, i);
+            result[attribute.name] = gl.getAttribLocation(program, attribute.name);
+        }
+        const numUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
+        for (let i = 0; i < numUniforms; i++) {
+            const uniform = gl.getActiveUniform(program, i);
+            result[uniform.name] = gl.getUniformLocation(program, uniform.name);
+        }
+        return result;
+    }
+
     _createProgramCached(name, programConfiguration) {
         this.cache = this.cache || {};
         const key = `${name}${programConfiguration.cacheKey}${!!this._showOverdrawInspector}`;
         if (!this.cache[key]) {
-            this.cache[key] = programConfiguration.createProgram(name, this._showOverdrawInspector, this.gl);
+            this.cache[key] = this.createProgram(name, this._showOverdrawInspector, this.gl, programConfiguration);
         }
         return this.cache[key];
     }
 
     useProgram(name, programConfiguration) {
         const gl = this.gl;
-        const nextProgram = this._createProgramCached(name, programConfiguration || this.emptyProgramConfiguration);
+        const nextProgram = this._createProgramCached(name, programConfiguration || {});
 
         if (this.currentProgram !== nextProgram) {
             gl.useProgram(nextProgram.program);
@@ -376,6 +416,15 @@ class Painter {
 
         return nextProgram;
     }
+}
+
+function applyPragmas(source, pragmas) {
+    return source.replace(/#pragma mapbox: ([\w]+) ([\w]+) ([\w]+) ([\w]+)/g, (match, operation, precision, type, name) => {
+        return pragmas[name][operation]
+            .join('\n')
+            .replace(/{type}/g, type)
+            .replace(/{precision}/g, precision);
+    });
 }
 
 module.exports = Painter;

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -398,7 +398,7 @@ class Painter {
 
     _createProgramCached(name, programConfiguration) {
         this.cache = this.cache || {};
-        const key = `${name}${programConfiguration.cacheKey}${!!this._showOverdrawInspector}`;
+        const key = `${name}${programConfiguration.cacheKey || ''}/${!!this._showOverdrawInspector}`;
         if (!this.cache[key]) {
             this.cache[key] = this.createProgram(name, this._showOverdrawInspector, this.gl, programConfiguration);
         }

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -52,6 +52,7 @@ class Painter {
         this.lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
 
         this.basicFillProgramConfiguration = ProgramConfiguration.createStatic(['color', 'opacity']);
+        this.emptyProgramConfiguration = new ProgramConfiguration();
     }
 
     /*
@@ -368,13 +369,13 @@ class Painter {
         }
 
         const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-        gl.shaderSource(fragmentShader, applyPragmas(definesSource + definition.fragmentSource, configuration.fragmentPragmas));
+        gl.shaderSource(fragmentShader, configuration.applyPragmas(definesSource + definition.fragmentSource, 'fragment'));
         gl.compileShader(fragmentShader);
         assert(gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(fragmentShader));
         gl.attachShader(program, fragmentShader);
 
         const vertexShader = gl.createShader(gl.VERTEX_SHADER);
-        gl.shaderSource(vertexShader, applyPragmas(definesSource + shaders.util + definition.vertexSource, configuration.vertexPragmas));
+        gl.shaderSource(vertexShader, configuration.applyPragmas(definesSource + shaders.util + definition.vertexSource, 'vertex'));
         gl.compileShader(vertexShader);
         assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(vertexShader));
         gl.attachShader(program, vertexShader);
@@ -408,7 +409,7 @@ class Painter {
 
     useProgram(name, programConfiguration) {
         const gl = this.gl;
-        const nextProgram = this._createProgramCached(name, programConfiguration || {});
+        const nextProgram = this._createProgramCached(name, programConfiguration || this.emptyProgramConfiguration);
 
         if (this.currentProgram !== nextProgram) {
             gl.useProgram(nextProgram.program);
@@ -417,15 +418,6 @@ class Painter {
 
         return nextProgram;
     }
-}
-
-function applyPragmas(source, pragmas) {
-    return source.replace(/#pragma mapbox: ([\w]+) ([\w]+) ([\w]+) ([\w]+)/g, (match, operation, precision, type, name) => {
-        return pragmas[name][operation]
-            .join('\n')
-            .replace(/{type}/g, type)
-            .replace(/{precision}/g, precision);
-    });
 }
 
 module.exports = Painter;

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -367,11 +367,9 @@ class Painter {
 
     useProgram(name, programConfiguration) {
         const gl = this.gl;
-
         const nextProgram = this._createProgramCached(name, programConfiguration || this.emptyProgramConfiguration);
-        const previousProgram = this.currentProgram;
 
-        if (previousProgram !== nextProgram) {
+        if (this.currentProgram !== nextProgram) {
             gl.useProgram(nextProgram.program);
             this.currentProgram = nextProgram;
         }

--- a/js/style/style_declaration.js
+++ b/js/style/style_declaration.js
@@ -13,6 +13,7 @@ class StyleDeclaration {
         // immutable representation of value. used for comparison
         this.json = JSON.stringify(this.value);
 
+        this.minimum = reference.minimum;
         this.isColor = reference.type === 'color';
 
         const parsedValue = this.isColor && this.value ? parseColor(this.value) : value;
@@ -46,6 +47,9 @@ class StyleDeclaration {
         const value = this.function(globalProperties && globalProperties.zoom, featureProperties || {});
         if (this.isColor && value) {
             return parseColor(value);
+        }
+        if (this.minimum !== undefined && value < this.minimum) {
+            return this.minimum;
         }
         return value;
     }

--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -157,9 +157,9 @@ class StyleLayer extends Evented {
         }
     }
 
-    getPaintInterpolationT(name, zoom) {
+    getPaintInterpolationT(name, globalProperties) {
         const transition = this._paintTransitions[name];
-        return transition.declaration.calculateInterpolationT({ zoom: zoom });
+        return transition.declaration.calculateInterpolationT(globalProperties);
     }
 
     isPaintValueFeatureConstant(name) {

--- a/js/style/style_layer/fill_style_layer.js
+++ b/js/style/style_layer/fill_style_layer.js
@@ -21,11 +21,11 @@ class FillStyleLayer extends StyleLayer {
         }
     }
 
-    getPaintInterpolationT(name, zoom) {
+    getPaintInterpolationT(name, globalProperties) {
         if (name === 'fill-outline-color' && this.getPaintProperty('fill-outline-color') === undefined) {
-            return super.getPaintInterpolationT('fill-color', zoom);
+            return super.getPaintInterpolationT('fill-color', globalProperties);
         } else {
-            return super.getPaintInterpolationT(name, zoom);
+            return super.getPaintInterpolationT(name, globalProperties);
         }
     }
 

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -43,9 +43,8 @@ test('Bucket', (t) => {
             elementArrayType2: createElementArrayType(2),
 
             paintAttributes: options.paintAttributes || [{
-                name: 'a_map',
-                type: 'Int16',
-                paintProperty: 'circle-opacity'
+                property: 'circle-opacity',
+                type: 'Int16'
             }]
         };
 
@@ -96,7 +95,7 @@ test('Bucket', (t) => {
         const paintVertex = bucket.arrays.layerData.layerid.paintVertexArray;
         t.equal(paintVertex.length, 1);
         const p0 = paintVertex.get(0);
-        t.equal(p0.a_map, 17);
+        t.equal(p0.a_opacity, 17);
 
         const testElement = bucket.arrays.elementArray;
         t.equal(testElement.length, 1);
@@ -125,8 +124,8 @@ test('Bucket', (t) => {
         const v0 = bucket.arrays.layoutVertexArray.get(0);
         const a0 = bucket.arrays.layerData.one.paintVertexArray.get(0);
         const b0 = bucket.arrays.layerData.two.paintVertexArray.get(0);
-        t.equal(a0.a_map, 17);
-        t.equal(b0.a_map, 17);
+        t.equal(a0.a_opacity, 17);
+        t.equal(b0.a_opacity, 17);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
 
@@ -136,9 +135,8 @@ test('Bucket', (t) => {
     t.test('add features, disabled attribute', (t) => {
         const bucket = create({
             paintAttributes: [{
-                name: 'a_map',
-                type: 'Int16',
-                paintProperty: 'circle-opacity'
+                property: 'circle-opacity',
+                type: 'Int16'
             }],
             layoutAttributes: [],
             layers: [

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -23,8 +23,8 @@ test('Bucket', (t) => {
 
     const dataDrivenPaint = {
         'circle-opacity': {
-            stops: [[0, 0], [100, 1.0]],
-            property: 'mapbox'
+            stops: [[0, 0], [100, 100]],
+            property: 'x'
         }
     };
 
@@ -45,9 +45,6 @@ test('Bucket', (t) => {
             paintAttributes: options.paintAttributes || [{
                 name: 'a_map',
                 type: 'Int16',
-                getValue: function(layer, globalProperties, featureProperties) {
-                    return [featureProperties.x];
-                },
                 paintProperty: 'circle-opacity'
             }]
         };
@@ -141,7 +138,6 @@ test('Bucket', (t) => {
             paintAttributes: [{
                 name: 'a_map',
                 type: 'Int16',
-                getValue: function() { return [5]; },
                 paintProperty: 'circle-opacity'
             }],
             layoutAttributes: [],
@@ -153,11 +149,6 @@ test('Bucket', (t) => {
         bucket.populate([createFeature(17, 42)], createOptions());
 
         t.equal(bucket.arrays.layoutVertexArray.bytesPerElement, 0);
-        t.deepEqual(
-            bucket.arrays.layerData.one.programConfiguration.uniforms[0].getValue.call(bucket),
-            [5]
-        );
-
         t.end();
     });
 

--- a/test/js/data/bucket.test.js
+++ b/test/js/data/bucket.test.js
@@ -22,8 +22,8 @@ test('Bucket', (t) => {
     }
 
     const dataDrivenPaint = {
-        'circle-color': {
-            stops: [[0, 'red'], [100, 'violet']],
+        'circle-opacity': {
+            stops: [[0, 0], [100, 1.0]],
             property: 'mapbox'
         }
     };
@@ -48,7 +48,7 @@ test('Bucket', (t) => {
                 getValue: function(layer, globalProperties, featureProperties) {
                     return [featureProperties.x];
                 },
-                paintProperty: 'circle-color'
+                paintProperty: 'circle-opacity'
             }]
         };
 
@@ -142,7 +142,7 @@ test('Bucket', (t) => {
                 name: 'a_map',
                 type: 'Int16',
                 getValue: function() { return [5]; },
-                paintProperty: 'circle-color'
+                paintProperty: 'circle-opacity'
             }],
             layoutAttributes: [],
             layers: [

--- a/test/js/style/style_declaration.test.js
+++ b/test/js/style/style_declaration.test.js
@@ -12,6 +12,12 @@ test('StyleDeclaration', (t) => {
         t.end();
     });
 
+    t.test('with minimum value', (t) => {
+        t.equal((new StyleDeclaration({type: "number", minimum: -2}, -5)).calculate({zoom: 0}), -2);
+        t.equal((new StyleDeclaration({type: "number", minimum: -2}, 5)).calculate({zoom: 0}), 5);
+        t.end();
+    });
+
     t.test('interpolated functions', (t) => {
         const reference = {type: "number", function: "interpolated"};
         t.equal((new StyleDeclaration(reference, { stops: [[0, 1]] })).calculate({zoom: 0}), 1);


### PR DESCRIPTION
A work in progress, closes #3525. cc @jfirebaugh @lucaswoj 

The tests are failing because of `bucket.test.js`, which is mocked in a very complex way so I can't figure out how to fix a few of its failing assertions yet.