### PR TITLE
Fix #3612 (opaque fills on top of transparent fills not rendering correctly)

### DIFF
--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -80,7 +80,9 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
     const rotateWithMap = rotationAlignment === 'map';
     const pitchWithMap = pitchAlignment === 'map';
 
-    if (pitchWithMap) {
+    let depthOn = pitchWithMap;
+
+    if (depthOn) {
         gl.enable(gl.DEPTH_TEST);
     } else {
         gl.disable(gl.DEPTH_TEST);
@@ -112,6 +114,8 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         drawTileSymbols(program, painter, layer, tile, buffers, isText, isSDF,
                 pitchWithMap, size, haloWidth, haloColor, haloBlur, color);
     }
+
+    if (!depthOn) gl.enable(gl.DEPTH_TEST);
 }
 
 function setSymbolDrawState(program, painter, isText, isSDF, rotateWithMap, pitchWithMap, fontstack, size,

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -80,7 +80,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
     const rotateWithMap = rotationAlignment === 'map';
     const pitchWithMap = pitchAlignment === 'map';
 
-    let depthOn = pitchWithMap;
+    const depthOn = pitchWithMap;
 
     if (depthOn) {
         gl.enable(gl.DEPTH_TEST);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#daed4f70dc47fa660f169cd52091716852aea811",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#e8092b401c1048112ce56dcec96bb0d66926e01d",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
This fixes https://github.com/mapbox/mapbox-gl-js/issues/3612 which was introduced in https://github.com/mapbox/mapbox-gl-js/commit/10d98cfb247e7c0e2444bdd5839e41d5f2b7c5e6#diff-6709b06e8fd7021244319a5b88e5308fL106 — we lost a gl state call to re-enable depth testing after being disabled in symbol rendering.

Regression test added in https://github.com/mapbox/mapbox-gl-test-suite/pull/171.

cc @lucaswoj 