### PR TITLE
Remove babel-preset-react from devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "babel-preset-react": "^6.11.1",
     "benchmark": "~2.1.0",
     "browserify": "^13.0.0",
     "clipboard": "^1.5.12",


### PR DESCRIPTION
@lucaswoj not sure why you added it but it seems to work without the dep.