### PR TITLE
Fix symbol rendering for multipoints

### DIFF
--- a/js/data/bucket/symbol_bucket.js
+++ b/js/data/bucket/symbol_bucket.js
@@ -20,6 +20,7 @@ const loadGeometry = require('../load_geometry');
 const CollisionFeature = require('../../symbol/collision_feature');
 const findPoleOfInaccessibility = require('../../util/find_pole_of_inaccessibility');
 const classifyRings = require('../../util/classify_rings');
+const VectorTileFeature = require('vector-tile').VectorTileFeature;
 
 const shapeText = Shaping.shapeText;
 const shapeIcon = Shaping.shapeIcon;
@@ -160,7 +161,8 @@ class SymbolBucket {
                 index: i,
                 sourceLayerIndex: feature.sourceLayerIndex,
                 geometry: loadGeometry(feature),
-                properties: feature.properties
+                properties: feature.properties,
+                type: VectorTileFeature.types[feature.type]
             });
 
             if (icon) {
@@ -339,26 +341,15 @@ class SymbolBucket {
             symbolPlacement = layout['symbol-placement'],
             textRepeatDistance = symbolMinDistance / 2;
 
-        function isMultipoint(lines) {
-            for (const line of lines) {
-                if (line.length > 1) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
         let list = null;
         if (symbolPlacement === 'line') {
             list = clipLine(lines, 0, 0, EXTENT, EXTENT);
         } else if (symbolPlacement === 'point') {
-            if (isMultipoint(lines)) {
+            if (feature.type === 'Polygon') {
+                list = classifyRings(lines, 0);
+            } else {
                 list = [];
                 for (const point of lines) list.push([point]);
-            } else {
-                // the feature is a polygon and we are rendering the label at
-                // the polygon's centroid
-                list = classifyRings(lines, 0);
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f9a1131df12227208812802b8108304a10380509",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#fbf93e01805bc82403b199e59d09b020d16b8cae",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#fbf93e01805bc82403b199e59d09b020d16b8cae",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#8a047e6226b996fa8fc4c61a30aebb55c6234896",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
Via a support request, @mapsam and I discovered that we do not render any symbols for multipoint geometries. This is inconsistent with our behaviour for circles in which we do render a circle at each point in the multipoint geometry (see https://github.com/mapbox/mapbox-gl-js/pull/2027). 

This PR tries to differentiate multipoint geometries from polygons and perform the correct label placement in each case. 

cc @mourner @flippmoke @mapsam @jfirebaugh @colleenmcginnis 

## Open Questions

 - Is there a better way to differentiate between a multipoint and a polygon within GL JS?
 - Should we have a different `symbol-placement` modes for `point`, `line`, and `polygon` / `centroid`?
 - Are there other cases in which we don't handle multipoints properly?

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page

