### PR TITLE
Return an empty array from queryRenderedFeatures when no style is loaded

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -601,6 +601,10 @@ class Map extends Camera {
             params = arguments[0];
         }
 
+        if (!this.style) {
+            return [];
+        }
+
         return this.style.queryRenderedFeatures(
             this._makeQueryGeometry(geometry),
             params,

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -872,6 +872,12 @@ test('Map', (t) => {
             });
         });
 
+        t.test('returns an empty array when no style is loaded', (t) => {
+            const map = createMap({style: undefined});
+            t.deepEqual(map.queryRenderedFeatures(), []);
+            t.end();
+        });
+
         t.end();
     });
 


### PR DESCRIPTION
Fix an edge case found while writing tests for #4329.