### PR TITLE
Fix collision debug rendering

### DIFF
--- a/js/render/draw_collision_debug.js
+++ b/js/render/draw_collision_debug.js
@@ -12,6 +12,8 @@ function drawCollisionDebug(painter, sourceCache, layer, coords) {
         const tile = sourceCache.getTile(coord);
         const bucket = tile.getBucket(layer);
         if (!bucket) continue;
+        const buffers = bucket.buffers.collisionBox;
+        if (!buffers) continue;
 
         gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
 
@@ -22,7 +24,6 @@ function drawCollisionDebug(painter, sourceCache, layer, coords) {
         gl.uniform1f(program.u_zoom, painter.transform.zoom * 10);
         gl.uniform1f(program.u_maxzoom, (tile.coord.z + 1) * 10);
 
-        const buffers = bucket.buffers.collisionBox;
         for (const segment of buffers.segments) {
             segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, null, segment.vertexOffset);
             gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);


### PR DESCRIPTION
A fix that makes sure `showCollisionBoxes` doesn't crash GL JS if it encounters a tile without visible symbol layers. Also may be the fix for #3305. 👀 @mollymerp 