### PR TITLE
Fix "Map#moveLayer" docs

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -771,12 +771,12 @@ class Map extends Camera {
      * Moves a layer to a different z-position.
      *
      * @param {string} id The ID of the layer to move.
-     * @param {string} [before] The ID of an existing layer to insert the new layer before.
+     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before.
      *   If this argument is omitted, the layer will be appended to the end of the layers array.
      * @returns {Map} `this`
      */
-    moveLayer(layerId, before) {
-        this.style.moveLayer(layerId, before);
+    moveLayer(id, beforeId) {
+        this.style.moveLayer(id, beforeId);
         this._update(true);
         return this;
     }


### PR DESCRIPTION
Note that both `id` and `layerId` are displayed here. 

<img width="694" alt="screen shot 2016-12-01 at 3 34 54 pm" src="https://cloud.githubusercontent.com/assets/281306/20817316/bac99e5c-b7db-11e6-92b3-be206eca61d3.png">
