### PR TITLE
Require namespaced @mapbox/unitbezier package

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,9 @@
 [ignore]
 
-.*/node_modules/.*
+.*/node_modules/jsonlint/.*
+.*/node_modules/jsonlint-lines-primitives/.*
+.*/node_modules/unflowify/.*
+.*/node_modules/mapbox-gl-style-spec/test/fixture/.*
 
 [include]
 

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -1,7 +1,7 @@
 'use strict';
 // @flow
 
-const UnitBezier = require('unitbezier');
+const UnitBezier = require('@mapbox/unitbezier');
 const Coordinate = require('../geo/coordinate');
 const Point = require('point-geometry');
 


### PR DESCRIPTION
Fresh `npm install` places unitbezier in `node_modules/@mapbox/unitbezier`, so I believe we need to require it w/ the namespace.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
