### PR TITLE
Fix error where querySourceFeatures has parameters omitted. #3540

### DIFF
--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -174,7 +174,7 @@ class Tile {
 
         if (!layer) return;
 
-        const filter = featureFilter(params.filter);
+        const filter = featureFilter(params && params.filter);
         const coord = { z: this.coord.z, x: this.coord.x, y: this.coord.y };
 
         for (let i = 0; i < layer.length; i++) {

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -575,7 +575,7 @@ class Map extends Camera {
      * representing features within the specified vector tile or GeoJSON source that satisfy the query parameters.
      *
      * @param {string} sourceID The ID of the vector tile or GeoJSON source to query.
-     * @param {Object} parameters
+     * @param {Object} [parameters]
      * @param {string} [parameters.sourceLayer] The name of the vector tile layer to query. *For vector tile
      *   sources, this parameter is required.* For GeoJSON sources, it is ignored.
      * @param {Array} [parameters.filter] A [filter](https://www.mapbox.com/mapbox-gl-style-spec/#types-filter)
@@ -600,8 +600,8 @@ class Map extends Camera {
      * @see [Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
      * @see [Highlight features containing similar data](https://www.mapbox.com/mapbox-gl-js/example/query-similar-features/)
      */
-    querySourceFeatures(sourceID, params) {
-        return this.style.querySourceFeatures(sourceID, params);
+    querySourceFeatures(sourceID, parameters) {
+        return this.style.querySourceFeatures(sourceID, parameters);
     }
 
     /**

--- a/test/js/source/tile.test.js
+++ b/test/js/source/tile.test.js
@@ -35,6 +35,9 @@ test('querySourceFeatures', (t) => {
         tile.rawTileData = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
 
         result = [];
+        tile.querySourceFeatures(result);
+        t.equal(result.length, 1);
+        result = [];
         tile.querySourceFeatures(result, {});
         t.equal(result.length, 1);
         t.deepEqual(result[0].properties, features[0].tags);


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

See #3540 for background on what this fixes.

There are a couple of places where this could be fixed, so I'm not sure where is best higher or lower in the call stack. I've opted to place it at the bottom of the stack.

 - [x] write tests for all new functionality

The test is quite verbose because if you don't add any features to the source and if this source isn't included in a source the code path which I ran into this error isn't triggered.

If you remove the fix the test fails if you include this fix the test passes.

 - [x] document any changes to public APIs

I've included a second commit which makes `parameters` optional although I'm not sure if this is correct as it's only optional for GeoJSON sources as per current documentation.

I needed to rename `params` as otherwise it would show up in the generated docs separately.

 - [ ] post benchmark scores
 - [ ] manually test the debug page
