### PR TITLE
FIX hasInvalidDimension call with 1 argument where 0 are expected

### DIFF
--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -44,7 +44,7 @@ class CanvasSource extends ImageSource {
         this.canvas = this.canvas || window.document.getElementById(this.options.canvas);
         this.width = this.canvas.width;
         this.height = this.canvas.height;
-        if (this._hasInvalidDimensions(this.canvas)) return this.fire('error', new Error('Canvas dimensions cannot be less than or equal to zero.'));
+        if (this._hasInvalidDimensions()) return this.fire('error', new Error('Canvas dimensions cannot be less than or equal to zero.'));
 
         let loopID;
 


### PR DESCRIPTION
**Problem**:
The function _hasInvalidDimensions takes 0 parameters but is called with 1 in function load.
Can cause an issue if the method ever changes (also see #4408).

**Problem Location**:
File: *src/source/canvas_source.js*
Class: *CanvasSource*
Function: *load*

**Fix**:
Removed the unwanted, unused parameter from the call.

**Test**:
All tests succeed. However, the load function which made the erroneous call has not been tested.
I do not know how to properly stub this (if possible). 
Advised to have a different manual check to rule out "Works on my machine" :)
