### PR TITLE
Fix map.isMoving for drag-pan/rotate

### DIFF
--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -95,6 +95,7 @@ class DragPanHandler {
 
         if (!this.isActive()) {
             this._active = true;
+            this._map.moving = true;
             this._fireEvent('dragstart', e);
             this._fireEvent('movestart', e);
         }
@@ -123,7 +124,10 @@ class DragPanHandler {
         this._fireEvent('dragend', e);
         this._drainInertiaBuffer();
 
-        const finish = () => this._fireEvent('moveend', e);
+        const finish = () => {
+            this._map.moving = false;
+            this._fireEvent('moveend', e);
+        };
 
         const inertia = this._inertia;
         if (inertia.length < 2) {

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -96,6 +96,7 @@ class DragRotateHandler {
 
         if (!this.isActive()) {
             this._active = true;
+            this._map.moving = true;
             this._fireEvent('rotatestart', e);
             this._fireEvent('movestart', e);
         }
@@ -143,6 +144,7 @@ class DragRotateHandler {
             if (Math.abs(mapBearing) < this._bearingSnap) {
                 map.resetNorth({noMoveStart: true}, { originalEvent: e });
             } else {
+                this._map.moving = false;
                 this._fireEvent('moveend', e);
             }
         };


### PR DESCRIPTION
Just something I noticed and fixed while hacking on custom GL layers. Continuation of #3941. Another way to do this would be to call `dragPan/Rotate.isActive()` in `map.isMoving()` implementation, but I think this way is clearer.

Note that we currently don't cover interaction handlers with unit tests so no changes on this front.

cc @stepankuzmin 