### PR TITLE
Use a custom gl-matrix build

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -7,7 +7,7 @@ const LngLat = require('./lng_lat'),
     interp = require('../util/interpolate'),
     TileCoord = require('../source/tile_coord'),
     EXTENT = require('../data/extent'),
-    glmatrix = require('gl-matrix');
+    glmatrix = require('@mapbox/gl-matrix');
 
 const vec4 = glmatrix.vec4,
     mat4 = glmatrix.mat4,

--- a/js/render/draw_debug.js
+++ b/js/render/draw_debug.js
@@ -2,7 +2,7 @@
 
 const textVertices = require('../lib/debugtext');
 const browser = require('../util/browser');
-const mat4 = require('gl-matrix').mat4;
+const mat4 = require('@mapbox/gl-matrix').mat4;
 const EXTENT = require('../data/extent');
 const Buffer = require('../data/buffer');
 const VertexArrayObject = require('./vertex_array_object');

--- a/js/render/draw_fill_extrusion.js
+++ b/js/render/draw_fill_extrusion.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const mat3 = require('gl-matrix').mat3;
-const mat4 = require('gl-matrix').mat4;
-const vec3 = require('gl-matrix').vec3;
+const glMatrix = require('@mapbox/gl-matrix');
 const Buffer = require('../data/buffer');
 const VertexArrayObject = require('./vertex_array_object');
 const PosArray = require('../data/pos_array');
 const pattern = require('./pattern');
+const mat3 = glMatrix.mat3;
+const mat4 = glMatrix.mat4;
+const vec3 = glMatrix.vec3;
 
 module.exports = draw;
 

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const browser = require('../util/browser');
-const mat4 = require('gl-matrix').mat4;
+const mat4 = require('@mapbox/gl-matrix').mat4;
 const FrameHistory = require('./frame_history');
 const SourceCache = require('../source/source_cache');
 const EXTENT = require('../data/extent');

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
+    "@mapbox/gl-matrix": "^0.0.1",
     "bubleify": "^0.5.1",
     "csscolorparser": "^1.0.2",
     "earcut": "^2.0.3",
@@ -19,7 +20,6 @@
     "flow-remove-types": "^1.0.4",
     "geojson-rewind": "^0.1.0",
     "geojson-vt": "^2.4.0",
-    "gl-matrix": "^2.3.1",
     "grid-index": "^1.0.0",
     "mapbox-gl-function": "mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#26733535ba2f1b164dd6a231d4d1868c3218eafd",


### PR DESCRIPTION
I made a ES6 fork of gl-matrix to be able to make customized builds here: https://github.com/mapbox/gl-matrix

The `mapbox` branch [configuration](https://github.com/mapbox/gl-matrix/blob/mapbox/src/mapbox-build.js) includes just the stuff needed by GL JS, and I published this version as `@mapbox/gl-matrix@0.0.1`. Resulting build sizes:

File | Original | New | Original (gz) | New (gz)
--- | --- | --- | --- | ---
mapbox-gl.js | 520.73KB | 471.02KB | 133.38KB | 122.21KB
mapbox-gl-dev.js | 3.69MB | 3.27MB | 785.75KB | 719.95KB

cc @jfirebaugh @lucaswoj @tmcw 