### PR TITLE
Unexport and undocument LogoControl

### DIFF
--- a/documentation.yml
+++ b/documentation.yml
@@ -18,7 +18,6 @@ toc:
   - GeolocateControl
   - AttributionControl
   - ScaleControl
-  - LogoControl
   - name: Handlers
     description: |
       Handlers add different kinds of interactivity to the map -

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ mapboxgl.workerCount = Math.max(Math.floor(browser.hardwareConcurrency / 2), 1);
 
 mapboxgl.Map = require('./ui/map');
 mapboxgl.NavigationControl = require('./ui/control/navigation_control');
-mapboxgl.LogoControl = require('./ui/control/logo_control');
 mapboxgl.GeolocateControl = require('./ui/control/geolocate_control');
 mapboxgl.AttributionControl = require('./ui/control/attribution_control');
 mapboxgl.ScaleControl = require('./ui/control/scale_control');

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -9,6 +9,7 @@ const util = require('../../util/util');
  * vector tiles and core styles.
  *
  * @implements {IControl}
+ * @private
 **/
 
 class LogoControl {


### PR DESCRIPTION
Other than the logoPosition map option, there's no public API -- it's shown/hidden automatically.