### PR TITLE
Fix #4246: RTL text plugin caused leak on Style#_remove()

### DIFF
--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -13,6 +13,14 @@ module.exports.registerForPluginAvailability = function(callback) {
     } else {
         pluginAvailableCallbacks.push(callback);
     }
+    return callback;
+};
+
+module.exports.deregisterPluginCallback = function(callback) {
+    const i = pluginAvailableCallbacks.indexOf(callback);
+    if (i >= 0) {
+        pluginAvailableCallbacks.splice(i, 1);
+    }
 };
 
 module.exports.errorCallback = null;
@@ -30,8 +38,8 @@ module.exports.setRTLTextPlugin = function(pluginURL, callback) {
             pluginBlobURL =
                 window.URL.createObjectURL(new window.Blob([response.data]), {type: "text/javascript"});
 
-            for (const pluginAvailableCallback of pluginAvailableCallbacks) {
-                pluginAvailableCallback(pluginBlobURL);
+            while (pluginAvailableCallbacks.length > 0) {
+                pluginAvailableCallbacks.shift()(pluginBlobURL);
             }
         }
     });

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -78,7 +78,7 @@ class Style extends Evented {
         this.fire('dataloading', {dataType: 'style'});
 
         const self = this;
-        rtlTextPlugin.registerForPluginAvailability((pluginBlobURL) => {
+        this.rtlTextPluginCallback = rtlTextPlugin.registerForPluginAvailability((pluginBlobURL) => {
             self.dispatcher.broadcast('loadRTLTextPlugin', pluginBlobURL, rtlTextPlugin.errorCallback);
             for (const id in self.sourceCaches) {
                 self.sourceCaches[id].reload(); // Should be a no-op if the plugin loads before any tiles load
@@ -824,6 +824,7 @@ class Style extends Evented {
     }
 
     _remove() {
+        rtlTextPlugin.deregisterPluginCallback(this.rtlTextPluginCallback);
         for (const id in this.sourceCaches) {
             this.sourceCaches[id].clearTiles();
         }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -78,8 +78,8 @@ class Style extends Evented {
         this.fire('dataloading', {dataType: 'style'});
 
         const self = this;
-        this.rtlTextPluginCallback = rtlTextPlugin.registerForPluginAvailability((pluginBlobURL) => {
-            self.dispatcher.broadcast('loadRTLTextPlugin', pluginBlobURL, rtlTextPlugin.errorCallback);
+        this._rtlTextPluginCallback = rtlTextPlugin.registerForPluginAvailability((args) => {
+            self.dispatcher.broadcast('loadRTLTextPlugin', args.pluginBlobURL, args.errorCallback);
             for (const id in self.sourceCaches) {
                 self.sourceCaches[id].reload(); // Should be a no-op if the plugin loads before any tiles load
             }
@@ -824,7 +824,7 @@ class Style extends Evented {
     }
 
     _remove() {
-        rtlTextPlugin.deregisterPluginCallback(this.rtlTextPluginCallback);
+        rtlTextPlugin.evented.off('pluginAvailable', this._rtlTextPluginCallback);
         for (const id in this.sourceCaches) {
             this.sourceCaches[id].clearTiles();
         }

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -2,6 +2,20 @@
 
 const util = require('./util');
 
+function _addEventListener(type, listener, listenerList) {
+    listenerList[type] = listenerList[type] || [];
+    listenerList[type].push(listener);
+}
+
+function _removeEventListener(type, listener, listenerList) {
+    if (listenerList && listenerList[type]) {
+        const index = listenerList[type].indexOf(listener);
+        if (index !== -1) {
+            listenerList[type].splice(index, 1);
+        }
+    }
+}
+
 /**
  * Methods mixed in to other classes for event capabilities.
  *
@@ -20,8 +34,7 @@ class Evented {
      */
     on(type, listener) {
         this._listeners = this._listeners || {};
-        this._listeners[type] = this._listeners[type] || [];
-        this._listeners[type].push(listener);
+        _addEventListener(type, listener, this._listeners);
 
         return this;
     }
@@ -34,12 +47,8 @@ class Evented {
      * @returns {Object} `this`
      */
     off(type, listener) {
-        if (this._listeners && this._listeners[type]) {
-            const index = this._listeners[type].indexOf(listener);
-            if (index !== -1) {
-                this._listeners[type].splice(index, 1);
-            }
-        }
+        _removeEventListener(type, listener, this._listeners);
+        _removeEventListener(type, listener, this._oneTimeListeners);
 
         return this;
     }
@@ -54,11 +63,9 @@ class Evented {
      * @returns {Object} `this`
      */
     once(type, listener) {
-        const wrapper = (data) => {
-            this.off(type, wrapper);
-            listener.call(this, data);
-        };
-        this.on(type, wrapper);
+        this._oneTimeListeners = this._oneTimeListeners || {};
+        _addEventListener(type, listener, this._oneTimeListeners);
+
         return this;
     }
 
@@ -79,6 +86,13 @@ class Evented {
 
             for (let i = 0; i < listeners.length; i++) {
                 listeners[i].call(this, data);
+            }
+
+            const oneTimeListeners = this._oneTimeListeners && this._oneTimeListeners[type] ? this._oneTimeListeners[type].slice() : [];
+
+            for (let i = 0; i < oneTimeListeners.length; i++) {
+                oneTimeListeners[i].call(this, data);
+                _removeEventListener(type, oneTimeListeners[i], this._oneTimeListeners);
             }
 
             if (this._eventedParent) {
@@ -102,7 +116,8 @@ class Evented {
      */
     listens(type) {
         return (
-            (this._listeners && this._listeners[type]) ||
+            (this._listeners && this._listeners[type] && this._listeners[type].length > 0) ||
+            (this._oneTimeListeners && this._oneTimeListeners[type] && this._oneTimeListeners[type].length > 0) ||
             (this._eventedParent && this._eventedParent.listens(type))
         );
     }

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -56,6 +56,19 @@ test('Style', (t) => {
         new Style(createStyleJSON(), eventedParent);
     });
 
+    t.test('registers plugin listener', (t) => {
+        t.spy(rtlTextPlugin, 'registerForPluginAvailability');
+        const style = new Style(createStyleJSON());
+        t.spy(style.dispatcher, 'broadcast');
+        t.ok(rtlTextPlugin.registerForPluginAvailability.calledOnce);
+
+        style.on('style.load', () => {
+            rtlTextPlugin.evented.fire('pluginAvailable');
+            t.ok(style.dispatcher.broadcast.calledWith('loadRTLTextPlugin'));
+            t.end();
+        });
+    });
+
     t.test('can be constructed from a URL', (t) => {
         window.useFakeXMLHttpRequest();
         window.server.respondWith('/style.json', JSON.stringify(require('../../fixtures/style')));
@@ -195,14 +208,14 @@ test('Style#_remove', (t) => {
 
     t.test('deregisters plugin listener', (t) => {
         t.spy(rtlTextPlugin, 'registerForPluginAvailability');
-        t.spy(rtlTextPlugin, 'deregisterPluginCallback');
         const style = new Style(createStyleJSON());
-        t.ok(rtlTextPlugin.registerForPluginAvailability.calledOnce);
-        t.notOk(rtlTextPlugin.deregisterPluginCallback.called);
+        t.spy(style.dispatcher, 'broadcast');
 
         style.on('style.load', () => {
             style._remove();
-            t.ok(rtlTextPlugin.deregisterPluginCallback.calledOnce);
+
+            rtlTextPlugin.evented.fire('pluginAvailable');
+            t.notOk(style.dispatcher.broadcast.calledWith('loadRTLTextPlugin'));
             t.end();
         });
     });

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -8,6 +8,7 @@ const StyleLayer = require('../../../src/style/style_layer');
 const util = require('../../../src/util/util');
 const Evented = require('../../../src/util/evented');
 const window = require('../../../src/util/window');
+const rtlTextPlugin = require('../../../src/source/rtl_text_plugin');
 
 function createStyleJSON(properties) {
     return util.extend({
@@ -188,6 +189,20 @@ test('Style#_remove', (t) => {
             t.spy(sourceCache, 'clearTiles');
             style._remove();
             t.ok(sourceCache.clearTiles.calledOnce);
+            t.end();
+        });
+    });
+
+    t.test('deregisters plugin listener', (t) => {
+        t.spy(rtlTextPlugin, 'registerForPluginAvailability');
+        t.spy(rtlTextPlugin, 'deregisterPluginCallback');
+        const style = new Style(createStyleJSON());
+        t.ok(rtlTextPlugin.registerForPluginAvailability.calledOnce);
+        t.notOk(rtlTextPlugin.deregisterPluginCallback.called);
+
+        style.on('style.load', () => {
+            style._remove();
+            t.ok(rtlTextPlugin.deregisterPluginCallback.calledOnce);
             t.end();
         });
     });

--- a/test/unit/util/evented.test.js
+++ b/test/unit/util/evented.test.js
@@ -22,6 +22,7 @@ test('Evented', (t) => {
         evented.fire('a');
         evented.fire('a');
         t.ok(listener.calledOnce);
+        t.notOk(evented.listens('a'));
         t.end();
     });
 
@@ -62,11 +63,30 @@ test('Evented', (t) => {
         t.end();
     });
 
+    t.test('removes one-time listeners with "off"', (t) => {
+        const evented = new Evented();
+        const listener = t.spy();
+        evented.once('a', listener);
+        evented.off('a', listener);
+        evented.fire('a');
+        t.ok(listener.notCalled);
+        t.end();
+    });
+
     t.test('reports if an event has listeners with "listens"', (t) => {
         const evented = new Evented();
         evented.on('a', () => {});
         t.ok(evented.listens('a'));
         t.notOk(evented.listens('b'));
+        t.end();
+    });
+
+    t.test('does not report true to "listens" if all listeners have been removed', (t) => {
+        const evented = new Evented();
+        const listener = () => {};
+        evented.on('a', listener);
+        evented.off('a', listener);
+        t.notOk(evented.listens('a'));
         t.end();
     });
 


### PR DESCRIPTION
The unit test verifies that the "deregister" call happens, but because actually exercising the plugin-loading code depends on the network, I fell back to manual testing.

I tested by creating two maps, verifying there were two callbacks registered, removing one map and seeing that the second callback was removed, then calling setRTLTextPlugin to verify the remaining callback was successfully called and then discarded.

@jfirebaugh @mourner 