### PR TITLE
fix jsdoc typo

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -317,7 +317,7 @@ class Camera extends Evented {
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {boolean} [options.linear=false] If `true`, the map transitions using
      *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
-     *     those functions and @{link AnimationOptions} for information about options available.
+     *     those functions and {@link AnimationOptions} for information about options available.
      * @param {Function} [options.easing] An easing function for the animated transition. See [AnimationOptions](#AnimationOptions).
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the map view transitions to the specified bounds.


### PR DESCRIPTION
Found this while reporting https://github.com/mapbox/mapbox-gl-js/issues/3680#issuecomment-293228951 and #4568.