### PR TITLE
Android SDK v5.0.0, iOS SDK v3.5.0, macOS SDK v0.4.0

### DIFF
--- a/docs/style-spec/_generate/index.html
+++ b/docs/style-spec/_generate/index.html
@@ -889,50 +889,50 @@ navigation:
             <tr>
               <td><code>property</code></td>
               <td class='center'>&gt;= 0.18.0</td>
-              <td class='center'>Not yet supported</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 5.0.0</td>
+              <td class='center'>&gt;= 3.5.0</td>
               <td class='center'>Not yet supported</td>
             </tr>
             <tr>
               <td><code>type</code></td>
               <td class='center'>&gt;= 0.18.0</td>
-              <td class='center'>Not yet supported</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 5.0.0</td>
+              <td class='center'>&gt;= 3.5.0</td>
               <td class='center'>Not yet supported</td>
             </tr>
             <tr>
               <td><code>exponential</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
-              <td class='center'>Not yet supported</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 5.0.0</td>
+              <td class='center'>&gt;= 3.5.0</td>
               <td class='center'>Not yet supported</td>
             </tr>
             <tr>
               <td><code>interval</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
-              <td class='center'>Not yet supported</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 5.0.0</td>
+              <td class='center'>&gt;= 3.5.0</td>
               <td class='center'>Not yet supported</td>
             </tr>
             <tr>
               <td><code>categorical</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
-              <td class='center'>Not yet supported</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 5.0.0</td>
+              <td class='center'>&gt;= 3.5.0</td>
               <td class='center'>Not yet supported</td>
             </tr>
             <tr>
               <td><code>identity</code> type</td>
               <td class='center'>&gt;= 0.26.0</td>
-              <td class='center'>Not yet supported</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 5.0.0</td>
+              <td class='center'>&gt;= 3.5.0</td>
               <td class='center'>Not yet supported</td>
             </tr>
             <tr>
               <td><code>default</code></td>
               <td class='center'>&gt;= 0.33.0</td>
-              <td class='center'>Not yet supported</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 5.0.0</td>
+              <td class='center'>&gt;= 3.5.0</td>
               <td class='center'>Not yet supported</td>
             </tr>
             <tr>

--- a/docs/style-spec/_generate/index.html
+++ b/docs/style-spec/_generate/index.html
@@ -891,49 +891,49 @@ navigation:
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>type</code></td>
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>exponential</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>interval</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>categorical</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>identity</code> type</td>
               <td class='center'>&gt;= 0.26.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>default</code></td>
               <td class='center'>&gt;= 0.33.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>colorSpace</code></td>

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -934,7 +934,8 @@
         "data-driven styling": {
           "js": "0.21.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1009,7 +1010,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1103,7 +1105,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1411,7 +1414,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1797,7 +1801,8 @@
         "data-driven styling": {
           "js": "0.21.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1824,7 +1829,8 @@
         "data-driven styling": {
           "js": "0.19.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1853,7 +1859,8 @@
         "data-driven styling": {
           "js": "0.19.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2085,7 +2092,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2112,7 +2120,8 @@
         "data-driven styling": {
           "js": "0.23.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2205,7 +2214,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2228,7 +2238,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2252,7 +2263,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2318,7 +2330,8 @@
         "data-driven styling": {
           "js": "0.18.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2340,7 +2353,8 @@
         "data-driven styling": {
           "js": "0.18.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2362,7 +2376,8 @@
         "data-driven styling": {
           "js": "0.20.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2386,7 +2401,8 @@
         "data-driven styling": {
           "js": "0.20.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2475,12 +2491,14 @@
         "basic functionality": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         },
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2496,12 +2514,14 @@
         "basic functionality": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         },
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2519,12 +2539,14 @@
         "basic functionality": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         },
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     }
@@ -2553,7 +2575,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2578,7 +2601,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2603,7 +2627,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2630,7 +2655,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2657,7 +2683,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2738,7 +2765,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2763,7 +2791,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2788,7 +2817,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2815,7 +2845,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2842,7 +2873,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -932,7 +932,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.21.0"
+          "js": "0.21.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -1005,7 +1007,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -1097,7 +1101,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -1403,7 +1409,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -1787,7 +1795,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.21.0"
+          "js": "0.21.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -1812,7 +1822,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.19.0"
+          "js": "0.19.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -1839,7 +1851,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.19.0"
+          "js": "0.19.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2069,7 +2083,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2094,7 +2110,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.23.0"
+          "js": "0.23.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2185,7 +2203,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2206,7 +2226,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2228,7 +2250,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2292,7 +2316,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.18.0"
+          "js": "0.18.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2312,7 +2338,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.18.0"
+          "js": "0.18.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2332,7 +2360,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.20.0"
+          "js": "0.20.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2354,7 +2384,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.20.0"
+          "js": "0.20.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2441,10 +2473,14 @@
       "doc": "The width of the circle's stroke. Strokes are placed outside of the `circle-radius`.",
       "sdk-support": {
         "basic functionality": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         },
         "data-driven styling": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2458,10 +2494,14 @@
       "transition": true,
       "sdk-support": {
         "basic functionality": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         },
         "data-driven styling": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2477,10 +2517,14 @@
       "transition": true,
       "sdk-support": {
         "basic functionality": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         },
         "data-driven styling": {
-          "js": "0.29.0"
+          "js": "0.29.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     }
@@ -2507,7 +2551,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2530,7 +2576,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2553,7 +2601,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2578,7 +2628,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2603,7 +2655,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2682,7 +2736,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2705,7 +2761,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2728,7 +2786,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2753,7 +2813,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },
@@ -2778,7 +2840,9 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.33.0"
+          "js": "0.33.0",
+          "android": "5.0.0",
+          "ios": "3.5.0"
         }
       }
     },


### PR DESCRIPTION
This PR updates the style specification JSON and documentation to reflect the fact that the native SDKs now support data-driven styling as of Android SDK v5.0.0, iOS SDK v3.5.0, and macOS SDK v0.4.0.

The Android SDK v5.0.0 and iOS SDK v3.5.0 changes were previously pushed to the mb-pages branch in #4469. I’ve cherry-picked that change here so that the copy of v8.json in master can remain the single source of truth. This is important because the [mapbox-gl-style-spec](https://www.npmjs.com/package/mapbox-gl-style-spec) package would be obtained from master, not mb-pages. Going forward, changes to the SDK support tables regarding the native SDKs should be merged to master first, then cherry-picked to mb-pages (so that the updates don’t have to wait until to the next GL JS release).

/cc @mapbox/android @mapbox/ios