### PR TITLE
Tested some uncovered parts of the src/style and scr/style-spec module

### DIFF
--- a/test/unit/style-spec/composite.test.js
+++ b/test/unit/style-spec/composite.test.js
@@ -58,3 +58,23 @@ test('does not composite vector + raster', (t) => {
     t.deepEqual(Object.keys(result.sources), ["a", "b"]);
     t.end();
 });
+
+test('incorrect url match', (t) => {
+    const result = composite({
+        "version": 7,
+        "sources": {
+            "a": {
+                "type": "vector",
+                "url": "mapbox://a"
+            },
+            "b": {
+                "type": "vector",
+                "url": ""
+            }
+        },
+        "layers": []
+    });
+
+    t.deepEqual(Object.keys(result.sources), ["a", "b"]);
+    t.end();
+});

--- a/test/unit/style-spec/diff.test.js
+++ b/test/unit/style-spec/diff.test.js
@@ -292,5 +292,20 @@ t('diff', (t) => {
         { command: 'addLayer', args: [{id: 'b', source: 'foo'}, 'c'] }
     ], 'changing a source removes and re-adds dependent layers');
 
+    t.deepEqual(diffStyles({
+        sources: { foo: { data: 1 }, bar: {} },
+        layers: [
+            { id: 'a', source: 'bar' }
+        ]
+    }, {
+        sources: { foo: { data: 1 }, bar: {} },
+        layers: [
+            { id: 'a', source: 'bar' }
+        ],
+        transition: 'transition'
+    }), [
+        { command: 'setTransition', args: ['transition'] }
+    ], 'changing transition');
+
     t.end();
 });

--- a/test/unit/style-spec/function/color_spaces.test.js
+++ b/test/unit/style-spec/function/color_spaces.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const test = require('mapbox-gl-js-test').test;
+const colorSpaces = require('../../../../src/style-spec/function/color_spaces');
+
+test('#hclToRgb zero', (t) => {
+    const hclColor = [0, 0, 0, null];
+    const rgbColor = [0, 0, 0, null];
+    t.deepEqual(colorSpaces.hcl.reverse(hclColor), rgbColor);
+    t.end();
+});
+
+test('#hclToRgb', (t) => {
+    const hclColor = [20, 20, 20, null];
+    const rgbColor = [76.04087881379073, 36.681898967046166, 39.08743507357837, null];
+    t.deepEqual(colorSpaces.hcl.reverse(hclColor), rgbColor);
+    t.end();
+});
+
+test('#rgbToHcl zero', (t) => {
+    const hclColor = [0, 0, 0, null];
+    const rgbColor = [0, 0, 0, null];
+    t.deepEqual(colorSpaces.hcl.forward(rgbColor), hclColor);
+    t.end();
+});
+
+test('#rgbToHcl', (t) => {
+    const hclColor = [158.19859051364818, 0.0000029334887311101764, 6.318928745123017, null];
+    const rgbColor = [20, 20, 20, null];
+    t.deepEqual(colorSpaces.hcl.forward(rgbColor), hclColor);
+    t.end();
+});

--- a/test/unit/style-spec/migrate.test.js
+++ b/test/unit/style-spec/migrate.test.js
@@ -12,7 +12,19 @@ const t = require('mapbox-gl-js-test').test,
 
 const UPDATE = !!process.env.UPDATE;
 
-t('migrates to latest version', (t) => {
+t('does not migrate from version 5', (t) => {
+    t.throws(() => {
+      migrate({version: 5, layers: []});
+    }, new Error('cannot migrate from', 5));
+    t.end();
+});
+
+t('migrates to latest version from version 6', (t) => {
+    t.deepEqual(migrate({version: 6, layers: []}).version, spec.latest.$version);
+    t.end();
+});
+
+t('migrates to latest version from version 7', (t) => {
     t.deepEqual(migrate({version: 7, layers: []}).version, spec.latest.$version);
     t.end();
 });

--- a/test/unit/style-spec/migrate.test.js
+++ b/test/unit/style-spec/migrate.test.js
@@ -14,7 +14,7 @@ const UPDATE = !!process.env.UPDATE;
 
 t('does not migrate from version 5', (t) => {
     t.throws(() => {
-      migrate({version: 5, layers: []});
+        migrate({version: 5, layers: []});
     }, new Error('cannot migrate from', 5));
     t.end();
 });

--- a/test/unit/style/style_layer.test.js
+++ b/test/unit/style/style_layer.test.js
@@ -305,6 +305,61 @@ test('StyleLayer#setPaintProperty', (t) => {
         t.end();
     });
 
+    t.test('sets null property value', (t) => {
+        const layer = StyleLayer.create({
+            "id": "background",
+            "type": "background"
+        });
+
+        layer.setPaintProperty('background-color-transition', null);
+
+        t.deepEqual(layer.getPaintProperty('background-color-transition'), null);
+        t.end();
+    });
+
+    test('StyleLayer#getPaintValueStopZoomLevels', (t) => {
+        t.test('get undefined paint value stop zoom levels', (t) => {
+            const layer = StyleLayer.create({
+                "id": "background",
+                "type": "fill",
+                "paint.blue": {
+                    "fill-color": "#8ccbf7",
+                    "fill-opacity": 1
+                },
+                "paint": {
+                    "fill-opacity": 0
+                }
+            });
+
+            t.deepEqual(layer.getPaintValueStopZoomLevels('background-color'), []);
+
+            t.end();
+        });
+
+        t.end();
+    });
+
+    test('StyleLayer#isPaintValueZoomConstant', (t) => {
+        t.test('is paint value zoom constant undefined', (t) => {
+            const layer = StyleLayer.create({
+                "id": "background",
+                "type": "fill",
+                "paint.blue": {
+                    "fill-color": "#8ccbf7",
+                    "fill-opacity": 1
+                },
+                "paint": {
+                    "fill-opacity": 0
+                }
+            });
+
+            t.equal(layer.isPaintValueZoomConstant('background-color'), true);
+
+            t.end();
+        });
+
+        t.end();
+    });
 
     t.end();
 });


### PR DESCRIPTION
This pull request does not change any functionality of the system. It only contains improvements for the testing suite. The `src/style` and `scr/style-spec` module contain untested functionality. I added tests for the following methods in the `src/style` module:

- The `setPaintProperty`, `getPaintValueStopZoomLevels` and the `isPaintValueZoomConstant` method of the `StyleLayer` class

I added tests for the following methods in the `src/style-spec` module:

- The `migrate` function
- The hcl related `color_spaces` functions
- Some untested behavior in the `composite` function
- Some untested behavior in the `diff#diffStyles` function

These added tests improve the line coverage in the `src/style` and `src/style-spec` module with 20 additional covered lines which is about +0,2% line coverage.