### PR TITLE
used a fixed popup offset radius in set popup example

### DIFF
--- a/docs/_posts/examples/3400-01-27-set-popup.html
+++ b/docs/_posts/examples/3400-01-27-set-popup.html
@@ -36,7 +36,7 @@ var map = new mapboxgl.Map({
 });
 
 // create the popup
-var popup = new mapboxgl.Popup({offset:[0, -30]})
+var popup = new mapboxgl.Popup({offset: 25})
     .setText('Construction on the Washington Monument began in 1848.');
 
 // create DOM element for the marker


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

In the [set popup example](https://www.mapbox.com/mapbox-gl-js/example/set-popup/) current behaviour is:

![selection_446](https://cloud.githubusercontent.com/assets/117278/22277323/be1258e8-e30e-11e6-84e5-7cf576cb8ba2.png)

This PR makes it look like this:

![selection_447](https://cloud.githubusercontent.com/assets/117278/22277326/c1356d62-e30e-11e6-9dd9-bc0016acb556.png)


 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
manually tested the example page
