### PR TITLE
Fallback for add/moveLayer when provided before-layer does not exist

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -434,7 +434,8 @@ class Style extends Evented {
 
         layer.setEventedParent(this, {layer: {id: id}});
 
-        const index = before ? this._order.indexOf(before) : this._order.length;
+        const beforeIndex = before ? this._order.indexOf(before) : -1;
+        const index = beforeIndex > -1 ? beforeIndex : this._order.length;
         this._order.splice(index, 0, id);
 
         this._layers[id] = layer;
@@ -474,7 +475,8 @@ class Style extends Evented {
         const index = this._order.indexOf(id);
         this._order.splice(index, 1);
 
-        const newIndex = before ? this._order.indexOf(before) : this._order.length;
+        const beforeIndex = before ? this._order.indexOf(before) : -1;
+        const newIndex = beforeIndex > -1 ? beforeIndex : this._order.length;
         this._order.splice(newIndex, 0, id);
 
         if (layer.type === 'symbol') {


### PR DESCRIPTION
In response to discussion in #3868.

When providing a <code>before</code> parameter to <code>addLayer</code> and <code>moveLayer</code> referencing a layer id that does not exist the current behaviour is to add the layer _second to last_ (since the indexOf lookup returns -1):

```javascript
   const index = before ? this._order.indexOf(before) : this._order.length;
   this._order.splice(index, 0, id);
```

This is not intuitive and this PR will instead make a fallback to adding the layer at the end (i.e. same as without the <code>before</code> parameter provided).

Another option could be to throw an exception in such a case.
