### PR TITLE
Don't clamp crossfade in the event of fadeout

### DIFF
--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -122,7 +122,7 @@ function getFadeValues(tile, parentTile, layer, transform) {
         // if no parent or parent is older, fade in; if parent is younger, fade out
         const fadeIn = !parentTile || Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ);
 
-        const childOpacity = (!!fadeIn && tile.refreshedUponExpiration) ? 1 : util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
+        const childOpacity = (fadeIn && tile.refreshedUponExpiration) ? 1 : util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
 
         // we don't crossfade tiles that were just refreshed upon expiring:
         // once they're old enough to pass the crossfading threshold

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -122,7 +122,7 @@ function getFadeValues(tile, parentTile, layer, transform) {
         // if no parent or parent is older, fade in; if parent is younger, fade out
         const fadeIn = !parentTile || Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ);
 
-        const childOpacity = tile.refreshedUponExpiration ? 1 : util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
+        const childOpacity = (!!fadeIn && tile.refreshedUponExpiration) ? 1 : util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
 
         // we don't crossfade tiles that were just refreshed upon expiring:
         // once they're old enough to pass the crossfading threshold


### PR DESCRIPTION
@anandthakker caught this case yesterday — if a tile is fading out and was just refreshed (i.e. zoom maneuver _right_ after refresh that would cause it to be fading out within 300ms) we won't want to clamp to 1.