### PR TITLE
add Geolocation PositionOptions as option to Geolocate Control (#3473)

### DIFF
--- a/debug/debug.html
+++ b/debug/debug.html
@@ -41,7 +41,11 @@ var map = window.map = new mapboxgl.Map({
 });
 
 map.addControl(new mapboxgl.NavigationControl());
-map.addControl(new mapboxgl.GeolocateControl());
+map.addControl(new mapboxgl.GeolocateControl({
+    positionOptions: {
+        enableHighAccuracy: true
+    }
+}));
 map.addControl(new mapboxgl.ScaleControl());
 
 map.on('load', function() {

--- a/js/ui/control/geolocate_control.js
+++ b/js/ui/control/geolocate_control.js
@@ -5,7 +5,7 @@ const DOM = require('../../util/dom');
 const window = require('../../util/window');
 const util = require('../../util/util');
 
-const geoOptions = { enableHighAccuracy: false, timeout: 6000 /* 6sec */ };
+const defaultGeoPositionOptions = { enableHighAccuracy: false, timeout: 6000 /* 6sec */ };
 const className = 'mapboxgl-ctrl';
 
 let supportsGeolocation;
@@ -41,13 +41,20 @@ function checkGeolocationSupport(callback) {
  * be visible.
  *
  * @implements {IControl}
+ * @param {Object} [options]
+ * @param {Object} [options.positionOptions={enableHighAccuracy: false, timeout: 6000}] A [PositionOptions](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions) object.
  * @example
- * map.addControl(new mapboxgl.GeolocateControl());
+ * map.addControl(new mapboxgl.GeolocateControl({
+ *     positionOptions: {
+ *         enableHighAccuracy: true
+ *     }
+ * }));
  */
 class GeolocateControl extends Evented {
 
-    constructor() {
+    constructor(options) {
         super();
+        this.options = options;
         util.bindAll([
             '_onSuccess',
             '_onError',
@@ -106,7 +113,7 @@ class GeolocateControl extends Evented {
     _onClickGeolocate() {
 
         window.navigator.geolocation.getCurrentPosition(
-            this._onSuccess, this._onError, geoOptions);
+            this._onSuccess, this._onError, util.extend(defaultGeoPositionOptions, this.options && this.options.positionOptions || {}));
 
         // This timeout ensures that we still call finish() even if
         // the user declines to share their location in Firefox


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

Implementation for https://github.com/mapbox/mapbox-gl-js/issues/3473, for example allowing developers to [enableHighAccuracy](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions/enableHighAccuracy).

 - [ ] write tests for all new functionality

There are currently no tests for the Geolocation control, and I'm not sure how I would write tests without creating a mock Geolocation API.

 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

