### PR TITLE
Implement TileJSON bounds property

### DIFF
--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -319,6 +319,10 @@ class SourceCache extends Evented {
                 roundZoom: this._source.roundZoom,
                 reparseOverscaled: this._source.reparseOverscaled
             });
+
+            if (this._source.hasTile) {
+                visibleCoords = visibleCoords.filter((coord) => this._source.hasTile(coord));
+            }
         }
 
         for (i = 0; i < visibleCoords.length; i++) {

--- a/js/source/tile_bounds.js
+++ b/js/source/tile_bounds.js
@@ -1,0 +1,40 @@
+const LngLatBounds = require('../geo/lng_lat_bounds');
+const clamp = require('../util/util').clamp;
+
+class TileBounds {
+  constructor(bounds, minzoom, maxzoom) {
+    this.bounds = LngLatBounds.convert(bounds);
+    this.minzoom = minzoom || 0;
+    this.maxzoom = maxzoom || 24;
+    this.cache = {};
+    this.updateCache();
+  }
+
+  contains(coord) {
+    const level = this.cache[coord.z];
+    let hit = coord.x >= level[0][0] && coord.x < level[1][0] && coord.y >= level[0][1] && coord.y < level[1][1];
+    return hit;
+  }
+
+  updateCache() {
+    for (let i = this.minzoom; i <= this.maxzoom; i++) {
+      this.cache[i] = [
+        [Math.floor(this.lngX(this.bounds.getWest(), i)), Math.floor(this.latY(this.bounds.getNorth(), i))],
+        [Math.ceil(this.lngX(this.bounds.getEast(), i)), Math.ceil(this.latY(this.bounds.getSouth(), i))]
+      ]
+    }
+  }
+
+  lngX(lng, zoom) {
+    return (lng + 180) * (Math.pow(2, zoom) / 360);
+  }
+
+  latY(lat, zoom) {
+    let f = clamp(Math.sin(Math.PI / 180 * lat), -0.9999, 0.9999);
+    let scale = Math.pow(2, zoom) / (2 * Math.PI);
+    return Math.pow(2, zoom-1) + 0.5 * Math.log((1 + f) / (1 - f)) * -scale;
+    return y;
+  }
+}
+
+module.exports = TileBounds;


### PR DESCRIPTION
This is rough code to implement the bounds property in TileJSON to prevent loading/rendering tile data outside an extent.  This functionality is useful for eliminating useless network roundtrips (that either result in 404 or an empty response) and eliminating lots and lots of error messages in the console in such a situation.  Addresses #1775 and probably others.

If someone can confirm this is something you'd accept and 👍 the approach, I'll clean it up for inclusion.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page

