### PR TITLE
Enable ESLint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 test/integration/**/index.html
 test/integration/**/actual.png
 test/integration/**/diff.png
+.eslintcache

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
   cache_directories:
     - './nvm'
     - '~/.yarn'
+    - '.eslintcache'
   override:
     - ./ci-scripts/dependencies.sh
 test:

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "build-docs": "flow-node docs/style-spec/_generate/generate.js && documentation build --github --format html --config ./docs/documentation.yml --theme ./docs/_theme --output docs/api/ src/index.js",
     "build": "npm run build-docs # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "npm run build-min && npm run build-docs && jekyll serve --watch",
-    "lint": "eslint --ignore-path .gitignore src test bench docs/_posts/examples/*.html debug/*.html",
+    "lint": "eslint --cache --ignore-path .gitignore src test bench docs/_posts/examples/*.html debug/*.html",
     "lint-docs": "documentation lint src/index.js",
     "open-changed-examples": "git diff --name-only mb-pages HEAD -- docs/_posts/examples/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "test": "run-s lint test-unit test-flow",


### PR DESCRIPTION
On my machine, this reduces `npm run lint` time from 20s to 3s for incremental runs. I'm using the command often, and this makes it much easier. May also reduce Circle builds by 10-15s.