### PR TITLE
Increase duration of a flaky camera test

### DIFF
--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1044,7 +1044,7 @@ test('camera', (t) => {
                 t.end();
             });
 
-            camera.flyTo({ center: [-170, 0], duration: 10 });
+            camera.flyTo({ center: [-170, 0], duration: 20 });
         });
 
         t.test('pans westward across the antimeridian', (t) => {


### PR DESCRIPTION
A temporary measure to hopefully make a flaky test (failing 10-15% of the time) more stable, until we come up with a more reliable way to test this.