### PR TITLE
Don't fail render tests on missing style.json files

### DIFF
--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -39,9 +39,17 @@ module.exports = function (directory, implementation, options, run) {
             if (!shouldRunTest(group, test))
                 return;
 
-            if (!fs.lstatSync(path.join(directory, group, test)).isDirectory() ||
-                !fs.lstatSync(path.join(directory, group, test, 'style.json')).isFile())
+            if (!fs.lstatSync(path.join(directory, group, test)).isDirectory())
+                // Skip files in this folder.
                 return;
+
+            try {
+                if (!fs.lstatSync(path.join(directory, group, test, 'style.json')).isFile())
+                    return;
+            } catch (err) {
+                console.log(colors.blue(`* omitting ${group} ${test} due to missing style`));
+                return;
+            }
 
             const style = require(path.join(directory, group, test, 'style.json'));
 


### PR DESCRIPTION
In our test harness, we have code to detect missing style.json files, but it doesn't catch the exception correctly. This leads to the test suite aborting when a folder misses a style.json file (e.g. due to leftover folders when switching branches).