### PR TITLE
Fix for issue #3658: improve line breaking

### DIFF
--- a/js/util/script_detection.js
+++ b/js/util/script_detection.js
@@ -18,10 +18,6 @@ module.exports.allowsVerticalWritingMode = function(chars) {
 };
 
 module.exports.charAllowsIdeographicBreaking = function(char) {
-    // Allow U+2027 "Interpunct" for hyphenation of Chinese words
-    // See https://github.com/mapbox/mapbox-gl-js/issues/3658
-    if (char === 0x2027) return true;
-
     // Return early for characters outside all ideographic ranges.
     if (char < 0x2E80) return false;
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f13a9710d754fe7357d04175ba960a298aa43a2c",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#53e5081d0a9c069b02758764a8997d9168e622e0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
This is an experimental new line breaking algorithm aiming to create as general a fix as possible to the problems discussed in issue #3658.

The general approach borrows heavily from the line breaking algorithm used by LaTeX -- we analyze a label as a graph of potential line breaks, and then assign each potential break a "badness" score based primarily on how much the length of the line deviates from the average line width of the label. We then choose the set of line breaks that minimizes "badness" across the whole label.

The advantages of this approach are:

* No (or at least much less) special treatment needed for ideographic characters, which also means that there's no problem mixing ideographic and non-ideographic characters in the same label.
* Punctuation marks can be included in ideographic labels and you get reasonable behavior (because the algorithm doesn't depend on any assumptions about character width)
* "Plain" latin labels get balanced too (this will really only make a difference with relatively long labels)

Finding the line breaks is O(n^2) on the number of potential line breaks (and ideographic text is basically *all* potential line breaks) -- it doesn't seem to be a performance issue, but if we need to we can put an upper limit on that by using a sliding window.

When I was discussing desiderata with @nickidlugash , one idea she suggested was to have the last line "shorten" to allow all the lines above it to remain the same length. Although this algorithm does encourage the last line to shorten first, it is still possible in many cases to end up with lower lines longer than upper lines (in the interests of minimizing overall raggedness).

The algorithm does not strictly enforce `maxWidth` because in cases where `maxWidth` is very close to the average line length, we get better results by going slightly over the limit.

To see some examples of the new algorithm applied to ideographic text with punctuation, see: https://github.com/mapbox/mapbox-gl-test-suite/blob/cloer_leastbad_linebreak/render-tests/text-max-width/ideographic-punctuation-breaking/expected.png

cc @ian29 @1ec5 @ansis @lucaswoj 