### PR TITLE
Reduce number of varyings for line_sdf shader

### DIFF
--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -68,7 +68,9 @@ class ProgramConfiguration {
         const pragmas = this.getPragmas(name);
 
         pragmas.define.push(`uniform {precision} {type} ${inputName};`);
+        pragmas.define_in.push(`uniform {precision} {type} ${inputName};`);
         pragmas.initialize.push(`{precision} {type} ${name} = ${inputName};`);
+        pragmas.initialize_in.push(`{precision} {type} ${name} = ${inputName};`);
 
         this.cacheKey += `/u_${name}`;
     }
@@ -86,7 +88,9 @@ class ProgramConfiguration {
         pragmas.define.push(`varying {precision} {type} ${name};`);
 
         pragmas.vertex.define.push(`attribute {precision} {type} ${attribute.name};`);
+        pragmas.vertex.define_in.push(`attribute {precision} {type} ${attribute.name};`);
         pragmas.vertex.initialize.push(`${name} = ${attribute.name} / ${attribute.multiplier}.0;`);
+        pragmas.vertex.initialize_in.push(`{precision} {type} ${name} = ${attribute.name} / ${attribute.multiplier}.0;`);
 
         this.cacheKey += `/a_${name}`;
     }
@@ -131,6 +135,7 @@ class ProgramConfiguration {
         const tName = `u_${name}_t`;
 
         pragmas.vertex.define.push(`uniform lowp float ${tName};`);
+        pragmas.vertex.define_in.push(`uniform lowp float ${tName};`);
 
         this.interpolationUniforms.push({
             name: tName,
@@ -152,6 +157,7 @@ class ProgramConfiguration {
                 zoomStops
             }));
             pragmas.vertex.define.push(`attribute {precision} vec4 ${attribute.name};`);
+            pragmas.vertex.define_in.push(`attribute {precision} vec4 ${attribute.name};`);
             componentNames.push(attribute.name);
 
         } else {
@@ -164,9 +170,12 @@ class ProgramConfiguration {
                     zoomStops: [zoomStops[k]]
                 }));
                 pragmas.vertex.define.push(`attribute {precision} {type} ${componentName};`);
+                pragmas.vertex.define_in.push(`attribute {precision} {type} ${componentName};`);
             }
         }
         pragmas.vertex.initialize.push(`${name} = evaluate_zoom_function_${attribute.components}(\
+            ${componentNames.join(', ')}, ${tName}) / ${attribute.multiplier}.0;`);
+        pragmas.vertex.initialize_in.push(`{precision} {type} ${name} = evaluate_zoom_function_${attribute.components}(\
             ${componentNames.join(', ')}, ${tName}) / ${attribute.multiplier}.0;`);
 
         this.cacheKey += `/z_${name}`;
@@ -174,15 +183,15 @@ class ProgramConfiguration {
 
     getPragmas(name) {
         if (!this.pragmas[name]) {
-            this.pragmas[name]          = {define: [], initialize: []};
-            this.pragmas[name].fragment = {define: [], initialize: []};
-            this.pragmas[name].vertex   = {define: [], initialize: []};
+            this.pragmas[name]          = {define: [], define_in: [], initialize: [], initialize_in: []};
+            this.pragmas[name].fragment = {define: [], define_in: [], initialize: [], initialize_in: []};
+            this.pragmas[name].vertex   = {define: [], define_in: [], initialize: [], initialize_in: []};
         }
         return this.pragmas[name];
     }
 
     applyPragmas(source, shaderType) {
-        return source.replace(/#pragma mapbox: ([\w]+) ([\w]+) ([\w]+) ([\w]+)/g, (match, operation, precision, type, name) => {
+        return source.replace(/#pragma mapbox: ([\w_]+) ([\w]+) ([\w]+) ([\w]+)/g, (match, operation, precision, type, name) => {
             return this.pragmas[name][operation].concat(this.pragmas[name][shaderType][operation])
                 .join('\n')
                 .replace(/{type}/g, type)

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -27,15 +27,15 @@ varying float v_gamma_scale;
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
-#pragma mapbox: define mediump float gapwidth
-#pragma mapbox: define lowp float offset
+#pragma mapbox: define_in mediump float gapwidth
+#pragma mapbox: define_in lowp float offset
 
 void main() {
     #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
-    #pragma mapbox: initialize mediump float gapwidth
-    #pragma mapbox: initialize lowp float offset
+    #pragma mapbox: initialize_in mediump float gapwidth
+    #pragma mapbox: initialize_in lowp float offset
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/shaders/line_pattern.vertex.glsl
+++ b/src/shaders/line_pattern.vertex.glsl
@@ -29,14 +29,14 @@ varying float v_gamma_scale;
 
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
-#pragma mapbox: define lowp float offset
-#pragma mapbox: define mediump float gapwidth
+#pragma mapbox: define_in lowp float offset
+#pragma mapbox: define_in mediump float gapwidth
 
 void main() {
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
-    #pragma mapbox: initialize lowp float offset
-    #pragma mapbox: initialize mediump float gapwidth
+    #pragma mapbox: initialize_in lowp float offset
+    #pragma mapbox: initialize_in mediump float gapwidth
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -35,15 +35,15 @@ varying float v_gamma_scale;
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
-#pragma mapbox: define mediump float gapwidth
-#pragma mapbox: define lowp float offset
+#pragma mapbox: define_in mediump float gapwidth
+#pragma mapbox: define_in lowp float offset
 
 void main() {
     #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float blur
     #pragma mapbox: initialize lowp float opacity
-    #pragma mapbox: initialize mediump float gapwidth
-    #pragma mapbox: initialize lowp float offset
+    #pragma mapbox: initialize_in mediump float gapwidth
+    #pragma mapbox: initialize_in lowp float offset
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;


### PR DESCRIPTION
The `line_sdf` shader currently uses a lot of varyings—too many for some OpenGL implementations. They fail to link the program with a message of `Too many varyings`. [OpenGL ES 2.0](https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGet.xml) has a minimum value of 8 for `GL_MAX_VARYING_VECTORS`, while this shader uses 10 or 11.

I believe we could easily merge some of the individual `float` varyings into a vector.

/cc @anandthakker 