### PR TITLE
Removed line in fitBounds that was setting bearing to 0

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -306,7 +306,6 @@ class Camera extends Evented {
 
     /**
      * Pans and zooms the map to contain its visible area within the specified geographical bounds.
-     * This function will also reset the map's bearing to 0 if bearing is nonzero.
      *
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Center these bounds in the viewport and use the highest
@@ -387,7 +386,6 @@ class Camera extends Evented {
 
         options.center = tr.unproject(nw.add(se).div(2));
         options.zoom = Math.min(tr.scaleZoom(tr.scale * Math.min(scaleX, scaleY)), options.maxZoom);
-        options.bearing = 0;
 
         return options.linear ?
             this.easeTo(options, eventData) :


### PR DESCRIPTION
Fixes #4221 
Inside the method fitBounds of the Camera class the bearing was specifically reset to 0 every time it was called, causing the "problem" as described in #4221 . However the resetting of the bearing was also documented in the methods comments, so it could be intended behavior. Either this PR fixes the issue or the issue #4221 should be closed. 