### PR TITLE
Explicitly set clearColor in extruison drawing

### DIFF
--- a/js/render/draw_fill_extrusion.js
+++ b/js/render/draw_fill_extrusion.js
@@ -23,6 +23,7 @@ function draw(painter, source, layer, coords) {
     const texture = new ExtrusionTexture(gl, painter, layer);
     texture.bindFramebuffer();
 
+    gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
     for (let i = 0; i < coords.length; i++) {


### PR DESCRIPTION
...in case it was set otherwise by background

@mourner 