### PR TITLE
Fallback of original jsdom HTML Canvas getContext

### DIFF
--- a/js/util/window.js
+++ b/js/util/window.js
@@ -30,12 +30,19 @@ function restore() {
     window.HTMLElement.prototype.clientLeft = 0;
     window.HTMLElement.prototype.clientTop = 0;
 
-    window.HTMLCanvasElement.prototype.getContext = function(type, attributes) {
-        if (!this._webGLContext) {
+    window.HTMLCanvasElement.prototype.getContext = (function () {
+      let original = window.HTMLCanvasElement.prototype.getContext;
+      return function (type, attributes) {
+        if (type === 'webgl') {
+          if (!this._webGLContext) {
             this._webGLContext = gl(this.width, this.height, attributes);
+          }
+          return this._webGLContext;
         }
-        return this._webGLContext;
-    };
+        original = original.bind(this);
+        return original(type, attributes);
+      };
+    }());
 
     window.useFakeXMLHttpRequest = function() {
         sinon.xhr.supportsCORS = true;

--- a/js/util/window.js
+++ b/js/util/window.js
@@ -31,17 +31,17 @@ function restore() {
     window.HTMLElement.prototype.clientTop = 0;
 
     window.HTMLCanvasElement.prototype.getContext = (function () {
-      let original = window.HTMLCanvasElement.prototype.getContext;
-      return function (type, attributes) {
-        if (type === 'webgl') {
-          if (!this._webGLContext) {
-            this._webGLContext = gl(this.width, this.height, attributes);
-          }
-          return this._webGLContext;
-        }
-        original = original.bind(this);
-        return original(type, attributes);
-      };
+        let original = window.HTMLCanvasElement.prototype.getContext;
+        return function (type, attributes) {
+            if (type === 'webgl') {
+                if (!this._webGLContext) {
+                    this._webGLContext = gl(this.width, this.height, attributes);
+                }
+                return this._webGLContext;
+            }
+            original = original.bind(this);
+            return original(type, attributes);
+        };
     }());
 
     window.useFakeXMLHttpRequest = function() {

--- a/js/util/window.js
+++ b/js/util/window.js
@@ -30,19 +30,18 @@ function restore() {
     window.HTMLElement.prototype.clientLeft = 0;
     window.HTMLElement.prototype.clientTop = 0;
 
-    window.HTMLCanvasElement.prototype.getContext = (function () {
-        let original = window.HTMLCanvasElement.prototype.getContext;
-        return function (type, attributes) {
-            if (type === 'webgl') {
-                if (!this._webGLContext) {
-                    this._webGLContext = gl(this.width, this.height, attributes);
-                }
-                return this._webGLContext;
+    // Add webgl context with the supplied GL
+    const originalGetContext = window.HTMLCanvasElement.prototype.getContext;
+    window.HTMLCanvasElement.prototype.getContext = function (type, attributes) {
+        if (type === 'webgl') {
+            if (!this._webGLContext) {
+                this._webGLContext = gl(this.width, this.height, attributes);
             }
-            original = original.bind(this);
-            return original(type, attributes);
-        };
-    }());
+            return this._webGLContext;
+        }
+        // Fallback to existing HTMLCanvasElement getContext behaviour
+        return originalGetContext.call(this, type, attributes);
+    };
 
     window.useFakeXMLHttpRequest = function() {
         sinon.xhr.supportsCORS = true;


### PR DESCRIPTION
Hi Guys, 

Submitting this PR. 

Motivation is that the current prototype affects HTMLCanvasElement to only supports 'webgl' context. If your current jsdom HTMLCanvasElement supports additional context (such as '2d' using node-canvas) the new PR will still support the context that is supported by the original window prototype. 

Scenario; If you try to create a mapboxgl.Map instance (in nodejs) with a mapbox style that has 2D context requirements, you will get an exception "context.drawImage is not a function". The jsdom supplied HTMLCanvasElement though could support other canvas context, but as this method forces context to only support webgl you will get TypeErrors thrown from inside Mapbox GL JS.

The PR works by falling back to the support of the current HTMLCanvasElement for any other context requests.

Thanks
Cam

