### PR TITLE
Fix issue #3887 -- backport line breaking changes from gl-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2bdca923fc4190156b5a22af71be29442451db54",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3136389f1c82345616bb9739f3b9be6d3120179c",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
- Put "breakable" punctuation (such as a hyphen) on the line that starts the break, not the line after the break.
- Process all characters with the line breaking algorithm, even if we don't have glyphs for them. Some fonts have glyph-less breakable characters (we end up treating them similarly to a "zero-width space").
- Don't include trailing white space in raggedness calculations
- Make the "favor short final lines" rule more aggressive (unlike the other changes, this one is purely an aesthetic choice)

@1ec5 @lucaswoj @nickidlugash 