### PR TITLE
Fix "build-docs" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "start": "run-p build-token watch-dev watch-benchmarks watch-benchmarks-view start-server",
     "start-debug": "run-p build-token watch-dev start-server",
     "start-bench": "run-p build-token watch-benchmarks watch-benchmarks-view start-server",
-    "build-docs": "flow-node docs/style-spec/_generate/generate.js && documentation build --github --format html --config ./docs/documentation.yml --theme ./docs/_theme --output docs/api/",
+    "build-docs": "flow-node docs/style-spec/_generate/generate.js && documentation build --github --format html --config ./docs/documentation.yml --theme ./docs/_theme --output docs/api/ src/index.js",
     "build": "npm run build-docs # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve --watch",
     "lint": "eslint --ignore-path .gitignore src test bench docs/_posts/examples/*.html debug/*.html",


### PR DESCRIPTION
Currently running `npm run build-docs` fails

```
> mapbox-gl@0.33.1 build-docs /Users/lucaswoj/Code/mapbox-gl-js
> flow-node docs/style-spec/_generate/generate.js && documentation build --github --format html --config ./docs/documentation.yml --theme ./docs/_theme --output docs/api/

[BABEL] Note: The code generator has deoptimised the styling of "/Users/lucaswoj/Code/mapbox-gl-js/dist/mapbox-gl.js" as it exceeds the max of "500KB".
/Users/lucaswoj/Code/mapbox-gl-js/node_modules/documentation/lib/commands/build.js:68
      throw err;
      ^

Error: Cannot find module './feature' from '/Users/lucaswoj/Code/mapbox-gl-js/dist'
    at /Users/lucaswoj/Code/mapbox-gl-js/node_modules/browser-resolve/node_modules/resolve/lib/async.js:55:21
    at load (/Users/lucaswoj/Code/mapbox-gl-js/node_modules/browser-resolve/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/lucaswoj/Code/mapbox-gl-js/node_modules/browser-resolve/node_modules/resolve/lib/async.js:92:31)
    at /Users/lucaswoj/Code/mapbox-gl-js/node_modules/browser-resolve/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:123:15)
```

This seems to be due to the changes in https://github.com/mapbox/mapbox-gl-js/pull/4423

This PR fixes the errors by explicitly pointing `documentation` at `src/index.js`. 

cc @andrewharvey 