### PR TITLE
Use the `reloadTile` worker method if GeoJSON tile is already loaded

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -180,7 +180,13 @@ class GeoJSONSource extends Evented {
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 
-        tile.workerID = this.dispatcher.send('loadTile', params, (err, data) => {
+        if (!tile.workerID || tile.state === 'expired') {
+            tile.workerID = this.dispatcher.send('loadTile', params, done.bind(this), this.workerID);
+        } else {
+            tile.workerID = this.dispatcher.send('reloadTile', params, done.bind(this), this.workerID);
+        }
+
+        function done(err, data) {
 
             tile.unloadVectorData();
 
@@ -199,8 +205,7 @@ class GeoJSONSource extends Evented {
             }
 
             return callback(null);
-
-        }, this.workerID);
+        }
     }
 
     abortTile(tile) {

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -83,11 +83,33 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
             this._indexData(data, params, (err, indexed) => {
                 if (err) { return callback(err); }
                 this._geoJSONIndexes[params.source] = indexed;
+                this.loaded[params.source] = {};
                 callback(null);
             });
         }.bind(this);
 
         this.loadGeoJSON(params, handleData);
+    }
+
+    /**
+    * Implements {@link WorkerSource#reloadTile}.
+    *
+    * If the tile is loaded, uses the implementation in VectorTileWorkerSource.
+    * Otherwise, such as after a setData() call, we load the tile fresh.
+    *
+    * @param {Object} params
+    * @param {string} params.source The id of the source for which we're loading this tile.
+    * @param {string} params.uid The UID for this tile.
+    */
+    reloadTile(params, callback) {
+        const loaded = this.loaded[params.source],
+            uid = params.uid;
+
+        if (loaded && loaded[uid]) {
+            return super.reloadTile(params, callback);
+        } else {
+            return this.loadTile(params, callback);
+        }
     }
 
     /**

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -3,6 +3,7 @@
 const test = require('mapbox-gl-js-test').test;
 const GeoJSONWorkerSource = require('../../../src/source/geojson_worker_source');
 const StyleLayerIndex = require('../../../src/style/style_layer_index');
+const TileCoord = require('../../../src/source/tile_coord');
 
 test('removeSource', (t) => {
     t.test('removes the source from _geoJSONIndexes', (t) => {
@@ -42,6 +43,85 @@ test('removeSource', (t) => {
                     t.equal(vectorTile, null);
                     t.end();
                 });
+            });
+        });
+    });
+
+    t.end();
+});
+
+test('reloadTile', (t) => {
+    t.test('does not rebuild vector data unless data has changed', (t) => {
+        const layers = [
+            {
+                id: 'mylayer',
+                source: 'sourceId',
+                type: 'symbol',
+            }
+        ];
+        const layerIndex = new StyleLayerIndex(layers);
+        const source = new GeoJSONWorkerSource(null, layerIndex);
+        const originalLoadVectorData = source.loadVectorData;
+        let loadVectorCallCount = 0;
+        source.loadVectorData = function(params, callback) {
+            loadVectorCallCount++;
+            return originalLoadVectorData.call(this, params, callback);
+        };
+        const geoJson = {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [0, 0]
+            }
+        };
+        const tileParams = {
+            source: 'sourceId',
+            uid: 0,
+            coord: new TileCoord(0, 0, 0),
+            maxZoom: 10
+        };
+
+        function addData(callback) {
+            source.loadData({ source: 'sourceId', data: JSON.stringify(geoJson) }, (err) => {
+                t.equal(err, null);
+                callback();
+            });
+        }
+
+        function reloadTile(callback) {
+            source.reloadTile(tileParams, (err, data) => {
+                t.equal(err, null);
+                return callback(data);
+            });
+        }
+
+        addData(() => {
+            // first call should load vector data from geojson
+            let firstData;
+            reloadTile(data => {
+                firstData = data;
+            });
+            t.equal(loadVectorCallCount, 1);
+
+            // second call won't give us new rawTileData
+            reloadTile(data => {
+                t.notOk('rawTileData' in data);
+                data.rawTileData = firstData.rawTileData;
+                t.deepEqual(data, firstData);
+            });
+
+            // also shouldn't call loadVectorData again
+            t.equal(loadVectorCallCount, 1);
+
+            // replace geojson data
+            addData(() => {
+                // should call loadVectorData again after changing geojson data
+                reloadTile(data => {
+                    t.ok('rawTileData' in data);
+                    t.deepEqual(data, firstData);
+                });
+                t.equal(loadVectorCallCount, 2);
+                t.end();
             });
         });
     });


### PR DESCRIPTION
During a style update, the source is reloaded. Because `GeoJSONSource` always calls `loadTile` in the worker, this means that any style change causes all tile PBFs to be regenerated. This makes hover effects on geojson sources very slow.

This PR fixes the performance issues by using the `reloadTile` worker method, just as in `VectorTileSource`. I believe we don't need to worry about the `loading` state because the `GeoJSONSource#loadVectorData` calls its callback synchronously, so there's only two branches here.

These changes perform very well in my use case but is relatively untested. 

Symptomatically related to issues discussed here: https://github.com/mapbox/mapbox-gl-js/issues/2874

Thanks a lot, yall!

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
