### PR TITLE
Add Map#setControlPosition method

### DIFF
--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -20,7 +20,6 @@ class LogoControl {
     onAdd(map) {
         this._map = map;
         this._container = DOM.create('div', 'mapboxgl-ctrl');
-
         this._map.on('data', this._updateLogo);
         this._updateLogo();
         return this._container;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -254,7 +254,7 @@ class Map extends Camera {
     removeControl(control) {
         control.onRemove(this);
         if (this._controls[control.constructor.name]) {
-            delete this._controls[control.constructor.name]
+            // delete this._controls[control.constructor.name];
         }
         return this;
     }
@@ -274,7 +274,7 @@ class Map extends Camera {
      */
 
     setControlPosition(control, position) {
-        const _control = typeof controlType === "string" ? this._controls[control] : control;
+        const _control = typeof control === "string" ? this._controls[control] : control;
         this.removeControl(_control);
         this.addControl(_control, position);
         return this;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -201,6 +201,8 @@ class Map extends Camera {
         if (options.classes) this.setClasses(options.classes);
         if (options.style) this.setStyle(options.style);
 
+        this._controls = {};
+
         if (options.attributionControl) this.addControl(new AttributionControl());
         this.addControl(new LogoControl(), options.logoPosition);
 
@@ -238,6 +240,8 @@ class Map extends Camera {
         } else {
             positionContainer.appendChild(controlElement);
         }
+        this._controls[control.constructor.name] = control;
+
         return this;
     }
 
@@ -249,6 +253,30 @@ class Map extends Camera {
      */
     removeControl(control) {
         control.onRemove(this);
+        if (this._controls[control.constructor.name]) {
+            delete this._controls[control.constructor.name]
+        }
+        return this;
+    }
+
+
+    /**
+     * Changes position of the control
+     *
+     * @param {string | IControl} control The [`IControl`](#IControl) or the name of the
+     * [`IControl`](#IControl) type you want to move.
+     * @param {string} position on the map to which the control will be moved.
+     * Valid values are `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
+     * @returns {Map} `this`
+     * @example
+     * map.setControlPosition('LogoControl', 'top-right');
+     *
+     */
+
+    setControlPosition(control, position) {
+        const _control = typeof controlType === "string" ? this._controls[control] : control;
+        this.removeControl(_control);
+        this.addControl(_control, position);
         return this;
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -254,7 +254,7 @@ class Map extends Camera {
     removeControl(control) {
         control.onRemove(this);
         if (this._controls[control.constructor.name]) {
-            // delete this._controls[control.constructor.name];
+            delete this._controls[control.constructor.name];
         }
         return this;
     }

--- a/test/unit/ui/control/logo.test.js
+++ b/test/unit/ui/control/logo.test.js
@@ -56,6 +56,16 @@ test('LogoControl appears in the position specified by the position option', (t)
         t.end();
     });
 });
+test('LogoControl position can be changed with map#setControlPosition', (t) => {
+    const map = createMap();
+    map.on('load', () => {
+        map.setControlPosition('LogoControl', 'top-left');
+        t.equal(map.getContainer().querySelectorAll(
+            '.mapboxgl-ctrl-top-left .mapboxgl-ctrl-logo'
+        ).length, 1);
+        t.end();
+    });
+});
 test('LogoControl is not added when the mapbox_logo property is false', (t) => {
     const map = createMap('top-left', false);
     map.on('load', () => {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -663,6 +663,18 @@ test('Map', (t) => {
         map.removeControl(control);
     });
 
+    t.test('#setControlPosition', (t) => {
+        const map = createMap();
+        map._controls['LogoControl'].onAdd = function() {
+            return window.document.createElement('div');
+        };
+        map._controls['LogoControl'].onRemove = function(_) {
+            t.equal(map, _, 'onRemove() called with map');
+            t.end();
+        };
+        map.setControlPosition('LogoControl', 'top-right');
+    });
+
     t.test('#addClass', (t) => {
         const map = createMap();
         map.addClass('night');


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

This adds a method that allows a user to change the position of a control. I have started saving the controls added to the map so that users will be able to modify controls that are automatically added to the map that they do not have a reference to. 
