### PR TITLE
Respect img height/width in addImage api

### DIFF
--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -69,7 +69,7 @@ exports.getImageData = function (img) {
     const context = canvas.getContext('2d');
     canvas.width = img.width;
     canvas.height = img.height;
-    context.drawImage(img, 0, 0);
+    context.drawImage(img, 0, 0, img.width, img.height);
     return context.getImageData(0, 0, img.width, img.height).data;
 };
 


### PR DESCRIPTION
When the user passes an `img` tag with a height and width that differ from the native height and width of the source image, mapbox should respect the user's choice and draw the scaled image. Currently mapbox draws image at its native size and then clips it to fit the specified height/width, which is unintuitive.

Example:

I use `addImage` to add this image tag. It's a 64x64 png natively, but I want to pretend it's 32x32.

![screen shot 2017-04-02 at 4 08 01 pm](https://cloud.githubusercontent.com/assets/37327/24591804/9d3933dc-17be-11e7-852e-ee79130ce2e6.png)

When mapbox draws it, I see:

![screen shot 2017-04-02 at 4 09 00 pm](https://cloud.githubusercontent.com/assets/37327/24591805/b170e8d6-17be-11e7-928c-fc2ec1448eb9.png)



