### PR TITLE
Revert "MAX_RENDERBUFFER_SIZE" check again

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -364,15 +364,6 @@ class Map extends Camera {
         this.transform.resize(width, height);
         this.painter.resize(width, height);
 
-        const gl = this.painter.gl;
-        const maxSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE) / 2;
-        if (this._canvas.width > maxSize || this._canvas.height > maxSize) {
-            util.warnOnce(
-                `Map is larger than maximum size supported by this system ` +
-                `(${maxSize}px by ${maxSize}px).`
-            );
-        }
-
         return this
             .fire('movestart')
             .fire('move')

--- a/test/js/ui/map.test.js
+++ b/test/js/ui/map.test.js
@@ -62,23 +62,6 @@ test('Map', (t) => {
                 container: 'anElementIdWhichDoesNotExistInTheDocument'
             });
         }, new Error("Container 'anElementIdWhichDoesNotExistInTheDocument' not found"), 'throws on invalid map container id');
-
-        t.end();
-    });
-
-    t.test('constructor, max size detection', (t) => {
-        t.stub(console, 'warn');
-
-        const container = window.document.createElement('div');
-        container.offsetWidth = 10000;
-        container.offsetHeight = 10000;
-        new Map({container});
-
-        t.match(
-            console.warn.getCall(0).args[0],
-            /Map is larger than maximum size supported by this system \([0-9]+px by [0-9]+px\)./
-        );
-
         t.end();
     });
 


### PR DESCRIPTION
Many users affected by this bug have reported that the bug was inadvertently fixed. Whether or not this is true, I suspect our detection of this error state is flawed because it often appears for functional maps. 

Additionally, browsers have their own warning message when a too-large canvas is created. 