### PR TITLE
Use highp for shader variable "gamma" to avoid text aliasing

### DIFF
--- a/src/shaders/symbol_sdf.fragment.glsl
+++ b/src/shaders/symbol_sdf.fragment.glsl
@@ -25,7 +25,7 @@ void main() {
     #pragma mapbox: initialize lowp float halo_blur
 
     lowp vec4 color = fill_color;
-    lowp float gamma = EDGE_GAMMA / u_gamma_scale;
+    highp float gamma = EDGE_GAMMA / u_gamma_scale;
     lowp float buff = (256.0 - 64.0) / 256.0;
     if (u_is_halo) {
         color = halo_color;


### PR DESCRIPTION
Cherry picked from `release-ios-v3.5.0-android-v5.0.0` commit 28e9725bd5d18cc623435292a408df6fbefa1da9