### PR TITLE
Fix regression #4054: use new ajax.getArrayBuffer interface for rtl-text

### DIFF
--- a/js/source/rtl_text_plugin.js
+++ b/js/source/rtl_text_plugin.js
@@ -28,7 +28,7 @@ module.exports.setRTLTextPlugin = function(pluginURL, callback) {
             callback(err);
         } else {
             pluginBlobURL =
-                window.URL.createObjectURL(new window.Blob([response]), {type: "text/javascript"});
+                window.URL.createObjectURL(new window.Blob([response.data]), {type: "text/javascript"});
 
             for (const pluginAvailableCallback of pluginAvailableCallbacks) {
                 pluginAvailableCallback(pluginBlobURL);


### PR DESCRIPTION
There's still no automated testing covering the asynchronous load (because we don't want automated tests dependent on any network interaction). Do we have mocks that would be useful here?