### PR TITLE
Add yarn to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 .DS_Store
 .nyc_output
 *_generated.js
+yarn.lock


### PR DESCRIPTION
Before we officially adopt Yarn #3364, let’s at least have the lockfile ignored for now so that for those who use it, it doesn’t always show up as a new file. @lucaswoj 