### PR TITLE
ensure erroring tiles dont block map from firing load events

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -431,7 +431,7 @@ class SourceCache extends Evented {
             const zoom = coord.z;
             const overscaling = zoom > this._source.maxzoom ? Math.pow(2, zoom - this._source.maxzoom) : 1;
             tile = new Tile(wrapped, this._source.tileSize * overscaling, this._source.maxzoom);
-            this.loadTile(tile, this._tileLoaded.bind(this, tile, coord.id));
+            this.loadTile(tile, this._tileLoaded.bind(this, tile, coord.id, tile.state));
         }
 
         tile.uses++;

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -284,12 +284,33 @@ test('SourceCache / Source lifecycle', (t) => {
         sourceCache.onAdd();
     });
 
-    t.test('loaded() true after error', (t) => {
+    t.test('loaded() true after source error', (t) => {
         const sourceCache = createSourceCache({ error: 'Error loading source' })
         .on('error', () => {
             t.ok(sourceCache.loaded());
             t.end();
         });
+        sourceCache.onAdd();
+    });
+
+    t.test('loaded() true after tile error', (t)=>{
+        const transform = new Transform();
+        transform.resize(511, 511);
+        transform.zoom = 0;
+        const sourceCache = createSourceCache({
+            loadTile: function (tile, callback) {
+                callback("error");
+            }
+        }).on('data', (e)=>{
+            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+                sourceCache.update(transform);
+            }
+        }).on('error', ()=>{
+            t.true(sourceCache.loaded());
+            t.end();
+        });
+
+
         sourceCache.onAdd();
     });
 


### PR DESCRIPTION
fix #4425 

the `previousState` argument for the [`_tileLoaded`](https://github.com/mapbox/mapbox-gl-js/blob/master/src/source/source_cache.js#L165) wasn't being bound here so the `err` wasn't being caught, and thus tiles that error out were preventing `map`, `style` and `source` from returning `true` from `#loaded()`

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
