### PR TITLE
Redo placement only for vector/geojson sources

### DIFF
--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -128,6 +128,10 @@ class Tile {
     }
 
     redoPlacement(source) {
+        if (source.type !== 'vector' && source.type !== 'geojson') {
+            return;
+        }
+
         if (this.state !== 'loaded' || this.state === 'reloading') {
             this.redoWhenDone = true;
             return;

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -683,7 +683,7 @@ class Style extends Evented {
 
     _redoPlacement() {
         for (const id in this.sourceCaches) {
-            if (this.sourceCaches[id].redoPlacement) this.sourceCaches[id].redoPlacement();
+            this.sourceCaches[id].redoPlacement();
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#e8092b401c1048112ce56dcec96bb0d66926e01d",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#4c409c0a7b83b1eccdb9888d6e6da4290f9e28ea",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
Fix #3614.

It looks like this regressed some time ago, possibly with the introduction of `SourceCache`. The assertions added in 26f04999c330094984910f2e5cf04015fb6b9192 made it a hard error (in debug builds), but the issue existed before that.

Filed #3623 for a followup issue I noticed.