### PR TITLE
min and max zoom getters

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -423,6 +423,13 @@ class Map extends Camera {
     }
 
     /**
+     * Returns the map's minimum allowable zoom level.
+     *
+     * @returns {number} minZoom
+     */
+    getMinZoom() { return this.transform.minZoom; }
+
+    /**
      * Sets or clears the map's maximum zoom level.
      * If the map's current zoom level is higher than the new maximum,
      * the map will zoom to the new maximum.
@@ -445,6 +452,14 @@ class Map extends Camera {
 
         } else throw new Error(`maxZoom must be between the current minZoom and ${defaultMaxZoom}, inclusive`);
     }
+
+    /**
+     * Returns the map's maximum allowable zoom level.
+     *
+     * @returns {number} maxZoom
+     */
+    getMaxZoom() { return this.transform.maxZoom; }
+
     /**
      * Returns a [`Point`](#Point) representing pixel coordinates, relative to the map's `container`,
      * that correspond to the specified geographical location.

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -459,6 +459,14 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('#getMinZoom', (t) => {
+        const map = createMap({zoom: 0});
+        t.equal(map.getMinZoom(), 0, 'returns default value');
+        map.setMinZoom(10);
+        t.equal(map.getMinZoom(), 10, 'returns custom value');
+        t.end();
+    });
+
     t.test('ignore minZooms over maxZoom', (t) => {
         const map = createMap({zoom:2, maxZoom:5});
         t.throws(() => {
@@ -482,6 +490,14 @@ test('Map', (t) => {
         map.setMaxZoom(null);
         map.setZoom(6);
         t.equal(map.getZoom(), 6);
+        t.end();
+    });
+
+    t.test('#getMaxZoom', (t) => {
+        const map = createMap({zoom: 0});
+        t.equal(map.getMaxZoom(), 20, 'returns default value');
+        map.setMaxZoom(10);
+        t.equal(map.getMaxZoom(), 10, 'returns custom value');
         t.end();
     });
 


### PR DESCRIPTION
Adds two new getters to resolve #3585 

1. `Map#getMaxZoom` - returns `map.transform.maxZoom`
1. `Map#getMinZoom` - returns `map.transform.minZoom`

cc @lucaswoj @mourner @Naimikan