### PR TITLE
Layer event delegation

### DIFF
--- a/docs/_posts/examples/3400-01-04-center-on-symbol.html
+++ b/docs/_posts/examples/3400-01-04-center-on-symbol.html
@@ -2,7 +2,7 @@
 layout: example
 category: example
 title: Center the map on a clicked symbol
-description: Using queryRenderedFeatures and flyTo to center the map on a symbol
+description: Using events and flyTo to center the map on a symbol
 tags:
   - camera
   - user-interaction
@@ -17,8 +17,7 @@ var map = new mapboxgl.Map({
 });
 
 map.on('load', function () {
-
-    // add source as a layer and apply some styles
+    // Add a symbol layer.
     map.addLayer({
         "id": "symbols",
         "type": "symbol",
@@ -66,28 +65,22 @@ map.on('load', function () {
         },
         "layout": {
             "icon-image": "rocket-15"
-        },
-        "paint": {}
+        }
     });
-});
 
-map.on('click', function (e) {
-    // Use queryRenderedFeatures to get features at a click event's point
-    // Use layer option to avoid getting results from other layers
-    var features = map.queryRenderedFeatures(e.point, { layers: ['symbols'] });
-    // if there are features within the given radius of the click event,
-    // fly to the location of the click event
-    if (features.length) {
-        // Get coordinates from the symbol and center the map on those coordinates
-        map.flyTo({center: features[0].geometry.coordinates});
-    }
-});
+    // Center the map on the coordinates of any clicked symbol from the 'symbols' layer.
+    map.on('click', 'symbols', function (e) {
+        map.flyTo({center: e.features[0].geometry.coordinates});
+    });
 
+    // Change the cursor to a pointer when the it enters a feature in the 'symbols' layer.
+    map.on('mouseenter', 'symbols', function () {
+        map.getCanvas().style.cursor = 'pointer';
+    });
 
-// Use the same approach as above to indicate that the symbols are clickable
-// by changing the cursor style to 'pointer'.
-map.on('mousemove', function (e) {
-    var features = map.queryRenderedFeatures(e.point, { layers: ['symbols'] });
-    map.getCanvas().style.cursor = features.length ? 'pointer' : '';
+    // Change it back to a pointer when it leaves.
+    map.on('mouseleave', 'symbols', function () {
+        map.getCanvas().style.cursor = '';
+    });
 });
 </script>

--- a/docs/_posts/examples/3400-01-04-hover-styles.html
+++ b/docs/_posts/examples/3400-01-04-hover-styles.html
@@ -2,7 +2,7 @@
 layout: example
 category: example
 title: Create a hover effect
-description: Using queryRenderedFeatures and a filter to change hover styles
+description: Using events and a filter to change hover styles
 tags:
   - user-interaction
 ---
@@ -55,21 +55,14 @@ map.on('load', function () {
         "filter": ["==", "name", ""]
     });
 
-    // When the user moves their mouse over the page, we look for features
-    // at the mouse position (e.point) and within the states layer (states-fill).
-    // If a feature is found, then we'll update the filter in the state-fills-hover
-    // layer to only show that state, thus making a hover effect.
-    map.on("mousemove", function(e) {
-        var features = map.queryRenderedFeatures(e.point, { layers: ["state-fills"] });
-        if (features.length) {
-            map.setFilter("state-fills-hover", ["==", "name", features[0].properties.name]);
-        } else {
-            map.setFilter("state-fills-hover", ["==", "name", ""]);
-        }
+    // When the user moves their mouse over the states-fill layer, we'll update the filter in
+    // the state-fills-hover layer to only show the matching state, thus making a hover effect.
+    map.on("mousemove", "state-fills", function(e) {
+        map.setFilter("state-fills-hover", ["==", "name", e.features[0].properties.name]);
     });
 
-    // Reset the state-fills-hover layer's filter when the mouse leaves the map
-    map.on("mouseout", function() {
+    // Reset the state-fills-hover layer's filter when the mouse leaves the layer.
+    map.on("mouseleave", "state-fills", function() {
         map.setFilter("state-fills-hover", ["==", "name", ""]);
     });
 });

--- a/docs/_posts/examples/3400-01-06-polygon-popup-on-click.html
+++ b/docs/_posts/examples/3400-01-06-polygon-popup-on-click.html
@@ -22,7 +22,6 @@ var map = new mapboxgl.Map({
 });
 
 map.on('load', function () {
-
     // Add a layer showing the state polygons.
     map.addLayer({
         'id': 'states-layer',
@@ -36,29 +35,24 @@ map.on('load', function () {
             'fill-outline-color': 'rgba(200, 100, 240, 1)'
         }
     });
-});
 
+    // When a click event occurs on a feature in the states layer, open a popup at the
+    // location of the click, with description HTML from its properties.
+    map.on('click', 'states-layer', function (e) {
+        new mapboxgl.Popup()
+            .setLngLat(e.lngLat)
+            .setHTML(e.features[0].properties.name)
+            .addTo(map);
+    });
 
-// When a click event occurs near a polygon, open a popup at the location of
-// the feature, with description HTML from its properties.
-map.on('click', function (e) {
-    var features = map.queryRenderedFeatures(e.point, { layers: ['states-layer'] });
-    if (!features.length) {
-        return;
-    }
+    // Change the cursor to a pointer when the mouse is over the states layer.
+    map.on('mouseenter', 'states-layer', function () {
+        map.getCanvas().style.cursor = 'pointer';
+    });
 
-    var feature = features[0];
-
-    var popup = new mapboxgl.Popup()
-        .setLngLat(map.unproject(e.point))
-        .setHTML(feature.properties.name)
-        .addTo(map);
-});
-
-// Use the same approach as above to indicate that the symbols are clickable
-// by changing the cursor style to 'pointer'.
-map.on('mousemove', function (e) {
-    var features = map.queryRenderedFeatures(e.point, { layers: ['states-layer'] });
-    map.getCanvas().style.cursor = (features.length) ? 'pointer' : '';
+    // Change it back to a pointer when it leaves.
+    map.on('mouseleave', 'states-layer', function () {
+        map.getCanvas().style.cursor = '';
+    });
 });
 </script>

--- a/docs/_posts/examples/3400-01-06-popup-on-click.html
+++ b/docs/_posts/examples/3400-01-06-popup-on-click.html
@@ -23,7 +23,6 @@ var map = new mapboxgl.Map({
 });
 
 map.on('load', function () {
-
     // Add a layer showing the places.
     map.addLayer({
         "id": "places",
@@ -130,32 +129,24 @@ map.on('load', function () {
             "icon-allow-overlap": true
         }
     });
-});
 
+    // When a click event occurs on a feature in the places layer, open a popup at the
+    // location of the feature, with description HTML from its properties.
+    map.on('click', 'places', function (e) {
+        new mapboxgl.Popup()
+            .setLngLat(e.features[0].geometry.coordinates)
+            .setHTML(e.features[0].properties.description)
+            .addTo(map);
+    });
 
-// When a click event occurs near a place, open a popup at the location of
-// the feature, with description HTML from its properties.
-map.on('click', function (e) {
-    var features = map.queryRenderedFeatures(e.point, { layers: ['places'] });
+    // Change the cursor to a pointer when the mouse is over the places layer.
+    map.on('mouseenter', 'places', function () {
+        map.getCanvas().style.cursor = 'pointer';
+    });
 
-    if (!features.length) {
-        return;
-    }
-
-    var feature = features[0];
-
-    // Populate the popup and set its coordinates
-    // based on the feature found.
-    var popup = new mapboxgl.Popup()
-        .setLngLat(feature.geometry.coordinates)
-        .setHTML(feature.properties.description)
-        .addTo(map);
-});
-
-// Use the same approach as above to indicate that the symbols are clickable
-// by changing the cursor style to 'pointer'.
-map.on('mousemove', function (e) {
-    var features = map.queryRenderedFeatures(e.point, { layers: ['places'] });
-    map.getCanvas().style.cursor = (features.length) ? 'pointer' : '';
+    // Change it back to a pointer when it leaves.
+    map.on('mouseleave', 'places', function () {
+        map.getCanvas().style.cursor = '';
+    });
 });
 </script>

--- a/docs/_posts/examples/3400-01-06-popup-on-hover.html
+++ b/docs/_posts/examples/3400-01-06-popup-on-hover.html
@@ -130,30 +130,27 @@ map.on('load', function() {
             "icon-allow-overlap": true
         }
     });
-});
 
-// Create a popup, but don't add it to the map yet.
-var popup = new mapboxgl.Popup({
-    closeButton: false,
-    closeOnClick: false
-});
+    // Create a popup, but don't add it to the map yet.
+    var popup = new mapboxgl.Popup({
+        closeButton: false,
+        closeOnClick: false
+    });
 
-map.on('mousemove', function(e) {
-    var features = map.queryRenderedFeatures(e.point, { layers: ['places'] });
-    // Change the cursor style as a UI indicator.
-    map.getCanvas().style.cursor = (features.length) ? 'pointer' : '';
+    map.on('mouseenter', 'places', function(e) {
+        // Change the cursor style as a UI indicator.
+        map.getCanvas().style.cursor = 'pointer';
 
-    if (!features.length) {
+        // Populate the popup and set its coordinates
+        // based on the feature found.
+        popup.setLngLat(e.features[0].geometry.coordinates)
+            .setHTML(e.features[0].properties.description)
+            .addTo(map);
+    });
+
+    map.on('mouseleave', 'places', function() {
+        map.getCanvas().style.cursor = '';
         popup.remove();
-        return;
-    }
-
-    var feature = features[0];
-
-    // Populate the popup and set its coordinates
-    // based on the feature found.
-    popup.setLngLat(feature.geometry.coordinates)
-        .setHTML(feature.properties.description)
-        .addTo(map);
+    });
 });
 </script>

--- a/docs/_posts/examples/3400-01-14-filter-features-within-map-view.html
+++ b/docs/_posts/examples/3400-01-14-filter-features-within-map-view.html
@@ -188,25 +188,20 @@ map.on('load', function() {
         }
     });
 
-    map.on('mousemove', function(e) {
-        var features = map.queryRenderedFeatures(e.point, {
-            layers: ['airport']
-        });
-
+    map.on('mousemove', 'airport', function(e) {
         // Change the cursor style as a UI indicator.
-        map.getCanvas().style.cursor = features.length ? 'pointer' : '';
+        map.getCanvas().style.cursor = 'pointer';
 
-        if (!features.length) {
-            popup.remove();
-            return;
-        }
-
-        var feature = features[0];
-        // Populate the popup and set its coordinates
-        // based on the feature found.
+        // Populate the popup and set its coordinates based on the feature.
+        var feature = e.features[0];
         popup.setLngLat(feature.geometry.coordinates)
             .setText(feature.properties.name + ' (' + feature.properties.abbrev + ')')
             .addTo(map);
+    });
+
+    map.on('mouseleave', 'airport', function() {
+        map.getCanvas().style.cursor = '';
+        popup.remove();
     });
 
     filterEl.addEventListener('keyup', function(e) {

--- a/docs/_posts/examples/3400-01-24-drag-a-point.html
+++ b/docs/_posts/examples/3400-01-24-drag-a-point.html
@@ -115,28 +115,21 @@ map.on('load', function() {
         }
     });
 
-    // If a feature is found on map movement,
-    // set a flag to permit a mousedown events.
-    map.on('mousemove', function(e) {
-        var features = map.queryRenderedFeatures(e.point, { layers: ['point'] });
-
-        // Change point and cursor style as a UI indicator
-        // and set a flag to enable other mouse events.
-        if (features.length) {
-            map.setPaintProperty('point', 'circle-color', '#3bb2d0');
-            canvas.style.cursor = 'move';
-            isCursorOverPoint = true;
-            map.dragPan.disable();
-        } else {
-            map.setPaintProperty('point', 'circle-color', '#3887be');
-            canvas.style.cursor = '';
-            isCursorOverPoint = false;
-            map.dragPan.enable();
-        }
+    // When the cursor enters a feature in the point layer, prepare for dragging.
+    map.on('mouseenter', 'point', function() {
+        map.setPaintProperty('point', 'circle-color', '#3bb2d0');
+        canvas.style.cursor = 'move';
+        isCursorOverPoint = true;
+        map.dragPan.disable();
     });
 
-    // Set `true` to dispatch the event before other functions call it. This
-    // is necessary for disabling the default map dragging behaviour.
-    map.on('mousedown', mouseDown, true);
+    map.on('mouseleave', 'point', function() {
+        map.setPaintProperty('point', 'circle-color', '#3887be');
+        canvas.style.cursor = '';
+        isCursorOverPoint = false;
+        map.dragPan.enable();
+    });
+
+    map.on('mousedown', mouseDown);
 });
 </script>

--- a/docs/_posts/examples/3400-01-24-query-similar-features.html
+++ b/docs/_posts/examples/3400-01-24-query-similar-features.html
@@ -3,7 +3,7 @@ layout: example
 category: example
 title: Highlight features containing similar data
 description: 'Hover over counties to highlight counties that share the same name.'
-tags: 
+tags:
   - user-interaction
 ---
 <style>
@@ -72,24 +72,12 @@ map.on('load', function() {
         "filter": ["in", "COUNTY", ""]
     }, 'place-city-sm'); // Place polygon under these labels.
 
-    map.on('mousemove', function(e) {
-        var features = map.queryRenderedFeatures(e.point, {
-            layers: ['counties']
-        });
-
+    map.on('mousemove', 'counties', function(e) {
         // Change the cursor style as a UI indicator.
-        map.getCanvas().style.cursor = features.length ? 'pointer' : '';
+        map.getCanvas().style.cursor = 'pointer';
 
-        // Remove things if no feature was found.
-        if (!features.length) {
-            popup.remove();
-            map.setFilter('counties-highlighted', ['in', 'COUNTY', '']);
-            overlay.style.display = 'none';
-            return;
-        }
-
-        // Single out the first found feature on mouseove.
-        var feature = features[0];
+        // Single out the first found feature.
+        var feature = e.features[0];
 
         // Query the counties layer visible in the map. Use the filter
         // param to only collect results that share the same county name.
@@ -123,6 +111,13 @@ map.on('load', function() {
         popup.setLngLat(e.lngLat)
             .setText(feature.properties.COUNTY)
             .addTo(map);
+    });
+
+    map.on('mouseleave', 'counties', function() {
+        map.getCanvas().style.cursor = '';
+        popup.remove();
+        map.setFilter('counties-highlighted', ['in', 'COUNTY', '']);
+        overlay.style.display = 'none';
     });
 });
 </script>

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -515,6 +515,136 @@ class Map extends Camera {
     }
 
     /**
+     * Adds a listener for events of a specified type.
+     *
+     * @method
+     * @name on
+     * @memberof Map
+     * @instance
+     * @param {string} type The event type to add a listen for.
+     * @param {Function} listener The function to be called when the event is fired.
+     *   The listener function is called with the data object passed to `fire`,
+     *   extended with `target` and `type` properties.
+     * @returns {Map} `this`
+     */
+
+    /**
+     * Adds a listener for events of a specified type occurring on features in a specified style layer.
+     *
+     * @param {string} type The event type to listen for; one of `'mousedown'`, `'mouseup'`, `'click'`, `'dblclick'`,
+     * `'mousemove'`, `'mouseenter'`, `'mouseleave'`, `'mouseover'`, `'mouseout'`, `'contextmenu'`, `'touchstart'`,
+     * `'touchend'`, or `'touchcancel'`. `mouseenter` and `mouseover` events are triggered when the cursor enters
+     * a visible portion of the specified layer from outside that layer or outside the map canvas. `mouseleave`
+     * and `mouseout` events are triggered when the cursor leaves a visible portion of the specified layer, or leaves
+     * the map canvas.
+     * @param {string} layer The ID of a style layer. Only events whose location is within a visible
+     * feature in this layer will trigger the listener. The event will have a `features` property containing
+     * an array of the matching features.
+     * @param {Function} listener The function to be called when the event is fired.
+     * @returns {Map} `this`
+     */
+    on(type, layer, listener) {
+        if (listener === undefined) {
+            return super.on(type, layer);
+        }
+
+        const delegatedListener = (() => {
+            if (type === 'mouseenter' || type === 'mouseover') {
+                let mousein = false;
+                const mousemove = (e) => {
+                    const features = this.queryRenderedFeatures(e.point, {layers: [layer]});
+                    if (!features.length) {
+                        mousein = false;
+                    } else if (!mousein) {
+                        mousein = true;
+                        listener.call(this, util.extend({features}, e, {type}));
+                    }
+                };
+                const mouseout = () => {
+                    mousein = false;
+                };
+                return {layer, listener, delegates: {mousemove, mouseout}};
+            } else if (type === 'mouseleave' || type === 'mouseout') {
+                let mousein = false;
+                const mousemove = (e) => {
+                    const features = this.queryRenderedFeatures(e.point, {layers: [layer]});
+                    if (features.length) {
+                        mousein = true;
+                    } else if (mousein) {
+                        mousein = false;
+                        listener.call(this, util.extend({}, e, {type}));
+                    }
+                };
+                const mouseout = (e) => {
+                    if (mousein) {
+                        mousein = false;
+                        listener.call(this, util.extend({}, e, {type}));
+                    }
+                };
+                return {layer, listener, delegates: {mousemove, mouseout}};
+            } else {
+                const delegate = (e) => {
+                    const features = this.queryRenderedFeatures(e.point, {layers: [layer]});
+                    if (features.length) {
+                        listener.call(this, util.extend({features}, e));
+                    }
+                };
+                return {layer, listener, delegates: {[type]: delegate}};
+            }
+        })();
+
+        this._delegatedListeners = this._delegatedListeners || {};
+        this._delegatedListeners[type] = this._delegatedListeners[type] || [];
+        this._delegatedListeners[type].push(delegatedListener);
+
+        for (const event in delegatedListener.delegates) {
+            this.on(event, delegatedListener.delegates[event]);
+        }
+
+        return this;
+    }
+
+    /**
+     * Removes an event listener previously added with `Map#on`.
+     *
+     * @method
+     * @name off
+     * @memberof Map
+     * @instance
+     * @param {string} type The event type previously used to install the listener.
+     * @param {Function} listener The function previously installed as a listener.
+     * @returns {Map} `this`
+     */
+
+    /**
+     * Removes an event listener for layer-specific events previously added with `Map#on`.
+     *
+     * @param {string} type The event type previously used to install the listener.
+     * @param {string} layer The layer ID previously used to install the listener.
+     * @param {Function} listener The function previously installed as a listener.
+     * @returns {Map} `this`
+     */
+    off(type, layer, listener) {
+        if (listener === undefined) {
+            return super.off(type, layer);
+        }
+
+        if (this._delegatedListeners && this._delegatedListeners[type]) {
+            const listeners = this._delegatedListeners[type];
+            for (let i = 0; i < listeners.length; i++) {
+                const delegatedListener = listeners[i];
+                if (delegatedListener.layer === layer && delegatedListener.listener === listener) {
+                    for (const event in delegatedListener.delegates) {
+                        this.off(event, delegatedListener.delegates[event]);
+                    }
+                    listeners.splice(i, 1);
+                    return this;
+                }
+            }
+        }
+    }
+
+    /**
      * Returns an array of [GeoJSON](http://geojson.org/)
      * [Feature objects](http://geojson.org/geojson-spec.html#feature-objects)
      * representing visible features that satisfy the query parameters.

--- a/test/node_modules/mapbox-gl-js-test/simulate_interaction.js
+++ b/test/node_modules/mapbox-gl-js-test/simulate_interaction.js
@@ -7,3 +7,11 @@ exports.click = function (element, options) {
     element.dispatchEvent(new MouseEvent('mouseup', options));
     element.dispatchEvent(new MouseEvent('click', options));
 };
+
+['mouseup', 'mousedown', 'mouseover', 'mousemove', 'mouseout'].forEach((event) => {
+    exports[event] = function (element, options) {
+        options = Object.assign({bubbles: true}, options);
+        const MouseEvent = element.ownerDocument.defaultView.MouseEvent;
+        element.dispatchEvent(new MouseEvent(event, options));
+    };
+});

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -1,0 +1,466 @@
+'use strict';
+
+const test = require('mapbox-gl-js-test').test;
+const Map = require('../../../src/ui/map');
+const window = require('../../../src/util/window');
+const simulate = require('mapbox-gl-js-test/simulate_interaction');
+
+function createMap() {
+    return new Map({
+        container: window.document.createElement('div')
+    });
+}
+
+test('Map#on adds a non-delegated event listener', (t) => {
+    const map = createMap();
+    const spy = t.spy(function (e) {
+        t.equal(this, map);
+        t.equal(e.type, 'click');
+    });
+
+    map.on('click', spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.calledOnce);
+    t.end();
+});
+
+test('Map#off removes a non-delegated event listener', (t) => {
+    const map = createMap();
+    const spy = t.spy();
+
+    map.on('click', spy);
+    map.off('click', spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.notCalled);
+    t.end();
+});
+
+test('Map#on adds a listener for an event on a given layer', (t) => {
+    const map = createMap();
+    const features = [{}];
+
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        t.deepEqual(options, {layers: ['layer']});
+        return features;
+    });
+
+    const spy = t.spy(function (e) {
+        t.equal(this, map);
+        t.equal(e.type, 'click');
+        t.equal(e.features, features);
+    });
+
+    map.on('click', 'layer', spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.calledOnce);
+    t.end();
+});
+
+test('Map#on adds a listener not triggered for events not matching any features', (t) => {
+    const map = createMap();
+    const features = [];
+
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        t.deepEqual(options, {layers: ['layer']});
+        return features;
+    });
+
+    const spy = t.spy();
+
+    map.on('click', 'layer', spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.notCalled);
+    t.end();
+});
+
+test('Map#on distinguishes distinct event types', (t) => {
+    const map = createMap();
+
+    t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+    const spyDown = t.spy((e) => {
+        t.equal(e.type, 'mousedown');
+    });
+
+    const spyUp = t.spy((e) => {
+        t.equal(e.type, 'mouseup');
+    });
+
+    map.on('mousedown', 'layer', spyDown);
+    map.on('mouseup', 'layer', spyUp);
+    simulate.click(map.getCanvas());
+
+    t.ok(spyDown.calledOnce);
+    t.ok(spyUp.calledOnce);
+    t.end();
+});
+
+test('Map#on distinguishes distinct layers', (t) => {
+    const map = createMap();
+    const featuresA = [{}];
+    const featuresB = [{}];
+
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        return options.layers[0] === 'A' ? featuresA : featuresB;
+    });
+
+    const spyA = t.spy((e) => {
+        t.equal(e.features, featuresA);
+    });
+
+    const spyB = t.spy((e) => {
+        t.equal(e.features, featuresB);
+    });
+
+    map.on('click', 'A', spyA);
+    map.on('click', 'B', spyB);
+    simulate.click(map.getCanvas());
+
+    t.ok(spyA.calledOnce);
+    t.ok(spyB.calledOnce);
+    t.end();
+});
+
+test('Map#on distinguishes distinct listeners', (t) => {
+    const map = createMap();
+
+    t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+    const spyA = t.spy();
+    const spyB = t.spy();
+
+    map.on('click', 'layer', spyA);
+    map.on('click', 'layer', spyB);
+    simulate.click(map.getCanvas());
+
+    t.ok(spyA.calledOnce);
+    t.ok(spyB.calledOnce);
+    t.end();
+});
+
+test('Map#off removes a delegated event listener', (t) => {
+    const map = createMap();
+
+    t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+    const spy = t.spy();
+
+    map.on('click', 'layer', spy);
+    map.off('click', 'layer', spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.notCalled);
+    t.end();
+});
+
+test('Map#off distinguishes distinct event types', (t) => {
+    const map = createMap();
+
+    t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+    const spy = t.spy((e) => {
+        t.equal(e.type, 'mousedown');
+    });
+
+    map.on('mousedown', 'layer', spy);
+    map.on('mouseup', 'layer', spy);
+    map.off('mouseup', 'layer', spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.calledOnce);
+    t.end();
+});
+
+test('Map#off distinguishes distinct layers', (t) => {
+    const map = createMap();
+    const featuresA = [{}];
+
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        t.deepEqual(options, {layers: ['A']});
+        return featuresA;
+    });
+
+    const spy = t.spy((e) => {
+        t.equal(e.features, featuresA);
+    });
+
+    map.on('click', 'A', spy);
+    map.on('click', 'B', spy);
+    map.off('click', 'B', spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.calledOnce);
+    t.end();
+});
+
+test('Map#off distinguishes distinct listeners', (t) => {
+    const map = createMap();
+
+    t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+    const spyA = t.spy();
+    const spyB = t.spy();
+
+    map.on('click', 'layer', spyA);
+    map.on('click', 'layer', spyB);
+    map.off('click', 'layer', spyB);
+    simulate.click(map.getCanvas());
+
+    t.ok(spyA.calledOnce);
+    t.ok(spyB.notCalled);
+    t.end();
+});
+
+['mouseenter', 'mouseover'].forEach((event) => {
+    test(`Map#on ${event} fires when entering the specified layer`, (t) => {
+        const map = createMap();
+        const features = [{}];
+
+        t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+            t.deepEqual(options, {layers: ['layer']});
+            return features;
+        });
+
+        const spy = t.spy(function (e) {
+            t.equal(this, map);
+            t.equal(e.type, event);
+            t.equal(e.features, features);
+        });
+
+        map.on(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#on ${event} does not fire on mousemove within the specified layer`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when reentering the specified layer`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures')
+            .onFirstCall().returns([{}])
+            .onSecondCall().returns([])
+            .onThirdCall().returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledTwice);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when reentering the specified layer after leaving the canvas`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mouseout(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledTwice);
+        t.end();
+    });
+
+    test(`Map#on ${event} distinguishes distinct layers`, (t) => {
+        const map = createMap();
+        const featuresA = [{}];
+        const featuresB = [{}];
+
+        t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+            return options.layers[0] === 'A' ? featuresA : featuresB;
+        });
+
+        const spyA = t.spy((e) => {
+            t.equal(e.features, featuresA);
+        });
+
+        const spyB = t.spy((e) => {
+            t.equal(e.features, featuresB);
+        });
+
+        map.on(event, 'A', spyA);
+        map.on(event, 'B', spyB);
+
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spyA.calledOnce);
+        t.ok(spyB.calledOnce);
+        t.end();
+    });
+
+    test(`Map#on ${event} distinguishes distinct listeners`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spyA = t.spy();
+        const spyB = t.spy();
+
+        map.on(event, 'layer', spyA);
+        map.on(event, 'layer', spyB);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spyA.calledOnce);
+        t.ok(spyB.calledOnce);
+        t.end();
+    });
+
+    test(`Map#off ${event} removes a delegated event listener`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, 'layer', spy);
+        map.off(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.notCalled);
+        t.end();
+    });
+
+    test(`Map#off ${event} distinguishes distinct layers`, (t) => {
+        const map = createMap();
+        const featuresA = [{}];
+
+        t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+            t.deepEqual(options, {layers: ['A']});
+            return featuresA;
+        });
+
+        const spy = t.spy((e) => {
+            t.equal(e.features, featuresA);
+        });
+
+        map.on(event, 'A', spy);
+        map.on(event, 'B', spy);
+        map.off(event, 'B', spy);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#off ${event} distinguishes distinct listeners`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spyA = t.spy();
+        const spyB = t.spy();
+
+        map.on(event, 'layer', spyA);
+        map.on(event, 'layer', spyB);
+        map.off(event, 'layer', spyB);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spyA.calledOnce);
+        t.ok(spyB.notCalled);
+        t.end();
+    });
+});
+
+['mouseleave', 'mouseout'].forEach((event) => {
+    test(`Map#on ${event} does not fire on mousemove when entering or within the specified layer`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.notCalled);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when exiting the specified layer`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures')
+            .onFirstCall().returns([{}])
+            .onSecondCall().returns([]);
+
+        const spy = t.spy(function (e) {
+            t.equal(this, map);
+            t.equal(e.type, event);
+            t.equal(e.features, undefined);
+        });
+
+        map.on(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when exiting the canvas`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy(function (e) {
+            t.equal(this, map);
+            t.equal(e.type, event);
+            t.equal(e.features, undefined);
+        });
+
+        map.on(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mouseout(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#off ${event} removes a delegated event listener`, (t) => {
+        const map = createMap();
+
+        t.stub(map, 'queryRenderedFeatures')
+            .onFirstCall().returns([{}])
+            .onSecondCall().returns([]);
+
+        const spy = t.spy();
+
+        map.on(event, 'layer', spy);
+        map.off(event, 'layer', spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+        simulate.mouseout(map.getCanvas());
+
+        t.ok(spy.notCalled);
+        t.end();
+    });
+});


### PR DESCRIPTION
Fixes #1002. I found that in order to really simplify most examples, we need special handling for `mouseenter`/`mouseleave` in addition to basic event delegation. But once we have that, a lot of common cases are simplified.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] should the special behavior apply to `mouseenter`/`mouseleave` or `mouseover`/`mouseout`?
   - both
 - [x] document the behavior for enter/leave (or over/out)
 - [x] leave/out event should also be triggered when cursor leaves the map element
 - [x] write tests for all new functionality
 - [x] manually test the debug page
