### PR TITLE
Fix fullscreen control in Firefox

### DIFF
--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -54,8 +54,14 @@ class FullscreenControl {
         return this._fullscreen;
     }
 
-    _changeIcon(e) {
-        if (e.target === this._mapContainer) {
+    _changeIcon() {
+        const fullscreenElement =
+            window.document.fullscreenElement ||
+            window.document.mozFullScreenElement ||
+            window.document.webkitFullscreenElement ||
+            window.document.msFullscreenElement;
+
+        if ((fullscreenElement === this._mapContainer) !== this._fullscreen) {
             this._fullscreen = !this._fullscreen;
             const className = 'mapboxgl-ctrl';
             this._fullscreenButton.classList.toggle(`${className}-shrink`);


### PR DESCRIPTION
Firefox does not set `e.target` like other browsers. Copy the solution from Leaflet.fullscreen.

Fixes #4663.