### PR TITLE
Fix showTileBoundaries erroring if there are no sources yet

### DIFF
--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -214,7 +214,9 @@ class Painter {
 
         if (this.options.showTileBoundaries) {
             const sourceCache = this.style.sourceCaches[Object.keys(this.style.sourceCaches)[0]];
-            draw.debug(this, sourceCache, sourceCache.getVisibleCoordinates());
+            if (sourceCache) {
+                draw.debug(this, sourceCache, sourceCache.getVisibleCoordinates());
+            }
         }
     }
 


### PR DESCRIPTION
Closes #3849. The new behavior only shows tile boundaries for the first source found (because showing them for multiple sources at the same time looks terrible and is not useful), but it led to an when the option is enabled while there are no sources yet.