### PR TITLE
Ensure DragRotate stops after releasing mouse button when Ctrl is already released. Fixes #1888

### DIFF
--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -210,7 +210,7 @@ class DragRotateHandler {
                 // using Control + left click
                 eventButton = 0;
             }
-            return (e.type === 'mousemove' ? e.buttons & buttons === 0 : eventButton !== button);
+            return (e.type === 'mousemove' ? e.buttons & buttons === 0 : !this.isActive() && eventButton !== button);
         }
     }
 


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

Fixes #1888. I've tried my best to test this doesn't have any other unintended consequences but it would be great if others can test it too.

In my view this is fairly high priority to fix as it creates a poor user experience and seems to affect quite a number of people.

 - [ ] write tests for all new functionality

I couldn't find any interaction unit tests for the DragRotateHandler, so I didn't add a test case.

 - [ ] document any changes to public APIs
N/A
 - [ ] post benchmark scores

 - [x] manually test the debug page

I've only tested in on my Linux machine under Chrome and Firefox, specifically I can confirm that these all work:

- Pan (left mouse)
- Rotate (right mouse)
- Rotate (drag left mouse on the reset north button)
- Shift Zoom
- Rotate (left mouse + Ctrl, letting go of left mouse first)
- Rotate (left mouse + Ctrl, letting go of Ctrl first)

Further details on my reasoning and approach:

The DragRotateHandler._keyUp method fires on a mouseup event so it can stop the
rotation/active state when you release the mouse button. However this
method also fires due to other interactions with the map such as
DragPan. So the _ignoreEvent method determines if the event mouseup or
other is to be ignored because it doesn't affect the DragRotateHandler.

This commit ensures that when the mouseup event happens on the left
mouse button without the Ctrl key pressed and DragRotate is still active
that the event is not ignored so that DragRotate can be deactivated.

