### PR TITLE
Fix color buffer conflicts between background rendering and extrusions

### DIFF
--- a/js/render/draw_background.js
+++ b/js/render/draw_background.js
@@ -6,16 +6,14 @@ module.exports = drawBackground;
 
 function drawBackground(painter, sourceCache, layer) {
     const gl = painter.gl;
+    const transform = painter.transform;
+    const tileSize = transform.tileSize;
     const color = layer.paint['background-color'];
     const image = layer.paint['background-pattern'];
     const opacity = layer.paint['background-opacity'];
 
     const isOpaque = !image && color[3] === 1 && opacity === 1;
     if (painter.isOpaquePass !== isOpaque) return;
-
-    // if the background layer is bottommost and not patterned,
-    // we render it with gl.clearColor earlier
-    if (!image && painter.currentLayer === 0) return;
 
     gl.disable(gl.STENCIL_TEST);
 
@@ -34,8 +32,6 @@ function drawBackground(painter, sourceCache, layer) {
 
     gl.uniform1f(program.u_opacity, opacity);
 
-    const transform = painter.transform;
-    const tileSize = transform.tileSize;
     const coords = transform.coveringTiles({tileSize});
 
     for (const coord of coords) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -118,23 +118,7 @@ class Painter {
      */
     clearColor() {
         const gl = this.gl;
-        const firstGroup = this.style._groups[0];
-        const background = firstGroup && firstGroup[0].type === 'background' ? firstGroup[0] : null;
-
-        // if the bottommost layer is a solid background, use its color for clearColor
-        // to avoid rendering with full quads later
-        if (background && !background.paint['background-pattern'] && !background.isHidden()) {
-            const color = background.paint['background-color'];
-            const opacity = background.paint['background-opacity'];
-            gl.clearColor(
-                color[0] * opacity,
-                color[1] * opacity,
-                color[2] * opacity,
-                color[3] * opacity);
-        } else {
-            gl.clearColor(0, 0, 0, 0);
-        }
-
+        gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
     }
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#dd7bdc97f066a0e219ee4a44b76e5881521f6ef2",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#abcb16eefbfb4b7222e33c932300257b8b7987df",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
@mourner — in adding a regression test for the issue of color buffer conflict addressed in https://github.com/mapbox/mapbox-gl-js/commit/5b9ba0212df3810c4ea7d1be02c53de101f5e02e, I realized this wasn't the full fix — clearing the color buffer to (0,0,0,0) in draw_fill_extrusion causes the background not to render. I created the expected image in the regression test (https://github.com/mapbox/mapbox-gl-test-suite/pull/160) by locally reverting changes from https://github.com/mapbox/mapbox-gl-js/commit/2fc3651139d18f4e68e6d7b5d43169ff4c63b568.

This PR updates the test-suite SHA to reflect the regression test; right now it will fail. I haven't figured out yet if there's a way to maintain the optimizations from https://github.com/mapbox/mapbox-gl-js/commit/2fc3651139d18f4e68e6d7b5d43169ff4c63b568 while still effectively clearing the color buffer when needed in drawing extrusions, but this needs further investigation as right now it is broken 🚑  planning to dig in more this weekend.