### PR TITLE
clean up matrix creation

### DIFF
--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -439,16 +439,6 @@ class Transform {
         if (!m) throw new Error("failed to invert matrix");
         this.pixelMatrixInverse = m;
 
-        // line antialiasing matrix
-        m = mat2.create();
-        mat2.scale(m, m, [1, Math.cos(this._pitch)]);
-        mat2.rotate(m, m, this.angle);
-        this.lineAntialiasingMatrix = m;
-
-        // calculate how much longer the real world distance is at the top of the screen
-        // than at the middle of the screen.
-        const topEdgeLength = Math.sqrt((this.height * this.height + this.cameraToCenterDistance * this.cameraToCenterDistance) / 4);
-        this.lineStretch = (this.height / 2 * Math.tan(this._pitch)) / topEdgeLength;
     }
 }
 

--- a/js/geo/transform.js
+++ b/js/geo/transform.js
@@ -406,15 +406,14 @@ class Transform {
         const groundAngle = Math.PI / 2 + this._pitch;
         const topHalfSurfaceDistance = Math.sin(halfFov) * this.cameraToCenterDistance / Math.sin(Math.PI - groundAngle - halfFov);
 
-        // Calculate z value of the farthest fragment that should be rendered.
-        const farZ = Math.cos(Math.PI / 2 - this._pitch) * topHalfSurfaceDistance + this.cameraToCenterDistance;
+        // Calculate z distance of the farthest fragment that should be rendered.
+        const furthestDistance = Math.cos(Math.PI / 2 - this._pitch) * topHalfSurfaceDistance + this.cameraToCenterDistance;
+        // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
+        const farZ = furthestDistance * 1.01;
 
         // matrix for conversion from location to GL coordinates (-1 .. 1)
         let m = new Float64Array(16);
-        mat4.perspective(m, this._fov, this.width / this.height, 0.1, farZ);
-
-        // a hack around https://github.com/mapbox/mapbox-gl-js/issues/2270
-        m[14] = Math.min(m[14], m[15]);
+        mat4.perspective(m, this._fov, this.width / this.height, 1, farZ);
 
         mat4.scale(m, m, [1, -1, 1]);
         mat4.translate(m, m, [0, 0, -this.cameraToCenterDistance]);

--- a/js/render/draw_circle.js
+++ b/js/render/draw_circle.js
@@ -32,8 +32,8 @@ function drawCircles(painter, sourceCache, layer, coords) {
         if (layer.paint['circle-pitch-scale'] === 'map') {
             gl.uniform1i(program.u_scale_with_map, true);
             gl.uniform2f(program.u_extrude_scale,
-                painter.transform.pixelsToGLUnits[0] * painter.transform.altitude,
-                painter.transform.pixelsToGLUnits[1] * painter.transform.altitude);
+                painter.transform.pixelsToGLUnits[0] * painter.transform.cameraToCenterDistance,
+                painter.transform.pixelsToGLUnits[1] * painter.transform.cameraToCenterDistance);
         } else {
             gl.uniform1i(program.u_scale_with_map, false);
             gl.uniform2fv(program.u_extrude_scale, painter.transform.pixelsToGLUnits);

--- a/js/render/draw_line.js
+++ b/js/render/draw_line.js
@@ -80,6 +80,8 @@ function drawLineTile(program, painter, tile, buffers, layer, coord, layerData, 
             gl.uniform2f(program.u_pattern_size_a, imagePosA.size[0] * image.fromScale / tileRatio, imagePosB.size[1]);
             gl.uniform2f(program.u_pattern_size_b, imagePosB.size[0] * image.toScale / tileRatio, imagePosB.size[1]);
         }
+
+        gl.uniform2f(program.u_gl_units_to_pixels, 1 / painter.transform.pixelsToGLUnits[0], 1 / painter.transform.pixelsToGLUnits[1]);
     }
 
     if (programChanged) {
@@ -105,9 +107,6 @@ function drawLineTile(program, painter, tile, buffers, layer, coord, layerData, 
             gl.uniform1f(program.u_fade, image.t);
         }
         gl.uniform1f(program.u_width, layer.paint['line-width']);
-
-        gl.uniformMatrix2fv(program.u_antialiasingmatrix, false, painter.transform.lineAntialiasingMatrix);
-        gl.uniform1f(program.u_extra, painter.transform.lineStretch);
     }
 
     painter.enableTileClippingMask(coord);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -173,12 +173,12 @@ function drawTileSymbols(program, painter, layer, tile, buffers, isText, isSDF,
         const s = pixelsToTileUnits(tile, fontScale, tr.zoom);
         gl.uniform2f(program.u_extrude_scale, s, s);
     } else {
-        const s = tr.altitude * fontScale;
+        const s = tr.cameraToCenterDistance * fontScale;
         gl.uniform2f(program.u_extrude_scale, tr.pixelsToGLUnits[0] * s, tr.pixelsToGLUnits[1] * s);
     }
 
     if (isSDF) {
-        const gammaScale = fontScale * (pitchWithMap ? Math.cos(tr._pitch) : 1) * tr.altitude;
+        const gammaScale = fontScale * (pitchWithMap ? Math.cos(tr._pitch) : 1) * tr.cameraToCenterDistance;
 
         if (haloWidth) { // Draw halo underneath the text.
             gl.uniform1f(program.u_gamma, (haloBlur * blurOffset / sdfPx + gamma) / gammaScale);

--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -178,7 +178,7 @@ function drawTileSymbols(program, painter, layer, tile, buffers, isText, isSDF,
     }
 
     if (isSDF) {
-        const gammaScale = fontScale * (pitchWithMap ? Math.cos(tr._pitch) : 1);
+        const gammaScale = fontScale * (pitchWithMap ? Math.cos(tr._pitch) : 1) * tr.altitude;
 
         if (haloWidth) { // Draw halo underneath the text.
             gl.uniform1f(program.u_gamma, (haloBlur * blurOffset / sdfPx + gamma) / gammaScale);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#52acb6e9e4b75b7e765ef087a0e539739e9846c1",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f13a9710d754fe7357d04175ba960a298aa43a2c",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/shaders/line.vertex.glsl
+++ b/shaders/line.vertex.glsl
@@ -17,9 +17,8 @@ attribute vec4 a_data;
 
 uniform mat4 u_matrix;
 uniform mediump float u_ratio;
-uniform mediump float u_extra;
-uniform mat2 u_antialiasingmatrix;
 uniform mediump float u_width;
+uniform vec2 u_gl_units_to_pixels;
 
 varying vec2 v_normal;
 varying vec2 v_width2;
@@ -71,19 +70,16 @@ void main() {
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
 
-    // Remove the texture normal bit of the position before scaling it with the
-    // model/view matrix.
-    gl_Position = u_matrix * vec4(floor(a_pos * 0.5) + (offset2 + dist) / u_ratio, 0.0, 1.0);
+    // Remove the texture normal bit to get the position
+    vec2 pos = floor(a_pos * 0.5);
 
-    // position of y on the screen
-    float y = gl_Position.y / gl_Position.w;
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
 
-    // how much features are squished in the y direction by the tilt
-    float squish_scale = length(a_extrude) / length(u_antialiasingmatrix * a_extrude);
-
-    // how much features are squished in all directions by the perspectiveness
-    float perspective_scale = 1.0 / (1.0 - min(y * u_extra, 0.9));
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_gl_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
 
     v_width2 = vec2(outset, inset);
-    v_gamma_scale = perspective_scale * squish_scale;
 }

--- a/shaders/line_pattern.vertex.glsl
+++ b/shaders/line_pattern.vertex.glsl
@@ -20,8 +20,7 @@ attribute vec4 a_data;
 uniform mat4 u_matrix;
 uniform mediump float u_ratio;
 uniform mediump float u_width;
-uniform mediump float u_extra;
-uniform mat2 u_antialiasingmatrix;
+uniform vec2 u_gl_units_to_pixels;
 
 varying vec2 v_normal;
 varying vec2 v_width2;
@@ -72,20 +71,17 @@ void main() {
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
 
-    // Remove the texture normal bit of the position before scaling it with the
-    // model/view matrix.
-    gl_Position = u_matrix * vec4(floor(a_pos * 0.5) + (offset2 + dist) / u_ratio, 0.0, 1.0);
+    // Remove the texture normal bit to get the position
+    vec2 pos = floor(a_pos * 0.5);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_gl_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
     v_linesofar = a_linesofar;
-
-    // position of y on the screen
-    float y = gl_Position.y / gl_Position.w;
-
-    // how much features are squished in the y direction by the tilt
-    float squish_scale = length(a_extrude) / length(u_antialiasingmatrix * a_extrude);
-
-    // how much features are squished in all directions by the perspectiveness
-    float perspective_scale = 1.0 / (1.0 - min(y * u_extra, 0.9));
-
     v_width2 = vec2(outset, inset);
-    v_gamma_scale = perspective_scale * squish_scale;
 }

--- a/shaders/symbol_sdf.vertex.glsl
+++ b/shaders/symbol_sdf.vertex.glsl
@@ -75,7 +75,7 @@ void main() {
         gl_Position = u_matrix * vec4(a_pos, 0, 1) + vec4(extrude, 0, 0);
     }
 
-    v_gamma_scale = (gl_Position.w - 0.5);
+    v_gamma_scale = gl_Position.w;
 
     v_tex = a_tex / u_texsize;
     v_fade_tex = vec2(a_labelminzoom / 255.0, 0.0);

--- a/test/js/geo/transform.test.js
+++ b/test/js/geo/transform.test.js
@@ -113,6 +113,9 @@ test('transform', (t) => {
         const transform = new Transform();
         transform.resize(200, 200);
 
+        // make slightly off center so that sort order is not subject to precision issues
+        transform.center = { lng: -0.01, lat: 0.01 };
+
         transform.zoom = 0;
         t.deepEqual(transform.coveringTiles(options), []);
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -443,7 +443,9 @@ test('SourceCache#update', (t) => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 16;
-        transform.center = new LngLat(0, 0);
+
+        // use slightly offset center so that sort order is better defined
+        transform.center = new LngLat(-0.001, 0.001);
 
 
         const sourceCache = createSourceCache({
@@ -459,8 +461,8 @@ test('SourceCache#update', (t) => {
             t.deepEqual(sourceCache.getRenderableIds(), [
                 new TileCoord(16, 8191, 8191, 0).id,
                 new TileCoord(16, 8192, 8191, 0).id,
-                new TileCoord(16, 8192, 8192, 0).id,
-                new TileCoord(16, 8191, 8192, 0).id
+                new TileCoord(16, 8191, 8192, 0).id,
+                new TileCoord(16, 8192, 8192, 0).id
             ]);
 
             transform.zoom = 15;
@@ -469,8 +471,8 @@ test('SourceCache#update', (t) => {
             t.deepEqual(sourceCache.getRenderableIds(), [
                 new TileCoord(16, 8191, 8191, 0).id,
                 new TileCoord(16, 8192, 8191, 0).id,
-                new TileCoord(16, 8192, 8192, 0).id,
-                new TileCoord(16, 8191, 8192, 0).id
+                new TileCoord(16, 8191, 8192, 0).id,
+                new TileCoord(16, 8192, 8192, 0).id
             ]);
             t.end();
         });

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -9,6 +9,7 @@ const LngLat = require('../../../js/geo/lng_lat');
 const fixed = require('mapbox-gl-js-test/fixed');
 const fixedNum = fixed.Num;
 const fixedLngLat = fixed.LngLat;
+const fixedCoord = fixed.Coord;
 
 function createMap(options, callback) {
     const container = window.document.createElement('div');
@@ -505,7 +506,7 @@ test('Map', (t) => {
         });
 
         function toFixed(bounds) {
-            const n = 10;
+            const n = 9;
             return [
                 [bounds[0][0].toFixed(n), bounds[0][1].toFixed(n)],
                 [bounds[1][0].toFixed(n), bounds[1][1].toFixed(n)]
@@ -659,7 +660,7 @@ test('Map', (t) => {
 
     t.test('#unproject', (t) => {
         const map = createMap();
-        t.deepEqual(map.unproject([100, 100]), { lng: 0, lat: 0 });
+        t.deepEqual(fixedLngLat(map.unproject([100, 100])), { lng: 0, lat: 0 });
         t.end();
     });
 
@@ -689,7 +690,7 @@ test('Map', (t) => {
                 const output = map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
 
                 const args = map.style.queryRenderedFeatures.getCall(0).args;
-                t.deepEqual(args[0], [{ column: 0.5, row: 0.5, zoom: 0 }]); // query geometry
+                t.deepEqual(args[0].map(c => fixedCoord(c)), [{ column: 0.5, row: 0.5, zoom: 0 }]); // query geometry
                 t.deepEqual(args[1], {}); // params
                 t.deepEqual(args[2], 0); // bearing
                 t.deepEqual(args[3], 0); // zoom
@@ -738,8 +739,8 @@ test('Map', (t) => {
 
                 map.queryRenderedFeatures(map.project(new LngLat(360, 0)));
 
-                const coords = map.style.queryRenderedFeatures.getCall(0).args[0];
-                t.equal(parseFloat(coords[0].column.toFixed(4)), 1.5);
+                const coords = map.style.queryRenderedFeatures.getCall(0).args[0].map(c => fixedCoord(c));
+                t.equal(coords[0].column, 1.5);
                 t.equal(coords[0].row, 0.5);
                 t.equal(coords[0].zoom, 0);
 

--- a/test/node_modules/mapbox-gl-js-test/fixed.js
+++ b/test/node_modules/mapbox-gl-js-test/fixed.js
@@ -12,7 +12,7 @@ function fixedNum(n, precision) {
 }
 
 function fixedLngLat(l, precision) {
-    if (precision === undefined) precision = 10;
+    if (precision === undefined) precision = 9;
     return {
         lng: fixedNum(l.lng, precision),
         lat: fixedNum(l.lat, precision)


### PR DESCRIPTION
This cleans up a bunch of matrix and antialiasing code.

- removes the confusing `altitude` and replaces it with `fov`
- fixes text blurriness at non-default FOVs
- removes the hack added in #3740 and adds a different fix
- makes pitched line antialiasing clearer and removes `lineStretch` and `lineAntialiasingMatrix`

related prs:
https://github.com/mapbox/mapbox-gl-shaders/pull/41
https://github.com/mapbox/mapbox-gl-test-suite/pull/193

benchmark | master 32fcbfe | matrix-cleanup d2f5d09
--- | --- | ---
**map-load** | 207 ms  | 152 ms 
**style-load** | 95 ms  | 94 ms 
**buffer** | 1,027 ms  | 1,001 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 4.5 ms, 0% > 16ms  | 4.6 ms, 0% > 16ms 
**query-point** | 1.00 ms  | 1.14 ms 
**query-box** | 85.19 ms  | 79.48 ms 
**geojson-setdata-small** | 7 ms  | 5 ms 
**geojson-setdata-large** | 299 ms  | 286 ms 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page

TODO:
- [x] debug the render test that's failing on ci but not locally
- [x] open issue about porting to -native

@lucaswoj @mourner 