### PR TITLE
Refactor transform

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -224,11 +224,6 @@ class Transform {
         return 360 / Math.PI * Math.atan(Math.exp(y2 * Math.PI / 180)) - 90;
     }
 
-    panBy(offset) {
-        const point = this.centerPoint._add(offset);
-        this.center = this.pointLocation(point);
-    }
-
     setLocationAtPoint(lnglat, point) {
         const c = this.locationCoordinate(lnglat);
         const coordAtPoint = this.pointCoordinate(point);

--- a/js/source/tile_coord.js
+++ b/js/source/tile_coord.js
@@ -32,7 +32,7 @@ class TileCoord {
     }
 
     toCoordinate(sourceMaxZoom) {
-        const zoom = Math.min(this.z, sourceMaxZoom);
+        const zoom = Math.min(this.z, sourceMaxZoom === undefined ? this.z : sourceMaxZoom);
         const tileScale = Math.pow(2, zoom);
         const row = this.y;
         const column = this.x + tileScale * this.w;

--- a/js/ui/camera.js
+++ b/js/ui/camera.js
@@ -621,7 +621,6 @@ class Camera extends Evented {
             from = tr.point,
             to = 'center' in options ? tr.project(center).sub(offset.div(scale)) : from;
 
-        const startWorldSize = tr.worldSize;
         let rho = options.curve;
 
             // w₀: Initial visible span, measured in pixels at the initial scale.
@@ -708,8 +707,9 @@ class Camera extends Evented {
             const s = k * S,
                 us = u(s);
 
-            tr.zoom = startZoom + tr.scaleZoom(1 / w(s));
-            tr.center = tr.unproject(from.add(to.sub(from).mult(us)), startWorldSize);
+            const scale = 1 / w(s);
+            tr.zoom = startZoom + tr.scaleZoom(scale);
+            tr.center = tr.unproject(from.add(to.sub(from).mult(us)).mult(scale));
 
             if (this.rotating) {
                 tr.bearing = interpolate(startBearing, bearing, k);

--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -52,16 +52,6 @@ test('transform', (t) => {
         t.end();
     });
 
-    t.test('panBy', (t) => {
-        const transform = new Transform();
-        transform.resize(500, 500);
-        transform.latRange = undefined;
-        t.deepEqual(transform.center, { lng: 0, lat: 0 });
-        t.equal(transform.panBy(new Point(10, 10)), undefined);
-        t.deepEqual(fixedLngLat(transform.center), fixedLngLat({ lng: 7.03125, lat: -7.01366792756663 }));
-        t.end();
-    });
-
     t.test('setLocationAt', (t) => {
         const transform = new Transform();
         transform.resize(500, 500);


### PR DESCRIPTION
Various clean up and simplification in transform code. As a side-effect, improves performance of `locationPoint` and related methods:

```
# before
locationPoint x 3,028,354 ops/sec ±0.82% (85 runs sampled)
pointLocation x 4,866,038 ops/sec ±1.07% (84 runs sampled)

# after
locationPoint x 4,814,249 ops/sec ±0.72% (89 runs sampled)
pointLocation x 4,535,500 ops/sec ±0.93% (90 runs sampled)
```

👀 @lucaswoj 