### PR TITLE
move markers to the best world for the current view

### DIFF
--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -68,6 +68,36 @@ class LngLat {
     toString() {
         return `LngLat(${this.lng}, ${this.lat})`;
     }
+
+    /**
+     * Returns a new `LngLat` object snapped to the best world to draw it provided a map `center` `LngLat`.
+     *
+     * When the map is close to the anti-meridian showing a point on world -1 or 1 is a better
+     * choice. The heuristic used is to minimize the distance from the map center to the point.
+     *
+     * Only works where the `LngLat` is wrapped with `LngLat.wrap()` and `center` is within the main world map.
+     *
+     * @param {LngLat} center Map center within the main world.
+     * @return {LngLat} The `LngLat` object in the best world to draw it for the provided map `center`.
+     * @example
+     * var ll = new mapboxgl.LngLat(170, 0);
+     * var mapCenter = new mapboxgl.LngLat(-170, 0);
+     * var snapped = ll.snapToWorld(mapCenter);
+     * snapped; // = { lng: -190, lat: 0 }
+     */
+    snapToWorld(center) {
+        const snapped = new LngLat(this.lng, this.lat);
+
+        if (Math.abs(this.lng - center.lng) > 180) {
+            if (center.lng < 0) {
+                snapped.lng -= 360;
+            } else {
+                snapped.lng += 360;
+            }
+        }
+
+        return snapped;
+    }
 }
 
 /**

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -46,6 +46,36 @@ class LngLat {
     }
 
     /**
+     * Returns a new `LngLat` object wrapped to the best world to draw it provided a map `center` `LngLat`.
+     *
+     * When the map is close to the anti-meridian showing a point on world -1 or 1 is a better
+     * choice. The heuristic used is to minimize the distance from the map center to the point.
+     *
+     * Only works where the `LngLat` is wrapped with `LngLat.wrap()` and `center` is within the main world map.
+     *
+     * @param {LngLat} center Map center within the main world.
+     * @return {LngLat} The `LngLat` object in the best world to draw it for the provided map `center`.
+     * @example
+     * var ll = new mapboxgl.LngLat(170, 0);
+     * var mapCenter = new mapboxgl.LngLat(-170, 0);
+     * var snapped = ll.wrapToWorld(mapCenter);
+     * snapped; // = { lng: -190, lat: 0 }
+     */
+    wrapToWorld(center) {
+        const wrapped = new LngLat(this.lng, this.lat);
+
+        if (Math.abs(this.lng - center.lng) > 180) {
+            if (center.lng < 0) {
+                wrapped.lng -= 360;
+            } else {
+                wrapped.lng += 360;
+            }
+        }
+
+        return wrapped;
+    }
+
+    /**
      * Returns the coordinates represented as an array of two numbers.
      *
      * @returns {Array<number>} The coordinates represeted as an array of longitude and latitude.
@@ -67,36 +97,6 @@ class LngLat {
      */
     toString() {
         return `LngLat(${this.lng}, ${this.lat})`;
-    }
-
-    /**
-     * Returns a new `LngLat` object snapped to the best world to draw it provided a map `center` `LngLat`.
-     *
-     * When the map is close to the anti-meridian showing a point on world -1 or 1 is a better
-     * choice. The heuristic used is to minimize the distance from the map center to the point.
-     *
-     * Only works where the `LngLat` is wrapped with `LngLat.wrap()` and `center` is within the main world map.
-     *
-     * @param {LngLat} center Map center within the main world.
-     * @return {LngLat} The `LngLat` object in the best world to draw it for the provided map `center`.
-     * @example
-     * var ll = new mapboxgl.LngLat(170, 0);
-     * var mapCenter = new mapboxgl.LngLat(-170, 0);
-     * var snapped = ll.snapToWorld(mapCenter);
-     * snapped; // = { lng: -190, lat: 0 }
-     */
-    snapToWorld(center) {
-        const snapped = new LngLat(this.lng, this.lat);
-
-        if (Math.abs(this.lng - center.lng) > 180) {
-            if (center.lng < 0) {
-                snapped.lng -= 360;
-            } else {
-                snapped.lng += 360;
-            }
-        }
-
-        return snapped;
     }
 }
 

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -58,10 +58,10 @@ class LngLat {
      * @example
      * var ll = new mapboxgl.LngLat(170, 0);
      * var mapCenter = new mapboxgl.LngLat(-170, 0);
-     * var snapped = ll.wrapToWorld(mapCenter);
+     * var snapped = ll.wrapToBestWorld(mapCenter);
      * snapped; // = { lng: -190, lat: 0 }
      */
-    wrapToWorld(center) {
+    wrapToBestWorld(center) {
         const wrapped = new LngLat(this.lng, this.lat);
 
         if (Math.abs(this.lng - center.lng) > 180) {

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -146,7 +146,7 @@ class Marker {
 
     _update(e) {
         if (!this._map) return;
-        let pos = this._map.project(this._map.transform.renderWorldCopies ? this._lngLat.wrapToWorld(this._map.getCenter()) : this._lngLat)._add(this._offset);
+        let pos = this._map.project(this._map.transform.renderWorldCopies ? this._lngLat.wrapToBestWorld(this._map.getCenter()) : this._lngLat)._add(this._offset);
         // because rouding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
         // no arguments (when the Marker is initialized or Marker#setLngLat is invoked).

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -146,7 +146,7 @@ class Marker {
 
     _update(e) {
         if (!this._map) return;
-        let pos = this._map.project(this._map.transform._renderWorldCopies ? this._lngLat.wrapToWorld(this._map.getCenter()) : this._lngLat)._add(this._offset);
+        let pos = this._map.project(this._map.transform.renderWorldCopies ? this._lngLat.wrapToWorld(this._map.getCenter()) : this._lngLat)._add(this._offset);
         // because rouding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
         // no arguments (when the Marker is initialized or Marker#setLngLat is invoked).

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -146,7 +146,7 @@ class Marker {
 
     _update(e) {
         if (!this._map) return;
-        let pos = this._map.project(this._map.transform._renderWorldCopies ? this._lngLat.snapToWorld(this._map.getCenter()) : this._lngLat)._add(this._offset);
+        let pos = this._map.project(this._map.transform._renderWorldCopies ? this._lngLat.wrapToWorld(this._map.getCenter()) : this._lngLat)._add(this._offset);
         // because rouding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
         // no arguments (when the Marker is initialized or Marker#setLngLat is invoked).

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -146,7 +146,7 @@ class Marker {
 
     _update(e) {
         if (!this._map) return;
-        let pos = this._map.project(this._lngLat)._add(this._offset);
+        let pos = this._map.project(this._map.transform._renderWorldCopies ? this._lngLat.snapToWorld(this._map.getCenter()) : this._lngLat)._add(this._offset);
         // because rouding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
         // no arguments (when the Marker is initialized or Marker#setLngLat is invoked).

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -234,7 +234,7 @@ class Popup extends Evented {
 
         let anchor = this.options.anchor;
         const offset = normalizeOffset(this.options.offset);
-        const pos = this._map.project(this._map.transform.renderWorldCopies ? this._lngLat.wrapToWorld(this._map.getCenter()) : this._lngLat).round();
+        const pos = this._map.project(this._map.transform.renderWorldCopies ? this._lngLat.wrapToBestWorld(this._map.getCenter()) : this._lngLat).round();
 
         if (!anchor) {
             const width = this._container.offsetWidth,

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -234,7 +234,7 @@ class Popup extends Evented {
 
         let anchor = this.options.anchor;
         const offset = normalizeOffset(this.options.offset);
-        const pos = this._map.project(this._map.transform._renderWorldCopies ? this._lngLat.wrapToWorld(this._map.getCenter()) : this._lngLat).round();
+        const pos = this._map.project(this._map.transform.renderWorldCopies ? this._lngLat.wrapToWorld(this._map.getCenter()) : this._lngLat).round();
 
         if (!anchor) {
             const width = this._container.offsetWidth,

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -234,7 +234,7 @@ class Popup extends Evented {
 
         let anchor = this.options.anchor;
         const offset = normalizeOffset(this.options.offset);
-        const pos = this._map.project(this._lngLat).round();
+        const pos = this._map.project(this._map.transform._renderWorldCopies ? this._lngLat.snapToWorld(this._map.getCenter()) : this._lngLat).round();
 
         if (!anchor) {
             const width = this._container.offsetWidth,

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -234,7 +234,7 @@ class Popup extends Evented {
 
         let anchor = this.options.anchor;
         const offset = normalizeOffset(this.options.offset);
-        const pos = this._map.project(this._map.transform._renderWorldCopies ? this._lngLat.snapToWorld(this._map.getCenter()) : this._lngLat).round();
+        const pos = this._map.project(this._map.transform._renderWorldCopies ? this._lngLat.wrapToWorld(this._map.getCenter()) : this._lngLat).round();
 
         if (!anchor) {
             const width = this._container.offsetWidth,

--- a/test/unit/geo/lng_lat.test.js
+++ b/test/unit/geo/lng_lat.test.js
@@ -50,15 +50,15 @@ test('LngLat', (t) => {
         t.end();
     });
 
-    test('#wrapToWorld', (t) => {
-        t.deepEqual(new LngLat(179, 0).wrapToWorld(new LngLat(0, 0)), { lng: 179, lat: 0 }, 'center view, position in world 0');
-        t.deepEqual(new LngLat(-179, 0).wrapToWorld(new LngLat(0, 0)), { lng: -179, lat: 0 }, 'center view, position in world 0');
+    test('#wrapToBestWorld', (t) => {
+        t.deepEqual(new LngLat(179, 0).wrapToBestWorld(new LngLat(0, 0)), { lng: 179, lat: 0 }, 'center view, position in world 0');
+        t.deepEqual(new LngLat(-179, 0).wrapToBestWorld(new LngLat(0, 0)), { lng: -179, lat: 0 }, 'center view, position in world 0');
 
-        t.deepEqual(new LngLat(180, 0).wrapToWorld(new LngLat(0, 0)), { lng: 180, lat: 0 }, 'center view, position on the edge of world 0');
-        t.deepEqual(new LngLat(-180, 0).wrapToWorld(new LngLat(0, 0)), { lng: -180, lat: 0 }, 'center view, position on the edge of world 0');
+        t.deepEqual(new LngLat(180, 0).wrapToBestWorld(new LngLat(0, 0)), { lng: 180, lat: 0 }, 'center view, position on the edge of world 0');
+        t.deepEqual(new LngLat(-180, 0).wrapToBestWorld(new LngLat(0, 0)), { lng: -180, lat: 0 }, 'center view, position on the edge of world 0');
 
-        t.deepEqual(new LngLat(179, 0).wrapToWorld(new LngLat(-179, 0)), { lng: -181, lat: 0 }, 'view at US shows position at NZ in world -1');
-        t.deepEqual(new LngLat(-179, 0).wrapToWorld(new LngLat(179, 0)), { lng: 181, lat: 0 }, 'view at NZ shows position at US in world 1');
+        t.deepEqual(new LngLat(179, 0).wrapToBestWorld(new LngLat(-179, 0)), { lng: -181, lat: 0 }, 'view at US shows position at NZ in world -1');
+        t.deepEqual(new LngLat(-179, 0).wrapToBestWorld(new LngLat(179, 0)), { lng: 181, lat: 0 }, 'view at NZ shows position at US in world 1');
 
         t.end();
     });

--- a/test/unit/geo/lng_lat.test.js
+++ b/test/unit/geo/lng_lat.test.js
@@ -50,5 +50,18 @@ test('LngLat', (t) => {
         t.end();
     });
 
+    test('#snapToWorld', (t) => {
+        t.deepEqual(new LngLat(179, 0).snapToWorld(new LngLat(0, 0)), { lng: 179, lat: 0 }, 'center view, position in world 0');
+        t.deepEqual(new LngLat(-179, 0).snapToWorld(new LngLat(0, 0)), { lng: -179, lat: 0 }, 'center view, position in world 0');
+
+        t.deepEqual(new LngLat(180, 0).snapToWorld(new LngLat(0, 0)), { lng: 180, lat: 0 }, 'center view, position on the edge of world 0');
+        t.deepEqual(new LngLat(-180, 0).snapToWorld(new LngLat(0, 0)), { lng: -180, lat: 0 }, 'center view, position on the edge of world 0');
+
+        t.deepEqual(new LngLat(179, 0).snapToWorld(new LngLat(-179, 0)), { lng: -181, lat: 0 }, 'view at US shows position at NZ in world -1');
+        t.deepEqual(new LngLat(-179, 0).snapToWorld(new LngLat(179, 0)), { lng: 181, lat: 0 }, 'view at NZ shows position at US in world 1');
+
+        t.end();
+    });
+
     t.end();
 });

--- a/test/unit/geo/lng_lat.test.js
+++ b/test/unit/geo/lng_lat.test.js
@@ -50,15 +50,15 @@ test('LngLat', (t) => {
         t.end();
     });
 
-    test('#snapToWorld', (t) => {
-        t.deepEqual(new LngLat(179, 0).snapToWorld(new LngLat(0, 0)), { lng: 179, lat: 0 }, 'center view, position in world 0');
-        t.deepEqual(new LngLat(-179, 0).snapToWorld(new LngLat(0, 0)), { lng: -179, lat: 0 }, 'center view, position in world 0');
+    test('#wrapToWorld', (t) => {
+        t.deepEqual(new LngLat(179, 0).wrapToWorld(new LngLat(0, 0)), { lng: 179, lat: 0 }, 'center view, position in world 0');
+        t.deepEqual(new LngLat(-179, 0).wrapToWorld(new LngLat(0, 0)), { lng: -179, lat: 0 }, 'center view, position in world 0');
 
-        t.deepEqual(new LngLat(180, 0).snapToWorld(new LngLat(0, 0)), { lng: 180, lat: 0 }, 'center view, position on the edge of world 0');
-        t.deepEqual(new LngLat(-180, 0).snapToWorld(new LngLat(0, 0)), { lng: -180, lat: 0 }, 'center view, position on the edge of world 0');
+        t.deepEqual(new LngLat(180, 0).wrapToWorld(new LngLat(0, 0)), { lng: 180, lat: 0 }, 'center view, position on the edge of world 0');
+        t.deepEqual(new LngLat(-180, 0).wrapToWorld(new LngLat(0, 0)), { lng: -180, lat: 0 }, 'center view, position on the edge of world 0');
 
-        t.deepEqual(new LngLat(179, 0).snapToWorld(new LngLat(-179, 0)), { lng: -181, lat: 0 }, 'view at US shows position at NZ in world -1');
-        t.deepEqual(new LngLat(-179, 0).snapToWorld(new LngLat(179, 0)), { lng: 181, lat: 0 }, 'view at NZ shows position at US in world 1');
+        t.deepEqual(new LngLat(179, 0).wrapToWorld(new LngLat(-179, 0)), { lng: -181, lat: 0 }, 'view at US shows position at NZ in world -1');
+        t.deepEqual(new LngLat(-179, 0).wrapToWorld(new LngLat(179, 0)), { lng: 181, lat: 0 }, 'view at NZ shows position at US in world 1');
 
         t.end();
     });


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR
DOM Elements like Markers and Popups are only drawn in world 0. However when you're close to the anti-meridian, DOM Elements which should appear might not, and in some cases it makes sense to draw the DOM elements in world -1 and 1.

This aims to address #3770. However until #2071 is fixed, this PR only addresses issues when the view is in world 0.

 - [x] write tests for all new functionality
 - [x] document any changes to public APIs

public LngLat.wrapToWorld(center) added JS doc.

 - [ ] post benchmark scores
 - [x] manually test the debug page
I did some manual testing of this, with both a marker and popup around long 170 and at long -170, and it works well for world -1, 0 and 1, so long as the camera always wraps to world 0 this is enough.

When zoomed out the marker/popup will jump which might be a poor UX, but I think it's okay and probably better than the alternative of it disappearing off the view.