### PR TITLE
Optimize layer update

### DIFF
--- a/js/style/style_layer_index.js
+++ b/js/style/style_layer_index.js
@@ -6,29 +6,29 @@ const featureFilter = require('feature-filter');
 const groupByLayout = require('mapbox-gl-style-spec/lib/group_by_layout');
 
 class StyleLayerIndex {
-    constructor(layers) {
-        if (layers) {
-            this.replace(layers);
+    constructor(layerConfigs) {
+        if (layerConfigs) {
+            this.replace(layerConfigs);
         }
     }
 
-    replace(layers) {
+    replace(layerConfigs) {
         this.symbolOrder = [];
-        for (const layer of layers) {
-            if (layer.type === 'symbol') {
-                this.symbolOrder.push(layer.id);
+        for (const layerConfig of layerConfigs) {
+            if (layerConfig.type === 'symbol') {
+                this.symbolOrder.push(layerConfig.id);
             }
         }
-        this._layers = {};
-        this.update(layers, []);
+        this._layerConfigs = {};
+        this.update(layerConfigs, []);
     }
 
-    update(layers, removedIds, symbolOrder) {
-        for (const layer of layers) {
-            this._layers[layer.id] = layer;
+    update(layerConfigs, removedIds, symbolOrder) {
+        for (const layerConfig of layerConfigs) {
+            this._layerConfigs[layerConfig.id] = layerConfig;
         }
         for (const id of removedIds) {
-            delete this._layers[id];
+            delete this._layerConfigs[id];
         }
         if (symbolOrder) {
             this.symbolOrder = symbolOrder;
@@ -36,9 +36,10 @@ class StyleLayerIndex {
 
         this.familiesBySource = {};
 
-        const groups = groupByLayout(util.values(this._layers));
-        for (let layers of groups) {
-            layers = layers.map((layer) => {
+        const groups = groupByLayout(util.values(this._layerConfigs));
+
+        for (const layerConfigs of groups) {
+            const layers = layerConfigs.map((layer) => {
                 layer = StyleLayer.create(layer);
                 layer.updatePaintTransitions({}, {transition: false});
                 layer.filter = featureFilter(layer.filter);

--- a/js/style/style_layer_index.js
+++ b/js/style/style_layer_index.js
@@ -20,15 +20,21 @@ class StyleLayerIndex {
             }
         }
         this._layerConfigs = {};
+        this._layers = {};
         this.update(layerConfigs, []);
     }
 
     update(layerConfigs, removedIds, symbolOrder) {
         for (const layerConfig of layerConfigs) {
             this._layerConfigs[layerConfig.id] = layerConfig;
+
+            const layer = this._layers[layerConfig.id] = StyleLayer.create(layerConfig);
+            layer.updatePaintTransitions({}, {transition: false});
+            layer.filter = featureFilter(layer.filter);
         }
         for (const id of removedIds) {
             delete this._layerConfigs[id];
+            delete this._layers[id];
         }
         if (symbolOrder) {
             this.symbolOrder = symbolOrder;
@@ -39,12 +45,7 @@ class StyleLayerIndex {
         const groups = groupByLayout(util.values(this._layerConfigs));
 
         for (const layerConfigs of groups) {
-            const layers = layerConfigs.map((layer) => {
-                layer = StyleLayer.create(layer);
-                layer.updatePaintTransitions({}, {transition: false});
-                layer.filter = featureFilter(layer.filter);
-                return layer;
-            });
+            const layers = layerConfigs.map((layerConfig) => this._layers[layerConfig.id]);
 
             const layer = layers[0];
             if (layer.layout && layer.layout.visibility === 'none') {


### PR DESCRIPTION
This change makes the worker avoid recreating all layer instances when updating just a few layers (e.g. with `setFilter`). 

This fixes performance for cases where the updated source doesn't contain much data, but the update is bogged down by all other layers from the basemap — e.g. as on our [official hover example](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/). Ref #2874 (comments). 

cc @jfirebaugh @lucaswoj 