### PR TITLE
Fix garbled text on zoom

### DIFF
--- a/js/render/draw_symbol.js
+++ b/js/render/draw_symbol.js
@@ -88,7 +88,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         gl.disable(gl.DEPTH_TEST);
     }
 
-    let program;
+    let program, prevFontstack;
 
     for (const coord of coords) {
         const tile = sourceCache.getTile(coord);
@@ -99,7 +99,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         const isSDF = isText || bucket.sdfIcons;
 
-        if (!program) {
+        if (!program || bucket.fontstack !== prevFontstack) {
             program = painter.useProgram(isSDF ? 'symbolSDF' : 'symbolIcon');
 
             setSymbolDrawState(program, painter, isText, isSDF, rotateWithMap, pitchWithMap, bucket.fontstack, size,
@@ -113,6 +113,8 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         drawTileSymbols(program, painter, layer, tile, buffers, isText, isSDF,
                 pitchWithMap, size, haloWidth, haloColor, haloBlur, color);
+
+        prevFontstack = bucket.fontstack;
     }
 
     if (!depthOn) gl.enable(gl.DEPTH_TEST);


### PR DESCRIPTION
Fixes #3669. Sorry for regressing this. The bug happened when different tiles of the same symbol layer had different fontstacks, which can sometimes happen during zoom when only a part of tiles is parsed before rendering.

I have no idea how to add a regression test for this though because it only happens intermittently and depends on a lot of factors like network speed, etc. So I suggest merging this without a test for now.

`frame-duration` benchmark shows no difference.