### PR TITLE
GL Native: enable tests for 180º + very acute line join fixes

### DIFF
--- a/test/integration/render-tests/line-join/bevel-transparent/style.json
+++ b/test/integration/render-tests/line-join/bevel-transparent/style.json
@@ -4,10 +4,7 @@
     "test": {
       "width": 112,
       "height": 64,
-      "diff": 0.00075,
-      "ignored":{
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7778"
-      }
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/line-join/bevel/style.json
+++ b/test/integration/render-tests/line-join/bevel/style.json
@@ -4,10 +4,7 @@
     "test": {
       "width": 112,
       "height": 64,
-      "diff": 0.00075,
-      "ignored":{
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7778"
-      }
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/line-join/default/style.json
+++ b/test/integration/render-tests/line-join/default/style.json
@@ -4,10 +4,7 @@
     "test": {
       "width": 112,
       "height": 64,
-      "diff": 0.00075,
-      "ignored":{
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7778"
-      }
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/line-join/miter-transparent/style.json
+++ b/test/integration/render-tests/line-join/miter-transparent/style.json
@@ -4,10 +4,7 @@
     "test": {
       "width": 112,
       "height": 64,
-      "diff": 0.00075,
-      "ignored":{
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7778"
-      }
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/line-join/miter/style.json
+++ b/test/integration/render-tests/line-join/miter/style.json
@@ -4,10 +4,7 @@
     "test": {
       "width": 112,
       "height": 64,
-      "diff": 0.00075,
-      "ignored":{
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7778"
-      }
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/line-join/round-transparent/style.json
+++ b/test/integration/render-tests/line-join/round-transparent/style.json
@@ -4,10 +4,7 @@
     "test": {
       "width": 112,
       "height": 64,
-      "diff": 0.00075,
-      "ignored":{
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7778"
-      }
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/line-join/round/style.json
+++ b/test/integration/render-tests/line-join/round/style.json
@@ -4,10 +4,7 @@
     "test": {
       "width": 112,
       "height": 64,
-      "diff": 0.00075,
-      "ignored":{
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7778"
-      }
+      "diff": 0.00075
     }
   },
   "sources": {


### PR DESCRIPTION
This enables the tests for https://github.com/mapbox/mapbox-gl-native/issues/7778