### PR TITLE
Unbind events after dragging ends

### DIFF
--- a/docs/_posts/examples/3400-01-24-drag-a-point.html
+++ b/docs/_posts/examples/3400-01-24-drag-a-point.html
@@ -92,7 +92,7 @@ function onUp(e) {
     coordinates.innerHTML = 'Longitude: ' + coords.lng + '<br />Latitude: ' + coords.lat;
     canvas.style.cursor = '';
     isDragging = false;
-    
+
     // Unbind mouse events
     map.off('mousemove', onMove);
 }

--- a/docs/_posts/examples/3400-01-24-drag-a-point.html
+++ b/docs/_posts/examples/3400-01-24-drag-a-point.html
@@ -66,7 +66,7 @@ function mouseDown() {
 
     // Mouse events
     map.on('mousemove', onMove);
-    map.on('mouseup', onUp);
+    map.once('mouseup', onUp);
 }
 
 function onMove(e) {
@@ -92,6 +92,9 @@ function onUp(e) {
     coordinates.innerHTML = 'Longitude: ' + coords.lng + '<br />Latitude: ' + coords.lat;
     canvas.style.cursor = '';
     isDragging = false;
+    
+    // Unbind mouse events
+    map.off('mousemove', onMove);
 }
 
 map.on('load', function() {


### PR DESCRIPTION
Mouse callbacks are being created every time the `mousedown` event is triggered and never destroyed.

I think `once` method can be used to bind the `mouseup` event (after all, you want to call it once per drag), and unbind the `mousemove` normally when the point was dropped.


