### PR TITLE
Switch test suite to use @mapbox-scoped version of rtl-text

### DIFF
--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -8,7 +8,7 @@ const Map = require('../js/ui/map');
 const window = require('../js/util/window');
 const browser = require('../js/util/browser');
 const rtlTextPlugin = require('../js/source/rtl_text_plugin');
-const rtlText = require('mapbox-gl-rtl-text');
+const rtlText = require('@mapbox/mapbox-gl-rtl-text');
 
 rtlTextPlugin['applyArabicShaping'] = rtlText.applyArabicShaping;
 rtlTextPlugin['processBidirectionalText'] = rtlText.processBidirectionalText;


### PR DESCRIPTION
I'm not sure why CI passed before making this change, once I did a clean build locally the tests were broken.