### PR TITLE
Improve batch updates

### DIFF
--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -11,9 +11,6 @@ const PosArray = require('../data/pos_array');
 module.exports = drawDebug;
 
 function drawDebug(painter, sourceCache, coords) {
-    if (painter.isOpaquePass) return;
-    if (!painter.options.debug) return;
-
     for (let i = 0; i < coords.length; i++) {
         drawDebugTile(painter, sourceCache, coords[i]);
     }

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -211,6 +211,11 @@ class Painter {
         this.renderPass();
         this.isOpaquePass = false;
         this.renderPass();
+
+        if (this.options.showTileBoundaries) {
+            const sourceCache = this.style.sourceCaches[Object.keys(this.style.sourceCaches)[0]];
+            draw.debug(this, sourceCache, sourceCache.getVisibleCoordinates());
+        }
     }
 
     renderPass() {
@@ -222,20 +227,15 @@ class Painter {
 
         for (let i = 0; i < layerIds.length; i++) {
             const layer = this.style._layers[layerIds[this.currentLayer]];
-            let sourceChanged = false;
 
             if (layer.source !== (sourceCache && sourceCache.id)) {
                 sourceCache = this.style.sourceCaches[layer.source];
                 coords = [];
-                sourceChanged = true;
 
                 if (sourceCache) {
                     if (sourceCache.prepare) sourceCache.prepare();
-                    coords = sourceCache.getVisibleCoordinates();
-                    for (const coord of coords) {
-                        coord.posMatrix = this.transform.calculatePosMatrix(coord, sourceCache.getSource().maxzoom);
-                    }
                     this.clearStencil();
+                    coords = sourceCache.getVisibleCoordinates();
                     if (sourceCache.getSource().isTileClipped) {
                         this._renderTileClippingMasks(coords);
                     }
@@ -252,11 +252,6 @@ class Painter {
             }
 
             this.renderLayer(this, sourceCache, layer, coords);
-
-            if (sourceChanged && sourceCache) {
-                draw.debug(this, sourceCache, coords);
-            }
-
             this.currentLayer += this.isOpaquePass ? -1 : 1;
         }
     }

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -512,7 +512,11 @@ class SourceCache extends Evented {
     }
 
     getVisibleCoordinates() {
-        return this.getRenderableIds().map(TileCoord.fromID);
+        const coords = this.getRenderableIds().map(TileCoord.fromID);
+        for (const coord of coords) {
+            coord.posMatrix = this.transform.calculatePosMatrix(coord, this._source.maxzoom);
+        }
+        return coords;
     }
 }
 

--- a/js/source/worker.js
+++ b/js/source/worker.js
@@ -33,12 +33,12 @@ class Worker {
         };
     }
 
-    setLayers(mapId, layerDefinitions) {
-        this.getLayerIndex(mapId).replace(layerDefinitions);
+    setLayers(mapId, layers) {
+        this.getLayerIndex(mapId).replace(layers);
     }
 
-    updateLayers(mapId, layerDefinitions) {
-        this.getLayerIndex(mapId).update(layerDefinitions);
+    updateLayers(mapId, params) {
+        this.getLayerIndex(mapId).update(params.layers, params.removedIds, params.symbolOrder);
     }
 
     loadTile(mapId, params, callback) {

--- a/js/source/worker_tile.js
+++ b/js/source/worker_tile.js
@@ -124,10 +124,9 @@ class WorkerTile {
 
         // Symbol buckets must be placed in reverse order.
         this.symbolBuckets = [];
-        for (let i = layerIndex.order.length - 1; i >= 0; i--) {
-            const id = layerIndex.order[i];
-            const bucket = buckets[id];
-            if (bucket && bucket.layers[0].type === 'symbol') {
+        for (let i = layerIndex.symbolOrder.length - 1; i >= 0; i--) {
+            const bucket = buckets[layerIndex.symbolOrder[i]];
+            if (bucket) {
                 this.symbolBuckets.push(bucket);
             }
         }

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -360,16 +360,14 @@ class Style extends Evented {
      * @returns {Style} `this`
      * @private
      */
-    addLayer(layer, before, options) {
+    addLayer(layerObject, before, options) {
         this._checkLoaded();
 
-        if (!(layer instanceof StyleLayer)) {
-            // this layer is not in the style.layers array, so we pass an impossible array index
-            if (this._validate(validateStyle.layer,
-                    `layers.${layer.id}`, layer, {arrayIndex: -1}, options)) return this;
+        // this layer is not in the style.layers array, so we pass an impossible array index
+        if (this._validate(validateStyle.layer,
+                `layers.${layerObject.id}`, layerObject, {arrayIndex: -1}, options)) return this;
 
-            layer = StyleLayer.create(layer);
-        }
+        const layer = StyleLayer.create(layerObject);
         this._validateLayer(layer);
 
         layer.setEventedParent(this, {layer: {id: layer.id}});
@@ -580,7 +578,7 @@ class Style extends Evented {
         if (params && params.layers) {
             for (let i = 0; i < params.layers.length; i++) {
                 const layer = this._layers[params.layers[i]];
-                if (!(layer instanceof StyleLayer)) {
+                if (!layer) {
                     // this layer is not in the style.layers array
                     return this.fire('error', {error: `The layer '${params.layers[i]
                         }' does not exist in the map's style and cannot be queried for features.`});

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -241,10 +241,9 @@ class Style extends Evented {
 
     /**
      * Apply queued style updates in a batch
-     * @private
      */
     update(classes, options) {
-        if (!this._changed) return this;
+        if (!this._changed) return;
 
         this._updateWorkerLayers();
 
@@ -259,8 +258,6 @@ class Style extends Evented {
         this.fire('data', {dataType: 'style'});
 
         this._resetUpdates();
-
-        return this;
     }
 
     _updateWorkerLayers() {
@@ -304,7 +301,7 @@ class Style extends Evented {
 
         const builtIns = ['vector', 'raster', 'geojson', 'video', 'image'];
         const shouldValidate = builtIns.indexOf(source.type) >= 0;
-        if (shouldValidate && this._validate(validateStyle.source, `sources.${id}`, source, null, options)) return this;
+        if (shouldValidate && this._validate(validateStyle.source, `sources.${id}`, source, null, options)) return;
 
         source = new SourceCache(id, source, this.dispatcher);
         this.sourceCaches[id] = source;
@@ -313,16 +310,12 @@ class Style extends Evented {
 
         if (source.onAdd) source.onAdd(this.map);
         this._changed = true;
-
-        return this;
     }
 
     /**
      * Remove a source from this stylesheet, given its id.
      * @param {string} id id of the source to remove
-     * @returns {Style} this style
      * @throws {Error} if no source is found with the given ID
-     * @private
      */
     removeSource(id) {
         this._checkLoaded();
@@ -338,15 +331,12 @@ class Style extends Evented {
 
         if (sourceCache.onRemove) sourceCache.onRemove(this.map);
         this._changed = true;
-
-        return this;
     }
 
     /**
      * Get a source by id.
      * @param {string} id id of the desired source
      * @returns {Object} source
-     * @private
      */
     getSource(id) {
         return this.sourceCaches[id] && this.sourceCaches[id].getSource();
@@ -357,8 +347,6 @@ class Style extends Evented {
      * ID `before`, or appended if `before` is omitted.
      * @param {StyleLayer|Object} layer
      * @param {string=} before  ID of an existing layer to insert before
-     * @returns {Style} `this`
-     * @private
      */
     addLayer(layerObject, before, options) {
         this._checkLoaded();
@@ -367,7 +355,7 @@ class Style extends Evented {
 
         // this layer is not in the style.layers array, so we pass an impossible array index
         if (this._validate(validateStyle.layer,
-                `layers.${id}`, layerObject, {arrayIndex: -1}, options)) return this;
+                `layers.${id}`, layerObject, {arrayIndex: -1}, options)) return;
 
         const layer = StyleLayer.create(layerObject);
         this._validateLayer(layer);
@@ -389,7 +377,7 @@ class Style extends Evented {
             this._updatedSources[layer.source] = true;
         }
 
-        return this.updateClasses(id);
+        this.updateClasses(id);
     }
 
     /**
@@ -422,9 +410,7 @@ class Style extends Evented {
     /**
      * Remove a layer from this stylesheet, given its id.
      * @param {string} id id of the layer to remove
-     * @returns {Style} this style
      * @throws {Error} if no layer is found with the given ID
-     * @private
      */
     removeLayer(id) {
         this._checkLoaded();
@@ -446,8 +432,6 @@ class Style extends Evented {
         delete this._layers[id];
         delete this._updatedLayers[id];
         delete this._updatedPaintProps[id];
-
-        return this;
     }
 
     /**
@@ -455,7 +439,6 @@ class Style extends Evented {
      *
      * @param {string} id - id of the desired layer
      * @returns {?Object} a layer, if one with the given `id` exists
-     * @private
      */
     getLayer(id) {
         return this._layers[id];
@@ -466,7 +449,7 @@ class Style extends Evented {
 
         const layer = this.getLayer(layerId);
 
-        if (layer.minzoom === minzoom && layer.maxzoom === maxzoom) return this;
+        if (layer.minzoom === minzoom && layer.maxzoom === maxzoom) return;
 
         if (minzoom != null) {
             layer.minzoom = minzoom;
@@ -474,7 +457,7 @@ class Style extends Evented {
         if (maxzoom != null) {
             layer.maxzoom = maxzoom;
         }
-        return this._updateLayer(layer);
+        this._updateLayer(layer);
     }
 
     setFilter(layerId, filter) {
@@ -482,19 +465,18 @@ class Style extends Evented {
 
         const layer = this.getLayer(layerId);
 
-        if (filter !== null && this._validate(validateStyle.filter, `layers.${layer.id}.filter`, filter)) return this;
+        if (filter !== null && this._validate(validateStyle.filter, `layers.${layer.id}.filter`, filter)) return;
 
-        if (util.deepEqual(layer.filter, filter)) return this;
+        if (util.deepEqual(layer.filter, filter)) return;
         layer.filter = util.clone(filter);
 
-        return this._updateLayer(layer);
+        this._updateLayer(layer);
     }
 
     /**
      * Get a layer's filter object
      * @param {string} layer the layer to inspect
      * @returns {*} the layer's filter, if any
-     * @private
      */
     getFilter(layer) {
         return util.clone(this.getLayer(layer).filter);
@@ -505,10 +487,10 @@ class Style extends Evented {
 
         const layer = this.getLayer(layerId);
 
-        if (util.deepEqual(layer.getLayoutProperty(name), value)) return this;
+        if (util.deepEqual(layer.getLayoutProperty(name), value)) return;
 
         layer.setLayoutProperty(name, value);
-        return this._updateLayer(layer);
+        this._updateLayer(layer);
     }
 
     /**
@@ -516,7 +498,6 @@ class Style extends Evented {
      * @param {string} layer the layer to inspect
      * @param {string} name the name of the layout property
      * @returns {*} the property value
-     * @private
      */
     getLayoutProperty(layer, name) {
         return this.getLayer(layer).getLayoutProperty(name);
@@ -527,7 +508,7 @@ class Style extends Evented {
 
         const layer = this.getLayer(layerId);
 
-        if (util.deepEqual(layer.getPaintProperty(name, klass), value)) return this;
+        if (util.deepEqual(layer.getPaintProperty(name, klass), value)) return;
 
         const wasFeatureConstant = layer.isPaintValueFeatureConstant(name);
         layer.setPaintProperty(name, value, klass);
@@ -546,7 +527,7 @@ class Style extends Evented {
             }
         }
 
-        return this.updateClasses(layerId, name);
+        this.updateClasses(layerId, name);
     }
 
     getPaintProperty(layer, name, klass) {
@@ -562,7 +543,6 @@ class Style extends Evented {
             if (!props[layerId]) props[layerId] = {};
             props[layerId][paintName || 'all'] = true;
         }
-        return this;
     }
 
     serialize() {
@@ -589,7 +569,6 @@ class Style extends Evented {
             this._updatedSources[layer.source] = true;
         }
         this._changed = true;
-        return this;
     }
 
     _flattenRenderedFeatures(sourceResults) {
@@ -619,8 +598,9 @@ class Style extends Evented {
                 const layer = this._layers[params.layers[i]];
                 if (!layer) {
                     // this layer is not in the style.layers array
-                    return this.fire('error', {error: `The layer '${params.layers[i]
+                    this.fire('error', {error: `The layer '${params.layers[i]
                         }' does not exist in the map's style and cannot be queried for features.`});
+                    return;
                 }
                 includedSources[layer.source] = true;
             }
@@ -676,12 +656,12 @@ class Style extends Evented {
                 break;
             }
         }
-        if (!_update) return this;
+        if (!_update) return;
 
         const transition = this.stylesheet.transition || {};
 
         this.light.setLight(lightOptions);
-        return this.light.updateLightTransitions(transitionOptions || {transition: true}, transition, this.animationLoop);
+        this.light.updateLightTransitions(transitionOptions || {transition: true}, transition, this.animationLoop);
     }
 
     _validate(validate, key, value, props, options) {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -294,16 +294,9 @@ class Style extends Evented {
             this._reloadSource(updatedSourceIds[i]);
         }
 
-        for (i = 0; i < this._updates.events.length; i++) {
-            const args = this._updates.events[i];
-            this.fire(args[0], args[1]);
-        }
-
         this._applyClasses(classes, options);
 
-        if (this._updates.changed) {
-            this.fire('data', {dataType: 'style'});
-        }
+        this.fire('data', {dataType: 'style'});
 
         this._resetUpdates();
 
@@ -312,7 +305,7 @@ class Style extends Evented {
 
     _resetUpdates() {
         this._updates = {
-            events: [],
+            changed: false,
             layers: {},
             sources: {},
             paintProps: {}
@@ -544,7 +537,7 @@ class Style extends Evented {
         return this.getLayer(layer).getPaintProperty(name, klass);
     }
 
-    updateClasses (layerId, paintName) {
+    updateClasses(layerId, paintName) {
         this._updates.changed = true;
         if (!layerId) {
             this._updates.allPaintProps = true;
@@ -574,7 +567,7 @@ class Style extends Evented {
         }, (value) => { return value !== undefined; });
     }
 
-    _updateLayer (layer) {
+    _updateLayer(layer) {
         this._updates.layers[layer.id] = true;
         if (layer.source) {
             this._updates.sources[layer.source] = true;

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -37,7 +37,6 @@ class Style extends Evented {
 
         this._layers = {};
         this._order  = [];
-        this._groups = [];
         this.sourceCaches = {};
         this.zoomHistory = {};
         this._loaded = false;
@@ -139,40 +138,18 @@ class Style extends Evented {
     _resolve() {
         const layers = deref(this.stylesheet.layers);
 
-        this._order = layers.map((layer) => {
-            return layer.id;
-        });
+        this._order = layers.map((layer) => layer.id);
 
         this._layers = {};
         for (let layer of layers) {
             layer = StyleLayer.create(layer);
-            this._layers[layer.id] = layer;
             layer.setEventedParent(this, {layer: {id: layer.id}});
+            this._layers[layer.id] = layer;
         }
 
-        this._groupLayers();
         this._updateWorkerLayers();
 
         this.light = new Light(this.stylesheet.light);
-    }
-
-    _groupLayers() {
-        let group;
-
-        this._groups = [];
-
-        // Split into groups of consecutive top-level layers with the same source.
-        for (let i = 0; i < this._order.length; ++i) {
-            const layer = this._layers[this._order[i]];
-
-            if (!group || layer.source !== group.source) {
-                group = [];
-                group.source = layer.source;
-                this._groups.push(group);
-            }
-
-            group.push(layer);
-        }
     }
 
     _updateWorkerLayers(ids) {
@@ -279,7 +256,6 @@ class Style extends Evented {
         if (!this._updates.changed) return this;
 
         if (this._updates.allLayers) {
-            this._groupLayers();
             this._updateWorkerLayers();
         } else {
             const updatedIds = Object.keys(this._updates.layers);
@@ -563,7 +539,7 @@ class Style extends Evented {
             glyphs: this.stylesheet.glyphs,
             transition: this.stylesheet.transition,
             sources: util.mapObject(this.sourceCaches, (source) => source.serialize()),
-            layers: this._order.map((id) => this._layers[id].serialize(), this)
+            layers: this._order.map((id) => this._layers[id].serialize())
         }, (value) => { return value !== undefined; });
     }
 

--- a/js/style/style_layer_index.js
+++ b/js/style/style_layer_index.js
@@ -13,14 +13,25 @@ class StyleLayerIndex {
     }
 
     replace(layers) {
-        this.order = layers.map((layer) => layer.id);
+        this.symbolOrder = [];
+        for (const layer of layers) {
+            if (layer.type === 'symbol') {
+                this.symbolOrder.push(layer.id);
+            }
+        }
         this._layers = {};
-        this.update(layers);
+        this.update(layers, []);
     }
 
-    update(layers) {
+    update(layers, removedIds, symbolOrder) {
         for (const layer of layers) {
             this._layers[layer.id] = layer;
+        }
+        for (const id of removedIds) {
+            delete this._layers[id];
+        }
+        if (symbolOrder) {
+            this.symbolOrder = symbolOrder;
         }
 
         this.familiesBySource = {};

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -768,6 +768,20 @@ class Map extends Camera {
     }
 
     /**
+     * Moves a layer to a different z-position.
+     *
+     * @param {string} id The ID of the layer to move.
+     * @param {string} [before] The ID of an existing layer to insert the new layer before.
+     *   If this argument is omitted, the layer will be appended to the end of the layers array.
+     * @returns {Map} `this`
+     */
+    moveLayer(layerId, before) {
+        this.style.moveLayer(layerId, before);
+        this._update(true);
+        return this;
+    }
+
+    /**
      * Removes a layer from the map's style.
      *
      * @param {string} id The ID of the layer to remove.

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1126,9 +1126,8 @@ class Map extends Camera {
         }
 
         this.painter.render(this.style, {
-            debug: this.showTileBoundaries,
+            showTileBoundaries: this.showTileBoundaries,
             showOverdrawInspector: this._showOverdrawInspector,
-            vertices: this.vertices,
             rotating: this.rotating,
             zooming: this.zooming
         });

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -1116,7 +1116,6 @@ test('Style defers expensive methods', (t) => {
         t.spy(style, 'fire');
         t.spy(style, '_reloadSource');
         t.spy(style, '_updateWorkerLayers');
-        t.spy(style, '_groupLayers');
 
         style.addLayer({ id: 'first', type: 'symbol', source: 'streets' });
         style.addLayer({ id: 'second', type: 'symbol', source: 'streets' });
@@ -1128,7 +1127,6 @@ test('Style defers expensive methods', (t) => {
         t.notOk(style.fire.called, 'fire is deferred');
         t.notOk(style._reloadSource.called, '_reloadSource is deferred');
         t.notOk(style._updateWorkerLayers.called, '_updateWorkerLayers is deferred');
-        t.notOk(style._groupLayers.called, '_groupLayers is deferred');
 
         style.update();
 
@@ -1141,7 +1139,6 @@ test('Style defers expensive methods', (t) => {
 
         // called once
         t.ok(style._updateWorkerLayers.calledOnce, '_updateWorkerLayers is called once');
-        t.ok(style._groupLayers.calledOnce, '_groupLayers is called once');
 
         t.end();
     });

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -290,15 +290,6 @@ test('Style#_resolve', (t) => {
 });
 
 test('Style#addSource', (t) => {
-    t.test('returns self', (t) => {
-        const style = new Style(createStyleJSON()),
-            source = createSource();
-        style.on('style.load', () => {
-            t.equal(style.addSource('source-id', source), style);
-            t.end();
-        });
-    });
-
     t.test('throw before loaded', (t) => {
         const style = new Style(createStyleJSON()),
             source = createSource();
@@ -389,16 +380,6 @@ test('Style#addSource', (t) => {
 });
 
 test('Style#removeSource', (t) => {
-    t.test('returns self', (t) => {
-        const style = new Style(createStyleJSON()),
-            source = createSource();
-        style.on('style.load', () => {
-            style.addSource('source-id', source);
-            t.equal(style.removeSource('source-id'), style);
-            t.end();
-        });
-    });
-
     t.test('throw before loaded', (t) => {
         const style = new Style(createStyleJSON({
             "sources": {
@@ -487,16 +468,6 @@ test('Style#removeSource', (t) => {
 });
 
 test('Style#addLayer', (t) => {
-    t.test('returns self', (t) => {
-        const style = new Style(createStyleJSON()),
-            layer = {id: 'background', type: 'background'};
-
-        style.on('style.load', () => {
-            t.equal(style.addLayer(layer), style);
-            t.end();
-        });
-    });
-
     t.test('throw before loaded', (t) => {
         const style = new Style(createStyleJSON()),
             layer = {id: 'background', type: 'background'};
@@ -671,17 +642,6 @@ test('Style#addLayer', (t) => {
 });
 
 test('Style#removeLayer', (t) => {
-    t.test('returns self', (t) => {
-        const style = new Style(createStyleJSON()),
-            layer = {id: 'background', type: 'background'};
-
-        style.on('style.load', () => {
-            style.addLayer(layer);
-            t.equal(style.removeLayer('background'), style);
-            t.end();
-        });
-    });
-
     t.test('throw before loaded', (t) => {
         const style = new Style(createStyleJSON({
             "layers": [{id: 'background', type: 'background'}]

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -737,7 +737,7 @@ test('Style#removeLayer', (t) => {
         style.on('style.load', () => {
             t.throws(() => {
                 style.removeLayer('background');
-            }, /There is no layer with this ID/);
+            }, /Layer not found: background/);
             t.end();
         });
     });
@@ -775,6 +775,63 @@ test('Style#removeLayer', (t) => {
             style.removeLayer('a');
             t.equal(style.getLayer('a'), undefined);
             t.notEqual(style.getLayer('b'), undefined);
+            t.end();
+        });
+    });
+
+    t.end();
+});
+
+test('Style#moveLayer', (t) => {
+
+    t.test('throw before loaded', (t) => {
+        const style = new Style(createStyleJSON({
+            "layers": [{id: 'background', type: 'background'}]
+        }));
+        t.throws(() => {
+            style.moveLayer('background');
+        }, Error, /load/i);
+        style.on('style.load', () => {
+            t.end();
+        });
+    });
+
+    t.test('fires "data" event', (t) => {
+        const style = new Style(createStyleJSON()),
+            layer = {id: 'background', type: 'background'};
+
+        style.once('data', t.end);
+
+        style.on('style.load', () => {
+            style.addLayer(layer);
+            style.moveLayer('background');
+            style.update();
+        });
+    });
+
+    t.test('throws on non-existence', (t) => {
+        const style = new Style(createStyleJSON());
+
+        style.on('style.load', () => {
+            t.throws(() => {
+                style.moveLayer('background');
+            }, /Layer not found: background/);
+            t.end();
+        });
+    });
+
+    t.test('changes the order', (t) => {
+        const style = new Style(createStyleJSON({
+            layers: [
+                {id: 'a', type: 'background'},
+                {id: 'b', type: 'background'},
+                {id: 'c', type: 'background'}
+            ]
+        }));
+
+        style.on('style.load', () => {
+            style.moveLayer('a', 'c');
+            t.deepEqual(style._order, ['b', 'a', 'c']);
             t.end();
         });
     });

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -217,42 +217,16 @@ test('Style#_updateWorkerLayers', (t) => {
     style.on('style.load', () => {
         style.addLayer({id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer' }, 'second');
         style.addLayer({id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer' });
+        style.removeLayer('second');
 
         style.dispatcher.broadcast = function(key, value) {
-            t.equal(key, 'setLayers');
-            t.deepEqual(value.map((layer) => { return layer.id; }), ['first', 'second', 'third']);
+            t.equal(key, 'updateLayers');
+            t.deepEqual(value.layers.map((layer) => { return layer.id; }), ['first', 'third']);
+            t.deepEqual(value.removedIds, ['second']);
             t.end();
         };
 
         style._updateWorkerLayers();
-    });
-});
-
-test('Style#_updateWorkerLayers with specific ids', (t) => {
-    const style = new Style({
-        'version': 8,
-        'sources': {
-            'source': {
-                'type': 'vector'
-            }
-        },
-        'layers': [
-            {id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer'},
-            {id: 'second', source: 'source', type: 'fill', 'source-layer': 'source-layer'},
-            {id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer'}
-        ]
-    });
-
-    style.on('error', (error) => { t.error(error); });
-
-    style.on('style.load', () => {
-        style.dispatcher.broadcast = function(key, value) {
-            t.equal(key, 'updateLayers');
-            t.deepEqual(value.map((layer) => { return layer.id; }), ['second', 'third']);
-            t.end();
-        };
-
-        style._updateWorkerLayers(['second', 'third']);
     });
 });
 
@@ -827,8 +801,8 @@ test('Style#setFilter', (t) => {
         style.on('style.load', () => {
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'updateLayers');
-                t.deepEqual(value[0].id, 'symbol');
-                t.deepEqual(value[0].filter, ['==', 'id', 1]);
+                t.deepEqual(value.layers[0].id, 'symbol');
+                t.deepEqual(value.layers[0].filter, ['==', 'id', 1]);
                 t.end();
             };
 
@@ -865,8 +839,8 @@ test('Style#setFilter', (t) => {
 
             style.dispatcher.broadcast = function(key, value) {
                 t.equal(key, 'updateLayers');
-                t.deepEqual(value[0].id, 'symbol');
-                t.deepEqual(value[0].filter, ['==', 'id', 2]);
+                t.deepEqual(value.layers[0].id, 'symbol');
+                t.deepEqual(value.layers[0].filter, ['==', 'id', 2]);
                 t.end();
             };
             filter[2] = 2;

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -196,7 +196,7 @@ test('Style#_remove', (t) => {
 
 });
 
-test('Style#_updateWorkerLayers', (t) => {
+test('Style#update', (t) => {
     const style = new Style({
         'version': 8,
         'sources': {
@@ -226,7 +226,7 @@ test('Style#_updateWorkerLayers', (t) => {
             t.end();
         };
 
-        style._updateWorkerLayers();
+        style.update();
     });
 });
 

--- a/test/js/style/style_layer_index.test.js
+++ b/test/js/style/style_layer_index.test.js
@@ -36,7 +36,7 @@ test('StyleLayerIndex#update', (t) => {
         { id: '1', type: 'fill', source: 'bar', 'source-layer': 'layer', paint: { 'fill-color': 'cyan' } },
         { id: '2', type: 'circle', source: 'bar', 'source-layer': 'layer', paint: { 'circle-color': 'magenta' } },
         { id: '3', type: 'circle', source: 'bar', 'source-layer': 'layer', paint: { 'circle-color': 'yellow' } }
-    ]);
+    ], []);
 
     const families = index.familiesBySource['bar']['layer'];
     t.equal(families.length, 2);

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -706,7 +706,7 @@ test('Map', (t) => {
             map.on('style.load', () => {
                 map.style.dispatcher.broadcast = function(key, value) {
                     t.equal(key, 'updateLayers');
-                    t.deepEqual(value.map((layer) => { return layer.id; }), ['symbol']);
+                    t.deepEqual(value.layers.map((layer) => { return layer.id; }), ['symbol']);
                 };
 
                 map.setLayoutProperty('symbol', 'text-transform', 'lowercase');


### PR DESCRIPTION
A work in progress on improving batch style updates, including fixing #3576.

- [x] more efficient `addLayer` and `removeLayer` methods
- [x] add `moveLayer` method
- [x] clean up source reloading logic
- [ ] (optional) update `moveLayer` only do `redoPlacement` instead of reparsing tiles for symbol layers