### PR TITLE
Make sure parent tiles are retained for fading

### DIFF
--- a/debug/satellite.html
+++ b/debug/satellite.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-77.01866, 38.888],
+    style: 'mapbox://styles/mapbox/satellite-v9',
+    hash: true
+});
+
+</script>
+</body>
+</html>

--- a/js/source/image_source.js
+++ b/js/source/image_source.js
@@ -50,6 +50,7 @@ class ImageSource extends Evented {
         this.dispatcher = dispatcher;
         this.coordinates = options.coordinates;
 
+        this.type = 'image';
         this.minzoom = 0;
         this.maxzoom = 22;
         this.tileSize = 512;

--- a/js/source/raster_tile_source.js
+++ b/js/source/raster_tile_source.js
@@ -14,6 +14,7 @@ class RasterTileSource extends Evented {
         this.dispatcher = dispatcher;
         this.setEventedParent(eventedParent);
 
+        this.type = 'raster';
         this.minzoom = 0;
         this.maxzoom = 22;
         this.roundZoom = true;

--- a/js/source/video_source.js
+++ b/js/source/video_source.js
@@ -40,6 +40,7 @@ class VideoSource extends ImageSource {
     constructor(id, options, dispatcher, eventedParent) {
         super(id, options, dispatcher, eventedParent);
         this.roundZoom = true;
+        this.type = 'video';
         this.options = options;
     }
 

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -457,6 +457,67 @@ test('SourceCache#update', (t) => {
     });
 
 
+    t.test('retains children for fading when tile.fadeEndTime is not set', (t) => {
+        const transform = new Transform();
+        transform.resize(511, 511);
+        transform.zoom = 1;
+
+        const sourceCache = createSourceCache({
+            loadTile: function(tile, callback) {
+                tile.timeAdded = Date.now();
+                tile.state = 'loaded';
+                callback();
+            }
+        });
+
+        sourceCache._source.type = 'raster';
+
+        sourceCache.on('source.load', () => {
+            sourceCache.update(transform);
+
+            transform.zoom = 0;
+            sourceCache.update(transform);
+
+            t.equal(sourceCache.getRenderableIds().length, 5, 'retains 0/0/0 and its four children');
+            t.end();
+        });
+        sourceCache.onAdd();
+    });
+
+
+    t.test('retains children when tile.fadeEndTime is in the future', (t) => {
+        const transform = new Transform();
+        transform.resize(511, 511);
+        transform.zoom = 1;
+
+        const sourceCache = createSourceCache({
+            loadTile: function(tile, callback) {
+                tile.timeAdded = Date.now();
+                tile.state = 'loaded';
+                tile.fadeEndTime = Date.now() + 100;
+                callback();
+            }
+        });
+
+        sourceCache._source.type = 'raster';
+
+        sourceCache.on('source.load', () => {
+            sourceCache.update(transform);
+
+            transform.zoom = 0;
+            sourceCache.update(transform);
+
+            t.equal(sourceCache.getRenderableIds().length, 5, 'retains 0/0/0 and its four children');
+            setTimeout(() => {
+                sourceCache.update(transform);
+                t.equal(sourceCache.getRenderableIds().length, 1, 'drops children after fading is complete');
+                t.end();
+            }, 100);
+        });
+        sourceCache.onAdd();
+    });
+
+
     t.test('retains overscaled loaded children', (t) => {
         const transform = new Transform();
         transform.resize(511, 511);

--- a/test/js/source/source_cache.test.js
+++ b/test/js/source/source_cache.test.js
@@ -388,7 +388,7 @@ test('SourceCache#update', (t) => {
         sourceCache.onAdd();
     });
 
-    t.test('includes partially covered tiles in rendered tiles', (t) => {
+    t.test('retains covered child tiles while parent tile is fading in', (t) => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 2;
@@ -402,6 +402,8 @@ test('SourceCache#update', (t) => {
                 callback();
             }
         });
+
+        sourceCache._source.type = 'raster';
 
         sourceCache.on('source.load', () => {
             sourceCache.update(transform);
@@ -436,6 +438,8 @@ test('SourceCache#update', (t) => {
                 callback();
             }
         });
+
+        sourceCache._source.type = 'raster';
 
         sourceCache.on('source.load', () => {
             sourceCache.update(transform);


### PR DESCRIPTION
Closes #2467

@mourner The issue was that `SourceCache#update()` gets called after a tile is loaded, but before `drawRasterTile()` has had a chance to call `tile.registerFadeDuration` for the first.  since we were using `tile.fadeEndTime` to decide whether to retain parents/children for fading, the children get removed from the source cache as soon as the tile is loaded.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs **N/A**
 - [x] post benchmark scores
 - [x] manually test the debug page
