### PR TITLE
Fix easeTo interpolation on pitched maps

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -515,8 +515,7 @@ class Camera extends Evented {
         const screenPoint = tr.centerPoint.add(offset);
 
         const from = tr.project(tr.pointLocation(screenPoint));
-        const to = tr.project(center);
-        const delta = to.sub(from);
+        const delta = tr.project(center).sub(from);
         const finalScale = tr.zoomScale(zoom - startZoom);
 
         let around, aroundPoint;
@@ -549,10 +548,11 @@ class Camera extends Evented {
                 tr.setLocationAtPoint(around, aroundPoint);
             } else {
                 const scale = tr.zoomScale(tr.zoom - startZoom);
-                const k2 = k * (
-                    zoom > startZoom ? Math.pow(2, 1 - k) :
-                    zoom < startZoom ? Math.pow(2, k - 1) : 1);
-                const newCenter = tr.unproject(from.add(to.sub(from).mult(k2)).mult(scale));
+                const base = zoom > startZoom ?
+                    Math.min(2, finalScale) :
+                    Math.max(0.5, finalScale);
+                const speedup = Math.pow(base, 1 - k);
+                const newCenter = tr.unproject(from.add(delta.mult(k * speedup)).mult(scale));
                 tr.setLocationAtPoint(tr.renderWorldCopies ? newCenter.wrap() : newCenter, screenPoint);
             }
 

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -549,7 +549,9 @@ class Camera extends Evented {
                 tr.setLocationAtPoint(around, aroundPoint);
             } else {
                 const scale = tr.zoomScale(tr.zoom - startZoom);
-                const k2 = k * Math.pow(2, 1 - k);
+                const k2 = k * (
+                    zoom > startZoom ? Math.pow(2, 1 - k) :
+                    zoom < startZoom ? Math.pow(2, k) : 1);
                 const newCenter = tr.unproject(from.add(to.sub(from).mult(k2)).mult(scale));
                 tr.setLocationAtPoint(tr.renderWorldCopies ? newCenter.wrap() : newCenter, screenPoint);
             }

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -551,7 +551,7 @@ class Camera extends Evented {
                 const scale = tr.zoomScale(tr.zoom - startZoom);
                 const k2 = k * (
                     zoom > startZoom ? Math.pow(2, 1 - k) :
-                    zoom < startZoom ? Math.pow(2, k) : 1);
+                    zoom < startZoom ? Math.pow(2, k - 1) : 1);
                 const newCenter = tr.unproject(from.add(to.sub(from).mult(k2)).mult(scale));
                 tr.setLocationAtPoint(tr.renderWorldCopies ? newCenter.wrap() : newCenter, screenPoint);
             }

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1053,7 +1053,7 @@ test('camera', (t) => {
             let crossedAntimeridian;
 
             camera.on('move', () => {
-                if (camera.getCenter().lng < -170) {
+                if (fixedLngLat(camera.getCenter(), 10).lng < -170) {
                     crossedAntimeridian = true;
                 }
             });


### PR DESCRIPTION
A PR in place of #4320. Should close #4178 and #3112.

Changes `easeTo` implementation to have more robust interpolation, fixing weird behavior on pitched maps, making it more consistent with `flyTo`, and makes the definition of `offset` less ambiguous.

Haven't updated expected values in the camera tests, but otherwise this is ready for review.

cc @joswinter

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
