### PR TITLE
Use mapbox-namespaced unitbezier

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tinyqueue": "^1.1.0",
     "unassertify": "^2.0.0",
     "unflowify": "^1.0.0",
-    "unitbezier": "^0.0.0",
+    "@mapbox/unitbezier": "^0.0.0",
     "vector-tile": "^1.3.0",
     "vt-pbf": "^2.0.2",
     "webworkify": "^1.4.0",


### PR DESCRIPTION
The published namespaced version, 0.0.0, has no code changes,
so there should not be any functional ramifications of this switch.