### PR TITLE
[for discussion] Draft proposal - arbitrary expressions for style functions

### DIFF
--- a/debug/expressions.html
+++ b/debug/expressions.html
@@ -8,14 +8,33 @@
     <style>
         body { margin: 0; padding: 0; }
         html, body, #map { height: 100%; }
+        #map, #chart { width: 49%; display: inline-block; }
+
+        path { 
+            stroke: steelblue;
+            stroke-width: 2;
+            fill: none;
+        }
+
+        .axis path,
+        .axis line {
+            fill: none;
+            stroke: grey;
+            stroke-width: 1;
+            shape-rendering: crispEdges;
+        }
     </style>
 </head>
 
 <body>
 <div id='map'></div>
+<div id='chart'></div>
 
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
+
+<script src="http://d3js.org/d3.v3.min.js"></script>
+
 <script>
 
 var style = {
@@ -48,7 +67,8 @@ var style = {
                             [ 'number_data', 'x' ],
                             [ 'number_data', 'y' ]
                         ]
-                    ]
+                    ],
+                    zoomInterpolationBase: 1
                 },
                 'circle-opacity': {
                     type: 'expression',
@@ -77,6 +97,87 @@ var map = window.map = new mapboxgl.Map({
     hash: true
 });
 
+// Set the dimensions of the canvas / graph
+var margin = {top: 30, right: 20, bottom: 30, left: 50},
+    width = 600 - margin.left - margin.right,
+    height = 270 - margin.top - margin.bottom;
+
+// Set the ranges
+var x = d3.scale.linear().range([0, width]);
+var y = d3.scale.linear().range([height, 0]);
+
+// Define the axes
+var xAxis = d3.svg.axis().scale(x)
+    .orient("bottom").ticks(5);
+
+var yAxis = d3.svg.axis().scale(y)
+    .orient("left").ticks(5);
+
+// Define the line
+var valueline = d3.svg.line()
+    .x(function(d) { return x(d.x); })
+    .y(function(d) { return y(d.y); });
+    
+// Adds the svg canvas
+var svg = d3.select("#chart")
+    .append("svg")
+        .attr("width", width + margin.left + margin.right)
+        .attr("height", height + margin.top + margin.bottom)
+    .append("g")
+        .attr("transform", 
+              "translate(" + margin.left + "," + margin.top + ")");
+
+map.on('load', function () {
+    const styleFunction = map.getPaintProperty('circle', 'circle-radius')
+    var compiledExpression = mapboxgl.createFunction(styleFunction, {});
+
+    const data = [];
+    for (let z = 0; z < 5; z += 0.01) {
+        let output
+        if (!compiledExpression.isFeatureConstant && !compiledExpression.isZoomConstant) {
+            const zLow = Math.floor(z);
+            const zHigh = Math.ceil(z);
+            const interp = mapboxgl.createFunction({
+                type: 'exponential',
+                stops: [ [ zLow, 0 ], [ zHigh, 1 ] ],
+                base: compiledExpression.zoomInterpolationBase
+            }, { type: 'number' })
+            const t = interp(z);
+            const outLow = compiledExpression(zLow, {x: 5, y: 5});
+            const outHigh = compiledExpression(zHigh, {x: 5, y: 5});
+            output = outLow + (outHigh - outLow) * t;
+        } else {
+            output = compiledExpression(z, {x: 5, y: 5});
+        }
+        data.push({x: z, y: output});
+    }
+
+    initChart(data);
+})
+
+// Get the data
+function initChart(data) {
+    // Scale the range of the data
+    x.domain(d3.extent(data, function(d) { return d.x; }));
+    y.domain([0, d3.max(data, function(d) { return d.y; })]);
+
+    // Add the valueline path.
+    svg.append("path")
+        .attr("class", "line")
+        .attr("d", valueline(data));
+
+    // Add the X Axis
+    svg.append("g")
+        .attr("class", "x axis")
+        .attr("transform", "translate(0," + height + ")")
+        .call(xAxis);
+
+    // Add the Y Axis
+    svg.append("g")
+        .attr("class", "y axis")
+        .call(yAxis);
+
+};
 </script>
 </body>
 </html>

--- a/debug/expressions.html
+++ b/debug/expressions.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
+
+var style = {
+    sprite: "mapbox://sprites/mapbox/streets-v10",
+    glyphs: "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    sources: {
+        "geojson": {
+            "type": "geojson",
+            "data": {
+                "type": "FeatureCollection",
+                "features": [{"type":"Feature","properties":{"x":-10,"y":-10},"geometry":{"type":"Point","coordinates":[-10,-10]}},{"type":"Feature","properties":{"x":-10,"y":-6},"geometry":{"type":"Point","coordinates":[-10,-6]}},{"type":"Feature","properties":{"x":-10,"y":-2},"geometry":{"type":"Point","coordinates":[-10,-2]}},{"type":"Feature","properties":{"x":-10,"y":2},"geometry":{"type":"Point","coordinates":[-10,2]}},{"type":"Feature","properties":{"x":-10,"y":6},"geometry":{"type":"Point","coordinates":[-10,6]}},{"type":"Feature","properties":{"x":-10,"y":10},"geometry":{"type":"Point","coordinates":[-10,10]}},{"type":"Feature","properties":{"x":-6,"y":-10},"geometry":{"type":"Point","coordinates":[-6,-10]}},{"type":"Feature","properties":{"x":-6,"y":-6},"geometry":{"type":"Point","coordinates":[-6,-6]}},{"type":"Feature","properties":{"x":-6,"y":-2},"geometry":{"type":"Point","coordinates":[-6,-2]}},{"type":"Feature","properties":{"x":-6,"y":2},"geometry":{"type":"Point","coordinates":[-6,2]}},{"type":"Feature","properties":{"x":-6,"y":6},"geometry":{"type":"Point","coordinates":[-6,6]}},{"type":"Feature","properties":{"x":-6,"y":10},"geometry":{"type":"Point","coordinates":[-6,10]}},{"type":"Feature","properties":{"x":-2,"y":-10},"geometry":{"type":"Point","coordinates":[-2,-10]}},{"type":"Feature","properties":{"x":-2,"y":-6},"geometry":{"type":"Point","coordinates":[-2,-6]}},{"type":"Feature","properties":{"x":-2,"y":-2},"geometry":{"type":"Point","coordinates":[-2,-2]}},{"type":"Feature","properties":{"x":-2,"y":2},"geometry":{"type":"Point","coordinates":[-2,2]}},{"type":"Feature","properties":{"x":-2,"y":6},"geometry":{"type":"Point","coordinates":[-2,6]}},{"type":"Feature","properties":{"x":-2,"y":10},"geometry":{"type":"Point","coordinates":[-2,10]}},{"type":"Feature","properties":{"x":2,"y":-10},"geometry":{"type":"Point","coordinates":[2,-10]}},{"type":"Feature","properties":{"x":2,"y":-6},"geometry":{"type":"Point","coordinates":[2,-6]}},{"type":"Feature","properties":{"x":2,"y":-2},"geometry":{"type":"Point","coordinates":[2,-2]}},{"type":"Feature","properties":{"x":2,"y":2},"geometry":{"type":"Point","coordinates":[2,2]}},{"type":"Feature","properties":{"x":2,"y":6},"geometry":{"type":"Point","coordinates":[2,6]}},{"type":"Feature","properties":{"x":2,"y":10},"geometry":{"type":"Point","coordinates":[2,10]}},{"type":"Feature","properties":{"x":6,"y":-10},"geometry":{"type":"Point","coordinates":[6,-10]}},{"type":"Feature","properties":{"x":6,"y":-6},"geometry":{"type":"Point","coordinates":[6,-6]}},{"type":"Feature","properties":{"x":6,"y":-2},"geometry":{"type":"Point","coordinates":[6,-2]}},{"type":"Feature","properties":{"x":6,"y":2},"geometry":{"type":"Point","coordinates":[6,2]}},{"type":"Feature","properties":{"x":6,"y":6},"geometry":{"type":"Point","coordinates":[6,6]}},{"type":"Feature","properties":{"x":6,"y":10},"geometry":{"type":"Point","coordinates":[6,10]}},{"type":"Feature","properties":{"x":10,"y":-10},"geometry":{"type":"Point","coordinates":[10,-10]}},{"type":"Feature","properties":{"x":10,"y":-6},"geometry":{"type":"Point","coordinates":[10,-6]}},{"type":"Feature","properties":{"x":10,"y":-2},"geometry":{"type":"Point","coordinates":[10,-2]}},{"type":"Feature","properties":{"x":10,"y":2},"geometry":{"type":"Point","coordinates":[10,2]}},{"type":"Feature","properties":{"x":10,"y":6},"geometry":{"type":"Point","coordinates":[10,6]}},{"type":"Feature","properties":{"x":10,"y":10},"geometry":{"type":"Point","coordinates":[10,10]}}]
+            }
+        }
+    },
+    layers: [
+        {
+            id: 'circle',
+            type: 'circle',
+            source: 'geojson',
+            paint: {
+                'circle-radius': {
+                    type: 'expression',
+                    expression: [
+                        '*',
+                        [ '^', 2, {ref: 'map', key: 'zoom'} ],
+                        0.125,
+                        [
+                            '+',
+                            20,
+                            {ref: 'feature', key: 'x'},
+                            {ref: 'feature', key: 'y'}
+                        ]
+                    ]
+                },
+                'circle-opacity': {
+                    type: 'expression',
+                    expression: [ '/', [ '+', 10, {ref: 'feature', key: 'x'} ], 30 ]
+                },
+                'circle-color': {
+                    type: 'expression',
+                    expression: [
+                        'concat',
+                        'rgb(',
+                            [ '+', 128, [ '*', 10, {ref: 'feature', key: 'x'} ] ],
+                            ',',
+                            [ '+', 128, [ '*', 10, {ref: 'feature', key: 'y'} ] ],
+                            ',',
+                            128,
+                        ')'
+                    ]
+                }
+            }
+        }
+    ],
+    version: 8
+}
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 0,
+    center: [0, 0],
+    style: style,
+    hash: true
+});
+
+</script>
+</body>
+</html>

--- a/debug/expressions.html
+++ b/debug/expressions.html
@@ -40,31 +40,27 @@ var style = {
                     type: 'expression',
                     expression: [
                         '*',
-                        [ '^', 2, {ref: 'map', key: 'zoom'} ],
+                        [ '^', 2, ['zoom'] ],
                         0.125,
                         [
                             '+',
                             20,
-                            {ref: 'feature', key: 'x'},
-                            {ref: 'feature', key: 'y'}
+                            [ 'number_data', 'x' ],
+                            [ 'number_data', 'y' ]
                         ]
                     ]
                 },
                 'circle-opacity': {
                     type: 'expression',
-                    expression: [ '/', [ '+', 10, {ref: 'feature', key: 'x'} ], 30 ]
+                    expression: [ '/', [ '+', 10, ['number_data', 'x'] ], 30 ]
                 },
                 'circle-color': {
                     type: 'expression',
                     expression: [
-                        'concat',
-                        'rgb(',
-                            [ '+', 128, [ '*', 10, {ref: 'feature', key: 'x'} ] ],
-                            ',',
-                            [ '+', 128, [ '*', 10, {ref: 'feature', key: 'y'} ] ],
-                            ',',
-                            128,
-                        ')'
+                        'rgb',
+                            [ '+', 128, [ '*', 10, ['number_data', 'x'] ] ],
+                            [ '+', 128, [ '*', 10, ['number_data', 'y'] ] ],
+                            128
                     ]
                 }
             }

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -9,17 +9,20 @@
 - JSON string / number / boolean literal
 
 **Property lookup:**
-- Feature property: `[ "data", key_expr ]`
-- Map property:
+- Feature property:
+  - `[ "number_data", key_expr ]` reads `feature.properties[key_expr]`, coercing it to a number if necessary.
+  - `[ "string_data", key_expr ]` reads `feature.properties[key_expr]`, coercing it to a string if necessary.
+  - `[ "boolean_data", key_expr ]` reads `feature.properties[key_expr]`, coercing it to a boolean if necessary, with `0`, `''`, `null`, and missing properties mapping to `false`, and all other values mapping to `true`.
+  - `[ "has", key_expr ]` returns `true` if the property is present, false otherwise.
+  - `[ "typeof", key_expr ]` yields the data type of `feature.properties[key_expr]`: one of `'string'`, `'number'`, `'boolean'`, `'object'`, `'array'`, or, in the case that the property is not present, `'none'`.
+
+**Map property:**
   - `[ "zoom" ]` (Note: expressions that refer to the map zoom level are only evaluated at integer zoomslevels. When the map is at non-integer zoom levels, the expression's value will be approximated using linear or exponential interpolation.)
-  - `[ "pitch" ]`
-  - etc.
 
 **Decision:**
 - `["if", boolean_expr, expr_if_true, expr_if_false]` 
 
-**Boolean:**
-- `[ "has", key_expr ]`
+**Comparison and boolean operations:**
 - `[ "==", expr1, expr2]` (similar for `!=`)
 - `[ ">", lhs_expr, rhs_expr ]` (similar for <, >=, <=)
 - `[ "between", value_expr, lower_bound_expr, upper_bound_expr ]`

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -1,0 +1,40 @@
+# Style Function Expressions
+
+**Constants:**
+- LN2
+- PI
+- e
+
+**Literal:**
+- JSON string / number / boolean literal
+
+**Property lookup:**
+- Feature property:  `{ "ref": "feature", "key": propertyName, "default": defaultValue}`
+- Map property:  `{"ref": "map",  "key": "zoom"|"pitch"|… }`
+  - Note: expressions that refer to the map zoom level are only evaluated at integer zoomslevels. When the map is at non-integer zoom levels, the expression's value will be approximated using linear or exponential interpolation.
+
+**Decision:**
+- `["if", boolean_expr, expr_if_true, expr_if_false]` 
+  - Alternative: `[` `"``if``"``, [ filter_expr, expr_if_true ], [ filter_expr, expr_if_true], …, expr_otherwise]` (where the first matching filter wins)
+
+**Boolean:**
+- has, !has
+- ==, !=
+- >, <, >=, <=, between(?),
+- in, !in
+- all, any, none
+
+**String:**
+- `["concat", expr1, expr2, …]`
+- `["transform", string_expr, "uppercase"|"lowecase"]`
+
+**Numeric:**
+- +, -, \*, /, %, ^ (e.g. `["+", expr1, expr2, expr3, …]`, `["-", expr1, expr2 ]`, etc.)
+- log10, ln, log2
+- sin, cos, tan, asin, acos, atan
+- ceil, floor, round, abs
+- min, max
+
+**Color:**
+- rgb, hsl, hcl, lab, hex, (others?)
+

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -1,32 +1,34 @@
 # Style Function Expressions
 
 **Constants:**
-- LN2
-- PI
-- e
+- `[ "ln2" ]`
+- `[ "pi" ]`
+- `[ "e" ]`
 
 **Literal:**
 - JSON string / number / boolean literal
 
 **Property lookup:**
-- Feature property:  `{ "ref": "feature", "key": propertyName, "default": defaultValue}`
-- Map property:  `{"ref": "map",  "key": "zoom"|"pitch"|… }`
-  - Note: expressions that refer to the map zoom level are only evaluated at integer zoomslevels. When the map is at non-integer zoom levels, the expression's value will be approximated using linear or exponential interpolation.
+- Feature property: `[ "data", key_expr ]`
+- Map property:
+  - `[ "zoom" ]` (Note: expressions that refer to the map zoom level are only evaluated at integer zoomslevels. When the map is at non-integer zoom levels, the expression's value will be approximated using linear or exponential interpolation.)
+  - `[ "pitch" ]`
+  - etc.
 
 **Decision:**
 - `["if", boolean_expr, expr_if_true, expr_if_false]` 
-  - Alternative: `[` `"``if``"``, [ filter_expr, expr_if_true ], [ filter_expr, expr_if_true], …, expr_otherwise]` (where the first matching filter wins)
 
 **Boolean:**
-- has, !has
-- ==, !=
-- >, <, >=, <=, between(?),
-- in, !in
-- all, any, none
+- `[ "has", key_expr ]`
+- `[ "==", expr1, expr2]`
+- `[ ">", lhs_expr, rhs_expr ]` (similar for <, >=, <=)
+- `[ "between", value_expr, lower_bound_expr, upper_bound_expr ]`
+- `[ "in", value_expr, item1_expr, item2_expr, ... ]`
+- `[ "all", boolean_expr1, boolean_expr2, ... ]` (similar for any, none)
 
 **String:**
 - `["concat", expr1, expr2, …]`
-- `["transform", string_expr, "uppercase"|"lowecase"]`
+- `["upcase", string_expr]`, `["downcase", string_expr]`
 
 **Numeric:**
 - +, -, \*, /, %, ^ (e.g. `["+", expr1, expr2, expr3, …]`, `["-", expr1, expr2 ]`, etc.)

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -16,6 +16,7 @@
   - `[ "has", key_expr ]` returns `true` if the property is present, false otherwise.
   - `[ "typeof", key_expr ]` yields the data type of `feature.properties[key_expr]`: one of `'string'`, `'number'`, `'boolean'`, `'object'`, `'array'`, or, in the case that the property is not present, `'none'`.
 - `[ "geometry_type" ]` returns the value of `feature.geometry.type`.
+- `[ "string_id" ]`, `[ "number_id" ]` returns the value of `feature.id`.
 
 **Map property:**
   - `[ "zoom" ]` (Note: expressions that refer to the map zoom level are only evaluated at integer zoomslevels. When the map is at non-integer zoom levels, the expression's value will be approximated using linear or exponential interpolation.)

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -25,8 +25,6 @@
 **Comparison and boolean operations:**
 - `[ "==", expr1, expr2]` (similar for `!=`)
 - `[ ">", lhs_expr, rhs_expr ]` (similar for <, >=, <=)
-- `[ "between", value_expr, lower_bound_expr, upper_bound_expr ]`
-- `[ "in", value_expr, item1_expr, item2_expr, ... ]`
 - `[ "&&", boolean_expr1, boolean_expr2, ... ]` (similar for `||`)
 - `[ "!", boolean_expr]`
 

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -15,6 +15,7 @@
   - `[ "boolean_data", key_expr ]` reads `feature.properties[key_expr]`, coercing it to a boolean if necessary, with `0`, `''`, `null`, and missing properties mapping to `false`, and all other values mapping to `true`.
   - `[ "has", key_expr ]` returns `true` if the property is present, false otherwise.
   - `[ "typeof", key_expr ]` yields the data type of `feature.properties[key_expr]`: one of `'string'`, `'number'`, `'boolean'`, `'object'`, `'array'`, or, in the case that the property is not present, `'none'`.
+- `[ "geometry_type" ]` returns the value of `feature.geometry.type`.
 
 **Map property:**
   - `[ "zoom" ]` (Note: expressions that refer to the map zoom level are only evaluated at integer zoomslevels. When the map is at non-integer zoom levels, the expression's value will be approximated using linear or exponential interpolation.)

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -1,11 +1,102 @@
-# Style Function Expressions
+**NOTE: Consider the contents of this doc as a proposed replacement for the "Function" section of the style spec docs.  Drafting it here rather than in the HTML doc so that it's easier to read/comment on.**
+
+# Functions
+
+The value for any layout or paint property may be specified as a function. Functions allow you to make the appearance of a map feature change with the current zoom level and/or the feature's properties.
+
+## Property functions
+
+<p><strong>Property functions</strong> allow the appearance of a map feature to change with its properties. Property functions can be used to visually differentate types of features within the same layer or create data visualizations. Note that support for property functions is not available across all properties and platforms at this time.</p>
+
+`expression`
+_Required [expression value](#Expressions)_
+A property expression defines how one or more feature property values are combined using logical, mathematical, string, or color operations to produce the appropriate style value.  See [Expressions](#Expressions) for details.
+
+```js
+{
+  "circle-color": {
+    "expression": [
+      'rgb',
+      // red is higher when feature.properties.temperature is higher
+      ["number_data", "temperature"],
+      0,
+      // blue is higher when feature.properties.temperature is lower
+      ["-", 100, ["number_data", "temperature"]]
+    ]
+  }
+}
+```
+
+
+## Zoom functions
+
+**Zoom functions** allow the appearance of a map feature to change with map’s zoom level. Zoom functions can be used to create the illusion of depth and control data density.
+
+`stops`
+_Required array_
+Zoom functions are defined in terms of input values and output values. A set of one input value and one output value is known as a "stop."  Each stop is thus an array with two elements: the first is a zoom level; the second is either a style value or a property function.  Note that support for property functions is not yet complete.
+
+`base`
+_Optional number. Default is 1._
+The exponential base of the interpolation curve. It controls the rate at which the function output increases. Higher values make the output increase more towards the high end of the range. With values close to 1 the output increases linearly.
+
+`type`
+_Optional enum. One of exponential, interval._
+ - `exponential` functions generate an output by interpolating between stops just less than and just greater than the function input. The domain must be numeric. This is the default for properties marked with , the "exponential" symbol.
+ - `interval` functions return the output value of the stop just less than the function input. The domain must be numeric. This is the default for properties marked with , the "interval" symbol.
+
+
+### Example: a zoom-only function.
+
+```js
+{
+  "circle-radius": {
+    "stops": [
+
+      // zoom is 5 -> circle radius will be 1px
+      [5, 1],
+
+      // zoom is 10 -> circle radius will be 2px
+      [10, 2]
+
+    ]
+  }
+}
+```
+
+### Example: a zoom-and-property function
+
+Using property functions as the output value for one or more zoom stops allows 
+the appearance of a map feature to change with both the zoom level _and_ the
+feature's properties.
+
+```js
+{
+  "circle-radius": {
+    "stops": [
+      // zoom is 0 and "rating" is 0 -> circle radius will be 0px
+      // zoom is 0 and "rating" is 5 -> circle radius will be 5px
+      [0, { "expression": [ "number_data", "rating" ] }]
+
+      // zoom is 20 and "rating" is 0 -> circle radius will be 4 * 0 = 0px
+      // zoom is 20 and "rating" is 5 -> circle radius will be 4 * 5 = 20px
+      [20, { "expression": [ "*", 4, ["number_data", "rating"] ] }]
+    ]
+  }
+}
+```
+
+
+## Property Expressions
+
+Property expressions are represented using a Lisp-like structured syntax tree.
 
 **Constants:**
 - `[ "ln2" ]`
 - `[ "pi" ]`
 - `[ "e" ]`
 
-**Literal:**
+**Literals:**
 - JSON string / number / boolean literal
 
 **Property lookup:**
@@ -18,15 +109,15 @@
 - `[ "geometry_type" ]` returns the value of `feature.geometry.type`.
 - `[ "string_id" ]`, `[ "number_id" ]` returns the value of `feature.id`.
 
-**Map property:**
-  - `[ "zoom" ]` (Note: expressions that refer to the map zoom level are only evaluated at integer zoomslevels. When the map is at non-integer zoom levels, the expression's value will be approximated using linear or exponential interpolation.)
-
 **Decision:**
 - `["if", boolean_expr, expr_if_true, expr_if_false]` 
+- `["switch", default_result_expr, [bool_expr1, result_expr1], [bool_expr2, result_expr2], ...]`
+- `["match", input_expr, default_result_expr, [test_expr1, result_expr1], [test_expr2, result_expr2]]`
 
 **Comparison and boolean operations:**
 - `[ "==", expr1, expr2]` (similar for `!=`)
 - `[ ">", lhs_expr, rhs_expr ]` (similar for <, >=, <=)
+- `[ "between", "[]"|"(]"|"[)"|"()", test_expr, left_boundary_expr, right_boundary_expr ]` - tests whether `test_expr` is "between" the left and right boundaries, with the first argument dictating whether the each boundary is exclusive or inclusive.
 - `[ "&&", boolean_expr1, boolean_expr2, ... ]` (similar for `||`)
 - `[ "!", boolean_expr]`
 

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -20,11 +20,12 @@
 
 **Boolean:**
 - `[ "has", key_expr ]`
-- `[ "==", expr1, expr2]`
+- `[ "==", expr1, expr2]` (similar for `!=`)
 - `[ ">", lhs_expr, rhs_expr ]` (similar for <, >=, <=)
 - `[ "between", value_expr, lower_bound_expr, upper_bound_expr ]`
 - `[ "in", value_expr, item1_expr, item2_expr, ... ]`
-- `[ "all", boolean_expr1, boolean_expr2, ... ]` (similar for any, none)
+- `[ "&&", boolean_expr1, boolean_expr2, ... ]` (similar for `||`)
+- `[ "!", boolean_expr]`
 
 **String:**
 - `["concat", expr1, expr2, …]`

--- a/docs/style-spec/expressions.md
+++ b/docs/style-spec/expressions.md
@@ -111,13 +111,13 @@ Property expressions are represented using a Lisp-like structured syntax tree.
 
 **Decision:**
 - `["if", boolean_expr, expr_if_true, expr_if_false]` 
-- `["switch", default_result_expr, [bool_expr1, result_expr1], [bool_expr2, result_expr2], ...]`
-- `["match", input_expr, default_result_expr, [test_expr1, result_expr1], [test_expr2, result_expr2]]`
+- `["switch", [[bool_expr1, result_expr1], [bool_expr2, result_expr2], ...], default_result_expr]`
+- `["match", input_expr, [[test_expr1, result_expr1], [test_expr2, result_expr2]], default_result_expr]`
+- `["interval", numeric_expr, [lbound_expr1, result_expr1], [lbound_expr2, result_expr2], ...]`
 
 **Comparison and boolean operations:**
 - `[ "==", expr1, expr2]` (similar for `!=`)
 - `[ ">", lhs_expr, rhs_expr ]` (similar for <, >=, <=)
-- `[ "between", "[]"|"(]"|"[)"|"()", test_expr, left_boundary_expr, right_boundary_expr ]` - tests whether `test_expr` is "between" the left and right boundaries, with the first argument dictating whether the each boundary is exclusive or inclusive.
 - `[ "&&", boolean_expr1, boolean_expr2, ... ]` (similar for `||`)
 - `[ "!", boolean_expr]`
 
@@ -131,7 +131,9 @@ Property expressions are represented using a Lisp-like structured syntax tree.
 - sin, cos, tan, asin, acos, atan
 - ceil, floor, round, abs
 - min, max
+- `['linear', x, [ x1, y1 ], [ x2, y2 ] ]` - returns the output of the linear function determined by `(x1, y1)`, `(x2, y2)`, evaluated at `x`
 
 **Color:**
 - rgb, hsl, hcl, lab, hex, (others?)
+- `["color", color_name_expr]`
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,8 @@ mapboxgl.supported = require('./util/browser').supported;
 const config = require('./util/config');
 mapboxgl.config = config;
 
+mapboxgl.createFunction = require('./style-spec/function');
+
 const rtlTextPlugin = require('./source/rtl_text_plugin');
 
 mapboxgl.setRTLTextPlugin = rtlTextPlugin.setRTLTextPlugin;

--- a/src/style-spec/function/expression.js
+++ b/src/style-spec/function/expression.js
@@ -228,6 +228,22 @@ const functions = {
         input: [Type.String],
         output: Type.String
     },
+    'rgb': {
+        input: [Type.Number, Type.Number, Type.Number],
+        output: Type.Color
+    },
+    'rgba': {
+        input: [Type.Number, Type.Number, Type.Number, Type.Number],
+        output: Type.Color
+    },
+    'hsl': {
+        input: [Type.Number, Type.Number, Type.Number],
+        output: Type.Color
+    },
+    'hsla': {
+        input: [Type.Number, Type.Number, Type.Number, Type.Number],
+        output: Type.Color
+    },
     'if': {
         input: [Type.Boolean, Type.Any, Type.Any],
         output: null // determined at type-check time
@@ -325,6 +341,8 @@ function compile(expr) {
         compiled = `!(${args[0]})`;
     } else if (functions[op].math) {
         compiled = `Math.${op}(${args.join(', ')})`;
+    } else if (op === 'rgb' || op === 'rgba' || op === 'hsl' || op === 'hsla') {
+        compiled = `"${op}(" + ${args.join(' + "," + ')} + ")"`;
     } else {
         compiled = args.join(op);
     }

--- a/src/style-spec/function/expression.js
+++ b/src/style-spec/function/expression.js
@@ -40,7 +40,7 @@ module.exports = compileExpression;
  * {
  *   isFeatureConstant: boolean,
  *   isZoomConstant: boolean,
- *   compiledExpression: string,
+ *   expressionString: string,
  *   function: Function,
  *   errors: Array<{expression, error}>
  * }
@@ -55,7 +55,7 @@ function compileExpression(expr) {
 mapProperties = mapProperties || {};
 feature = feature || {};
 var props = feature.properties || {};
-return (${compiled.compiledExpression})
+return (${compiled.expressionString})
 `);
     }
     return compiled;
@@ -281,7 +281,7 @@ const functions = {
 
 function compile(expr) {
     if (!expr) return {
-        compiledExpression: 'undefined',
+        expressionString: 'undefined',
         isFeatureConstant: true,
         isZoomConstant: true,
         type: Type.None,
@@ -289,7 +289,7 @@ function compile(expr) {
     };
 
     if (typeof expr === 'string') return {
-        compiledExpression: JSON.stringify(expr),
+        expressionString: JSON.stringify(expr),
         isFeatureConstant: true,
         isZoomConstant: true,
         type: Type.String,
@@ -297,7 +297,7 @@ function compile(expr) {
     };
 
     if (typeof expr === 'number') return {
-        compiledExpression: JSON.stringify(expr),
+        expressionString: JSON.stringify(expr),
         isFeatureConstant: true,
         isZoomConstant: true,
         type: Type.Number,
@@ -305,7 +305,7 @@ function compile(expr) {
     };
 
     if (typeof expr === 'boolean') return {
-        compiledExpression: JSON.stringify(expr),
+        expressionString: JSON.stringify(expr),
         isFeatureConstant: true,
         isZoomConstant: true,
         type: Type.Boolean,
@@ -318,7 +318,7 @@ function compile(expr) {
     assert(Array.isArray(expr));
     const op = expr[0];
     const argExpressions = expr.slice(1).map(compile);
-    const args = argExpressions.map(s => `(${s.compiledExpression})`);
+    const args = argExpressions.map(s => `(${s.expressionString})`);
 
     if (!functions[op]) {
         errors.push({ expression: expr, error: `Unknown function ${op}`});
@@ -326,7 +326,7 @@ function compile(expr) {
 
     const type = checkType(expr, argExpressions.map(e => e.type), errors);
 
-    if (argExpressions.some(s => !s.compiledExpression)) {
+    if (argExpressions.some(s => !s.expressionString)) {
         return { errors, expression: expr };
     }
 
@@ -393,7 +393,7 @@ function compile(expr) {
     }
 
     return {
-        compiledExpression: compiled,
+        expressionString: compiled,
         errors,
         isFeatureConstant,
         isZoomConstant,

--- a/src/style-spec/function/expression.js
+++ b/src/style-spec/function/expression.js
@@ -1,7 +1,23 @@
 'use strict';
 
 const assert = require('assert');
-const createFilter = require('../feature_filter');
+
+const Type = {
+    None: {},
+    Any: {},
+    Number: {},
+    String: {},
+    Boolean: {},
+    Color: {}
+};
+
+Type.Array = {
+    [Type.Any]: {},
+    [Type.Number]: {},
+    [Type.String]: {},
+    [Type.Boolean]: {},
+    [Type.Color]: {}
+};
 
 module.exports = compileExpression;
 
@@ -16,86 +32,273 @@ return (${compiled.compiledExpression})
     return fun;
 }
 
+const functions = {
+    'ln2': {
+        input: [],
+        output: Type.Number,
+    },
+    'pi': {
+        input: [],
+        output: Type.Number,
+    },
+    'e': {
+        input: [],
+        output: Type.Number,
+    },
+    'zoom': {
+        input: [],
+        output: Type.Number,
+    },
+    'data': {
+        input: [Type.String],
+        output: Type.Any,
+    },
+    'has': {
+        input: [Type.String],
+        output: Type.Boolean
+    },
+    '+': {
+        input: [Type.Number, Type.Number],
+        output: Type.Number
+    },
+    '*': {
+        input: [Type.Number, Type.Number],
+        output: Type.Number
+    },
+    '-': {
+        input: [Type.Number, Type.Number],
+        output: Type.Number
+    },
+    '/': {
+        input: [Type.Number, Type.Number],
+        output: Type.Number
+    },
+    '^': {
+        input: [Type.Number, Type.Number],
+        output: Type.Number
+    },
+    '%': {
+        input: [Type.Number, Type.Number],
+        output: Type.Number
+    },
+    'log10': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'ln': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'log2': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'sin': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'cos': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'tan': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'asin': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'acos': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'atan': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'ceil': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'floor': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'round': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'abs': {
+        input: [Type.Number],
+        output: Type.Number,
+        math: true
+    },
+    'min': {
+        input: [Type.Array[Type.Number]],
+        output: Type.Number,
+        math: true
+    },
+    'max': {
+        input: [Type.Array[Type.Number]],
+        output: Type.Number,
+        math: true
+    },
+    '==': {
+        input: [Type.Any, Type.Any],
+        output: Type.Boolean
+    },
+    '!=': {
+        input: [Type.Any, Type.Any],
+        output: Type.Boolean
+    },
+    '>': {
+        input: [Type.Any, Type.Any],
+        output: Type.Boolean
+    },
+    '<': {
+        input: [Type.Any, Type.Any],
+        output: Type.Boolean
+    },
+    '>=': {
+        input: [Type.Any, Type.Any],
+        output: Type.Boolean
+    },
+    '<=': {
+        input: [Type.Any, Type.Any],
+        output: Type.Number
+    },
+    '&&': {
+        input: [Type.Boolean, Type.Boolean],
+        output: Type.Boolean
+    },
+    '||': {
+        input: [Type.Boolean, Type.Boolean],
+        output: Type.Boolean
+    },
+    '!': {
+        input: [Type.Boolean],
+        output: [Type.Boolean]
+    },
+    'concat': {
+        input: [Type.Array[Type.Any]],
+        output: Type.String
+    },
+    'upcase': {
+        input: [Type.String],
+        output: Type.String
+    },
+    'downcase': {
+        input: [Type.String],
+        output: Type.String
+    },
+    'if': {
+        input: [Type.Boolean, Type.Any, Type.Any],
+        output: Type.Any
+    }
+};
+
 function compile(expr) {
-    if (
-        !expr ||
-        typeof expr === 'string' ||
-        typeof expr === 'number' ||
-        typeof expr === 'boolean'
-    ) return {
-        compiledExpression: JSON.stringify(expr),
+    if (!expr) return {
+        compiledExpression: 'undefined',
         isFeatureConstant: true,
-        isZoomConstant: true
+        isZoomConstant: true,
+        type: Type.None
     };
 
-    if (expr.ref === 'feature') {
-        return {
-            compiledExpression: `
-                ${JSON.stringify(expr.key)} in props ?
-                    props[${JSON.stringify(expr.key)}] :
-                    (${JSON.stringify(expr.defaultValue)} || 0)
-            `,
-            isFeatureConstant: false,
-            isZoomConstant: true
-        };
-    }
+    if (typeof expr === 'string') return {
+        compiledExpression: JSON.stringify(expr),
+        isFeatureConstant: true,
+        isZoomConstant: true,
+        type: Type.String
+    };
 
-    if (expr.ref === 'map') {
-        return {
-            compiledExpression: `mapProperties[${JSON.stringify(expr.key)}]`,
-            isFeatureConstant: true,
-            isZoomConstant: expr.key !== 'zoom'
-        };
-    }
+    if (typeof expr === 'number') return {
+        compiledExpression: JSON.stringify(expr),
+        isFeatureConstant: true,
+        isZoomConstant: true,
+        type: Type.Number
+    };
+
+    if (typeof expr === 'boolean') return {
+        compiledExpression: JSON.stringify(expr),
+        isFeatureConstant: true,
+        isZoomConstant: true,
+        type: Type.Boolean
+    };
 
     assert(Array.isArray(expr));
-
     const op = expr[0];
+    const subExpressions = expr.slice(1).map(compile);
+    const args = subExpressions.map(s => `(${s.compiledExpression})`);
 
-    // feature filter
-    if (
-        op === '==' ||
-        op === '!=' ||
-        op === '<' ||
-        op === '>' ||
-        op === '<=' ||
-        op === '>=' ||
-        op === 'any' ||
-        op === 'all' ||
-        op === 'none' ||
-        op === 'in' ||
-        op === '!in' ||
-        op === 'has' ||
-        op === '!has'
-    ) {
-        const featureFilter = createFilter(expr);
-        return {
-            compiledExpression: `(${featureFilter.toString()})(feature)`,
-            isFeatureConstant: true,
-            isZoomConstant: true
-        };
+    if (!functions[op]) {
+        throw new Error(`Unknown function ${op}`);
     }
 
-    const subExpressions = expr.slice(1);
-    const args = subExpressions.map(compile).map(s => `(${s.compiledExpression})`);
+    checkArgumentTypes(functions[op].input, subExpressions);
 
     let compiled;
-    if (op === 'concat') {
+    let isFeatureConstant = subExpressions.reduce((memo, e) => memo && e.isFeatureConstant, true);
+    let isZoomConstant = subExpressions.reduce((memo, e) => memo && e.isZoomConstant, true);
+
+    if (op === 'e') {
+        compiled = `Math.E`;
+    } else if (op === 'ln2') {
+        compiled = `Math.LN2`;
+    } else if (op === 'pi') {
+        compiled = `Math.PI`;
+    } else if (op === 'data') {
+        compiled = `props[${args[0]}]`;
+        isFeatureConstant = false;
+    } else if (op === 'zoom') {
+        compiled = `mapProperties.zoom`;
+        isZoomConstant = false;
+    } else if (op === 'has') {
+        compiled = `${args[0]} in props`;
+        isFeatureConstant = false;
+    } else if (op === 'concat') {
         compiled = `[${args.join(',')}].join('')`;
-    } else if (op === '+' || op === '*') {
-        compiled = args.join(op);
+    } else if (op === 'upcase') {
+        compiled = `String(${args[0]}).toUpperCase()`;
+    } else if (op === 'downcase') {
+        compiled = `String(${args[0]}).toLowerCase()`;
     } else if (op === 'if') {
         compiled = `${args[0]} ? ${args[1]} : ${args[2]}`;
-    } else if (op === '-' || op === '/' || op === '%') {
-        compiled = `${args[0]} ${op} ${args[1]}`;
     } else if (op === '^') {
         compiled = `Math.pow(${args[0]}, ${args[1]})`;
+    } else if (op === 'ln') {
+        compiled = `Math.log(${args[0]})`;
+    } else if (op === '!') {
+        compiled = `!(${args[0]})`;
+    } else if (functions[op].math) {
+        compiled = `Math.${op}(${args.join(', ')})`;
+    } else {
+        compiled = args.join(op);
     }
 
     return {
         compiledExpression: compiled,
-        isFeatureConstant: subExpressions.reduce((memo, e) => memo && e.isFeatureConstant, true),
-        isZoomConstnat: subExpressions.reduce((memo, e) => memo && e.isZoomConstant, true)
+        isFeatureConstant,
+        isZoomConstant,
+        type: functions[op].type
     };
+}
+
+function checkArgumentTypes() {
+    // TODO
+    return;
 }
 

--- a/src/style-spec/function/expression.js
+++ b/src/style-spec/function/expression.js
@@ -36,7 +36,9 @@ module.exports = compileExpression;
 function compileExpression(expr) {
     const compiled = compile(expr);
     const fun = new Function('mapProperties', 'feature', `
-var props = (feature && feature.properties || {});
+mapProperties = mapProperties || {};
+feature = feature || {};
+var props = feature.properties || {};
 return (${compiled.compiledExpression})
 `);
     fun.isFeatureConstant = compiled.isFeatureConstant;
@@ -84,6 +86,14 @@ const functions = {
     'geometry_type': {
         input: [],
         output: Type.String
+    },
+    'string_id': {
+        input: [],
+        output: Type.String
+    },
+    'number_id': {
+        input: [],
+        output: Type.Number
     },
     '+': {
         input: [Type.Number, Type.Number],
@@ -327,7 +337,11 @@ function compile(expr) {
         compiled = `${args[0]} in props`;
         isFeatureConstant = false;
     } else if (op === 'geometry_type') {
-        compiled = `(feature && feature.geometry) ? feature.geometry.type : undefined`;
+        compiled = `feature.geometry ? feature.geometry.type : undefined`;
+    } else if (op === 'string_id') {
+        compiled = 'String(feature.id || \'\')';
+    } else if (op === 'number_id') {
+        compiled = 'Number(feature.id)';
     } else if (op === 'zoom') {
         compiled = `mapProperties.zoom`;
         isZoomConstant = false;

--- a/src/style-spec/function/expression.js
+++ b/src/style-spec/function/expression.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('assert');
+const createFilter = require('../feature_filter');
+
+module.exports = compileExpression;
+
+function compileExpression(expr) {
+    const compiled = compile(expr);
+    const fun = new Function('mapProperties', 'feature', `
+var props = (feature && feature.properties || {});
+return (${compiled.compiledExpression})
+`);
+    fun.isFeatureConstant = compiled.isFeatureConstant;
+    fun.isZoomConsant = compiled.isZoomConstant;
+    return fun;
+}
+
+function compile(expr) {
+    if (
+        !expr ||
+        typeof expr === 'string' ||
+        typeof expr === 'number' ||
+        typeof expr === 'boolean'
+    ) return {
+        compiledExpression: JSON.stringify(expr),
+        isFeatureConstant: true,
+        isZoomConstant: true
+    };
+
+    if (expr.ref === 'feature') {
+        return {
+            compiledExpression: `
+                ${JSON.stringify(expr.key)} in props ?
+                    props[${JSON.stringify(expr.key)}] :
+                    (${JSON.stringify(expr.defaultValue)} || 0)
+            `,
+            isFeatureConstant: false,
+            isZoomConstant: true
+        };
+    }
+
+    if (expr.ref === 'map') {
+        return {
+            compiledExpression: `mapProperties[${JSON.stringify(expr.key)}]`,
+            isFeatureConstant: true,
+            isZoomConstant: expr.key !== 'zoom'
+        };
+    }
+
+    assert(Array.isArray(expr));
+
+    const op = expr[0];
+
+    // feature filter
+    if (
+        op === '==' ||
+        op === '!=' ||
+        op === '<' ||
+        op === '>' ||
+        op === '<=' ||
+        op === '>=' ||
+        op === 'any' ||
+        op === 'all' ||
+        op === 'none' ||
+        op === 'in' ||
+        op === '!in' ||
+        op === 'has' ||
+        op === '!has'
+    ) {
+        const featureFilter = createFilter(expr);
+        return {
+            compiledExpression: `(${featureFilter.toString()})(feature)`,
+            isFeatureConstant: true,
+            isZoomConstant: true
+        };
+    }
+
+    const subExpressions = expr.slice(1);
+    const args = subExpressions.map(compile).map(s => `(${s.compiledExpression})`);
+
+    let compiled;
+    if (op === 'concat') {
+        compiled = `[${args.join(',')}].join('')`;
+    } else if (op === '+' || op === '*') {
+        compiled = args.join(op);
+    } else if (op === 'if') {
+        compiled = `${args[0]} ? ${args[1]} : ${args[2]}`;
+    } else if (op === '-' || op === '/' || op === '%') {
+        compiled = `${args[0]} ${op} ${args[1]}`;
+    } else if (op === '^') {
+        compiled = `Math.pow(${args[0]}, ${args[1]})`;
+    }
+
+    return {
+        compiledExpression: compiled,
+        isFeatureConstant: subExpressions.reduce((memo, e) => memo && e.isFeatureConstant, true),
+        isZoomConstnat: subExpressions.reduce((memo, e) => memo && e.isZoomConstant, true)
+    };
+}
+

--- a/src/style-spec/function/expression.js
+++ b/src/style-spec/function/expression.js
@@ -81,6 +81,10 @@ const functions = {
         input: [Type.String],
         output: Type.String
     },
+    'geometry_type': {
+        input: [],
+        output: Type.String
+    },
     '+': {
         input: [Type.Number, Type.Number],
         output: Type.Number
@@ -322,6 +326,8 @@ function compile(expr) {
     } else if (op === 'has') {
         compiled = `${args[0]} in props`;
         isFeatureConstant = false;
+    } else if (op === 'geometry_type') {
+        compiled = `(feature && feature.geometry) ? feature.geometry.type : undefined`;
     } else if (op === 'zoom') {
         compiled = `mapProperties.zoom`;
         isZoomConstant = false;

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -26,7 +26,7 @@ function createFunction(parameters, propertySpec) {
         fun.isFeatureConstant = true;
         fun.isZoomConstant = true;
     } else if (parameters.type === 'expression') {
-        const expressionFunction = compileExpression(parameters.expression);
+        const expressionFunction = compileExpression(parameters.expression).function;
         fun = function(zoom, featureProperties) {
             const result = expressionFunction({zoom}, {properties: featureProperties});
             return isColor ? parseColor(result) : result;

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -26,11 +26,14 @@ function createFunction(parameters, propertySpec) {
         fun.isFeatureConstant = true;
         fun.isZoomConstant = true;
     } else if (parameters.type === 'expression') {
-        const expressionFunction = compileExpression(parameters.expression).function;
+        const compiled = compileExpression(parameters.expression);
         fun = function(zoom, featureProperties) {
-            const result = expressionFunction({zoom}, {properties: featureProperties});
+            const result = compiled.function({zoom}, {properties: featureProperties});
             return isColor ? parseColor(result) : result;
         };
+        fun.isFeatureConstant = compiled.isFeatureConstant;
+        fun.isZoomConstant = compiled.isZoomConstant;
+        fun.zoomInterpolationBase = parameters.zoomInterpolationBase;
     } else {
         const zoomAndFeatureDependent = parameters.stops && typeof parameters.stops[0][0] === 'object';
         const featureDependent = zoomAndFeatureDependent || parameters.property !== undefined;

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1624,6 +1624,10 @@
     "doc": "The geometry type for the filter to select."
   },
   "function": {
+    "expression": {
+      "type": "*",
+      "doc": "A function expression"
+    },
     "stops": {
       "type": "array",
       "doc": "An array of stops.",
@@ -1654,6 +1658,9 @@
           },
           "categorical": {
               "doc": "Return the output value of the stop equal to the function input."
+          },
+          "expression": {
+              "doc": "Return the output value of the given function expression."
           }
       },
       "doc": "The interpolation strategy to use in function evaluation.",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1639,6 +1639,12 @@
       "minimum": 0,
       "doc": "The exponential base of the interpolation curve. It controls the rate at which the result increases. Higher values make the result increase more towards the high end of the range. With `1` the stops are interpolated linearly."
     },
+    "zoomInterpolationBase": {
+      "type": "number",
+      "default": 2,
+      "minimum": 0,
+      "doc": "The exponential base used to interpolate expression-based functions that are zoom-and-property-dependent."
+    },
     "property": {
       "type": "string",
       "doc": "The name of a feature property to use as the function input.",

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -39,7 +39,7 @@ module.exports = function validateFunction(options) {
         errors.push(new ValidationError(options.key, options.value, 'missing required property "property"'));
     }
 
-    if (functionType !== 'identity' && !options.value.stops) {
+    if (functionType !== 'identity' && functionType !== 'expression' && !options.value.stops) {
         errors.push(new ValidationError(options.key, options.value, 'missing required property "stops"'));
     }
 

--- a/src/style/style_declaration.js
+++ b/src/style/style_declaration.js
@@ -24,18 +24,32 @@ class StyleDeclaration {
         if (!this.isFeatureConstant && !this.isZoomConstant) {
             this.stopZoomLevels = [];
             const interpolationAmountStops = [];
-            for (const stop of this.value.stops) {
-                const zoom = stop[0].zoom;
-                if (this.stopZoomLevels.indexOf(zoom) < 0) {
-                    this.stopZoomLevels.push(zoom);
-                    interpolationAmountStops.push([zoom, interpolationAmountStops.length]);
+
+            let base;
+            if (this.value.type === 'expression') {
+                // generate "pseudo stops" for the function expression at
+                // integer zoom levels so that we can interpolate the
+                // render-time value the same way as for stop-based functions.
+                base = this.value.zoomInterpolationBase || 1;
+                for (let z = 0; z < 30; z++) {
+                    this.stopZoomLevels.push(z);
+                    interpolationAmountStops.push([z, interpolationAmountStops.length]);
+                }
+            } else {
+                base = this.value.base;
+                for (const stop of this.value.stops) {
+                    const zoom = stop[0].zoom;
+                    if (this.stopZoomLevels.indexOf(zoom) < 0) {
+                        this.stopZoomLevels.push(zoom);
+                        interpolationAmountStops.push([zoom, interpolationAmountStops.length]);
+                    }
                 }
             }
 
             this._functionInterpolationT = createFunction({
                 type: 'exponential',
                 stops: interpolationAmountStops,
-                base: value.base
+                base: base
             }, {
                 type: 'number'
             });

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -15,6 +15,16 @@ test('expressions', (t) => {
         t.end();
     });
 
+    t.test('constants', (t) => {
+        let f = createFunction([ 'ln2' ]);
+        t.equal(f(), Math.LN2);
+        f = createFunction([ 'pi' ]);
+        t.equal(f(), Math.PI);
+        f = createFunction([ 'e' ]);
+        t.equal(f(), Math.E);
+        t.end();
+    });
+
     t.test('number_data', (t) => {
         const f = createFunction(['number_data', 'x']);
         t.equal(f({}, { properties: { x: 42 } }), 42);

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -4,7 +4,7 @@ const test = require('mapbox-gl-js-test').test;
 const createFunction = require('../../../../src/style-spec/function/expression');
 
 test('expressions', (t) => {
-    t.test('constant', (t) => {
+    t.test('literals', (t) => {
         let f = createFunction(1);
         t.equal(f({}, {}), 1);
         f = createFunction("hi");
@@ -15,14 +15,56 @@ test('expressions', (t) => {
         t.end();
     });
 
-    t.test('feature property lookup', (t) => {
-        const f = createFunction(['data', 'x', 42]);
+    t.test('number_data', (t) => {
+        const f = createFunction(['number_data', 'x']);
         t.equal(f({}, { properties: { x: 42 } }), 42);
-        t.equal(f({}, {}), undefined);
+        t.equal(f({}, { properties: { x: '42' } }), 42);
+        t.ok(isNaN(f({}, {})));
         t.end();
     });
 
-    t.test('map property lookup', (t) => {
+    t.test('string_data', (t) => {
+        const f = createFunction(['string_data', 'x']);
+        t.equal(f({}, { properties: { x: 'hello' } }), 'hello');
+        t.equal(f({}, { properties: { x: 42 } }), '42');
+        t.equal(f({}, { properties: { x: true } }), 'true');
+        t.equal(f({}, {}), '');
+        t.end();
+    });
+
+    t.test('boolean_data', (t) => {
+        const f = createFunction(['boolean_data', 'x']);
+        t.equal(f({}, { properties: { x: true } }), true);
+        t.equal(f({}, { properties: { x: false } }), false);
+        t.equal(f({}, { properties: { x: 'hello' } }), true);
+        t.equal(f({}, { properties: { x: 42 } }), true);
+        t.equal(f({}, { properties: { x: '' } }), false);
+        t.equal(f({}, { properties: { x: 0 } }), false);
+        t.equal(f({}, {}), false);
+        t.end();
+    });
+
+    t.test('has', (t) => {
+        const f = createFunction(['has', 'x']);
+        t.equal(f({}, { properties: { x: 'foo' } }), true);
+        t.equal(f({}, { properties: { x: 0 } }), true);
+        t.equal(f({}, { properties: { x: null } }), true);
+        t.equal(f({}, { properties: {} }), false);
+        t.end();
+    });
+
+    t.test('typeof', (t) => {
+        const f = createFunction(['typeof', 'x']);
+        t.equal(f({}, { properties: { x: 'foo' } }), 'string');
+        t.equal(f({}, { properties: { x: 0 } }), 'number');
+        t.equal(f({}, { properties: { x: false } }), 'boolean');
+        t.equal(f({}, { properties: { x: [] } }), 'array');
+        t.equal(f({}, { properties: { x: {} } }), 'object');
+        t.equal(f({}, { properties: {} }), 'none');
+        t.end();
+    });
+
+    t.test('zoom', (t) => {
         const f = createFunction(['zoom']);
         t.equal(f({ zoom: 7 }, {}), 7);
         t.end();
@@ -32,22 +74,96 @@ test('expressions', (t) => {
         let f = createFunction([ '+', 1, 2 ]);
         t.equal(f({}, {}), 3);
 
-        f = createFunction([ '*', 2, ['data', 'x'] ]);
+        f = createFunction([ '*', 2, ['number_data', 'x'] ]);
         t.equal(f({}, { properties: { x: 42 } }), 84);
 
-        f = createFunction([ '/', [ 'data', 'y' ], [ 'data', 'x' ] ]);
+        f = createFunction([ '/', [ 'number_data', 'y' ], [ 'number_data', 'x' ] ]);
         t.equal(f({}, { properties: { x: -1, y: 12 } }), -12);
 
         t.end();
     });
 
-    t.test('concatenate strings', (t) => {
+    t.test('numeric comparison', (t) => {
+        let f = createFunction(['==', 1, ['number_data', 'x']]);
+        t.equal(f({}, {properties: {x: 1}}), true);
+        t.equal(f({}, {properties: {x: 2}}), false);
+        f = createFunction(['!=', 1, ['number_data', 'x']]);
+        t.equal(f({}, {properties: {x: 1}}), false);
+        t.equal(f({}, {properties: {x: 2}}), true);
+        f = createFunction(['>', 1, ['number_data', 'x']]);
+        t.equal(f({}, {properties: {x: 1}}), false);
+        t.equal(f({}, {properties: {x: 2}}), false);
+        t.equal(f({}, {properties: {x: 0}}), true);
+        f = createFunction(['<', 1, ['number_data', 'x']]);
+        t.equal(f({}, {properties: {x: 1}}), false);
+        t.equal(f({}, {properties: {x: 2}}), true);
+        t.equal(f({}, {properties: {x: 0}}), false);
+        f = createFunction(['>=', 1, ['number_data', 'x']]);
+        t.equal(f({}, {properties: {x: 1}}), true);
+        t.equal(f({}, {properties: {x: 2}}), false);
+        t.equal(f({}, {properties: {x: 0}}), true);
+        f = createFunction(['<=', 1, ['number_data', 'x']]);
+        t.equal(f({}, {properties: {x: 1}}), true);
+        t.equal(f({}, {properties: {x: 2}}), true);
+        t.equal(f({}, {properties: {x: 0}}), false);
+
+        t.throws(() => {
+            createFunction(['==', 1, ['string_data', 'x']]);
+        });
+
+        t.end();
+    });
+
+    t.test('string comparison', (t) => {
+        let f = createFunction(['==', 'abc', ['string_data', 'x']]);
+        t.equal(f({}, {properties: {x: 'abc'}}), true);
+        t.equal(f({}, {properties: {x: 'def'}}), false);
+        f = createFunction(['!=', 'abc', ['string_data', 'x']]);
+        t.equal(f({}, {properties: {x: 'abc'}}), false);
+        t.equal(f({}, {properties: {x: 'def'}}), true);
+        f = createFunction(['>', 'abc', ['string_data', 'x']]);
+        t.equal(f({}, {properties: {x: 'abc'}}), false);
+        t.equal(f({}, {properties: {x: 'def'}}), false);
+        t.equal(f({}, {properties: {x: 'aaa'}}), true);
+        f = createFunction(['<', 'abc', ['string_data', 'x']]);
+        t.equal(f({}, {properties: {x: 'abc'}}), false);
+        t.equal(f({}, {properties: {x: 'def'}}), true);
+        t.equal(f({}, {properties: {x: 'aaa'}}), false);
+        f = createFunction(['>=', 'abc', ['string_data', 'x']]);
+        t.equal(f({}, {properties: {x: 'abc'}}), true);
+        t.equal(f({}, {properties: {x: 'def'}}), false);
+        t.equal(f({}, {properties: {x: 'aaa'}}), true);
+        f = createFunction(['<=', 'abc', ['string_data', 'x']]);
+        t.equal(f({}, {properties: {x: 'abc'}}), true);
+        t.equal(f({}, {properties: {x: 'def'}}), true);
+        t.equal(f({}, {properties: {x: 'aaa'}}), false);
+
+        t.throws(() => {
+            createFunction(['==', 'abc', ['number_data', 'x']]);
+        });
+
+        t.end();
+    });
+
+    t.test('upcase', (t) => {
+        const f = createFunction(['upcase', ['string_data', 'x']]);
+        t.equal(f({}, {properties: {x: 'aBc'}}), 'ABC');
+        t.end();
+    });
+
+    t.test('downcase', (t) => {
+        const f = createFunction(['downcase', ['string_data', 'x']]);
+        t.equal(f({}, {properties: {x: 'AbC'}}), 'abc');
+        t.end();
+    });
+
+    t.test('concat', (t) => {
         let f = createFunction(['concat', 'a', 'b', 'c']);
 
         t.equal(f(), 'abc');
 
         f = createFunction([
-            'concat', ['data', 'name'], ' (', ['data', 'name_en'], ')'
+            'concat', ['string_data', 'name'], ' (', ['string_data', 'name_en'], ')'
         ]);
 
         t.equal(
@@ -55,41 +171,48 @@ test('expressions', (t) => {
             'B\'more (Baltimore)'
         );
 
+        f = createFunction(['concat', true, 1, 'foo']);
+        t.equal(f(), 'true1foo');
+
         t.end();
     });
 
-    t.test('conditional', (t) => {
+    t.test('if', (t) => {
         let f = createFunction([
             'if',
             [ 'has', 'x' ],
             [
                 '*',
-                ['data', 'y'],
-                ['data', 'x']
+                ['number_data', 'y'],
+                ['number_data', 'x']
             ],
-            'NONE'
+            -1
         ]);
 
         t.equal(f({}, { properties: { x: -1, y: 12 } }), -12);
-        t.equal(f({}, { properties: { y: 12 } }), 'NONE');
+        t.equal(f({}, { properties: { y: 12 } }), -1);
+
+        t.throws(() => {
+            createFunction(['if', ['has', 'x'], 1, 'two']);
+        });
 
         f = createFunction([
             'if', [ '&&', [ 'has', 'name_en' ], ['has', 'name'] ],
             [
                 'concat',
-                ['data', 'name'],
-                ' (', ['data', 'name_en'], ')'
+                ['string_data', 'name'],
+                ' (', ['string_data', 'name_en'], ')'
             ],
             [
                 'if', [ '&&', ['has', 'name_fr'], ['has', 'name'] ],
                 [
                     'concat',
-                    ['data', 'name'],
-                    ' (', ['data', 'name_fr'], ')'
+                    ['string_data', 'name'],
+                    ' (', ['string_data', 'name_fr'], ')'
                 ],
                 [
                     'if', ['has', 'name'],
-                    ['data', 'name'],
+                    ['string_data', 'name'],
                     'unnamed'
                 ]
             ]
@@ -102,6 +225,11 @@ test('expressions', (t) => {
             'Arispay (Paris)');
         t.equal(f({}, {}), 'unnamed');
 
+        t.end();
+    });
+
+    t.test('math functions require numeric arguments', (t) => {
+        t.throws(() => { createFunction(['+', '12', 6]); });
         t.end();
     });
 

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -145,6 +145,37 @@ test('expressions', (t) => {
         t.end();
     });
 
+    t.test('!', (t) => {
+        const f = createFunction(['!', ['==', ['number_data', 'x'], 1]]);
+        t.equal(f({}, {properties: {x: 1}}), false);
+        t.end();
+    });
+
+    t.test('&&', (t) => {
+        const f = createFunction([
+            '&&',
+            [ '==', [ 'number_data', 'x' ], 1 ],
+            [ '==', [ 'string_data', 'y' ], '2' ],
+            [ '==', [ 'string_data', 'z' ], '3' ]
+        ]);
+        t.equal(f({}, {properties: {x: 1, y: 2, z: 3}}), true);
+        t.equal(f({}, {properties: {x: 1, y: 0, z: 3}}), false);
+        t.end();
+    });
+
+    t.test('||', (t) => {
+        const f = createFunction([
+            '||',
+            [ '==', [ 'number_data', 'x' ], 1 ],
+            [ '==', [ 'string_data', 'y' ], '2' ],
+            [ '==', [ 'string_data', 'z' ], '3' ]
+        ]);
+        t.equal(f({}, {properties: {x: 1, y: 2, z: 3}}), true);
+        t.equal(f({}, {properties: {x: 1, y: 0, z: 3}}), true);
+        t.equal(f({}, {properties: {x: 0, y: 0, z: 0}}), false);
+        t.end();
+    });
+
     t.test('upcase', (t) => {
         const f = createFunction(['upcase', ['string_data', 'x']]);
         t.equal(f({}, {properties: {x: 'aBc'}}), 'ABC');

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -5,28 +5,28 @@ const createFunction = require('../../../../src/style-spec/function/expression')
 
 test('expressions', (t) => {
     t.test('literals', (t) => {
-        let f = createFunction(1);
+        let f = createFunction(1).function;
         t.equal(f({}, {}), 1);
-        f = createFunction("hi");
+        f = createFunction("hi").function;
         t.equal(f({}, {}), "hi");
-        f = createFunction(true);
+        f = createFunction(true).function;
         t.equal(f({}, {}), true);
 
         t.end();
     });
 
     t.test('constants', (t) => {
-        let f = createFunction([ 'ln2' ]);
+        let f = createFunction([ 'ln2' ]).function;
         t.equal(f(), Math.LN2);
-        f = createFunction([ 'pi' ]);
+        f = createFunction([ 'pi' ]).function;
         t.equal(f(), Math.PI);
-        f = createFunction([ 'e' ]);
+        f = createFunction([ 'e' ]).function;
         t.equal(f(), Math.E);
         t.end();
     });
 
     t.test('number_data', (t) => {
-        const f = createFunction(['number_data', 'x']);
+        const f = createFunction(['number_data', 'x']).function;
         t.equal(f({}, { properties: { x: 42 } }), 42);
         t.equal(f({}, { properties: { x: '42' } }), 42);
         t.ok(isNaN(f({}, {})));
@@ -34,7 +34,7 @@ test('expressions', (t) => {
     });
 
     t.test('string_data', (t) => {
-        const f = createFunction(['string_data', 'x']);
+        const f = createFunction(['string_data', 'x']).function;
         t.equal(f({}, { properties: { x: 'hello' } }), 'hello');
         t.equal(f({}, { properties: { x: 42 } }), '42');
         t.equal(f({}, { properties: { x: true } }), 'true');
@@ -43,7 +43,7 @@ test('expressions', (t) => {
     });
 
     t.test('boolean_data', (t) => {
-        const f = createFunction(['boolean_data', 'x']);
+        const f = createFunction(['boolean_data', 'x']).function;
         t.equal(f({}, { properties: { x: true } }), true);
         t.equal(f({}, { properties: { x: false } }), false);
         t.equal(f({}, { properties: { x: 'hello' } }), true);
@@ -55,28 +55,28 @@ test('expressions', (t) => {
     });
 
     t.test('geometry_type', (t) => {
-        const f = createFunction(['geometry_type']);
+        const f = createFunction(['geometry_type']).function;
         t.equal(f({}, { geometry: { type: 'LineString' }}), 'LineString');
         t.equal(f(), undefined);
         t.end();
     });
 
     t.test('string_id', (t) => {
-        const f = createFunction(['string_id']);
+        const f = createFunction(['string_id']).function;
         t.equal(f({}, { id: 1 }), '1');
         t.equal(f(), '');
         t.end();
     });
 
     t.test('number_id', (t) => {
-        const f = createFunction(['number_id']);
+        const f = createFunction(['number_id']).function;
         t.equal(f({}, { id: 1 }), 1);
         t.ok(isNaN(f()));
         t.end();
     });
 
     t.test('has', (t) => {
-        const f = createFunction(['has', 'x']);
+        const f = createFunction(['has', 'x']).function;
         t.equal(f({}, { properties: { x: 'foo' } }), true);
         t.equal(f({}, { properties: { x: 0 } }), true);
         t.equal(f({}, { properties: { x: null } }), true);
@@ -85,7 +85,7 @@ test('expressions', (t) => {
     });
 
     t.test('typeof', (t) => {
-        const f = createFunction(['typeof', 'x']);
+        const f = createFunction(['typeof', 'x']).function;
         t.equal(f({}, { properties: { x: 'foo' } }), 'string');
         t.equal(f({}, { properties: { x: 0 } }), 'number');
         t.equal(f({}, { properties: { x: false } }), 'boolean');
@@ -96,88 +96,90 @@ test('expressions', (t) => {
     });
 
     t.test('zoom', (t) => {
-        const f = createFunction(['zoom']);
+        const f = createFunction(['zoom']).function;
         t.equal(f({ zoom: 7 }, {}), 7);
         t.end();
     });
 
     t.test('basic arithmetic', (t) => {
-        let f = createFunction([ '+', 1, 2 ]);
+        let f = createFunction([ '+', 1, 2 ]).function;
         t.equal(f({}, {}), 3);
 
-        f = createFunction([ '*', 2, ['number_data', 'x'] ]);
+        f = createFunction([ '*', 2, ['number_data', 'x'] ]).function;
         t.equal(f({}, { properties: { x: 42 } }), 84);
 
-        f = createFunction([ '/', [ 'number_data', 'y' ], [ 'number_data', 'x' ] ]);
+        f = createFunction([ '/', [ 'number_data', 'y' ], [ 'number_data', 'x' ] ]).function;
         t.equal(f({}, { properties: { x: -1, y: 12 } }), -12);
 
         t.end();
     });
 
     t.test('numeric comparison', (t) => {
-        let f = createFunction(['==', 1, ['number_data', 'x']]);
+        let f = createFunction(['==', 1, ['number_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 1}}), true);
         t.equal(f({}, {properties: {x: 2}}), false);
-        f = createFunction(['!=', 1, ['number_data', 'x']]);
+        f = createFunction(['!=', 1, ['number_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 1}}), false);
         t.equal(f({}, {properties: {x: 2}}), true);
-        f = createFunction(['>', 1, ['number_data', 'x']]);
+        f = createFunction(['>', 1, ['number_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 1}}), false);
         t.equal(f({}, {properties: {x: 2}}), false);
         t.equal(f({}, {properties: {x: 0}}), true);
-        f = createFunction(['<', 1, ['number_data', 'x']]);
+        f = createFunction(['<', 1, ['number_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 1}}), false);
         t.equal(f({}, {properties: {x: 2}}), true);
         t.equal(f({}, {properties: {x: 0}}), false);
-        f = createFunction(['>=', 1, ['number_data', 'x']]);
+        f = createFunction(['>=', 1, ['number_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 1}}), true);
         t.equal(f({}, {properties: {x: 2}}), false);
         t.equal(f({}, {properties: {x: 0}}), true);
-        f = createFunction(['<=', 1, ['number_data', 'x']]);
+        f = createFunction(['<=', 1, ['number_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 1}}), true);
         t.equal(f({}, {properties: {x: 2}}), true);
         t.equal(f({}, {properties: {x: 0}}), false);
 
-        t.throws(() => {
-            createFunction(['==', 1, ['string_data', 'x']]);
-        });
+        t.deepEqual(
+            createFunction(['==', 1, ['string_data', 'x']]).errors.map(e => e.error),
+            ['Comparison operator == requires two expressions of matching types, but number and string do not match.']
+        );
 
         t.end();
     });
 
     t.test('string comparison', (t) => {
-        let f = createFunction(['==', 'abc', ['string_data', 'x']]);
+        let f = createFunction(['==', 'abc', ['string_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 'abc'}}), true);
         t.equal(f({}, {properties: {x: 'def'}}), false);
-        f = createFunction(['!=', 'abc', ['string_data', 'x']]);
+        f = createFunction(['!=', 'abc', ['string_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 'abc'}}), false);
         t.equal(f({}, {properties: {x: 'def'}}), true);
-        f = createFunction(['>', 'abc', ['string_data', 'x']]);
+        f = createFunction(['>', 'abc', ['string_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 'abc'}}), false);
         t.equal(f({}, {properties: {x: 'def'}}), false);
         t.equal(f({}, {properties: {x: 'aaa'}}), true);
-        f = createFunction(['<', 'abc', ['string_data', 'x']]);
+        f = createFunction(['<', 'abc', ['string_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 'abc'}}), false);
         t.equal(f({}, {properties: {x: 'def'}}), true);
         t.equal(f({}, {properties: {x: 'aaa'}}), false);
-        f = createFunction(['>=', 'abc', ['string_data', 'x']]);
+        f = createFunction(['>=', 'abc', ['string_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 'abc'}}), true);
         t.equal(f({}, {properties: {x: 'def'}}), false);
         t.equal(f({}, {properties: {x: 'aaa'}}), true);
-        f = createFunction(['<=', 'abc', ['string_data', 'x']]);
+        f = createFunction(['<=', 'abc', ['string_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 'abc'}}), true);
         t.equal(f({}, {properties: {x: 'def'}}), true);
         t.equal(f({}, {properties: {x: 'aaa'}}), false);
 
-        t.throws(() => {
-            createFunction(['==', 'abc', ['number_data', 'x']]);
-        });
+        t.deepEqual(
+            createFunction(['==', 'abc', ['number_data', 'x']]).errors.map(e => e.error),
+            ['Comparison operator == requires two expressions of matching types, but string and number do not match.']
+        );
 
         t.end();
     });
 
     t.test('!', (t) => {
-        const f = createFunction(['!', ['==', ['number_data', 'x'], 1]]);
+        const f = createFunction(['!', ['==', ['number_data', 'x'], 1]]).function;
         t.equal(f({}, {properties: {x: 1}}), false);
         t.end();
     });
@@ -188,7 +190,7 @@ test('expressions', (t) => {
             [ '==', [ 'number_data', 'x' ], 1 ],
             [ '==', [ 'string_data', 'y' ], '2' ],
             [ '==', [ 'string_data', 'z' ], '3' ]
-        ]);
+        ]).function;
         t.equal(f({}, {properties: {x: 1, y: 2, z: 3}}), true);
         t.equal(f({}, {properties: {x: 1, y: 0, z: 3}}), false);
         t.end();
@@ -200,7 +202,7 @@ test('expressions', (t) => {
             [ '==', [ 'number_data', 'x' ], 1 ],
             [ '==', [ 'string_data', 'y' ], '2' ],
             [ '==', [ 'string_data', 'z' ], '3' ]
-        ]);
+        ]).function;
         t.equal(f({}, {properties: {x: 1, y: 2, z: 3}}), true);
         t.equal(f({}, {properties: {x: 1, y: 0, z: 3}}), true);
         t.equal(f({}, {properties: {x: 0, y: 0, z: 0}}), false);
@@ -208,32 +210,32 @@ test('expressions', (t) => {
     });
 
     t.test('upcase', (t) => {
-        const f = createFunction(['upcase', ['string_data', 'x']]);
+        const f = createFunction(['upcase', ['string_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 'aBc'}}), 'ABC');
         t.end();
     });
 
     t.test('downcase', (t) => {
-        const f = createFunction(['downcase', ['string_data', 'x']]);
+        const f = createFunction(['downcase', ['string_data', 'x']]).function;
         t.equal(f({}, {properties: {x: 'AbC'}}), 'abc');
         t.end();
     });
 
     t.test('concat', (t) => {
-        let f = createFunction(['concat', 'a', 'b', 'c']);
+        let f = createFunction(['concat', 'a', 'b', 'c']).function;
 
         t.equal(f(), 'abc');
 
         f = createFunction([
             'concat', ['string_data', 'name'], ' (', ['string_data', 'name_en'], ')'
-        ]);
+        ]).function;
 
         t.equal(
             f({}, { properties: { name: 'B\'more', 'name_en': 'Baltimore' } }),
             'B\'more (Baltimore)'
         );
 
-        f = createFunction(['concat', true, 1, 'foo']);
+        f = createFunction(['concat', true, 1, 'foo']).function;
         t.equal(f(), 'true1foo');
 
         t.end();
@@ -245,7 +247,7 @@ test('expressions', (t) => {
             [ '+', 128, [ '*', 10, ['number_data', 'x'] ] ],
             [ '+', 128, [ '*', 10, ['number_data', 'y'] ] ],
             128
-        ]);
+        ]).function;
         t.equal(f({}, {properties: {x: -5, y: 5}}), 'rgb(78,178,128)');
         t.end();
     });
@@ -260,14 +262,15 @@ test('expressions', (t) => {
                 ['number_data', 'x']
             ],
             -1
-        ]);
+        ]).function;
 
         t.equal(f({}, { properties: { x: -1, y: 12 } }), -12);
         t.equal(f({}, { properties: { y: 12 } }), -1);
 
-        t.throws(() => {
-            createFunction(['if', ['has', 'x'], 1, 'two']);
-        });
+        t.deepEqual(
+            createFunction(['if', ['has', 'x'], 1, 'two']).errors.map(e => e.error),
+            ['Expected both branches of \'if\' to have the same type, but number and string do not match.']
+        );
 
         f = createFunction([
             'if', [ '&&', [ 'has', 'name_en' ], ['has', 'name'] ],
@@ -289,7 +292,7 @@ test('expressions', (t) => {
                     'unnamed'
                 ]
             ]
-        ]);
+        ]).function;
 
         t.equal(f({}, { properties: { name: 'Foo' } }), 'Foo');
         t.equal(f({}, { properties: { name: 'Illyphay', 'name_en': 'Philly' } }),
@@ -302,7 +305,10 @@ test('expressions', (t) => {
     });
 
     t.test('math functions require numeric arguments', (t) => {
-        t.throws(() => { createFunction(['+', '12', 6]); });
+        t.deepEqual(
+            createFunction(['+', '12', 6]).errors.map(e => e.error),
+            ['Expected number but found string']
+        );
         t.end();
     });
 

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -16,17 +16,14 @@ test('expressions', (t) => {
     });
 
     t.test('feature property lookup', (t) => {
-        let f = createFunction({ ref: 'feature', key: 'x', defaultValue: 12 });
-        t.equal(f({}, {}), 12);
+        const f = createFunction(['data', 'x', 42]);
         t.equal(f({}, { properties: { x: 42 } }), 42);
-
-        f = createFunction({ ref: 'feature', key: 'x' });
-        t.equal(f({}, {}), 0);
+        t.equal(f({}, {}), undefined);
         t.end();
     });
 
     t.test('map property lookup', (t) => {
-        const f = createFunction({ ref: 'map', key: 'zoom' });
+        const f = createFunction(['zoom']);
         t.equal(f({ zoom: 7 }, {}), 7);
         t.end();
     });
@@ -35,17 +32,10 @@ test('expressions', (t) => {
         let f = createFunction([ '+', 1, 2 ]);
         t.equal(f({}, {}), 3);
 
-        f = createFunction([
-            '*', 2,
-            { ref: 'feature', key: 'x' }
-        ]);
+        f = createFunction([ '*', 2, ['data', 'x'] ]);
         t.equal(f({}, { properties: { x: 42 } }), 84);
 
-        f = createFunction([
-            '/',
-            { ref: 'feature', key: 'y' },
-            { ref: 'feature', key: 'x' }
-        ]);
+        f = createFunction([ '/', [ 'data', 'y' ], [ 'data', 'x' ] ]);
         t.equal(f({}, { properties: { x: -1, y: 12 } }), -12);
 
         t.end();
@@ -57,9 +47,7 @@ test('expressions', (t) => {
         t.equal(f(), 'abc');
 
         f = createFunction([
-            'concat',
-            {ref: 'feature', key: 'name'},
-            ' (', {ref: 'feature', key: 'name_en'}, ')'
+            'concat', ['data', 'name'], ' (', ['data', 'name_en'], ')'
         ]);
 
         t.equal(
@@ -76,8 +64,8 @@ test('expressions', (t) => {
             [ 'has', 'x' ],
             [
                 '*',
-                { ref: 'feature', key: 'y' },
-                { ref: 'feature', key: 'x' }
+                ['data', 'y'],
+                ['data', 'x']
             ],
             'NONE'
         ]);
@@ -86,20 +74,24 @@ test('expressions', (t) => {
         t.equal(f({}, { properties: { y: 12 } }), 'NONE');
 
         f = createFunction([
-            'if', [ 'all', [ 'has', 'name_en' ], ['has', 'name'] ],
+            'if', [ '&&', [ 'has', 'name_en' ], ['has', 'name'] ],
             [
                 'concat',
-                {ref: 'feature', key: 'name'},
-                ' (', {ref: 'feature', key: 'name_en'}, ')'
+                ['data', 'name'],
+                ' (', ['data', 'name_en'], ')'
             ],
             [
-                'if', [ 'all', ['has', 'name_fr'], ['has', 'name'] ],
+                'if', [ '&&', ['has', 'name_fr'], ['has', 'name'] ],
                 [
                     'concat',
-                    {ref: 'feature', key: 'name'},
-                    ' (', {ref: 'feature', key: 'name_fr'}, ')'
+                    ['data', 'name'],
+                    ' (', ['data', 'name_fr'], ')'
                 ],
-                {ref: 'feature', key: 'name', defaultValue: 'unnamed'}
+                [
+                    'if', ['has', 'name'],
+                    ['data', 'name'],
+                    'unnamed'
+                ]
             ]
         ]);
 

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -177,6 +177,17 @@ test('expressions', (t) => {
         t.end();
     });
 
+    t.test('color functions', (t) => {
+        const f = createFunction([
+            'rgb',
+            [ '+', 128, [ '*', 10, ['number_data', 'x'] ] ],
+            [ '+', 128, [ '*', 10, ['number_data', 'y'] ] ],
+            128
+        ]);
+        t.equal(f({}, {properties: {x: -5, y: 5}}), 'rgb(78,178,128)');
+        t.end();
+    });
+
     t.test('if', (t) => {
         let f = createFunction([
             'if',

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -54,6 +54,13 @@ test('expressions', (t) => {
         t.end();
     });
 
+    t.test('geometry_type', (t) => {
+        const f = createFunction(['geometry_type']);
+        t.equal(f({}, { geometry: { type: 'LineString' }}), 'LineString');
+        t.equal(f(), undefined);
+        t.end();
+    });
+
     t.test('has', (t) => {
         const f = createFunction(['has', 'x']);
         t.equal(f({}, { properties: { x: 'foo' } }), true);

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const test = require('mapbox-gl-js-test').test;
+const createFunction = require('../../../../src/style-spec/function/expression');
+
+test('expressions', (t) => {
+    t.test('constant', (t) => {
+        let f = createFunction(1);
+        t.equal(f({}, {}), 1);
+        f = createFunction("hi");
+        t.equal(f({}, {}), "hi");
+        f = createFunction(true);
+        t.equal(f({}, {}), true);
+
+        t.end();
+    });
+
+    t.test('feature property lookup', (t) => {
+        let f = createFunction({ ref: 'feature', key: 'x', defaultValue: 12 });
+        t.equal(f({}, {}), 12);
+        t.equal(f({}, { properties: { x: 42 } }), 42);
+
+        f = createFunction({ ref: 'feature', key: 'x' });
+        t.equal(f({}, {}), 0);
+        t.end();
+    });
+
+    t.test('map property lookup', (t) => {
+        const f = createFunction({ ref: 'map', key: 'zoom' });
+        t.equal(f({ zoom: 7 }, {}), 7);
+        t.end();
+    });
+
+    t.test('basic arithmetic', (t) => {
+        let f = createFunction([ '+', 1, 2 ]);
+        t.equal(f({}, {}), 3);
+
+        f = createFunction([
+            '*', 2,
+            { ref: 'feature', key: 'x' }
+        ]);
+        t.equal(f({}, { properties: { x: 42 } }), 84);
+
+        f = createFunction([
+            '/',
+            { ref: 'feature', key: 'y' },
+            { ref: 'feature', key: 'x' }
+        ]);
+        t.equal(f({}, { properties: { x: -1, y: 12 } }), -12);
+
+        t.end();
+    });
+
+    t.test('concatenate strings', (t) => {
+        let f = createFunction(['concat', 'a', 'b', 'c']);
+
+        t.equal(f(), 'abc');
+
+        f = createFunction([
+            'concat',
+            {ref: 'feature', key: 'name'},
+            ' (', {ref: 'feature', key: 'name_en'}, ')'
+        ]);
+
+        t.equal(
+            f({}, { properties: { name: 'B\'more', 'name_en': 'Baltimore' } }),
+            'B\'more (Baltimore)'
+        );
+
+        t.end();
+    });
+
+    t.test('conditional', (t) => {
+        let f = createFunction([
+            'if',
+            [ 'has', 'x' ],
+            [
+                '*',
+                { ref: 'feature', key: 'y' },
+                { ref: 'feature', key: 'x' }
+            ],
+            'NONE'
+        ]);
+
+        t.equal(f({}, { properties: { x: -1, y: 12 } }), -12);
+        t.equal(f({}, { properties: { y: 12 } }), 'NONE');
+
+        f = createFunction([
+            'if', [ 'all', [ 'has', 'name_en' ], ['has', 'name'] ],
+            [
+                'concat',
+                {ref: 'feature', key: 'name'},
+                ' (', {ref: 'feature', key: 'name_en'}, ')'
+            ],
+            [
+                'if', [ 'all', ['has', 'name_fr'], ['has', 'name'] ],
+                [
+                    'concat',
+                    {ref: 'feature', key: 'name'},
+                    ' (', {ref: 'feature', key: 'name_fr'}, ')'
+                ],
+                {ref: 'feature', key: 'name', defaultValue: 'unnamed'}
+            ]
+        ]);
+
+        t.equal(f({}, { properties: { name: 'Foo' } }), 'Foo');
+        t.equal(f({}, { properties: { name: 'Illyphay', 'name_en': 'Philly' } }),
+            'Illyphay (Philly)');
+        t.equal(f({}, { properties: { name: 'Arispay', 'name_fr': 'Paris' } }),
+            'Arispay (Paris)');
+        t.equal(f({}, {}), 'unnamed');
+
+        t.end();
+    });
+
+    t.end();
+});

--- a/test/unit/style-spec/function/expression.test.js
+++ b/test/unit/style-spec/function/expression.test.js
@@ -61,6 +61,20 @@ test('expressions', (t) => {
         t.end();
     });
 
+    t.test('string_id', (t) => {
+        const f = createFunction(['string_id']);
+        t.equal(f({}, { id: 1 }), '1');
+        t.equal(f(), '');
+        t.end();
+    });
+
+    t.test('number_id', (t) => {
+        const f = createFunction(['number_id']);
+        t.equal(f({}, { id: 1 }), 1);
+        t.ok(isNaN(f()));
+        t.end();
+    });
+
     t.test('has', (t) => {
         const f = createFunction(['has', 'x']);
         t.equal(f({}, { properties: { x: 'foo' } }), true);


### PR DESCRIPTION
Starting work here on a draft/strawman implementation for adding arbitrary expressions to style functions.  This first attempt attempts to synthesize the fruits of a few long-running discussions on the topic, in particular, https://github.com/mapbox/mapbox-gl-function/issues/28, https://github.com/mapbox/mapbox-gl-js/issues/4077, and https://github.com/mapbox/mapbox-gl-js/issues/4079.

## Important use cases that the final design should cover:
- unit conversion
- number formatting
  - decimal precision
  - thousands separator
- conditionals (for the token defaults use case)
- concatenation (for the token defaults use case)
- customizable interpolation
- arithmetic on feature properties within functions
- localization

## Expression-based style functions

Proposed plan:
 - deprecate zoom+property functions
 - deprecate property functions
 - keep stop-based zoom functions
 - allow data-driven expressions (a) as style property values, and (b) as output values for zoom function stops.  (I.e., (a) replaces "property functions", and (b) replaces zoom+property functions.)

See `docs/style-spec/expressions.md` for the spec details.

See `debug/expressions.html` for a couple example usages.

### Things we should design into the initial implementation
- [x] a way to map exact values to subexpressions, replacing type: categorical **currently proposed as `match`**
- [x] a way to match a value to a corresponding interval, replacing type: interval **currently proposed as a combination of `switch` and `between`**
- [x] a way to easily interpolate values linearly
- [x] number to string with specified number of decimal places (`1.2345` to `"1.23"`) **possible with `round`**

### Things we could add support for later
- a way to easily interpolate values exponentially, replacing type: exponential
- number to localized string (`21000` to `"21,000"` or `"21 000"` depending on locale)
- methods for converting between distance units (metres, feet, kilometres, miles)
- some way of localizing text by choosing the right name property
- time formatting/localization? temperature? money?

### Questions/issues
 - [ ] Should we cover image fallbacks as part of expression evaluation, or separately?


## Additional ideas
- [ ] Using something like http://jsep.from.so/ ( h/t @1ec5 ), it should be quite straightforward to parse expression text into the AST structure outlined above.
   - This may be useful both for the studio interface (if that's the route @mapbox/studio wants to go) and as a convenience alternative in the GL JS API (i.e. allowing something like `circle-radius: { type: "expression", expression: "(1 + properties.foo) * 2^map.zoom)" }` when specifying styles via the runtime api.)



cc @mapbox/gl