### PR TITLE
jump back to world zero when crossing the antimeridian in flyTo and other camera operations. Fixes #2071

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -230,7 +230,10 @@ class Transform {
 
     setLocationAtPoint(lnglat, point) {
         const translate = this.pointCoordinate(point)._sub(this.pointCoordinate(this.centerPoint));
-        this.center = this.coordinateLocation(this.locationCoordinate(lnglat)._sub(translate)).wrap();
+        this.center = this.coordinateLocation(this.locationCoordinate(lnglat)._sub(translate));
+        if (this._renderWorldCopies) {
+            this.center = this.center.wrap();
+        }
     }
 
     /**

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -230,7 +230,7 @@ class Transform {
 
     setLocationAtPoint(lnglat, point) {
         const translate = this.pointCoordinate(point)._sub(this.pointCoordinate(this.centerPoint));
-        this.center = this.coordinateLocation(this.locationCoordinate(lnglat)._sub(translate));
+        this.center = this.coordinateLocation(this.locationCoordinate(lnglat)._sub(translate)).wrap();
     }
 
     /**

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -768,7 +768,10 @@ class Camera extends Evented {
 
             const scale = 1 / w(s);
             tr.zoom = startZoom + tr.scaleZoom(scale);
-            tr.center = tr.unproject(from.add(to.sub(from).mult(us)).mult(scale)).wrap();
+            tr.center = tr.unproject(from.add(to.sub(from).mult(us)).mult(scale));
+            if (tr._renderWorldCopies) {
+                tr.center = tr.center.wrap();
+            }
 
             if (this.rotating) {
                 tr.bearing = interpolate(startBearing, bearing, k);

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -769,7 +769,7 @@ class Camera extends Evented {
             const scale = 1 / w(s);
             tr.zoom = startZoom + tr.scaleZoom(scale);
             tr.center = tr.unproject(from.add(to.sub(from).mult(us)).mult(scale));
-            if (tr._renderWorldCopies) {
+            if (tr.renderWorldCopies) {
                 tr.center = tr.center.wrap();
             }
 

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -768,7 +768,7 @@ class Camera extends Evented {
 
             const scale = 1 / w(s);
             tr.zoom = startZoom + tr.scaleZoom(scale);
-            tr.center = tr.unproject(from.add(to.sub(from).mult(us)).mult(scale));
+            tr.center = tr.unproject(from.add(to.sub(from).mult(us)).mult(scale)).wrap();
 
             if (this.rotating) {
                 tr.bearing = interpolate(startBearing, bearing, k);

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1046,6 +1046,24 @@ test('camera', (t) => {
             camera.flyTo({ center: [170, 0], duration: 10 });
         });
 
+        t.test('jumps back to world 0 when crossing the antimeridian', (t) => {
+            const camera = createCamera();
+            camera.setCenter([-170, 0]);
+
+            let leftWorld0 = false;
+
+            camera.on('move', () => {
+                leftWorld0 = leftWorld0 || (camera.getCenter().lng < -180);
+            });
+
+            camera.on('moveend', () => {
+                t.false(leftWorld0);
+                t.end();
+            });
+
+            camera.flyTo({ center: [170, 0], duration: 10 });
+        });
+
         t.test('peaks at the specified zoom level', (t) => {
             const camera = createCamera({zoom: 20});
             const minZoom = 1;


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR
Some background in #2071. When `flyTo` decides to cross the anti-meridian from world 0, it will end up in either world -1 or 1. Because `Marker` DOM elements are only drawn in one place and only on world 0, they don't show up at the moment.

This PR aims to ensure that when flyTo is about to step across the anti-meridian into world -1 or 1, it teleports to ensure it lands back in world 0, and so `Marker` elements appear.

It also ensure's that other camera operations like `jumpTo`, `easeTo` don't leave the map in a non world 0 state.

 - [x] write tests for all new functionality

 - [ ] document any changes to public APIs
I feel this should be transparent to the public API, it's a private behaviour.

 - [ ] post benchmark scores
 - [x] manually test the debug page

I wrote a new debug page to test this, but haven't committed it.

- [ ] the world sometimes flashes white when you cross the anti-meridian, I'm not sure how to fix this.

- [x] only jump back to world 0 when renderWorldCopies is true