### PR TITLE
Ensure symbol shader attrib bound at 0 is always valid and used

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -393,27 +393,24 @@ class Painter {
         assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), gl.getShaderInfoLog(vertexShader));
         gl.attachShader(program, vertexShader);
 
-        const result = {program};
 
         // For the symbol program, manually ensure the attrib bound to position 0 is always used (either a_data or a_pos_offset would work here).
         // This is needed to fix https://github.com/mapbox/mapbox-gl-js/issues/4607 — otherwise a_size can be bound first, causing rendering to fail.
         // All remaining attribs will be bound dynamically below.
         if (name === 'symbolSDF') {
             gl.bindAttribLocation(program, 0, 'a_data');
-            result['a_data'] = 0;
         }
 
         gl.linkProgram(program);
         assert(gl.getProgramParameter(program, gl.LINK_STATUS), gl.getProgramInfoLog(program));
 
         const numAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
+        const result = {program, numAttributes};
 
-        result.numAttributes = numAttributes;
         for (let i = 0; i < numAttributes; i++) {
             const attribute = gl.getActiveAttrib(program, i);
             result[attribute.name] = gl.getAttribLocation(program, attribute.name);
         }
-
         const numUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
         for (let i = 0; i < numUniforms; i++) {
             const uniform = gl.getActiveUniform(program, i);

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -1,8 +1,7 @@
 const float PI = 3.141592653589793;
 
-// NOTE: attribute locations in this shader are currently manually bound (see https://github.com/mapbox/mapbox-gl-js/issues/4607).
-// If adding or removing attributes from this shader, modify the bindings in painter.js accordingly, making sure the attrib at
-// position 0 is always used.
+// NOTE: the a_data attribute in this shader is manually bound (see https://github.com/mapbox/mapbox-gl-js/issues/4607).
+// If removing or renaming a_data, revisit the manual binding in painter.js accordingly.
 attribute vec4 a_pos_offset;
 attribute vec4 a_data;
 

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -1,5 +1,8 @@
 const float PI = 3.141592653589793;
 
+// NOTE: attribute locations in this shader are currently manually bound (see https://github.com/mapbox/mapbox-gl-js/issues/4607).
+// If adding or removing attributes from this shader, modify the bindings in painter.js accordingly, making sure the attrib at
+// position 0 is always used.
 attribute vec4 a_pos_offset;
 attribute vec4 a_data;
 


### PR DESCRIPTION
Fixes #4607.
@jfirebaugh found the culprit [in Firefox](https://github.com/mapbox/mapbox-gl-js/issues/4607#issuecomment-299601225): binding an attrib to position 0 without using it "forces the browser to do expensive emulation work when running on desktop OpenGL platforms, for example on Mac." In this case, `a_size` was frequently being bound to position 0 and was not always used. This PR manually binds `a_data` (which is always used — either this or `a_pos_offset` would work) to position 0, and then lets the program dynamically bind the rest.