### PR TITLE
Clarify that Point and PointLike types are screen coordinates in pixels

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1403,13 +1403,13 @@ function removeNode(node) {
 
 /**
  * A [`Point` geometry](https://github.com/mapbox/point-geometry) object, which has
- * `x` and `y` properties representing coordinates.
+ * `x` and `y` properties representing screen coordinates in pixels.
  *
  * @typedef {Object} Point
  */
 
 /**
- * A [`Point`](#Point) or an array of two numbers representing `x` and `y` coordinates.
+ * A [`Point`](#Point) or an array of two numbers representing `x` and `y` screen coordinates in pixels.
  *
  * @typedef {(Point | Array<number>)} PointLike
  */


### PR DESCRIPTION
This pull request simply clarifies the data type and unit of the `Point` and `PointLike` types in the documentation. As is, it is unclear that `x` and `y` refer to _screen_ coordinates and not _geographic_ coordinates.

This is a follow up to issue #3888 