### PR TITLE
use anisotropic filtering for raster tiles #1064

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -113,6 +113,15 @@ class Painter {
         rasterBoundsArray.emplaceBack(EXTENT, EXTENT, 32767, 32767);
         this.rasterBoundsBuffer = Buffer.fromStructArray(rasterBoundsArray, Buffer.BufferType.VERTEX);
         this.rasterBoundsVAO = new VertexArrayObject();
+
+        this.extTextureFilterAnisotropic = (
+            gl.getExtension('EXT_texture_filter_anisotropic') ||
+            gl.getExtension('MOZ_EXT_texture_filter_anisotropic') ||
+            gl.getExtension('WEBKIT_EXT_texture_filter_anisotropic')
+        );
+        if (this.extTextureFilterAnisotropic) {
+            this.extTextureFilterAnisotropicMax = gl.getParameter(this.extTextureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT);
+        }
     }
 
     /*

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -90,6 +90,11 @@ class RasterTileSource extends Evented {
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+                if (this.map.painter.extTextureFilterAnisotropic) {
+                    gl.texParameterf(gl.TEXTURE_2D, this.map.painter.extTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, this.map.painter.extTextureFilterAnisotropicMax);
+                }
+
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
                 tile.texture.size = img.width;
             }


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR
Implements anisotropic filtering for raster tiles #1064
 - [ ] write tests for all new functionality
Rendering test fixtures may need to be updated, apart from that I don't think it's something that we can/need unit tests for.
 - [x] document any changes to public APIs
N/A
 - [x] post benchmark scores
I ran a modified fps benchmark with satellite-streets at pitch 60 and bearing 45. Got around the same 60FPS on both.

 - [x] manually test the debug page
Before/After
![selection_489](https://cloud.githubusercontent.com/assets/117278/24041065/f91650c4-0b5f-11e7-92b4-86e733ffb257.png)
![selection_490](https://cloud.githubusercontent.com/assets/117278/24041070/fbcc028c-0b5f-11e7-9bfd-d8ba73cc33db.png)

- [ ] test it falls back on unsupported devices
Not sure how to do this.
- [x] investigate if it makes any difference that this is enabled even when the map isn't pitched
My fps benchmark didn't seem to indicate any performance issues, so I think it's fine as is.
- [ ] "The filtering level used should depend on the current pitch."
Do we need to do this, or can we just use the max level?