### PR TITLE
fix boxZoom bug

### DIFF
--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -52,7 +52,14 @@ class BoxZoomHandler {
      */
     enable() {
         if (this.isEnabled()) return;
+
+        // the event listeners for the DragPanHandler have to fire _after_ the event listener for BoxZoomHandler in order,
+        // for the DragPanHandler's check on map.boxZoom.isActive() to tell whether or not to ignore a keydown event
+        // so this makes sure the firing order is preserved if the BoxZoomHandler is enabled after the DragPanHandler.
+        if (this._map.dragPan) this._map.dragPan.disable();
         this._el.addEventListener('mousedown', this._onMouseDown, false);
+        if (this._map.dragPan) this._map.dragPan.enable();
+
         this._enabled = true;
     }
 

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -190,6 +190,10 @@ class DragPanHandler {
     _ignoreEvent(e) {
         const map = this._map;
 
+        // if boxZoom is disabled and then re-enabled, the drag_pan event listener for mousedown will fire before
+        // the boxZoom event listener, so map.boxZoom.isActive() will return false resulting in an erroneous
+        // drag on mousemove once the boxZoom is released, so we need this additional check.
+        if (map.boxZoom && e.shiftKey && e.button === 0) return true;
         if (map.boxZoom && map.boxZoom.isActive()) return true;
         if (map.dragRotate && map.dragRotate.isActive()) return true;
         if (e.touches) {

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -190,10 +190,6 @@ class DragPanHandler {
     _ignoreEvent(e) {
         const map = this._map;
 
-        // if boxZoom is disabled and then re-enabled, the drag_pan event listener for mousedown will fire before
-        // the boxZoom event listener, so map.boxZoom.isActive() will return false resulting in an erroneous
-        // drag on mousemove once the boxZoom is released, so we need this additional check.
-        if (map.boxZoom && e.shiftKey && e.button === 0) return true;
         if (map.boxZoom && map.boxZoom.isActive()) return true;
         if (map.dragRotate && map.dragRotate.isActive()) return true;
         if (e.touches) {


### PR DESCRIPTION
fix #2237 where disabling then re-enabling the boxZoomHandler would result in a bug where the drag handler would be erroneously active after a boxZoom triggered `mouseup` event

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
