### PR TITLE
clarify icon-size units, fix #4661

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -811,7 +811,8 @@
       "function": "interpolated",
       "zoom-function": true,
       "property-function": true,
-      "doc": "Scale factor for icon. 1 is original size, 3 triples the size.",
+      "units": "factor of the original icon size",
+      "doc": "Scales the original size of the icon by the provided factor. The new pixel size of the image will be the original pixel size multiplied by `icon-size`. 1 is the original size; 3 triples the size of the image.",
       "requires": [
         "icon-image"
       ],


### PR DESCRIPTION
@gmaclennan thanks for opening #4661. Does this clarify the units enough?

"units": "factor of the original icon size"
"doc": "Scales the original size of the icon by the provided factor. The new pixel size of the image will be `original pixel size * 'image-size'`. 1 is the original size, 3 triples the size of the image."

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [N/A] write tests for all new functionality
 - [N/A] document any changes to public APIs
 - [N/A] post benchmark scores
 - [x] manually test the debug page
