### PR TITLE
Text placement is not redone during rotation

### DIFF
--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -116,9 +116,9 @@ class WorkerTile {
                 buckets: serializeBuckets(util.values(buckets), transferables),
                 featureIndex: featureIndex.serialize(transferables),
                 collisionTile: collisionTile.serialize(transferables),
-                collisionBoxArray: this.collisionBoxArray.serialize(transferables),
-                symbolInstancesArray: this.symbolInstancesArray.serialize(transferables),
-                symbolQuadsArray: this.symbolQuadsArray.serialize(transferables)
+                collisionBoxArray: this.collisionBoxArray.serialize(),
+                symbolInstancesArray: this.symbolInstancesArray.serialize(),
+                symbolQuadsArray: this.symbolQuadsArray.serialize()
             }, transferables);
         };
 

--- a/js/util/struct_array.js
+++ b/js/util/struct_array.js
@@ -54,6 +54,8 @@ const RESIZE_MULTIPLIER = 5;
  */
 class StructArray {
     constructor(serialized) {
+        this.isTransferred = false;
+
         if (serialized !== undefined) {
         // Create from an serialized StructArray
             this.arrayBuffer = serialized.arrayBuffer;
@@ -83,8 +85,12 @@ class StructArray {
      * Serialize this StructArray instance
      */
     serialize(transferables) {
-        this.trim();
+        assert(!this.isTransferred);
+
+        this._trim();
+
         if (transferables) {
+            this.isTransferred = true;
             transferables.push(this.arrayBuffer);
         }
         return {
@@ -98,13 +104,14 @@ class StructArray {
      * @param {number} index The index of the element.
      */
     get(index) {
+        assert(!this.isTransferred);
         return new this.StructType(this, index);
     }
 
     /**
      * Resize the array to discard unused capacity.
      */
-    trim() {
+    _trim() {
         if (this.length !== this.capacity) {
             this.capacity = this.length;
             this.arrayBuffer = this.arrayBuffer.slice(0, this.length * this.bytesPerElement);
@@ -119,6 +126,8 @@ class StructArray {
      * @param {number} n The new size of the array.
      */
     resize(n) {
+        assert(!this.isTransferred);
+
         this.length = n;
         if (n > this.capacity) {
             this.capacity = Math.max(n, Math.floor(this.capacity * RESIZE_MULTIPLIER), DEFAULT_CAPACITY);
@@ -145,6 +154,8 @@ class StructArray {
      * @param {number} endIndex
      */
     toArray(startIndex, endIndex) {
+        assert(!this.isTransferred);
+
         const array = [];
 
         for (let i = startIndex; i < endIndex; i++) {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#abcb16eefbfb4b7222e33c932300257b8b7987df",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#9c8a1e7b94a81abdbb7c7f5e51dd7bd64b109bb2",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/test/js/util/struct_array.test.js
+++ b/test/js/util/struct_array.test.js
@@ -87,7 +87,7 @@ test('StructArray', (t) => {
         array.emplaceBack(1, 1, 1);
         t.equal(array.capacity, capacityInitial);
 
-        array.trim();
+        array._trim();
         t.equal(array.capacity, 1);
         t.equal(array.arrayBuffer.byteLength, array.bytesPerElement);
 


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-js/pull/3490 marks `SymbolBucket#collisionBoxArray`, `SymbolBucket#symbolInstancesArray`, `SymbolBucket#symbolQuadsArray` as transferables. These `StructArray`s need to be persisted in the workerside `SymbolBucket` for layer use by `SymbolBucket#redoPlacement`.

This manifested as a bug in which text would render upside down after the map was rotated. 

![expected](https://cloud.githubusercontent.com/assets/281306/20158797/7fa298de-a691-11e6-9f32-0367a66c8f49.png)

ref https://github.com/mapbox/mapbox-gl-test-suite/pull/163

cc @jfirebaugh @mourner 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] post benchmark scores
 - [x] manually test the debug page

