### PR TITLE
Enable render test for native in mapbox-gl-js#4510

### DIFF
--- a/test/integration/render-tests/regressions/mapbox-gl-js#4150/style.json
+++ b/test/integration/render-tests/regressions/mapbox-gl-js#4150/style.json
@@ -4,9 +4,7 @@
     "test": {
       "width": 64,
       "height": 64,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/8075"
-      }
+      "ignored": {}
     }
   },
   "sources": {


### PR DESCRIPTION
Enables tests for https://github.com/mapbox/mapbox-gl-native/pull/8602
