### PR TITLE
fixed infinite loop when cellSize=0 due to bad polygons

### DIFF
--- a/src/util/find_pole_of_inaccessibility.js
+++ b/src/util/find_pole_of_inaccessibility.js
@@ -36,6 +36,8 @@ module.exports = function (polygonRings, precision, debug) {
     // a priority queue of cells in order of their "potential" (max distance to polygon)
     const cellQueue = new Queue(null, compareMax);
 
+	if (cellSize === 0) return [minX, minY];
+
     // cover polygon with initial cells
     for (let x = minX; x < maxX; x += cellSize) {
         for (let y = minY; y < maxY; y += cellSize) {


### PR DESCRIPTION
Hi folks,
Thanks for accepting the last change so quickly. I'm back with the other infinite loop fix to placing symbols on polygons. This time I fixed the other issue by backporting a fix from @mourner 's fix here: https://github.com/mapbox/polylabel/commit/a8b579222712d8b2c6f61748e226be412a011b36

Thanks!

fixes https://github.com/mapbox/mapbox-gl-js/issues/4211 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [X] manually test the debug page
