### PR TITLE
Tested some uncovered parts of the src/util module

### DIFF
--- a/test/unit/util/interpolate.test.js
+++ b/test/unit/util/interpolate.test.js
@@ -13,6 +13,11 @@ test('interpolate.number', (t) => {
     t.end();
 });
 
+test('interpolate.vec2', (t) => {
+    t.deepEqual(interpolate.vec2([0, 0], [1, 2], 0.5), [0.5, 1]);
+    t.end();
+});
+
 test('interpolate.color', (t) => {
     t.deepEqual(interpolate.color([0, 0, 0, 0], [1, 2, 3, 4], 0.5), [0.5, 1, 3 / 2, 2]);
     t.end();

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -213,6 +213,13 @@ test("mapbox", (t) => {
             t.end();
         });
 
+        t.test('throw error on falsy url input', (t) => {
+            t.throws(() => {
+                mapbox.normalizeTileURL('', mapboxSource);
+            }, new Error('Unable to parse URL object'));
+            t.end();
+        });
+
         browser.supportsWebp = true;
 
         t.end();

--- a/test/unit/util/struct_array.test.js
+++ b/test/unit/util/struct_array.test.js
@@ -94,5 +94,22 @@ test('StructArray', (t) => {
         t.end();
     });
 
+    t.test('toArray', (t) => {
+        const array = new TestArray();
+
+        array.emplaceBack(1, 7, 3);
+        array.emplaceBack(4, 2, 5);
+
+        const subArray = array.toArray(0, 1);
+
+        t.equal(array.get(0).map0, subArray[0].map0);
+        t.equal(array.get(0).box0, subArray[0].box0);
+        t.equal(array.get(0).box1, subArray[0].box1);
+
+        t.equal(subArray.length, 1);
+
+        t.end();
+    });
+
     t.end();
 });

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -216,6 +216,26 @@ test('util', (t) => {
         t.end();
     });
 
+    t.test('arraysIntersect', (t) => {
+        t.test('intersection', (t) => {
+            const a = ["1", "2", "3"];
+            const b = ["5", "4", "3"];
+
+            t.equal(util.arraysIntersect(a, b), true);
+            t.end();
+        });
+
+        t.test('no intersection', (t) => {
+            const a = ["1", "2", "3"];
+            const b = ["4", "5", "6"];
+
+            t.equal(util.arraysIntersect(a, b), false);
+            t.end();
+        });
+        
+        t.end();
+    });
+
     t.test('parseCacheControl', (t) => {
         t.test('max-age', (t) => {
             t.deepEqual(util.parseCacheControl('max-age=123456789'), {

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -4,6 +4,7 @@
 const test = require('mapbox-gl-js-test').test;
 const Coordinate = require('../../../src/geo/coordinate');
 const util = require('../../../src/util/util');
+const Point = require('point-geometry');
 
 test('util', (t) => {
     t.equal(util.easeCubicInOut(0), 0, 'easeCubicInOut=0');
@@ -232,7 +233,29 @@ test('util', (t) => {
             t.equal(util.arraysIntersect(a, b), false);
             t.end();
         });
-        
+
+        t.end();
+    });
+
+    t.test('isCounterClockwise ', (t) => {
+        t.test('counter clockwise', (t) => {
+            const a = new Point(0, 0);
+            const b = new Point(1, 0);
+            const c = new Point(1, 1);
+
+            t.equal(util.isCounterClockwise(a, b, c), true);
+            t.end();
+        });
+
+        t.test('clockwise', (t) => {
+            const a = new Point(0, 0);
+            const b = new Point(1, 0);
+            const c = new Point(1, 1);
+
+            t.equal(util.isCounterClockwise(c, b, a), false);
+            t.end();
+        });
+
         t.end();
     });
 

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -259,6 +259,31 @@ test('util', (t) => {
         t.end();
     });
 
+    t.test('isClosedPolygon', (t) => {
+        t.test('not enough points', (t) => {
+            const polygon = [new Point(0, 0), new Point(1, 0), new Point(0, 1)];
+
+            t.equal(util.isClosedPolygon(polygon), false);
+            t.end();
+        });
+
+        t.test('not equal first + last point', (t) => {
+            const polygon = [new Point(0, 0), new Point(1, 0), new Point(0, 1), new Point(1, 1)];
+
+            t.equal(util.isClosedPolygon(polygon), false);
+            t.end();
+        });
+
+        t.test('closed polygon', (t) => {
+            const polygon = [new Point(0, 0), new Point(1, 0), new Point(1, 1), new Point(0, 1), new Point(0, 0)];
+
+            t.equal(util.isClosedPolygon(polygon), true);
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.test('parseCacheControl', (t) => {
         t.test('max-age', (t) => {
             t.deepEqual(util.parseCacheControl('max-age=123456789'), {


### PR DESCRIPTION
This pull request does not change any functionality of the system. It only contains improvements for the testing suite.

The `src/util` module contained some untested functionality. I added tests for the untested `util#{arrayIntersect, isCounterClockwise, isClosedPolygon)` methods. I also added a test for the untested `StructArray#toArray` method and the untested `interpolate#vec2` method. Lastly, I added a test for some uncovered behavior in `mapbox#parseUrl`. These added tests improve the line coverage in the `src/util` module from **65.09%** to **66.75%**.