### PR TITLE
Clean up debug pages

### DIFF
--- a/debug/.eslintrc
+++ b/debug/.eslintrc
@@ -1,0 +1,16 @@
+{
+  "rules": {
+    "prefer-arrow-callback": "off",
+    "no-var": "off",
+    "strict": "off",
+    "no-unused-vars": "off",
+    "prefer-template": "off"
+  },
+  "env": {
+    "es6": false,
+    "browser": true
+  },
+  "globals": {
+    "mapboxgl": false
+  }
+}

--- a/debug/2762.html
+++ b/debug/2762.html
@@ -3,8 +3,7 @@
 <head>
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
@@ -14,47 +13,45 @@
 
 <body>
 <div id='map'></div>
-<script src='/dist/mapbox-gl-dev.js'></script>
-<script>
-    var map = new mapboxgl.Map({
-        container: 'map',
-        style: {
-            "version": 8,
-            "sources": {
-                "geojson": {
-                    "type": "geojson",
-                    "data": {
-                        "type": "Point",
-                        "coordinates": [
-                            0,
-                            0
-                        ]
-                    }
-                }
-            },
-            "transition": {
-                "duration": 1000
-            },
-            "layers": [
-                {
-                    "id": "circle",
-                    "type": "circle",
-                    "source": "geojson",
-                    "paint": {
-                        "circle-translate": [
-                            -50,
-                            -50
-                        ]
-                    }
-                }
-            ]
-        }
-    });
 
-    map.on('click', function(e) {
-        map.setPaintProperty("circle", "circle-color", "red");
-        map.setPaintProperty("circle", "circle-translate", [50, 50]);
-    });
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
+
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: {
+        "version": 8,
+        "sources": {
+            "geojson": {
+                "type": "geojson",
+                "data": {
+                    "type": "Point",
+                    "coordinates": [0, 0]
+                }
+            }
+        },
+        "transition": {
+            "duration": 1000
+        },
+        "layers": [
+            {
+                "id": "circle",
+                "type": "circle",
+                "source": "geojson",
+                "paint": {
+                    "circle-translate": [-50, -50]
+                }
+            }
+        ]
+    }
+});
+
+map.on('click', function(e) {
+    map.setPaintProperty("circle", "circle-color", "red");
+    map.setPaintProperty("circle", "circle-translate", [50, 50]);
+});
+
 </script>
 </body>
 </html>

--- a/debug/chinese.html
+++ b/debug/chinese.html
@@ -4,7 +4,6 @@
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
@@ -27,8 +26,8 @@
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 12.5,
@@ -62,6 +61,5 @@ map.on('load', function () {
 });
 
 </script>
-
 </body>
 </html>

--- a/debug/circles.html
+++ b/debug/circles.html
@@ -4,55 +4,20 @@
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
         html, body, #map { height: 100%; }
-        #checkboxes {
-            position: absolute;
-            background: #fff;
-            top:0;
-            left:0;
-            padding:10px;
-        }
-        #buffer {
-            position: absolute;
-            top:100px;
-            left:0;
-            pointer-events: none;
-        }
-        #buffer div {
-            background-color: #fff;
-            padding: 5px 0;
-            text-indent: 10px;
-            white-space: nowrap;
-            text-shadow:
-               -1px -1px 0 #fff,
-                1px -1px 0 #fff,
-                -1px 1px 0 #fff,
-                 1px 1px 0 #fff;
-        }
     </style>
 </head>
 
 <body>
 <div id='map'></div>
-<div id='checkboxes'>
-  <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
-  <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br />
-  <input id='show-overdraw-checkbox' name='show-overdraw' type='checkbox'> <label for='show-overdraw'>overdraw debug</label><br />
-  <input id='buffer-checkbox' name='buffer' type='checkbox'> <label for='buffer'>buffer stats</label>
-</div>
-
-<div id='buffer' style="display:none">
-    <em>Waiting for data...</em>
-</div>
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 3,
@@ -96,61 +61,8 @@ map.on('load', function() {
             }
         }
     });
-
-    var bufferTimes = {};
-    map.on('tile.stats', function(bufferTimes) {
-        var _stats = [];
-        for (var name in bufferTimes) {
-            var value = Math.round(bufferTimes[name]);
-            if (isNaN(value)) continue;
-            var width = value;
-            _stats.push({name: name, value: value, width: width});
-        }
-        _stats = _stats.sort(function(a, b) { return b.value - a.value }).slice(0, 10);
-
-        var html = '';
-        for (var i in _stats) {
-            html += '<div style="width:' + _stats[i].width * 2 + 'px">' + _stats[i].value + 'ms - ' + _stats[i].name + '</div>';
-        }
-
-        document.getElementById('buffer').innerHTML = html;
-    });
 });
-
-map.on('click', function(e) {
-    if (e.originalEvent.shiftKey) return;
-    (new mapboxgl.Popup())
-        .setLngLat(map.unproject(e.point))
-        .setHTML("<h1>Hello World!</h1>")
-        .addTo(map);
-});
-
-document.getElementById('show-tile-boundaries-checkbox').onclick = function() {
-    map.showTileBoundaries = !!this.checked;
-};
-
-document.getElementById('show-symbol-collision-boxes-checkbox').onclick = function() {
-    map.showCollisionBoxes = !!this.checked;
-};
-
-document.getElementById('show-overdraw-checkbox').onclick = function() {
-    map.showOverdrawInspector = !!this.checked;
-};
-
-document.getElementById('buffer-checkbox').onclick = function() {
-    document.getElementById('buffer').style.display = this.checked ? 'block' : 'none';
-};
-
-// keyboard shortcut for comparing rendering with Mapbox GL native
-document.onkeypress = function(e) {
-    if (e.charCode === 111 && !e.shiftKey && !e.metaKey && !e.altKey) {
-        var center = map.getCenter();
-        location.href = "mapboxgl://?center=" + center.lat + "," + center.lng + "&zoom=" + map.getZoom() + "&bearing=" + map.getBearing();
-        return false;
-    }
-};
 
 </script>
-
 </body>
 </html>

--- a/debug/cluster.html
+++ b/debug/cluster.html
@@ -19,60 +19,60 @@
 <script>
 
 var style = {
-  "version": 8,
-  "metadata": {
-    "test": {
-      "native": false,
-      "width": 512,
-      "height": 512
-    }
-  },
-  "center": [0, 0],
-  "zoom": 0,
-  "sources": {
-    "geojson": {
-      "type": "geojson",
-      "data": "/node_modules/mapbox-gl-test-suite/data/places.geojson",
-      "cluster": true,
-      "clusterRadius": 25
-    }
-  },
-  "glyphs": "/node_modules/mapbox-gl-test-suite/glyphs/{fontstack}/{range}.pbf",
-  "layers": [
-    {
-      "id": "cluster",
-      "type": "circle",
-      "source": "geojson",
-      "filter": ["==", "cluster", true],
-      "paint": {
-        "circle-color": "rgba(0, 200, 0, 1)",
-        "circle-radius": 20
-      }
+    "version": 8,
+    "metadata": {
+        "test": {
+            "native": false,
+            "width": 512,
+            "height": 512
+        }
     },
-    {
-      "id": "cluster_label",
-      "type": "symbol",
-      "source": "geojson",
-      "filter": ["==", "cluster", true],
-      "layout": {
-        "text-field": "{point_count}",
-        "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
-        "text-size": 12,
-        "text-allow-overlap": true,
-        "text-ignore-placement": true
-      }
+    "center": [0, 0],
+    "zoom": 0,
+    "sources": {
+        "geojson": {
+            "type": "geojson",
+            "data": "/node_modules/mapbox-gl-test-suite/data/places.geojson",
+            "cluster": true,
+            "clusterRadius": 25
+        }
     },
-    {
-      "id": "unclustered_point",
-      "type": "circle",
-      "source": "geojson",
-      "filter": ["!=", "cluster", true],
-      "paint": {
-        "circle-color": "rgba(0, 0, 200, 1)",
-        "circle-radius": 10
-      }
-    }
-  ]
+    "glyphs": "/node_modules/mapbox-gl-test-suite/glyphs/{fontstack}/{range}.pbf",
+    "layers": [
+        {
+            "id": "cluster",
+            "type": "circle",
+            "source": "geojson",
+            "filter": ["==", "cluster", true],
+            "paint": {
+                "circle-color": "rgba(0, 200, 0, 1)",
+                "circle-radius": 20
+            }
+        },
+        {
+            "id": "cluster_label",
+            "type": "symbol",
+            "source": "geojson",
+            "filter": ["==", "cluster", true],
+            "layout": {
+                "text-field": "{point_count}",
+                "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
+                "text-size": 12,
+                "text-allow-overlap": true,
+                "text-ignore-placement": true
+            }
+        },
+        {
+            "id": "unclustered_point",
+            "type": "circle",
+            "source": "geojson",
+            "filter": ["!=", "cluster", true],
+            "paint": {
+                "circle-color": "rgba(0, 0, 200, 1)",
+                "circle-radius": 10
+            }
+        }
+    ]
 };
 
 var map = window.map = new mapboxgl.Map({

--- a/debug/cluster.html
+++ b/debug/cluster.html
@@ -4,55 +4,20 @@
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
         html, body, #map { height: 100%; }
-        #checkboxes {
-            position: absolute;
-            background: #fff;
-            top:0;
-            left:0;
-            padding:10px;
-        }
-        #buffer {
-            position: absolute;
-            top:100px;
-            left:0;
-            pointer-events: none;
-        }
-        #buffer div {
-            background-color: #fff;
-            padding: 5px 0;
-            text-indent: 10px;
-            white-space: nowrap;
-            text-shadow:
-               -1px -1px 0 #fff,
-                1px -1px 0 #fff,
-                -1px 1px 0 #fff,
-                 1px 1px 0 #fff;
-        }
     </style>
 </head>
 
 <body>
 <div id='map'></div>
-<div id='checkboxes'>
-  <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
-  <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br />
-  <input id='show-overdraw-checkbox' name='show-overdraw' type='checkbox'> <label for='show-overdraw'>overdraw debug</label><br />
-  <input id='buffer-checkbox' name='buffer' type='checkbox'> <label for='buffer'>buffer stats</label>
-</div>
-
-<div id='buffer' style="display:none">
-    <em>Waiting for data...</em>
-</div>
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var style = {
   "version": 8,
   "metadata": {
@@ -62,10 +27,7 @@ var style = {
       "height": 512
     }
   },
-  "center": [
-    0,
-    0
-  ],
+  "center": [0, 0],
   "zoom": 0,
   "sources": {
     "geojson": {
@@ -81,11 +43,7 @@ var style = {
       "id": "cluster",
       "type": "circle",
       "source": "geojson",
-      "filter": [
-        "==",
-        "cluster",
-        true
-      ],
+      "filter": ["==", "cluster", true],
       "paint": {
         "circle-color": "rgba(0, 200, 0, 1)",
         "circle-radius": 20
@@ -95,17 +53,10 @@ var style = {
       "id": "cluster_label",
       "type": "symbol",
       "source": "geojson",
-      "filter": [
-        "==",
-        "cluster",
-        true
-      ],
+      "filter": ["==", "cluster", true],
       "layout": {
         "text-field": "{point_count}",
-        "text-font": [
-          "Open Sans Semibold",
-          "Arial Unicode MS Bold"
-        ],
+        "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
         "text-size": 12,
         "text-allow-overlap": true,
         "text-ignore-placement": true
@@ -115,18 +66,14 @@ var style = {
       "id": "unclustered_point",
       "type": "circle",
       "source": "geojson",
-      "filter": [
-        "!=",
-        "cluster",
-        true
-      ],
+      "filter": ["!=", "cluster", true],
       "paint": {
         "circle-color": "rgba(0, 0, 200, 1)",
         "circle-radius": 10
       }
     }
   ]
-}
+};
 
 var map = window.map = new mapboxgl.Map({
     container: 'map',
@@ -137,31 +84,6 @@ var map = window.map = new mapboxgl.Map({
 map.addControl(new mapboxgl.NavigationControl());
 map.addControl(new mapboxgl.GeolocateControl());
 
-document.getElementById('show-tile-boundaries-checkbox').onclick = function() {
-    map.showTileBoundaries = !!this.checked;
-};
-
-document.getElementById('show-symbol-collision-boxes-checkbox').onclick = function() {
-    map.showCollisionBoxes = !!this.checked;
-};
-
-document.getElementById('show-overdraw-checkbox').onclick = function() {
-    map.showOverdrawInspector = !!this.checked;
-};
-
-document.getElementById('buffer-checkbox').onclick = function() {
-    document.getElementById('buffer').style.display = this.checked ? 'block' : 'none';
-};
-
-// keyboard shortcut for comparing rendering with Mapbox GL native
-document.onkeypress = function(e) {
-    if (e.charCode === 111 && !e.shiftKey && !e.metaKey && !e.altKey) {
-        var center = map.getCenter();
-        location.href = "mapboxgl://?center=" + center.lat + "," + center.lng + "&zoom=" + map.getZoom() + "&bearing=" + map.getBearing();
-        return false;
-    }
-};
 </script>
-
 </body>
 </html>

--- a/debug/color_spaces.html
+++ b/debug/color_spaces.html
@@ -4,11 +4,11 @@
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
         html, body, #map { height: 100%; }
+
         #checkboxes {
             position: absolute;
             background: #fff;
@@ -16,44 +16,23 @@
             left:0;
             padding:10px;
         }
-        #buffer {
-            position: absolute;
-            top:100px;
-            left:0;
-            pointer-events: none;
-        }
-        #buffer div {
-            background-color: #fff;
-            padding: 5px 0;
-            text-indent: 10px;
-            white-space: nowrap;
-            text-shadow:
-               -1px -1px 0 #fff,
-                1px -1px 0 #fff,
-                -1px 1px 0 #fff,
-                 1px 1px 0 #fff;
-        }
     </style>
 </head>
 
 <body>
 <div id='map'></div>
 <div id='checkboxes'>
-  <select onchange='pickInterpolation(this)'>
-    <option value='rgb'>rgb</option>
-    <option value='hcl'>hcl</option>
-    <option value='lab'>lab</option>
-  </select>
-</div>
-
-<div id='buffer' style="display:none">
-    <em>Waiting for data...</em>
+    <select onchange='pickInterpolation(this)'>
+        <option value='rgb'>rgb</option>
+        <option value='hcl'>hcl</option>
+        <option value='lab'>lab</option>
+    </select>
 </div>
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 2.5,
@@ -87,55 +66,19 @@ map.on('load', function() {
           }
         }
     }, 'country-label-lg');
-
-    var bufferTimes = {};
-    map.on('tile.stats', function(bufferTimes) {
-        var _stats = [];
-        for (var name in bufferTimes) {
-            var value = Math.round(bufferTimes[name]);
-            if (isNaN(value)) continue;
-            var width = value;
-            _stats.push({name: name, value: value, width: width});
-        }
-        _stats = _stats.sort(function(a, b) { return b.value - a.value }).slice(0, 10);
-
-        var html = '';
-        for (var i in _stats) {
-            html += '<div style="width:' + _stats[i].width * 2 + 'px">' + _stats[i].value + 'ms - ' + _stats[i].name + '</div>';
-        }
-
-        document.getElementById('buffer').innerHTML = html;
-    });
-});
-
-map.on('click', function(e) {
-    if (e.originalEvent.shiftKey) return;
-    (new mapboxgl.Popup())
-        .setLngLat(map.unproject(e.point))
-        .setHTML("<h1>Hello World!</h1>")
-        .addTo(map);
 });
 
 function pickInterpolation(input) {
-  map.setPaintProperty('countries', 'fill-color', {
-    "property": "pop_est",
-    "colorSpace": input.value,
-    "stops": [
-      [0, 'blue'],
-      [140041247, 'red']
-    ]
-  });
+    map.setPaintProperty('countries', 'fill-color', {
+        "property": "pop_est",
+        "colorSpace": input.value,
+        "stops": [
+            [0, 'blue'],
+            [140041247, 'red']
+        ]
+    });
 };
 
-// keyboard shortcut for comparing rendering with Mapbox GL native
-document.onkeypress = function(e) {
-    if (e.charCode === 111 && !e.shiftKey && !e.metaKey && !e.altKey) {
-        var center = map.getCenter();
-        location.href = "mapboxgl://?center=" + center.lat + "," + center.lng + "&zoom=" + map.getZoom() + "&bearing=" + map.getBearing();
-        return false;
-    }
-};
 </script>
-
 </body>
 </html>

--- a/debug/color_spaces.html
+++ b/debug/color_spaces.html
@@ -56,14 +56,14 @@ map.on('load', function() {
         "type": "fill",
         "source": "geojson",
         "paint": {
-          "fill-color": {
-            "property": "pop_est",
-            "colorSpace": "lab",
-            "stops": [
-              [0, 'blue'],
-              [140041247, 'red']
-            ]
-          }
+            "fill-color": {
+                "property": "pop_est",
+                "colorSpace": "lab",
+                "stops": [
+                    [0, 'blue'],
+                    [140041247, 'red']
+                ]
+            }
         }
     }, 'country-label-lg');
 });
@@ -77,7 +77,7 @@ function pickInterpolation(input) {
             [140041247, 'red']
         ]
     });
-};
+}
 
 </script>
 </body>

--- a/debug/debug.html
+++ b/debug/debug.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+
+        #checkboxes {
+            position: absolute;
+            background: #fff;
+            top:0;
+            left:0;
+            padding:10px;
+        }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<div id='checkboxes'>
+    <label><input id='show-tile-boundaries-checkbox' type='checkbox'> tile debug</label><br />
+    <label><input id='show-symbol-collision-boxes-checkbox' type='checkbox'> collision debug</label><br />
+    <label><input id='show-overdraw-checkbox' type='checkbox'> overdraw debug</label><br />
+    <label><input id='pitch-checkbox' type='checkbox' checked> pitch with rotate</label><br />
+</div>
+
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-77.01866, 38.888],
+    style: 'mapbox://styles/mapbox/streets-v9',
+    hash: true
+});
+
+map.addControl(new mapboxgl.NavigationControl());
+map.addControl(new mapboxgl.GeolocateControl());
+map.addControl(new mapboxgl.ScaleControl());
+
+map.on('load', function() {
+    map.addSource('geojson', {
+        "type": "geojson",
+        "data": "/node_modules/mapbox-gl-test-suite/data/linestring.geojson"
+    });
+    map.addLayer({
+        "id": "route",
+        "type": "line",
+        "source": "geojson",
+        "paint": {
+            "line-color": "#EC8D8D",
+            "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+        }
+    }, 'country-label-lg');
+});
+
+map.on('click', function(e) {
+    if (e.originalEvent.shiftKey) return;
+    (new mapboxgl.Popup())
+        .setLngLat(map.unproject(e.point))
+        .setHTML("<h1>Hello World!</h1>")
+        .addTo(map);
+});
+
+document.getElementById('show-tile-boundaries-checkbox').onclick = function() {
+    map.showTileBoundaries = !!this.checked;
+};
+
+document.getElementById('show-symbol-collision-boxes-checkbox').onclick = function() {
+    map.showCollisionBoxes = !!this.checked;
+};
+
+document.getElementById('show-overdraw-checkbox').onclick = function() {
+    map.showOverdrawInspector = !!this.checked;
+};
+
+document.getElementById('pitch-checkbox').onclick = function() {
+    map.dragRotate._pitchWithRotate = !!this.checked;
+};
+
+// keyboard shortcut for comparing rendering with Mapbox GL native
+document.onkeypress = function(e) {
+    if (e.charCode === 111 && !e.shiftKey && !e.metaKey && !e.altKey) {
+        var center = map.getCenter();
+        location.href = "mapboxgl://?center=" + center.lat + "," + center.lng + "&zoom=" + map.getZoom() + "&bearing=" + map.getBearing();
+        return false;
+    }
+};
+
+</script>
+</body>
+</html>

--- a/debug/events.html
+++ b/debug/events.html
@@ -4,9 +4,9 @@
 <title>Mapbox GL JS debug page</title>
 <meta charset='utf-8'>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-
 <link rel='stylesheet' href='/dist/mapbox-gl.css' />
 <style>
+
 body {
     margin: 0;
     padding: 0;
@@ -88,8 +88,8 @@ html, body, #map {
 <body>
 <div id='map'></div>
 <div id='checkboxes'>
-  <input id='show-console' name='show-console' type='checkbox'><label for='show-console'>Show console</label><br/>
-  <hr/>
+    <input id='show-console' name='show-console' type='checkbox'><label for='show-console'>Show console</label><br/>
+    <hr/>
 </div>
 
 <div id='console' class='hide'></div>
@@ -190,7 +190,6 @@ var checkboxContainer = document.querySelector('#checkboxes');
 
     checkboxContainer.appendChild(document.createElement('br'));
 });
-
 
 </script>
 </body>

--- a/debug/events.html
+++ b/debug/events.html
@@ -109,7 +109,7 @@ var map = window.map = new mapboxgl.Map({
 map.addControl(new mapboxgl.NavigationControl());
 
 var consoleContainer = document.querySelector('#console');
-['info','log','warn','error'].forEach(function (verb) {
+['info', 'log', 'warn', 'error'].forEach(function (verb) {
     console[verb] = (function (method, verb, container) {
         return function (text) {
             method(text);
@@ -130,7 +130,7 @@ var consoleContainer = document.querySelector('#console');
 document.getElementById('show-console').onclick = function() {
     var node = document.getElementById('console');
     if (!node) return;
-    this.checked ? node.classList.remove('hide') : node.classList.add('hide');
+    node.classList[this.checked ? 'remove' : 'add']('hide');
     blurMap(this.checked);
 };
 
@@ -141,13 +141,13 @@ function formatTimestamp() {
     var sec = '00' + d.getSeconds();
     var ms = '000' + d.getMilliseconds();
     return hr.substr(-2) + ':' + min.substr(-2) + ':' + sec.substr(-2) + '.' + ms.substr(-3);
-};
+}
 
 function blurMap(val) {
     var node = document.getElementById('map');
     if (!node) return;
-    val ? node.classList.add('blur') : node.classList.remove('blur');
-};
+    node.classList[val ? 'add' : 'remove']('blur');
+}
 
 function checkEvent(type, checked) {
     map.off(type);
@@ -165,15 +165,16 @@ function checkEvent(type, checked) {
 // Which map events do we want to observe?
 var checkboxContainer = document.querySelector('#checkboxes');
 
-['touchstart', 'touchend', 'touchmove', 'touchcancel',
- 'mouseout', 'mousedown', 'mouseup', 'mousemove',
- 'click', 'dblclick', 'contextmenu',
- 'dragstart', 'drag', 'dragend',
- 'movestart', 'move', 'moveend',
- 'zoomstart', 'zoom', 'zoomend',
- 'rotatestart', 'rotate', 'rotateend',
- 'pitchstart', 'pitch', 'pitchend',
- 'boxzoomstart', 'boxzoomend', 'boxzoomcancel'
+[
+    'touchstart', 'touchend', 'touchmove', 'touchcancel',
+    'mouseout', 'mousedown', 'mouseup', 'mousemove',
+    'click', 'dblclick', 'contextmenu',
+    'dragstart', 'drag', 'dragend',
+    'movestart', 'move', 'moveend',
+    'zoomstart', 'zoom', 'zoomend',
+    'rotatestart', 'rotate', 'rotateend',
+    'pitchstart', 'pitch', 'pitchend',
+    'boxzoomstart', 'boxzoomend', 'boxzoomcancel'
 ].forEach(function (type) {
     var name = 'show-' + type;
     var input = document.createElement('input');

--- a/debug/image.html
+++ b/debug/image.html
@@ -3,8 +3,7 @@
 <head>
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
@@ -12,12 +11,13 @@
     </style>
 </head>
 
+<body>
 <div id='map'></div>
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var imageStyle = {
     "version": 8,
     "sources": {
@@ -46,15 +46,15 @@ var imageStyle = {
 };
 
 var map = new mapboxgl.Map({
-  container: 'map',
-  minZoom: 14,
-  zoom: 17,
-  center: [-122.514426, 37.562984],
-  bearing: -96,
-  style: imageStyle,
-  hash: false
+    container: 'map',
+    minZoom: 14,
+    zoom: 17,
+    center: [-122.514426, 37.562984],
+    bearing: -96,
+    style: imageStyle,
+    hash: false
 });
-</script>
 
+</script>
 </body>
 </html>

--- a/debug/index.html
+++ b/debug/index.html
@@ -4,153 +4,28 @@
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
         html, body, #map { height: 100%; }
-        #checkboxes {
-            position: absolute;
-            background: #fff;
-            top:0;
-            left:0;
-            padding:10px;
-        }
-        #buffer {
-            position: absolute;
-            top:100px;
-            left:0;
-            pointer-events: none;
-        }
-        #buffer div {
-            background-color: #fff;
-            padding: 5px 0;
-            text-indent: 10px;
-            white-space: nowrap;
-            text-shadow:
-               -1px -1px 0 #fff,
-                1px -1px 0 #fff,
-                -1px 1px 0 #fff,
-                 1px 1px 0 #fff;
-        }
     </style>
 </head>
 
 <body>
 <div id='map'></div>
-<div id='checkboxes'>
-  <label><input id='show-tile-boundaries-checkbox' type='checkbox'> tile debug</label><br />
-  <label><input id='show-symbol-collision-boxes-checkbox' type='checkbox'> collision debug</label><br />
-  <label><input id='show-overdraw-checkbox' type='checkbox'> overdraw debug</label><br />
-  <label><input id='pitch-checkbox' type='checkbox' checked> pitch with rotate</label><br />
-  <label><input id='buffer-checkbox' type='checkbox'> buffer stats</label>
-</div>
-
-<div id='buffer' style="display:none">
-    <em>Waiting for data...</em>
-</div>
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 12.5,
     center: [-77.01866, 38.888],
-    style: 'mapbox://styles/mapbox/streets-v9',
+    style: 'mapbox://styles/mapbox/streets-v10',
     hash: true
 });
 
-map.addControl(new mapboxgl.NavigationControl());
-map.addControl(new mapboxgl.GeolocateControl());
-map.addControl(new mapboxgl.ScaleControl(), 'bottom-left');
-
-map.on('load', function() {
-    map.addSource('geojson', {
-        "type": "geojson",
-        "data": "/node_modules/mapbox-gl-test-suite/data/linestring.geojson"
-    });
-
-    map.addLayer({
-        "id": "route",
-        "type": "line",
-        "source": "geojson",
-        "paint": {
-            "line-color": "#EC8D8D",
-            "line-width": {
-                "base": 1.5,
-                "stops": [
-                    [
-                        5,
-                        0.75
-                    ],
-                    [
-                        18,
-                        32
-                    ]
-                ]
-            }
-        }
-    }, 'country-label-lg');
-
-    var bufferTimes = {};
-    map.on('tile.stats', function(bufferTimes) {
-        var _stats = [];
-        for (var name in bufferTimes) {
-            var value = Math.round(bufferTimes[name]);
-            if (isNaN(value)) continue;
-            var width = value;
-            _stats.push({name: name, value: value, width: width});
-        }
-        _stats = _stats.sort(function(a, b) { return b.value - a.value }).slice(0, 10);
-
-        var html = '';
-        for (var i in _stats) {
-            html += '<div style="width:' + _stats[i].width * 2 + 'px">' + _stats[i].value + 'ms - ' + _stats[i].name + '</div>';
-        }
-
-        document.getElementById('buffer').innerHTML = html;
-    });
-});
-
-map.on('click', function(e) {
-    if (e.originalEvent.shiftKey) return;
-    (new mapboxgl.Popup())
-        .setLngLat(map.unproject(e.point))
-        .setHTML("<h1>Hello World!</h1>")
-        .addTo(map);
-});
-
-document.getElementById('show-tile-boundaries-checkbox').onclick = function() {
-    map.showTileBoundaries = !!this.checked;
-};
-
-document.getElementById('show-symbol-collision-boxes-checkbox').onclick = function() {
-    map.showCollisionBoxes = !!this.checked;
-};
-
-document.getElementById('show-overdraw-checkbox').onclick = function() {
-    map.showOverdrawInspector = !!this.checked;
-};
-
-document.getElementById('buffer-checkbox').onclick = function() {
-    document.getElementById('buffer').style.display = this.checked ? 'block' : 'none';
-};
-
-document.getElementById('pitch-checkbox').onclick = function() {
-    map.dragRotate._pitchWithRotate = !!this.checked;
-};
-
-// keyboard shortcut for comparing rendering with Mapbox GL native
-document.onkeypress = function(e) {
-    if (e.charCode === 111 && !e.shiftKey && !e.metaKey && !e.altKey) {
-        var center = map.getCenter();
-        location.href = "mapboxgl://?center=" + center.lat + "," + center.lng + "&zoom=" + map.getZoom() + "&bearing=" + map.getBearing();
-        return false;
-    }
-};
 </script>
-
 </body>
 </html>

--- a/debug/markers.html
+++ b/debug/markers.html
@@ -4,7 +4,6 @@
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
@@ -27,8 +26,8 @@
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 12.5,

--- a/debug/multiple.html
+++ b/debug/multiple.html
@@ -3,8 +3,7 @@
 <head>
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
@@ -12,6 +11,7 @@
     </style>
 </head>
 
+<body>
 <div class='map'></div>
 <div class='map'></div>
 <div class='map'></div>
@@ -19,8 +19,8 @@
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var style = {
     "version": 8,
     "sources": {
@@ -78,7 +78,7 @@ function popup(e) {
         .setHTML('<h3>' + e.point.x + ', ' + e.point.y + '</h3>')
         .addTo(this);
 }
-</script>
 
+</script>
 </body>
 </html>

--- a/debug/multiple.html
+++ b/debug/multiple.html
@@ -54,29 +54,20 @@ var style = {
 };
 
 function addMap (container) {
-  var map = new mapboxgl.Map({
-    container: container,
-    minZoom: 14,
-    zoom: 15.5,
-    center: [-122.514426, 37.562984],
-    bearing: -96,
-    style: style,
-    hash: false
-  });
-  map.on('click', popup.bind(map))
+    var map = new mapboxgl.Map({
+        container: container,
+        minZoom: 14,
+        zoom: 15.5,
+        center: [-122.514426, 37.562984],
+        bearing: -96,
+        style: style,
+        hash: false
+    });
 }
 
-var containers = document.querySelectorAll('.map')
+var containers = document.querySelectorAll('.map');
 for (var i = 0; i < containers.length; i++) {
     addMap(containers[i]);
-}
-
-function popup(e) {
-    if (e.originalEvent.shiftKey) return;
-    (new mapboxgl.Popup())
-        .setLngLat(e.lngLat)
-        .setHTML('<h3>' + e.point.x + ', ' + e.point.y + '</h3>')
-        .addTo(this);
 }
 
 </script>

--- a/debug/query_features.html
+++ b/debug/query_features.html
@@ -4,7 +4,6 @@
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
@@ -14,10 +13,11 @@
 
 <body>
 <div id='map'></div>
+
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var map = new mapboxgl.Map({
     container: 'map',
     zoom: 12.5,
@@ -95,15 +95,6 @@ map.on('click', function(e) {
         });
     }
 });
-
-// keyboard shortcut for comparing rendering with Mapbox GL native
-document.onkeypress = function(e) {
-    if (e.charCode === 111 && !e.shiftKey && !e.metaKey && !e.altKey) {
-        var center = map.getCenter();
-        location.href = "mapboxgl://?center=" + center.lat + "," + center.lng + "&zoom=" + map.getZoom() + "&bearing=" + map.getBearing();
-        return false;
-    }
-};
 
 </script>
 </body>

--- a/debug/query_features.html
+++ b/debug/query_features.html
@@ -28,7 +28,7 @@ var map = new mapboxgl.Map({
 
 map.addControl(new mapboxgl.NavigationControl());
 
-var emptyFc = { type: 'FeatureCollection', features: [] }
+var emptyFc = { type: 'FeatureCollection', features: [] };
 
 map.on('style.load', function() {
     map.addSource('queried', { type: 'geojson', data: emptyFc });
@@ -65,33 +65,33 @@ map.on('click', function(e) {
     }
     if (box.length === 2) {
         var boxcoords = box
-          .map(map.unproject.bind(map))
-          .map(function (latlng) { return [latlng.lng, latlng.lat]; })
-          .sort(function (a, b) { return a[0] - b[0]; });
+            .map(map.unproject.bind(map))
+            .map(function (latlng) { return [latlng.lng, latlng.lat]; })
+            .sort(function (a, b) { return a[0] - b[0]; });
 
         boxcoords = [
-          boxcoords[0],
-          [boxcoords[0][0], boxcoords[1][1]],
-          boxcoords[1],
-          [boxcoords[1][0], boxcoords[0][1]],
-          boxcoords[0]
+            boxcoords[0],
+            [boxcoords[0][0], boxcoords[1][1]],
+            boxcoords[1],
+            [boxcoords[1][0], boxcoords[0][1]],
+            boxcoords[0]
         ];
-        var results = map.queryRenderedFeatures(box, {})
+        var results = map.queryRenderedFeatures(box, {});
         map.getSource('queried').setData({
-          type: 'FeatureCollection',
-          features: results
+            type: 'FeatureCollection',
+            features: results
         });
 
         map.getSource('boxsource').setData({
-          type: 'FeatureCollection',
-          features: [{
-            type: 'Feature',
-            properties: {},
-            geometry: {
-              type: 'LineString',
-              coordinates: boxcoords
-            }
-          }]
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                    type: 'LineString',
+                    coordinates: boxcoords
+                }
+            }]
         });
     }
 });

--- a/debug/video.html
+++ b/debug/video.html
@@ -3,8 +3,7 @@
 <head>
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
         body { margin: 0; padding: 0; }
@@ -12,12 +11,13 @@
     </style>
 </head>
 
+<body>
 <div id='map'></div>
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var videoStyle = {
     "version": 8,
     "sources": {
@@ -55,15 +55,15 @@ var videoStyle = {
 };
 
 var map = new mapboxgl.Map({
-  container: 'map',
-  minZoom: 14,
-  zoom: 17,
-  center: [-122.514426, 37.562984],
-  bearing: -96,
-  style: videoStyle,
-  hash: false
+    container: 'map',
+    minZoom: 14,
+    zoom: 17,
+    center: [-122.514426, 37.562984],
+    bearing: -96,
+    style: videoStyle,
+    hash: false
 });
-</script>
 
+</script>
 </body>
 </html>

--- a/debug/wms.html
+++ b/debug/wms.html
@@ -31,8 +31,7 @@ map.addControl(new mapboxgl.NavigationControl());
 map.on('load', function() {
     map.addSource('wms-test', {
         "type": "raster",
-        "tiles": [
-'http://geodata.state.nj.us/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&width=256&height=256&layers=Natural2015'
+        "tiles": ['http://geodata.state.nj.us/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&width=256&height=256&layers=Natural2015'
         ],
         "tileSize": 256
     });

--- a/debug/wms.html
+++ b/debug/wms.html
@@ -1,41 +1,23 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Mapbox GL JS debug page</title>
-<meta charset='utf-8'>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-<link rel='stylesheet' href='/dist/mapbox-gl.css' />
-
-<style>
-body { margin: 0; padding: 0; }
-html, body, #map { height: 100%; }
-#checkboxes {
-    position: absolute;
-    border-radius: 4px;
-    background: rgba(255,255,255,0.85);
-    top: 10px;
-    left: 10px;
-    padding: 10px;
-}
-
-#checkboxes label {
-    padding-left: 5px;
-    font: 14px sans-serif;
-}
-</style>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
 </head>
 
 <body>
 <div id='map'></div>
-<div id='checkboxes'>
-  <input id='show-tile-boundaries-checkbox' name='show-tile-boundaries' type='checkbox'> <label for='show-tile-boundaries'>tile debug</label><br />
-  <input id='show-symbol-collision-boxes-checkbox' name='show-symbol-collision-boxes' type='checkbox'> <label for='show-symbol-collision-boxes'>collision debug</label><br/>
-</div>
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
-
 <script>
+
 var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 16,
@@ -62,14 +44,6 @@ map.on('load', function() {
         "paint": {}
     });
 });
-
-document.getElementById('show-tile-boundaries-checkbox').onclick = function() {
-    map.showTileBoundaries = !!this.checked;
-};
-
-document.getElementById('show-symbol-collision-boxes-checkbox').onclick = function() {
-    map.showCollisionBoxes = !!this.checked;
-};
 
 </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "build-docs": "documentation build --github --format html --config documentation.yml --theme ./docs/_theme --output docs/api/",
     "build": "npm run build-docs # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve --watch",
-    "lint": "eslint  --ignore-path .gitignore js test bench docs/_posts/examples/*.html",
+    "lint": "eslint  --ignore-path .gitignore js test bench docs/_posts/examples/*.html debug/*.html",
     "lint-docs": "documentation lint",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "plugin-deploy": "set -e; node plugins/exists.js; aws s3 sync --exclude *.DS_Store --acl public-read plugins/src s3://mapbox-gl-js/plugins/; echo ' -- DEPLOYED --'",


### PR DESCRIPTION
- Remove bufferStats (which no longer exist), close #2281.
- Move `index.html` to `debug.html`, make `index.html` a minimal page.
- Remove debug checkboxes and native compare shortcut from other debug pages (they were mostly copypasted and don't serve any purpose).
- Add debug page linting to the `lint` task and `.eslintrc` for debug pages.
- Fix indenting/whitespace/etc. lint errors.

@lucaswoj 👀 