### PR TITLE
Fix severe performance regression on bearing/pitch change

### DIFF
--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -99,7 +99,7 @@ class Tile {
 
         for (const id in this.buckets) {
             const bucket = this.buckets[id];
-            if (bucket.type === 'symbol') {
+            if (bucket.layers[0].type === 'symbol') {
                 bucket.destroy();
                 delete this.buckets[id];
             }


### PR DESCRIPTION
Closes #3856 and probably closes #3881 too. Took me ages to find the culprit but it turned out to be really simple.

The offending commit is https://github.com/mapbox/mapbox-gl-js/commit/cd72f381e7e27722f84322af417cc0eeeb807082, after which we didn't notice that [this line](https://github.com/mapbox/mapbox-gl-js/blob/878008895104b67861ce73f65809f7f6f0ed7263/js/source/tile.js#L102) stopped working properly.

We should merge this and do a patch release ASAP, but must follow-up with a new benchmark that exercises the `redoPlacement` routine (e.g. by rotating continuously).

Also note that increasing our flow annotations coverage should help preventing bugs like this.

@averas @stevage @kristfal @pbabik please confirm that this PR fixes the performance/crash issue you encountered.