### PR TITLE
Fix bug preventing symbols from being returned by Map#queryRenderedFeatures

### DIFF
--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -115,6 +115,7 @@ class SymbolBucket {
         this.zoom = options.zoom;
         this.overscaling = options.overscaling;
         this.layers = options.layers;
+        this.index = options.index;
         this.sdfIcons = options.sdfIcons;
         this.iconsNeedLinear = options.iconsNeedLinear;
         this.adjustedTextSize = options.adjustedTextSize;

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#72004863afdab1e7883ba6f06e0f892580e108c2",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#dd7bdc97f066a0e219ee4a44b76e5881521f6ef2",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#6267dbff51429bf382dccf54101ed49defd559b1",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#72004863afdab1e7883ba6f06e0f892580e108c2",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
As of #3478, `SymbolBucket` no longer inherits from `Bucket`.

Most of the constructor logic from `Bucket` was copied to `SymbolBucket` but the initialization of the `SymbolBucket#index` property was not. https://github.com/mapbox/mapbox-gl-js/pull/3478/files#diff-621f09c210ab28c3dbf7bc1f0f03c6b2R116

This PR restores the initialization of `SymbolBucket#index`

fixes #3534 

cc @mourner @jfirebaugh 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [ ] merge https://github.com/mapbox/mapbox-gl-test-suite/pull/156 & update SHA in this PR
