### PR TITLE
fix update edit link, add query parameters for map feedback

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -161,11 +161,12 @@ a.mapboxgl-ctrl-logo {
     color: inherit;
     text-decoration: underline;
 }
-.mapboxgl-ctrl-attrib .mapboxgl-improve-map {
+/* stylelint-disable */
+.mapboxgl-ctrl-attrib .mapbox-improve-map {
     font-weight: bold;
     margin-left: 2px;
 }
-
+/*stylelint-enable*/
 .mapboxgl-ctrl-scale {
     background-color: rgba(255,255,255,0.75);
     font-size: 10px;
@@ -318,8 +319,11 @@ a.mapboxgl-ctrl-logo {
     border: 2px dotted #202020;
     opacity: 0.5;
 }
+
 @media print {
-    .mapboxgl-improve-map {
+/* stylelint-disable */
+    .mapbox-improve-map {
         display:none;
     }
+/* stylelint-enable */
 }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -68,13 +68,22 @@ class AttributionControl {
 
     _updateEditLink() {
         if (!this._editLink) this._editLink = this._container.querySelector('.mapbox-improve-map');
+        const params = [
+            {key: "pitch", value: this._map.getPitch()},
+            {key: "bearing", value: this._map.getBearing()},
+            {key: "owner", value: this.styleOwner},
+            {key: "id", value: this.styleId},
+            {key: "access_token", value: config.ACCESS_TOKEN}
+        ];
+
         if (this._editLink) {
             const center = this._map.getCenter();
-            const styleParams = (this.styleOwner && this.styleId) ? config.ACCESS_TOKEN ? `?owner=${this.styleOwner}&id=${this.styleId}&access_token=${config.ACCESS_TOKEN}` : `?owner=${this.styleOwner}&id=${this.styleId}` : '';
-            this._editLink.href = `https://www.mapbox.com/feedback/${styleParams}#/${
+            const paramString = params.reduce((acc, next, i) => acc += next.value !== undefined ? `${next.key}=${next.value}${i < params.length - 1 ? '&' : ''}` : '', `?`);
+            this._editLink.href = `https://www.mapbox.com/feedback/${paramString}#/${
                     Math.round(center.lng * 1000) / 1000}/${Math.round(center.lat * 1000) / 1000}/${Math.round(this._map.getZoom())}`;
         }
     }
+
 
     _updateData(e) {
         if (e && e.sourceDataType === 'metadata') {

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -81,7 +81,7 @@ class AttributionControl {
                 }
                 return acc;
             }, `?`);
-            this._editLink.href = `https://www.mapbox.com/feedback/${paramString}${this._map.hash ? this._map.hash.getHashString() : ''}`;
+            this._editLink.href = `https://www.mapbox.com/feedback/${paramString}${this._map.hash ? this._map.hash.getHashString(true) : ''}`;
 
         }
     }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -69,11 +69,9 @@ class AttributionControl {
         if (!this._editLink) this._editLink = this._container.querySelector('.mapbox-improve-map');
         if (this._editLink) {
             const center = this._map.getCenter();
-            this._editLink.href = `https://www.mapbox.com/map-feedback/#/${
+            const styleParams = (this.styleOwner && this.styleId) ? `?owner=${this.styleOwner}&id=${this.styleId}` : '';
+            this._editLink.href = `https://www.mapbox.com/feedback/${styleParams}#/${
                     Math.round(center.lng * 1000) / 1000}/${Math.round(center.lat * 1000) / 1000}/${Math.round(this._map.getZoom())}`;
-            if (this.styleOwner && this.styleId) {
-                this._editLink.href += `?owner=${this.styleOwner}&id=${this.styleId}`;
-            }
         }
     }
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -81,7 +81,7 @@ class AttributionControl {
                 }
                 return acc;
             }, `?`);
-            this._editLink.href = `https://www.mapbox.com/feedback/${paramString}${this._map.hash ? this._map.hash.getHashString(true) : ''}`;
+            this._editLink.href = `https://www.mapbox.com/feedback/${paramString}${this._map._hash ? this._map._hash.getHashString(true) : ''}`;
 
         }
     }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -69,18 +69,20 @@ class AttributionControl {
     _updateEditLink() {
         if (!this._editLink) this._editLink = this._container.querySelector('.mapbox-improve-map');
         const params = [
-            {key: "pitch", value: this._map.getPitch()},
-            {key: "bearing", value: this._map.getBearing()},
             {key: "owner", value: this.styleOwner},
             {key: "id", value: this.styleId},
             {key: "access_token", value: config.ACCESS_TOKEN}
         ];
 
         if (this._editLink) {
-            const center = this._map.getCenter();
-            const paramString = params.reduce((acc, next, i) => acc += next.value !== undefined ? `${next.key}=${next.value}${i < params.length - 1 ? '&' : ''}` : '', `?`);
-            this._editLink.href = `https://www.mapbox.com/feedback/${paramString}#/${
-                    Math.round(center.lng * 1000) / 1000}/${Math.round(center.lat * 1000) / 1000}/${Math.round(this._map.getZoom())}`;
+            const paramString = params.reduce((acc, next, i) => {
+                if (next.value !== undefined) {
+                    acc += `${next.key}=${next.value}${i < params.length - 1 ? '&' : ''}`;
+                }
+                return acc;
+            }, `?`);
+            this._editLink.href = `https://www.mapbox.com/feedback/${paramString}${this._map.hash ? this._map.hash.getHashString() : ''}`;
+
         }
     }
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -2,6 +2,7 @@
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');
+const config = require('../../util/config');
 
 /**
  * An `AttributionControl` control presents the map's [attribution information](https://www.mapbox.com/help/attribution/).
@@ -69,7 +70,7 @@ class AttributionControl {
         if (!this._editLink) this._editLink = this._container.querySelector('.mapbox-improve-map');
         if (this._editLink) {
             const center = this._map.getCenter();
-            const styleParams = (this.styleOwner && this.styleId) ? `?owner=${this.styleOwner}&id=${this.styleId}` : '';
+            const styleParams = (this.styleOwner && this.styleId) ? config.ACCESS_TOKEN ? `?owner=${this.styleOwner}&id=${this.styleId}&access_token=${config.ACCESS_TOKEN}` : `?owner=${this.styleOwner}&id=${this.styleId}` : '';
             this._editLink.href = `https://www.mapbox.com/feedback/${styleParams}#/${
                     Math.round(center.lng * 1000) / 1000}/${Math.round(center.lat * 1000) / 1000}/${Math.round(this._map.getZoom())}`;
         }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -66,11 +66,14 @@ class AttributionControl {
     }
 
     _updateEditLink() {
-        if (!this._editLink) this._editLink = this._container.querySelector('.mapboxgl-improve-map');
+        if (!this._editLink) this._editLink = this._container.querySelector('.mapbox-improve-map');
         if (this._editLink) {
             const center = this._map.getCenter();
             this._editLink.href = `https://www.mapbox.com/map-feedback/#/${
-                    center.lng}/${center.lat}/${Math.round(this._map.getZoom() + 1)}`;
+                    Math.round(center.lng * 1000) / 1000}/${Math.round(center.lat * 1000) / 1000}/${Math.round(this._map.getZoom())}`;
+            if (this.styleOwner && this.styleId) {
+                this._editLink.href += `?owner=${this.styleOwner}&id=${this.styleId}`;
+            }
         }
     }
 
@@ -84,6 +87,12 @@ class AttributionControl {
     _updateAttributions() {
         if (!this._map.style) return;
         let attributions = [];
+
+        if (this._map.style.stylesheet) {
+            const stylesheet = this._map.style.stylesheet;
+            this.styleOwner = stylesheet.owner;
+            this.styleId = stylesheet.id;
+        }
 
         const sourceCaches = this._map.style.sourceCaches;
         for (const id in sourceCaches) {

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -42,16 +42,22 @@ class Hash {
         return this;
     }
 
-    getHashString() {
+    getHashString(mapFeedback) {
         const center = this._map.getCenter(),
-            zoom = this._map.getZoom(),
+            zoom = Math.round(this._map.getZoom() * 100) / 100,
+            precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2)),
+            lng = Math.round(center.lng * Math.pow(10, precision)) / Math.pow(10, precision),
+            lat = Math.round(center.lat * Math.pow(10, precision)) / Math.pow(10, precision),
             bearing = this._map.getBearing(),
-            pitch = this._map.getPitch(),
-            precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
-
-        let hash = `#${Math.round(zoom * 100) / 100
-                }/${Math.round(center.lat * Math.pow(10, precision)) / Math.pow(10, precision)
-                }/${Math.round(center.lng * Math.pow(10, precision)) / Math.pow(10, precision)}`;
+            pitch = this._map.getPitch();
+        let hash = '';
+        if (mapFeedback) {
+            // new map feedback site has some constraints that don't allow
+            // us to use the same hash format as we do for the Map hash option.
+            hash += `#/${lng}/${lat}/${zoom}`;
+        } else {
+            hash += `#${zoom}/${lat}/${lng}`;
+        }
 
         if (bearing || pitch) hash += (`/${Math.round(bearing * 10) / 10}`);
         if (pitch) hash += (`/${Math.round(pitch)}`);
@@ -73,7 +79,7 @@ class Hash {
     }
 
     _updateHash() {
-        const hash = this.getHashString(this._map);
+        const hash = this.getHashString();
         window.history.replaceState('', '', hash);
     }
 

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -42,6 +42,22 @@ class Hash {
         return this;
     }
 
+    getHashString() {
+        const center = this._map.getCenter(),
+            zoom = this._map.getZoom(),
+            bearing = this._map.getBearing(),
+            pitch = this._map.getPitch(),
+            precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
+
+        let hash = `#${Math.round(zoom * 100) / 100
+                }/${Math.round(center.lat * Math.pow(10, precision)) / Math.pow(10, precision)
+                }/${Math.round(center.lng * Math.pow(10, precision)) / Math.pow(10, precision)}`;
+
+        if (bearing || pitch) hash += (`/${Math.round(bearing * 10) / 10}`);
+        if (pitch) hash += (`/${Math.round(pitch)}`);
+        return hash;
+    }
+
     _onHashChange() {
         const loc = window.location.hash.replace('#', '').split('/');
         if (loc.length >= 3) {
@@ -57,21 +73,10 @@ class Hash {
     }
 
     _updateHash() {
-        const center = this._map.getCenter(),
-            zoom = this._map.getZoom(),
-            bearing = this._map.getBearing(),
-            pitch = this._map.getPitch(),
-            precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
-
-        let hash = `#${Math.round(zoom * 100) / 100
-                }/${center.lat.toFixed(precision)
-                }/${center.lng.toFixed(precision)}`;
-
-        if (bearing || pitch) hash += (`/${Math.round(bearing * 10) / 10}`);
-        if (pitch) hash += (`/${Math.round(pitch)}`);
-
+        const hash = this.getHashString(this._map);
         window.history.replaceState('', '', hash);
     }
+
 }
 
 module.exports = Hash;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -192,9 +192,9 @@ class Map extends Camera {
 
         bindHandlers(this, options);
 
-        this.hash = options.hash && (new Hash()).addTo(this);
+        this._hash = options.hash && (new Hash()).addTo(this);
         // don't set position from options if set through hash
-        if (!this.hash || !this.hash._onHashChange()) {
+        if (!this._hash || !this._hash._onHashChange()) {
             this.jumpTo({
                 center: options.center,
                 zoom: options.zoom,
@@ -1458,7 +1458,7 @@ class Map extends Camera {
      * methods on the map.
      */
     remove() {
-        if (this.hash) this.hash.remove();
+        if (this._hash) this._hash.remove();
         browser.cancelFrame(this._frameId);
         this.setStyle(null);
         if (typeof window !== 'undefined') {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -192,9 +192,9 @@ class Map extends Camera {
 
         bindHandlers(this, options);
 
-        this._hash = options.hash && (new Hash()).addTo(this);
+        this.hash = options.hash && (new Hash()).addTo(this);
         // don't set position from options if set through hash
-        if (!this._hash || !this._hash._onHashChange()) {
+        if (!this.hash || !this.hash._onHashChange()) {
             this.jumpTo({
                 center: options.center,
                 zoom: options.zoom,
@@ -1458,7 +1458,7 @@ class Map extends Camera {
      * methods on the map.
      */
     remove() {
-        if (this._hash) this._hash.remove();
+        if (this.hash) this.hash.remove();
         browser.cancelFrame(this._frameId);
         this.setStyle(null);
         if (typeof window !== 'undefined') {

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -18,7 +18,8 @@ function createMap() {
             layers: [],
             owner: 'mapbox',
             id: 'streets-v10',
-        }
+        },
+        hash: true
     });
 
 }
@@ -112,9 +113,9 @@ test('AttributionControl has the correct edit map link', (t) => {
         map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/feedback/" target="_blank">Improve this map</a>'});
         map.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?pitch=0&bearing=0&owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/0', 'edit link contains map location data');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#0/0/0', 'edit link contains map location data');
                 map.setZoom(2);
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?pitch=0&bearing=0&owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/2', 'edit link updates on mapmove');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#2/0/0', 'edit link updates on mapmove');
                 t.end();
             }
         });

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -3,10 +3,12 @@
 const test = require('mapbox-gl-js-test').test;
 const window = require('../../../../src/util/window');
 const Map = require('../../../../src/ui/map');
+const config = require('../../../../src/util/config');
 const AttributionControl = require('../../../../src/ui/control/attribution_control');
 
 function createMap() {
     const container = window.document.createElement('div');
+    config.ACCESS_TOKEN = 'pk.123';
     return new Map({
         container: container,
         attributionControl: false,
@@ -15,9 +17,10 @@ function createMap() {
             sources: {},
             layers: [],
             owner: 'mapbox',
-            id: 'streets-v10'
+            id: 'streets-v10',
         }
     });
+
 }
 
 test('AttributionControl appears in bottom-right by default', (t) => {
@@ -105,14 +108,13 @@ test('AttributionControl has the correct edit map link', (t) => {
     const map = createMap();
     const attribution = new AttributionControl();
     map.addControl(attribution);
-
     map.on('load', () => {
         map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/feedback/" target="_blank">Improve this map</a>'});
         map.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10#/0/0/0', 'edit link contains map location data');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/0', 'edit link contains map location data');
                 map.setZoom(2);
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10#/0/0/2', 'edit link updates on mapmove');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/2', 'edit link updates on mapmove');
                 t.end();
             }
         });

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -110,9 +110,9 @@ test('AttributionControl has the correct edit map link', (t) => {
         map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>'});
         map.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/0?owner=mapbox&id=streets-v10', 'edit link contains map location data');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10#/0/0/0', 'edit link contains map location data');
                 map.setZoom(2);
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/2?owner=mapbox&id=streets-v10', 'edit link updates on mapmove');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10#/0/0/2', 'edit link updates on mapmove');
                 t.end();
             }
         });

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -13,7 +13,9 @@ function createMap() {
         style: {
             version: 8,
             sources: {},
-            layers: []
+            layers: [],
+            owner: 'mapbox',
+            id: 'streets-v10'
         }
     });
 }
@@ -105,12 +107,12 @@ test('AttributionControl has the correct edit map link', (t) => {
     map.addControl(attribution);
 
     map.on('load', () => {
-        map.addSource('1', {type: 'vector', attribution: '<a class="mapboxgl-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>'});
+        map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>'});
         map.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/1', 'edit link contains map location data');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/0?owner=mapbox&id=streets-v10', 'edit link contains map location data');
                 map.setZoom(2);
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/3', 'edit link updates on mapmove');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/map-feedback/#/0/0/2?owner=mapbox&id=streets-v10', 'edit link updates on mapmove');
                 t.end();
             }
         });

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -112,9 +112,9 @@ test('AttributionControl has the correct edit map link', (t) => {
         map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/feedback/" target="_blank">Improve this map</a>'});
         map.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/0', 'edit link contains map location data');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?pitch=0&bearing=0&owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/0', 'edit link contains map location data');
                 map.setZoom(2);
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/2', 'edit link updates on mapmove');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?pitch=0&bearing=0&owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/2', 'edit link updates on mapmove');
                 t.end();
             }
         });

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -113,9 +113,9 @@ test('AttributionControl has the correct edit map link', (t) => {
         map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/feedback/" target="_blank">Improve this map</a>'});
         map.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#0/0/0', 'edit link contains map location data');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/0', 'edit link contains map location data');
                 map.setZoom(2);
-                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#2/0/0', 'edit link updates on mapmove');
+                t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/2', 'edit link updates on mapmove');
                 t.end();
             }
         });

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -107,7 +107,7 @@ test('AttributionControl has the correct edit map link', (t) => {
     map.addControl(attribution);
 
     map.on('load', () => {
-        map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>'});
+        map.addSource('1', {type: 'vector', attribution: '<a class="mapbox-improve-map" href="https://www.mapbox.com/feedback/" target="_blank">Improve this map</a>'});
         map.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
                 t.equal(attribution._editLink.href, 'https://www.mapbox.com/feedback/?owner=mapbox&id=streets-v10#/0/0/0', 'edit link contains map location data');

--- a/test/unit/ui/hash.test.js
+++ b/test/unit/ui/hash.test.js
@@ -121,8 +121,8 @@ test('hash', (t) => {
 
         t.equal(newHash.length, 3);
         t.equal(newHash[0], '#3');
-        t.equal(newHash[1], '1.00');
-        t.equal(newHash[2], '2.00');
+        t.equal(newHash[1], '1');
+        t.equal(newHash[2], '2');
 
         map.setPitch(60);
 
@@ -130,8 +130,8 @@ test('hash', (t) => {
 
         t.equal(newHash.length, 5);
         t.equal(newHash[0], '#3');
-        t.equal(newHash[1], '1.00');
-        t.equal(newHash[2], '2.00');
+        t.equal(newHash[1], '1');
+        t.equal(newHash[2], '2');
         t.equal(newHash[3], '0');
         t.equal(newHash[4], '60');
 
@@ -141,8 +141,8 @@ test('hash', (t) => {
 
         t.equal(newHash.length, 5);
         t.equal(newHash[0], '#3');
-        t.equal(newHash[1], '1.00');
-        t.equal(newHash[2], '2.00');
+        t.equal(newHash[1], '1');
+        t.equal(newHash[2], '2');
         t.equal(newHash[3], '135');
         t.equal(newHash[4], '60');
 


### PR DESCRIPTION
This PR does two things:
- fix the edit link that we didn't know was broken as a result of #4381 – the HTML for the map feedback link comes from the TileJSON which mapbox-gl-js does not control, so when I changed the `mapboxgl` prefix for the `queryselector` class that modifies the edit link it stopped getting updated, and the test didn't catch it bc we provide the TileJSON html inside the test. 
- adds query parameters for #3558 

an alternative to this approach would be editing the tilejson in place to abide by our `mapboxgl-` prefix requirement.

closes #3558 

cc @tristen 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
