### PR TITLE
Update doc types from Control to IControl

### DIFF
--- a/documentation.yml
+++ b/documentation.yml
@@ -50,7 +50,7 @@ toc:
     description: |
       This event functionality is used by Mapbox GL JS itself
       and can be useful to other developers who want to create
-      [Controls](#Control) or other extensions.
+      [IControls](#IControl) or other extensions.
   - Evented
   - MapMouseEvent
   - MapTouchEvent

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -212,9 +212,9 @@ class Map extends Camera {
     }
 
     /**
-     * Adds a [`Control`](#Control) to the map, calling `control.onAdd(this)`.
+     * Adds a [`IControl`](#IControl) to the map, calling `control.onAdd(this)`.
      *
-     * @param {Control} control The [`Control`](#Control) to add.
+     * @param {IControl} control The [`IControl`](#IControl) to add.
      * @param {string} [position='top-right'] position on the map to which the control will be added.
      * valid values are 'top-left', 'top-right', 'bottom-left', and 'bottom-right'
      * @returns {Map} `this`
@@ -240,7 +240,7 @@ class Map extends Camera {
     /**
      * Removes the control from the map.
      *
-     * @param {Control} control The [`Control`](#Control) to add.
+     * @param {IControl} control The [`IControl`](#IControl) to add.
      * @returns {Map} `this`
      */
     removeControl(control) {

--- a/plugins/src/mapbox-gl-directions/v2.2.0/mapbox-gl-directions.js
+++ b/plugins/src/mapbox-gl-directions/v2.2.0/mapbox-gl-directions.js
@@ -6688,7 +6688,7 @@ var Directions = function () {
     /**
      * Removes the control from the map it has been added to.
      *
-     * @returns {Control} `this`
+     * @returns {IControl} `this`
      */
 
   }, {


### PR DESCRIPTION
The `Control` type was renamed to `IControl` in v0.27.0, this PR updates references to the correct type.

Issue: #3613