### PR TITLE
Update access-tokens API documentation URL

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -4,7 +4,7 @@
 const config = require('./config');
 const browser = require('./browser');
 
-const help = 'See https://www.mapbox.com/developers/api/#access-tokens';
+const help = 'See https://www.mapbox.com/api-documentation/#access-tokens';
 
 type UrlObject = {|
     protocol: string,


### PR DESCRIPTION
Although there is a redirect from https://www.mapbox.com/developers/api/ to https://www.mapbox.com/api-documentation/, the #access-tokens anchor is lost, so it's best to point to the new URL.