### PR TITLE
Make Nyc play nicely with Flow-typed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "test-render": "node test/render.test.js",
     "test-query": "node test/query.test.js",
     "test-flow": "flow .",
-    "test-cov": "nyc --reporter=text-summary --cache run-s test-unit test-render test-query",
+    "test-cov": "nyc --require flow-remove-types/register --reporter=text-summary --cache run-s test-unit test-render test-query",
     "prepublish": "in-publish && run-s build-dev build-min || not-in-publish"
   }
 }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "test-render": "node test/render.test.js",
     "test-query": "node test/query.test.js",
     "test-flow": "flow .",
-    "test-cov": "nyc --require flow-remove-types/register --reporter=text-summary --cache run-s test-unit test-render test-query",
+    "test-cov": "nyc --require=./test/remove_types --reporter=text-summary --reporter=lcov --cache run-s test-unit test-render test-query",
     "prepublish": "in-publish && run-s build-dev build-min || not-in-publish"
   }
 }

--- a/test/remove_types.js
+++ b/test/remove_types.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const fs = require('fs');
+const removeTypes = require('flow-remove-types');
+
+require.extensions['.js'] = function(module, filename) {
+    let source = fs.readFileSync(filename, 'utf8');
+    if (filename.indexOf('node_modules') === -1) {
+        source = removeTypes(source);
+    }
+    module._compile(source, filename);
+};


### PR DESCRIPTION
This PR restores coverage for flow-typed files. Currently, Circle says "failed to instrument ... util.js"  when runnng `npm run test-cov`, and continues running tests, but without `util.js` included. You can see this decrease in the "Coveralls lines covered" chart as well:

![image](https://cloud.githubusercontent.com/assets/25395/19994736/50c236a0-a20e-11e6-8497-6a2ad338554a.png)

We didn't catch this because coverage _percentage_ didn't decrease much — uninstrumented code is not included in the total lines count too.

Unfortunately `flow-remove-types/register` does not work with Nyc out of the box, for which I reported https://github.com/leebyron/flow-remove-types/issues/15. Meanwhile, I temporarily added a custom register code (`remove_types.js`) that does work correctly (see https://coveralls.io/builds/8661140 to confirm). We can remove the hack after the upstream issue is resolved.

Super-glad that I managed to get this resolved at the end of the day — spent hours debugging the issue.

@lucaswoj @jfirebaugh @tmcw 