### PR TITLE
Handle for cases where tile returned from server is already

### DIFF
--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -122,7 +122,13 @@ function getFadeValues(tile, parentTile, layer, transform) {
         // if no parent or parent is older, fade in; if parent is younger, fade out
         const fadeIn = !parentTile || Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ);
 
-        const childOpacity = (fadeIn && tile.refreshedUponExpiration) ? 1 : util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
+        const childOpacity = tile.refreshedUponExpiration ? 1 : util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
+
+        // we don't crossfade tiles that were just refreshed upon expiring:
+        // once they're old enough to pass the crossfading threshold
+        // (fadeDuration), unset the `refreshedUponExpiration` flag so we don't
+        // incorrectly fail to crossfade them when zooming
+        if (tile.refreshedUponExpiration && sinceTile >= 1) tile.refreshedUponExpiration = false;
 
         if (parentTile) {
             return {

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -122,7 +122,7 @@ function getFadeValues(tile, parentTile, layer, transform) {
         // if no parent or parent is older, fade in; if parent is younger, fade out
         const fadeIn = !parentTile || Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ);
 
-        const childOpacity = util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
+        const childOpacity = (fadeIn && tile.refreshedUponExpiration) ? 1 : util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
 
         if (parentTile) {
             return {

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -69,7 +69,7 @@ class RasterTileSource extends Evented {
                 return callback(err);
             }
 
-            tile.setExpiryData(img);
+            if (!this.map._noRefreshOnExpiration) tile.setExpiryData(img);
             delete img.cacheControl;
             delete img.expires;
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -69,7 +69,7 @@ class RasterTileSource extends Evented {
                 return callback(err);
             }
 
-            if (!this.map._noRefreshOnExpiration) tile.setExpiryData(img);
+            if (!this.map._refreshExpiredTiles) tile.setExpiryData(img);
             delete img.cacheControl;
             delete img.expires;
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -155,10 +155,10 @@ class SourceCache extends Evented {
             tile.state = state;
         }
 
-        this.loadTile(tile, this._tileLoaded.bind(this, tile, id));
+        this.loadTile(tile, this._tileLoaded.bind(this, tile, id, state));
     }
 
-    _tileLoaded(tile, id, err) {
+    _tileLoaded(tile, id, previousState, err) {
         if (err) {
             tile.state = 'errored';
             this._source.fire('error', {tile: tile, error: err});
@@ -167,6 +167,7 @@ class SourceCache extends Evented {
 
         tile.sourceCache = this;
         tile.timeAdded = new Date().getTime();
+        if (previousState === 'expired') tile.refreshedUponExpiration = true;
         this._setTileReloadTimer(id, tile);
         this._source.fire('data', {tile: tile, coord: tile.coord, dataType: 'tile'});
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -142,6 +142,11 @@ class SourceCache extends Evented {
     reloadTile(id, state) {
         const tile = this._tiles[id];
 
+        // TODO potentially does not address all underlying
+        // issues https://github.com/mapbox/mapbox-gl-js/issues/4252
+        // - hard to tell without repro steps
+        if (!tile) return;
+
         // The difference between "loading" tiles and "reloading" or "expired"
         // tiles is that "reloading"/"expired" tiles are "renderable".
         // Therefore, a "loading" tile cannot become a "reloading" tile without
@@ -433,22 +438,22 @@ class SourceCache extends Evented {
     }
 
     _setTileReloadTimer(id, tile) {
-        const tileExpires = tile.getExpiry();
-        if (tileExpires) {
+        const expiryTimeout = tile.getExpiryTimeout();
+        if (expiryTimeout) {
             this._timers[id] = setTimeout(() => {
                 this.reloadTile(id, 'expired');
                 this._timers[id] = undefined;
-            }, Math.min(tileExpires - new Date().getTime(), Math.pow(2, 31) - 1));
+            }, expiryTimeout);
         }
     }
 
     _setCacheInvalidationTimer(id, tile) {
-        const tileExpires = tile.getExpiry();
-        if (tileExpires) {
+        const expiryTimeout = tile.getExpiryTimeout();
+        if (expiryTimeout) {
             this._cacheTimers[id] = setTimeout(() => {
                 this._cache.remove(id);
                 this._cacheTimers[id] = undefined;
-            }, Math.min(tileExpires - new Date().getTime(), Math.pow(2, 31) - 1));
+            }, expiryTimeout);
         }
     }
 

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -255,6 +255,7 @@ class Tile {
             if (this.expiredRequests) {
                 return 1000 * (1 << Math.min(this.expiredRequests - 1, 31));
             } else {
+                // Max value for `setTimeout` implementations is a 32 bit integer; cap this accordingly
                 return Math.min(this.expires - new Date().getTime(), Math.pow(2, 31) - 1);
             }
         }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -207,7 +207,7 @@ class Tile {
 
         if (data.cacheControl) {
             const parsedCC = util.parseCacheControl(data.cacheControl);
-            if (parsedCC['max-age']) this.expires = this.timeAdded + parsedCC['max-age'] * 1000;
+            if (parsedCC['max-age']) this.expires = Date.now() + parsedCC['max-age'] * 1000;
         } else if (data.expires) {
             this.expires = new Date(data.expires).getTime();
         }

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -86,7 +86,7 @@ class VectorTileSource extends Evented {
                 return callback(err);
             }
 
-            tile.setExpiryData(data);
+            if (!this.map._noRefreshOnExpiration) tile.setExpiryData(data);
             tile.loadVectorData(data, this.map.painter);
 
             if (tile.redoWhenDone) {

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -86,7 +86,7 @@ class VectorTileSource extends Evented {
                 return callback(err);
             }
 
-            if (!this.map._noRefreshOnExpiration) tile.setExpiryData(data);
+            if (!this.map._refreshExpiredTiles) tile.setExpiryData(data);
             tile.loadVectorData(data, this.map.painter);
 
             if (tile.redoWhenDone) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -106,6 +106,7 @@ const defaultOptions = {
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the performance of Mapbox
  *   GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
  * @param {boolean} [options.preserveDrawingBuffer=false] If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`. This is `false` by default as a performance optimization.
+ * @param {boolean} [options.noRefreshOnExpiration=false] If `true`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
  * @param {LngLatBoundsLike} [options.maxBounds] If set, the map will be constrained to the given bounds.
  * @param {boolean|Object} [options.scrollZoom=true] If `true`, the "scroll to zoom" interaction is enabled. An `Object` value is passed as options to [`ScrollZoomHandler#enable`](#ScrollZoomHandler#enable).
  * @param {boolean} [options.boxZoom=true] If `true`, the "box zoom" interaction is enabled (see [`BoxZoomHandler`](#BoxZoomHandler)).

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -54,7 +54,9 @@ const defaultOptions = {
 
     trackResize: true,
 
-    renderWorldCopies: true
+    renderWorldCopies: true,
+
+    noRefreshOnExpiration: false
 };
 
 /**
@@ -145,6 +147,7 @@ class Map extends Camera {
         this._preserveDrawingBuffer = options.preserveDrawingBuffer;
         this._trackResize = options.trackResize;
         this._bearingSnap = options.bearingSnap;
+        this._noRefreshOnExpiration = options.noRefreshOnExpiration;
 
         if (typeof options.container === 'string') {
             this._container = window.document.getElementById(options.container);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -56,7 +56,7 @@ const defaultOptions = {
 
     renderWorldCopies: true,
 
-    noRefreshOnExpiration: false
+    refreshExpiredTiles: true
 };
 
 /**
@@ -106,7 +106,7 @@ const defaultOptions = {
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the performance of Mapbox
  *   GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
  * @param {boolean} [options.preserveDrawingBuffer=false] If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`. This is `false` by default as a performance optimization.
- * @param {boolean} [options.noRefreshOnExpiration=false] If `true`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
+ * @param {boolean} [options.refreshExpiredTiles=true] If `false`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
  * @param {LngLatBoundsLike} [options.maxBounds] If set, the map will be constrained to the given bounds.
  * @param {boolean|Object} [options.scrollZoom=true] If `true`, the "scroll to zoom" interaction is enabled. An `Object` value is passed as options to [`ScrollZoomHandler#enable`](#ScrollZoomHandler#enable).
  * @param {boolean} [options.boxZoom=true] If `true`, the "box zoom" interaction is enabled (see [`BoxZoomHandler`](#BoxZoomHandler)).
@@ -148,7 +148,7 @@ class Map extends Camera {
         this._preserveDrawingBuffer = options.preserveDrawingBuffer;
         this._trackResize = options.trackResize;
         this._bearingSnap = options.bearingSnap;
-        this._noRefreshOnExpiration = options.noRefreshOnExpiration;
+        this._refreshExpiredTiles = options.refreshExpiredTiles;
 
         if (typeof options.container === 'string') {
             this._container = window.document.getElementById(options.container);

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -131,7 +131,7 @@ test('SourceCache#addTile', (t) => {
         };
         sourceCache.loadTile = (tile, callback) => {
             tile.state = 'loaded';
-            tile.getExpiry = () => time;
+            tile.getExpiryTimeout = () => time;
             sourceCache._setTileReloadTimer(coord.id, tile);
             callback();
         };
@@ -899,7 +899,7 @@ test('SourceCache reloads expiring tiles', (t) => {
         const coord = new TileCoord(1, 0, 0);
 
         const expiryDate = new Date();
-        expiryDate.setMilliseconds(expiryDate.getMilliseconds() + 5);
+        expiryDate.setMilliseconds(expiryDate.getMilliseconds() + 50);
         const sourceCache = createSourceCache({ expires: expiryDate });
 
         sourceCache.reloadTile = (id, state) => {

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -210,7 +210,7 @@ test('expiring tiles', (t) => {
         const expiryTimeout = tile.getExpiryTimeout();
         t.ok(expiryTimeout >= 8000 && expiryTimeout <= 10000, 'expiry timeout as expected when fresh');
 
-        let justNow = new Date();
+        const justNow = new Date();
         justNow.setSeconds(justNow.getSeconds() - 1);
 
         // every time we set a tile's expiration to a date already expired,

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -180,8 +180,9 @@ test('expiring tiles', (t) => {
             cacheControl: 'max-age=60'
         });
 
-        t.equal(tile.cacheControl, 'max-age=60', 'set cache-control');
-        t.equal(tile.getExpiry(), tile.timeAdded + 60000, 'cache-control parsed as expected');
+        // times are fuzzy, so we'll give this a little leeway:
+        let expiryTimeout = tile.getExpiryTimeout();
+        t.ok(expiryTimeout > 58000 && expiryTimeout < 60000, 'cache-control parsed as expected');
 
         const date = new Date();
         date.setMinutes(date.getMinutes() + 10);
@@ -191,12 +192,33 @@ test('expiring tiles', (t) => {
             expires: date.toString()
         });
 
-        // this shouldn't happen, but if both expiry data are set, cacheControl takes precedence
-        t.equal(tile.getExpiry(), tile.timeAdded + 60000, 'cache-control takes precedence over expires');
+        expiryTimeout = tile.getExpiryTimeout();
+        t.ok(expiryTimeout > 598000 && expiryTimeout < 600000, 'expires header set date as expected');
 
-        delete tile.cacheControl;
+        t.end();
+    });
 
-        t.equal(tile.getExpiry(), date.getTime(), 'expires header set date as expected');
+    t.test('exponential backoff handling', (t) => {
+        const tile = new Tile(new TileCoord(1, 1, 1));
+        tile.state = 'loaded';
+        tile.timeAdded = Date.now();
+
+        tile.setExpiryData({
+            cacheControl: 'max-age=10'
+        });
+
+        let expiryTimeout = tile.getExpiryTimeout();
+        t.ok(expiryTimeout >= 8000 && expiryTimeout <= 10000, 'expiry timeout as expected when fresh');
+
+        tile.expiredRequests = 1;
+        t.equal(tile.getExpiryTimeout(), 1000, 'tile with one expired request retries after 1 second');
+
+        tile.expiredRequests++;
+        t.equal(tile.getExpiryTimeout(), 2000, 'exponential backoff');
+        tile.expiredRequests++;
+        t.equal(tile.getExpiryTimeout(), 4000, 'exponential backoff');
+        tile.expiredRequests++;
+        t.equal(tile.getExpiryTimeout(), 8000, 'exponential backoff');
 
         t.end();
     });

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -207,7 +207,7 @@ test('expiring tiles', (t) => {
             cacheControl: 'max-age=10'
         });
 
-        let expiryTimeout = tile.getExpiryTimeout();
+        const expiryTimeout = tile.getExpiryTimeout();
         t.ok(expiryTimeout >= 8000 && expiryTimeout <= 10000, 'expiry timeout as expected when fresh');
 
         tile.expiredRequests = 1;


### PR DESCRIPTION
Parity with https://github.com/mapbox/mapbox-gl-native/pull/4019 ; 
fixes https://github.com/mapbox/mapbox-gl-js/issues/4345 and https://github.com/mapbox/mapbox-gl-js/issues/4252.

This PR does the following:
* implements exponential backoff for retrying tile requests that are received with expiration times already in the past 
* disables crossfading on raster tiles that are refreshed from expiration refresh mechanisms (should fix flickering described in #4252)
* fixes bug wherein a tile was setting its expiration data before it had a `timeAdded` property, thus setting expiration incorrectly
* adds a `noRefreshOnExpiration` map option that disables refreshing-upon-tile-expiration mechanism altogether

cc @lucaswoj @anandthakker @jfirebaugh 