### PR TITLE
fix(painter): correctly access retained tile textures

### DIFF
--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -319,12 +319,9 @@ class Painter {
         this.reusableTextures.viewport.texture = texture;
     }
 
-    getTileTexture(width, height) {
-        const widthTextures = this.reusableTextures[width];
-        if (widthTextures) {
-            const textures = widthTextures[height || width];
-            return textures && textures.length > 0 ? textures.pop() : null;
-        }
+    getTileTexture(size) {
+        const textures = this.reusableTextures[size];
+        return textures && textures.length > 0 ? textures.pop() : null;
     }
 
     getViewportTexture(width, height) {

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -39,7 +39,7 @@ class Painter {
 
         this.reusableTextures = {
             tiles: {},
-            viewport: {}
+            viewport: null
         };
         this.preFbos = {};
 
@@ -318,7 +318,7 @@ class Painter {
     }
 
     saveViewportTexture(texture) {
-        this.reusableTextures.viewport.texture = texture;
+        this.reusableTextures.viewport = texture;
     }
 
     getTileTexture(size) {
@@ -327,14 +327,14 @@ class Painter {
     }
 
     getViewportTexture(width, height) {
-        const texture = this.reusableTextures.viewport.texture;
+        const texture = this.reusableTextures.viewport;
         if (!texture) return;
 
         if (texture.width === width && texture.height === height) {
             return texture;
         } else {
             this.gl.deleteTexture(texture);
-            this.reusableTextures.viewport.texture = null;
+            this.reusableTextures.viewport = null;
             return;
         }
     }

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -37,7 +37,10 @@ class Painter {
         this.gl = gl;
         this.transform = transform;
 
-        this.reusableTextures = {};
+        this.reusableTextures = {
+            tiles: {},
+            viewport: {}
+        };
         this.preFbos = {};
 
         this.frameHistory = new FrameHistory();
@@ -306,28 +309,26 @@ class Painter {
     }
 
     saveTileTexture(texture) {
-        const textures = this.reusableTextures[texture.size];
+        const textures = this.reusableTextures.tiles[texture.size];
         if (!textures) {
-            this.reusableTextures[texture.size] = [texture];
+            this.reusableTextures.tiles[texture.size] = [texture];
         } else {
             textures.push(texture);
         }
     }
 
     saveViewportTexture(texture) {
-        if (!this.reusableTextures.viewport) this.reusableTextures.viewport = {};
         this.reusableTextures.viewport.texture = texture;
     }
 
     getTileTexture(size) {
-        const textures = this.reusableTextures[size];
+        const textures = this.reusableTextures.tiles[size];
         return textures && textures.length > 0 ? textures.pop() : null;
     }
 
     getViewportTexture(width, height) {
-        if (!this.reusableTextures.viewport) return;
-
         const texture = this.reusableTextures.viewport.texture;
+        if (!texture) return;
 
         if (texture.width === width && texture.height === height) {
             return texture;


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

As explained here https://github.com/mapbox/mapbox-gl-js/issues/3951#issuecomment-272171042 the tile textures retained by the `painter` are indexed by their size only (1 dimension), but are accessed using `width` AND `height` (2 dimension) as indices. A lot of textures will be retained, but never accessed again, leading to a build-up of `WebGLTexture` objects in memory.
This also results in `RasterTileSources` doing a lot of expensive `gl.createTexture` calls, because they can't find reusable ones.

 - [x] manually test the debug page

I though about a doing an extra nesting level in `this.reusableTextures`. So it will look like this:

```js
{
  tiles: {},
  viewport: {}
}
```

This would make it easier to differentiate the types of textures being saved. Any thoughts?