### PR TITLE
Set default maxZoom to 22

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -23,7 +23,7 @@ const LogoControl = require('./control/logo_control');
 const isSupported = require('mapbox-gl-supported');
 
 const defaultMinZoom = 0;
-const defaultMaxZoom = 20;
+const defaultMaxZoom = 22;
 const defaultOptions = {
     center: [0, 0],
     zoom: 0,
@@ -69,8 +69,8 @@ const defaultOptions = {
  * @extends Evented
  * @param {Object} options
  * @param {HTMLElement|string} options.container The HTML element in which Mapbox GL JS will render the map, or the element's string `id`.
- * @param {number} [options.minZoom=0] The minimum zoom level of the map (1-20).
- * @param {number} [options.maxZoom=20] The maximum zoom level of the map (1-20).
+ * @param {number} [options.minZoom=0] The minimum zoom level of the map (0-22).
+ * @param {number} [options.maxZoom=22] The maximum zoom level of the map (0-22).
  * @param {Object|string} [options.style] The map's Mapbox style. This must be an a JSON object conforming to
  * the schema described in the [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL to
  * such JSON.

--- a/test/integration/render-tests/line-width/very-overscaled/style.json
+++ b/test/integration/render-tests/line-width/very-overscaled/style.json
@@ -9,7 +9,7 @@
     13.417504,
     52.499167
   ],
-  "zoom": 21,
+  "zoom": 20,
   "sources": {
     "mapbox": {
       "type": "vector",

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -612,7 +612,7 @@ test('Map', (t) => {
 
     t.test('#getMaxZoom', (t) => {
         const map = createMap({zoom: 0});
-        t.equal(map.getMaxZoom(), 20, 'returns default value');
+        t.equal(map.getMaxZoom(), 22, 'returns default value');
         map.setMaxZoom(10);
         t.equal(map.getMaxZoom(), 10, 'returns custom value');
         t.end();


### PR DESCRIPTION
As I know, all mapbox public sources such as satellite and streets are 0~22 zoom level. And maps in Mapbox studio can be zoomed into 22 max level. However, the default maxZoom level for mapbox-gl-js is 20. This cause inconsistency when a developer zoomed his maps in Mapbox studio to 22 and get stuck at 20 in his application. The shared URL provided by  mapbox studio also stuck at 20. I know developers can set default maxZoom of mapbox-gl-js to 22 explicitly, but it needs some effort for them to figure out the solution.