### PR TITLE
Prevent infinite loop in binarySearchForIndex when duplicate stops are present

### DIFF
--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -212,7 +212,7 @@ function binarySearchForIndex(stops, input) {
         currentIndex = Math.floor((lowerIndex + upperIndex) / 2);
         currentValue = stops[currentIndex][0];
         upperValue = stops[currentIndex + 1][0];
-        if (input >= currentValue && input < upperValue) { // Search complete
+        if (input === currentValue || input > currentValue && input < upperValue) { // Search complete
             return currentIndex;
         } else if (currentValue < input) {
             lowerIndex = currentIndex + 1;

--- a/test/unit/style-spec/function.test.js
+++ b/test/unit/style-spec/function.test.js
@@ -47,6 +47,23 @@ test('constant function', (t) => {
     t.end();
 });
 
+test('binary search', (t) => {
+    t.test('will eventually terminate.', (t) => {
+        const f = createFunction({
+            stops: [[9, 10], [17, 11], [17, 11], [18, 13]],
+            base: 2
+        }, {
+            type: 'number',
+            function: 'interpolated'
+        });
+        // Nan because the interpolation will fail when given to stops with the same value.
+        // This is however more desirable than looping forever.
+        t.equal(isNaN(f(17)), true);
+        t.end();
+    });
+    t.end();
+});
+
 test('exponential function', (t) => {
     t.test('is the default for interpolated properties', (t) => {
         const f = createFunction({


### PR DESCRIPTION
Between 0.32.1 and 0.33.0 the `binarySearchForIndex` function [fixed a bug](https://github.com/mapbox/mapbox-gl-function/pull/35) where the index wasn't properly being set. However, when a style has multiple of the same stops, for example: `[[9, 10], [17, 11], [17, 11], [18, 13]]`, the `binarySearchForIndex` function will loop forever eating resources and will prevent  `map.loaded()` from ever returning `true`.
