### PR TITLE
Validate duplicate stops in stylesheets.

### DIFF
--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -78,8 +78,22 @@ module.exports = function validateFunction(options) {
             arrayElementValidator: validateFunctionStop
         }));
 
-        if (getType(value) === 'array' && value.length === 0) {
-            errors.push(new ValidationError(options.key, value, 'array must have at least one stop'));
+        if (getType(value) === 'array') {
+            if (value.length === 0) {
+                errors.push(new ValidationError(options.key, value, 'array must have at least one stop'));
+            } else {
+                const seenStops = Object.create(null);
+                value.every(stop => {
+                    if (getType(stop) !== 'array' || getType(stop[0]) !== 'number') {
+                        return false;
+                    }
+                    if (seenStops[stop[0]]) {
+                        errors.push(new ValidationError(options.key, value, 'stops must not have duplicate pairs.'));
+                    }
+                    seenStops[stop[0]] = stop[1];
+                    return true;
+                });
+            }
         }
 
         return errors;

--- a/test/unit/style-spec/fixture/functions.input.json
+++ b/test/unit/style-spec/fixture/functions.input.json
@@ -839,6 +839,20 @@
           "default": "invalid"
         }
       }
+    },
+    {
+      "id": "invalid duplicate stop pairs",
+      "type": "symbol",
+      "source": "source",
+      "source-layer": "layer",
+      "layout": {
+        "text-size": {
+          "stops": [
+            [0, 1],
+            [0, 1]
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/unit/style-spec/fixture/functions.output.json
+++ b/test/unit/style-spec/fixture/functions.output.json
@@ -157,5 +157,9 @@
   {
     "message": "layers[43].paint.fill-color.default: color expected, \"invalid\" found",
     "line": 839
+  },
+  {
+    "message": "layers[44].layout.text-size.stops: stops must not have duplicate pairs.",
+    "line": 850
   }
 ]


### PR DESCRIPTION
Otherwise, duplicate pairs for a stop in a  style can cause [binarySearchForIndex()](https://github.com/mapbox/mapbox-gl-js/blob/b9e10b939c6a3fe5d7ecac209f751b4871970ede/src/style-spec/function/index.js#L211) to enter an infinite loop. This didn't immediately cause issues because of an earlier bug in [mapbox-gl-function](https://github.com/mapbox/mapbox-gl-function/commit/4f829622413f336080d3c710244c251421c0ec30) that was introduced between 0.32.1 and 0.33 as part of [this rebase with the mapbox-gl-function library](https://github.com/mapbox/mapbox-gl-js/commit/d92eb6eb397b9f05ddfb5ab52b1704cace14cc36#diff-b9cfc7f2cdf78a7f4b91a753d10865a2).