### PR TITLE
fix attribution default pos test

### DIFF
--- a/test/js/ui/control/attribution.test.js
+++ b/test/js/ui/control/attribution.test.js
@@ -20,7 +20,7 @@ function createMap() {
 
 test('AttributionControl appears in bottom-right by default', (t) => {
     const map = createMap();
-    map.addControl(new AttributionControl(), 'bottom-right');
+    map.addControl(new AttributionControl());
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-bottom-right .mapboxgl-ctrl-attrib').length, 1);
     t.end();


### PR DESCRIPTION
The test was supposed to test the default position of the control, but it passed a `position` argument so the test wasn't doing its job.
