### PR TITLE
Add type='button' to Fullscreen button

### DIFF
--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -37,6 +37,7 @@ class FullscreenControl {
         const container = this._container = DOM.create('div', `${className} mapboxgl-ctrl-group`);
         const button = this._fullscreenButton = DOM.create('button', (`${className}-icon ${className}-fullscreen`), this._container);
         button.setAttribute("aria-label", "Toggle fullscreen");
+        button.type = 'button';
         this._fullscreenButton.addEventListener('click', this._onClickFullscreen);
         this._mapContainer = map.getContainer();
         window.document.addEventListener(this._fullscreenchange, this._changeIcon);


### PR DESCRIPTION
Prevent Fullscreen control's button from acting like form submit buttons. 

Similar to #2934, #2935

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
