### PR TITLE
Fix expired tiles refreshing

### DIFF
--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -74,7 +74,7 @@ class RasterTileSource extends Evented {
                 return callback(err);
             }
 
-            if (!this.map._refreshExpiredTiles) tile.setExpiryData(img);
+            if (this.map._refreshExpiredTiles) tile.setExpiryData(img);
             delete img.cacheControl;
             delete img.expires;
 

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -90,7 +90,7 @@ class VectorTileSource extends Evented {
                 return callback(err);
             }
 
-            if (!this.map._refreshExpiredTiles) tile.setExpiryData(data);
+            if (this.map._refreshExpiredTiles) tile.setExpiryData(data);
             tile.loadVectorData(data, this.map.painter);
 
             if (tile.redoWhenDone) {


### PR DESCRIPTION
Hello.
There is true and false mixed up.
When I initialized my map with 'refreshExpiredTiles: false', it started to refresh.
