### PR TITLE
Revert #3841 to fix full-page rendering in Firefox

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1060,13 +1060,6 @@ class Map extends Camera {
             return;
         }
 
-        const MAX_RENDERBUFFER_SIZE = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE) / 2;
-        if (this._canvas.width > MAX_RENDERBUFFER_SIZE ||
-            this._canvas.height > MAX_RENDERBUFFER_SIZE) {
-            throw new Error(`Map canvas (${this._canvas.width}x${this._canvas.height}) ` +
-            `is larger than half of gl.MAX_RENDERBUFFER_SIZE (${MAX_RENDERBUFFER_SIZE})`);
-        }
-
         this.painter = new Painter(gl, this.transform);
     }
 

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -62,17 +62,6 @@ test('Map', (t) => {
                 container: 'anElementIdWhichDoesNotExistInTheDocument'
             });
         }, new Error("Container 'anElementIdWhichDoesNotExistInTheDocument' not found"), 'throws on invalid map container id');
-
-        const largeContainer = window.document.createElement('div');
-        largeContainer.offsetWidth = 10000;
-        largeContainer.offsetHeight = 10000;
-        t.throws(() => {
-            new Map({
-                container: largeContainer
-            });
-        }, /Map canvas \(\d+x\d+\) is larger than half of gl.MAX_RENDERBUFFER_SIZE \(\d+\)/,
-        'throws on then map canvas is larger than allowed by gl.MAX_RENDERBUFFER_SIZE');
-
         t.end();
     });
 


### PR DESCRIPTION
This PR reverts #3841 until we figure out why the `MAX_RENDERBUFFER_SIZE` check regresses support for Firefox, as reported in #3915.

/cc @lucaswoj @stepankuzmin @jfirebaugh @morganherlocker