### PR TITLE
Use two times less workers for better performance

### DIFF
--- a/js/mapbox-gl.js
+++ b/js/mapbox-gl.js
@@ -6,8 +6,7 @@ const browser = require('./util/browser');
 const mapboxgl = module.exports = {};
 
 mapboxgl.version = require('../package.json').version;
-mapboxgl.workerCount = Math.max(browser.hardwareConcurrency - 1, 1);
-
+mapboxgl.workerCount = Math.max(Math.floor(browser.hardwareConcurrency / 2), 1);
 
 mapboxgl.Map = require('./ui/map');
 mapboxgl.Control = require('./ui/control/control');

--- a/test/js/mapbox-gl.js
+++ b/test/js/mapbox-gl.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const test = require('mapbox-gl-js-test').test;
-const proxyquire = require('proxyquire');
 const mapboxgl = require('../../js/mapbox-gl');
 
 test('mapboxgl', (t) => {
@@ -10,11 +9,8 @@ test('mapboxgl', (t) => {
         t.end();
     });
 
-    t.test('.workerCount defaults to hardwareConcurrency - 1', (t) => {
-        const mapboxgl = proxyquire('../../js/mapbox-gl', {
-            './util/browser': { hardwareConcurrency: 15 }
-        });
-        t.equal(mapboxgl.workerCount, 14);
+    t.test('workerCount', (t) => {
+        t.ok(typeof mapboxgl.workerCount === 'number');
         t.end();
     });
     t.end();


### PR DESCRIPTION
Based on our conversation with Chrome engineers, using anything more than `num_cores / 2` actually makes things worse because those additional workers usually get heavily deprioritized to make room for other stuff (for Chrome and the system). You can see which workers are deprioritized based on their background color in the tracing profile, and also comparing the wall time to CPU time there.

This may explain our earlier observations where worker messages would suddenly get deprioritized and start lagging heavily, such as on the point drag example.

Per further recommendations from the Chrome engineers, we need to follow-up with a PR that sets the worker count to `1` for mobile devices, although we first need to come up with a good way to detect a mobile phone (preferably not involving user agent parsing).

cc @jfirebaugh @ansis @lucaswoj 