### PR TITLE
Return from keyboard handler on non-action key.

### DIFF
--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -119,6 +119,9 @@ class KeyboardHandler {
                 e.preventDefault();
             }
             break;
+
+        default:
+            return;
         }
 
         const map = this._map;


### PR DESCRIPTION
Added a return statement to the keyboard handler when a non-action key is pressed. In certain environments, holding down the shift key was triggering numerous calls to the easeTo method which was interfering with the easeTo call in the shift zoom. This fixes issue #3334.
