### PR TITLE
Improve LRU cache behavior

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -47,7 +47,7 @@ class SourceCache extends Evented {
         this._source = Source.create(id, options, dispatcher, this);
 
         this._tiles = {};
-        this._cache = new Cache(0, this.unloadTile.bind(this));
+        this._cache = new Cache(0, this.unloadTileFromCache.bind(this));
         this._timers = {};
         this._cacheTimers = {};
 
@@ -97,11 +97,13 @@ class SourceCache extends Evented {
     }
 
     unloadTile(tile) {
-        if (this._tiles[tile.coord.id])
-            return;
-
         if (this._source.unloadTile)
             return this._source.unloadTile(tile);
+    }
+
+    unloadTileFromCache(tile) {
+        if (!this._tiles[tile.coord.id])
+            return this.unloadTile(tile);
     }
 
     abortTile(tile) {

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -97,6 +97,9 @@ class SourceCache extends Evented {
     }
 
     unloadTile(tile) {
+        if (this._tiles[tile.coord.id])
+            return;
+
         if (this._source.unloadTile)
             return this._source.unloadTile(tile);
     }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -47,7 +47,7 @@ class SourceCache extends Evented {
         this._source = Source.create(id, options, dispatcher, this);
 
         this._tiles = {};
-        this._cache = new Cache(0, this.unloadTileFromCache.bind(this));
+        this._cache = new Cache(0, this.unloadTile.bind(this));
         this._timers = {};
         this._cacheTimers = {};
 
@@ -99,11 +99,6 @@ class SourceCache extends Evented {
     unloadTile(tile) {
         if (this._source.unloadTile)
             return this._source.unloadTile(tile);
-    }
-
-    unloadTileFromCache(tile) {
-        if (!this._tiles[tile.coord.id])
-            return this.unloadTile(tile);
     }
 
     abortTile(tile) {
@@ -414,6 +409,7 @@ class SourceCache extends Evented {
         if (!tile) {
             tile = this._cache.get(wrapped.id);
             if (tile) {
+                this._cache.remove(wrapped.id);
                 tile.redoPlacement(this._source);
                 if (this._cacheTimers[wrapped.id]) {
                     clearTimeout(this._cacheTimers[wrapped.id]);
@@ -451,7 +447,7 @@ class SourceCache extends Evented {
         const tileExpires = tile.getExpiry();
         if (tileExpires) {
             this._cacheTimers[id] = setTimeout(() => {
-                this._cache.remove(id);
+                this._cache.remove(id, true);
                 this._cacheTimers[id] = undefined;
             }, tileExpires - new Date().getTime());
         }

--- a/src/util/lru_cache.js
+++ b/src/util/lru_cache.js
@@ -62,8 +62,7 @@ class LRUCache<T> {
             this.order.push(key);
 
             if (this.order.length > this.max) {
-                const removedData = this.get(this.order[0]);
-                if (removedData) this.onRemove(removedData);
+                this.remove(this.order[0]);
             }
         }
 
@@ -104,8 +103,8 @@ class LRUCache<T> {
 
         const data = this.data[key];
 
-        delete this.data[key];
         this.order.splice(this.order.indexOf(key), 1);
+        this.order.push(key);
 
         return data;
     }
@@ -139,8 +138,7 @@ class LRUCache<T> {
         this.max = max;
 
         while (this.order.length > this.max) {
-            const removedData = this.get(this.order[0]);
-            if (removedData) this.onRemove(removedData);
+            this.remove(this.order[0]);
         }
 
         return this;

--- a/src/util/lru_cache.js
+++ b/src/util/lru_cache.js
@@ -62,7 +62,7 @@ class LRUCache<T> {
             this.order.push(key);
 
             if (this.order.length > this.max) {
-                this.remove(this.order[0]);
+                this.remove(this.order[0], true);
             }
         }
 
@@ -116,12 +116,16 @@ class LRUCache<T> {
      * @returns {LRUCache} this cache
      * @private
      */
-    remove(key: string) {
+    remove(key: string, expired: boolean) {
         if (!this.has(key)) { return this; }
 
         const data = this.data[key];
         delete this.data[key];
-        this.onRemove(data);
+
+        if (expired) {
+            this.onRemove(data);
+        }
+
         this.order.splice(this.order.indexOf(key), 1);
 
         return this;
@@ -138,7 +142,7 @@ class LRUCache<T> {
         this.max = max;
 
         while (this.order.length > this.max) {
-            this.remove(this.order[0]);
+            this.remove(this.order[0], true);
         }
 
         return this;

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -642,30 +642,6 @@ test('SourceCache#clearTiles', (t) => {
     t.end();
 });
 
-test('SourceCache#unloadTileFromCache', (t) => {
-    t.test('does not unload a tile present in _tiles', (t) => {
-        const coord = new TileCoord(0, 0, 0);
-        let unload = 0;
-
-        const sourceCache = createSourceCache({
-            unloadTile: function(tile) {
-                t.deepEqual(tile.coord, coord);
-                unload++;
-            }
-        });
-        sourceCache.onAdd();
-
-        sourceCache.addTile(coord);
-        sourceCache.unloadTileFromCache({ coord });
-
-        t.equal(unload, 0);
-
-        t.end();
-    });
-
-    t.end();
-});
-
 test('SourceCache#tilesIn', (t) => {
     t.test('graceful response before source loaded', (t) => {
         const sourceCache = createSourceCache({ noLoad: true });

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -642,6 +642,30 @@ test('SourceCache#clearTiles', (t) => {
     t.end();
 });
 
+test('SourceCache#unloadTileFromCache', (t) => {
+    t.test('does not unload a tile present in _tiles', (t) => {
+        const coord = new TileCoord(0, 0, 0);
+        let unload = 0;
+
+        const sourceCache = createSourceCache({
+            unloadTile: function(tile) {
+                t.deepEqual(tile.coord, coord);
+                unload++;
+            }
+        });
+        sourceCache.onAdd();
+
+        sourceCache.addTile(coord);
+        sourceCache.unloadTileFromCache({ coord });
+
+        t.equal(unload, 0);
+
+        t.end();
+    });
+
+    t.end();
+});
+
 test('SourceCache#tilesIn', (t) => {
     t.test('graceful response before source loaded', (t) => {
         const sourceCache = createSourceCache({ noLoad: true });
@@ -871,7 +895,7 @@ test('SourceCache#findLoadedParent', (t) => {
         t.equal(sourceCache.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
         t.equal(sourceCache.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
         t.deepEqual(retain, expectedRetain);
-        t.equal(sourceCache._cache.order.length, 0);
+        t.equal(sourceCache._cache.order.length, 1);
 
         t.end();
     });

--- a/test/unit/util/lru_cache.test.js
+++ b/test/unit/util/lru_cache.test.js
@@ -46,7 +46,11 @@ test('LRUCache - duplicate add', (t) => {
 });
 
 test('LRUCache - remove', (t) => {
-    const cache = new LRUCache(10, () => {});
+    let called;
+    const cache = new LRUCache(10, (removed) => {
+        t.equal(removed, 'dc');
+        called = true;
+    });
 
     cache.add('washington', 'dc');
     cache.add('baltimore', 'md');
@@ -61,6 +65,10 @@ test('LRUCache - remove', (t) => {
     t.notOk(cache.has('baltimore'));
 
     t.ok(cache.remove('baltimore'));
+
+    t.notOk(called);
+    cache.remove('washington', true);
+    t.ok(called);
 
     t.end();
 });

--- a/test/unit/util/lru_cache.test.js
+++ b/test/unit/util/lru_cache.test.js
@@ -12,9 +12,22 @@ test('LRUCache', (t) => {
     t.deepEqual(cache.keys(), ['washington'], '.keys()');
     t.equal(cache.has('washington'), true, '.has()');
     t.equal(cache.get('washington'), 'dc', '.get()');
-    t.equal(cache.get('washington'), null, '.get()');
-    t.equal(cache.has('washington'), false, '.has()');
-    t.deepEqual(cache.keys(), [], '.keys()');
+    t.equal(cache.get('washington'), 'dc', '.get()');
+    t.equal(cache.has('washington'), true, '.has()');
+    t.deepEqual(cache.keys(), ['washington'], '.keys()');
+    t.end();
+});
+
+test('LRUCache - get moves key to top of order stack', (t) => {
+    const cache = new LRUCache(10, (removed) => {
+        t.equal(removed, 'dc');
+    });
+    t.equal(cache.add('washington', 'dc'), cache, '.add()');
+    t.equal(cache.add('san francisco', 'ca'), cache, '.add()');
+    t.deepEqual(cache.keys(), ['washington', 'san francisco'], '.keys()');
+    t.equal(cache.has('washington'), true, '.has()');
+    t.equal(cache.get('washington'), 'dc', '.get()');
+    t.deepEqual(cache.keys(), ['san francisco', 'washington'], '.keys()');
     t.end();
 });
 


### PR DESCRIPTION
### Background

A few days ago, we noticed some performance issues with raster tiles on our maps. We were seeing some cases where tiles were reloading when they should have already been cached. For instance, in [this jsbin](http://jsbin.com/bavubamapi/edit?html,output), a ring of tiles reloads pretty consistently when zooming in and then back out:

![image](https://cloud.githubusercontent.com/assets/15995/22621204/eb67ea26-eaeb-11e6-8d99-00ac1f57de5c.png)

### Problem

We dove into the code and noticed that the [LRU tile cache](https://github.com/chrisvoll/mapbox-gl-js/blob/master/js/util/lru_cache.js) was discarding tiles when it wasn't supposed to. Based on the commit history, it looks like it was once an MRU cache, and still has some of the behavior of an MRU cache, where `get` operations delete the key and its data.

Normally this wouldn't have any significant consequences, but the cache is accessed more than once: [here in `findLoadedParent`](https://github.com/chrisvoll/mapbox-gl-js/blob/master/js/source/source_cache.js#L265), and [here in `addTile`](https://github.com/chrisvoll/mapbox-gl-js/blob/master/js/source/source_cache.js#L410). The first call in `findLoadedParent` purges the tile from the cache, so the call in `addTile` came up empty-handed and led to the tile being reloaded.

### Solution

My PR changes the behavior of the cache to function like an LRU cache: `get` operations will now move the key to the top of the `order` stack instead of deleting it.

~~This works pretty well, but it uncovers an unrelated issue that gives us a beautiful artistic impression of the map we want:~~ (my incorrect cache changes in earlier commits contributed to this, but my analysis below about the cache size still seems accurate)

![image](https://cloud.githubusercontent.com/assets/15995/22621252/3efad382-eaed-11e6-90ad-c69aa2410892.png)

What I've found is that the LRU cache size isn't always set to the correct value for raster tiles. In `SourceCache`, [`updateCacheSize`](https://github.com/chrisvoll/mapbox-gl-js/blob/master/js/source/source_cache.js#L279) is sometimes given misleading data. In the jsbin above, for instance, `transform` has `tileSize: 512` (the dimensions of the retina-sized image tiles), but they're rendered at `256px`. It may think that there is a 4x4 grid of tiles (16 total), for example, when it's actually 8x8 (64 total). Then you get a cache size of `80` instead of `320`.

The cache runs into its limit pretty quickly, and starts discarding tiles that are still present in `SourceCache._tiles`. Their textures are then [recycled](https://github.com/chrisvoll/mapbox-gl-js/blob/master/js/source/raster_tile_source.js#L107) so newer tiles can use them. The textures are overwritten, but the older `SourceCache._tiles` tiles still reference them, leading to the screenshot above.

My PR doesn't fix the underlying issue (the incorrect cache size—I'm not sure how to approach this without potentially breaking something else), but ~~adds a change that prevents textures from being recycled if a tile is purged from the cache but remains in `SourceCache._tiles`~~ (I removed this in subsequent changes). Now the tiles are happily cached and zooming is smoother.

### Launch Checklist

This was my first big dive into the mapbox-gl-js code, so hopefully everything I mentioned here is accurate and makes sense! I'm more than happy to answer any questions or make any changes as needed.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs - no API changes
 - [x] post benchmark scores
 - [x] manually test the debug page

#### Benchmarks

benchmark | master 7b2b879 | cv-lru-cache 545a88d
--- | --- | ---
**map-load** | 158 ms  | 104 ms 
**style-load** | 149 ms  | 142 ms 
**buffer** | 894 ms  | 923 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 3.6 ms, 0% > 16ms  | 3.6 ms, 0% > 16ms 
**query-point** | 0.90 ms  | 1.00 ms 
**query-box** | 64.17 ms  | 66.08 ms 
**geojson-setdata-small** | 8 ms  | 7 ms 
**geojson-setdata-large** | 104 ms  | 108 ms 
