### PR TITLE
Use polyfill for Math.sign, which is unsupported in IE11. Fix #3814.

### DIFF
--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -2,7 +2,6 @@
 
 const scriptDetection = require('../util/script_detection');
 const verticalizePunctuation = require('../util/verticalize_punctuation');
-const util = require('../util/util');
 
 
 const WritingMode = {
@@ -113,7 +112,7 @@ function calculateBadness(lineWidth, targetWidth, penalty, isLastBreak) {
         // Be more tolerant of short final lines
         return Math.max(0, raggedness - 150);
     }
-    return raggedness + (util.sign(penalty) * Math.pow(penalty, 2));
+    return raggedness + Math.abs(penalty) * penalty;
 }
 
 function calculatePenalty(codePoint, previousCodePoint) {

--- a/js/symbol/shaping.js
+++ b/js/symbol/shaping.js
@@ -2,6 +2,7 @@
 
 const scriptDetection = require('../util/script_detection');
 const verticalizePunctuation = require('../util/verticalize_punctuation');
+const util = require('../util/util');
 
 
 const WritingMode = {
@@ -112,7 +113,7 @@ function calculateBadness(lineWidth, targetWidth, penalty, isLastBreak) {
         // Be more tolerant of short final lines
         return Math.max(0, raggedness - 150);
     }
-    return raggedness + (Math.sign(penalty) * Math.pow(penalty, 2));
+    return raggedness + (util.sign(penalty) * Math.pow(penalty, 2));
 }
 
 function calculatePenalty(codePoint, previousCodePoint) {

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -112,6 +112,20 @@ exports.values = function (obj: Object): Array<string> {
 };
 
 /*
+ * Polyfill for Math.sign, unsupported in IE11 as of 12/15/16
+ * https://github.com/mapbox/mapbox-gl-js/issues/3814
+ *
+ * @private
+ */
+exports.sign = function(x: Number): Number {
+    x = +x;
+    if (x === 0 || isNaN(x)) {
+        return Number(x);
+    }
+    return x > 0 ? 1 : -1;
+}
+
+/*
  * Compute the difference between the keys in one object and the keys
  * in another object.
  *

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -117,7 +117,7 @@ exports.values = function (obj: Object): Array<string> {
  *
  * @private
  */
-exports.sign = function(x: Number): Number {
+exports.sign = function(x: number): number {
     x = +x;
     if (x === 0 || isNaN(x)) {
         return Number(x);

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -112,20 +112,6 @@ exports.values = function (obj: Object): Array<string> {
 };
 
 /*
- * Polyfill for Math.sign, unsupported in IE11 as of 12/15/16
- * https://github.com/mapbox/mapbox-gl-js/issues/3814
- *
- * @private
- */
-exports.sign = function(x: number): number {
-    x = +x;
-    if (x === 0 || isNaN(x)) {
-        return Number(x);
-    }
-    return x > 0 ? 1 : -1;
-};
-
-/*
  * Compute the difference between the keys in one object and the keys
  * in another object.
  *

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -123,7 +123,7 @@ exports.sign = function(x: Number): Number {
         return Number(x);
     }
     return x > 0 ? 1 : -1;
-}
+};
 
 /*
  * Compute the difference between the keys in one object and the keys


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/3814: `Math.sign` is not supported in IE11.