### PR TITLE
Preserve parent tiles in the source cache

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -262,7 +262,7 @@ class SourceCache extends Evented {
             }
             if (this._cache.has(coord.id)) {
                 retain[coord.id] = true;
-                return this._cache.get(coord.id);
+                return this._cache.getWithoutRemoving(coord.id);
             }
         }
     }

--- a/src/util/lru_cache.js
+++ b/src/util/lru_cache.js
@@ -111,6 +111,21 @@ class LRUCache<T> {
     }
 
     /**
+     * Get the value attached to a specific key without removing data
+     * from the cache. If the key is not found, returns `null`
+     *
+     * @param {string} key the key to look up
+     * @returns {*} the data, or null if it isn't found
+     * @private
+     */
+    getWithoutRemoving(key: string): ?T {
+        if (!this.has(key)) { return null; }
+
+        const data = this.data[key];
+        return data;
+    }
+
+    /**
      * Remove a key/value combination from the cache.
      *
      * @param {string} key the key for the pair to delete

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -871,7 +871,7 @@ test('SourceCache#findLoadedParent', (t) => {
         t.equal(sourceCache.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
         t.equal(sourceCache.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
         t.deepEqual(retain, expectedRetain);
-        t.equal(sourceCache._cache.order.length, 0);
+        t.equal(sourceCache._cache.order.length, 1);
 
         t.end();
     });

--- a/test/unit/util/lru_cache.test.js
+++ b/test/unit/util/lru_cache.test.js
@@ -18,6 +18,16 @@ test('LRUCache', (t) => {
     t.end();
 });
 
+test('LRUCache - getWithoutRemoving', (t) => {
+    const cache = new LRUCache(10, () => {
+        t.fail();
+    });
+    t.equal(cache.add('washington', 'dc'), cache, '.add()');
+    t.equal(cache.getWithoutRemoving('washington'), 'dc', '.getWithoutRemoving()');
+    t.deepEqual(cache.keys(), ['washington'], '.keys()');
+    t.end();
+});
+
 test('LRUCache - duplicate add', (t) => {
     const cache = new LRUCache(10, () => {
         t.fail();


### PR DESCRIPTION
This PR is an alternative to #4210, and aims to resolve an issue where tiles in the source cache are prematurely deleted, resulting in tiles reloading when zooming in and out:

![image](https://cloud.githubusercontent.com/assets/15995/23183203/3d1112ca-f849-11e6-949f-52357ce84fdb.png)

This behavior is visible in [this jsbin](http://jsbin.com/colugelobe/edit?html,output) by clicking the Zoom In button twice, and then the Zoom Out button twice.

## Future work

- For raster tiles, [`updateCacheSize`](https://github.com/mapbox/mapbox-gl-js/blob/master/src/source/source_cache.js#L279) sometimes receives misleading tile size information that results in the cache being too small (e.g., it may think that an 8x8 grid of retina tiles is actually a 4x4 grid). Resolving this should improve the reliability of the cache. I can open a separate issue with more details

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page

benchmark | master 4995e5d | cv-cache-performance 494d1e2
--- | --- | ---
**map-load** | 126 ms  | 116 ms 
**style-load** | 117 ms  | 104 ms 
**buffer** | 978 ms  | 984 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 3.8 ms, 0% > 16ms  | 3.8 ms, 0% > 16ms 
**query-point** | 0.99 ms  | 0.96 ms 
**query-box** | 69.83 ms  | 69.10 ms 
**geojson-setdata-small** | 10 ms  | 4 ms 
**geojson-setdata-large** | 88 ms  | 96 ms 

cc @lucaswoj — as always, I'm happy to provide any additional info or changes necessary 😄 