### PR TITLE
Minor extrusion shader cleanup

### DIFF
--- a/shaders/extrusion_texture.fragment.glsl
+++ b/shaders/extrusion_texture.fragment.glsl
@@ -5,4 +5,8 @@ varying vec2 v_pos;
 
 void main() {
     gl_FragColor = texture2D(u_texture, v_pos) * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(0.0);
+#endif
 }

--- a/shaders/fill_extrusion.fragment.glsl
+++ b/shaders/fill_extrusion.fragment.glsl
@@ -9,4 +9,8 @@ void main() {
     #pragma mapbox: initialize lowp vec4 color
 
     gl_FragColor = v_color;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(0.0);
+#endif
 }

--- a/shaders/fill_extrusion.fragment.glsl
+++ b/shaders/fill_extrusion.fragment.glsl
@@ -11,6 +11,6 @@ void main() {
     gl_FragColor = v_color;
 
 #ifdef OVERDRAW_INSPECTOR
-    gl_FragColor = vec4(0.0);
+    gl_FragColor = vec4(1.0);
 #endif
 }

--- a/shaders/fill_extrusion.vertex.glsl
+++ b/shaders/fill_extrusion.vertex.glsl
@@ -2,7 +2,6 @@ uniform mat4 u_matrix;
 uniform vec3 u_lightcolor;
 uniform lowp vec3 u_lightpos;
 uniform lowp float u_lightintensity;
-uniform lowp vec4 u_outline_color;
 
 attribute vec2 a_pos;
 attribute vec3 a_normal;
@@ -24,10 +23,6 @@ void main() {
     float t = mod(a_normal.x, 2.0);
 
     gl_Position = u_matrix * vec4(a_pos, t > 0.0 ? height : base, 1);
-
-#ifdef OUTLINE
-    color = u_outline_color;
-#endif
 
     // Relative luminance (how dark/bright is the surface color?)
     float colorvalue = color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722;


### PR DESCRIPTION
* Removes unused outline color uniform from fill-extrusion shader
* Add overdraw defines to extrusion_texture and fill_extrusion fragment shaders (without which an assertion fails on native)