### PR TITLE
Fix race condition in Tile redoPlacement

### DIFF
--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -129,7 +129,7 @@ class Tile {
     }
 
     redoPlacement(source) {
-        if ((source.type !== 'vector' && source.type !== 'geojson')) {
+        if (source.type !== 'vector' && source.type !== 'geojson') {
             return;
         }
         if (this.state !== 'loaded') {

--- a/js/source/tile.js
+++ b/js/source/tile.js
@@ -129,12 +129,14 @@ class Tile {
     }
 
     redoPlacement(source) {
-        if (source.type !== 'vector' && source.type !== 'geojson') {
+        if ((source.type !== 'vector' && source.type !== 'geojson')) {
             return;
         }
-
-        if (this.state !== 'loaded' || this.state === 'reloading') {
+        if (this.state !== 'loaded') {
             this.redoWhenDone = true;
+            return;
+        }
+        if (!this.collisionTile) { // empty tile
             return;
         }
 
@@ -147,9 +149,7 @@ class Tile {
             angle: source.map.transform.angle,
             pitch: source.map.transform.pitch,
             showCollisionBoxes: source.map.showCollisionBoxes
-        }, done.bind(this), this.workerID);
-
-        function done(_, data) {
+        }, (_, data) => {
             this.reloadSymbolData(data, source.map.style);
             source.fire('data', {tile: this, coord: this.coord, dataType: 'tile'});
 
@@ -157,11 +157,12 @@ class Tile {
             if (source.map) source.map.painter.tileExtentVAO.vao = null;
 
             this.state = 'loaded';
+
             if (this.redoWhenDone) {
-                this.redoPlacement(source);
                 this.redoWhenDone = false;
+                this.redoPlacement(source);
             }
-        }
+        }, this.workerID);
     }
 
     getBucket(layer) {

--- a/test/js/source/tile.test.js
+++ b/test/js/source/tile.test.js
@@ -116,6 +116,14 @@ test('querySourceFeatures', (t) => {
     t.end();
 });
 
+test('Tile#redoPlacement on an empty tile', (t) => {
+    const tile = new Tile(new TileCoord(1, 1, 1));
+    tile.loadVectorData(null, createPainter());
+
+    t.doesNotThrow(() => tile.redoPlacement({type: 'vector'}));
+    t.end();
+});
+
 function createRawTileData() {
     return fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'));
 }

--- a/test/js/source/tile.test.js
+++ b/test/js/source/tile.test.js
@@ -116,11 +116,45 @@ test('querySourceFeatures', (t) => {
     t.end();
 });
 
-test('Tile#redoPlacement on an empty tile', (t) => {
-    const tile = new Tile(new TileCoord(1, 1, 1));
-    tile.loadVectorData(null, createPainter());
+test('Tile#redoPlacement', (t) => {
 
-    t.doesNotThrow(() => tile.redoPlacement({type: 'vector'}));
+    test('redoPlacement on an empty tile', (t) => {
+        const tile = new Tile(new TileCoord(1, 1, 1));
+        tile.loadVectorData(null, createPainter());
+
+        t.doesNotThrow(() => tile.redoPlacement({type: 'vector'}));
+        t.notOk(tile.redoWhenDone);
+        t.end();
+    });
+
+    test('redoPlacement on a loading tile', (t) => {
+        const tile = new Tile(new TileCoord(1, 1, 1));
+        t.doesNotThrow(() => tile.redoPlacement({type: 'vector'}));
+        t.ok(tile.redoWhenDone);
+        t.end();
+    });
+
+    test('redoPlacement on a reloading tile', (t) => {
+        const tile = new Tile(new TileCoord(1, 1, 1));
+        tile.loadVectorData(createVectorData(), createPainter());
+
+        const options = {
+            type: 'vector',
+            dispatcher: {
+                send: () => {}
+            },
+            map: {
+                transform: {}
+            }
+        };
+
+        tile.redoPlacement(options);
+        tile.redoPlacement(options);
+
+        t.ok(tile.redoWhenDone);
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Closes #3700. @sguignot please confirm that this fixes the issue for you.

The race condition happened when `redoPlacement` was called for an [empty GeoJSON tile](https://github.com/mapbox/mapbox-gl-js/blob/ac70fa7aaa1fe4d8505b4ca783047abf36a4cebd/js/source/tile.js#L69-L70). In this case tile `state` is `loaded`, but all the data variables are `null`, causing `redoPlacement` to proceed sending the request to redo placement when it's not necessary, and breaking in the callback. Added a basic tests to make sure this doesn't regress.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - ~~document any changes to public APIs~~
 - ~~post benchmark scores~~
 - [x] manually test the debug page
