### PR TITLE
Ensure images always fade in completely, fix broken "raster-fade-duration" property

### DIFF
--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -36,6 +36,8 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     const tile = sourceCache.getTile(coord);
     const posMatrix = painter.transform.calculatePosMatrix(coord, sourceCache.getSource().maxzoom);
 
+    tile.setAnimationLoop(painter.style.animationLoop, layer.paint['raster-fade-duration']);
+
     const program = painter.useProgram('raster');
     gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
 
@@ -47,7 +49,7 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     gl.uniform3fv(program.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));
 
     const parentTile = tile.sourceCache && tile.sourceCache.findLoadedParent(coord, 0, {}),
-        opacities = getOpacities(tile, parentTile, layer, painter.transform, painter.style.rasterFadeDuration);
+        opacities = getOpacities(tile, parentTile, layer, painter.transform);
 
     let parentScaleBy, parentTL;
 
@@ -103,8 +105,9 @@ function saturationFactor(saturation) {
         -saturation;
 }
 
-function getOpacities(tile, parentTile, layer, transform, fadeDuration) {
+function getOpacities(tile, parentTile, layer, transform) {
     const opacities = [1, 0];
+    const fadeDuration = layer.paint['raster-fade-duration'];
 
     if (tile.sourceCache && fadeDuration > 0) {
         const now = Date.now();

--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -47,7 +47,7 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     gl.uniform3fv(program.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));
 
     const parentTile = tile.sourceCache && tile.sourceCache.findLoadedParent(coord, 0, {}),
-        opacities = getOpacities(tile, parentTile, layer, painter.transform);
+        opacities = getOpacities(tile, parentTile, layer, painter.transform, painter.style.rasterFadeDuration);
 
     let parentScaleBy, parentTL;
 
@@ -103,9 +103,8 @@ function saturationFactor(saturation) {
         -saturation;
 }
 
-function getOpacities(tile, parentTile, layer, transform) {
+function getOpacities(tile, parentTile, layer, transform, fadeDuration) {
     const opacities = [1, 0];
-    const fadeDuration = layer.paint['raster-fade-duration'];
 
     if (tile.sourceCache && fadeDuration > 0) {
         const now = Date.now();

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -156,7 +156,6 @@ class ImageSource extends Evented {
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-            this.map.animationLoop.set(this.tile.timeAdded + this.map.style.rasterFadeDuration - Date.now());
 
         } else if (image instanceof window.HTMLVideoElement) {
             gl.bindTexture(gl.TEXTURE_2D, this.tile.texture);

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -156,6 +156,8 @@ class ImageSource extends Evented {
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+            this.map.animationLoop.set(this.tile.timeAdded + this.map.style.rasterFadeDuration - Date.now());
+
         } else if (image instanceof window.HTMLVideoElement) {
             gl.bindTexture(gl.TEXTURE_2D, this.tile.texture);
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, image);

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -156,7 +156,6 @@ class ImageSource extends Evented {
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-
         } else if (image instanceof window.HTMLVideoElement) {
             gl.bindTexture(gl.TEXTURE_2D, this.tile.texture);
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, image);

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -82,8 +82,6 @@ class RasterTileSource extends Evented {
             }
             gl.generateMipmap(gl.TEXTURE_2D);
 
-            this.map.animationLoop.set(this.map.style.rasterFadeDuration);
-
             tile.state = 'loaded';
 
             callback(null);

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -42,7 +42,7 @@ class SourceCache extends Evented {
             if (this._sourceLoaded && event.dataType === 'source') {
                 this.reload();
                 if (this.transform) {
-                    this.update(this.transform, this.map && this.map.style.rasterFadeDuration);
+                    this.update(this.transform);
                 }
             }
         });
@@ -278,7 +278,7 @@ class SourceCache extends Evented {
      * are inside the viewport.
      * @private
      */
-    update(transform, fadeDuration) {
+    update(transform) {
         if (!this._sourceLoaded) { return; }
         let i;
         let coord;
@@ -295,7 +295,6 @@ class SourceCache extends Evented {
         // the most ideal tile for the current viewport. This may include tiles like
         // parent or child tiles that are *already* loaded.
         const retain = {};
-        const now = new Date().getTime();
 
         // Covered is a list of retained tiles who's areas are full covered by other,
         // better, retained tiles. They are not drawn separately.
@@ -339,7 +338,7 @@ class SourceCache extends Evented {
             const id = ids[k];
             coord = TileCoord.fromID(id);
             tile = this._tiles[id];
-            if (tile && tile.timeAdded > now - (fadeDuration || 0)) {
+            if (tile && tile.animationLoopEndTime >= Date.now()) {
                 // This tile is still fading in. Find tiles to cross-fade with it.
                 if (this.findLoadedChildren(coord, maxCoveringZoom, retain)) {
                     retain[id] = true;

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -41,6 +41,14 @@ class Tile {
         this.state = 'loading';
     }
 
+    setAnimationLoop(animationLoop, t) {
+        this.animationLoopEndTime = t + Date.now();
+        if (this.animationLoopId !== undefined) {
+            animationLoop.cancel(this.animationLoopId);
+        }
+        this.animationLoopId = animationLoop.set(t);
+    }
+
     /**
      * Given a data object with a 'buffers' property, load it into
      * this tile's elementGroups and buffers properties and set loaded

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -221,7 +221,6 @@ class Style extends Evented {
 
         this._updateZoomHistory(z);
 
-        this.rasterFadeDuration = 300;
         for (const layerId in this._layers) {
             const layer = this._layers[layerId];
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -2,6 +2,7 @@
 
 const test = require('mapbox-gl-js-test').test;
 const SourceCache = require('../../../js/source/source_cache');
+const AnimationLoop = require('../../../js/style/animation_loop');
 const Source = require('../../../js/source/source');
 const TileCoord = require('../../../js/source/tile_coord');
 const Transform = require('../../../js/geo/transform');
@@ -378,17 +379,19 @@ test('SourceCache#update', (t) => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 2;
+        const animationLoop = new AnimationLoop();
 
         const sourceCache = createSourceCache({
             loadTile: function(tile, callback) {
                 tile.timeAdded = Infinity;
                 tile.state = 'loaded';
+                tile.setAnimationLoop(animationLoop, 100);
                 callback();
             }
         });
 
         sourceCache.on('source.load', () => {
-            sourceCache.update(transform, 100);
+            sourceCache.update(transform);
             t.deepEqual(sourceCache.getIds(), [
                 new TileCoord(2, 1, 1).id,
                 new TileCoord(2, 2, 1).id,
@@ -397,7 +400,7 @@ test('SourceCache#update', (t) => {
             ]);
 
             transform.zoom = 0;
-            sourceCache.update(transform, 100);
+            sourceCache.update(transform);
 
             t.deepEqual(sourceCache.getRenderableIds().length, 5);
             t.end();
@@ -409,22 +412,25 @@ test('SourceCache#update', (t) => {
         transform.resize(511, 511);
         transform.zoom = 0;
 
+        const animationLoop = new AnimationLoop();
+
         const sourceCache = createSourceCache({
             loadTile: function(tile, callback) {
                 tile.timeAdded = Infinity;
                 tile.state = 'loaded';
+                tile.setAnimationLoop(animationLoop, 100);
                 callback();
             }
         });
 
         sourceCache.on('source.load', () => {
-            sourceCache.update(transform, 100);
+            sourceCache.update(transform);
 
             transform.zoom = 2;
-            sourceCache.update(transform, 100);
+            sourceCache.update(transform);
 
             transform.zoom = 1;
-            sourceCache.update(transform, 100);
+            sourceCache.update(transform);
 
             t.equal(sourceCache._coveredTiles[(new TileCoord(0, 0, 0).id)], true);
             t.end();


### PR DESCRIPTION
As explained in #3526 , Mapbox GL JS does not properly implement `raster-fade-duration`. This PR fully removes support for "raster-fade-duration" and thereby ensures that images always fade in completely.

cc @jfirebaugh @mollymerp @mourner @mapsam 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~write tests for all new functionality~ we do not have any infrastructure to test animations
 - [x] document any changes to public APIs
 - [x] manually test the debug page

