### PR TITLE
add check to make sure invalid bounds on tilejson don't error out

### DIFF
--- a/src/source/tile_bounds.js
+++ b/src/source/tile_bounds.js
@@ -5,9 +5,15 @@ const clamp = require('../util/util').clamp;
 
 class TileBounds {
     constructor(bounds, minzoom, maxzoom) {
-        this.bounds = LngLatBounds.convert(bounds);
+        this.bounds = this.validateBounds(bounds) ? LngLatBounds.convert(bounds) : LngLatBounds.convert([-180, -90, 180, 90]);
         this.minzoom = minzoom || 0;
         this.maxzoom = maxzoom || 24;
+    }
+
+    validateBounds(bounds) {
+        if (!Array.isArray(bounds) || bounds.length !== 4) return false;
+        if (bounds[0] < -180 || bounds[1] < -90 || bounds[2] > 180 || bounds[3] > 90) return false;
+        return true;
     }
 
     contains(coord, maxzoom) {

--- a/src/source/tile_bounds.js
+++ b/src/source/tile_bounds.js
@@ -5,15 +5,15 @@ const clamp = require('../util/util').clamp;
 
 class TileBounds {
     constructor(bounds, minzoom, maxzoom) {
-        this.bounds = this.validateBounds(bounds) ? LngLatBounds.convert(bounds) : LngLatBounds.convert([-180, -90, 180, 90]);
+        this.bounds = LngLatBounds.convert(this.validateBounds(bounds));
         this.minzoom = minzoom || 0;
         this.maxzoom = maxzoom || 24;
     }
 
     validateBounds(bounds) {
-        if (!Array.isArray(bounds) || bounds.length !== 4) return false;
-        if (bounds[0] < -180 || bounds[1] < -90 || bounds[2] > 180 || bounds[3] > 90) return false;
-        return true;
+        // make sure the bounds property contains valid longitude and latitudes
+        if (!Array.isArray(bounds) || bounds.length !== 4) return [-180, -90, 180, 90];
+        return [Math.max(-180, bounds[0]), Math.max(-90, bounds[1]), Math.min(180, bounds[2]), Math.min(90, bounds[3])];
     }
 
     contains(coord, maxzoom) {

--- a/test/unit/source/raster_tile_source.test.js
+++ b/test/unit/source/raster_tile_source.test.js
@@ -49,7 +49,7 @@ test('RasterTileSource', (t) => {
             tiles: ["http://example.com/{z}/{x}/{y}.png"],
         });
         source.setBounds([-47, -7, -45, 91]);
-        t.true(source.hasTile({z: 8, x:50, y: 50}), 'returns true for all tiles');
+        t.deepEqual(source.tileBounds.bounds, {_sw:{lng: -47, lat: -7}, _ne:{lng: -45, lat: 90}}, 'converts invalid bounds to closest valid bounds');
         t.end();
     });
 

--- a/test/unit/source/raster_tile_source.test.js
+++ b/test/unit/source/raster_tile_source.test.js
@@ -35,9 +35,21 @@ test('RasterTileSource', (t) => {
             attribution: "Mapbox",
             tiles: ["http://example.com/{z}/{x}/{y}.png"],
         });
-        source.setBounds([[-47, -7], [-45, -5]]);
+        source.setBounds([-47, -7, -45, -5]);
         t.false(source.hasTile({z: 8, x:96, y: 132}), 'returns false for tiles outside bounds');
         t.true(source.hasTile({z: 8, x:95, y: 132}), 'returns true for tiles inside bounds');
+        t.end();
+    });
+
+    t.test('does not error on invalid bounds', (t)=>{
+        const source = createSource({
+            minzoom: 0,
+            maxzoom: 22,
+            attribution: "Mapbox",
+            tiles: ["http://example.com/{z}/{x}/{y}.png"],
+        });
+        source.setBounds([-47, -7, -45, 91]);
+        t.true(source.hasTile({z: 8, x:50, y: 50}), 'returns true for all tiles');
         t.end();
     });
 
@@ -47,7 +59,7 @@ test('RasterTileSource', (t) => {
             maxzoom: 22,
             attribution: "Mapbox",
             tiles: ["http://example.com/{z}/{x}/{y}.png"],
-            bounds: [[-47, -7], [-45, -5]]
+            bounds: [-47, -7, -45, -5]
         }));
         const source = createSource({ url: "/source.json" });
 

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -200,7 +200,7 @@ test('VectorTileSource', (t) => {
             tiles: ["http://example.com/{z}/{x}/{y}.png"],
         });
         source.setBounds([-47, -7, -45, 91]);
-        t.true(source.hasTile({z: 8, x:50, y: 50}), 'returns true for all tiles');
+        t.deepEqual(source.tileBounds.bounds, {_sw:{lng: -47, lat: -7}, _ne:{lng: -45, lat: 90}}, 'converts invalid bounds to closest valid bounds');
         t.end();
     });
 

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -186,12 +186,23 @@ test('VectorTileSource', (t) => {
             attribution: "Mapbox",
             tiles: ["http://example.com/{z}/{x}/{y}.png"],
         });
-        source.setBounds([[-47, -7], [-45, -5]]);
+        source.setBounds([-47, -7, -45, -5]);
         t.false(source.hasTile({z: 8, x:96, y: 132}), 'returns false for tiles outside bounds');
         t.true(source.hasTile({z: 8, x:95, y: 132}), 'returns true for tiles inside bounds');
         t.end();
     });
 
+    t.test('does not error on invalid bounds', (t)=>{
+        const source = createSource({
+            minzoom: 0,
+            maxzoom: 22,
+            attribution: "Mapbox",
+            tiles: ["http://example.com/{z}/{x}/{y}.png"],
+        });
+        source.setBounds([-47, -7, -45, 91]);
+        t.true(source.hasTile({z: 8, x:50, y: 50}), 'returns true for all tiles');
+        t.end();
+    });
 
     t.test('respects TileJSON.bounds when loaded from TileJSON', (t)=>{
         window.server.respondWith('/source.json', JSON.stringify({
@@ -199,7 +210,7 @@ test('VectorTileSource', (t) => {
             maxzoom: 22,
             attribution: "Mapbox",
             tiles: ["http://example.com/{z}/{x}/{y}.png"],
-            bounds: [[-47, -7], [-45, -5]]
+            bounds: [-47, -7, -45, -5]
         }));
         const source = createSource({ url: "/source.json" });
 


### PR DESCRIPTION
#Turns out some sources uploaded through Mapbox studio will have invalid bounds due perhaps to a bug in Mapnik with rounding / precision? 
for example: 

<img width="809" alt="screen shot 2017-04-25 at 8 47 27 am" src="https://cloud.githubusercontent.com/assets/2425307/25410716/609a9fa8-29cd-11e7-9191-145313423556.png">

Maps that use a source with invalid bounds fail to render since #4556 bc they error out on `LngLatBounds#convert`. This PR prevents that error from causing maps not to render. 
cc @jfirebaugh @mourner @julieemunro @danswick @aparlato 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
