### PR TITLE
Fixes for anti-meridian crossing in animations

### DIFF
--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -727,6 +727,44 @@ test('camera', (t) => {
             });
         });
 
+        t.test('pans eastward across the antimeridian', (t) => {
+            const camera = createCamera();
+            camera.setCenter([170, 0]);
+            let crossedAntimeridian;
+
+            camera.on('move', () => {
+                if (camera.getCenter().lng > 170) {
+                    crossedAntimeridian = true;
+                }
+            });
+
+            camera.on('moveend', () => {
+                t.ok(crossedAntimeridian);
+                t.end();
+            });
+
+            camera.easeTo({ center: [-170, 0], duration: 10 });
+        });
+
+        t.test('pans westward across the antimeridian', (t) => {
+            const camera = createCamera();
+            camera.setCenter([-170, 0]);
+            let crossedAntimeridian;
+
+            camera.on('move', () => {
+                if (camera.getCenter().lng < -170) {
+                    crossedAntimeridian = true;
+                }
+            });
+
+            camera.on('moveend', () => {
+                t.ok(crossedAntimeridian);
+                t.end();
+            });
+
+            camera.easeTo({ center: [170, 0], duration: 10 });
+        });
+
         t.end();
     });
 


### PR DESCRIPTION
- Enable anti-meridian crossing for `easeTo`-based methods for consistency with `flyTo`.
- Fix #2521 by disabling anti-meridian crossing if `maxBounds` is set.