### PR TITLE
Add workaround for quirky FF left click + Control behavior; fix #3131

### DIFF
--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -201,9 +201,10 @@ class DragRotateHandler {
             const buttons = (e.ctrlKey ? 1 : 2),  // ? ctrl+left button : right button
                 button = (e.ctrlKey ? 0 : 2);   // ? ctrl+left button : right button
             let eventButton = e.button;
-            if (typeof InstallTrigger !== 'undefined' && e.button === 2 && e.ctrlKey) {
+            if (typeof InstallTrigger !== 'undefined' && e.button === 2 && e.ctrlKey &&
+                window.navigator.platform.toUpperCase().indexOf('MAC') >= 0) {
                 // Fix for https://github.com/mapbox/mapbox-gl-js/issues/3131:
-                // Firefox (detected by InstallTrigger) determines e.button = 2 when
+                // Firefox (detected by InstallTrigger) on Mac determines e.button = 2 when
                 // using Control + left click
                 eventButton = 0;
             }

--- a/js/ui/handler/drag_rotate.js
+++ b/js/ui/handler/drag_rotate.js
@@ -200,7 +200,14 @@ class DragRotateHandler {
         } else {
             const buttons = (e.ctrlKey ? 1 : 2),  // ? ctrl+left button : right button
                 button = (e.ctrlKey ? 0 : 2);   // ? ctrl+left button : right button
-            return (e.type === 'mousemove' ? e.buttons & buttons === 0 : e.button !== button);
+            let eventButton = e.button;
+            if (typeof InstallTrigger !== 'undefined' && e.button === 2 && e.ctrlKey) {
+                // Fix for https://github.com/mapbox/mapbox-gl-js/issues/3131:
+                // Firefox (detected by InstallTrigger) determines e.button = 2 when
+                // using Control + left click
+                eventButton = 0;
+            }
+            return (e.type === 'mousemove' ? e.buttons & buttons === 0 : eventButton !== button);
         }
     }
 


### PR DESCRIPTION
Firefox behaves inconsistently with Chrome/Safari when a left click event happens while <kbd>`Ctrl`</kbd> is pressed: these click events have `e.ctrlKey = true` and `e.button = 2` (indicating a _right_ button). Chrome and Safari interpret this event more literally as `e.ctrlKey = true` and `e.button = 0` (indicating left button). After talking with @1ec5 I'm not sure if/that this is a FF bug so much as undefined behavior.

Our codebase assumes that <kbd>`Ctrl`</kbd> + left click will produce behavior like that of Chrome/Safari, which causes #3131 🐞. The fix here
* screens for Firefox (`typeof InstallTrigger`)
* determines whether the event has `.ctrlKey = true` and `.button = 2`, and if so
* pretends the button is `0`

I don't think this is a perfect solution, but it's a messy problem, _and_ I'm not aware of any reason why we should treat <kbd>`Ctrl`</kbd> + right click differently, but this is definitely open to debate. 💭?

cc @1ec5 @scothis @tmcw 