### PR TITLE
Note CSS in Browserify installation instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ npm run start-docs
 You can view the documentation at
 
 ```bash
-open http://127.0.0.1:4000/mapbox-gl-js
+open http://127.0.0.1:4000/mapbox-gl-js/
 ```
 
 ### Troubleshooting

--- a/docs/_theme/index.hbs
+++ b/docs/_theme/index.hbs
@@ -172,7 +172,7 @@ var map = new mapboxgl.Map({
 {% endhighlight %}
 </div>
 
-<p class="space-top2">Also, add to your site the Mapbox GL JS CSS from <code>mapbox-gl/dist/mapbox-gl.css</code> or (via CDN) <code>{{site.tileApi}}/mapbox-gl-js/v{{site.data.package.version}}/mapbox-gl.css</code>.</p>
+<p class="space-top2">Also, add to your site the Mapbox GL JS CSS from <code>node_modules/mapbox-gl/dist/mapbox-gl.css</code> or (via CDN) <code>{{site.tileApi}}/mapbox-gl-js/v{{site.data.package.version}}/mapbox-gl.css</code>.</p>
 
         </div>
       </div>

--- a/docs/_theme/index.hbs
+++ b/docs/_theme/index.hbs
@@ -171,6 +171,9 @@ var map = new mapboxgl.Map({
 });
 {% endhighlight %}
 </div>
+
+<p class="space-top2">Also, add to your site the Mapbox GL JS CSS from <code>mapbox-gl/dist/mapbox-gl.css</code> or (via CDN) <code>{{site.tileApi}}/mapbox-gl-js/v{{site.data.package.version}}/mapbox-gl.css</code>.</p>
+
         </div>
       </div>
       </section>

--- a/docs/_theme/index.hbs
+++ b/docs/_theme/index.hbs
@@ -172,7 +172,7 @@ var map = new mapboxgl.Map({
 {% endhighlight %}
 </div>
 
-<p class="space-top2">Also, add to your site the Mapbox GL JS CSS from <code>node_modules/mapbox-gl/dist/mapbox-gl.css</code> or (via CDN) <code>{{site.tileApi}}/mapbox-gl-js/v{{site.data.package.version}}/mapbox-gl.css</code>.</p>
+<p class="space-top2">Add the CSS file at <code>node_modules/mapbox-gl/dist/mapbox-gl.css</code> or <code>{{site.tileApi}}/mapbox-gl-js/v{{site.data.package.version}}/mapbox-gl.css</code>.</p>
 
         </div>
       </div>


### PR DESCRIPTION
Follow-up to #4021, noting CSS in the website's API docs. We end up with this (a new sentence at the end):

![screen shot 2017-01-19 at 5 08 52 pm](https://cloud.githubusercontent.com/assets/628431/22130564/0e4a77fe-de6a-11e6-9726-095ae0a09a04.png)

I also added a slash in the `docs/README.md` instruction, because without it the command landed me on a 404.