### PR TITLE
fire an error when setting a "source-layer" on a layer that uses a GeoJSON source

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -128,9 +128,9 @@ class Style extends Evented {
         if (!layer.sourceLayer) return;
         if (!sourceCache) return;
         const source = sourceCache.getSource();
-        if (!source.vectorLayerIds) return;
 
-        if (source.vectorLayerIds.indexOf(layer.sourceLayer) === -1) {
+        if (source.type === 'geojson' || (source.vectorLayerIds &&
+            source.vectorLayerIds.indexOf(layer.sourceLayer) === -1)) {
             this.fire('error', {
                 error: new Error(
                     `Source layer "${layer.sourceLayer}" ` +

--- a/test/js/style/style.test.js
+++ b/test/js/style/style.test.js
@@ -692,6 +692,33 @@ test('Style#addLayer', (t) => {
         });
     });
 
+    t.test('fires an error on non-existant source layer', (t) => {
+        const style = new Style(util.extend(createStyleJSON(), {
+            sources: {
+                dummy: {
+                    type: 'geojson',
+                    data: { type: 'FeatureCollection', features: [] }
+                }
+            }
+        }));
+
+        const layer = {
+            id: 'dummy',
+            source: 'dummy',
+            type: 'background',
+            'source-layer': 'dummy'
+        };
+
+        style.on('style.load', () => {
+            style.on('error', ({ error }) => {
+                t.match(error.message, /does not exist on source/);
+                t.end();
+            });
+            style.addLayer(layer);
+        });
+
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
This will fire an error when setting a `source-layer` on a layer that uses a GeoJSON source, according to #3784 
