### PR TITLE
Make attribution control responsive.

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -70,16 +70,16 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
-.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-out {
+.mapboxgl-ctrl-icon {
     padding: 5px;
+}
+.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-out {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20viewBox%3D%270%200%2020%2020%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%0A%20%20%3Cpath%20style%3D%27fill%3A%23333333%3B%27%20d%3D%27m%207%2C9%20c%20-0.554%2C0%20-1%2C0.446%20-1%2C1%200%2C0.554%200.446%2C1%201%2C1%20l%206%2C0%20c%200.554%2C0%201%2C-0.446%201%2C-1%200%2C-0.554%20-0.446%2C-1%20-1%2C-1%20z%27%20%2F%3E%0A%3C%2Fsvg%3E%0A");
 }
-.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-in  {
-    padding: 5px;
+.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-in {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20viewBox%3D%270%200%2020%2020%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%0A%20%20%3Cpath%20style%3D%27fill%3A%23333333%3B%27%20d%3D%27M%2010%206%20C%209.446%206%209%206.4459904%209%207%20L%209%209%20L%207%209%20C%206.446%209%206%209.446%206%2010%20C%206%2010.554%206.446%2011%207%2011%20L%209%2011%20L%209%2013%20C%209%2013.55401%209.446%2014%2010%2014%20C%2010.554%2014%2011%2013.55401%2011%2013%20L%2011%2011%20L%2013%2011%20C%2013.554%2011%2014%2010.554%2014%2010%20C%2014%209.446%2013.554%209%2013%209%20L%2011%209%20L%2011%207%20C%2011%206.4459904%2010.554%206%2010%206%20z%27%20%2F%3E%0A%3C%2Fsvg%3E%0A");
 }
 .mapboxgl-ctrl-icon.mapboxgl-ctrl-geolocate  {
-    padding: 5px;
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%270%200%2020%2020%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%0D%0A%20%20%3Cpath%20style%3D%27fill%3A%23333%3B%27%20d%3D%27M10%204C9%204%209%205%209%205L9%205.1A5%205%200%200%200%205.1%209L5%209C5%209%204%209%204%2010%204%2011%205%2011%205%2011L5.1%2011A5%205%200%200%200%209%2014.9L9%2015C9%2015%209%2016%2010%2016%2011%2016%2011%2015%2011%2015L11%2014.9A5%205%200%200%200%2014.9%2011L15%2011C15%2011%2016%2011%2016%2010%2016%209%2015%209%2015%209L14.9%209A5%205%200%200%200%2011%205.1L11%205C11%205%2011%204%2010%204zM10%206.5A3.5%203.5%200%200%201%2013.5%2010%203.5%203.5%200%200%201%2010%2013.5%203.5%203.5%200%200%201%206.5%2010%203.5%203.5%200%200%201%2010%206.5zM10%208.3A1.8%201.8%200%200%200%208.3%2010%201.8%201.8%200%200%200%2010%2011.8%201.8%201.8%200%200%200%2011.8%2010%201.8%201.8%200%200%200%2010%208.3z%27%20%2F%3E%0D%0A%3C%2Fsvg%3E");
 }
 .mapboxgl-ctrl-icon.mapboxgl-ctrl-geolocate.watching  {
@@ -97,8 +97,35 @@
 
 .mapboxgl-ctrl.mapboxgl-ctrl-attrib {
     padding: 0 5px;
-    background-color: rgba(255,255,255,0.5);
+    background-color: rgba(255, 255, 255, .5);
     margin: 0;
+}
+.mapboxgl-ctrl-attrib.compact {
+    padding-top: 2px;
+    padding-bottom: 2px;
+    margin: 0 10px 10px 10px;
+    position: relative;
+    padding-right: 24px;
+    background-color: #fff;
+    border-radius: 3px 12px 12px 3px;
+    visibility: hidden;
+}
+.mapboxgl-ctrl-attrib.compact:hover {
+    visibility: visible;
+}
+.mapboxgl-ctrl-attrib.compact:after {
+    content: '';
+    cursor: pointer;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%270%200%2020%2020%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%0D%0A%09%3Cpath%20fill%3D%27%23333333%27%20fill-rule%3D%27evenodd%27%20d%3D%27M4%2C10a6%2C6%200%201%2C0%2012%2C0a6%2C6%200%201%2C0%20-12%2C0%20M9%2C7a1%2C1%200%201%2C0%202%2C0a1%2C1%200%201%2C0%20-2%2C0%20M9%2C10a1%2C1%200%201%2C1%202%2C0l0%2C3a1%2C1%200%201%2C1%20-2%2C0%27%20%2F%3E%0D%0A%3C%2Fsvg%3E");
+    background-color: rgba(255, 255, 255, .5);
+    width: 24px;
+    height: 24px;
+    box-sizing: border-box;
+    visibility: visible;
+    border-radius: 12px;
 }
 .mapboxgl-ctrl-attrib a {
     color: rgba(0,0,0,0.75);

--- a/dist/svg/mapboxgl-ctrl-attrib.svg
+++ b/dist/svg/mapboxgl-ctrl-attrib.svg
@@ -1,0 +1,3 @@
+<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'>
+	<path fill='#333333' fill-rule='evenodd' d='M4,10a6,6 0 1,0 12,0a6,6 0 1,0 -12,0 M9,7a1,1 0 1,0 2,0a1,1 0 1,0 -2,0 M9,10a1,1 0 1,1 2,0l0,3a1,1 0 1,1 -2,0' />
+</svg>

--- a/js/ui/control/attribution_control.js
+++ b/js/ui/control/attribution_control.js
@@ -7,9 +7,13 @@ const util = require('../../util/util');
  * An `AttributionControl` control presents the map's [attribution information](https://www.mapbox.com/help/attribution/).
  *
  * @implements {IControl}
+ * @param {Object} [options]
+ * @param {boolean} [options.compact] If `true` force a compact attribution that shows the full attribution on mouse hover, or if `false` force the full attribution control. The default is a responsive attribution that collapses when the map is less than 640 pixels wide.
  * @example
  * var map = new mapboxgl.Map({attributionControl: false})
- *     .addControl(new mapboxgl.AttributionControl());
+ *     .addControl(new mapboxgl.AttributionControl({
+ *         compact: true
+ *     }));
  */
 class AttributionControl {
 

--- a/js/ui/control/attribution_control.js
+++ b/js/ui/control/attribution_control.js
@@ -13,10 +13,13 @@ const util = require('../../util/util');
  */
 class AttributionControl {
 
-    constructor() {
+    constructor(options) {
+        this.options = options;
+
         util.bindAll([
             '_updateEditLink',
-            '_updateData'
+            '_updateData',
+            '_updateCompact'
         ], this);
     }
 
@@ -25,15 +28,25 @@ class AttributionControl {
     }
 
     onAdd(map) {
+        const compact = this.options && this.options.compact;
+
         this._map = map;
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-attrib');
 
+        if (compact) {
+            this._container.classList.add('compact');
+        }
 
         this._updateAttributions();
         this._updateEditLink();
 
         this._map.on('data', this._updateData);
         this._map.on('moveend', this._updateEditLink);
+
+        if (compact === undefined) {
+            this._map.on('resize', this._updateCompact);
+            this._updateCompact();
+        }
 
         return this._container;
     }
@@ -43,6 +56,7 @@ class AttributionControl {
 
         this._map.off('data', this._updateData);
         this._map.off('moveend', this._updateEditLink);
+        this._map.off('resize', this._updateCompact);
 
         this._map = undefined;
     }
@@ -88,6 +102,12 @@ class AttributionControl {
         this._container.innerHTML = attributions.join(' | ');
         // remove old DOM node from _editLink
         this._editLink = null;
+    }
+
+    _updateCompact() {
+        const compact = this._map.getCanvasContainer().offsetWidth <= 640;
+
+        this._container.classList[compact ? 'add' : 'remove']('compact');
     }
 
 }

--- a/test/js/ui/control/attribution.test.js
+++ b/test/js/ui/control/attribution.test.js
@@ -34,6 +34,46 @@ test('AttributionControl appears in the position specified by the position optio
     t.end();
 });
 
+test('AttributionControl appears in compact mode if compact option is used', (t) => {
+    const map = createMap();
+    map.getCanvasContainer().offsetWidth = 700;
+
+    let attributionControl = new AttributionControl({
+        compact: true
+    });
+    map.addControl(attributionControl);
+
+    const container = map.getContainer();
+
+    t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib.compact').length, 1);
+    map.removeControl(attributionControl);
+
+    map.getCanvasContainer().offsetWidth = 600;
+    attributionControl = new AttributionControl({
+        compact: false
+    });
+
+    map.addControl(attributionControl);
+    t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib:not(.compact)').length, 1);
+    t.end();
+});
+
+test('AttributionControl appears in compact mode if container is less then 640 pixel wide', (t) => {
+    const map = createMap();
+    map.getCanvasContainer().offsetWidth = 700;
+    map.addControl(new AttributionControl());
+
+    const container = map.getContainer();
+
+    t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib:not(.compact)').length, 1);
+
+    map.getCanvasContainer().offsetWidth = 600;
+    map.resize();
+
+    t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib.compact').length, 1);
+    t.end();
+});
+
 test('AttributionControl dedupes attributions that are substrings of others', (t) => {
     const map = createMap();
     const attribution = new AttributionControl();


### PR DESCRIPTION
This PR adds responsiveness to AttributionControl by adding a compact version. This is very similar to the mapbox.js API and can also be activated by passing `compact: true` as an option to the AttributionControl.

``` js
var map = new mapboxgl.Map({ attributionControl: false })
    .addControl(new mapboxgl.AttributionControl({
        compact: true
    }));
```

Fixes: #3284

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] gather feedback for the given changes
 - [x] write tests for all new functionalities
 - [x] document any changes to public APIs

Happy to hear your feedback.