### PR TITLE
Don't restrict functions for piecewise-constant properties to integer zoom levels

### DIFF
--- a/js/style-spec/validate/validate_function.js
+++ b/js/style-spec/validate/validate_function.js
@@ -129,21 +129,13 @@ module.exports = function validateFunction(options) {
             }));
         }
 
-        errors = errors.concat(validate({
+        return errors.concat(validate({
             key: `${key}[1]`,
             value: value[1],
             valueSpec: functionValueSpec,
             style: options.style,
             styleSpec: options.styleSpec
         }));
-
-        if (getType(value[0]) === 'number') {
-            if (functionValueSpec.function === 'piecewise-constant' && value[0] % 1 !== 0) {
-                errors.push(new ValidationError(`${key}[0]`, value[0], 'zoom level for piecewise-constant functions must be an integer'));
-            }
-        }
-
-        return errors;
     }
 
     function validateStopDomainValue(options) {

--- a/test/js/style-spec/fixture/functions.output.json
+++ b/test/js/style-spec/fixture/functions.output.json
@@ -48,10 +48,6 @@
     "line": 152
   },
   {
-    "message": "layers[11].paint.fill-antialias.stops[0][0]: zoom level for piecewise-constant functions must be an integer",
-    "line": 204
-  },
-  {
     "message": "layers[12].paint.fill-color.stops[1]: object expected, number found",
     "line": 227
   },
@@ -80,11 +76,11 @@
     "line": 341
   },
   {
-    "message": "layers[31].paint.fill-color.stops[0][0]: stop domain value must be a number, string, or boolean"
-  },
-  {
     "message": "layers[19].paint.fill-color: \"property\" property is required",
     "line": 354
+  },
+  {
+    "message": "layers[31].paint.fill-color.stops[0][0]: stop domain value must be a number, string, or boolean"
   },
   {
     "message": "layers[22].paint.background-color.stops: identity function may not have a \"stops\" property",


### PR DESCRIPTION
Fixes #4147