### PR TITLE
Fix qRF on filtered symbols

### DIFF
--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -134,7 +134,8 @@ class SymbolBucket {
         const stacks = options.glyphDependencies;
         const stack = stacks[textFont] = stacks[textFont] || {};
 
-        for (const feature of features) {
+        for (let i = 0; i < features.length; i++) {
+            const feature = features[i];
             if (!this.layers[0].filter(feature)) {
                 continue;
             }
@@ -156,7 +157,7 @@ class SymbolBucket {
             this.features.push({
                 text,
                 icon,
-                index: this.features.length,
+                index: i,
                 sourceLayerIndex: feature.sourceLayerIndex,
                 geometry: loadGeometry(feature),
                 properties: feature.properties

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#9ced2fae7dee417d8d0fef90641f0cf973ebf2f6",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#a6034b0c94b560cf4df971da2b6dac99081adc46",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#a0b0e3be927dff9a01b0869a4d0b41c830370388",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#9ced2fae7dee417d8d0fef90641f0cf973ebf2f6",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
This fixes https://github.com/mapbox/mapbox-gl-js/issues/3591

This bug was introduced in https://github.com/mapbox/mapbox-gl-js/pull/3418. Calling `queryRenderedFeatures` on symbols within filtered layers is no bueno because we assign their indices based on the _unfiltered_ feature array. Added a test case to catch regressions in the future. 

ref https://github.com/mapbox/mapbox-gl-test-suite/pull/167

cc @ansis @jfirebaugh @mapsam @mourner 
