### PR TITLE
Ensure generated composite function stops are in the correct order

### DIFF
--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -98,21 +98,24 @@ function createFunction(parameters, propertySpec) {
 
         if (zoomAndFeatureDependent) {
             const featureFunctions = {};
-            const featureFunctionStops = [];
+            const zoomStops = [];
             for (let s = 0; s < parameters.stops.length; s++) {
                 const stop = parameters.stops[s];
-                if (featureFunctions[stop[0].zoom] === undefined) {
-                    featureFunctions[stop[0].zoom] = {
-                        zoom: stop[0].zoom,
+                const zoom = stop[0].zoom;
+                if (featureFunctions[zoom] === undefined) {
+                    featureFunctions[zoom] = {
+                        zoom: zoom,
                         type: parameters.type,
                         property: parameters.property,
                         stops: []
                     };
+                    zoomStops.push(zoom);
                 }
-                featureFunctions[stop[0].zoom].stops.push([stop[0].value, stop[1]]);
+                featureFunctions[zoom].stops.push([stop[0].value, stop[1]]);
             }
 
-            for (const z in featureFunctions) {
+            const featureFunctionStops = [];
+            for (const z of zoomStops) {
                 featureFunctionStops.push([featureFunctions[z].zoom, createFunction(featureFunctions[z], propertySpec)]);
             }
             fun = function(zoom, feature) {

--- a/test/unit/style-spec/function.test.js
+++ b/test/unit/style-spec/function.test.js
@@ -455,6 +455,30 @@ test('exponential function', (t) => {
         t.end();
     });
 
+    test('zoom-and-property function, four stops, integer and fractional zooms', (t) => {
+        const f = createFunction({
+            type: 'exponential',
+            property: 'prop',
+            base: 1,
+            stops: [
+                [{ zoom: 1, value: 0 }, 0],
+                [{ zoom: 1.5, value: 0 }, 1],
+                [{ zoom: 2, value: 0 }, 10],
+                [{ zoom: 2.5, value: 0 }, 20]
+            ]
+        }, {
+            type: 'number'
+        });
+
+        t.equal(f(1, { prop: 0 }), 0);
+        t.equal(f(1.5, { prop: 0 }), 1);
+        t.equal(f(2, { prop: 0 }), 10);
+        t.equal(f(2.5, { prop: 0 }), 20);
+
+        t.end();
+    });
+
+
     t.test('zoom-and-property function, no default', (t) => {
         // This can happen for fill-outline-color, where the spec has no default.
 


### PR DESCRIPTION
This fixes a bug in the generated stops used by the implementation of composite
functions, wherein zoom stops were sorted lexicographically rather than
numerically.