### PR TITLE
fix formatting for Map#addControl

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -215,8 +215,8 @@ class Map extends Camera {
      * Adds a [`IControl`](#IControl) to the map, calling `control.onAdd(this)`.
      *
      * @param {IControl} control The [`IControl`](#IControl) to add.
-     * @param {string} [position='top-right'] position on the map to which the control will be added.
-     * valid values are 'top-left', 'top-right', 'bottom-left', and 'bottom-right'
+     * @param {string} [position] position on the map to which the control will be added.
+     * Valid values are `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`. Defaults to `'top-right'`.
      * @returns {Map} `this`
      * @see [Display map navigation controls](https://www.mapbox.com/mapbox-gl-js/example/navigation/)
      */


### PR DESCRIPTION
For some reason, setting the default with documentation.js markup produced weird formatting. Proposing a workaround here:

_before_
![screen shot 2016-12-06 at 11 48 19 am](https://cloud.githubusercontent.com/assets/2425307/20944489/877469b6-bbb8-11e6-8df0-9535564c9fb0.png)

_after_
![screen shot 2016-12-06 at 11 49 09 am](https://cloud.githubusercontent.com/assets/2425307/20944497/8f1b2b5a-bbb8-11e6-9076-21605a58d573.png)

cc @lucaswoj
