### PR TITLE
set icon-rotation-alignment to map

### DIFF
--- a/docs/_posts/examples/3400-01-10-rotating-controllable-marker.html
+++ b/docs/_posts/examples/3400-01-10-rotating-controllable-marker.html
@@ -69,7 +69,8 @@ map.on('load', function () {
         "type": "symbol",
         "source": "drone",
         "layout": {
-            "icon-image": "airport-15"
+            "icon-image": "airport-15",
+            "icon-rotation-alignment": "map"
         }
     });
 


### PR DESCRIPTION
Sets `icon-rotation-alignment` for the airplane icon in [this example](https://www.mapbox.com/mapbox-gl-js/example/rotating-controllable-marker/) to `map` so that the icon retains its rotation after the user rotates the map. 
