### PR TITLE
fixed infinite loop when initial centroid returns NaN due to bad geometry

### DIFF
--- a/src/util/find_pole_of_inaccessibility.js
+++ b/src/util/find_pole_of_inaccessibility.js
@@ -52,7 +52,7 @@ module.exports = function (polygonRings, precision, debug) {
         const cell = cellQueue.pop();
 
         // update the best cell if we found a better one
-        if (cell.d > bestCell.d) {
+        if (cell.d > bestCell.d || !bestCell.d) { 
             bestCell = cell;
             if (debug) console.log('found best %d after %d probes', Math.round(1e4 * cell.d) / 1e4, numProbes);
         }


### PR DESCRIPTION
Hi all,
I had a hang issue when drawing symbols from some gnarly multipolygons from a local geojson and I traced it to bestCell.d being set to NaN. I'm not totally sure this is the best overall fix, but this works for me. 

The polygon ring input to this function that was causing the issue was: [[4221, 3907], [4207,3909], [4221, 3907]]. A line! 😭  For what it's worth, my source geometry doesn't seem to include a line but it seems like this was interacting with tiles to produce a line.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [X] manually test the debug page
