### PR TITLE
Update sdk-support tables for macOS SDK v0.4.0

### DIFF
--- a/docs/style-spec/_generate/index.html
+++ b/docs/style-spec/_generate/index.html
@@ -891,49 +891,49 @@ navigation:
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>type</code></td>
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>exponential</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>interval</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>categorical</code> type</td>
               <td class='center'>&gt;= 0.18.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>identity</code> type</td>
               <td class='center'>&gt;= 0.26.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>default</code></td>
               <td class='center'>&gt;= 0.33.0</td>
               <td class='center'>&gt;= 5.0.0</td>
               <td class='center'>&gt;= 3.5.0</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 0.4.0</td>
             </tr>
             <tr>
               <td><code>colorSpace</code></td>

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -931,7 +931,8 @@
         "data-driven styling": {
           "js": "0.21.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1006,7 +1007,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1100,7 +1102,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1405,7 +1408,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1788,7 +1792,8 @@
         "data-driven styling": {
           "js": "0.21.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1815,7 +1820,8 @@
         "data-driven styling": {
           "js": "0.19.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -1844,7 +1850,8 @@
         "data-driven styling": {
           "js": "0.19.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2076,7 +2083,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2103,7 +2111,8 @@
         "data-driven styling": {
           "js": "0.23.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2196,7 +2205,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2219,7 +2229,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2243,7 +2254,8 @@
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2309,7 +2321,8 @@
         "data-driven styling": {
           "js": "0.18.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2331,7 +2344,8 @@
         "data-driven styling": {
           "js": "0.18.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2353,7 +2367,8 @@
         "data-driven styling": {
           "js": "0.20.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2377,7 +2392,8 @@
         "data-driven styling": {
           "js": "0.20.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2466,12 +2482,14 @@
         "basic functionality": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         },
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2487,12 +2505,14 @@
         "basic functionality": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         },
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2510,12 +2530,14 @@
         "basic functionality": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         },
         "data-driven styling": {
           "js": "0.29.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     }
@@ -2544,7 +2566,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2569,7 +2592,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2594,7 +2618,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2621,7 +2646,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2648,7 +2674,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2729,7 +2756,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2754,7 +2782,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2779,7 +2808,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2806,7 +2836,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },
@@ -2833,7 +2864,8 @@
         "data-driven styling": {
           "js": "0.33.0",
           "android": "5.0.0",
-          "ios": "3.5.0"
+          "ios": "3.5.0",
+          "macos": "0.4.0"
         }
       }
     },


### PR DESCRIPTION
Cherry-picked 879929a2e590bd476dd15b51a449d3726e59176a from #4530.