### PR TITLE
Update test-suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#4c409c0a7b83b1eccdb9888d6e6da4290f9e28ea",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7f9f6837dd8e7c595d684680c69da0880e07d7eb",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
Follows the rendering expectation update for `regressions/mapbox-gl-js#3612` in sync with -native (https://github.com/mapbox/mapbox-gl-native/pull/7007).

/cc @jfirebaugh 