### PR TITLE
Update documentation introduction for monorepo

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -18,8 +18,7 @@ options: full
     </h1>
 
     <div class='prose space-bottom2'>
-      <p>Mapbox GL JS is a JavaScript library that uses WebGL to render interactive maps from <a href='{{site.url}}/help/define-vector-tiles'>vector tiles</a> and <a href='{{site.url}}/mapbox-gl-style-spec'>Mapbox styles</a>.<p>
-      <p>It is part of the <a href='https://github.com/mapbox/mapbox-gl'>Mapbox GL ecosystem</a> which includes <a href='{{site.url}}/mobile/'>Mapbox Mobile</a>, a suite of compatible SDKs for native desktop and mobile applications.</p>
+      <p>Mapbox GL JS is a JavaScript library that renders interactive maps from <a href='{{site.url}}/help/define-vector-tiles'>vector tiles</a> and <a href='{{site.url}}/mapbox-gl-style-spec'>Mapbox styles</a> using WebGL. Mapbox GL JS is part of the <a href='https://www.mapbox.com/maps/'>cross-platform Mapbox GL ecosystem</a>, which also includes <a href='https://github.com/mapbox/mapbox-gl-native/'>compatible SDKs for native applications</a> on desktop and mobile platforms.</p>
     </div>
     <a href='https://www.mapbox.com/gallery/'><img alt='Mapbox GL JS gallery' src='{{site.baseurl}}/assets/gallery.png'></a>
   </section>


### PR DESCRIPTION
This is a followup to #4004 that updates the description of GL JS in the introduction to the generated API documentation to no longer point to the deprecated [mapbox/mapbox-gl](https://github.com/mapbox/mapbox-gl/) repository. (An errant opening `<p>` tag was also removed.)