### PR TITLE
fix tinting rasters with alpha, fix #3723

### DIFF
--- a/js/render/draw_raster.js
+++ b/js/render/draw_raster.js
@@ -49,7 +49,7 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     gl.uniform3fv(program.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));
 
     const parentTile = tile.sourceCache && tile.sourceCache.findLoadedParent(coord, 0, {}),
-        opacities = getOpacities(tile, parentTile, layer, painter.transform);
+        fade = getFadeValues(tile, parentTile, layer, painter.transform);
 
     let parentScaleBy, parentTL;
 
@@ -71,8 +71,8 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     gl.uniform2fv(program.u_tl_parent, parentTL || [0, 0]);
     gl.uniform1f(program.u_scale_parent, parentScaleBy || 1);
     gl.uniform1f(program.u_buffer_scale, 1);
-    gl.uniform1f(program.u_opacity0, opacities[0]);
-    gl.uniform1f(program.u_opacity1, opacities[1]);
+    gl.uniform1f(program.u_fade_t, fade.mix);
+    gl.uniform1f(program.u_opacity, fade.opacity * layer.paint['raster-opacity']);
     gl.uniform1i(program.u_image0, 0);
     gl.uniform1i(program.u_image1, 1);
 
@@ -105,8 +105,7 @@ function saturationFactor(saturation) {
         -saturation;
 }
 
-function getOpacities(tile, parentTile, layer, transform) {
-    const opacities = [1, 0];
+function getFadeValues(tile, parentTile, layer, transform) {
     const fadeDuration = layer.paint['raster-fade-duration'];
 
     if (tile.sourceCache && fadeDuration > 0) {
@@ -123,13 +122,23 @@ function getOpacities(tile, parentTile, layer, transform) {
         // if no parent or parent is older, fade in; if parent is younger, fade out
         const fadeIn = !parentTile || Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ);
 
-        opacities[0] = util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
-        opacities[1] = parentTile ? 1 - opacities[0] : 0;
+        const childOpacity = util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
+
+        if (parentTile) {
+            return {
+                opacity: 1,
+                mix: 1 - childOpacity
+            };
+        } else {
+            return {
+                opacity: childOpacity,
+                mix: 0
+            };
+        }
+    } else {
+        return {
+            opacity: 1,
+            mix: 0
+        };
     }
-
-    const opacity = layer.paint['raster-opacity'];
-    opacities[0] *= opacity;
-    opacities[1] *= opacity;
-
-    return opacities;
 }

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -80,7 +80,6 @@ class RasterTileSource extends Evented {
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-                gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
                 tile.texture.size = img.width;
             }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#1ca07142aa1dc27c404563ed4f8e0c9b69bfb71f",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2bdca923fc4190156b5a22af71be29442451db54",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",

--- a/shaders/raster.fragment.glsl
+++ b/shaders/raster.fragment.glsl
@@ -1,5 +1,7 @@
-uniform float u_opacity0;
-uniform float u_opacity1;
+uniform float u_fade_opacity0;
+uniform float u_fade_opacity1;
+uniform float u_fade_t;
+uniform float u_opacity;
 uniform sampler2D u_image0;
 uniform sampler2D u_image1;
 varying vec2 v_pos0;
@@ -17,7 +19,8 @@ void main() {
     // read and cross-fade colors from the main and parent tiles
     vec4 color0 = texture2D(u_image0, v_pos0);
     vec4 color1 = texture2D(u_image1, v_pos1);
-    vec4 color = color0 * u_opacity0 + color1 * u_opacity1;
+    vec4 color = mix(color0, color1, u_fade_t);
+    color.a *= u_opacity;
     vec3 rgb = color.rgb;
 
     // spin
@@ -37,7 +40,7 @@ void main() {
     vec3 u_high_vec = vec3(u_brightness_low, u_brightness_low, u_brightness_low);
     vec3 u_low_vec = vec3(u_brightness_high, u_brightness_high, u_brightness_high);
 
-    gl_FragColor = vec4(mix(u_high_vec, u_low_vec, rgb), color.a);
+    gl_FragColor = vec4(mix(u_high_vec, u_low_vec, rgb) * color.a, color.a);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);


### PR DESCRIPTION
Rasters need to be non-premultiplied when blended. This switches the textures to non-premultiplied and the premultiplies them at the end.

I also changed how fading, mixing and opacity uniforms are calculated and passed to the shaders. Have the `mix` value separate from the `opacity` is necessary for us to be able to blend in unpremultiplied space.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

@jfirebaugh 