### PR TITLE
issue a clearer error message when queryRenderedFeatures parameters.layers isn't an Array

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -742,6 +742,10 @@ class Style extends Evented {
 
         const includedSources = {};
         if (params && params.layers) {
+            if (!Array.isArray(params.layers)) {
+                this.fire('error', {error: 'parameters.layers must be an Array.'});
+                return;
+            }
             for (const layerId of params.layers) {
                 const layer = this._layers[layerId];
                 if (!layer) {

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1216,6 +1216,16 @@ test('Style#queryRenderedFeatures', (t) => {
             t.end();
         });
 
+        t.test('checks type of `layers` option', (t) => {
+            let errors = 0;
+            t.stub(style, 'fire', (type, data) => {
+                if (data.error && data.error.includes('parameters.layers must be an Array.')) errors++;
+            });
+            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:'string'});
+            t.equals(errors, 1);
+            t.end();
+        });
+
         t.test('includes layout properties', (t) => {
             const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
             const layout = results[0].layer.layout;


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

if you call `map.queryRenderedFeatures` passing `parameters.layers` as a String such as `layer` by mistake (it expects an Array of strings) it will issue an error:

```
The layer 'l' does not exist in the map's style and cannot be queried for features.
```

This PR adds a different error message to let you know you need to pass an Array.

 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs

No changes.

 - [ ] post benchmark scores
 - [ ] manually test the debug page