### PR TITLE
Re-request expired resources

### DIFF
--- a/bench/benchmarks/buffer.js
+++ b/bench/benchmarks/buffer.js
@@ -108,8 +108,8 @@ function preloadAssets(stylesheet, callback) {
 
         function getTile(url, callback) {
             ajax.getArrayBuffer(url, (err, response) => {
-                assets.tiles[url] = response;
-                callback(err, response);
+                assets.tiles[url] = response.data;
+                callback(err, response.data);
             });
         }
 

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -69,6 +69,10 @@ class RasterTileSource extends Evented {
                 return callback(err);
             }
 
+            tile.setExpiryData(img);
+            delete img.cacheControl;
+            delete img.expires;
+
             const gl = this.map.painter.gl;
             tile.texture = this.map.painter.getTileTexture(img.width);
             if (tile.texture) {

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -487,19 +487,6 @@ class SourceCache extends Evented {
     }
 
     /**
-     * Remove tiles that h
-     * @private
-     */
-    clearExpiredTiles() {
-        for (const id in this._tiles)
-            // check if the header is before now
-            // remove it if it is
-            this.removeTile(id);
-        this._cache.reset();
-    }
-
-
-    /**
      * Search through our current tiles and attempt to find the tiles that
      * cover the given bounds.
      * @param {Array<Coordinate>} queryGeometry coordinates of the corners of bounding rectangle

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -162,8 +162,7 @@ class SourceCache extends Evented {
 
         tile.sourceCache = this;
         tile.timeAdded = new Date().getTime();
-
-        this._setTimers(id, tile);
+        this._setTileReloadTimer(id, tile);
         this._source.fire('data', {tile: tile, coord: tile.coord, dataType: 'tile'});
 
         // HACK this is necessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
@@ -414,7 +413,7 @@ class SourceCache extends Evented {
                 if (this._cacheTimers[wrapped.id]) {
                     clearTimeout(this._cacheTimers[wrapped.id]);
                     this._cacheTimers[wrapped.id] = undefined;
-                    this._setTimers(wrapped.id, tile);
+                    this._setTileReloadTimer(wrapped.id, tile);
                 }
             }
         }
@@ -433,7 +432,7 @@ class SourceCache extends Evented {
         return tile;
     }
 
-    _setTimers(id, tile) {
+    _setTileReloadTimer(id, tile) {
         const tileExpires = tile.getExpiry();
         if (tileExpires) {
             this._timers[id] = setTimeout(() => {
@@ -443,7 +442,7 @@ class SourceCache extends Evented {
         }
     }
 
-    _setCacheTimers(id, tile) {
+    _setCacheInvalidationTimer(id, tile) {
         const tileExpires = tile.getExpiry();
         if (tileExpires) {
             this._cacheTimers[id] = setTimeout(() => {
@@ -478,7 +477,7 @@ class SourceCache extends Evented {
         if (tile.hasData()) {
             const wrappedId = tile.coord.wrapped().id;
             this._cache.add(wrappedId, tile);
-            this._setCacheTimers(wrappedId, tile);
+            this._setCacheInvalidationTimer(wrappedId, tile);
         } else {
             tile.aborted = true;
             this.abortTile(tile);

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -459,6 +459,19 @@ class SourceCache extends Evented {
     }
 
     /**
+     * Remove tiles that h
+     * @private
+     */
+    clearExpiredTiles() {
+        for (const id in this._tiles)
+            // check if the header is before now
+            // remove it if it is
+            this.removeTile(id);
+        this._cache.reset();
+    }
+
+
+    /**
      * Search through our current tiles and attempt to find the tiles that
      * cover the given bounds.
      * @param {Array<Coordinate>} queryGeometry coordinates of the corners of bounding rectangle

--- a/js/source/source_cache.js
+++ b/js/source/source_cache.js
@@ -263,15 +263,7 @@ class SourceCache extends Evented {
             }
             if (this._cache.has(coord.id)) {
                 retain[coord.id] = true;
-                const cachedTile = this._cache.get(coord.id);
-
-                if (this._cacheTimers[coord.id]) {
-                    clearTimeout(this._cacheTimers[coord.id]);
-                    delete this._cacheTimers[coord.id];
-                    this._setTimers(coord.id, cachedTile);
-                }
-
-                return cachedTile;
+                return this._cache.get(coord.id);
             }
         }
     }
@@ -421,7 +413,7 @@ class SourceCache extends Evented {
                 tile.redoPlacement(this._source);
                 if (this._cacheTimers[wrapped.id]) {
                     clearTimeout(this._cacheTimers[wrapped.id]);
-                    delete this._cacheTimers[wrapped.id];
+                    this._cacheTimers[wrapped.id] = undefined;
                     this._setTimers(wrapped.id, tile);
                 }
             }
@@ -446,7 +438,7 @@ class SourceCache extends Evented {
         if (tileExpires) {
             this._timers[id] = setTimeout(() => {
                 this.reloadTile(id, 'expired');
-                delete this._timers[id];
+                this._timers[id] = undefined;
             }, tileExpires - new Date().getTime());
         }
     }
@@ -456,7 +448,7 @@ class SourceCache extends Evented {
         if (tileExpires) {
             this._cacheTimers[id] = setTimeout(() => {
                 this._cache.remove(id);
-                delete this._timers[id];
+                this._cacheTimers[id] = undefined;
             }, tileExpires - new Date().getTime());
         }
     }
@@ -476,7 +468,7 @@ class SourceCache extends Evented {
         delete this._tiles[id];
         if (this._timers[id]) {
             clearTimeout(this._timers[id]);
-            delete this._timers[id];
+            this._timers[id] = undefined;
         }
         this._source.fire('data', { tile: tile, coord: tile.coord, dataType: 'tile' });
 

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -204,6 +204,18 @@ class Tile {
         if (data.cacheControl) this.cacheControl = data.cacheControl;
         if (data.expires) this.expires = data.expires;
     }
+
+    getExpiry() {
+        if (this.cacheControl) {
+            // Cache-Control headers set max age (in seconds) from the time of request
+            const parsedCC = util.parseCacheControl(this.cacheControl);
+            if (parsedCC['max-age']) return this.timeAdded + parsedCC['max-age'] * 1000;
+            // what about s-maxage? what if s-maxage and not max-age?
+        } else if (this.expires) {
+            // Expires headers set absolute expiration times
+            return new Date(this.expires).getTime();
+        }
+    }
 }
 
 module.exports = Tile;

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -30,6 +30,8 @@ class Tile {
         this.tileSize = size;
         this.sourceMaxZoom = sourceMaxZoom;
         this.buckets = {};
+        this.expires = null;
+        this.cacheControl = null;
 
         // `this.state` must be one of
         //
@@ -38,6 +40,7 @@ class Tile {
         // - `reloading`: Tile data has been loaded and is being updated. Tile can be rendered.
         // - `unloaded`:  Tile data has been deleted.
         // - `errored`:   Tile data was not loaded because of an error.
+        // - `expired`:   Tile data was previously loaded, but has expired per its HTTP headers and is in the process of refreshing.
         this.state = 'loading';
     }
 
@@ -194,7 +197,12 @@ class Tile {
     }
 
     hasData() {
-        return this.state === 'loaded' || this.state === 'reloading';
+        return this.state === 'loaded' || this.state === 'reloading' || this.state === 'expired';
+    }
+
+    setExpiryData(data) {
+        if (data.cacheControl) this.cacheControl = data.cacheControl;
+        if (data.expires) this.expires = data.expires;
     }
 }
 

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -210,7 +210,6 @@ class Tile {
             // Cache-Control headers set max age (in seconds) from the time of request
             const parsedCC = util.parseCacheControl(this.cacheControl);
             if (parsedCC['max-age']) return this.timeAdded + parsedCC['max-age'] * 1000;
-            // what about s-maxage? what if s-maxage and not max-age?
         } else if (this.expires) {
             // Expires headers set absolute expiration times
             return new Date(this.expires).getTime();

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -69,7 +69,7 @@ class VectorTileSource extends Evented {
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 
-        if (!tile.workerID) {
+        if (!tile.workerID || tile.state === 'expired') {
             tile.workerID = this.dispatcher.send('loadTile', params, done.bind(this));
         } else if (tile.state === 'loading') {
             // schedule tile reloading after it has been loaded
@@ -85,6 +85,7 @@ class VectorTileSource extends Evented {
             if (err) {
                 return callback(err);
             }
+            tile.setExpiryData(data);
 
             tile.loadVectorData(data, this.map.painter);
 

--- a/js/source/vector_tile_source.js
+++ b/js/source/vector_tile_source.js
@@ -85,8 +85,8 @@ class VectorTileSource extends Evented {
             if (err) {
                 return callback(err);
             }
-            tile.setExpiryData(data);
 
+            tile.setExpiryData(data);
             tile.loadVectorData(data, this.map.painter);
 
             if (tile.redoWhenDone) {

--- a/js/source/vector_tile_worker_source.js
+++ b/js/source/vector_tile_worker_source.js
@@ -61,9 +61,13 @@ class VectorTileWorkerSource {
             workerTile.parse(vectorTile, this.layerIndex, this.actor, (err, result, transferrables) => {
                 if (err) return callback(err);
 
+                const cacheControl = {};
+                if (vectorTile.expires) cacheControl.expires = vectorTile.expires;
+                if (vectorTile.cacheControl) cacheControl.cacheControl = vectorTile.cacheControl;
+
                 // Not transferring rawTileData because the worker needs to retain its copy.
                 callback(null,
-                    util.extend({rawTileData: vectorTile.rawData}, result),
+                    util.extend({rawTileData: vectorTile.rawData}, result, cacheControl),
                     transferrables);
             });
 
@@ -167,7 +171,8 @@ class VectorTileWorkerSource {
             if (err) { return callback(err); }
             const vectorTile = new vt.VectorTile(new Protobuf(response.data));
             vectorTile.rawData = response.data;
-            vectorTile.cacheControl = xhr.getResponseHeader('Cache-Control');
+            vectorTile.cacheControl = response.cacheControl;
+            vectorTile.expires = response.expires;
             callback(err, vectorTile);
         }
     }

--- a/js/source/vector_tile_worker_source.js
+++ b/js/source/vector_tile_worker_source.js
@@ -163,10 +163,11 @@ class VectorTileWorkerSource {
     loadVectorData(params, callback) {
         const xhr = ajax.getArrayBuffer(params.url, done.bind(this));
         return function abort () { xhr.abort(); };
-        function done(err, arrayBuffer) {
+        function done(err, response) {
             if (err) { return callback(err); }
-            const vectorTile = new vt.VectorTile(new Protobuf(arrayBuffer));
-            vectorTile.rawData = arrayBuffer;
+            const vectorTile = new vt.VectorTile(new Protobuf(response.data));
+            vectorTile.rawData = response.data;
+            vectorTile.cacheControl = xhr.getResponseHeader('Cache-Control');
             callback(err, vectorTile);
         }
     }

--- a/js/symbol/glyph_source.js
+++ b/js/symbol/glyph_source.js
@@ -116,8 +116,8 @@ class GlyphSource {
             const rangeName = `${range * 256}-${range * 256 + 255}`;
             const url = glyphUrl(fontstack, rangeName, this.url);
 
-            ajax.getArrayBuffer(url, (err, data) => {
-                const glyphs = !err && new Glyphs(new Protobuf(data));
+            ajax.getArrayBuffer(url, (err, response) => {
+                const glyphs = !err && new Glyphs(new Protobuf(response.data));
                 for (let i = 0; i < loading[range].length; i++) {
                     loading[range][i](err, range, glyphs);
                 }

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -38,7 +38,10 @@ exports.getArrayBuffer = function(url, callback) {
             return callback(new Error('http status 200 returned without content.'));
         }
         if (xhr.status >= 200 && xhr.status < 300 && xhr.response) {
-            callback(null, xhr.response);
+            callback(null, {
+                data: xhr.response,
+                cacheControl: xhr.getResponseHeader('Cache-Control')
+            });
         } else {
             callback(new Error(xhr.statusText));
         }

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -40,7 +40,8 @@ exports.getArrayBuffer = function(url, callback) {
         if (xhr.status >= 200 && xhr.status < 300 && xhr.response) {
             callback(null, {
                 data: xhr.response,
-                cacheControl: xhr.getResponseHeader('Cache-Control')
+                cacheControl: xhr.getResponseHeader('Cache-Control'),
+                expires: xhr.getResponseHeader('Expires')
             });
         } else {
             callback(new Error(xhr.statusText));

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -70,8 +70,8 @@ exports.getImage = function(url, callback) {
             callback(null, img);
             URL.revokeObjectURL(img.src);
         };
-        const blob = new window.Blob([new Uint8Array(imgData)], { type: 'image/png' });
-        img.src = imgData.byteLength ? URL.createObjectURL(blob) : transparentPngUrl;
+        const blob = new window.Blob([new Uint8Array(imgData.data)], { type: 'image/png' });
+        img.src = imgData.data.byteLength ? URL.createObjectURL(blob) : transparentPngUrl;
     });
 };
 

--- a/js/util/ajax.js
+++ b/js/util/ajax.js
@@ -71,6 +71,8 @@ exports.getImage = function(url, callback) {
             URL.revokeObjectURL(img.src);
         };
         const blob = new window.Blob([new Uint8Array(imgData.data)], { type: 'image/png' });
+        img.cacheControl = imgData.cacheControl;
+        img.expires = imgData.expires;
         img.src = imgData.data.byteLength ? URL.createObjectURL(blob) : transparentPngUrl;
     });
 };

--- a/js/util/lru_cache.js
+++ b/js/util/lru_cache.js
@@ -120,8 +120,9 @@ class LRUCache<T> {
     remove(key: string) {
         if (!this.has(key)) { return this; }
 
-        this.onRemove(this.data[key]);
+        const data = this.data[key];
         delete this.data[key];
+        this.onRemove(data);
         this.order.splice(this.order.indexOf(key), 1);
 
         return this;

--- a/js/util/lru_cache.js
+++ b/js/util/lru_cache.js
@@ -111,6 +111,23 @@ class LRUCache<T> {
     }
 
     /**
+     * Remove a key/value combination from the cache.
+     *
+     * @param {string} key the key for the pair to delete
+     * @returns {LRUCache} this cache
+     * @private
+     */
+    remove(key: string) {
+        if (!this.has(key)) { return this; }
+
+        this.onRemove(this.data[key]);
+        delete this.data[key];
+        this.order.splice(this.order.indexOf(key), 1);
+
+        return this;
+    }
+
+    /**
      * Change the max size of the cache.
      *
      * @param {number} max the max size of the cache

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -448,11 +448,5 @@ exports.parseCacheControl = function(cacheControl: string): Object {
         else header['max-age'] = maxAge;
     }
 
-    if (header['s-maxage']) {
-        const sMaxAge = parseInt(header['s-maxage'], 10);
-        if (isNaN(sMaxAge)) delete header['s-maxage'];
-        else header['s-maxage'] = sMaxAge;
-    }
-
     return header;
 };

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -423,3 +423,36 @@ exports.sphericalToCartesian = function(spherical: Array<number>): Array<number>
         r * Math.cos(polar)
     ];
 };
+
+/**
+ * Parses data from 'Cache-Control' headers.
+ *
+ * @param cacheControl Value of 'Cache-Control' header
+ * @return object containing parsed header info.
+ */
+
+exports.parseCacheControl = function(cacheControl) {
+    // Taken from [Wreck](https://github.com/hapijs/wreck)
+    const re = /(?:^|(?:\s*\,\s*))([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)(?:\=(?:([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)|(?:\"((?:[^"\\]|\\.)*)\")))?/g;
+
+    const header = {};
+    cacheControl.replace(re, ($0, $1, $2, $3) => {
+        const value = $2 || $3;
+        header[$1] = value ? value.toLowerCase() : true;
+        return '';
+    });
+
+    if (header['max-age']) {
+        const maxAge = parseInt(header['max-age'], 10);
+        if (isNaN(maxAge)) delete header['max-age'];
+        else header['max-age'] = maxAge;
+    }
+
+    if (header['s-maxage']) {
+        const sMaxAge = parseInt(header['s-maxage'], 10);
+        if (isNaN(sMaxAge)) delete header['s-maxage'];
+        else header['s-maxage'] = sMaxAge;
+    }
+
+    return header;
+};

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -431,7 +431,7 @@ exports.sphericalToCartesian = function(spherical: Array<number>): Array<number>
  * @return object containing parsed header info.
  */
 
-exports.parseCacheControl = function(cacheControl) {
+exports.parseCacheControl = function(cacheControl: string): Object {
     // Taken from [Wreck](https://github.com/hapijs/wreck)
     const re = /(?:^|(?:\s*\,\s*))([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)(?:\=(?:([^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)|(?:\"((?:[^"\\]|\\.)*)\")))?/g;
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -123,16 +123,16 @@ test('SourceCache#addTile', (t) => {
         time.setSeconds(time.getSeconds() + 5);
 
         const sourceCache = createSourceCache();
-        sourceCache._setTimers = (id) => {
+        sourceCache._setTileReloadTimer = (id) => {
             sourceCache._timers[id] = setTimeout(() => {}, 0);
         };
-        sourceCache._setCacheTimers = (id) => {
+        sourceCache._setCacheInvalidationTimer = (id) => {
             sourceCache._cacheTimers[id] = setTimeout(() => {}, 0);
         };
         sourceCache.loadTile = (tile, callback) => {
             tile.state = 'loaded';
             tile.getExpiry = () => time;
-            sourceCache._setTimers(coord.id, tile);
+            sourceCache._setTileReloadTimer(coord.id, tile);
             callback();
         };
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -26,6 +26,11 @@ function MockSourceType(id, sourceOptions, _dispatcher, eventedParent) {
             this.setEventedParent(eventedParent);
         }
         loadTile(tile, callback) {
+            if (sourceOptions.expires) {
+                tile.setExpiryData({
+                    expires: sourceOptions.expires
+                });
+            }
             setTimeout(callback, 0);
         }
         onAdd() {
@@ -108,6 +113,52 @@ test('SourceCache#addTile', (t) => {
 
         t.equal(load, 1);
         t.equal(add, 2);
+
+        t.end();
+    });
+
+    t.test('moves timers when adding tile from cache', (t) => {
+        const coord = new TileCoord(0, 0, 0);
+        const time = new Date();
+        time.setSeconds(time.getSeconds() + 5);
+
+        const sourceCache = createSourceCache();
+        sourceCache._setTimers = (id) => {
+            sourceCache._timers[id] = setTimeout(() => {}, 0);
+        };
+        sourceCache._setCacheTimers = (id) => {
+            sourceCache._cacheTimers[id] = setTimeout(() => {}, 0);
+        };
+        sourceCache.loadTile = (tile, callback) => {
+            tile.state = 'loaded';
+            tile.getExpiry = () => time;
+            sourceCache._setTimers(coord.id, tile);
+            callback();
+        };
+
+        const tr = new Transform();
+        tr.width = 512;
+        tr.height = 512;
+        sourceCache.updateCacheSize(tr);
+
+        const id = coord.id;
+        t.notOk(sourceCache._timers[id]);
+        t.notOk(sourceCache._cacheTimers[id]);
+
+        sourceCache.addTile(coord);
+
+        t.ok(sourceCache._timers[id]);
+        t.notOk(sourceCache._cacheTimers[id]);
+
+        sourceCache.removeTile(coord.id);
+
+        t.notOk(sourceCache._timers[id]);
+        t.ok(sourceCache._cacheTimers[id]);
+
+        sourceCache.addTile(coord);
+
+        t.ok(sourceCache._timers[id]);
+        t.notOk(sourceCache._cacheTimers[id]);
 
         t.end();
     });
@@ -838,6 +889,25 @@ test('SourceCache#reload', (t) => {
         }, null, 'reload ignored gracefully');
 
         t.end();
+    });
+
+    t.end();
+});
+
+test('SourceCache reloads expiring tiles', (t) => {
+    t.test('calls reloadTile when tile expires', (t) => {
+        const coord = new TileCoord(1, 0, 0);
+
+        const expiryDate = new Date();
+        expiryDate.setMilliseconds(expiryDate.getMilliseconds() + 5);
+        const sourceCache = createSourceCache({ expires: expiryDate });
+
+        sourceCache.reloadTile = (id, state) => {
+            t.equal(state, 'expired');
+            t.end();
+        };
+
+        sourceCache.addTile(coord);
     });
 
     t.end();

--- a/test/js/source/vector_tile_source.test.js
+++ b/test/js/source/vector_tile_source.test.js
@@ -149,7 +149,8 @@ test('VectorTileSource', (t) => {
                 loadVectorData: function () {
                     this.state = 'loaded';
                     events.push('tileLoaded');
-                }
+                },
+                setExpiryData: function() {}
             };
             source.loadTile(tile, () => {});
             t.equal(tile.state, 'loading');

--- a/test/js/util/lru_cache.test.js
+++ b/test/js/util/lru_cache.test.js
@@ -32,6 +32,26 @@ test('LRUCache - duplicate add', (t) => {
     t.end();
 });
 
+test('LRUCache - remove', (t) => {
+    const cache = new LRUCache(10, () => {});
+
+    cache.add('washington', 'dc');
+    cache.add('baltimore', 'md');
+    cache.add('richmond', 'va');
+
+    t.deepEqual(cache.keys(), ['washington', 'baltimore', 'richmond']);
+    t.ok(cache.has('baltimore'));
+
+    cache.remove('baltimore');
+
+    t.deepEqual(cache.keys(), ['washington', 'richmond']);
+    t.notOk(cache.has('baltimore'));
+
+    t.ok(cache.remove('baltimore'));
+
+    t.end();
+});
+
 test('LRUCache - overflow', (t) => {
     const cache = new LRUCache(1, (removed) => {
         t.equal(removed, 'b');

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -216,5 +216,38 @@ test('util', (t) => {
         t.end();
     });
 
+    t.test('parseCacheControl', (t) => {
+        t.test('max-age', (t) => {
+            t.deepEqual(util.parseCacheControl('max-age=123456789'), {
+                'max-age': 123456789
+            }, 'returns valid max-age header');
+
+            t.deepEqual(util.parseCacheControl('max-age=1000'), {
+                'max-age': 1000
+            }, 'returns valid max-age header');
+
+            t.deepEqual(util.parseCacheControl('max-age=null'), {}, 'does not return invalid max-age header');
+
+            t.end();
+        });
+
+        t.test('s-maxage', (t) => {
+            t.deepEqual(util.parseCacheControl('s-maxage=200'), {
+                's-maxage': 200
+            }, 'returns valid s-maxage header');
+
+            t.deepEqual(util.parseCacheControl('max-age=43200,s-maxage=300'), {
+                'max-age': 43200,
+                's-maxage': 300
+            }, 'returns valid headers');
+
+            t.deepEqual(util.parseCacheControl('s-maxage=something'), {}, 'does not return invalid s-maxage header');
+
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.end();
 });

--- a/test/js/util/util.test.js
+++ b/test/js/util/util.test.js
@@ -231,21 +231,6 @@ test('util', (t) => {
             t.end();
         });
 
-        t.test('s-maxage', (t) => {
-            t.deepEqual(util.parseCacheControl('s-maxage=200'), {
-                's-maxage': 200
-            }, 'returns valid s-maxage header');
-
-            t.deepEqual(util.parseCacheControl('max-age=43200,s-maxage=300'), {
-                'max-age': 43200,
-                's-maxage': 300
-            }, 'returns valid headers');
-
-            t.deepEqual(util.parseCacheControl('s-maxage=something'), {}, 'does not return invalid s-maxage header');
-
-            t.end();
-        });
-
         t.end();
     });
 

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -136,8 +136,8 @@ sinon.stub(ajax, 'getArrayBuffer', (url, callback) => {
     if (cache[url]) return cached(cache[url], callback);
     return request({url: url, encoding: null}, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
-            cache[url] = body;
-            callback(null, body);
+            cache[url] = {data: body};
+            callback(null, {data: body});
         } else {
             callback(error || new Error(response.statusCode));
         }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js/issues/1947.

This PR modifies `ajax#getArrayBuffer` to request `Cache-Control` and `Expires` headers. `SourceCache` maintains timers for tiles with set expiry dates for both active and cached tiles:
* when an active tile's timer expires, it re-requests the tile
* when a cached tile's timer expires, it is removed from the cache

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
