### PR TITLE
Fix type links in API docs

### DIFF
--- a/docs/_theme/index.hbs
+++ b/docs/_theme/index.hbs
@@ -17,7 +17,7 @@ category: api
           <% docs.forEach(function(doc) { %>
             <% var hasMembers = doc.members.static.length || doc.members.instance.length %>
             <li class="<% if (doc.kind === 'note') { %>space-top1<% } %>"><a
-              href='#<%=doc.namespace%>'
+              href='#<%= doc.namespace.toLowerCase() %>'
               class="<% if (doc.kind === 'note') { %>dark-link<% } %><% if (hasMembers) { %> toggle-sibling rcon caret-right tight-icon<% } %>">
               <%- doc.name %>
             </a>
@@ -28,7 +28,7 @@ category: api
                 <li class='block small quiet truncate'>Static members</li>
                 <% doc.members.static.forEach(function(member) { %>
                   <li><a
-                    href='#<%=member.namespace%>'
+                    href='#<%= member.namespace.toLowerCase() %>'
                     class='block small truncate pre-open'>
                     .<%- member.name %>
                   </a></li>
@@ -40,7 +40,7 @@ category: api
                   <li class='block small quiet truncate'>Instance members</li>
                   <% doc.members.instance.forEach(function(member) { %>
                   <li><a
-                    href='#<%=member.namespace%>'
+                    href='#<%= member.namespace.toLowerCase() %>'
                     class='block small truncate pre-open'>
                     #<%- member.name %>
                   </a></li>
@@ -52,7 +52,7 @@ category: api
                   <li class='block small truncate quiet'>Events</li>
                   <% doc.members.events.forEach(function(member) { %>
                     <li><a
-                      href='#<%=member.namespace%>'
+                      href='#<%= member.namespace.toLowerCase() %>'
                       class='block small truncate pre-open'>
                       ⓔ <%- member.name %>
                     </a></li>

--- a/docs/_theme/note.hbs
+++ b/docs/_theme/note.hbs
@@ -1,6 +1,6 @@
 <section class='pad2 space-bottom4 fill-darken0 clearfix prose'>
 
-  <div id='<%- note.namespace %>' class='strong'>
+  <div id='<%- note.namespace.toLowerCase() %>' class='strong'>
     <%- note.name %>
   </div>
 

--- a/docs/_theme/section.hbs
+++ b/docs/_theme/section.hbs
@@ -2,7 +2,7 @@
 
   <% if (typeof nested === 'undefined') { %>
   <div class='clearfix'>
-    <h2 class='fl' id='<%- section.namespace %>'>
+    <h2 class='fl' id='<%- section.namespace.toLowerCase() %>'>
       <%- section.name %>
     </h2>
     <% if (section.context && section.context.github) { %>

--- a/docs/_theme/section_list.hbs
+++ b/docs/_theme/section_list.hbs
@@ -1,7 +1,7 @@
 <div class="clearfix">
   <% members.forEach(function(member) { %>
-    <div class='keyline-bottom' id='<%- member.namespace %>'>
-      <div class="clearfix small pointer toggle-sibling" data-href="#<%=member.namespace%>">
+    <div class='keyline-bottom' id='<%- member.namespace.toLowerCase() %>'>
+      <div class="clearfix small pointer toggle-sibling" data-href="#<%= member.namespace.toLowerCase() %>">
         <div class="pad1y contain">
             <a class='rcon pin-right pad1y dark-link caret-right'></a>
             <span class='code strong strong truncate'><%= member.name%></span>


### PR DESCRIPTION
This PR fixes #3680 by lowercasing all anchors in the API docs. 

We may choose to revert this change once https://github.com/documentationjs/documentation/pull/537 lands upstream.


