### PR TITLE
Allow user to specify n, s, e, w padding options for fitBounds

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -1,31 +1,124 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
-        body { margin: 0; padding: 0; }
-        html, body, #map { height: 100%; }
+    body {
+        margin: 0;
+        padding: 0;
+    }
+
+    #map {
+        position: absolute;
+        height: 100%;
+        left:0;
+        right:0;
+    }
+
+    #sidebar {
+        width: 200px;
+        position: absolute;
+        top:0;
+        left:0;
+        height: 100%;
+        background-color: white;
+        opacity: .3;
+        z-index: 99;
+    }
     </style>
 </head>
 
 <body>
-<div id='map'></div>
+    <div id='map'></div>
+    <div id="sidebar"></div>
+    <script src='/dist/mapbox-gl-dev.js'></script>
+    <script src='/debug/access_token_generated.js'></script>
+    <script>
+    var map = window.map = new mapboxgl.Map({
+        container: 'map',
+        zoom: 5,
+        center: [-77.01866, 38.888],
+        bearing: 0,
+        style: 'mapbox://styles/mapbox/streets-v10',
+        hash: false
+    });
 
-<script src='/dist/mapbox-gl-dev.js'></script>
-<script src='/debug/access_token_generated.js'></script>
-<script>
+    map.on('load', () => {
+        const boundsSW = [-132.890625,
+          19.31114335506464],
+            boundsNE = [-56.953125,
+          52.05249047600099],
+            bounds = mapboxgl.LngLatBounds.convert([boundsSW, boundsNE]);        // map.fitBounds(bounds);
+        // [n,e,s,w]
+        // sw: [w,s] = [x,y]
+        // ne: [e,n] = [x,y]
+        const padding = {north: 30, east: 0, south: 0, west: 200};
+        // var newNE = map.project(bounds.getNorthEast()).add(mapboxgl.Point.convert([padding.east, -padding.north]));
+        // var newSW = map.project(bounds.getSouthWest()).add(mapboxgl.Point.convert([-padding.west, padding.south]));
 
-var map = window.map = new mapboxgl.Map({
-    container: 'map',
-    zoom: 12.5,
-    center: [-77.01866, 38.888],
-    style: 'mapbox://styles/mapbox/streets-v10',
-    hash: true
-});
-
-</script>
+        // const newNEgeo = map.unproject(newNE);
+        // const newSWgeo = map.unproject(newSW);
+        map.addSource('original', {
+            type: 'geojson',
+            data: {
+                type: 'FeatureCollection',
+                features: [{
+                    type: 'Feature',
+                    geometry: {
+                        type: 'Point',
+                        coordinates: boundsNE
+                    },
+                    properties: {}
+                }, {
+                    type: 'Feature',
+                    geometry: {
+                        type: 'Point',
+                        coordinates: boundsSW
+                    },
+                    properties: {}
+                }]
+            }
+        });
+        // map.addSource('new', {
+        //     type: 'geojson',
+        //     data: {
+        //         type: 'FeatureCollection',
+        //         features: [{
+        //             type: 'Feature',
+        //             geometry: {
+        //                 type: 'Point',
+        //                 coordinates: [newNEgeo.lng, newNEgeo.lat]
+        //             },
+        //             properties: {}
+        //         }, {
+        //             type: 'Feature',
+        //             geometry: {
+        //                 type: 'Point',
+        //                 coordinates: [newSWgeo.lng, newSWgeo.lat]
+        //             },
+        //             properties: {}
+        //         }]
+        //     }
+        // });
+        setTimeout(()=>{
+            map.fitBounds(bounds);
+        }, 1000);
+        map.addLayer({
+            id: 'original',
+            source: 'original',
+            type: 'circle',
+            paint: {
+                'circle-radius': 5,
+                'circle-color': 'blue',
+                'circle-opacity': 0.7
+            }
+        })
+    });
+    </script>
 </body>
+
 </html>

--- a/debug/index.html
+++ b/debug/index.html
@@ -1,124 +1,31 @@
 <!DOCTYPE html>
 <html>
-
 <head>
     <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />
     <style>
-    body {
-        margin: 0;
-        padding: 0;
-    }
-
-    #map {
-        position: absolute;
-        height: 100%;
-        left:0;
-        right:0;
-    }
-
-    #sidebar {
-        width: 200px;
-        position: absolute;
-        top:0;
-        left:0;
-        height: 100%;
-        background-color: white;
-        opacity: .3;
-        z-index: 99;
-    }
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
     </style>
 </head>
 
 <body>
-    <div id='map'></div>
-    <div id="sidebar"></div>
-    <script src='/dist/mapbox-gl-dev.js'></script>
-    <script src='/debug/access_token_generated.js'></script>
-    <script>
-    var map = window.map = new mapboxgl.Map({
-        container: 'map',
-        zoom: 5,
-        center: [-77.01866, 38.888],
-        bearing: 0,
-        style: 'mapbox://styles/mapbox/streets-v10',
-        hash: false
-    });
+<div id='map'></div>
 
-    map.on('load', () => {
-        const boundsSW = [-132.890625,
-          19.31114335506464],
-            boundsNE = [-56.953125,
-          52.05249047600099],
-            bounds = mapboxgl.LngLatBounds.convert([boundsSW, boundsNE]);        // map.fitBounds(bounds);
-        // [n,e,s,w]
-        // sw: [w,s] = [x,y]
-        // ne: [e,n] = [x,y]
-        const padding = {north: 30, east: 0, south: 0, west: 200};
-        // var newNE = map.project(bounds.getNorthEast()).add(mapboxgl.Point.convert([padding.east, -padding.north]));
-        // var newSW = map.project(bounds.getSouthWest()).add(mapboxgl.Point.convert([-padding.west, padding.south]));
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
 
-        // const newNEgeo = map.unproject(newNE);
-        // const newSWgeo = map.unproject(newSW);
-        map.addSource('original', {
-            type: 'geojson',
-            data: {
-                type: 'FeatureCollection',
-                features: [{
-                    type: 'Feature',
-                    geometry: {
-                        type: 'Point',
-                        coordinates: boundsNE
-                    },
-                    properties: {}
-                }, {
-                    type: 'Feature',
-                    geometry: {
-                        type: 'Point',
-                        coordinates: boundsSW
-                    },
-                    properties: {}
-                }]
-            }
-        });
-        // map.addSource('new', {
-        //     type: 'geojson',
-        //     data: {
-        //         type: 'FeatureCollection',
-        //         features: [{
-        //             type: 'Feature',
-        //             geometry: {
-        //                 type: 'Point',
-        //                 coordinates: [newNEgeo.lng, newNEgeo.lat]
-        //             },
-        //             properties: {}
-        //         }, {
-        //             type: 'Feature',
-        //             geometry: {
-        //                 type: 'Point',
-        //                 coordinates: [newSWgeo.lng, newSWgeo.lat]
-        //             },
-        //             properties: {}
-        //         }]
-        //     }
-        // });
-        setTimeout(()=>{
-            map.fitBounds(bounds);
-        }, 1000);
-        map.addLayer({
-            id: 'original',
-            source: 'original',
-            type: 'circle',
-            paint: {
-                'circle-radius': 5,
-                'circle-color': 'blue',
-                'circle-opacity': 0.7
-            }
-        })
-    });
-    </script>
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-77.01866, 38.888],
+    style: 'mapbox://styles/mapbox/streets-v10',
+    hash: true
+});
+
+</script>
 </body>
-
 </html>

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -304,22 +304,32 @@ class Camera extends Evented {
      *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
      *     {@link Map#flyTo} for information about the options specific to that animated transition.
      * @param {Function} [options.easing] An easing function for the animated transition.
-     * @param {number} [options.padding=0] The amount of padding, in pixels, to allow around the specified bounds.
+     * @param {number|Array} options.padding how much padding there is around the given bounds on each side in pixels. Accepts a number for all padding edges or an array [n, e, s, w]
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the map view transitions to the specified bounds.
      * @param {Object} [eventData] Data to propagate to any event listeners.
      * @fires movestart
      * @fires moveend
      * @returns {Map} `this`
+	 * @example
+     * var bbox = [[-79, 43], [-73, 45]];
+     * map.fitBounds(bbox, {
+     *   padding: [10, 40, 10, 40]
+     * });
      * @see [Fit a map to a bounding box](https://www.mapbox.com/mapbox-gl-js/example/fitbounds/)
      */
     fitBounds(bounds, options, eventData) {
 
         options = util.extend({
-            padding: 0,
+            padding: [0, 0, 0, 0],
             offset: [0, 0],
             maxZoom: this.getMaxZoom()
         }, options);
+
+        if (typeof options.padding === 'number') {
+            var p = options.padding;
+            options.padding = [p, p, p, p];
+        }
 
         bounds = LngLatBounds.convert(bounds);
 
@@ -328,8 +338,8 @@ class Camera extends Evented {
             nw = tr.project(bounds.getNorthWest()),
             se = tr.project(bounds.getSouthEast()),
             size = se.sub(nw),
-            scaleX = (tr.width - options.padding * 2 - Math.abs(offset.x) * 2) / size.x,
-            scaleY = (tr.height - options.padding * 2 - Math.abs(offset.y) * 2) / size.y;
+            scaleX = (tr.width - (options.padding[1] + options.padding[3]) * 2 - Math.abs(offset.x) * 2) / size.x,
+            scaleY = (tr.height - (options.padding[0] + options.padding[2]) * 2 - Math.abs(offset.y) * 2) / size.y;
 
         options.center = tr.unproject(nw.add(se).div(2));
         options.zoom = Math.min(tr.scaleZoom(tr.scale * Math.min(scaleX, scaleY)), options.maxZoom);

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -311,7 +311,8 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
      *      zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
-     * @param {AnimationOptions | CameraOptions | PaddingOptions} [options]
+     * @param {AnimationOptions | CameraOptions } [options]
+     * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {boolean} [options.linear=false] If `true`, the map transitions using
      *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
      *     {@link Map#flyTo} for information about the options specific to that animated transition.

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -34,6 +34,17 @@ const Evented = require('../util/evented');
  * @property {boolean} animate If `false`, no animation will occur.
  */
 
+/**
+ * Options for setting padding on a call to {@link Map#fitBounds}. All properties of this object must be
+ * non-negative integers.
+ *
+ * @typedef {Object} PaddingOptions
+ * @property {number} top Padding in pixels from the top of the map canvas.
+ * @property {number} bottom Padding in pixels from the bottom of the map canvas.
+ * @property {number} left Padding in pixels from the left of the map canvas.
+ * @property {number} right Padding in pixels from the right of the map canvas.
+ */
+
 class Camera extends Evented {
 
     constructor(transform, options) {
@@ -300,12 +311,11 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
      *      zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
-     * @param {Object} [options]
+     * @param {AnimationOptions | CameraOptions | PaddingOptions} [options]
      * @param {boolean} [options.linear=false] If `true`, the map transitions using
      *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
      *     {@link Map#flyTo} for information about the options specific to that animated transition.
      * @param {Function} [options.easing] An easing function for the animated transition.
-     * @param {number|Object} [options.padding] Sets padding around the given bounds on each side in pixels. Accepts a number for all padding edges or an object with padding for each compass direction (north, south, east, and west)
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the map view transitions to the specified bounds.
      * @param {Object} [eventData] Data to propagate to any event listeners.
@@ -315,7 +325,7 @@ class Camera extends Evented {
 	 * @example
      * var bbox = [[-79, 43], [-73, 45]];
      * map.fitBounds(bbox, {
-     *   padding: {north: 10, east:25, south: 15, west: 5}
+     *   padding: {top: 10, bottom:25, left: 15, right: 5}
      * });
      * @see [Fit a map to a bounding box](https://www.mapbox.com/mapbox-gl-js/example/fitbounds/)
      */

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -304,7 +304,7 @@ class Camera extends Evented {
      *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
      *     {@link Map#flyTo} for information about the options specific to that animated transition.
      * @param {Function} [options.easing] An easing function for the animated transition.
-     * @param {number|Array} options.padding how much padding there is around the given bounds on each side in pixels. Accepts a number for all padding edges or an array [n, e, s, w]
+     * @param {number|Object} [options.padding] Sets padding around the given bounds on each side in pixels. Accepts a number for all padding edges or an object with padding for each compass direction (north, south, east, and west)
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the map view transitions to the specified bounds.
      * @param {Object} [eventData] Data to propagate to any event listeners.
@@ -314,7 +314,7 @@ class Camera extends Evented {
 	 * @example
      * var bbox = [[-79, 43], [-73, 45]];
      * map.fitBounds(bbox, {
-     *   padding: [10, 40, 10, 40]
+     *   padding: {north: 10, east:25, south: 15, west: 5}
      * });
      * @see [Fit a map to a bounding box](https://www.mapbox.com/mapbox-gl-js/example/fitbounds/)
      */

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -323,11 +323,11 @@ class Camera extends Evented {
         options = util.extend({
             padding: [0, 0, 0, 0],
             offset: [0, 0],
-            maxZoom: this.getMaxZoom()
+            maxZoom: this.transform.maxZoom
         }, options);
 
         if (typeof options.padding === 'number') {
-            var p = options.padding;
+            const p = options.padding;
             options.padding = [p, p, p, p];
         }
 
@@ -335,8 +335,12 @@ class Camera extends Evented {
 
         const offset = Point.convert(options.offset),
             tr = this.transform,
-            nw = tr.project(bounds.getNorthWest()),
-            se = tr.project(bounds.getSouthEast()),
+            // options padding order is [n, e, s, w], so we add the appropriate paddings
+            // to the given bounds to adjust the viewport bounds.
+            nwPadding = Point.convert([options.padding[0], options.padding[3]]),
+            sePadding = Point.convert([options.padding[1], options.padding[2]]),
+            nw = tr.project(bounds.getNorthWest()).add(nwPadding),
+            se = tr.project(bounds.getSouthEast()).add(sePadding),
             size = se.sub(nw),
             scaleX = (tr.width - (options.padding[1] + options.padding[3]) * 2 - Math.abs(offset.x) * 2) / size.x,
             scaleY = (tr.height - (options.padding[0] + options.padding[2]) * 2 - Math.abs(offset.y) * 2) / size.y;

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -339,11 +339,13 @@ class Camera extends Evented {
             // to the given bounds to adjust the viewport bounds.
             nwPadding = Point.convert([options.padding[0], options.padding[3]]),
             sePadding = Point.convert([options.padding[1], options.padding[2]]),
-            nw = tr.project(bounds.getNorthWest()).add(nwPadding),
+            // because both x and y decrease in the nw direction in screen coordinates
+            // we subtract the nw padding, and add the se padding to get the appropriate bounds.
+            nw = tr.project(bounds.getNorthWest()).sub(nwPadding),
             se = tr.project(bounds.getSouthEast()).add(sePadding),
             size = se.sub(nw),
-            scaleX = (tr.width - (options.padding[1] + options.padding[3]) * 2 - Math.abs(offset.x) * 2) / size.x,
-            scaleY = (tr.height - (options.padding[0] + options.padding[2]) * 2 - Math.abs(offset.y) * 2) / size.y;
+            scaleX = (tr.width - Math.abs(offset.x) * 2) / size.x,
+            scaleY = (tr.height - Math.abs(offset.y) * 2) / size.y;
 
         options.center = tr.unproject(nw.add(se).div(2));
         options.zoom = Math.min(tr.scaleZoom(tr.scale * Math.min(scaleX, scaleY)), options.maxZoom);

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -360,6 +360,7 @@ class Camera extends Evented {
         options.center = tr.unproject(nw.add(se).div(2));
         options.zoom = Math.min(tr.scaleZoom(tr.scale * Math.min(scaleX, scaleY)), options.maxZoom);
         options.bearing = 0;
+        // options.bearing = tr.bearing;
 
         return options.linear ?
             this.easeTo(options, eventData) :

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -321,25 +321,35 @@ class Camera extends Evented {
     fitBounds(bounds, options, eventData) {
 
         options = util.extend({
-            padding: [0, 0, 0, 0],
+            padding: {
+                north: 0,
+                south: 0,
+                east: 0,
+                west: 0
+            },
             offset: [0, 0],
             maxZoom: this.transform.maxZoom
         }, options);
 
         if (typeof options.padding === 'number') {
             const p = options.padding;
-            options.padding = [p, p, p, p];
+            options.padding = {
+                north: p,
+                south: p,
+                east: p,
+                west: p
+            };
         }
-
         bounds = LngLatBounds.convert(bounds);
 
         const offset = Point.convert(options.offset),
             tr = this.transform,
-            // options padding order is [n, e, s, w], so we add the appropriate paddings
-            // to the given bounds to adjust the viewport bounds.
-            nwPadding = Point.convert([options.padding[0], options.padding[3]]),
-            sePadding = Point.convert([options.padding[1], options.padding[2]]),
-            // because both x and y decrease in the nw direction in screen coordinates
+            // add the appropriate paddings to the given bounds to adjust the viewport bounds.
+            // for NW: [x,y] = [w, n]
+            nwPadding = Point.convert([ options.padding.west || 0, options.padding.north || 0]),
+            // for SE: [x,y] = [e, s]
+            sePadding = Point.convert([ options.padding.east || 0, options.padding.south || 0]),
+            // because x decreases in the west direction and y decreases in the n direction in screen coordinates
             // we subtract the nw padding, and add the se padding to get the appropriate bounds.
             nw = tr.project(bounds.getNorthWest()).sub(nwPadding),
             se = tr.project(bounds.getSouthEast()).add(sePadding),

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -322,10 +322,10 @@ class Camera extends Evented {
 
         options = util.extend({
             padding: {
-                north: 0,
-                south: 0,
-                east: 0,
-                west: 0
+                top: 0,
+                bottom: 0,
+                right: 0,
+                left: 0
             },
             offset: [0, 0],
             maxZoom: this.transform.maxZoom
@@ -334,10 +334,10 @@ class Camera extends Evented {
         if (typeof options.padding === 'number') {
             const p = options.padding;
             options.padding = {
-                north: p,
-                south: p,
-                east: p,
-                west: p
+                top: p,
+                bottom: p,
+                right: p,
+                left: p
             };
         }
         bounds = LngLatBounds.convert(bounds);
@@ -346,9 +346,9 @@ class Camera extends Evented {
             tr = this.transform,
             // add the appropriate paddings to the given bounds to adjust the viewport bounds.
             // for NW: [x,y] = [w, n]
-            nwPadding = Point.convert([ options.padding.west || 0, options.padding.north || 0]),
+            nwPadding = Point.convert([ options.padding.left || 0, options.padding.top || 0]),
             // for SE: [x,y] = [e, s]
-            sePadding = Point.convert([ options.padding.east || 0, options.padding.south || 0]),
+            sePadding = Point.convert([ options.padding.right || 0, options.padding.bottom || 0]),
             // because x decreases in the west direction and y decreases in the n direction in screen coordinates
             // we subtract the nw padding, and add the se padding to get the appropriate bounds.
             nw = tr.project(bounds.getNorthWest()).sub(nwPadding),

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -352,20 +352,13 @@ class Camera extends Evented {
                 left: p
             };
         }
-
-        if (!util.deepEqual(Object.keys(options.padding).sort((a, b)=> {
+        if (!util.deepEqual(Object.keys(options.padding).sort((a, b) => {
             if (a < b) return -1;
             if (a > b) return 1;
             return 0;
         }), ["bottom", "left", "right", "top"])) {
             util.warnOnce("options.padding must be a positive number, or an Object with keys 'bottom', 'left', 'right', 'top'");
-            console.log(Object.keys(options.padding).sort((a, b)=> {
-                if (a < b) return -1;
-                if (a > b) return 1;
-                return 0;
-            }));
             return;
-
         }
 
         bounds = LngLatBounds.convert(bounds);

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1153,7 +1153,7 @@ test('camera', (t) => {
 
             camera.fitBounds(bb, { padding: 15, duration:0 });
             t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -100.5, lat: 34.717077774 }, 'pans to coordinates based on fitBounds with padding option as number applied');
-            t.equal(fixedNum(camera.getZoom(), 3), 2.064);
+            t.equal(fixedNum(camera.getZoom(), 3), 2.382);
             t.end();
         });
 
@@ -1161,8 +1161,8 @@ test('camera', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
 
-            camera.fitBounds(bb, { padding: {north: 10, east: 75, south: 50, west: 25}, duration:0 });
-            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -82.921875, lat: 22.403743206 }, 'pans to coordinates based on fitBounds with padding option as object applied');
+            camera.fitBounds(bb, { padding: {top: 10, right: 75, bottom: 50, left: 25}, duration:0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -91.522099448, lat: 28.608945184 }, 'pans to coordinates based on fitBounds with padding option as object applied');
             t.end();
         });
 

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1136,41 +1136,34 @@ test('camera', (t) => {
         t.end();
     });
 
-    t.test('#fitBounds', function(t) {
-        t.test('no options passsed', function(t) {
-            var camera = createCamera();
-            var bb = [[-79, 43], [-73, 45]];
+    t.test('#fitBounds', (t) => {
+        t.test('no padding passed', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16],[-68, 50]];
 
-            camera.fitBounds(bb);
-
-            camera.on('moveend', function() {
-                t.deepEqual(camera.getCenter(), { lng: -76.00000000000006, lat: 44.008428892836804 }, 'pans to coordinates based on fitBounds');
-                t.end();
-            });
+            camera.fitBounds(bb, {duration:0});
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -100.5, lat: 34.717077774 }, 'pans to coordinates based on fitBounds');
+            t.equal(fixedNum(camera.getZoom(), 3), 2.469)
+            t.end();
         });
 
-        t.test('padding number', function(t) {
-            var camera = createCamera();
-            var bb = [[-79, 43], [-73, 45]];
+        t.test('padding number', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16],[-68, 50]];
 
-            camera.fitBounds(bb, { padding: 80 });
-
-            camera.on('moveend', function() {
-                t.deepEqual(camera.getCenter(), { lng: -76.00000000000001, lat: 44.008428892836804 }, 'pans to coordinates based on fitBounds with padding option as number applied');
-                t.end();
-            });
+            camera.fitBounds(bb, { padding: 50, duration:0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -100.5, lat: 34.717077774 }, 'pans to coordinates based on fitBounds with padding option as number applied');
+            t.equal(fixedNum(camera.getZoom(), 3), 1.412);
+            t.end();
         });
 
-        t.test('padding array', function(t) {
-            var camera = createCamera();
-            var bb = [[-79, 43], [-73, 45]];
+        t.test('padding array', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16],[-68, 50]];
 
-            camera.fitBounds(bb, { padding: [10, 50, 10, 20] });
-
-            camera.on('moveend', function() {
-                t.deepEqual(camera.getCenter(), { lng: -75.99999999999997, lat: 44.008428892836776 }, 'pans to coordinates based on fitBounds with padding option as array applied');
-                t.end();
-            });
+            camera.fitBounds(bb, { padding: [50, 15, 25, 75], duration:0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -102.5831167, lat: 35.4274358 }, 'pans to coordinates based on fitBounds with padding option as array applied');
+            t.end();
         });
 
         t.end();

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1142,7 +1142,7 @@ test('camera', (t) => {
             const bb = [[-133, 16], [-68, 50]];
 
             camera.fitBounds(bb, {duration:0});
-            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -100.5, lat: 34.717077774 }, 'pans to coordinates based on fitBounds');
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), { lng: -100.5, lat: 34.7171 }, 'pans to coordinates based on fitBounds');
             t.equal(fixedNum(camera.getZoom(), 3), 2.469);
             t.end();
         });
@@ -1152,7 +1152,7 @@ test('camera', (t) => {
             const bb = [[-133, 16], [-68, 50]];
 
             camera.fitBounds(bb, { padding: 15, duration:0 });
-            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -100.5, lat: 34.717077774 }, 'pans to coordinates based on fitBounds with padding option as number applied');
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), { lng: -100.5, lat: 34.7171 }, 'pans to coordinates based on fitBounds with padding option as number applied');
             t.equal(fixedNum(camera.getZoom(), 3), 2.382);
             t.end();
         });
@@ -1162,7 +1162,7 @@ test('camera', (t) => {
             const bb = [[-133, 16], [-68, 50]];
 
             camera.fitBounds(bb, { padding: {top: 10, right: 75, bottom: 50, left: 25}, duration:0 });
-            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -91.522099448, lat: 28.608945184 }, 'pans to coordinates based on fitBounds with padding option as object applied');
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), { lng: -91.5221, lat: 28.6089 }, 'pans to coordinates based on fitBounds with padding option as object applied');
             t.end();
         });
 

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1139,30 +1139,30 @@ test('camera', (t) => {
     t.test('#fitBounds', (t) => {
         t.test('no padding passed', (t) => {
             const camera = createCamera();
-            const bb = [[-133, 16],[-68, 50]];
+            const bb = [[-133, 16], [-68, 50]];
 
             camera.fitBounds(bb, {duration:0});
             t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -100.5, lat: 34.717077774 }, 'pans to coordinates based on fitBounds');
-            t.equal(fixedNum(camera.getZoom(), 3), 2.469)
+            t.equal(fixedNum(camera.getZoom(), 3), 2.469);
             t.end();
         });
 
         t.test('padding number', (t) => {
             const camera = createCamera();
-            const bb = [[-133, 16],[-68, 50]];
+            const bb = [[-133, 16], [-68, 50]];
 
-            camera.fitBounds(bb, { padding: 50, duration:0 });
+            camera.fitBounds(bb, { padding: 15, duration:0 });
             t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -100.5, lat: 34.717077774 }, 'pans to coordinates based on fitBounds with padding option as number applied');
-            t.equal(fixedNum(camera.getZoom(), 3), 1.412);
+            t.equal(fixedNum(camera.getZoom(), 3), 2.519);
             t.end();
         });
 
         t.test('padding array', (t) => {
             const camera = createCamera();
-            const bb = [[-133, 16],[-68, 50]];
+            const bb = [[-133, 16], [-68, 50]];
 
             camera.fitBounds(bb, { padding: [50, 15, 25, 75], duration:0 });
-            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -102.5831167, lat: 35.4274358 }, 'pans to coordinates based on fitBounds with padding option as array applied');
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -102.8164, lat: 35.50661 }, 'pans to coordinates based on fitBounds with padding option as array applied');
             t.end();
         });
 

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1136,5 +1136,45 @@ test('camera', (t) => {
         t.end();
     });
 
+    t.test('#fitBounds', function(t) {
+        t.test('no options passsed', function(t) {
+            var camera = createCamera();
+            var bb = [[-79, 43], [-73, 45]];
+
+            camera.fitBounds(bb);
+
+            camera.on('moveend', function() {
+                t.deepEqual(camera.getCenter(), { lng: -76.00000000000006, lat: 44.008428892836804 }, 'pans to coordinates based on fitBounds');
+                t.end();
+            });
+        });
+
+        t.test('padding number', function(t) {
+            var camera = createCamera();
+            var bb = [[-79, 43], [-73, 45]];
+
+            camera.fitBounds(bb, { padding: 80 });
+
+            camera.on('moveend', function() {
+                t.deepEqual(camera.getCenter(), { lng: -76.00000000000001, lat: 44.008428892836804 }, 'pans to coordinates based on fitBounds with padding option as number applied');
+                t.end();
+            });
+        });
+
+        t.test('padding array', function(t) {
+            var camera = createCamera();
+            var bb = [[-79, 43], [-73, 45]];
+
+            camera.fitBounds(bb, { padding: [10, 50, 10, 20] });
+
+            camera.on('moveend', function() {
+                t.deepEqual(camera.getCenter(), { lng: -75.99999999999997, lat: 44.008428892836776 }, 'pans to coordinates based on fitBounds with padding option as array applied');
+                t.end();
+            });
+        });
+
+        t.end();
+    });
+
     t.end();
 });

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1153,16 +1153,16 @@ test('camera', (t) => {
 
             camera.fitBounds(bb, { padding: 15, duration:0 });
             t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -100.5, lat: 34.717077774 }, 'pans to coordinates based on fitBounds with padding option as number applied');
-            t.equal(fixedNum(camera.getZoom(), 3), 2.519);
+            t.equal(fixedNum(camera.getZoom(), 3), 2.064);
             t.end();
         });
 
-        t.test('padding array', (t) => {
+        t.test('padding object', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
 
-            camera.fitBounds(bb, { padding: [50, 15, 25, 75], duration:0 });
-            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -102.8164, lat: 35.50661 }, 'pans to coordinates based on fitBounds with padding option as array applied');
+            camera.fitBounds(bb, { padding: {north: 10, east: 75, south: 50, west: 25}, duration:0 });
+            t.deepEqual(fixedLngLat(camera.getCenter()), { lng: -82.921875, lat: 22.403743206 }, 'pans to coordinates based on fitBounds with padding option as object applied');
             t.end();
         });
 


### PR DESCRIPTION
## Launch Checklist
Continuing on @tristen's PR from #1682.
In order to have separate padding pixels on each side of the map bounds. Right now its set up as `[n,e,s,w]` but I'm not sure this makes the most sense. Should we be consistent with the `offset` option and take 2 `Points` (one for each corner of the bounds)?

~~Testing the debug page is showing me I'm slightly off on the adjustments right now so I have to figure out what I did wrong in adjusting the camera function.~~ flipped x, y 😭 

cc @lucaswoj 
closes #1339 
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
