### PR TITLE
Use a more helpful error message when Map options.container doesn't exist in the document

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -139,6 +139,7 @@ class Map extends Camera {
 
         if (typeof options.container === 'string') {
             this._container = window.document.getElementById(options.container);
+            if (!this._container) throw new Error(`Container '${options.container}' not found.`);
         } else {
             this._container = options.container;
         }

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -56,6 +56,11 @@ test('Map', (t) => {
         t.ok(map.keyboard.isEnabled());
         t.ok(map.scrollZoom.isEnabled());
         t.ok(map.touchZoomRotate.isEnabled());
+        t.throws(() => {
+            new Map({
+                container: 'anElementIdWhichDoesNotExistInTheDocument'
+            });
+        }, new Error("Container 'anElementIdWhichDoesNotExistInTheDocument' not found"), 'throws on invalid map container id');
         t.end();
     });
 


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

Currently if create a new Map but pass in an element ID to `options.container` which doesn't actually exist in the document, the console will log the error:

    Uncaught TypeError: Cannot read property 'classList' of null

I suggest we use a more helpful error message

    Uncaught Error: No element found in the document with ID '${options.container}' as specified as the container in the map constructor.

 - [x] write tests for all new functionality

Although the test I added just checks that an Error is thrown not the exact message, but an Error was already thrown before, so the test I added actually passes without this change.

 - [x] document any changes to public APIs

None.

 - [ ] post benchmark scores

Shouldn't affect benchmarks.

 - [x] manually test the debug page

Manually tested.