### PR TITLE
MapEventData#isSourceLoaded fix

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -384,7 +384,7 @@ class Style extends Evented {
         const sourceCache = this.sourceCaches[id] = new SourceCache(id, source, this.dispatcher);
         sourceCache.style = this;
         sourceCache.setEventedParent(this, () => ({
-            isSourceLoaded: sourceCache.loaded(),
+            isSourceLoaded: () => { return this.loaded(); },
             source: sourceCache.serialize(),
             sourceId: id
         }));

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -384,7 +384,7 @@ class Style extends Evented {
         const sourceCache = this.sourceCaches[id] = new SourceCache(id, source, this.dispatcher);
         sourceCache.style = this;
         sourceCache.setEventedParent(this, () => ({
-            isSourceLoaded: () => { return this.loaded(); },
+            isSourceLoaded: this.loaded(),
             source: sourceCache.serialize(),
             sourceId: id
         }));

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -733,6 +733,15 @@ class Map extends Camera {
     }
 
     /**
+     * Returns a Boolean indicating whether the style is loaded.
+     *
+     * @returns {boolean} A boolean indicating whether the style is loaded.
+     */
+    isStyleLoaded(){
+        return this.style.loaded();
+    }
+
+    /**
      * Adds a source to the map's style.
      *
      * @param {string} id The ID of the source to add. Must not conflict with existing sources.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -733,15 +733,6 @@ class Map extends Camera {
     }
 
     /**
-     * Returns a Boolean indicating whether the style is loaded.
-     *
-     * @returns {boolean} A boolean indicating whether the style is loaded.
-     */
-    isStyleLoaded(){
-        return this.style.loaded();
-    }
-
-    /**
      * Adds a source to the map's style.
      *
      * @param {string} id The ID of the source to add. Must not conflict with existing sources.

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -71,8 +71,12 @@ class Evented {
      */
     fire(type, data) {
         if (this.listens(type)) {
-
             data = util.extend({}, data, {type: type, target: this});
+
+            // determine if source is loaded when event is fired
+            if (typeof data.isSourceLoaded === "function") {
+                data.isSourceLoaded = data.isSourceLoaded();
+            };
 
             // make sure adding or removing listeners inside other listeners won't cause an infinite loop
             const listeners = this._listeners && this._listeners[type] ? this._listeners[type].slice() : [];

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -73,11 +73,6 @@ class Evented {
         if (this.listens(type)) {
             data = util.extend({}, data, {type: type, target: this});
 
-            // determine if source is loaded when event is fired
-            if (typeof data.isSourceLoaded === "function") {
-                data.isSourceLoaded = data.isSourceLoaded();
-            };
-
             // make sure adding or removing listeners inside other listeners won't cause an infinite loop
             const listeners = this._listeners && this._listeners[type] ? this._listeners[type].slice() : [];
 
@@ -86,7 +81,7 @@ class Evented {
             }
 
             if (this._eventedParent) {
-                this._eventedParent.fire(type, util.extend({}, data, this._eventedParentData));
+                this._eventedParent.fire(type, util.extend({}, data, typeof this._eventedParentData === 'function' ? this._eventedParentData() : this._eventedParentData));
             }
 
         // To ensure that no error events are dropped, print them to the
@@ -121,7 +116,7 @@ class Evented {
      */
     setEventedParent(parent, data) {
         this._eventedParent = parent;
-        this._eventedParentData = typeof data === 'function' ? data() : data;
+        this._eventedParentData = data;
 
         return this;
     }

--- a/test/unit/util/evented.test.js
+++ b/test/unit/util/evented.test.js
@@ -159,6 +159,20 @@ test('Evented', (t) => {
             t.end();
         });
 
+
+        t.test('eventedParent data function is evaluated on every fire', (t) => {
+            const eventedSource = new Evented();
+            const eventedParent = new Evented();
+            let i = 0;
+            eventedSource.setEventedParent(eventedParent, () => i++);
+            eventedSource.on('a', () => {});
+            eventedSource.fire('a');
+            t.equal(i, 1);
+            eventedSource.fire('a');
+            t.equal(i, 2);
+            t.end();
+        });
+
         t.end();
 
     });


### PR DESCRIPTION
Working on fixing evaluation of `MapEventData#isSourceLoaded`

Fixes #3958 

Questions:
We only fire a `data` event with `dataType: source` when the TileJSON is loaded, but `isSourceLoaded: true` only occurs after all the tiles in for the source in the current viewport are loaded, so for `dataType:source` `EventData#isSourceLoaded` is still never `true`. Should we fire another `data` event of type `source` when all tiles are loaded `isSourceLoaded` flips to `true` ?

cc @lucaswoj @anandthakker @lbud 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
