### PR TITLE
Tested uncovered parts of the src/geo module

### DIFF
--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -103,7 +103,7 @@ test('LngLatBounds', (t) => {
         const bounds1 = new LngLatBounds(undefined, undefined);
         const bounds2 = new LngLatBounds([-10, -10], [10, 10]);
 
-        bounds1.extend(bounds2)
+        bounds1.extend(bounds2);
 
         t.equal(bounds1.getSouth(), -10);
         t.equal(bounds1.getWest(), -10);

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -86,6 +86,33 @@ test('LngLatBounds', (t) => {
         t.end();
     });
 
+    t.test('#extend with null', (t) => {
+        const bounds = new LngLatBounds([0, 0], [10, 10]);
+
+        bounds.extend(null);
+
+        t.equal(bounds.getSouth(), 0);
+        t.equal(bounds.getWest(), 0);
+        t.equal(bounds.getNorth(), 10);
+        t.equal(bounds.getEast(), 10);
+
+        t.end();
+    });
+
+    t.test('#extend undefined bounding box', (t) => {
+        const bounds1 = new LngLatBounds(undefined, undefined);
+        const bounds2 = new LngLatBounds([-10, -10], [10, 10]);
+
+        bounds1.extend(bounds2)
+
+        t.equal(bounds1.getSouth(), -10);
+        t.equal(bounds1.getWest(), -10);
+        t.equal(bounds1.getNorth(), 10);
+        t.equal(bounds1.getEast(), 10);
+
+        t.end();
+    });
+
     t.test('accessors', (t) => {
         const sw = new LngLat(0, 0);
         const ne = new LngLat(-10, -20);

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -81,6 +81,15 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test('set fov', (t) => {
+        const transform = new Transform();
+        transform.fov = 10;
+        t.equal(transform.fov, 10);
+        transform.fov = 10;
+        t.equal(transform.fov, 10);
+        t.end();
+    });
+
     t.test('lngRange & latRange constrain zoom and center', (t) => {
         const transform = new Transform();
         transform.center = new LngLat(0, 0);


### PR DESCRIPTION
This pull request does not change any functionality of the system. It only contains improvements for the testing suite.

The `src/geo` module contained some untested functionality. I added a test for the untested `Transform#{set,get}fov` methods. I also added a test for some untested behavior in the `LngLatBounds#extend` method. These added tests improve the line coverage in the `src/geo` module to **100%**.

- src/geo/lng_lat_bounds.js line coverage improved from 93.88% to 100% (https://coveralls.io/builds/10581856/source?filename=src%2Fgeo%2Flng_lat_bounds.js#L86)
- src/geo/transform.js line coverage improved from 96.88% to 100% (https://coveralls.io/builds/10581856/source?filename=src%2Fgeo%2Ftransform.js#L93)

