### PR TITLE
Don't attempt to clear "undefined" sources

### DIFF
--- a/js/style/style.js
+++ b/js/style/style.js
@@ -444,7 +444,7 @@ class Style extends Evented {
 
         this._layers[id] = layer;
 
-        if (this._removedLayers[id]) {
+        if (this._removedLayers[id] && layer.source) {
             // If, in the current batch, we have already removed this layer
             // and we are now re-adding it, then we need to clear (rather
             // than just reload) the underyling source's tiles.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "in-publish": "^2.0.0",
     "jsdom": "^9.4.2",
     "lodash.template": "^4.4.0",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3136389f1c82345616bb9739f3b9be6d3120179c",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7438620cfcdb406c6ea7f4a10918e4f5a2d517d6",
     "minifyify": "^7.0.1",
     "npm-run-all": "^3.0.0",
     "nyc": "^8.3.0",


### PR DESCRIPTION
When I upgraded from mapbox 0.28.0 to 0.30.0 I noticed that when my application tried to "update" a `background`-type layer I got an NPE. The root cause seems to be that when a background layer is removed-and-added in a single batched style update group its source gets marked for "clear"-ing.

This sucks because `layer.source === undefined` for `background` layers, and when `style.js#283` attempts to call `_clearSource` on `undefined` it throws an exception.