### PR TITLE
Update README for monorepo

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,81 @@
+# Getting started with Mapbox on the web
+
+### Using Mapbox vector tiles and styles
+
+To use the [vector tiles](https://www.mapbox.com/maps/) and styles hosted on [mapbox.com](http://mapbox.com), you must [create an account](https://www.mapbox.com/studio/signup/) and then [obtain an access token](https://www.mapbox.com/studio/account/tokens/). You may learn more about access tokens [here](https://www.mapbox.com/help/define-access-token/).
+
+### Using Mapbox with a `<script>` tag
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css' rel='stylesheet' />
+</head>
+
+<body>
+    <div id='map' style='width: 400px; height: 300px;' />
+
+    <script>
+        mapboxgl.accessToken = '<your access token here>';
+        var map = new mapboxgl.Map({
+            container: 'map',
+            style: 'mapbox://styles/mapbox/streets-v9'
+        });
+    </script>
+</body>
+</html>
+```
+
+### Using Mapbox with [Browserify](http://browserify.org/)
+
+Install the [`mapbox-gl` npm package](https://www.npmjs.com/package/mapbox-gl)
+
+```bash
+npm install --save mapbox-gl
+```
+
+Instantiate `mapboxgl.Map`
+
+```js
+var mapboxgl = require('mapbox-gl');
+mapboxgl.accessToken = '<your access token here>';
+var map = new mapboxgl.Map({
+    container: '<your HTML element id>',
+    style: 'mapbox://styles/mapbox/streets-v9'
+});
+```
+
+### Using Mapbox with other module systems
+
+Since our build system depends on Browserify, to use Mapbox GL with any other module bundlers like [Webpack](https://webpack.github.io/), [SystemJS](https://github.com/systemjs/systemjs), you have to require the distribution build instead of the package entry point:
+
+```js
+var mapboxgl = require('mapbox-gl/dist/mapbox-gl.js');
+```
+
+If you're using the ES6 module system (e.g. with [Rollup](https://github.com/rollup/rollup) as a bundler), you can import `mapboxgl` like so:
+
+```js
+import mapboxgl from 'mapbox-gl/dist/mapbox-gl.js';
+```
+
+### Using Mapbox with [CSP](https://developer.mozilla.org/en-US/docs/Web/Security/CSP)
+
+You may use a Content Security Policy to restrict the resources your page has
+access to, as a way of guarding against Cross-Site Scripting and other types of
+attacks. If you do, Mapbox GL JS requires the following directives:
+
+```
+child-src blob: ;
+img-src data: blob: ;
+script-src 'unsafe-eval' ;
+```
+
+Requesting styles from Mapbox or other services will require additional
+directives. For Mapbox, you can use this `connect-src` setting:
+
+```
+connect-src https://*.tiles.mapbox.com https://api.mapbox.com
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,8 @@ var map = new mapboxgl.Map({
 });
 ```
 
+Add the CSS file at `node_modules/mapbox-gl/dist/mapbox-gl.css` or `https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css`.
+
 ### Using Mapbox with other module systems
 
 Since our build system depends on Browserify, to use Mapbox GL with any other module bundlers like [Webpack](https://webpack.github.io/), [SystemJS](https://github.com/systemjs/systemjs), you have to require the distribution build instead of the package entry point:
@@ -60,6 +62,8 @@ If you're using the ES6 module system (e.g. with [Rollup](https://github.com/rol
 ```js
 import mapboxgl from 'mapbox-gl/dist/mapbox-gl.js';
 ```
+
+Add the CSS file at `node_modules/mapbox-gl/dist/mapbox-gl.css` or `https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css`.
 
 ### Using Mapbox with [CSP](https://developer.mozilla.org/en-US/docs/Web/Security/CSP)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Build Status](https://circleci.com/gh/mapbox/mapbox-gl-js.svg?style=svg)](https://circleci.com/gh/mapbox/mapbox-gl-js) [![Coverage Status](https://coveralls.io/repos/github/mapbox/mapbox-gl-js/badge.svg?branch=master)](https://coveralls.io/github/mapbox/mapbox-gl-js?branch=master)
 
-[Mapbox provides an ecosystem of libraries for rendering maps on the web, iOS, Android, Qt, macOS and more.](https://www.mapbox.com/maps/). This repository holds the files and issues shared among all platforms.
+[Mapbox GL is an ecosystem of libraries for rendering maps using WebGL/OpenGL on the web, iOS, Android, Qt, macOS and more.](https://www.mapbox.com/maps/). This repository holds the files and issues shared among all platforms.
 
-[<img width="981" alt="Mapbox GL JS gallery" src="https://cloud.githubusercontent.com/assets/281306/14547142/a3c98294-025f-11e6-92f4-d6b0f50c8e89.png">](https://www.mapbox.com/gallery/)
+[<img width="981" alt="Mapbox GL gallery" src="https://cloud.githubusercontent.com/assets/281306/14547142/a3c98294-025f-11e6-92f4-d6b0f50c8e89.png">](https://www.mapbox.com/gallery/)
 
-## Mapbox on the web
+## Mapbox GL on the web
 
 This repository holds the files and issues that relate to the web platform.
 
@@ -14,20 +14,22 @@ This repository holds the files and issues that relate to the web platform.
 - [Roadmap](https://www.mapbox.com/mapbox-gl-js/roadmap/)
 - [Contributor Documentation](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md)
 
-## Mapbox on iOS, Android, Qt, macOS ...
+## Mapbox GL on iOS, Android, Qt, macOS ...
 
 The [`mapbox/mapbox-gl-native` repository](https://github.com/mapbox/mapbox-gl-native) holds the files and issues that relate to the Andriod, iOS, macOS, Qt, and other platforms.
 
-## Mapbox styles
+## Mapbox GL styles
 
-The [`mapbox/mapbox-gl-styles` repository](https://github.com/mapbox/mapbox-gl-styles) contains some open source map styles.
+The [`mapbox/mapbox-gl-styles` repository](https://github.com/mapbox/mapbox-gl-styles) contains some open source map styles for Mapbox GL.
 
-## Mapbox plugins & utilities
+## Mapbox GL plugins & utilities
+
+### Mapbox-suported plugins
 
 * [mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw) – Adds support for drawing and editing features on Mapbox GL JS maps
 * [mapbox-gl-filter-simplify](https://github.com/mapbox/mapbox-gl-filter-simplify) – Simplifies and complexifies filters in Mapbox GL Styles
 
-## Third party plugins & utilities
+### Community-suported plugins
 
 These projects are maintained by the GL JS community. Feel free to open a PR add your own projects to this list. We :heart: third party projects!
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,25 @@
-[Mapbox GL is an ecosystem of libraries for rendering maps using WebGL/OpenGL on the web, iOS, Android, Qt, macOS and more](https://www.mapbox.com/maps/). This repository holds the files and issues shared among all platforms.
+# Mapbox GL JS
+
+Mapbox GL JS is a JavaScript library that renders interactive maps from vector tiles and Mapbox styles using WebGL. Mapbox GL JS is part of the [cross-platform Mapbox GL ecosystem](https://www.mapbox.com/maps/), which also includes compatible native SDKs for applications on [Android](https://www.mapbox.com/android-sdk/), [iOS](https://www.mapbox.com/ios-sdk/), [macOS](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos), and [Qt](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/qt).
+
+In addition to GL JS, this repository contains code, issues, and test fixtures that are common to both GL JS and the native SDKs. For code and issues specific to the native SDKs, see the [mapbox/mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native/) repository.
+
+- [Getting started](https://github.com/mapbox/mapbox-gl-js/blob/master/INSTALL.md)
+- [API documentation](https://www.mapbox.com/mapbox-gl-js/api)
+- [Examples](https://www.mapbox.com/mapbox-gl-js/examples/)
+- [Style documentation](https://www.mapbox.com/mapbox-gl-style-spec)
+- [Open source styles](https://github.com/mapbox/mapbox-gl-styles)
+- [Roadmap](https://www.mapbox.com/mapbox-gl-js/roadmap/)
+- [Contributor documentation](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md)
 
 [<img width="981" alt="Mapbox GL gallery" src="https://cloud.githubusercontent.com/assets/281306/14547142/a3c98294-025f-11e6-92f4-d6b0f50c8e89.png">](https://www.mapbox.com/gallery/)
 
-## Mapbox GL JS
-
-This repository holds the files and issues that relate to the web platform.
-
-- [Getting Started](https://github.com/mapbox/mapbox-gl-js/blob/master/INSTALL.md)
-- [API Documentation](https://www.mapbox.com/mapbox-gl-js/api)
-- [API Examples](https://www.mapbox.com/mapbox-gl-js/examples/)
-- [Roadmap](https://www.mapbox.com/mapbox-gl-js/roadmap/)
-- [Contributor Documentation](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md)
-
-## Mapbox iOS, Android, Qt, and macOS SDKs
-
-The [`mapbox/mapbox-gl-native` repository](https://github.com/mapbox/mapbox-gl-native) holds the files and issues that relate to the Andriod, iOS, macOS, Qt, and other platforms.
-
-## Mapbox GL styles
-
-The [`mapbox/mapbox-gl-styles` repository](https://github.com/mapbox/mapbox-gl-styles) contains some open source map styles for Mapbox GL.
-
-## Mapbox GL plugins & utilities
-
-### Mapbox-suported plugins
+## Mapbox-suported plugins
 
 * [mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw) – Adds support for drawing and editing features on Mapbox GL JS maps
 * [mapbox-gl-filter-simplify](https://github.com/mapbox/mapbox-gl-filter-simplify) – Simplifies and complexifies filters in Mapbox GL Styles
 
-### Community-suported plugins
+## Community-suported plugins
 
 These projects are maintained by the GL JS community. Feel free to open a PR add your own projects to this list. We :heart: third party projects!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://circleci.com/gh/mapbox/mapbox-gl-js.svg?style=svg)](https://circleci.com/gh/mapbox/mapbox-gl-js) [![Coverage Status](https://coveralls.io/repos/github/mapbox/mapbox-gl-js/badge.svg?branch=master)](https://coveralls.io/github/mapbox/mapbox-gl-js?branch=master)
 
-[Mapbox provides is an ecosystem of libraries for rendering maps on the web, iOS, Android, Qt, macOS and more.](https://www.mapbox.com/maps/). This repository holds the files and issues shared among all platforms.
+[Mapbox provides an ecosystem of libraries for rendering maps on the web, iOS, Android, Qt, macOS and more.](https://www.mapbox.com/maps/). This repository holds the files and issues shared among all platforms.
 
 [<img width="981" alt="Mapbox GL JS gallery" src="https://cloud.githubusercontent.com/assets/281306/14547142/a3c98294-025f-11e6-92f4-d6b0f50c8e89.png">](https://www.mapbox.com/gallery/)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-[![Build Status](https://circleci.com/gh/mapbox/mapbox-gl-js.svg?style=svg)](https://circleci.com/gh/mapbox/mapbox-gl-js) [![Coverage Status](https://coveralls.io/repos/github/mapbox/mapbox-gl-js/badge.svg?branch=master)](https://coveralls.io/github/mapbox/mapbox-gl-js?branch=master)
-
-[Mapbox GL is an ecosystem of libraries for rendering maps using WebGL/OpenGL on the web, iOS, Android, Qt, macOS and more.](https://www.mapbox.com/maps/). This repository holds the files and issues shared among all platforms.
+[Mapbox GL is an ecosystem of libraries for rendering maps using WebGL/OpenGL on the web, iOS, Android, Qt, macOS and more](https://www.mapbox.com/maps/). This repository holds the files and issues shared among all platforms.
 
 [<img width="981" alt="Mapbox GL gallery" src="https://cloud.githubusercontent.com/assets/281306/14547142/a3c98294-025f-11e6-92f4-d6b0f50c8e89.png">](https://www.mapbox.com/gallery/)
 
-## Mapbox GL on the web
+## Mapbox GL JS
 
 This repository holds the files and issues that relate to the web platform.
 
@@ -14,7 +12,7 @@ This repository holds the files and issues that relate to the web platform.
 - [Roadmap](https://www.mapbox.com/mapbox-gl-js/roadmap/)
 - [Contributor Documentation](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md)
 
-## Mapbox GL on iOS, Android, Qt, macOS ...
+## Mapbox iOS, Android, Qt, and macOS SDKs
 
 The [`mapbox/mapbox-gl-native` repository](https://github.com/mapbox/mapbox-gl-native) holds the files and issues that relate to the Andriod, iOS, macOS, Qt, and other platforms.
 

--- a/README.md
+++ b/README.md
@@ -1,114 +1,37 @@
 [![Build Status](https://circleci.com/gh/mapbox/mapbox-gl-js.svg?style=svg)](https://circleci.com/gh/mapbox/mapbox-gl-js) [![Coverage Status](https://coveralls.io/repos/github/mapbox/mapbox-gl-js/badge.svg?branch=master)](https://coveralls.io/github/mapbox/mapbox-gl-js?branch=master)
 
-# Mapbox GL JS
-
-Mapbox GL JS is a Javascript & WebGL library that renders interactive maps from [vector tiles](https://www.mapbox.com/blog/vector-tiles/) and [Mapbox styles](https://www.mapbox.com/mapbox-gl-style-spec).
-
-It is part of the [Mapbox GL ecosystem](https://github.com/mapbox/mapbox-gl) which includes [Mapbox GL Native](https://github.com/mapbox/mapbox-gl-native), a suite of compatible SDKs for native desktop and mobile applications.
-
-- [API Documentation](https://www.mapbox.com/mapbox-gl-js/api)
-- [API Examples](https://www.mapbox.com/mapbox-gl-js/examples/)
-- [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec)
-- [Gallery](https://www.mapbox.com/gallery/)
-- [Roadmap](https://www.mapbox.com/mapbox-gl-js/roadmap/)
-- [Top Github Issues](https://mapbox.github.io/top-issues/#!mapbox/mapbox-gl-js)
+[Mapbox provides is an ecosystem of libraries for rendering maps on the web, iOS, Android, Qt, macOS and more.](https://www.mapbox.com/maps/). This repository holds the files and issues shared among all platforms.
 
 [<img width="981" alt="Mapbox GL JS gallery" src="https://cloud.githubusercontent.com/assets/281306/14547142/a3c98294-025f-11e6-92f4-d6b0f50c8e89.png">](https://www.mapbox.com/gallery/)
 
-## Using Mapbox vector tiles and styles
+## Mapbox on the web
 
-To use the [vector tiles](https://www.mapbox.com/maps/) and styles hosted on http://mapbox.com, you must [create an account](https://www.mapbox.com/studio/signup/) and then [obtain an access token](https://www.mapbox.com/studio/account/tokens/). You may learn more about access tokens [here](https://www.mapbox.com/help/define-access-token/).
+This repository holds the files and issues that relate to the web platform.
 
-## Using Mapbox GL JS with a `<script>` tag
+- [Getting Started](https://github.com/mapbox/mapbox-gl-js/blob/master/INSTALL.md)
+- [API Documentation](https://www.mapbox.com/mapbox-gl-js/api)
+- [API Examples](https://www.mapbox.com/mapbox-gl-js/examples/)
+- [Roadmap](https://www.mapbox.com/mapbox-gl-js/roadmap/)
+- [Contributor Documentation](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md)
 
-```html
-<!DOCTYPE html>
-<html>
-<head>
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css' rel='stylesheet' />
-</head>
+## Mapbox on iOS, Android, Qt, macOS ...
 
-<body>
-    <div id='map' style='width: 400px; height: 300px;' />
+The [`mapbox/mapbox-gl-native` repository](https://github.com/mapbox/mapbox-gl-native) holds the files and issues that relate to the Andriod, iOS, macOS, Qt, and other platforms.
 
-    <script>
-        mapboxgl.accessToken = '<your access token here>';
-        var map = new mapboxgl.Map({
-            container: 'map',
-            style: 'mapbox://styles/mapbox/streets-v9'
-        });
-    </script>
-</body>
-</html>
-```
+## Mapbox styles
 
-## Using Mapbox GL JS with [Browserify](http://browserify.org/)
+The [`mapbox/mapbox-gl-styles` repository](https://github.com/mapbox/mapbox-gl-styles) contains some open source map styles.
 
-Install the [`mapbox-gl` npm package](https://www.npmjs.com/package/mapbox-gl)
+## Mapbox plugins & utilities
 
-```bash
-npm install --save mapbox-gl
-```
+* [mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw) – Adds support for drawing and editing features on Mapbox GL JS maps
+* [mapbox-gl-filter-simplify](https://github.com/mapbox/mapbox-gl-filter-simplify) – Simplifies and complexifies filters in Mapbox GL Styles
 
-Instantiate `mapboxgl.Map`
+## Third party plugins & utilities
 
-```js
-var mapboxgl = require('mapbox-gl');
-mapboxgl.accessToken = '<your access token here>';
-var map = new mapboxgl.Map({
-    container: '<your HTML element id>',
-    style: 'mapbox://styles/mapbox/streets-v9'
-});
-```
-
-Add the CSS file at `node_modules/mapbox-gl/dist/mapbox-gl.css` or `https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css`.
-
-## Using Mapbox GL JS with other module systems
-
-Since our build system depends on Browserify, to use Mapbox GL with any other module bundlers like [Webpack](https://webpack.github.io/), [SystemJS](https://github.com/systemjs/systemjs), you have to require the distribution build instead of the package entry point:
-
-```js
-var mapboxgl = require('mapbox-gl/dist/mapbox-gl.js');
-```
-
-If you're using the ES6 module system (e.g. with [Rollup](https://github.com/rollup/rollup) as a bundler), you can import `mapboxgl` like so:
-
-```js
-import mapboxgl from 'mapbox-gl/dist/mapbox-gl.js';
-```
-
-Add the CSS file at `node_modules/mapbox-gl/dist/mapbox-gl.css` or `https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css`.
-
-## Third Party Projects
-
-These projects are written and maintained by the GL JS community. Feel free to open a PR add your own projects to this list. We :heart: third party projects!
+These projects are maintained by the GL JS community. Feel free to open a PR add your own projects to this list. We :heart: third party projects!
 
  - [Typescript Definitions on DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/mapbox-gl)
  - [wtMapbox: Webtoolkit Integration](https://github.com/yvanvds/wtMapbox)
  - [deck.gl: Advanced WebGL visualization layers](https://github.com/uber/deck.gl)
  - [echartslayer: echarts extension for mapboxgl](https://github.com/lzxue/echartLayer)
-
-
-## Using Mapbox GL JS with [CSP](https://developer.mozilla.org/en-US/docs/Web/Security/CSP)
-
-You may use a Content Security Policy to restrict the resources your page has
-access to, as a way of guarding against Cross-Site Scripting and other types of
-attacks. If you do, Mapbox GL JS requires the following directives:
-
-```
-child-src blob: ;
-img-src data: blob: ;
-script-src 'unsafe-eval' ;
-```
-
-Requesting styles from Mapbox or other services will require additional
-directives. For Mapbox, you can use this `connect-src` setting:
-
-```
-connect-src https://*.tiles.mapbox.com https://api.mapbox.com
-```
-
-## Contributing to Mapbox GL JS
-
-See [CONTRIBUTING.md](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
This PR updates the `README.md` to be a better hub for the monorepo. I tried my best to emphasize the Mapbox branding and demphasize the GL branding as much as possible.