### PR TITLE
add aria-label to map canvas

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1013,6 +1013,7 @@ class Map extends Camera {
         this._canvas.addEventListener('webglcontextlost', this._contextLost, false);
         this._canvas.addEventListener('webglcontextrestored', this._contextRestored, false);
         this._canvas.setAttribute('tabindex', 0);
+        this._canvas.setAttribute('aria-label', 'Map');
 
         const dimensions = this._containerDimensions();
         this._resizeCanvas(dimensions[0], dimensions[1]);


### PR DESCRIPTION
When Assistive Technology such as ChromeVox reads aloud a GL JS map it will announce the navigation controls and the attribution but not the map itself even though it gets focus. In this PR I propose to add [`aria-label`](https://www.w3.org/TR/wai-aria/states_and_properties#aria-label) to the map canvas so that when it has focus AT will announce it to users (keeping in mind that when focused users can use the keyboard to navigate).

Specifically ChromeVox and possible other AT skips `aria-label`'s on the map element `.mapboxgl-map` and the canvas container `.mapboxgl-canvas-container`, so `aria-label` needs to be on the canvas element.

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

I think "Map" is the most appropriate value as it succinctly names what the element is, given that `aria-label` isn't meant to contain a description (see instead [aria-describedby](https://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby)) I think it's rare that a different name would be needed, so I haven't exposed this as a Map option. Anyone who needs that could also modify the DOM directly themselves.