### PR TITLE
Note CSS in npm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ var map = new mapboxgl.Map({
 });
 ```
 
-Also, add to your site the Mapbox GL JS CSS in `node_modules/mapbox-gl/dist/mapbox-gl.css`.
+Add the CSS file at `node_modules/mapbox-gl/dist/mapbox-gl.css` or `https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css`.
 
 ## Using Mapbox GL JS with other module systems
 
@@ -78,7 +78,7 @@ If you're using the ES6 module system (e.g. with [Rollup](https://github.com/rol
 import mapboxgl from 'mapbox-gl/dist/mapbox-gl.js';
 ```
 
-Also, add to your site the Mapbox GL JS CSS in `node_modules/mapbox-gl/dist/mapbox-gl.css`.
+Add the CSS file at `node_modules/mapbox-gl/dist/mapbox-gl.css` or `https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css`.
 
 ## Third Party Projects
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ var map = new mapboxgl.Map({
 });
 ```
 
-Also, add to your site the Mapbox GL JS CSS in `mapbox-gl/dist/mapbox-gl.css`.
+Also, add to your site the Mapbox GL JS CSS in `node_modules/mapbox-gl/dist/mapbox-gl.css`.
 
 ## Using Mapbox GL JS with other module systems
 
@@ -78,7 +78,7 @@ If you're using the ES6 module system (e.g. with [Rollup](https://github.com/rol
 import mapboxgl from 'mapbox-gl/dist/mapbox-gl.js';
 ```
 
-Also, add to your site the Mapbox GL JS CSS in `mapbox-gl/dist/mapbox-gl.css`.
+Also, add to your site the Mapbox GL JS CSS in `node_modules/mapbox-gl/dist/mapbox-gl.css`.
 
 ## Third Party Projects
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ var map = new mapboxgl.Map({
 });
 ```
 
+Also, add to your site the Mapbox GL JS CSS in `mapbox-gl/dist/mapbox-gl.css`.
+
 ## Using Mapbox GL JS with other module systems
 
 Since our build system depends on Browserify, to use Mapbox GL with any other module bundlers like [Webpack](https://webpack.github.io/), [SystemJS](https://github.com/systemjs/systemjs), you have to require the distribution build instead of the package entry point:
@@ -75,6 +77,8 @@ If you're using the ES6 module system (e.g. with [Rollup](https://github.com/rol
 ```js
 import mapboxgl from 'mapbox-gl/dist/mapbox-gl.js';
 ```
+
+Also, add to your site the Mapbox GL JS CSS in `mapbox-gl/dist/mapbox-gl.css`.
 
 ## Third Party Projects
 


### PR DESCRIPTION
I saw that there was no mention of the required CSS file outside of the "Using Mapbox GL JS with a `<script>` tag" section. I thought it might be a good idea to include it in each installation section, for readers who are skipping to the section that concerns them.

(I deleted the Launch Checklist since this is just a README change.)
