### PR TITLE
Always use highp for color attributes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   environment:
     XCODE_SCHEME: "no"
     XCODE_WORKSPACE: "no"
-    NODE_VERSION: 6
+    NODE_VERSION: 6.10.0
 
 dependencies:
   cache_directories:

--- a/src/shaders/README.md
+++ b/src/shaders/README.md
@@ -13,10 +13,10 @@ Some variables change type depending on their context:
 We abstract over this functionality using pragmas.
 
 ```glsl
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 
 main() {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     ...
     gl_FragColor = color;
 }

--- a/src/shaders/circle.fragment.glsl
+++ b/src/shaders/circle.fragment.glsl
@@ -1,8 +1,8 @@
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 #pragma mapbox: define mediump float radius
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
-#pragma mapbox: define lowp vec4 stroke_color
+#pragma mapbox: define highp vec4 stroke_color
 #pragma mapbox: define mediump float stroke_width
 #pragma mapbox: define lowp float stroke_opacity
 
@@ -10,11 +10,11 @@ varying vec2 v_extrude;
 varying lowp float v_antialiasblur;
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize mediump float radius
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
-    #pragma mapbox: initialize lowp vec4 stroke_color
+    #pragma mapbox: initialize highp vec4 stroke_color
     #pragma mapbox: initialize mediump float stroke_width
     #pragma mapbox: initialize lowp float stroke_opacity
 

--- a/src/shaders/circle.vertex.glsl
+++ b/src/shaders/circle.vertex.glsl
@@ -4,11 +4,11 @@ uniform vec2 u_extrude_scale;
 
 attribute vec2 a_pos;
 
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 #pragma mapbox: define mediump float radius
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
-#pragma mapbox: define lowp vec4 stroke_color
+#pragma mapbox: define highp vec4 stroke_color
 #pragma mapbox: define mediump float stroke_width
 #pragma mapbox: define lowp float stroke_opacity
 
@@ -16,11 +16,11 @@ varying vec2 v_extrude;
 varying lowp float v_antialiasblur;
 
 void main(void) {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize mediump float radius
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
-    #pragma mapbox: initialize lowp vec4 stroke_color
+    #pragma mapbox: initialize highp vec4 stroke_color
     #pragma mapbox: initialize mediump float stroke_width
     #pragma mapbox: initialize lowp float stroke_opacity
 

--- a/src/shaders/debug.fragment.glsl
+++ b/src/shaders/debug.fragment.glsl
@@ -1,4 +1,4 @@
-uniform lowp vec4 u_color;
+uniform highp vec4 u_color;
 
 void main() {
     gl_FragColor = u_color;

--- a/src/shaders/fill.fragment.glsl
+++ b/src/shaders/fill.fragment.glsl
@@ -1,8 +1,8 @@
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float opacity
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float opacity
 
     gl_FragColor = color * opacity;

--- a/src/shaders/fill.vertex.glsl
+++ b/src/shaders/fill.vertex.glsl
@@ -2,11 +2,11 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float opacity
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float opacity
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -1,12 +1,12 @@
 varying vec4 v_color;
 #pragma mapbox: define lowp float base
 #pragma mapbox: define lowp float height
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 
 void main() {
     #pragma mapbox: initialize lowp float base
     #pragma mapbox: initialize lowp float height
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
 
     gl_FragColor = v_color;
 

--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -12,12 +12,12 @@ varying vec4 v_color;
 #pragma mapbox: define lowp float base
 #pragma mapbox: define lowp float height
 
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 
 void main() {
     #pragma mapbox: initialize lowp float base
     #pragma mapbox: initialize lowp float height
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
 
     float ed = a_edgedistance; // use each attrib in order to not trip a VAO assert
     float t = mod(a_normal.x, 2.0);

--- a/src/shaders/fill_outline.fragment.glsl
+++ b/src/shaders/fill_outline.fragment.glsl
@@ -1,10 +1,10 @@
-#pragma mapbox: define lowp vec4 outline_color
+#pragma mapbox: define highp vec4 outline_color
 #pragma mapbox: define lowp float opacity
 
 varying vec2 v_pos;
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 outline_color
+    #pragma mapbox: initialize highp vec4 outline_color
     #pragma mapbox: initialize lowp float opacity
 
     float dist = length(v_pos - gl_FragCoord.xy);

--- a/src/shaders/fill_outline.vertex.glsl
+++ b/src/shaders/fill_outline.vertex.glsl
@@ -5,11 +5,11 @@ uniform vec2 u_world;
 
 varying vec2 v_pos;
 
-#pragma mapbox: define lowp vec4 outline_color
+#pragma mapbox: define highp vec4 outline_color
 #pragma mapbox: define lowp float opacity
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 outline_color
+    #pragma mapbox: initialize highp vec4 outline_color
     #pragma mapbox: initialize lowp float opacity
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -1,4 +1,4 @@
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
 
@@ -7,7 +7,7 @@ varying vec2 v_normal;
 varying float v_gamma_scale;
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
 

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -24,14 +24,14 @@ varying vec2 v_normal;
 varying vec2 v_width2;
 varying float v_gamma_scale;
 
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
 #pragma mapbox: define mediump float gapwidth
 #pragma mapbox: define lowp float offset
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
     #pragma mapbox: initialize mediump float gapwidth

--- a/src/shaders/line_sdf.fragment.glsl
+++ b/src/shaders/line_sdf.fragment.glsl
@@ -9,12 +9,12 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
 

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -32,14 +32,14 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
 #pragma mapbox: define mediump float gapwidth
 #pragma mapbox: define lowp float offset
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
     #pragma mapbox: initialize mediump float gapwidth

--- a/src/shaders/symbol_sdf.fragment.glsl
+++ b/src/shaders/symbol_sdf.fragment.glsl
@@ -2,8 +2,8 @@
 #define EDGE_GAMMA 0.105/DEVICE_PIXEL_RATIO
 
 uniform bool u_is_halo;
-#pragma mapbox: define lowp vec4 fill_color
-#pragma mapbox: define lowp vec4 halo_color
+#pragma mapbox: define highp vec4 fill_color
+#pragma mapbox: define highp vec4 halo_color
 #pragma mapbox: define lowp float opacity
 #pragma mapbox: define lowp float halo_width
 #pragma mapbox: define lowp float halo_blur
@@ -18,8 +18,8 @@ varying vec2 v_fade_tex;
 varying float v_gamma_scale;
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 fill_color
-    #pragma mapbox: initialize lowp vec4 halo_color
+    #pragma mapbox: initialize highp vec4 fill_color
+    #pragma mapbox: initialize highp vec4 halo_color
     #pragma mapbox: initialize lowp float opacity
     #pragma mapbox: initialize lowp float halo_width
     #pragma mapbox: initialize lowp float halo_blur

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -4,8 +4,8 @@ attribute vec4 a_pos_offset;
 attribute vec2 a_texture_pos;
 attribute vec4 a_data;
 
-#pragma mapbox: define lowp vec4 fill_color
-#pragma mapbox: define lowp vec4 halo_color
+#pragma mapbox: define highp vec4 fill_color
+#pragma mapbox: define highp vec4 halo_color
 #pragma mapbox: define lowp float opacity
 #pragma mapbox: define lowp float halo_width
 #pragma mapbox: define lowp float halo_blur
@@ -28,8 +28,8 @@ varying vec2 v_fade_tex;
 varying float v_gamma_scale;
 
 void main() {
-    #pragma mapbox: initialize lowp vec4 fill_color
-    #pragma mapbox: initialize lowp vec4 halo_color
+    #pragma mapbox: initialize highp vec4 fill_color
+    #pragma mapbox: initialize highp vec4 halo_color
     #pragma mapbox: initialize lowp float opacity
     #pragma mapbox: initialize lowp float halo_width
     #pragma mapbox: initialize lowp float halo_blur


### PR DESCRIPTION
Use `highp` for all color attributes, because as of https://github.com/mapbox/mapbox-gl-native/pull/8267 two color components may be packed into a single float, a process which assumes that at least 16 bits are available.

Refs https://github.com/mapbox/mapbox-gl-native/issues/8385

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page

benchmark | master 9941dde
--- | ---
**map-load** | 140 ms 
**style-load** | 115 ms 
**buffer** | 1,061 ms 
**fps** | 60 fps 
**frame-duration** | 5.2 ms, 0% > 16ms 
**query-point** | 1.21 ms 
**query-box** | 65.76 ms 
**geojson-setdata-small** | 6 ms 
**geojson-setdata-large** | 199 ms 
