### PR TITLE
Restore "MAX_RENDERBUFFER_SIZE" check as a warning rather than an error

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -346,6 +346,15 @@ class Map extends Camera {
         this.transform.resize(width, height);
         this.painter.resize(width, height);
 
+        const gl = this.painter.gl;
+        const maxSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE) / 2;
+        if (this._canvas.width > maxSize || this._canvas.height > maxSize) {
+            util.warnOnce(
+                `Map is larger than maximum size supported by this system ` +
+                `(${maxSize}px by ${maxSize}px).`
+            );
+        }
+
         return this
             .fire('movestart')
             .fire('move')
@@ -1058,15 +1067,6 @@ class Map extends Camera {
         if (!gl) {
             this.fire('error', { error: new Error('Failed to initialize WebGL') });
             return;
-        }
-
-        const maxSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE) / 2;
-        if (this._canvas.width > maxSize || this._canvas.height > maxSize) {
-            util.warnOnce(
-                `Map size (${this._canvas.width}px by ${this._canvas.height}px) ` +
-                `is larger than maximum size supported by this system ` +
-                `(${maxSize}px by ${maxSize}px).`
-            );
         }
 
         this.painter = new Painter(gl, this.transform);

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1060,6 +1060,15 @@ class Map extends Camera {
             return;
         }
 
+        const maxSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE) / 2;
+        if (this._canvas.width > maxSize || this._canvas.height > maxSize) {
+            util.warnOnce(
+                `Map size (${this._canvas.width}px by ${this._canvas.height}px) ` +
+                `is larger than maximum size supported by this system ` +
+                `(${maxSize}px by ${maxSize}px).`
+            );
+        }
+
         this.painter = new Painter(gl, this.transform);
     }
 

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -62,6 +62,23 @@ test('Map', (t) => {
                 container: 'anElementIdWhichDoesNotExistInTheDocument'
             });
         }, new Error("Container 'anElementIdWhichDoesNotExistInTheDocument' not found"), 'throws on invalid map container id');
+
+        t.end();
+    });
+
+    t.test('constructor, max size detection', (t) => {
+        t.stub(console, 'warn');
+
+        const container = window.document.createElement('div');
+        container.offsetWidth = 10000;
+        container.offsetHeight = 10000;
+        new Map({container});
+
+        t.match(
+            console.warn.getCall(0).args[0],
+            /Map size \(10000px by 10000px\) is larger than maximum size supported by this system \([0-9]+px by [0-9]+px\)./
+        );
+
         t.end();
     });
 

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -76,7 +76,7 @@ test('Map', (t) => {
 
         t.match(
             console.warn.getCall(0).args[0],
-            /Map size \(10000px by 10000px\) is larger than maximum size supported by this system \([0-9]+px by [0-9]+px\)./
+            /Map is larger than maximum size supported by this system \([0-9]+px by [0-9]+px\)./
         );
 
         t.end();


### PR DESCRIPTION
## History

 - https://github.com/mapbox/mapbox-gl-js/issues/2893 noted weird behaviour when a too-large map is created
 - https://github.com/mapbox/mapbox-gl-js/pull/3841 added an error when a too-large map was created
 - https://github.com/mapbox/mapbox-gl-js/issues/3915 noted some cases where the error message caused otherwise functional maps to stop working
 - https://github.com/mapbox/mapbox-gl-js/pull/3986 reverted the error message
 - this PR restores the check but makes it a warning rather than an error message

fixes #2893

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
