### PR TITLE
Fix attribution position example

### DIFF
--- a/docs/_posts/examples/3400-01-15-attribution-position.html
+++ b/docs/_posts/examples/3400-01-15-attribution-position.html
@@ -14,8 +14,7 @@ var map = new mapboxgl.Map({
     style: 'mapbox://styles/mapbox/light-v9',
     center: [-77.04, 38.907],
     zoom: 11.15,
-    attributionControl: {
-        position: 'top-left'
-    }
+    attributionControl: false
 });
+map.addControl(new mapboxgl.AttributionControl(), 'top-left');
 </script>


### PR DESCRIPTION
## Launch Checklist

This updating examples for the new control API: the `attributionControl` map constructor option previously supported an options argument but never documented this usage. The new API has the code follow the documentation, so the correct way to place an attributionControl elsewhere is with the addControl API.

cc @mapsam for the review