### PR TITLE
Ensure DragRotate stops when the window looses focus. Fixes #3389

### DIFF
--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -84,6 +84,8 @@ class DragPanHandler {
             window.document.addEventListener('mousemove', this._onMove);
             window.document.addEventListener('mouseup', this._onMouseUp);
         }
+        /* Deactivate DragPan when the window looses focus. Otherwise if a mouseup occurs when the window isn't in focus, DragPan will still be active even though the mouse is no longer pressed. */
+        window.addEventListener('blur', this._onMouseUp);
 
         this._active = false;
         this._startPos = this._pos = DOM.mousePos(this._el, e);
@@ -169,6 +171,7 @@ class DragPanHandler {
         this._onUp(e);
         window.document.removeEventListener('mousemove', this._onMove);
         window.document.removeEventListener('mouseup', this._onMouseUp);
+        window.removeEventListener('blur', this._onMouseUp);
     }
 
     _onTouchEnd(e) {
@@ -193,7 +196,7 @@ class DragPanHandler {
             if (e.ctrlKey) return true;
             const buttons = 1,  // left button
                 button = 0;   // left button
-            return (e.type === 'mousemove' ? e.buttons & buttons === 0 : e.button !== button);
+            return (e.type === 'mousemove' ? e.buttons & buttons === 0 : e.button && e.button !== button);
         }
     }
 

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -82,7 +82,7 @@ class DragRotateHandler {
 
         window.document.addEventListener('mousemove', this._onMove);
         window.document.addEventListener('mouseup', this._onUp);
-        /* Deactivate DragRotate when the window looses focus. Otherwise if a mouseup occurs when the window isn't in focus DragRotate will still be active even though the mouse is no longer pressed. */
+        /* Deactivate DragRotate when the window looses focus. Otherwise if a mouseup occurs when the window isn't in focus, DragRotate will still be active even though the mouse is no longer pressed. */
         window.addEventListener('blur', this._onUp);
 
         this._active = false;

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -29,8 +29,7 @@ class DragRotateHandler {
         util.bindAll([
             '_onDown',
             '_onMove',
-            '_onUp',
-            '_onBlur'
+            '_onUp'
         ], this);
 
     }
@@ -83,7 +82,8 @@ class DragRotateHandler {
 
         window.document.addEventListener('mousemove', this._onMove);
         window.document.addEventListener('mouseup', this._onUp);
-        window.addEventListener('blur', this._onBlur);
+        /* Deactivate DragRotate when the window looses focus. Otherwise if a mouseup occurs when the window isn't in focus DragRotate will still be active even though the mouse is no longer pressed. */
+        window.addEventListener('blur', this._onUp);
 
         this._active = false;
         this._inertia = [[Date.now(), this._map.getBearing()]];
@@ -91,14 +91,6 @@ class DragRotateHandler {
         this._center = this._map.transform.centerPoint;  // Center of rotation
 
         e.preventDefault();
-    }
-
-    /**
-     * Deactivates DragRotate when the window looses focus. Otherwise the mouseup event is never fired and when the
-     * window comes back in focus DragRotate is still active even though the mouse isn't down.
-     */
-    _onBlur(e) {
-        this._onUp(e);
     }
 
     _onMove(e) {
@@ -139,7 +131,7 @@ class DragRotateHandler {
         if (this._ignoreEvent(e)) return;
         window.document.removeEventListener('mousemove', this._onMove);
         window.document.removeEventListener('mouseup', this._onUp);
-        window.removeEventListener('blur', this._onBlur);
+        window.removeEventListener('blur', this._onUp);
 
         if (!this.isActive()) return;
 

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -29,7 +29,8 @@ class DragRotateHandler {
         util.bindAll([
             '_onDown',
             '_onMove',
-            '_onUp'
+            '_onUp',
+            '_onBlur'
         ], this);
 
     }
@@ -82,6 +83,7 @@ class DragRotateHandler {
 
         window.document.addEventListener('mousemove', this._onMove);
         window.document.addEventListener('mouseup', this._onUp);
+        window.addEventListener('blur', this._onBlur);
 
         this._active = false;
         this._inertia = [[Date.now(), this._map.getBearing()]];
@@ -89,6 +91,14 @@ class DragRotateHandler {
         this._center = this._map.transform.centerPoint;  // Center of rotation
 
         e.preventDefault();
+    }
+
+    /**
+     * Deactivates DragRotate when the window looses focus. Otherwise the mouseup event is never fired and when the
+     * window comes back in focus DragRotate is still active even though the mouse isn't down.
+     */
+    _onBlur(e) {
+        this._onUp(e);
     }
 
     _onMove(e) {
@@ -129,6 +139,7 @@ class DragRotateHandler {
         if (this._ignoreEvent(e)) return;
         window.document.removeEventListener('mousemove', this._onMove);
         window.document.removeEventListener('mouseup', this._onUp);
+        window.removeEventListener('blur', this._onBlur);
 
         if (!this.isActive()) return;
 


### PR DESCRIPTION
## Launch Checklist

The depends on #4389. Without it you might not observe this PR fixing the issue.

 - [x] briefly describe the changes in this PR

Ensure DragRotate stops when the window looses focus. Fixes #3389

 - [ ] write tests for all new functionality

I couldn't find any existing unit tests for DragRotate.

 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

Manually tested on Linux with Chrome and Firefox (with #4389 applied).
