### PR TITLE
Fix documentation type for Map.logoPosition

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -102,7 +102,7 @@ const defaultOptions = {
  *   in an HTML element's `class` attribute. To learn more about Mapbox style classes, read about
  *   [Layers](https://www.mapbox.com/mapbox-gl-style-spec/#layers) in the style specification.
  * @param {boolean} [options.attributionControl=true] If `true`, an [AttributionControl](#AttributionControl) will be added to the map.
- * @param {boolean} [options.logoPosition='bottom-left'] Position of the Mapbox wordmark on the map. Valid options are ['top-left','top-right', 'bottom-left', 'bottom-right'].
+ * @param {string} [options.logoPosition='bottom-left'] A string representing the position of the Mapbox wordmark on the map. Valid options are `top-left`,`top-right`, `bottom-left`, `bottom-right`.
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the performance of Mapbox
  *   GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
  * @param {boolean} [options.preserveDrawingBuffer=false] If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`. This is `false` by default as a performance optimization.


### PR DESCRIPTION
Changes documentation type for `Map.logoPosition` from `{boolean}` to `{string}`

![screen shot 2017-03-20 at 3 16 05 pm](https://cloud.githubusercontent.com/assets/10850812/24117357/4bddb870-0d80-11e7-9bdd-59d8e5b04451.png)
