### PR TITLE
fix for re-request expired resources causing infinite loop

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -438,7 +438,7 @@ class SourceCache extends Evented {
             this._timers[id] = setTimeout(() => {
                 this.reloadTile(id, 'expired');
                 this._timers[id] = undefined;
-            }, tileExpires - new Date().getTime());
+            }, Math.min(tileExpires - new Date().getTime(), 2147483647));
         }
     }
 
@@ -448,7 +448,7 @@ class SourceCache extends Evented {
             this._cacheTimers[id] = setTimeout(() => {
                 this._cache.remove(id);
                 this._cacheTimers[id] = undefined;
-            }, tileExpires - new Date().getTime());
+            }, Math.min(tileExpires - new Date().getTime(), 2147483647));
         }
     }
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -438,7 +438,7 @@ class SourceCache extends Evented {
             this._timers[id] = setTimeout(() => {
                 this.reloadTile(id, 'expired');
                 this._timers[id] = undefined;
-            }, Math.min(tileExpires - new Date().getTime(), 2147483647));
+            }, Math.min(tileExpires - new Date().getTime(), Math.pow(2, 31) - 1));
         }
     }
 
@@ -448,7 +448,7 @@ class SourceCache extends Evented {
             this._cacheTimers[id] = setTimeout(() => {
                 this._cache.remove(id);
                 this._cacheTimers[id] = undefined;
-            }, Math.min(tileExpires - new Date().getTime(), 2147483647));
+            }, Math.min(tileExpires - new Date().getTime(), Math.pow(2, 31) - 1));
         }
     }
 


### PR DESCRIPTION
Credit to @AndyMoreland for figuring the problem out (see discussion on #3944). 

setTimeout has a [maximum value of 2147483647](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Maximum_delay_value) (32bit integer) for all browsers. If set higher than that, the timeout is *immediately* fired. 

For a tile with an expiry longer than ~24 days, like a tile with a `max-age=2592000` Cache-Control header (30 days), `tileExpires - new Date().getTime()` >  2147483647, and you end up in an infinite tile fetch loop. 

Fortunately the browser knows the tile hasn't expired so it feeds GL JS from the browser cache and doesn't pound the tile server. But it does pound the browser pretty hard.
