### PR TITLE
Fix to add .json extension required in webpack environments

### DIFF
--- a/src/style-spec/migrate/v7.js
+++ b/src/style-spec/migrate/v7.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ref = require('../reference/v7');
+const ref = require('../reference/v7.json');
 
 function eachLayer(layer, callback) {
     for (const k in layer.layers) {

--- a/src/style-spec/migrate/v8.js
+++ b/src/style-spec/migrate/v8.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Reference = require('../reference/v8');
+const Reference = require('../reference/v8.json');
 const URL = require('url');
 
 function getPropertyReference(propertyName) {


### PR DESCRIPTION
Webpack requires `.json` extension to be present when requiring json files. So `require('../reference/v7');` will currently fail, this PR fixes that. All other environments currently support the  `require('../reference/v7.json');` syntax. 