### PR TITLE
Fix for Windows browsers capturing not current but previous right clicks

### DIFF
--- a/js/ui/bind_handlers.js
+++ b/js/ui/bind_handlers.js
@@ -17,7 +17,6 @@ module.exports = function bindHandlers(map, options) {
     const el = map.getCanvasContainer();
     let contextMenuEvent = null;
     let mouseDown = false;
-    let mapRotating = false;
     let startPos = null;
     let tapped = null;
 
@@ -62,16 +61,12 @@ module.exports = function bindHandlers(map, options) {
 
         contextMenuEvent = null;
         mouseDown = false;
-        mapRotating = false;
         fireMouseEvent('mouseup', e);
     }
 
     function onMouseMove(e) {
         if (map.dragPan && map.dragPan.isActive()) return;
-        if (map.dragRotate && map.dragRotate.isActive()) {
-            mapRotating = true;
-            return;
-        }
+        if (map.dragRotate && map.dragRotate.isActive()) return;
 
         let target = e.toElement || e.target;
         while (target && target !== el) target = target.parentNode;
@@ -127,7 +122,7 @@ module.exports = function bindHandlers(map, options) {
 
     function onContextMenu(e) {
         const rotating = map.dragRotate && map.dragRotate.isActive();
-        if (!mouseDown && !rotating && !mapRotating) {
+        if (!mouseDown && !rotating) {
             // Windows: contextmenu fired on mouseup, so fire event now
             fireMouseEvent('contextmenu', e);
         } else if (mouseDown) {


### PR DESCRIPTION
Fixes #3803.

Browsers on OSX fire `contextmenu` events on `mousedown`, whereas Windows browsers fire it on `mouseup`. The way we've been capturing `contextmenu` events is to preserve them on `contextmenu` and fire them on `mouseup` in order to produce consistent behavior between Mac and Windows. However, Windows browsers consistently fire `mouseup` _before_ `contextmenu`, resulting in #3803.

This fixes #3803 by preserving a `mousedown` boolean so that we can determine when to fire `contextmenu` events on `contextmenu` (which we want to do on Windows).