### PR TITLE
Single-pass halo text

### DIFF
--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -214,13 +214,7 @@ function drawTileSymbols(program, programConfiguration, painter, layer, tile, bu
         const hasHalo = !layer.isPaintValueFeatureConstant(haloWidthProperty) || layer.paint[haloWidthProperty];
         const gammaScale = (pitchWithMap ? Math.cos(tr._pitch) : 1) * tr.cameraToCenterDistance;
         gl.uniform1f(program.u_gamma_scale, gammaScale);
-
-        if (hasHalo) { // Draw halo underneath the text.
-            gl.uniform1f(program.u_is_halo, 1);
-            drawSymbolElements(buffers, layer, gl, program);
-        }
-
-        gl.uniform1f(program.u_is_halo, 0);
+        gl.uniform1f(program.u_has_halo, hasHalo ? 1 : 0);
     }
 
     drawSymbolElements(buffers, layer, gl, program);

--- a/src/shaders/symbol_sdf.fragment.glsl
+++ b/src/shaders/symbol_sdf.fragment.glsl
@@ -1,7 +1,7 @@
 #define SDF_PX 8.0
 #define EDGE_GAMMA 0.105/DEVICE_PIXEL_RATIO
 
-uniform bool u_is_halo;
+uniform bool u_has_halo;
 #pragma mapbox: define highp vec4 fill_color
 #pragma mapbox: define highp vec4 halo_color
 #pragma mapbox: define lowp float opacity
@@ -26,20 +26,24 @@ void main() {
     #pragma mapbox: initialize lowp float halo_blur
 
     float fontScale = u_is_text ? v_size / 24.0 : v_size;
+    
+    lowp float dist = texture2D(u_texture, v_tex).a;
+    lowp float fade_alpha = texture2D(u_fadetexture, v_fade_tex).a;
 
     lowp vec4 color = fill_color;
     highp float gamma = EDGE_GAMMA / (fontScale * u_gamma_scale);
     lowp float buff = (256.0 - 64.0) / 256.0;
-    if (u_is_halo) {
-        color = halo_color;
-        gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
-        buff = (6.0 - halo_width / fontScale) / SDF_PX;
-    }
-
-    lowp float dist = texture2D(u_texture, v_tex).a;
-    lowp float fade_alpha = texture2D(u_fadetexture, v_fade_tex).a;
     highp float gamma_scaled = gamma * v_gamma_scale;
     highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist) * fade_alpha;
+
+    if (u_has_halo) {
+        gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
+        highp float gamma_scaled_halo = gamma * v_gamma_scale;
+        lowp float buff_halo = (6.0 - halo_width / fontScale) / SDF_PX;
+        highp float alpha_halo = smoothstep(buff_halo - gamma_scaled, buff_halo + gamma_scaled, dist) * fade_alpha;
+        color = mix(halo_color, color, alpha);
+        alpha = alpha_halo;
+    }
 
     gl_FragColor = color * (alpha * opacity);
 


### PR DESCRIPTION
With this change, halo text is rendered in the same shader pass as the text itself.

The motivation for this was to improve the appearance of overlapping text as shown below:

![screen shot 2017-05-17 at 10 55 23](https://cloud.githubusercontent.com/assets/4244876/26149474/51df38bc-3af2-11e7-800d-fd2bf06c6be2.png)

Presumably it also has a somewhat beneficial impact on performance.

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs   _...none in this case_
 - [ ] post benchmark scores
 - [ ] manually test the debug page
