### PR TITLE
Fix tests on node 6.10.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   environment:
     XCODE_SCHEME: "no"
     XCODE_WORKSPACE: "no"
-    NODE_VERSION: 6.10.0
+    NODE_VERSION: 6.10.1
 
 dependencies:
   cache_directories:

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -6,18 +6,20 @@ const sinon = require('sinon');
 const util = require('./util');
 
 function restore() {
-
     // Remove previous window from module.exports
     const previousWindow = module.exports;
     if (previousWindow.close) previousWindow.close();
-    for (const key in previousWindow) if (previousWindow.hasOwnProperty(key)) delete previousWindow[key];
+    for (const key in previousWindow) {
+        if (previousWindow.hasOwnProperty(key)) {
+            delete previousWindow[key];
+        }
+    }
 
     // Create new window and inject into module.exports
     const window = jsdom.jsdom(undefined, {
         // Send jsdom console output to the node console object.
         virtualConsole: jsdom.createVirtualConsole().sendTo(console)
     }).defaultView;
-    util.extend(module.exports, window);
 
     window.devicePixelRatio = 1;
 
@@ -40,13 +42,13 @@ function restore() {
     };
 
     window.useFakeHTMLCanvasGetContext = function() {
-        window.HTMLCanvasElement.prototype.getContext = sinon.stub().returns('2d');
+        this.HTMLCanvasElement.prototype.getContext = sinon.stub().returns('2d');
     };
 
     window.useFakeXMLHttpRequest = function() {
         sinon.xhr.supportsCORS = true;
-        window.server = sinon.fakeServer.create();
-        window.XMLHttpRequest = window.server.xhr;
+        this.server = sinon.fakeServer.create();
+        this.XMLHttpRequest = this.server.xhr;
     };
 
     window.URL.revokeObjectURL = function () {};
@@ -54,6 +56,8 @@ function restore() {
     window.restore = restore;
 
     window.ImageData = window.ImageData || sinon.stub().returns(false);
+
+    util.extend(module.exports, window);
 
     return window;
 }


### PR DESCRIPTION
Fixes #4471.

Updating the version in circle.yml, but keeping it pinned so that we don't suddenly start getting broken builds next time this happens. (It's like the equivalent of yarn.lock for the node version.)