### PR TITLE
Remove "StyleLayer#set"

### DIFF
--- a/js/style/style_layer.js
+++ b/js/style/style_layer.js
@@ -13,10 +13,7 @@ const TRANSITION_SUFFIX = '-transition';
 class StyleLayer extends Evented {
     constructor(layer) {
         super();
-        this.set(layer);
-    }
 
-    set(layer) {
         this.id = layer.id;
         this.metadata = layer.metadata;
         this.type = layer.type;


### PR DESCRIPTION
This method was a kludge that I needed for an earlier implementation of data-driven styling. I would like to discourage its use in the future. 

