### PR TITLE
Use "navigator.permissions" to detect geolocation support

### DIFF
--- a/js/ui/control/geolocate_control.js
+++ b/js/ui/control/geolocate_control.js
@@ -11,34 +11,22 @@ const className = 'mapboxgl-ctrl';
 let supportsGeolocation;
 
 function checkGeolocationSupport(callback) {
-
     if (supportsGeolocation !== undefined) {
-        if (supportsGeolocation === true) {
-            callback();
-        }
-        return;
-    }
+        callback(supportsGeolocation);
 
-    // Test for the case where a browser disables Geolocation because of an
-    // insecure origin
-    // https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-powerful-features-on-insecure-origins
-    //
-    // navigator.permissions has incomplete browser support
-    // http://caniuse.com/#feat=permissions-api
-    if (window.navigator.permissions !== undefined) {
-        window.navigator.permissions
-            .query({ name:'geolocation' })
-            .then((p) => {
-                supportsGeolocation = p.state !== 'denied';
-                if (supportsGeolocation === true) {
-                    callback();
-                }
-            });
+    } else if (window.navigator.permissions !== undefined) {
+        // navigator.permissions has incomplete browser support
+        // http://caniuse.com/#feat=permissions-api
+        // Test for the case where a browser disables Geolocation because of an
+        // insecure origin
+        window.navigator.permissions.query({ name: 'geolocation' }).then((p) => {
+            supportsGeolocation = p.state !== 'denied';
+            callback(supportsGeolocation);
+        });
+
     } else {
         supportsGeolocation = !!window.navigator.geolocation;
-        if (supportsGeolocation === true) {
-            callback();
-        }
+        callback(supportsGeolocation);
     }
 }
 
@@ -102,7 +90,8 @@ class GeolocateControl extends Evented {
         this._timeoutId = undefined;
     }
 
-    _setupUI() {
+    _setupUI(supported) {
+        if (supported === false) return;
         this._container.addEventListener('contextmenu',
             e => e.preventDefault());
         this._geolocateButton = DOM.create('button',

--- a/js/util/browser.js
+++ b/js/util/browser.js
@@ -96,5 +96,3 @@ webpImgTest.onload = function() {
     exports.supportsWebp = true;
 };
 webpImgTest.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';
-
-exports.supportsGeolocation = !!window.navigator.geolocation;

--- a/test/js/util/browser.test.js
+++ b/test/js/util/browser.test.js
@@ -40,10 +40,5 @@ test('browser', (t) => {
         t.end();
     });
 
-    t.test('supportsGeolocation', (t) => {
-        t.equal(typeof browser.supportsGeolocation, 'boolean');
-        t.end();
-    });
-
     t.end();
 });


### PR DESCRIPTION
Due to new [security restrictions](https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-powerful-features-on-insecure-origins), the presence of `navigator.geolocation` is no longer a complete indication of geolocation support: the `navigator.permissions` API allows one to query for access to the API. This PR moves geolocation support checking to the GeolocationControl in order to support this asynchronous API.

Testing plan:

1. `npm run start-debug`
2. edit /etc/hosts to give your localhost another creative name, since the Chrome HTTPS rule whitelists localhost
3. confirm that the control is not visible on the alternative name, but is visible on localhost

Implementation notes:

Since the permissions API is async and is not instant, this approach caches the result. I have not found any cases where the result will change.

## Launch Checklist

Fixes #3568 - ~~waiting on #3497 because this needs to move the geolocation detection into the geocodercontrol itself.~~ Actionable - workingonit.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page