### PR TITLE
FIX unloadVectorData call with 1 argument where 0 are expected

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -69,7 +69,7 @@ class Tile {
      */
     loadVectorData(data, painter) {
         if (this.hasData()) {
-            this.unloadVectorData(painter);
+            this.unloadVectorData();
         }
 
         this.state = 'loaded';

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -87,7 +87,7 @@ test('querySourceFeatures', (t) => {
 
         tile.loadVectorData(null, painter);
 
-        t.ok(tile.unloadVectorData.calledWith(painter));
+        t.ok(tile.unloadVectorData.calledWith());
         t.end();
     });
 


### PR DESCRIPTION
This pull request extends #3351 which changed the function unloadVectorData to take 0 parameters instead of 1. All calls to this function were properly changed instead of 1.

This pull requests removes the parameter in the call to unloadVectorData in src/source/tile.js.

Altough calling a function with more parameters then required is allowed in JavaScript and you can access them with args[], the fact that args is not used in unloadVectorData can cause a bug if the function parameters will ever change again. Wanted to prevent that 😄 

I changed one test which stubbed the unloadVectorData function and checked if it was called with the painter. I changed the test to check if the data is called with 0 parameters.