### PR TITLE
Enable image tests for native

### DIFF
--- a/test/integration/render-tests/runtime-styling/image-add-2x-image-1x-screen/style.json
+++ b/test/integration/render-tests/runtime-styling/image-add-2x-image-1x-screen/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native" : "https://github.com/mapbox/mapbox-gl-native/issues/8839"
-      },
       "width": 64,
       "height": 64,
       "pixelRatio": 1,

--- a/test/integration/render-tests/runtime-styling/image-add-2x-image-2x-screen/style.json
+++ b/test/integration/render-tests/runtime-styling/image-add-2x-image-2x-screen/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native" : "https://github.com/mapbox/mapbox-gl-native/issues/8839"
-      },
       "width": 64,
       "height": 64,
       "pixelRatio" :2,

--- a/test/integration/render-tests/runtime-styling/image-add-alpha/style.json
+++ b/test/integration/render-tests/runtime-styling/image-add-alpha/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native" : "https://github.com/mapbox/mapbox-gl-native/issues/8839"
-      },
       "width": 64,
       "height": 64,
       "operations": [


### PR DESCRIPTION
This is for https://github.com/mapbox/mapbox-gl-native/issues/8839

Enable the runtime styling tests for Map.addImage on native.
Should be merged after tests pass for https://github.com/mapbox/mapbox-gl-native/pull/8843 