### PR TITLE
Upgrade jsdom to 9.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "glob": "^7.0.3",
     "highlight.js": "^9.9.0",
     "in-publish": "^2.0.0",
-    "jsdom": "^9.4.2",
+    "jsdom": "^9.11.0",
     "lodash": "^4.16.0",
     "minifyify": "^7.0.1",
     "npm-run-all": "^4.0.1",

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -26,10 +26,6 @@ function restore() {
     };
     window.cancelAnimationFrame = clearImmediate;
 
-    // Stub some CSSOM-related properties that jsdom doesn't implement.
-    window.HTMLElement.prototype.clientLeft = 0;
-    window.HTMLElement.prototype.clientTop = 0;
-
     // Add webgl context with the supplied GL
     const originalGetContext = window.HTMLCanvasElement.prototype.getContext;
     window.HTMLCanvasElement.prototype.getContext = function (type, attributes) {

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -25,8 +25,8 @@ module.exports = function(style, options, _callback) {
     window.devicePixelRatio = options.pixelRatio;
 
     const container = window.document.createElement('div');
-    container.offsetHeight = options.height;
-    container.offsetWidth = options.width;
+    Object.defineProperty(container, 'offsetWidth', {value: options.width});
+    Object.defineProperty(container, 'offsetHeight', {value: options.height});
 
     const map = new Map({
         container: container,

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -36,7 +36,7 @@ test('AttributionControl appears in the position specified by the position optio
 
 test('AttributionControl appears in compact mode if compact option is used', (t) => {
     const map = createMap();
-    map.getCanvasContainer().offsetWidth = 700;
+    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 700, configurable: true});
 
     let attributionControl = new AttributionControl({
         compact: true
@@ -48,7 +48,7 @@ test('AttributionControl appears in compact mode if compact option is used', (t)
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib.compact').length, 1);
     map.removeControl(attributionControl);
 
-    map.getCanvasContainer().offsetWidth = 600;
+    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 600, configurable: true});
     attributionControl = new AttributionControl({
         compact: false
     });
@@ -60,14 +60,14 @@ test('AttributionControl appears in compact mode if compact option is used', (t)
 
 test('AttributionControl appears in compact mode if container is less then 640 pixel wide', (t) => {
     const map = createMap();
-    map.getCanvasContainer().offsetWidth = 700;
+    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 700, configurable: true});
     map.addControl(new AttributionControl());
 
     const container = map.getContainer();
 
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib:not(.compact)').length, 1);
 
-    map.getCanvasContainer().offsetWidth = 600;
+    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 600, configurable: true});
     map.resize();
 
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib.compact').length, 1);

--- a/test/unit/ui/hash.test.js
+++ b/test/unit/ui/hash.test.js
@@ -12,8 +12,8 @@ test('hash', (t) => {
 
     function createMap() {
         const container = window.document.createElement('div');
-        container.offsetWidth = 512;
-        container.offsetHeight = 512;
+        Object.defineProperty(container, 'offsetWidth', {value: 512});
+        Object.defineProperty(container, 'offsetHeight', {value: 512});
         return new Map({container: container});
     }
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -13,8 +13,8 @@ const fixedCoord = fixed.Coord;
 
 function createMap(options, callback) {
     const container = window.document.createElement('div');
-    container.offsetWidth = 200;
-    container.offsetHeight = 200;
+    Object.defineProperty(container, 'offsetWidth', {value: 200, configurable: true});
+    Object.defineProperty(container, 'offsetHeight', {value: 200, configurable: true});
 
     const map = new Map(util.extend({
         container: container,
@@ -402,8 +402,8 @@ test('Map', (t) => {
             const map = createMap(),
                 container = map.getContainer();
 
-            container.offsetWidth = 250;
-            container.offsetHeight = 250;
+            Object.defineProperty(container, 'offsetWidth', {value: 250});
+            Object.defineProperty(container, 'offsetHeight', {value: 250});
             map.resize();
 
             t.equal(map.transform.width, 250);

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -8,8 +8,8 @@ const Popup = require('../../../src/ui/popup');
 
 function createMap() {
     const container = window.document.createElement('div');
-    container.offsetWidth = 512;
-    container.offsetHeight = 512;
+    Object.defineProperty(container, 'offsetWidth', {value: 512});
+    Object.defineProperty(container, 'offsetHeight', {value: 512});
     return new Map({container: container});
 }
 

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -13,8 +13,8 @@ const containerHeight = 512;
 
 function createMap() {
     const container = window.document.createElement('div');
-    container.offsetWidth = containerWidth;
-    container.offsetHeight = containerHeight;
+    Object.defineProperty(container, 'offsetWidth', {value: containerWidth});
+    Object.defineProperty(container, 'offsetHeight', {value: containerHeight});
     return new Map({container: container});
 }
 
@@ -209,8 +209,8 @@ test('Popup anchors as specified by the anchor option', (t) => {
             .setText('Test')
             .addTo(map);
 
-        popup._container.offsetWidth = 100;
-        popup._container.offsetHeight = 100;
+        Object.defineProperty(popup._container, 'offsetWidth', {value: 100});
+        Object.defineProperty(popup._container, 'offsetHeight', {value: 100});
 
         t.stub(map, 'project', () => { return point; });
         popup.setLngLat([0, 0]);
@@ -245,8 +245,8 @@ test('Popup automatically anchors to top if its bottom offset would push it off-
         .setText('Test')
         .addTo(map);
 
-    popup._container.offsetWidth = (containerWidth / 2);
-    popup._container.offsetHeight = (containerHeight / 2);
+    Object.defineProperty(popup._container, 'offsetWidth', {value: containerWidth / 2});
+    Object.defineProperty(popup._container, 'offsetHeight', {value: containerHeight / 2});
 
     t.stub(map, 'project', () => { return point; });
     popup.setLngLat([0, 0]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@ JSONStream@^1.0.3:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abab@^1.0.0:
+abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
@@ -40,11 +40,11 @@ abbrev@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
-acorn-globals@^1.0.4:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-1.0.9.tgz#55bb5e98691507b74579d0513413217c380c54cf"
+acorn-globals@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
   dependencies:
-    acorn "^2.1.0"
+    acorn "^4.0.4"
 
 acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   version "3.0.1"
@@ -66,7 +66,7 @@ acorn@^1.0.3:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-1.2.2.tgz#c8ce27de0acc76d896d2b1fad3df588d9e82f014"
 
-acorn@^2.1.0, acorn@^2.4.0, acorn@^2.7.0:
+acorn@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
 
@@ -74,7 +74,7 @@ acorn@^3.0.4, acorn@^3.1.0, acorn@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.0:
+acorn@^4.0.0, acorn@^4.0.4:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.8.tgz#f41e52020ce78118a3c68ed0e9215eb8fc68b5b1"
 
@@ -1642,11 +1642,11 @@ crypto-browserify@^3.0.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
 
-cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0":
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.36 < 0.3.0":
+"cssstyle@>= 0.2.37 < 0.3.0":
   version "0.2.37"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
@@ -2904,10 +2904,6 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@^0.4.13:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
-
 ieee754@^1.1.4, ieee754@^1.1.6:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
@@ -3308,30 +3304,29 @@ jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 
-jsdom@^9.4.2:
-  version "9.9.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.9.1.tgz#84f3972ad394ab963233af8725211bce4d01bfd5"
+jsdom@^9.11.0:
+  version "9.11.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.11.0.tgz#a95b0304e521a2ca5a63c6ea47bf7708a7a84591"
   dependencies:
-    abab "^1.0.0"
-    acorn "^2.4.0"
-    acorn-globals "^1.0.4"
+    abab "^1.0.3"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
     array-equal "^1.0.0"
     content-type-parser "^1.0.1"
-    cssom ">= 0.3.0 < 0.4.0"
-    cssstyle ">= 0.2.36 < 0.3.0"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
     escodegen "^1.6.1"
     html-encoding-sniffer "^1.0.1"
-    iconv-lite "^0.4.13"
     nwmatcher ">= 1.3.9 < 2.0.0"
     parse5 "^1.5.1"
-    request "^2.55.0"
-    sax "^1.1.4"
-    symbol-tree ">= 3.1.0 < 4.0.0"
-    tough-cookie "^2.3.1"
-    webidl-conversions "^3.0.1"
+    request "^2.79.0"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.2"
+    webidl-conversions "^4.0.0"
     whatwg-encoding "^1.0.1"
-    whatwg-url "^4.1.0"
-    xml-name-validator ">= 2.0.1 < 3.0.0"
+    whatwg-url "^4.3.0"
+    xml-name-validator "^2.0.1"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -4760,7 +4755,7 @@ replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-request@2, request@^2.55.0, request@^2.79.0:
+request@2, request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -4885,9 +4880,9 @@ samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
 
-sax@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+sax@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
 select@^1.0.6:
   version "1.1.0"
@@ -5279,9 +5274,9 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-"symbol-tree@>= 3.1.0 < 4.0.0":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.1.tgz#8549dd1d01fa9f893c18cc9ab0b106b4d9b168cb"
+symbol-tree@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
 syntax-error@^1.1.1:
   version "1.1.6"
@@ -5492,7 +5487,7 @@ to-utf8@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
 
-tough-cookie@^2.3.1, tough-cookie@~2.3.0:
+tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
@@ -5870,9 +5865,13 @@ watchify@^3.7.0:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-webidl-conversions@^3.0.0, webidl-conversions@^3.0.1:
+webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+
+webidl-conversions@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.0.tgz#0a8c727ae4e5649687b7742368dcfbf13ed40118"
 
 websocket-driver@>=0.5.1:
   version "0.6.5"
@@ -5898,7 +5897,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-url@^4.1.0:
+whatwg-url@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.3.0.tgz#92aaee21f4f2a642074357d70ef8500a7cbb171a"
   dependencies:
@@ -5966,7 +5965,7 @@ x-is-string@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
 
-"xml-name-validator@>= 2.0.1 < 3.0.0":
+xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 


### PR DESCRIPTION
This version added read-only stub properties for clientWidth, offsetWidth, etc., so we need to use Object.defineProperty to override the new default value of 0.