### PR TITLE
Clamp negative heights to zero in extrusion shaders

### DIFF
--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -19,6 +19,9 @@ void main() {
     #pragma mapbox: initialize lowp float height
     #pragma mapbox: initialize highp vec4 color
 
+    base = max(0.0, base);
+    height = max(0.0, height);
+
     float ed = a_edgedistance; // use each attrib in order to not trip a VAO assert
     float t = mod(a_normal.x, 2.0);
 

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -28,6 +28,9 @@ void main() {
     #pragma mapbox: initialize lowp float base
     #pragma mapbox: initialize lowp float height
 
+    base = max(0.0, base);
+    height = max(0.0, height);
+
     float t = mod(a_normal.x, 2.0);
     float z = t > 0.0 ? height : base;
 


### PR DESCRIPTION
These changes clamp negative height and base values to zero; part of https://github.com/mapbox/mapbox-gl-native/pull/8431.