### PR TITLE
adds section for search meta tag

### DIFF
--- a/docs/_layouts/pages.html
+++ b/docs/_layouts/pages.html
@@ -3,6 +3,7 @@ layout: wrapper
 hasdocnav: true
 class: fill-light
 options: full
+section: Mapbox GL JS
 examples:
   - name: Styles
     id: styles


### PR DESCRIPTION
Adds “section” to the pages layout so that Swiftype/search will properly tag all pages on this site as “Mapbox GL JS” - important for Mapbox site-wide search

cc @geografa 