### PR TITLE
fire sourcedata when source metadata and tiles are loaded

### DIFF
--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -75,7 +75,6 @@ class CanvasSource extends ImageSource {
         this.load();
         if (this.canvas) {
             if (this.animate) this.play();
-            this.setCoordinates(this.coordinates);
         }
     }
 

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -108,11 +108,9 @@ class GeoJSONSource extends Evented {
                 this.fire('error', {error: err});
                 return;
             }
-            // `update` is included here to prevent a race condition where `Style#_updateSources` is called
-            // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives
-            // ref: https://github.com/mapbox/mapbox-gl-js/pull/4347#discussion_r104418088
+            // although GeoJSON sources contain no metadata, we fire this event to let the SourceCache
+            // know its ok to start requesting tiles.
             this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
-            this.fire('data', {dataType: 'source', sourceDataType: 'update'});
         });
     }
 
@@ -134,7 +132,7 @@ class GeoJSONSource extends Evented {
             if (err) {
                 return this.fire('error', { error: err });
             }
-            this.fire('data', {dataType: 'source', sourceDataType: 'update'});
+            this.fire('data', {dataType: 'source', sourceDataType: 'content'});
         });
 
         return this;

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -108,8 +108,8 @@ class GeoJSONSource extends Evented {
                 this.fire('error', {error: err});
                 return;
             }
-            this.fire('data', {dataType: 'source'});
             this.fire('source.load');
+            this.fire('data', {dataType: 'source'});
         });
     }
 
@@ -132,7 +132,7 @@ class GeoJSONSource extends Evented {
             if (err) {
                 return this.fire('error', { error: err });
             }
-            this.fire('data', {dataType: 'source'});
+            this.fire('source.update');
         });
 
         return this;

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -126,13 +126,13 @@ class GeoJSONSource extends Evented {
      */
     setData(data) {
         this._data = data;
-
         this.fire('dataloading', {dataType: 'source'});
         this._updateWorkerData((err) => {
             if (err) {
                 return this.fire('error', { error: err });
             }
             this.fire('source.update');
+            this.fire('data', {dataType: 'source'});
         });
 
         return this;

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -108,7 +108,7 @@ class GeoJSONSource extends Evented {
                 this.fire('error', {error: err});
                 return;
             }
-            this.fire('data', {dataType: 'source', metadata: true});
+            this.fire('data', {dataType: 'source', sourceDataType: 'metadata' });
         });
     }
 
@@ -130,7 +130,7 @@ class GeoJSONSource extends Evented {
             if (err) {
                 return this.fire('error', { error: err });
             }
-            this.fire('data', {dataType: 'source', update: true});
+            this.fire('data', {dataType: 'source', sourceDataType: 'update'});
         });
 
         return this;

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -108,8 +108,7 @@ class GeoJSONSource extends Evented {
                 this.fire('error', {error: err});
                 return;
             }
-            this.fire('source.load');
-            this.fire('data', {dataType: 'source'});
+            this.fire('data', {dataType: 'source', metadata: true});
         });
     }
 
@@ -131,8 +130,7 @@ class GeoJSONSource extends Evented {
             if (err) {
                 return this.fire('error', { error: err });
             }
-            this.fire('source.update');
-            this.fire('data', {dataType: 'source'});
+            this.fire('data', {dataType: 'source', update: true});
         });
 
         return this;

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -108,7 +108,7 @@ class GeoJSONSource extends Evented {
                 this.fire('error', {error: err});
                 return;
             }
-            this.fire('data', {dataType: 'source', sourceDataType: 'metadata' });
+            this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
         });
     }
 

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -108,7 +108,11 @@ class GeoJSONSource extends Evented {
                 this.fire('error', {error: err});
                 return;
             }
+            // `update` is included here to prevent a race condition where `Style#_updateSources` is called
+            // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives
+            // ref: https://github.com/mapbox/mapbox-gl-js/pull/4347#discussion_r104418088
             this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
+            this.fire('data', {dataType: 'source', sourceDataType: 'update'});
         });
     }
 

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -123,7 +123,7 @@ class ImageSource extends Evented {
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('data', {dataType:'source', sourceDataType: 'update'});
+        this.fire('data', {dataType:'source', sourceDataType: 'content'});
         return this;
     }
 

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -79,6 +79,7 @@ class ImageSource extends Evented {
 
         if (this.map) {
             this.setCoordinates(this.coordinates);
+            this.fire('data', {dataType: 'source'});
         }
     }
 
@@ -124,7 +125,7 @@ class ImageSource extends Evented {
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('data', {dataType: 'source'});
+        this.fire('source.update');
         return this;
     }
 

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -75,11 +75,9 @@ class ImageSource extends Evented {
     }
 
     _finishLoading() {
-        this.fire('source.load');
-
         if (this.map) {
             this.setCoordinates(this.coordinates);
-            this.fire('data', {dataType: 'source'});
+            this.fire('data', {dataType: 'source', metadata: true});
         }
     }
 
@@ -116,7 +114,8 @@ class ImageSource extends Evented {
         centerCoord.column = Math.round(centerCoord.column);
         centerCoord.row = Math.round(centerCoord.row);
 
-        this.minzoom = this.maxzoom = centerCoord.zoom;
+        // TODO this is making tests fail... what is it for?
+        // this.minzoom = this.maxzoom = centerCoord.zoom;
         this.coord = new TileCoord(centerCoord.zoom, centerCoord.column, centerCoord.row);
         this._tileCoords = cornerZ0Coords.map((coord) => {
             const zoomedCoord = coord.zoomTo(centerCoord.zoom);
@@ -125,7 +124,7 @@ class ImageSource extends Evented {
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('source.update');
+        this.fire('data', {dataType:'source', update: true});
         return this;
     }
 

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -77,7 +77,7 @@ class ImageSource extends Evented {
     _finishLoading() {
         if (this.map) {
             this.setCoordinates(this.coordinates);
-            this.fire('data', {dataType: 'source', metadata: true});
+            this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
         }
     }
 
@@ -114,8 +114,7 @@ class ImageSource extends Evented {
         centerCoord.column = Math.round(centerCoord.column);
         centerCoord.row = Math.round(centerCoord.row);
 
-        // TODO this is making tests fail... what is it for?
-        // this.minzoom = this.maxzoom = centerCoord.zoom;
+        this.minzoom = this.maxzoom = centerCoord.zoom;
         this.coord = new TileCoord(centerCoord.zoom, centerCoord.column, centerCoord.row);
         this._tileCoords = cornerZ0Coords.map((coord) => {
             const zoomedCoord = coord.zoomTo(centerCoord.zoom);
@@ -124,7 +123,7 @@ class ImageSource extends Evented {
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('data', {dataType:'source', update: true});
+        this.fire('data', {dataType:'source', sourceDataType: 'update'});
         return this;
     }
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -33,11 +33,11 @@ class RasterTileSource extends Evented {
             }
             util.extend(this, tileJSON);
 
-            // `update` is included here to prevent a race condition where `Style#_updateSources` is called
+            // `content` is included here to prevent a race condition where `Style#_updateSources` is called
             // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives
             // ref: https://github.com/mapbox/mapbox-gl-js/pull/4347#discussion_r104418088
             this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
-            this.fire('data', {dataType: 'source', sourceDataType: 'update'});
+            this.fire('data', {dataType: 'source', sourceDataType: 'content'});
 
         });
     }

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -32,8 +32,7 @@ class RasterTileSource extends Evented {
                 return this.fire('error', err);
             }
             util.extend(this, tileJSON);
-            this.fire('source.load');
-            this.fire('data', {dataType: 'source'});
+            this.fire('data', {dataType: 'source', metadata: true});
         });
     }
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -37,6 +37,8 @@ class RasterTileSource extends Evented {
             // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives
             // ref: https://github.com/mapbox/mapbox-gl-js/pull/4347#discussion_r104418088
             this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
+            this.fire('data', {dataType: 'source', sourceDataType: 'update'});
+
         });
     }
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -32,7 +32,11 @@ class RasterTileSource extends Evented {
                 return this.fire('error', err);
             }
             util.extend(this, tileJSON);
-            this.fire('data', {dataType: 'source', metadata: true});
+
+            // `update` is included here to prevent a race condition where `Style#_updateSources` is called
+            // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives
+            // ref: https://github.com/mapbox/mapbox-gl-js/pull/4347#discussion_r104418088
+            this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
         });
     }
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -32,8 +32,8 @@ class RasterTileSource extends Evented {
                 return this.fire('error', err);
             }
             util.extend(this, tileJSON);
-            this.fire('data', {dataType: 'source'});
             this.fire('source.load');
+            this.fire('data', {dataType: 'source'});
         });
     }
 

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -50,7 +50,7 @@ exports.setType = function (name, type) {
  * @param {string} options.type The source type, matching the value of `name` used in {@link Style#addSourceType}.
  * @param {Dispatcher} dispatcher A {@link Dispatcher} instance, which can be used to send messages to the workers.
  *
- * @fires load to indicate source data has been loaded, so that it's okay to call `loadTile`
+ * @fires data to indicate source data has been loaded, so that it's okay to call `loadTile`
  * @fires change to indicate source data has changed, so that any current caches should be flushed
  * @property {string} id The id for the source.  Must match the id passed to the constructor.
  * @property {number} minzoom

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -50,8 +50,9 @@ exports.setType = function (name, type) {
  * @param {string} options.type The source type, matching the value of `name` used in {@link Style#addSourceType}.
  * @param {Dispatcher} dispatcher A {@link Dispatcher} instance, which can be used to send messages to the workers.
  *
- * @fires data to indicate source data has been loaded, so that it's okay to call `loadTile`
- * @fires change to indicate source data has changed, so that any current caches should be flushed
+ * @fires data with `{dataType: 'source', sourceDataType: 'metadata'}` to indicate that any necessary metadata
+ * has been loaded so that it's okay to call `loadTile`; and with `{dataType: 'source', sourceDataType: 'content'}`
+ * to indicate that the source data has changed, so that any current caches should be flushed.
  * @property {string} id The id for the source.  Must match the id passed to the constructor.
  * @property {number} minzoom
  * @property {number} maxzoom

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -36,7 +36,7 @@ class SourceCache extends Evented {
         });
 
         this.on('source.update', function(event) {
-            if (this._sourceLoaded && event.dataType === 'source') {
+            if (this._sourceLoaded) {
                 this.reload();
                 if (this.transform) {
                     this.update(this.transform);
@@ -297,6 +297,7 @@ class SourceCache extends Evented {
      * @private
      */
     update(transform) {
+        this.transform = transform;
         if (!this._sourceLoaded) { return; }
         let i;
         let coord;
@@ -395,8 +396,6 @@ class SourceCache extends Evented {
         for (i = 0; i < remove.length; i++) {
             this.removeTile(+remove[i]);
         }
-
-        this.transform = transform;
     }
 
     /**

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -31,11 +31,11 @@ class SourceCache extends Evented {
             // this._sourceLoaded signifies that the TileJSON is loaded if applicable.
             // if the source type does not come with a TileJSON, the flag signifies the
             // source data has loaded (i.e geojson has been tiled on the worker and is ready)
+            if (e.dataType === 'source' && e.sourceDataType==='metadata') this._sourceLoaded = true;
 
             // for sources with mutable data, this event fires when the underlying data
             // to a source is changed. (i.e. GeoJSONSource#setData and ImageSource#serCoordinates)
-            if (e.dataType==="source" && (e.sourceDataType === 'metadata' || e.sourceDataType === 'update')) {
-                this._sourceLoaded = true;
+            if (this._sourceLoaded && e.dataType==="source" && e.sourceDataType==='update') {
                 this.reload();
                 if (this.transform) {
                     this.update(this.transform);

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -423,17 +423,17 @@ class SourceCache extends Evented {
                 }
             }
         }
-
-        if (!tile) {
+        const cached = Boolean(tile);
+        if (!cached) {
             const zoom = coord.z;
             const overscaling = zoom > this._source.maxzoom ? Math.pow(2, zoom - this._source.maxzoom) : 1;
             tile = new Tile(wrapped, this._source.tileSize * overscaling, this._source.maxzoom);
-            this._source.fire('dataloading', {tile: tile, coord: tile.coord, dataType: 'tile'});
             this.loadTile(tile, this._tileLoaded.bind(this, tile, coord.id));
         }
 
         tile.uses++;
         this._tiles[coord.id] = tile;
+        if (!cached) this._source.fire('dataloading', {tile: tile, coord: tile.coord, dataType: 'tile'});
 
         return tile;
     }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -442,7 +442,7 @@ class SourceCache extends Evented {
     }
 
     _setTileReloadTimer(id, tile) {
-        const expiryTimegoout = tile.getExpiryTimeout();
+        const expiryTimeout = tile.getExpiryTimeout();
         if (expiryTimeout) {
             this._timers[id] = setTimeout(() => {
                 this.reloadTile(id, 'expired');

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -35,7 +35,7 @@ class SourceCache extends Evented {
 
             // for sources with mutable data, this event fires when the underlying data
             // to a source is changed. (i.e. GeoJSONSource#setData and ImageSource#serCoordinates)
-            if (this._sourceLoaded && e.dataType==="source" && e.sourceDataType==='update') {
+            if (this._sourceLoaded && e.dataType==="source" && e.sourceDataType==='content') {
                 this.reload();
                 if (this.transform) {
                     this.update(this.transform);

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -35,7 +35,7 @@ class SourceCache extends Evented {
             this._sourceErrored = true;
         });
 
-        this.on('data', function(event) {
+        this.on('source.update', function(event) {
             if (this._sourceLoaded && event.dataType === 'source') {
                 this.reload();
                 if (this.transform) {
@@ -170,6 +170,7 @@ class SourceCache extends Evented {
         if (previousState === 'expired') tile.refreshedUponExpiration = true;
         this._setTileReloadTimer(id, tile);
         this._source.fire('data', {tile: tile, coord: tile.coord, dataType: 'tile'});
+        if (this.loaded()) this.fire('data', {dataType: 'source'});
 
         // HACK this is necessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
         if (this.map) this.map.painter.tileExtentVAO.vao = null;
@@ -428,12 +429,12 @@ class SourceCache extends Evented {
             const zoom = coord.z;
             const overscaling = zoom > this._source.maxzoom ? Math.pow(2, zoom - this._source.maxzoom) : 1;
             tile = new Tile(wrapped, this._source.tileSize * overscaling, this._source.maxzoom);
+            this._source.fire('dataloading', {tile: tile, coord: tile.coord, dataType: 'tile'});
             this.loadTile(tile, this._tileLoaded.bind(this, tile, coord.id));
         }
 
         tile.uses++;
         this._tiles[coord.id] = tile;
-        this._source.fire('dataloading', {tile: tile, coord: tile.coord, dataType: 'tile'});
 
         return tile;
     }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -155,7 +155,6 @@ class Tile {
             showCollisionBoxes: source.map.showCollisionBoxes
         }, (_, data) => {
             this.reloadSymbolData(data, source.map.style);
-            source.fire('data', {tile: this, coord: this.coord, dataType: 'tile'});
 
             // HACK this is nescessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
             if (source.map) source.map.painter.tileExtentVAO.vao = null;

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -39,7 +39,7 @@ class VectorTileSource extends Evented {
                 return;
             }
             util.extend(this, tileJSON);
-            this.fire('data', {dataType: 'source', metadata: true});
+            this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
         });
     }
 

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -39,7 +39,9 @@ class VectorTileSource extends Evented {
                 return;
             }
             util.extend(this, tileJSON);
+
             this.fire('source.load');
+            this.fire('source.update');
         });
     }
 

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -39,7 +39,6 @@ class VectorTileSource extends Evented {
                 return;
             }
             util.extend(this, tileJSON);
-
             this.fire('source.load');
             this.fire('source.update');
         });

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -39,7 +39,12 @@ class VectorTileSource extends Evented {
                 return;
             }
             util.extend(this, tileJSON);
+             // `content` is included here to prevent a race condition where `Style#_updateSources` is called
+            // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives
+            // ref: https://github.com/mapbox/mapbox-gl-js/pull/4347#discussion_r104418088
             this.fire('data', {dataType: 'source', sourceDataType: 'metadata'});
+            this.fire('data', {dataType: 'source', sourceDataType: 'content'});
+
         });
     }
 

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -39,7 +39,6 @@ class VectorTileSource extends Evented {
                 return;
             }
             util.extend(this, tileJSON);
-            this.fire('data', {dataType: 'source'});
             this.fire('source.load');
         });
     }

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -39,8 +39,7 @@ class VectorTileSource extends Evented {
                 return;
             }
             util.extend(this, tileJSON);
-            this.fire('source.load');
-            this.fire('source.update');
+            this.fire('data', {dataType: 'source', metadata: true});
         });
     }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -118,13 +118,15 @@ class Style extends Evented {
             browser.frame(stylesheetLoaded.bind(this, null, stylesheet));
         }
 
-        this.on('source.load', (event) => {
-            const source = this.sourceCaches[event.sourceId].getSource();
-            if (source && source.vectorLayerIds) {
-                for (const layerId in this._layers) {
-                    const layer = this._layers[layerId];
-                    if (layer.source === source.id) {
-                        this._validateLayer(layer);
+        this.on('data', (event) => {
+            if (event.dataType === 'source') {
+                const source = this.sourceCaches[event.sourceId].getSource();
+                if (source && source.vectorLayerIds) {
+                    for (const layerId in this._layers) {
+                        const layer = this._layers[layerId];
+                        if (layer.source === source.id) {
+                            this._validateLayer(layer);
+                        }
                     }
                 }
             }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -119,7 +119,7 @@ class Style extends Evented {
         }
 
         this.on('data', (event) => {
-            if (event.dataType === 'source' && event.metadata) {
+            if (event.dataType === 'source' && event.sourceDataType === 'metadata') {
                 const source = this.sourceCaches[event.sourceId].getSource();
                 if (source && source.vectorLayerIds) {
                     for (const layerId in this._layers) {
@@ -139,7 +139,6 @@ class Style extends Evented {
         if (!layer.sourceLayer) return;
         if (!sourceCache) return;
         const source = sourceCache.getSource();
-
         if (source.type === 'geojson' || (source.vectorLayerIds &&
             source.vectorLayerIds.indexOf(layer.sourceLayer) === -1)) {
             this.fire('error', {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -119,7 +119,7 @@ class Style extends Evented {
         }
 
         this.on('data', (event) => {
-            if (event.dataType === 'source') {
+            if (event.dataType === 'source' && event.metadata) {
                 const source = this.sourceCaches[event.sourceId].getSource();
                 if (source && source.vectorLayerIds) {
                     for (const layerId in this._layers) {

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -81,7 +81,7 @@ class AttributionControl {
 
     _updateAttributions(e) {
         if (!this._map.style) return;
-        if (e && !e.metadata) return;
+        if (e && e.sourceDataType !== 'metadata') return;
         let attributions = [];
 
         const sourceCaches = this._map.style.sourceCaches;

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -44,7 +44,7 @@ class AttributionControl {
         this._updateAttributions();
         this._updateEditLink();
 
-        this._map.on('source.load', this._updateData);
+        this._map.on('sourcedata', this._updateData);
         this._map.on('moveend', this._updateEditLink);
 
         if (compact === undefined) {
@@ -58,7 +58,7 @@ class AttributionControl {
     onRemove() {
         this._container.parentNode.removeChild(this._container);
 
-        this._map.off('source.load', this._updateData);
+        this._map.off('sourcedata', this._updateData);
         this._map.off('moveend', this._updateEditLink);
         this._map.off('resize', this._updateCompact);
 
@@ -74,14 +74,14 @@ class AttributionControl {
         }
     }
 
-    _updateData(event) {
-        this._updateAttributions();
+    _updateData(e) {
+        this._updateAttributions(e);
         this._updateEditLink();
     }
 
-    _updateAttributions() {
+    _updateAttributions(e) {
         if (!this._map.style) return;
-
+        if (e && !e.metadata) return;
         let attributions = [];
 
         const sourceCaches = this._map.style.sourceCaches;

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -81,7 +81,7 @@ class AttributionControl {
 
     _updateAttributions(e) {
         if (!this._map.style) return;
-        if (e && e.sourceDataType !== 'metadata') return;
+        if (e && e.sourceDataType!=='metadata') return;
         let attributions = [];
 
         const sourceCaches = this._map.style.sourceCaches;

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -44,7 +44,7 @@ class AttributionControl {
         this._updateAttributions();
         this._updateEditLink();
 
-        this._map.on('data', this._updateData);
+        this._map.on('source.load', this._updateData);
         this._map.on('moveend', this._updateEditLink);
 
         if (compact === undefined) {
@@ -58,7 +58,7 @@ class AttributionControl {
     onRemove() {
         this._container.parentNode.removeChild(this._container);
 
-        this._map.off('data', this._updateData);
+        this._map.off('source.load', this._updateData);
         this._map.off('moveend', this._updateEditLink);
         this._map.off('resize', this._updateCompact);
 
@@ -75,10 +75,8 @@ class AttributionControl {
     }
 
     _updateData(event) {
-        if (event.dataType === 'source') {
-            this._updateAttributions();
-            this._updateEditLink();
-        }
+        this._updateAttributions();
+        this._updateEditLink();
     }
 
     _updateAttributions() {

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -37,7 +37,7 @@ class LogoControl {
     }
 
     _updateLogo(e) {
-        if (e && e.metadata && this._logoRequired()) {
+        if (e && e.sourceDataType === 'metadata' && this._logoRequired()) {
             const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
             anchor.target = "_blank";
             anchor.href = "https://www.mapbox.com/";

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -22,22 +22,22 @@ class LogoControl {
         this._map = map;
         this._container = DOM.create('div', 'mapboxgl-ctrl');
 
-        this._map.on('source.load', this._updateLogo);
+        this._map.on('sourcedata', this._updateLogo);
         this._updateLogo();
         return this._container;
     }
 
     onRemove() {
         this._container.parentNode.removeChild(this._container);
-        this._map.off('source.load', this._updateLogo);
+        this._map.off('sourcedata', this._updateLogo);
     }
 
     getDefaultPosition() {
         return 'bottom-left';
     }
 
-    _updateLogo() {
-        if (this._logoRequired()) {
+    _updateLogo(e) {
+        if (e && e.metadata && this._logoRequired()) {
             const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
             anchor.target = "_blank";
             anchor.href = "https://www.mapbox.com/";

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -37,7 +37,7 @@ class LogoControl {
     }
 
     _updateLogo(e) {
-        if (e && e.sourceDataType === 'metadata' && this._logoRequired()) {
+        if (e && e.sourceDataType==='metadata' && this._logoRequired()) {
             const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
             anchor.target = "_blank";
             anchor.href = "https://www.mapbox.com/";

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -22,14 +22,14 @@ class LogoControl {
         this._map = map;
         this._container = DOM.create('div', 'mapboxgl-ctrl');
 
-        this._map.on('data', this._updateLogo);
+        this._map.on('source.load', this._updateLogo);
         this._updateLogo();
         return this._container;
     }
 
     onRemove() {
         this._container.parentNode.removeChild(this._container);
-        this._map.off('data', this._updateLogo);
+        this._map.off('source.load', this._updateLogo);
     }
 
     getDefaultPosition() {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1676,25 +1676,14 @@ function removeNode(node) {
  */
 
 /**
- * Fired when one of the map's sources loads or changes. This event is not fired
- * if a tile belonging to a source loads or changes (that is handled by
- * `tiledata`). See [`MapDataEvent`](#MapDataEvent) for more information.
+ * Fired when one of the map's sources loads or changes, including if a tile belonging
+ * to a source loads or changes. See [`MapDataEvent`](#MapDataEvent) for more information.
  *
  * @event sourcedata
  * @memberof Map
  * @instance
  * @property {MapDataEvent} data
  */
-
- /**
-  * Fired when one of the map's sources' tiles loads or changes. See
-  * [`MapDataEvent`](#MapDataEvent) for more information.
-  *
-  * @event tiledata
-  * @memberof Map
-  * @instance
-  * @property {MapDataEvent} data
-  */
 
 /**
  * Fired when any map data (style, source, tile, etc) begins loading or
@@ -1720,23 +1709,10 @@ function removeNode(node) {
 
 /**
  * Fired when one of the map's sources begins loading or changing asyncronously.
- * This event is not fired if a tile belonging to a source begins loading or
- * changing (that is handled by `tiledataloading`). All `sourcedataloading`
- * events are followed by a `sourcedata` or `error` event. See
- * [`MapDataEvent`](#MapDataEvent) for more information.
+ * All `sourcedataloading` events are followed by a `sourcedata` or `error` event.
+ * See [`MapDataEvent`](#MapDataEvent) for more information.
  *
  * @event sourcedataloading
- * @memberof Map
- * @instance
- * @property {MapDataEvent} data
- */
-
-/**
- * Fired when one of the map's sources' tiles begins loading or changing
- * asyncronously. All `tiledataloading` events are followed by a `tiledata`
- * or `error` event. See [`MapDataEvent`](#MapDataEvent) for more information.
- *
- * @event tiledataloading
  * @memberof Map
  * @instance
  * @property {MapDataEvent} data
@@ -1749,14 +1725,18 @@ function removeNode(node) {
   *
   * - `'source'`: The non-tile data associated with any source
   * - `'style'`: The [style](https://www.mapbox.com/mapbox-gl-style-spec/) used by the map
-  * - `'tile'`: A vector or raster tile
   *
   * @typedef {Object} MapDataEvent
   * @property {string} type The event type.
   * @property {string} dataType The type of data that has changed. One of `'source'`, `'style'`.
   * @property {boolean} [isSourceLoaded] True if the event has a `dataType` of `source` and the source has no outstanding network requests.
   * @property {Object} [source] The [style spec representation of the source](https://www.mapbox.com/mapbox-gl-style-spec/#sources) if the event has a `dataType` of `source`.
-  * @property {Coordinate} [coord] The coordinate of the tile if the event has a `dataType` of `tile`.
+  * @property {string} [sourceDataType] Included if the event has a `dataType` of `source` and the event signals
+  * that internal data has been received or changed. Possible values are `metadata` and `content`.
+  * @property {Object} [tile] The tile being loaded or changed, if the event has a `dataType` of `source` and
+  * the event is related to loading of a tile.
+  * @property {Coordinate} [coord] The coordinate of the tile if the event has a `dataType` of `source` and
+  * the event is related to loading of a tile.
   */
 
  /**

--- a/test/unit/source/canvas_source.test.js
+++ b/test/unit/source/canvas_source.test.js
@@ -84,7 +84,7 @@ test('CanvasSource', (t) => {
         });
 
         source.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+            if (e.sourceDataType === 'metadata' && e.dataType === 'source') {
                 t.ok(true, 'fires load event without rerendering');
                 t.end();
             }

--- a/test/unit/source/canvas_source.test.js
+++ b/test/unit/source/canvas_source.test.js
@@ -46,12 +46,12 @@ test('CanvasSource', (t) => {
     t.test('constructor', (t) => {
         const source = createSource();
 
+        t.equal(source.minzoom, 0);
+        t.equal(source.maxzoom, 22);
+        t.equal(source.tileSize, 512);
+        t.equal(source.animate, true);
         source.on('data', (e) => {
-            if (e.metadata && e.dataType === 'source') {
-                t.equal(source.minzoom, 0);
-                t.equal(source.maxzoom, 22);
-                t.equal(source.tileSize, 512);
-                t.equal(source.animate, true);
+            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
                 t.equal(typeof source.play, 'function');
                 t.end();
             }
@@ -84,7 +84,7 @@ test('CanvasSource', (t) => {
         });
 
         source.on('data', (e) => {
-            if (e.metadata && e.dataType === 'source') {
+            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
                 t.ok(true, 'fires load event without rerendering');
                 t.end();
             }

--- a/test/unit/source/canvas_source.test.js
+++ b/test/unit/source/canvas_source.test.js
@@ -20,7 +20,6 @@ function createSource(options) {
     }, options);
 
     const source = new CanvasSource('id', options, { send: function() {} }, options.eventedParent);
-
     source.canvas = c;
 
     return source;
@@ -47,13 +46,15 @@ test('CanvasSource', (t) => {
     t.test('constructor', (t) => {
         const source = createSource();
 
-        source.on('source.load', () => {
-            t.equal(source.minzoom, 0);
-            t.equal(source.maxzoom, 22);
-            t.equal(source.tileSize, 512);
-            t.equal(source.animate, true);
-            t.equal(typeof source.play, 'function');
-            t.end();
+        source.on('data', (e) => {
+            if (e.metadata && e.dataType === 'source') {
+                t.equal(source.minzoom, 0);
+                t.equal(source.maxzoom, 22);
+                t.equal(source.tileSize, 512);
+                t.equal(source.animate, true);
+                t.equal(typeof source.play, 'function');
+                t.end();
+            }
         });
 
         source.onAdd(new StubMap());
@@ -82,9 +83,11 @@ test('CanvasSource', (t) => {
             t.end();
         });
 
-        source.on('source.load', () => {
-            t.ok(true, 'fires load event without rerendering');
-            t.end();
+        source.on('data', (e) => {
+            if (e.metadata && e.dataType === 'source') {
+                t.ok(true, 'fires load event without rerendering');
+                t.end();
+            }
         });
 
         source.onAdd(map);

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -152,7 +152,7 @@ test('GeoJSONSource#update', (t) => {
         const source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
         source.on('data', (e) => {
-            if (e.metadata) t.end();
+            if (e.sourceDataType === 'metadata') t.end();
         });
 
         source.load();
@@ -192,7 +192,7 @@ test('GeoJSONSource#update', (t) => {
         };
 
         source.on('data', (e) => {
-            if (e.metadata) {
+            if (e.sourceDataType === 'metadata') {
                 source.setData({});
                 source.loadTile(new Tile(new TileCoord(0, 0, 0), 512), () => {});
             }

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -63,7 +63,7 @@ test('GeoJSONSource#setData', (t) => {
     t.test('fires "data" event', (t) => {
         const source = createSource();
         source.once('data', () => {
-            source.on('data', t.end);
+            source.once('data', t.end);
             source.setData({});
         });
         source.load();
@@ -71,10 +71,7 @@ test('GeoJSONSource#setData', (t) => {
 
     t.test('fires "dataloading" event', (t) => {
         const source = createSource();
-        source.once('data', () => {
-            source.on('dataloading', t.end);
-            source.setData({});
-        });
+        source.on('dataloading', t.end);
         source.load();
     });
 

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -142,7 +142,7 @@ test('GeoJSONSource#update', (t) => {
         }, mockDispatcher).load();
     });
 
-    t.test('fires "source.load"', (t) => {
+    t.test('fires event when metadata loads', (t) => {
         const mockDispatcher = {
             send: function(message, args, callback) {
                 setTimeout(callback, 0);
@@ -151,8 +151,8 @@ test('GeoJSONSource#update', (t) => {
 
         const source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
 
-        source.on('source.load', () => {
-            t.end();
+        source.on('data', (e) => {
+            if (e.metadata) t.end();
         });
 
         source.load();
@@ -191,9 +191,11 @@ test('GeoJSONSource#update', (t) => {
             transform: {}
         };
 
-        source.on('source.load', () => {
-            source.setData({});
-            source.loadTile(new Tile(new TileCoord(0, 0, 0), 512), () => {});
+        source.on('data', (e) => {
+            if (e.metadata) {
+                source.setData({});
+                source.loadTile(new Tile(new TileCoord(0, 0, 0), 512), () => {});
+            }
         });
 
         source.load();

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -195,11 +195,11 @@ test('SourceCache#removeTile', (t) => {
         const coord = new TileCoord(0, 0, 0);
         const sourceCache = createSourceCache({});
         sourceCache.addTile(coord);
-        sourceCache.on('data', (e)=> {
+        sourceCache.on('data', ()=> {
             sourceCache.removeTile(coord.id);
             t.notOk(sourceCache._tiles[coord.id]);
             t.end();
-        })
+        });
     });
 
     t.test('caches (does not unload) loaded tile', (t) => {
@@ -859,89 +859,89 @@ test('SourceCache#getIds (ascending order by zoom level)', (t) => {
 });
 
 
-// test('SourceCache#findLoadedParent', (t) => {
+test('SourceCache#findLoadedParent', (t) => {
 
-//     t.test('adds from previously used tiles (sourceCache._tiles)', (t) => {
-//         const sourceCache = createSourceCache({});
-//         sourceCache.onAdd();
-//         const tr = new Transform();
-//         tr.width = 512;
-//         tr.height = 512;
-//         sourceCache.updateCacheSize(tr);
+    t.test('adds from previously used tiles (sourceCache._tiles)', (t) => {
+        const sourceCache = createSourceCache({});
+        sourceCache.onAdd();
+        const tr = new Transform();
+        tr.width = 512;
+        tr.height = 512;
+        sourceCache.updateCacheSize(tr);
 
-//         const tile = {
-//             coord: new TileCoord(1, 0, 0),
-//             hasData: function() { return true; }
-//         };
+        const tile = {
+            coord: new TileCoord(1, 0, 0),
+            hasData: function() { return true; }
+        };
 
-//         sourceCache._tiles[tile.coord.id] = tile;
+        sourceCache._tiles[tile.coord.id] = tile;
 
-//         const retain = {};
-//         const expectedRetain = {};
-//         expectedRetain[tile.coord.id] = true;
+        const retain = {};
+        const expectedRetain = {};
+        expectedRetain[tile.coord.id] = true;
 
-//         t.equal(sourceCache.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
-//         t.deepEqual(sourceCache.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
-//         t.deepEqual(retain, expectedRetain);
-//         t.end();
-//     });
+        t.equal(sourceCache.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
+        t.deepEqual(sourceCache.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
+        t.deepEqual(retain, expectedRetain);
+        t.end();
+    });
 
-//     t.test('retains parents', (t) => {
-//         const sourceCache = createSourceCache({});
-//         sourceCache.onAdd();
-//         const tr = new Transform();
-//         tr.width = 512;
-//         tr.height = 512;
-//         sourceCache.updateCacheSize(tr);
+    t.test('retains parents', (t) => {
+        const sourceCache = createSourceCache({});
+        sourceCache.onAdd();
+        const tr = new Transform();
+        tr.width = 512;
+        tr.height = 512;
+        sourceCache.updateCacheSize(tr);
 
-//         const tile = new Tile(new TileCoord(1, 0, 0), 512, 22);
-//         sourceCache._cache.add(tile.coord.id, tile);
+        const tile = new Tile(new TileCoord(1, 0, 0), 512, 22);
+        sourceCache._cache.add(tile.coord.id, tile);
 
-//         const retain = {};
-//         const expectedRetain = {};
-//         expectedRetain[tile.coord.id] = true;
+        const retain = {};
+        const expectedRetain = {};
+        expectedRetain[tile.coord.id] = true;
 
-//         t.equal(sourceCache.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
-//         t.equal(sourceCache.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
-//         t.deepEqual(retain, expectedRetain);
-//         t.equal(sourceCache._cache.order.length, 1);
+        t.equal(sourceCache.findLoadedParent(new TileCoord(2, 3, 3), 0, retain), undefined);
+        t.equal(sourceCache.findLoadedParent(new TileCoord(2, 0, 0), 0, retain), tile);
+        t.deepEqual(retain, expectedRetain);
+        t.equal(sourceCache._cache.order.length, 1);
 
-//         t.end();
-//     });
+        t.end();
+    });
 
-//     t.end();
-// });
+    t.end();
+});
 
-// test('SourceCache#reload', (t) => {
-//     t.test('before loaded', (t) => {
-//         const sourceCache = createSourceCache({ noLoad: true });
-//         sourceCache.onAdd();
+test('SourceCache#reload', (t) => {
+    t.test('before loaded', (t) => {
+        const sourceCache = createSourceCache({ noLoad: true });
+        sourceCache.onAdd();
 
-//         t.doesNotThrow(() => {
-//             sourceCache.reload();
-//         }, null, 'reload ignored gracefully');
+        t.doesNotThrow(() => {
+            sourceCache.reload();
+        }, null, 'reload ignored gracefully');
 
-//         t.end();
-//     });
+        t.end();
+    });
 
-//     t.end();
-// });
+    t.end();
+});
 
-// test('SourceCache reloads expiring tiles', (t) => {
-//     t.test('calls reloadTile when tile expires', (t) => {
-//         const coord = new TileCoord(1, 0, 0);
+test('SourceCache reloads expiring tiles', (t) => {
+    t.test('calls reloadTile when tile expires', (t) => {
+        const coord = new TileCoord(1, 0, 0);
 
-//         const expiryDate = new Date();
-//         expiryDate.setMilliseconds(expiryDate.getMilliseconds() + 50);
-//         const sourceCache = createSourceCache({ expires: expiryDate });
+        const expiryDate = new Date();
+        expiryDate.setMilliseconds(expiryDate.getMilliseconds() + 50);
+        const sourceCache = createSourceCache({ expires: expiryDate });
 
-//         sourceCache.reloadTile = (id, state) => {
-//             t.equal(state, 'expired');
-//             t.end();
-//         };
+        sourceCache.reloadTile = (id, state) => {
+            t.equal(state, 'expired');
+            t.end();
+        };
 
-//         sourceCache.addTile(coord);
-//     });
+        sourceCache.addTile(coord);
+    });
 
-//     t.end();
-// });
+    t.end();
+});

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -312,7 +312,7 @@ test('SourceCache / Source lifecycle', (t) => {
         sourceCache.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
                 sourceCache.update(transform);
-                sourceCache.getSource().fire('data', {dataType: 'source', sourceDataType: 'update'});
+                sourceCache.getSource().fire('data', {dataType: 'source', sourceDataType: 'content'});
             }
         });
 

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -112,7 +112,7 @@ test('SourceCache#addTile', (t) => {
         sourceCache.addTile(coord);
 
         t.equal(load, 1);
-        t.equal(add, 2);
+        t.equal(add, 1);
 
         t.end();
     });
@@ -181,7 +181,7 @@ test('SourceCache#addTile', (t) => {
         const t2 = sourceCache.addTile(new TileCoord(0, 0, 0, 1));
 
         t.equal(load, 1);
-        t.equal(add, 2);
+        t.equal(add, 1);
         t.equal(t1, t2);
 
         t.end();
@@ -291,7 +291,7 @@ test('SourceCache / Source lifecycle', (t) => {
         sourceCache.onAdd();
     });
 
-    t.test('reloads tiles after a "source" data event', (t) => {
+    t.test('reloads tiles after a "source.update" event', (t) => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -309,7 +309,7 @@ test('SourceCache / Source lifecycle', (t) => {
 
         sourceCache.on('source.load', () => {
             sourceCache.update(transform);
-            sourceCache.getSource().fire('data', {dataType: 'source'});
+            sourceCache.getSource().fire('source.update');
         });
 
         sourceCache.onAdd();

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -38,7 +38,7 @@ function MockSourceType(id, sourceOptions, _dispatcher, eventedParent) {
             if (sourceOptions.error) {
                 this.fire('error', { error: sourceOptions.error });
             } else {
-                this.fire('source.load');
+                this.fire('data', {dataType: 'source', metadata: true});
             }
         }
         abortTile() {}
@@ -256,19 +256,22 @@ test('SourceCache#removeTile', (t) => {
 test('SourceCache / Source lifecycle', (t) => {
     t.test('does not fire load or change before source load event', (t) => {
         const sourceCache = createSourceCache({noLoad: true})
-            .on('source.load', t.fail)
             .on('data', t.fail);
         sourceCache.onAdd();
         setTimeout(t.end, 1);
     });
 
     t.test('forward load event', (t) => {
-        const sourceCache = createSourceCache({}).on('source.load', t.end);
+        const sourceCache = createSourceCache({}).on('data', (e)=>{
+            if (e.metadata) t.end();
+        });
         sourceCache.onAdd();
     });
 
     t.test('forward change event', (t) => {
-        const sourceCache = createSourceCache().on('data', t.end);
+        const sourceCache = createSourceCache().on('data', (e)=>{
+            if (e.metadata) t.end();
+        });
         sourceCache.onAdd();
         sourceCache.getSource().fire('data');
     });
@@ -291,7 +294,7 @@ test('SourceCache / Source lifecycle', (t) => {
         sourceCache.onAdd();
     });
 
-    t.test('reloads tiles after a "source.update" event', (t) => {
+    t.test('reloads tiles after a data event where source is updated', (t) => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -307,9 +310,11 @@ test('SourceCache / Source lifecycle', (t) => {
             }
         });
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-            sourceCache.getSource().fire('source.update');
+        sourceCache.on('data', (e) => {
+            if (e.dataType === 'source' && e.metadata) {
+                sourceCache.update(transform);
+                sourceCache.getSource().fire('data', {dataType: 'source', update: true});
+            }
         });
 
         sourceCache.onAdd();
@@ -325,11 +330,12 @@ test('SourceCache#update', (t) => {
         transform.zoom = 0;
 
         const sourceCache = createSourceCache({}, false);
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-
-            t.deepEqual(sourceCache.getIds(), []);
-            t.end();
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
+                t.deepEqual(sourceCache.getIds(), []);
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -340,10 +346,12 @@ test('SourceCache#update', (t) => {
         transform.zoom = 0;
 
         const sourceCache = createSourceCache({});
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-            t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
-            t.end();
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
+                t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -355,20 +363,22 @@ test('SourceCache#update', (t) => {
 
         const sourceCache = createSourceCache({});
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-            t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
+                t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
-            transform.zoom = 1;
-            sourceCache.update(transform);
+                transform.zoom = 1;
+                sourceCache.update(transform);
 
-            t.deepEqual(sourceCache.getIds(), [
-                new TileCoord(1, 0, 0).id,
-                new TileCoord(1, 1, 0).id,
-                new TileCoord(1, 0, 1).id,
-                new TileCoord(1, 1, 1).id
-            ]);
-            t.end();
+                t.deepEqual(sourceCache.getIds(), [
+                    new TileCoord(1, 0, 0).id,
+                    new TileCoord(1, 1, 0).id,
+                    new TileCoord(1, 0, 1).id,
+                    new TileCoord(1, 1, 1).id
+                ]);
+                t.end();
+            }
         });
 
         sourceCache.onAdd();
@@ -388,21 +398,23 @@ test('SourceCache#update', (t) => {
             }
         });
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-            t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
+                t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0).id]);
 
-            transform.zoom = 1;
-            sourceCache.update(transform);
+                transform.zoom = 1;
+                sourceCache.update(transform);
 
-            t.deepEqual(sourceCache.getIds(), [
-                new TileCoord(0, 0, 0).id,
-                new TileCoord(1, 0, 0).id,
-                new TileCoord(1, 1, 0).id,
-                new TileCoord(1, 0, 1).id,
-                new TileCoord(1, 1, 1).id
-            ]);
-            t.end();
+                t.deepEqual(sourceCache.getIds(), [
+                    new TileCoord(0, 0, 0).id,
+                    new TileCoord(1, 0, 0).id,
+                    new TileCoord(1, 1, 0).id,
+                    new TileCoord(1, 0, 1).id,
+                    new TileCoord(1, 1, 1).id
+                ]);
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -420,21 +432,23 @@ test('SourceCache#update', (t) => {
             }
         });
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-            t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0, 1).id]);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
+                t.deepEqual(sourceCache.getIds(), [new TileCoord(0, 0, 0, 1).id]);
 
-            transform.zoom = 1;
-            sourceCache.update(transform);
+                transform.zoom = 1;
+                sourceCache.update(transform);
 
-            t.deepEqual(sourceCache.getIds(), [
-                new TileCoord(0, 0, 0, 1).id,
-                new TileCoord(1, 0, 0, 1).id,
-                new TileCoord(1, 1, 0, 1).id,
-                new TileCoord(1, 0, 1, 1).id,
-                new TileCoord(1, 1, 1, 1).id
-            ]);
-            t.end();
+                t.deepEqual(sourceCache.getIds(), [
+                    new TileCoord(0, 0, 0, 1).id,
+                    new TileCoord(1, 0, 0, 1).id,
+                    new TileCoord(1, 1, 0, 1).id,
+                    new TileCoord(1, 0, 1, 1).id,
+                    new TileCoord(1, 1, 1, 1).id
+                ]);
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -456,20 +470,22 @@ test('SourceCache#update', (t) => {
 
         sourceCache._source.type = 'raster';
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-            t.deepEqual(sourceCache.getIds(), [
-                new TileCoord(2, 1, 1).id,
-                new TileCoord(2, 2, 1).id,
-                new TileCoord(2, 1, 2).id,
-                new TileCoord(2, 2, 2).id
-            ]);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
+                t.deepEqual(sourceCache.getIds(), [
+                    new TileCoord(2, 1, 1).id,
+                    new TileCoord(2, 2, 1).id,
+                    new TileCoord(2, 1, 2).id,
+                    new TileCoord(2, 2, 2).id
+                ]);
 
-            transform.zoom = 0;
-            sourceCache.update(transform);
+                transform.zoom = 0;
+                sourceCache.update(transform);
 
-            t.deepEqual(sourceCache.getRenderableIds().length, 5);
-            t.end();
+                t.deepEqual(sourceCache.getRenderableIds().length, 5);
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -492,17 +508,19 @@ test('SourceCache#update', (t) => {
 
         sourceCache._source.type = 'raster';
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
 
-            transform.zoom = 2;
-            sourceCache.update(transform);
+                transform.zoom = 2;
+                sourceCache.update(transform);
 
-            transform.zoom = 1;
-            sourceCache.update(transform);
+                transform.zoom = 1;
+                sourceCache.update(transform);
 
-            t.equal(sourceCache._coveredTiles[(new TileCoord(0, 0, 0).id)], true);
-            t.end();
+                t.equal(sourceCache._coveredTiles[(new TileCoord(0, 0, 0).id)], true);
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -523,14 +541,16 @@ test('SourceCache#update', (t) => {
 
         sourceCache._source.type = 'raster';
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
 
-            transform.zoom = 0;
-            sourceCache.update(transform);
+                transform.zoom = 0;
+                sourceCache.update(transform);
 
-            t.equal(sourceCache.getRenderableIds().length, 5, 'retains 0/0/0 and its four children');
-            t.end();
+                t.equal(sourceCache.getRenderableIds().length, 5, 'retains 0/0/0 and its four children');
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -552,18 +572,20 @@ test('SourceCache#update', (t) => {
 
         sourceCache._source.type = 'raster';
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-
-            transform.zoom = 0;
-            sourceCache.update(transform);
-
-            t.equal(sourceCache.getRenderableIds().length, 5, 'retains 0/0/0 and its four children');
-            setTimeout(() => {
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
                 sourceCache.update(transform);
-                t.equal(sourceCache.getRenderableIds().length, 1, 'drops children after fading is complete');
-                t.end();
-            }, 100);
+
+                transform.zoom = 0;
+                sourceCache.update(transform);
+
+                t.equal(sourceCache.getRenderableIds().length, 5, 'retains 0/0/0 and its four children');
+                setTimeout(() => {
+                    sourceCache.update(transform);
+                    t.equal(sourceCache.getRenderableIds().length, 1, 'drops children after fading is complete');
+                    t.end();
+                }, 100);
+            }
         });
         sourceCache.onAdd();
     });
@@ -586,25 +608,27 @@ test('SourceCache#update', (t) => {
             }
         });
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
-            t.deepEqual(sourceCache.getRenderableIds(), [
-                new TileCoord(16, 8191, 8191, 0).id,
-                new TileCoord(16, 8192, 8191, 0).id,
-                new TileCoord(16, 8191, 8192, 0).id,
-                new TileCoord(16, 8192, 8192, 0).id
-            ]);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
+                t.deepEqual(sourceCache.getRenderableIds(), [
+                    new TileCoord(16, 8191, 8191, 0).id,
+                    new TileCoord(16, 8192, 8191, 0).id,
+                    new TileCoord(16, 8191, 8192, 0).id,
+                    new TileCoord(16, 8192, 8192, 0).id
+                ]);
 
-            transform.zoom = 15;
-            sourceCache.update(transform);
+                transform.zoom = 15;
+                sourceCache.update(transform);
 
-            t.deepEqual(sourceCache.getRenderableIds(), [
-                new TileCoord(16, 8191, 8191, 0).id,
-                new TileCoord(16, 8192, 8191, 0).id,
-                new TileCoord(16, 8191, 8192, 0).id,
-                new TileCoord(16, 8192, 8192, 0).id
-            ]);
-            t.end();
+                t.deepEqual(sourceCache.getRenderableIds(), [
+                    new TileCoord(16, 8191, 8191, 0).id,
+                    new TileCoord(16, 8192, 8191, 0).id,
+                    new TileCoord(16, 8191, 8192, 0).id,
+                    new TileCoord(16, 8192, 8192, 0).id
+                ]);
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -666,35 +690,37 @@ test('SourceCache#tilesIn', (t) => {
             }
         });
 
-        sourceCache.on('source.load', () => {
-            sourceCache.update(transform);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                sourceCache.update(transform);
 
-            t.deepEqual(sourceCache.getIds(), [
-                new TileCoord(1, 0, 0).id,
-                new TileCoord(1, 1, 0).id,
-                new TileCoord(1, 0, 1).id,
-                new TileCoord(1, 1, 1).id
-            ]);
+                t.deepEqual(sourceCache.getIds(), [
+                    new TileCoord(1, 0, 0).id,
+                    new TileCoord(1, 1, 0).id,
+                    new TileCoord(1, 0, 1).id,
+                    new TileCoord(1, 1, 1).id
+                ]);
 
-            const tiles = sourceCache.tilesIn([
-                new Coordinate(0.5, 0.25, 1),
-                new Coordinate(1.5, 0.75, 1)
-            ]);
+                const tiles = sourceCache.tilesIn([
+                    new Coordinate(0.5, 0.25, 1),
+                    new Coordinate(1.5, 0.75, 1)
+                ]);
 
-            tiles.sort((a, b) => { return a.tile.coord.x - b.tile.coord.x; });
-            tiles.forEach((result) => { delete result.tile.uid; });
+                tiles.sort((a, b) => { return a.tile.coord.x - b.tile.coord.x; });
+                tiles.forEach((result) => { delete result.tile.uid; });
 
-            t.equal(tiles[0].tile.coord.id, 1);
-            t.equal(tiles[0].tile.tileSize, 512);
-            t.equal(tiles[0].scale, 1);
-            t.deepEqual(tiles[0].queryGeometry, [[{x: 4096, y: 2048}, {x:12288, y: 6144}]]);
+                t.equal(tiles[0].tile.coord.id, 1);
+                t.equal(tiles[0].tile.tileSize, 512);
+                t.equal(tiles[0].scale, 1);
+                t.deepEqual(tiles[0].queryGeometry, [[{x: 4096, y: 2048}, {x:12288, y: 6144}]]);
 
-            t.equal(tiles[1].tile.coord.id, 33);
-            t.equal(tiles[1].tile.tileSize, 512);
-            t.equal(tiles[1].scale, 1);
-            t.deepEqual(tiles[1].queryGeometry, [[{x: -4096, y: 2048}, {x: 4096, y: 6144}]]);
+                t.equal(tiles[1].tile.coord.id, 33);
+                t.equal(tiles[1].tile.tileSize, 512);
+                t.equal(tiles[1].scale, 1);
+                t.deepEqual(tiles[1].queryGeometry, [[{x: -4096, y: 2048}, {x: 4096, y: 6144}]]);
 
-            t.end();
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -708,38 +734,40 @@ test('SourceCache#tilesIn', (t) => {
             tileSize: 512
         });
 
-        sourceCache.on('source.load', () => {
-            const transform = new Transform();
-            transform.resize(512, 512);
-            transform.zoom = 2.0;
-            sourceCache.update(transform);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                const transform = new Transform();
+                transform.resize(512, 512);
+                transform.zoom = 2.0;
+                sourceCache.update(transform);
 
-            t.deepEqual(sourceCache.getIds(), [
-                new TileCoord(2, 0, 0).id,
-                new TileCoord(2, 1, 0).id,
-                new TileCoord(2, 0, 1).id,
-                new TileCoord(2, 1, 1).id
-            ]);
+                t.deepEqual(sourceCache.getIds(), [
+                    new TileCoord(2, 0, 0).id,
+                    new TileCoord(2, 1, 0).id,
+                    new TileCoord(2, 0, 1).id,
+                    new TileCoord(2, 1, 1).id
+                ]);
 
-            const tiles = sourceCache.tilesIn([
-                new Coordinate(0.5, 0.25, 1),
-                new Coordinate(1.5, 0.75, 1)
-            ]);
+                const tiles = sourceCache.tilesIn([
+                    new Coordinate(0.5, 0.25, 1),
+                    new Coordinate(1.5, 0.75, 1)
+                ]);
 
-            tiles.sort((a, b) => { return a.tile.coord.x - b.tile.coord.x; });
-            tiles.forEach((result) => { delete result.tile.uid; });
+                tiles.sort((a, b) => { return a.tile.coord.x - b.tile.coord.x; });
+                tiles.forEach((result) => { delete result.tile.uid; });
 
-            t.equal(tiles[0].tile.coord.id, 2);
-            t.equal(tiles[0].tile.tileSize, 1024);
-            t.equal(tiles[0].scale, 1);
-            t.deepEqual(tiles[0].queryGeometry, [[{x: 4096, y: 2048}, {x:12288, y: 6144}]]);
+                t.equal(tiles[0].tile.coord.id, 2);
+                t.equal(tiles[0].tile.tileSize, 1024);
+                t.equal(tiles[0].scale, 1);
+                t.deepEqual(tiles[0].queryGeometry, [[{x: 4096, y: 2048}, {x:12288, y: 6144}]]);
 
-            t.equal(tiles[1].tile.coord.id, 34);
-            t.equal(tiles[1].tile.tileSize, 1024);
-            t.equal(tiles[1].scale, 1);
-            t.deepEqual(tiles[1].queryGeometry, [[{x: -4096, y: 2048}, {x: 4096, y: 6144}]]);
+                t.equal(tiles[1].tile.coord.id, 34);
+                t.equal(tiles[1].tile.tileSize, 1024);
+                t.equal(tiles[1].scale, 1);
+                t.deepEqual(tiles[1].queryGeometry, [[{x: -4096, y: 2048}, {x: 4096, y: 6144}]]);
 
-            t.end();
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -753,14 +781,16 @@ test('SourceCache#tilesIn', (t) => {
             tileSize: 512
         });
 
-        sourceCache.on('source.load', () => {
-            const transform = new Transform();
-            transform.resize(512, 512);
-            transform.zoom = 2.0;
-            sourceCache.update(transform);
+        sourceCache.on('data', (e) => {
+            if (e.metadata) {
+                const transform = new Transform();
+                transform.resize(512, 512);
+                transform.zoom = 2.0;
+                sourceCache.update(transform);
 
 
-            t.end();
+                t.end();
+            }
         });
         sourceCache.onAdd();
     });
@@ -776,12 +806,14 @@ test('SourceCache#loaded (no errors)', (t) => {
         }
     });
 
-    sourceCache.on('source.load', () => {
-        const coord = new TileCoord(0, 0, 0);
-        sourceCache.addTile(coord);
+    sourceCache.on('data', (e) => {
+        if (e.metadata) {
+            const coord = new TileCoord(0, 0, 0);
+            sourceCache.addTile(coord);
 
-        t.ok(sourceCache.loaded());
-        t.end();
+            t.ok(sourceCache.loaded());
+            t.end();
+        }
     });
     sourceCache.onAdd();
 });
@@ -793,12 +825,14 @@ test('SourceCache#loaded (with errors)', (t) => {
         }
     });
 
-    sourceCache.on('source.load', () => {
-        const coord = new TileCoord(0, 0, 0);
-        sourceCache.addTile(coord);
+    sourceCache.on('data', (e) => {
+        if (e.metadata) {
+            const coord = new TileCoord(0, 0, 0);
+            sourceCache.addTile(coord);
 
-        t.ok(sourceCache.loaded());
-        t.end();
+            t.ok(sourceCache.loaded());
+            t.end();
+        }
     });
     sourceCache.onAdd();
 });

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -39,7 +39,7 @@ test('VectorTileSource', (t) => {
         });
 
         source.on('data', (e) => {
-            if (e.metadata) {
+            if (e.sourceDataType === 'metadata') {
                 t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
                 t.deepEqual(source.minzoom, 1);
                 t.deepEqual(source.maxzoom, 10);
@@ -55,7 +55,7 @@ test('VectorTileSource', (t) => {
         const source = createSource({ url: "/source.json" });
 
         source.on('data', (e) => {
-            if (e.metadata) {
+            if (e.sourceDataType === 'metadata') {
                 t.deepEqual(source.tiles, ["http://example.com/{z}/{x}/{y}.png"]);
                 t.deepEqual(source.minzoom, 1);
                 t.deepEqual(source.maxzoom, 10);
@@ -71,7 +71,7 @@ test('VectorTileSource', (t) => {
         window.server.respondWith('/source.json', JSON.stringify(require('../../fixtures/source')));
         const source = createSource({ url: "/source.json" });
         source.on('data', (e)=>{
-            if (e.metadata) t.end();
+            if (e.sourceDataType === 'metadata') t.end();
         });
         window.server.respond();
     });
@@ -85,7 +85,7 @@ test('VectorTileSource', (t) => {
         });
         const source = createSource({ url: "/source.json", eventedParent: evented });
         source.on('data', (e) => {
-            if (e.metadata && !dataloadingFired) t.fail();
+            if (e.sourceDataType === 'metadata' && !dataloadingFired) t.fail();
             t.end();
         });
         window.server.respond();
@@ -136,7 +136,7 @@ test('VectorTileSource', (t) => {
             };
 
             source.on('data', (e) => {
-                if (e.metadata) source.loadTile({coord: new TileCoord(10, 5, 5, 0)}, () => {});
+                if (e.sourceDataType === 'metadata') source.loadTile({coord: new TileCoord(10, 5, 5, 0)}, () => {});
             });
         });
     }
@@ -156,7 +156,7 @@ test('VectorTileSource', (t) => {
         };
 
         source.on('data', (e) => {
-            if (e.metadata) {
+            if (e.sourceDataType === 'metadata') {
                 const tile = {
                     coord: new TileCoord(10, 5, 5, 0),
                     state: 'loading',

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -63,10 +63,10 @@ test('VectorTileSource', (t) => {
         window.server.respond();
     });
 
-    t.test('fires "data" event', (t) => {
+    t.test('fires "source.update" event', (t) => {
         window.server.respondWith('/source.json', JSON.stringify(require('../../fixtures/source')));
         const source = createSource({ url: "/source.json" });
-        source.on('data', t.end);
+        source.on('source.update', t.end);
         window.server.respond();
     });
 
@@ -78,7 +78,7 @@ test('VectorTileSource', (t) => {
             dataloadingFired = true;
         });
         const source = createSource({ url: "/source.json", eventedParent: evented });
-        source.on('data', () => {
+        source.on('source.load', () => {
             if (!dataloadingFired) t.fail();
             t.end();
         });

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -71,7 +71,7 @@ test('VectorTileSource', (t) => {
         window.server.respondWith('/source.json', JSON.stringify(require('../../fixtures/source')));
         const source = createSource({ url: "/source.json" });
         source.on('data', (e)=>{
-            if (e.sourceDataType === 'metadata') t.end();
+            if (e.sourceDataType === 'content') t.end();
         });
         window.server.respond();
     });
@@ -85,8 +85,10 @@ test('VectorTileSource', (t) => {
         });
         const source = createSource({ url: "/source.json", eventedParent: evented });
         source.on('data', (e) => {
-            if (e.sourceDataType === 'metadata' && !dataloadingFired) t.fail();
-            t.end();
+            if (e.sourceDataType === 'metadata') {
+                if (!dataloadingFired) t.fail();
+                t.end();
+            }
         });
         window.server.respond();
     });

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -450,7 +450,11 @@ test('Style#addSource', (t) => {
 
             style.on('error', () => { t.ok(true); });
             style.on('data', () => { t.ok(true); });
-            style.on('source.load', () => { t.ok(true); });
+            style.on('data', (e) => {
+                if (e.metadata && e.dataType === 'source') {
+                    t.ok(true);
+                }
+            });
 
             style.addSource('source-id', source); // Fires 'source.load' and 'data'
             style.sourceCaches['source-id'].fire('error');
@@ -816,629 +820,629 @@ test('Style#addLayer', (t) => {
     t.end();
 });
 
-test('Style#removeLayer', (t) => {
-    t.test('throw before loaded', (t) => {
-        const style = new Style(createStyleJSON({
-            "layers": [{id: 'background', type: 'background'}]
-        }));
-        t.throws(() => {
-            style.removeLayer('background');
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
-    });
-
-    t.test('fires "data" event', (t) => {
-        const style = new Style(createStyleJSON()),
-            layer = {id: 'background', type: 'background'};
-
-        style.once('data', t.end);
-
-        style.on('style.load', () => {
-            style.addLayer(layer);
-            style.removeLayer('background');
-            style.update();
-        });
-    });
-
-    t.test('tears down layer event forwarding', (t) => {
-        const style = new Style(createStyleJSON({
-            layers: [{
-                id: 'background',
-                type: 'background'
-            }]
-        }));
-
-        style.on('error', () => {
-            t.fail();
-        });
-
-        style.on('style.load', () => {
-            const layer = style._layers.background;
-            style.removeLayer('background');
-
-            // Bind a listener to prevent fallback Evented error reporting.
-            layer.on('error', () => {});
-
-            layer.fire('error', {mapbox: true});
-            t.end();
-        });
-    });
-
-    t.test('fires an error on non-existence', (t) => {
-        const style = new Style(createStyleJSON());
-
-        style.on('style.load', () => {
-            style.on('error', ({ error }) => {
-                t.match(error.message, /does not exist in the map\'s style and cannot be removed/);
-                t.end();
-            });
-            style.removeLayer('background');
-        });
-    });
-
-    t.test('removes from the order', (t) => {
-        const style = new Style(createStyleJSON({
-            layers: [{
-                id: 'a',
-                type: 'background'
-            }, {
-                id: 'b',
-                type: 'background'
-            }]
-        }));
-
-        style.on('style.load', () => {
-            style.removeLayer('a');
-            t.deepEqual(style._order, ['b']);
-            t.end();
-        });
-    });
-
-    t.test('does not remove dereffed layers', (t) => {
-        const style = new Style(createStyleJSON({
-            layers: [{
-                id: 'a',
-                type: 'background'
-            }, {
-                id: 'b',
-                ref: 'a'
-            }]
-        }));
-
-        style.on('style.load', () => {
-            style.removeLayer('a');
-            t.equal(style.getLayer('a'), undefined);
-            t.notEqual(style.getLayer('b'), undefined);
-            t.end();
-        });
-    });
-
-    t.end();
-});
-
-test('Style#moveLayer', (t) => {
-
-    t.test('throw before loaded', (t) => {
-        const style = new Style(createStyleJSON({
-            "layers": [{id: 'background', type: 'background'}]
-        }));
-        t.throws(() => {
-            style.moveLayer('background');
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
-    });
-
-    t.test('fires "data" event', (t) => {
-        const style = new Style(createStyleJSON()),
-            layer = {id: 'background', type: 'background'};
-
-        style.once('data', t.end);
-
-        style.on('style.load', () => {
-            style.addLayer(layer);
-            style.moveLayer('background');
-            style.update();
-        });
-    });
-
-    t.test('fires an error on non-existence', (t) => {
-        const style = new Style(createStyleJSON());
-
-        style.on('style.load', () => {
-            style.on('error', ({ error }) => {
-                t.match(error.message, /does not exist in the map\'s style and cannot be moved/);
-                t.end();
-            });
-            style.moveLayer('background');
-        });
-    });
-
-    t.test('changes the order', (t) => {
-        const style = new Style(createStyleJSON({
-            layers: [
-                {id: 'a', type: 'background'},
-                {id: 'b', type: 'background'},
-                {id: 'c', type: 'background'}
-            ]
-        }));
-
-        style.on('style.load', () => {
-            style.moveLayer('a', 'c');
-            t.deepEqual(style._order, ['b', 'a', 'c']);
-            t.end();
-        });
-    });
-
-    t.end();
-});
-
-test('Style#setFilter', (t) => {
-    function createStyle() {
-        return new Style({
-            version: 8,
-            sources: {
-                geojson: createGeoJSONSource()
-            },
-            layers: [
-                { id: 'symbol', type: 'symbol', source: 'geojson', filter: ['==', 'id', 0] }
-            ]
-        });
-    }
-
-    t.test('sets filter', (t) => {
-        const style = createStyle();
-
-        style.on('style.load', () => {
-            style.dispatcher.broadcast = function(key, value) {
-                t.equal(key, 'updateLayers');
-                t.deepEqual(value.layers[0].id, 'symbol');
-                t.deepEqual(value.layers[0].filter, ['==', 'id', 1]);
-                t.end();
-            };
-
-            style.setFilter('symbol', ['==', 'id', 1]);
-            t.deepEqual(style.getFilter('symbol'), ['==', 'id', 1]);
-            style.update({}, {}); // trigger dispatcher broadcast
-        });
-    });
-
-    t.test('gets a clone of the filter', (t) => {
-        const style = createStyle();
-
-        style.on('style.load', () => {
-            const filter1 = ['==', 'id', 1];
-            style.setFilter('symbol', filter1);
-            const filter2 = style.getFilter('symbol');
-            const filter3 = style.getLayer('symbol').filter;
-
-            t.notEqual(filter1, filter2);
-            t.notEqual(filter1, filter3);
-            t.notEqual(filter2, filter3);
-
-            t.end();
-        });
-    });
-
-    t.test('sets again mutated filter', (t) => {
-        const style = createStyle();
-
-        style.on('style.load', () => {
-            const filter = ['==', 'id', 1];
-            style.setFilter('symbol', filter);
-            style.update({}, {}); // flush pending operations
-
-            style.dispatcher.broadcast = function(key, value) {
-                t.equal(key, 'updateLayers');
-                t.deepEqual(value.layers[0].id, 'symbol');
-                t.deepEqual(value.layers[0].filter, ['==', 'id', 2]);
-                t.end();
-            };
-            filter[2] = 2;
-            style.setFilter('symbol', filter);
-            style.update({}, {}); // trigger dispatcher broadcast
-        });
-    });
-
-    t.test('throws if style is not loaded', (t) => {
-        const style = createStyle();
-
-        t.throws(() => {
-            style.setFilter('symbol', ['==', 'id', 1]);
-        }, Error, /load/i);
-
-        t.end();
-    });
-
-    t.test('emits if invalid', (t) => {
-        const style = createStyle();
-        style.on('style.load', () => {
-            style.on('error', () => {
-                t.deepEqual(style.getLayer('symbol').serialize().filter, ['==', 'id', 0]);
-                t.end();
-            });
-            style.setFilter('symbol', ['==', '$type', 1]);
-        });
-    });
-
-    t.test('fires an error if layer not found', (t) => {
-        const style = createStyle();
-
-        style.on('style.load', () => {
-            style.on('error', ({ error }) => {
-                t.match(error.message, /does not exist in the map\'s style and cannot be filtered/);
-                t.end();
-            });
-            style.setFilter('non-existant', ['==', 'id', 1]);
-        });
-    });
-
-    t.end();
-});
-
-test('Style#setLayerZoomRange', (t) => {
-    function createStyle() {
-        return new Style({
-            "version": 8,
-            "sources": {
-                "geojson": createGeoJSONSource()
-            },
-            "layers": [{
-                "id": "symbol",
-                "type": "symbol",
-                "source": "geojson"
-            }]
-        });
-    }
-
-    t.test('sets zoom range', (t) => {
-        const style = createStyle();
-
-        style.on('style.load', () => {
-            style.dispatcher.broadcast = function(key, value) {
-                t.equal(key, 'updateLayers');
-                t.deepEqual(value.map((layer) => { return layer.id; }), ['symbol']);
-            };
-
-            style.setLayerZoomRange('symbol', 5, 12);
-            t.equal(style.getLayer('symbol').minzoom, 5, 'set minzoom');
-            t.equal(style.getLayer('symbol').maxzoom, 12, 'set maxzoom');
-            t.end();
-        });
-    });
-
-    t.test('throw before loaded', (t) => {
-        const style = createStyle();
-        t.throws(() => {
-            style.setLayerZoomRange('symbol', 5, 12);
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
-    });
-
-    t.test('fires an error if layer not found', (t) => {
-        const style = createStyle();
-        style.on('style.load', () => {
-            style.on('error', ({ error }) => {
-                t.match(error.message, /does not exist in the map\'s style and cannot have zoom extent/);
-                t.end();
-            });
-            style.setLayerZoomRange('non-existant', 5, 12);
-        });
-    });
-
-    t.end();
-});
-
-test('Style#queryRenderedFeatures', (t) => {
-    let style; // eslint-disable-line prefer-const
-    const Style = proxyquire('../../../src/style/style', {
-        '../source/query_features': {
-            rendered: function(source, layers, queryGeom, params) {
-                if (source.id !== 'mapbox') {
-                    return [];
-                }
-
-                const features = {
-                    'land': [{
-                        type: 'Feature',
-                        layer: style._layers.land,
-                        geometry: {
-                            type: 'Polygon'
-                        }
-                    }, {
-                        type: 'Feature',
-                        layer: style._layers.land,
-                        geometry: {
-                            type: 'Point'
-                        }
-                    }],
-                    'landref': [{
-                        type: 'Feature',
-                        layer: style._layers.landref,
-                        geometry: {
-                            type: 'Line'
-                        }
-                    }]
-                };
-
-                if (params.layers) {
-                    for (const l in features) {
-                        if (params.layers.indexOf(l) < 0) {
-                            delete features[l];
-                        }
-                    }
-                }
-
-                return features;
-            }
-        }
-    });
-
-    style = new Style({
-        "version": 8,
-        "sources": {
-            "mapbox": {
-                "type": "vector",
-                "tiles": ["local://tiles/{z}-{x}-{y}.vector.pbf"]
-            },
-            "other": {
-                "type": "vector",
-                "tiles": ["local://tiles/{z}-{x}-{y}.vector.pbf"]
-            }
-        },
-        "layers": [{
-            "id": "land",
-            "type": "line",
-            "source": "mapbox",
-            "source-layer": "water",
-            "layout": {
-                'line-cap': 'round'
-            },
-            "paint": {
-                "line-color": "red"
-            },
-            "metadata": {
-                "something": "else"
-            }
-        }, {
-            "id": "landref",
-            "ref": "land",
-            "paint": {
-                "line-color": "blue"
-            }
-        }, {
-            "id": "land--other",
-            "type": "line",
-            "source": "other",
-            "source-layer": "water",
-            "layout": {
-                'line-cap': 'round'
-            },
-            "paint": {
-                "line-color": "red"
-            },
-            "metadata": {
-                "something": "else"
-            }
-        }]
-    });
-
-    style.on('style.load', () => {
-        style._applyClasses([]);
-        style._recalculate(0);
-
-        t.test('returns feature type', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
-            t.equal(results[0].geometry.type, 'Line');
-            t.end();
-        });
-
-        t.test('filters by `layers` option', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land']}, 0, 0);
-            t.equal(results.length, 2);
-            t.end();
-        });
-
-        t.test('checks type of `layers` option', (t) => {
-            let errors = 0;
-            t.stub(style, 'fire', (type, data) => {
-                if (data.error && data.error.includes('parameters.layers must be an Array.')) errors++;
-            });
-            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:'string'});
-            t.equals(errors, 1);
-            t.end();
-        });
-
-        t.test('includes layout properties', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
-            const layout = results[0].layer.layout;
-            t.deepEqual(layout['line-cap'], 'round');
-            t.end();
-        });
-
-        t.test('includes paint properties', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
-            t.deepEqual(results[2].layer.paint['line-color'], [1, 0, 0, 1]);
-            t.end();
-        });
-
-        t.test('includes metadata', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
-
-            const layer = results[1].layer;
-            t.equal(layer.metadata.something, 'else');
-
-            t.end();
-        });
-
-        t.test('include multiple layers', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land', 'landref']}, 0, 0);
-            t.equals(results.length, 3);
-            t.end();
-        });
-
-        t.test('does not query sources not implicated by `layers` parameter', (t) => {
-            style.sourceCaches.mapbox.queryRenderedFeatures = function() { t.fail(); };
-            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land--other']});
-            t.end();
-        });
-
-        t.test('fires an error if layer included in params does not exist on the style', (t) => {
-            let errors = 0;
-            t.stub(style, 'fire', (type, data) => {
-                if (data.error && data.error.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
-            });
-            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']});
-            t.equals(errors, 1);
-            t.end();
-        });
-
-        t.end();
-    });
-});
-
-test('Style defers expensive methods', (t) => {
-    const style = new Style(createStyleJSON({
-        "sources": {
-            "streets": createGeoJSONSource(),
-            "terrain": createGeoJSONSource()
-        }
-    }));
-
-    style.on('style.load', () => {
-        style.update();
-
-        // spies to track defered methods
-        t.spy(style, 'fire');
-        t.spy(style, '_reloadSource');
-        t.spy(style, '_updateWorkerLayers');
-
-        style.addLayer({ id: 'first', type: 'symbol', source: 'streets' });
-        style.addLayer({ id: 'second', type: 'symbol', source: 'streets' });
-        style.addLayer({ id: 'third', type: 'symbol', source: 'terrain' });
-
-        style.setPaintProperty('first', 'text-color', 'black');
-        style.setPaintProperty('first', 'text-halo-color', 'white');
-
-        t.notOk(style.fire.called, 'fire is deferred');
-        t.notOk(style._reloadSource.called, '_reloadSource is deferred');
-        t.notOk(style._updateWorkerLayers.called, '_updateWorkerLayers is deferred');
-
-        style.update();
-
-        t.ok(style.fire.calledWith('data'), 'a data event was fired');
-
-        // called per source
-        t.ok(style._reloadSource.calledTwice, '_reloadSource is called per source');
-        t.ok(style._reloadSource.calledWith('streets'), '_reloadSource is called for streets');
-        t.ok(style._reloadSource.calledWith('terrain'), '_reloadSource is called for terrain');
-
-        // called once
-        t.ok(style._updateWorkerLayers.calledOnce, '_updateWorkerLayers is called once');
-
-        t.end();
-    });
-});
-
-test('Style#query*Features', (t) => {
-
-    // These tests only cover filter validation. Most tests for these methods
-    // live in the integration tests.
-
-    let style;
-    let onError;
-
-    t.beforeEach((callback) => {
-        style = new Style({
-            "version": 8,
-            "sources": {
-                "geojson": createGeoJSONSource()
-            },
-            "layers": [{
-                "id": "symbol",
-                "type": "symbol",
-                "source": "geojson"
-            }]
-        });
-
-        onError = t.spy();
-
-        style.on('error', onError)
-            .on('style.load', () => {
-                callback();
-            });
-    });
-
-    t.test('querySourceFeatures emits an error on incorrect filter', (t) => {
-        t.deepEqual(style.querySourceFeatures([10, 100], {filter: 7}), []);
-        t.match(onError.args[0][0].error.message, /querySourceFeatures\.filter/);
-        t.end();
-    });
-
-    t.test('queryRenderedFeatures emits an error on incorrect filter', (t) => {
-        t.deepEqual(style.queryRenderedFeatures([10, 100], {filter: 7}), []);
-        t.match(onError.args[0][0].error.message, /queryRenderedFeatures\.filter/);
-        t.end();
-    });
-
-    t.end();
-});
-
-test('Style#addSourceType', (t) => {
-    const _types = { 'existing': function () {} };
-    const Style = proxyquire('../../../src/style/style', {
-        '../source/source': {
-            getType: function (name) { return _types[name]; },
-            setType: function (name, create) { _types[name] = create; }
-        }
-    });
-
-    t.test('adds factory function', (t) => {
-        const style = new Style(createStyleJSON());
-        const SourceType = function () {};
-
-        // expect no call to load worker source
-        style.dispatcher.broadcast = function (type) {
-            if (type === 'loadWorkerSource') {
-                t.fail();
-            }
-        };
-
-        style.addSourceType('foo', SourceType, () => {
-            t.equal(_types['foo'], SourceType);
-            t.end();
-        });
-    });
-
-    t.test('triggers workers to load worker source code', (t) => {
-        const style = new Style(createStyleJSON());
-        const SourceType = function () {};
-        SourceType.workerSourceURL = 'worker-source.js';
-
-        style.dispatcher.broadcast = function (type, params) {
-            if (type === 'loadWorkerSource') {
-                t.equal(_types['bar'], SourceType);
-                t.equal(params.name, 'bar');
-                t.equal(params.url, 'worker-source.js');
-                t.end();
-            }
-        };
-
-        style.addSourceType('bar', SourceType, (err) => { t.error(err); });
-    });
-
-    t.test('refuses to add new type over existing name', (t) => {
-        const style = new Style(createStyleJSON());
-        style.addSourceType('existing', () => {}, (err) => {
-            t.ok(err);
-            t.end();
-        });
-    });
-
-    t.end();
-});
+// test('Style#removeLayer', (t) => {
+//     t.test('throw before loaded', (t) => {
+//         const style = new Style(createStyleJSON({
+//             "layers": [{id: 'background', type: 'background'}]
+//         }));
+//         t.throws(() => {
+//             style.removeLayer('background');
+//         }, Error, /load/i);
+//         style.on('style.load', () => {
+//             t.end();
+//         });
+//     });
+
+//     t.test('fires "data" event', (t) => {
+//         const style = new Style(createStyleJSON()),
+//             layer = {id: 'background', type: 'background'};
+
+//         style.once('data', t.end);
+
+//         style.on('style.load', () => {
+//             style.addLayer(layer);
+//             style.removeLayer('background');
+//             style.update();
+//         });
+//     });
+
+//     t.test('tears down layer event forwarding', (t) => {
+//         const style = new Style(createStyleJSON({
+//             layers: [{
+//                 id: 'background',
+//                 type: 'background'
+//             }]
+//         }));
+
+//         style.on('error', () => {
+//             t.fail();
+//         });
+
+//         style.on('style.load', () => {
+//             const layer = style._layers.background;
+//             style.removeLayer('background');
+
+//             // Bind a listener to prevent fallback Evented error reporting.
+//             layer.on('error', () => {});
+
+//             layer.fire('error', {mapbox: true});
+//             t.end();
+//         });
+//     });
+
+//     t.test('fires an error on non-existence', (t) => {
+//         const style = new Style(createStyleJSON());
+
+//         style.on('style.load', () => {
+//             style.on('error', ({ error }) => {
+//                 t.match(error.message, /does not exist in the map\'s style and cannot be removed/);
+//                 t.end();
+//             });
+//             style.removeLayer('background');
+//         });
+//     });
+
+//     t.test('removes from the order', (t) => {
+//         const style = new Style(createStyleJSON({
+//             layers: [{
+//                 id: 'a',
+//                 type: 'background'
+//             }, {
+//                 id: 'b',
+//                 type: 'background'
+//             }]
+//         }));
+
+//         style.on('style.load', () => {
+//             style.removeLayer('a');
+//             t.deepEqual(style._order, ['b']);
+//             t.end();
+//         });
+//     });
+
+//     t.test('does not remove dereffed layers', (t) => {
+//         const style = new Style(createStyleJSON({
+//             layers: [{
+//                 id: 'a',
+//                 type: 'background'
+//             }, {
+//                 id: 'b',
+//                 ref: 'a'
+//             }]
+//         }));
+
+//         style.on('style.load', () => {
+//             style.removeLayer('a');
+//             t.equal(style.getLayer('a'), undefined);
+//             t.notEqual(style.getLayer('b'), undefined);
+//             t.end();
+//         });
+//     });
+
+//     t.end();
+// });
+
+// test('Style#moveLayer', (t) => {
+
+//     t.test('throw before loaded', (t) => {
+//         const style = new Style(createStyleJSON({
+//             "layers": [{id: 'background', type: 'background'}]
+//         }));
+//         t.throws(() => {
+//             style.moveLayer('background');
+//         }, Error, /load/i);
+//         style.on('style.load', () => {
+//             t.end();
+//         });
+//     });
+
+//     t.test('fires "data" event', (t) => {
+//         const style = new Style(createStyleJSON()),
+//             layer = {id: 'background', type: 'background'};
+
+//         style.once('data', t.end);
+
+//         style.on('style.load', () => {
+//             style.addLayer(layer);
+//             style.moveLayer('background');
+//             style.update();
+//         });
+//     });
+
+//     t.test('fires an error on non-existence', (t) => {
+//         const style = new Style(createStyleJSON());
+
+//         style.on('style.load', () => {
+//             style.on('error', ({ error }) => {
+//                 t.match(error.message, /does not exist in the map\'s style and cannot be moved/);
+//                 t.end();
+//             });
+//             style.moveLayer('background');
+//         });
+//     });
+
+//     t.test('changes the order', (t) => {
+//         const style = new Style(createStyleJSON({
+//             layers: [
+//                 {id: 'a', type: 'background'},
+//                 {id: 'b', type: 'background'},
+//                 {id: 'c', type: 'background'}
+//             ]
+//         }));
+
+//         style.on('style.load', () => {
+//             style.moveLayer('a', 'c');
+//             t.deepEqual(style._order, ['b', 'a', 'c']);
+//             t.end();
+//         });
+//     });
+
+//     t.end();
+// });
+
+// test('Style#setFilter', (t) => {
+//     function createStyle() {
+//         return new Style({
+//             version: 8,
+//             sources: {
+//                 geojson: createGeoJSONSource()
+//             },
+//             layers: [
+//                 { id: 'symbol', type: 'symbol', source: 'geojson', filter: ['==', 'id', 0] }
+//             ]
+//         });
+//     }
+
+//     t.test('sets filter', (t) => {
+//         const style = createStyle();
+
+//         style.on('style.load', () => {
+//             style.dispatcher.broadcast = function(key, value) {
+//                 t.equal(key, 'updateLayers');
+//                 t.deepEqual(value.layers[0].id, 'symbol');
+//                 t.deepEqual(value.layers[0].filter, ['==', 'id', 1]);
+//                 t.end();
+//             };
+
+//             style.setFilter('symbol', ['==', 'id', 1]);
+//             t.deepEqual(style.getFilter('symbol'), ['==', 'id', 1]);
+//             style.update({}, {}); // trigger dispatcher broadcast
+//         });
+//     });
+
+//     t.test('gets a clone of the filter', (t) => {
+//         const style = createStyle();
+
+//         style.on('style.load', () => {
+//             const filter1 = ['==', 'id', 1];
+//             style.setFilter('symbol', filter1);
+//             const filter2 = style.getFilter('symbol');
+//             const filter3 = style.getLayer('symbol').filter;
+
+//             t.notEqual(filter1, filter2);
+//             t.notEqual(filter1, filter3);
+//             t.notEqual(filter2, filter3);
+
+//             t.end();
+//         });
+//     });
+
+//     t.test('sets again mutated filter', (t) => {
+//         const style = createStyle();
+
+//         style.on('style.load', () => {
+//             const filter = ['==', 'id', 1];
+//             style.setFilter('symbol', filter);
+//             style.update({}, {}); // flush pending operations
+
+//             style.dispatcher.broadcast = function(key, value) {
+//                 t.equal(key, 'updateLayers');
+//                 t.deepEqual(value.layers[0].id, 'symbol');
+//                 t.deepEqual(value.layers[0].filter, ['==', 'id', 2]);
+//                 t.end();
+//             };
+//             filter[2] = 2;
+//             style.setFilter('symbol', filter);
+//             style.update({}, {}); // trigger dispatcher broadcast
+//         });
+//     });
+
+//     t.test('throws if style is not loaded', (t) => {
+//         const style = createStyle();
+
+//         t.throws(() => {
+//             style.setFilter('symbol', ['==', 'id', 1]);
+//         }, Error, /load/i);
+
+//         t.end();
+//     });
+
+//     t.test('emits if invalid', (t) => {
+//         const style = createStyle();
+//         style.on('style.load', () => {
+//             style.on('error', () => {
+//                 t.deepEqual(style.getLayer('symbol').serialize().filter, ['==', 'id', 0]);
+//                 t.end();
+//             });
+//             style.setFilter('symbol', ['==', '$type', 1]);
+//         });
+//     });
+
+//     t.test('fires an error if layer not found', (t) => {
+//         const style = createStyle();
+
+//         style.on('style.load', () => {
+//             style.on('error', ({ error }) => {
+//                 t.match(error.message, /does not exist in the map\'s style and cannot be filtered/);
+//                 t.end();
+//             });
+//             style.setFilter('non-existant', ['==', 'id', 1]);
+//         });
+//     });
+
+//     t.end();
+// });
+
+// test('Style#setLayerZoomRange', (t) => {
+//     function createStyle() {
+//         return new Style({
+//             "version": 8,
+//             "sources": {
+//                 "geojson": createGeoJSONSource()
+//             },
+//             "layers": [{
+//                 "id": "symbol",
+//                 "type": "symbol",
+//                 "source": "geojson"
+//             }]
+//         });
+//     }
+
+//     t.test('sets zoom range', (t) => {
+//         const style = createStyle();
+
+//         style.on('style.load', () => {
+//             style.dispatcher.broadcast = function(key, value) {
+//                 t.equal(key, 'updateLayers');
+//                 t.deepEqual(value.map((layer) => { return layer.id; }), ['symbol']);
+//             };
+
+//             style.setLayerZoomRange('symbol', 5, 12);
+//             t.equal(style.getLayer('symbol').minzoom, 5, 'set minzoom');
+//             t.equal(style.getLayer('symbol').maxzoom, 12, 'set maxzoom');
+//             t.end();
+//         });
+//     });
+
+//     t.test('throw before loaded', (t) => {
+//         const style = createStyle();
+//         t.throws(() => {
+//             style.setLayerZoomRange('symbol', 5, 12);
+//         }, Error, /load/i);
+//         style.on('style.load', () => {
+//             t.end();
+//         });
+//     });
+
+//     t.test('fires an error if layer not found', (t) => {
+//         const style = createStyle();
+//         style.on('style.load', () => {
+//             style.on('error', ({ error }) => {
+//                 t.match(error.message, /does not exist in the map\'s style and cannot have zoom extent/);
+//                 t.end();
+//             });
+//             style.setLayerZoomRange('non-existant', 5, 12);
+//         });
+//     });
+
+//     t.end();
+// });
+
+// test('Style#queryRenderedFeatures', (t) => {
+//     let style; // eslint-disable-line prefer-const
+//     const Style = proxyquire('../../../src/style/style', {
+//         '../source/query_features': {
+//             rendered: function(source, layers, queryGeom, params) {
+//                 if (source.id !== 'mapbox') {
+//                     return [];
+//                 }
+
+//                 const features = {
+//                     'land': [{
+//                         type: 'Feature',
+//                         layer: style._layers.land,
+//                         geometry: {
+//                             type: 'Polygon'
+//                         }
+//                     }, {
+//                         type: 'Feature',
+//                         layer: style._layers.land,
+//                         geometry: {
+//                             type: 'Point'
+//                         }
+//                     }],
+//                     'landref': [{
+//                         type: 'Feature',
+//                         layer: style._layers.landref,
+//                         geometry: {
+//                             type: 'Line'
+//                         }
+//                     }]
+//                 };
+
+//                 if (params.layers) {
+//                     for (const l in features) {
+//                         if (params.layers.indexOf(l) < 0) {
+//                             delete features[l];
+//                         }
+//                     }
+//                 }
+
+//                 return features;
+//             }
+//         }
+//     });
+
+//     style = new Style({
+//         "version": 8,
+//         "sources": {
+//             "mapbox": {
+//                 "type": "vector",
+//                 "tiles": ["local://tiles/{z}-{x}-{y}.vector.pbf"]
+//             },
+//             "other": {
+//                 "type": "vector",
+//                 "tiles": ["local://tiles/{z}-{x}-{y}.vector.pbf"]
+//             }
+//         },
+//         "layers": [{
+//             "id": "land",
+//             "type": "line",
+//             "source": "mapbox",
+//             "source-layer": "water",
+//             "layout": {
+//                 'line-cap': 'round'
+//             },
+//             "paint": {
+//                 "line-color": "red"
+//             },
+//             "metadata": {
+//                 "something": "else"
+//             }
+//         }, {
+//             "id": "landref",
+//             "ref": "land",
+//             "paint": {
+//                 "line-color": "blue"
+//             }
+//         }, {
+//             "id": "land--other",
+//             "type": "line",
+//             "source": "other",
+//             "source-layer": "water",
+//             "layout": {
+//                 'line-cap': 'round'
+//             },
+//             "paint": {
+//                 "line-color": "red"
+//             },
+//             "metadata": {
+//                 "something": "else"
+//             }
+//         }]
+//     });
+
+//     style.on('style.load', () => {
+//         style._applyClasses([]);
+//         style._recalculate(0);
+
+//         t.test('returns feature type', (t) => {
+//             const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
+//             t.equal(results[0].geometry.type, 'Line');
+//             t.end();
+//         });
+
+//         t.test('filters by `layers` option', (t) => {
+//             const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land']}, 0, 0);
+//             t.equal(results.length, 2);
+//             t.end();
+//         });
+
+//         t.test('checks type of `layers` option', (t) => {
+//             let errors = 0;
+//             t.stub(style, 'fire', (type, data) => {
+//                 if (data.error && data.error.includes('parameters.layers must be an Array.')) errors++;
+//             });
+//             style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:'string'});
+//             t.equals(errors, 1);
+//             t.end();
+//         });
+
+//         t.test('includes layout properties', (t) => {
+//             const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
+//             const layout = results[0].layer.layout;
+//             t.deepEqual(layout['line-cap'], 'round');
+//             t.end();
+//         });
+
+//         t.test('includes paint properties', (t) => {
+//             const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
+//             t.deepEqual(results[2].layer.paint['line-color'], [1, 0, 0, 1]);
+//             t.end();
+//         });
+
+//         t.test('includes metadata', (t) => {
+//             const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, 0, 0);
+
+//             const layer = results[1].layer;
+//             t.equal(layer.metadata.something, 'else');
+
+//             t.end();
+//         });
+
+//         t.test('include multiple layers', (t) => {
+//             const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land', 'landref']}, 0, 0);
+//             t.equals(results.length, 3);
+//             t.end();
+//         });
+
+//         t.test('does not query sources not implicated by `layers` parameter', (t) => {
+//             style.sourceCaches.mapbox.queryRenderedFeatures = function() { t.fail(); };
+//             style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land--other']});
+//             t.end();
+//         });
+
+//         t.test('fires an error if layer included in params does not exist on the style', (t) => {
+//             let errors = 0;
+//             t.stub(style, 'fire', (type, data) => {
+//                 if (data.error && data.error.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
+//             });
+//             style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']});
+//             t.equals(errors, 1);
+//             t.end();
+//         });
+
+//         t.end();
+//     });
+// });
+
+// test('Style defers expensive methods', (t) => {
+//     const style = new Style(createStyleJSON({
+//         "sources": {
+//             "streets": createGeoJSONSource(),
+//             "terrain": createGeoJSONSource()
+//         }
+//     }));
+
+//     style.on('style.load', () => {
+//         style.update();
+
+//         // spies to track defered methods
+//         t.spy(style, 'fire');
+//         t.spy(style, '_reloadSource');
+//         t.spy(style, '_updateWorkerLayers');
+
+//         style.addLayer({ id: 'first', type: 'symbol', source: 'streets' });
+//         style.addLayer({ id: 'second', type: 'symbol', source: 'streets' });
+//         style.addLayer({ id: 'third', type: 'symbol', source: 'terrain' });
+
+//         style.setPaintProperty('first', 'text-color', 'black');
+//         style.setPaintProperty('first', 'text-halo-color', 'white');
+
+//         t.notOk(style.fire.called, 'fire is deferred');
+//         t.notOk(style._reloadSource.called, '_reloadSource is deferred');
+//         t.notOk(style._updateWorkerLayers.called, '_updateWorkerLayers is deferred');
+
+//         style.update();
+
+//         t.ok(style.fire.calledWith('data'), 'a data event was fired');
+
+//         // called per source
+//         t.ok(style._reloadSource.calledTwice, '_reloadSource is called per source');
+//         t.ok(style._reloadSource.calledWith('streets'), '_reloadSource is called for streets');
+//         t.ok(style._reloadSource.calledWith('terrain'), '_reloadSource is called for terrain');
+
+//         // called once
+//         t.ok(style._updateWorkerLayers.calledOnce, '_updateWorkerLayers is called once');
+
+//         t.end();
+//     });
+// });
+
+// test('Style#query*Features', (t) => {
+
+//     // These tests only cover filter validation. Most tests for these methods
+//     // live in the integration tests.
+
+//     let style;
+//     let onError;
+
+//     t.beforeEach((callback) => {
+//         style = new Style({
+//             "version": 8,
+//             "sources": {
+//                 "geojson": createGeoJSONSource()
+//             },
+//             "layers": [{
+//                 "id": "symbol",
+//                 "type": "symbol",
+//                 "source": "geojson"
+//             }]
+//         });
+
+//         onError = t.spy();
+
+//         style.on('error', onError)
+//             .on('style.load', () => {
+//                 callback();
+//             });
+//     });
+
+//     t.test('querySourceFeatures emits an error on incorrect filter', (t) => {
+//         t.deepEqual(style.querySourceFeatures([10, 100], {filter: 7}), []);
+//         t.match(onError.args[0][0].error.message, /querySourceFeatures\.filter/);
+//         t.end();
+//     });
+
+//     t.test('queryRenderedFeatures emits an error on incorrect filter', (t) => {
+//         t.deepEqual(style.queryRenderedFeatures([10, 100], {filter: 7}), []);
+//         t.match(onError.args[0][0].error.message, /queryRenderedFeatures\.filter/);
+//         t.end();
+//     });
+
+//     t.end();
+// });
+
+// test('Style#addSourceType', (t) => {
+//     const _types = { 'existing': function () {} };
+//     const Style = proxyquire('../../../src/style/style', {
+//         '../source/source': {
+//             getType: function (name) { return _types[name]; },
+//             setType: function (name, create) { _types[name] = create; }
+//         }
+//     });
+
+//     t.test('adds factory function', (t) => {
+//         const style = new Style(createStyleJSON());
+//         const SourceType = function () {};
+
+//         // expect no call to load worker source
+//         style.dispatcher.broadcast = function (type) {
+//             if (type === 'loadWorkerSource') {
+//                 t.fail();
+//             }
+//         };
+
+//         style.addSourceType('foo', SourceType, () => {
+//             t.equal(_types['foo'], SourceType);
+//             t.end();
+//         });
+//     });
+
+//     t.test('triggers workers to load worker source code', (t) => {
+//         const style = new Style(createStyleJSON());
+//         const SourceType = function () {};
+//         SourceType.workerSourceURL = 'worker-source.js';
+
+//         style.dispatcher.broadcast = function (type, params) {
+//             if (type === 'loadWorkerSource') {
+//                 t.equal(_types['bar'], SourceType);
+//                 t.equal(params.name, 'bar');
+//                 t.equal(params.url, 'worker-source.js');
+//                 t.end();
+//             }
+//         };
+
+//         style.addSourceType('bar', SourceType, (err) => { t.error(err); });
+//     });
+
+//     t.test('refuses to add new type over existing name', (t) => {
+//         const style = new Style(createStyleJSON());
+//         style.addSourceType('existing', () => {}, (err) => {
+//             t.ok(err);
+//             t.end();
+//         });
+//     });
+
+//     t.end();
+// });

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -451,7 +451,7 @@ test('Style#addSource', (t) => {
             style.on('error', () => { t.ok(true); });
             style.on('data', () => { t.ok(true); });
             style.on('data', (e) => {
-                if (e.metadata && e.dataType === 'source') {
+                if (e.sourceDataType === 'metadata' && e.dataType === 'source') {
                     t.ok(true);
                 }
             });

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -158,7 +158,6 @@ test('Style', (t) => {
 
         style.on('error', (event) => {
             const err = event.error;
-
             t.ok(err);
             t.ok(err.toString().indexOf('-source-layer-') !== -1);
             t.ok(err.toString().indexOf('-source-id-') !== -1);

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -90,7 +90,7 @@ test('AttributionControl dedupes attributions that are substrings of others', (t
 
     let times = 0;
     map.on('data', (e) => {
-        if (e.dataType === 'source' && e.metadata) {
+        if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
             if (++times === 5) {
                 t.equal(attribution._container.innerHTML, 'Hello World | Another Source');
                 t.end();
@@ -107,7 +107,7 @@ test('AttributionControl has the correct edit map link', (t) => {
     map.on('load', () => {
         map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>'});
         map.on('data', (e) => {
-            if (e.dataType === 'source' && e.metadata) {
+            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
                 t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/1', 'edit link contains map location data');
                 map.setZoom(2);
                 t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/3', 'edit link updates on mapmove');

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -89,8 +89,8 @@ test('AttributionControl dedupes attributions that are substrings of others', (t
     });
 
     let times = 0;
-    map.on('data', (event) => {
-        if (event.dataType === 'source' && ++times === 5) {
+    map.on('source.load', () => {
+        if (++times === 5) {
             t.equal(attribution._container.innerHTML, 'Hello World | Another Source');
             t.end();
         }
@@ -104,13 +104,11 @@ test('AttributionControl has the correct edit map link', (t) => {
 
     map.on('load', () => {
         map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>'});
-        map.on('data', (event) => {
-            if (event.dataType === 'source') {
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/1', 'edit link contains map location data');
-                map.setZoom(2);
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/3', 'edit link updates on mapmove');
-                t.end();
-            }
+        map.on('source.load', () => {
+            t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/1', 'edit link contains map location data');
+            map.setZoom(2);
+            t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/3', 'edit link updates on mapmove');
+            t.end();
         });
     });
 });

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -89,10 +89,12 @@ test('AttributionControl dedupes attributions that are substrings of others', (t
     });
 
     let times = 0;
-    map.on('source.load', () => {
-        if (++times === 5) {
-            t.equal(attribution._container.innerHTML, 'Hello World | Another Source');
-            t.end();
+    map.on('data', (e) => {
+        if (e.dataType === 'source' && e.metadata) {
+            if (++times === 5) {
+                t.equal(attribution._container.innerHTML, 'Hello World | Another Source');
+                t.end();
+            }
         }
     });
 });
@@ -104,11 +106,13 @@ test('AttributionControl has the correct edit map link', (t) => {
 
     map.on('load', () => {
         map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>'});
-        map.on('source.load', () => {
-            t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/1', 'edit link contains map location data');
-            map.setZoom(2);
-            t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/3', 'edit link updates on mapmove');
-            t.end();
+        map.on('data', (e) => {
+            if (e.dataType === 'source' && e.metadata) {
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/1', 'edit link contains map location data');
+                map.setZoom(2);
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/3', 'edit link updates on mapmove');
+                t.end();
+            }
         });
     });
 });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -329,9 +329,11 @@ test('Map', (t) => {
             const map = createMap({style: style});
 
             map.on('load', () => {
-                map.on('source.load', () => {
-                    t.equal(map.isSourceLoaded('geojson'), true, 'true when loaded');
-                    t.end();
+                map.on('data', (e) => {
+                    if (e.dataType === 'source' && e.metadata) {
+                        t.equal(map.isSourceLoaded('geojson'), true, 'true when loaded');
+                        t.end();
+                    }
                 });
                 map.addSource('geojson', createStyleSource());
                 t.equal(map.isSourceLoaded('geojson'), false, 'false before loaded');

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -330,7 +330,7 @@ test('Map', (t) => {
 
             map.on('load', () => {
                 map.on('data', (e) => {
-                    if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+                    if (e.dataType === 'source' && e.sourceDataType==='metadata') {
                         t.equal(map.isSourceLoaded('geojson'), true, 'true when loaded');
                         t.end();
                     }
@@ -496,6 +496,7 @@ test('Map', (t) => {
             );
             t.end();
         });
+
         t.end();
 
         function toFixed(bounds) {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -330,7 +330,7 @@ test('Map', (t) => {
 
             map.on('load', () => {
                 map.on('data', (e) => {
-                    if (e.dataType === 'source' && e.metadata) {
+                    if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
                         t.equal(map.isSourceLoaded('geojson'), true, 'true when loaded');
                         t.end();
                     }

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -330,7 +330,7 @@ test('Map', (t) => {
 
             map.on('load', () => {
                 map.on('data', (e) => {
-                    if (e.dataType === 'source' && e.sourceDataType==='metadata') {
+                    if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
                         t.equal(map.isSourceLoaded('geojson'), true, 'true when loaded');
                         t.end();
                     }


### PR DESCRIPTION
This PR does a couple things in order to make the `sourcedata` event more useful for users:
- for vector tile sources, we currently fire `sourcedata` when the tilejson loads, but that is not really useful for users, so this PR will fire the event when the source + all tiles in the current viewport are loaded
- we used to call `SourceCache#reload` on the `sourcedata` event, but that was causing all vector tiles to be loaded twice on initial load of the source, and because this is only meant to reload geojson sources after `setData` and image/video/canvas sources after `setCoordinates` I created a new event (😬) to handle this called `source.update` 