### PR TITLE
Remove paint class support

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -166,10 +166,6 @@ const defaultOptions = {
  *   bearing (rotation) will snap to north. For example, with a `bearingSnap` of 7, if the user rotates
  *   the map within 7 degrees of north, the map will automatically snap to exact north.
  * @param {boolean} [options.pitchWithRotate=true] If `false`, the map's pitch (tilt) control with "drag to rotate" interaction will be disabled.
- * @param {Array<string>} [options.classes] Mapbox style class names with which to initialize the map.
- *   Keep in mind that these classes are used for controlling a style layer's paint properties, so are *not* reflected
- *   in an HTML element's `class` attribute. To learn more about Mapbox style classes, read about
- *   [Layers](https://www.mapbox.com/mapbox-gl-style-spec/#layers) in the style specification.
  * @param {boolean} [options.attributionControl=true] If `true`, an {@link AttributionControl} will be added to the map.
  * @param {string} [options.logoPosition='bottom-left'] A string representing the position of the Mapbox wordmark on the map. Valid options are `top-left`,`top-right`, `bottom-left`, `bottom-right`.
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the performance of Mapbox
@@ -333,11 +329,8 @@ class Map extends Camera {
             });
         }
 
-        this._classes = [];
-
         this.resize();
 
-        if (options.classes) this.setClasses(options.classes);
         if (options.style) this.setStyle(options.style, { localIdeographFontFamily: options.localIdeographFontFamily });
 
         if (options.attributionControl) this.addControl(new AttributionControl());
@@ -347,7 +340,7 @@ class Map extends Camera {
             if (this.transform.unmodified) {
                 this.jumpTo(this.style.stylesheet);
             }
-            this.style.update(this._classes, {transition: false});
+            this.style.update({transition: false});
         });
 
         this.on('data', this._onData);
@@ -389,103 +382,6 @@ class Map extends Camera {
     removeControl(control: IControl) {
         control.onRemove(this);
         return this;
-    }
-
-    /**
-     * Adds a Mapbox style class to the map.
-     *
-     * Keep in mind that these classes are used for controlling a style layer's paint properties, so are *not* reflected
-     * in an HTML element's `class` attribute. To learn more about Mapbox style classes, read about
-     * [Layers](https://www.mapbox.com/mapbox-gl-style-spec/#layers) in the style specification.
-     *
-     * **Note:** Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.
-     *
-     * @param {string} klass The style class to add.
-     * @param {Object} [options]
-     * @param {boolean} [options.transition] If `true`, property changes will smoothly transition.
-     * @fires change
-     * @returns {Map} `this`
-     */
-    addClass(klass: string, options: ?{transition: boolean}) {
-        util.warnOnce('Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.');
-        if (this._classes.indexOf(klass) >= 0 || klass === '') return this;
-        this._classes.push(klass);
-        this._classOptions = options;
-
-        if (this.style) this.style.updateClasses();
-        return this._update(true);
-    }
-
-    /**
-     * Removes a Mapbox style class from the map.
-     *
-     * **Note:** Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.
-     *
-     * @param {string} klass The style class to remove.
-     * @param {Object} [options]
-     * @param {boolean} [options.transition] If `true`, property changes will smoothly transition.
-     * @fires change
-     * @returns {Map} `this`
-     */
-    removeClass(klass: string, options: ?{transition: boolean}) {
-        util.warnOnce('Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.');
-        const i = this._classes.indexOf(klass);
-        if (i < 0 || klass === '') return this;
-        this._classes.splice(i, 1);
-        this._classOptions = options;
-
-        if (this.style) this.style.updateClasses();
-        return this._update(true);
-    }
-
-    /**
-     * Replaces the map's existing Mapbox style classes with a new array of classes.
-     *
-     * **Note:** Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.
-     *
-     * @param {Array<string>} klasses The style classes to set.
-     * @param {Object} [options]
-     * @param {boolean} [options.transition] If `true`, property changes will smoothly transition.
-     * @fires change
-     * @returns {Map} `this`
-     */
-    setClasses(klasses: Array<string>, options: ?{transition: boolean}) {
-        util.warnOnce('Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.');
-        const uniqueClasses = {};
-        for (let i = 0; i < klasses.length; i++) {
-            if (klasses[i] !== '') uniqueClasses[klasses[i]] = true;
-        }
-        this._classes = Object.keys(uniqueClasses);
-        this._classOptions = options;
-
-        if (this.style) this.style.updateClasses();
-        return this._update(true);
-    }
-
-    /**
-     * Returns a Boolean indicating whether the map has the
-     * specified Mapbox style class.
-     *
-     * **Note:** Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.
-     *
-     * @param {string} klass The style class to test.
-     * @returns {boolean} `true` if the map has the specified style class.
-     */
-    hasClass(klass: string) {
-        util.warnOnce('Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.');
-        return this._classes.indexOf(klass) >= 0;
-    }
-
-    /**
-     * Returns the map's Mapbox style classes.
-     *
-     * **Note:** Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.
-     *
-     * @returns {Array<string>} The map's style classes.
-     */
-    getClasses() {
-        util.warnOnce('Style classes are deprecated and will be removed in an upcoming release of Mapbox GL JS.');
-        return this._classes;
     }
 
     /**
@@ -1301,7 +1197,6 @@ class Map extends Camera {
      * @param {string} name The name of the paint property to set.
      * @param {*} value The value of the paint propery to set.
      *   Must be of a type appropriate for the property, as defined in the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/).
-     * @param {string=} klass A style class specifier for the paint property.
      * @returns {Map} `this`
      * @example
      * map.setPaintProperty('my-layer', 'fill-color', '#faafee');
@@ -1309,8 +1204,8 @@ class Map extends Camera {
      * @see [Adjust a layer's opacity](https://www.mapbox.com/mapbox-gl-js/example/adjust-layer-opacity/)
      * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
-    setPaintProperty(layer: string, name: string, value: any, klass?: string) {
-        this.style.setPaintProperty(layer, name, value, klass);
+    setPaintProperty(layer: string, name: string, value: any) {
+        this.style.setPaintProperty(layer, name, value);
         this._update(true);
         return this;
     }
@@ -1320,11 +1215,10 @@ class Map extends Camera {
      *
      * @param {string} layer The ID of the layer to get the paint property from.
      * @param {string} name The name of a paint property to get.
-     * @param {string=} klass A class specifier for the paint property.
      * @returns {*} The value of the specified paint property.
      */
-    getPaintProperty(layer: string, name: string, klass?: string) {
-        return this.style.getPaintProperty(layer, name, klass);
+    getPaintProperty(layer: string, name: string) {
+        return this.style.getPaintProperty(layer, name);
     }
 
     /**
@@ -1552,8 +1446,7 @@ class Map extends Camera {
         //  - Recalculate zoom-dependent paint properties.
         if (this.style && this._styleDirty) {
             this._styleDirty = false;
-            this.style.update(this._classes, this._classOptions);
-            this._classOptions = null;
+            this.style.update();
             this.style._recalculate(this.transform.zoom);
         }
 

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1524,7 +1524,7 @@ test('Style#queryRenderedFeatures', (t) => {
     });
 
     style.on('style.load', () => {
-        style._applyClasses([]);
+        style._applyPaintPropertyUpdates();
         style._recalculate(0);
 
         t.test('returns feature type', (t) => {

--- a/test/unit/style/style_layer.test.js
+++ b/test/unit/style/style_layer.test.js
@@ -31,61 +31,6 @@ test('StyleLayer#updatePaintTransition', (t) => {
         t.end();
     });
 
-    t.test('updates paint transition with class', (t) => {
-        const layer = StyleLayer.create({
-            "id": "background",
-            "type": "background",
-            "paint": {
-                "background-color": "red"
-            },
-            "paint.mapbox": {
-                "background-color": "blue"
-            }
-        });
-        layer.updatePaintTransition('background-color', ['mapbox'], {});
-        t.deepEqual(layer.getPaintValue('background-color'), [0, 0, 1, 1]);
-        t.end();
-    });
-
-    t.test('updates paint transition with extraneous class', (t) => {
-        const layer = StyleLayer.create({
-            "id": "background",
-            "type": "background",
-            "paint": {
-                "background-color": "red"
-            }
-        });
-        layer.updatePaintTransition('background-color', ['mapbox'], {});
-        t.deepEqual(layer.getPaintValue('background-color'), [1, 0, 0, 1]);
-        t.end();
-    });
-
-    t.end();
-});
-
-test('StyleLayer#updatePaintTransitions', (t) => {
-    t.test('respects classes regardless of layer properties order', (t) => {
-        const layer = StyleLayer.create({
-            "id": "background",
-            "type": "fill",
-            "paint.blue": {
-                "fill-color": "#8ccbf7",
-                "fill-opacity": 1
-            },
-            "paint": {
-                "fill-opacity": 0
-            }
-        });
-
-        layer.updatePaintTransitions([], {transition: false}, null, createAnimationLoop());
-        t.equal(layer.getPaintValue('fill-opacity'), 0);
-
-        layer.updatePaintTransitions(['blue'], {transition: false}, null, createAnimationLoop());
-        t.equal(layer.getPaintValue('fill-opacity'), 1);
-
-        t.end();
-    });
-
     t.end();
 });
 
@@ -138,46 +83,6 @@ test('StyleLayer#setPaintProperty', (t) => {
         t.end();
     });
 
-    t.test('sets classed paint value', (t) => {
-        const layer = StyleLayer.create({
-            "id": "background",
-            "type": "background",
-            "paint.night": {
-                "background-color": "red"
-            }
-        });
-
-        layer.setPaintProperty('background-color', 'blue', 'night');
-
-        t.deepEqual(layer.getPaintProperty('background-color', 'night'), 'blue');
-        t.end();
-    });
-
-    t.test('unsets classed paint value', (t) => {
-        const layer = StyleLayer.create({
-            "id": "background",
-            "type": "background",
-            "paint": {
-                "background-color": "red",
-                "background-opacity": 1
-            },
-            "paint.night": {
-                "background-color": "blue",
-                "background-opacity": 0.1
-            }
-        });
-        layer.updatePaintTransitions(['night'], {transition: false}, null, createAnimationLoop());
-        t.deepEqual(layer.getPaintProperty('background-color', 'night'), 'blue');
-        t.deepEqual(layer.getPaintValue('background-color'), [0, 0, 1, 1]);
-
-        layer.setPaintProperty('background-color', null, 'night');
-        layer.updatePaintTransitions(['night'], {transition: false}, null, createAnimationLoop());
-        t.deepEqual(layer.getPaintValue('background-color'), [1, 0, 0, 1]);
-        t.equal(layer.getPaintProperty('background-color', 'night'), undefined);
-
-        t.end();
-    });
-
     t.test('preserves existing transition', (t) => {
         const layer = StyleLayer.create({
             "id": "background",
@@ -208,21 +113,6 @@ test('StyleLayer#setPaintProperty', (t) => {
         layer.setPaintProperty('background-color-transition', {duration: 400});
 
         t.deepEqual(layer.getPaintProperty('background-color-transition'), {duration: 400});
-        t.end();
-    });
-
-    t.test('sets transition with a class name equal to the property name', (t) => {
-        const layer = StyleLayer.create({
-            "id": "background",
-            "type": "background",
-            "paint": {
-                "background-color": "red"
-            }
-        });
-
-        layer.setPaintProperty('background-color-transition', {duration: 400}, 'background-color');
-        layer.updatePaintTransitions([], {transition: false}, null, createAnimationLoop());
-        t.deepEqual(layer.getPaintProperty('background-color-transition', 'background-color'), {duration: 400});
         t.end();
     });
 
@@ -421,19 +311,6 @@ test('StyleLayer#serialize', (t) => {
         t.deepEqual(
             StyleLayer.create(createSymbolLayer()).serialize(),
             createSymbolLayer()
-        );
-        t.end();
-    });
-
-    t.test('serializes layers with paint classes', (t) => {
-        const layer = createSymbolLayer({
-            'paint.night': {
-                'text-color': 'orange'
-            }
-        });
-        t.deepEqual(
-            StyleLayer.create(layer).serialize(),
-            layer
         );
         t.end();
     });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1271,47 +1271,6 @@ test('Map', (t) => {
     t.end();
 });
 
-test('Map deprecated methods', (t) => {
-    t.test('#addClass', (t) => {
-        t.stub(console, 'warn');
-        const map = createMap();
-        map.addClass('night');
-        t.ok(map.hasClass('night'));
-        t.end();
-    });
-
-    t.test('#removeClass', (t) => {
-        t.stub(console, 'warn');
-        const map = createMap();
-        map.addClass('night');
-        map.removeClass('night');
-        t.ok(!map.hasClass('night'));
-        t.end();
-    });
-
-    t.test('#setClasses', (t) => {
-        t.stub(console, 'warn');
-        const map = createMap();
-        map.addClass('night');
-        map.setClasses([]);
-        t.ok(!map.hasClass('night'));
-
-        map.setClasses(['night']);
-        t.ok(map.hasClass('night'));
-        t.end();
-    });
-
-    t.test('#getClasses', (t) => {
-        t.stub(console, 'warn');
-        const map = createMap();
-        map.addClass('night');
-        t.deepEqual(map.getClasses(), ['night']);
-        t.end();
-    });
-
-    t.end();
-});
-
 function createStyle() {
     return {
         version: 8,


### PR DESCRIPTION
Prerequisites:
 - [x] Merge upstream PR #3621 and then rebase here
 - [x] `-test-suite`: merge https://github.com/mapbox/mapbox-gl-test-suite/pull/178 (Ignore paint class tests in gl-js) 
 - [x] `-style-spec`: merge https://github.com/mapbox/mapbox-gl-style-spec/pull/576 (update docs and spec)
 - [x] Fix bug wherein unsetting and resetting fill-outline-color causes TypeError to be thrown https://github.com/mapbox/mapbox-gl-js/issues/3657
 - [ ] Add setStyle examples to the docs #3660 

**UPDATE:** Removed https://github.com/mapbox/mapbox-gl-js/pull/3662#issuecomment-273650393 from the prerequisites, in light of `setSprite` being (a) orthogonal to paint classes, and (b) a pretty complicated / significant lift.