### PR TITLE
Export the "dist" file in npm

### DIFF
--- a/docs/_includes/quickstart-bundler.html
+++ b/docs/_includes/quickstart-bundler.html
@@ -11,8 +11,8 @@ npm install --save mapbox-gl
 <p>Include the following code in the <code>&lt;body&gt;</code> of your HTML file.</p>
 <div class='js-replace-token'>
 {% copyable %}{% highlight javascript %}
-import mapboxgl from 'mapbox-gl/dist/mapbox-gl';
-// or "const mapboxgl = require('mapbox-gl/dist/mapbox-gl');"
+import mapboxgl from 'mapbox-gl';
+// or "const mapboxgl = require('mapbox-gl');"
 
 mapboxgl.accessToken = '<your access token here>';
 const map = new mapboxgl.Map({

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
   "version": "0.33.1",
-  "main": "src/index.js",
+  "main": "dist/mapbox-gl.js",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "build": "npm run build-docs # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve --watch",
     "lint": "eslint --ignore-path .gitignore src test bench docs/_posts/examples/*.html debug/*.html",
-    "lint-docs": "documentation lint",
+    "lint-docs": "documentation lint src/index.js",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "test": "run-s lint test-unit test-flow",
     "test-suite": "run-s test-render test-query",


### PR DESCRIPTION
Brought into this repository from https://github.com/mapbox/mapbox-gl-js/pull/4391

> When installing mapbox-gl via npm and importing the library like:
>
> import * as mapboxgl from 'mapbox-gl';
> 
> The npm resolver is looking for tha main attribute in package.json to further resolve the correct JavaScript file for import.
>
> fixes #3551

