### PR TITLE
Added strict type checking to categorical style functions

### DIFF
--- a/test/js/style-spec/function.test.js
+++ b/test/js/style-spec/function.test.js
@@ -693,8 +693,8 @@ test('categorical function', (t) => {
             type: 'string'
         });
 
-        t.equal(numberKeys(0, {foo: "0"}), 'default');
-        t.equal(numberKeys(0, {foo: "1"}), 'default');
+        t.equal(numberKeys(0, {foo: '0'}), 'default');
+        t.equal(numberKeys(0, {foo: '1'}), 'default');
         t.equal(numberKeys(0, {foo: false}), 'default');
         t.equal(numberKeys(0, {foo: true}), 'default');
 
@@ -702,7 +702,7 @@ test('categorical function', (t) => {
         t.equal(stringKeys(0, {foo: 1}), 'default');
         t.equal(stringKeys(0, {foo: false}), 'default');
         t.equal(stringKeys(0, {foo: true}), 'default');
-        
+
         t.end();
     });
 

--- a/test/js/style-spec/function.test.js
+++ b/test/js/style-spec/function.test.js
@@ -674,6 +674,39 @@ test('categorical function', (t) => {
         t.end();
     });
 
+    t.test('strict type checking', (t) => {
+        const numberKeys = createFunction({
+            property: 'foo',
+            type: 'categorical',
+            stops: [[0, 'zero'], [1, 'one'], [2, 'two']],
+            default: 'default'
+        }, {
+            type: 'string'
+        });
+
+        const stringKeys = createFunction({
+            property: 'foo',
+            type: 'categorical',
+            stops: [['0', 'zero'], ['1', 'one'], ['2', 'two'], ['true', 'yes'], ['false', 'no']],
+            default: 'default'
+        }, {
+            type: 'string'
+        });
+
+        t.equal(numberKeys(0, {foo: "0"}), 'default');
+        t.equal(numberKeys(0, {foo: "1"}), 'default');
+        t.equal(numberKeys(0, {foo: false}), 'default');
+        t.equal(numberKeys(0, {foo: true}), 'default');
+
+        t.equal(stringKeys(0, {foo: 0}), 'default');
+        t.equal(stringKeys(0, {foo: 1}), 'default');
+        t.equal(stringKeys(0, {foo: false}), 'default');
+        t.equal(stringKeys(0, {foo: true}), 'default');
+        
+        t.end();
+    });
+
+
     t.test('string spec default', (t) => {
         const f = createFunction({
             property: 'foo',


### PR DESCRIPTION
Fixes #4174 by storing `typeof` from the first categorical stop. Return the default value if passed an input value of a different type.

cc @jfirebaugh for review