### PR TITLE
Fix broken map on pitch=0 on some systems

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -408,6 +408,9 @@ class Transform {
         mat4.perspective(m, 2 * Math.atan((this.height / 2) / this.altitude), this.width / this.height, 0.1, farZ);
         mat4.translate(m, m, [0, 0, -this.altitude]);
 
+        // a hack around https://github.com/mapbox/mapbox-gl-js/issues/2270
+        m[14] = Math.min(m[14], m[15]);
+
         // After the rotateX, z values are in pixel units. Convert them to
         // altitude units. 1 altitude unit = the screen height.
         mat4.scale(m, m, [1, -1, 1 / this.height]);


### PR DESCRIPTION
Fixes #2270 by making sure a floating point error does not accumulate into a broken projection matrix.

When pitch = 0, a `Float32Array` perspective matrix would end up with `1.5000001192092896, 1.5` as the last values, while `Float64Array` produces correct `1.5, 1.5`. Empirically, I found that the first value never exceeds the second one with proper precision. When it does (which happens even with `Float64Array` on some systems), the map disappears. So while I don't fully grasp the math behind this, this hack seems to fix the pitch=0 bug.

cc @ansis @jfirebaugh @lucaswoj 