### PR TITLE
Add style#setSprite method

### DIFF
--- a/debug/dark-v9.js
+++ b/debug/dark-v9.js
@@ -85,7 +85,7 @@ window.darkv9 = {
       "type": "vector"
     }
   },
-  "sprite": "mapbox://sprites/mapbox/light-v9",
+  "sprite": "mapbox://sprites/mapbox/dark-v9",
   "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
   "layers": [
     {

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -34,9 +34,9 @@ const supportedDiffOperations = util.pick(diff.operations, [
     'removeSource',
     'setLayerZoomRange',
     'setLight',
-    'setTransition'
+    'setTransition',
+    'setSprite'
     // 'setGlyphs',
-    // 'setSprite',
 ]);
 
 const ignoredDiffOperations = util.pick(diff.operations, [
@@ -94,8 +94,7 @@ class Style extends Evented {
             }
 
             if (stylesheet.sprite) {
-                this.sprite = new ImageSprite(stylesheet.sprite);
-                this.sprite.setEventedParent(this);
+                this.setSprite(stylesheet.sprite);
             }
 
             this.glyphSource = new GlyphSource(stylesheet.glyphs);
@@ -312,6 +311,8 @@ class Style extends Evented {
 
         this._updatedPaintProps = {};
         this._updatedAllPaintProps = false;
+
+        this._updatedSprite = false;
     }
 
     /**
@@ -776,6 +777,23 @@ class Style extends Evented {
     _redoPlacement() {
         for (const id in this.sourceCaches) {
             this.sourceCaches[id].redoPlacement();
+        }
+    }
+
+    setSprite(sprite) {
+        if (this.sprite) {
+            this.sprite.setEventedParent(null);
+            this.spriteAtlas = new SpriteAtlas(1024, 1024);
+        }
+        this.sprite = new ImageSprite(sprite);
+        this.sprite.setEventedParent(this);
+        this._updatedSprite = true;
+
+        for (const layerId in this._layers) {
+            const layer = this._layers[layerId];
+            if (layer.type === 'symbol' && !this._updatedSources[layer.source]) {
+                this._updatedSources[layer.source] = 'reload';
+            }
         }
     }
 


### PR DESCRIPTION
⚠️ *note the base branch* of this PR is `smart-set-style` (https://github.com/mapbox/mapbox-gl-js/pull/3621), not `master` ⚠️ 

Closes #2058 

This turned out to be simpler than I thought (unless I'm missing something).  Render tests, including the new set-style runtime styling tests, still pass, and the light/dark setStyle debug page works, now with changing `sprite` URIs.