### PR TITLE
Move pattern coordinate division by texture size into shader

### DIFF
--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -79,6 +79,7 @@ function drawLineTile(program, painter, tile, buffers, layer, coord, layerData, 
 
             gl.uniform2f(program.u_pattern_size_a, imagePosA.size[0] * image.fromScale / tileRatio, imagePosB.size[1]);
             gl.uniform2f(program.u_pattern_size_b, imagePosB.size[0] * image.toScale / tileRatio, imagePosB.size[1]);
+            gl.uniform2f(program.u_texsize, painter.spriteAtlas.width, painter.spriteAtlas.height);
         }
 
         gl.uniform2f(program.u_gl_units_to_pixels, 1 / painter.transform.pixelsToGLUnits[0], 1 / painter.transform.pixelsToGLUnits[1]);

--- a/src/render/pattern.js
+++ b/src/render/pattern.js
@@ -28,6 +28,7 @@ exports.prepare = function (image, painter, program) {
     gl.uniform2fv(program.u_pattern_br_a, imagePosA.br);
     gl.uniform2fv(program.u_pattern_tl_b, imagePosB.tl);
     gl.uniform2fv(program.u_pattern_br_b, imagePosB.br);
+    gl.uniform2f(program.u_texsize, painter.spriteAtlas.width, painter.spriteAtlas.height);
     gl.uniform1f(program.u_mix, image.t);
     gl.uniform2fv(program.u_pattern_size_a, imagePosA.size);
     gl.uniform2fv(program.u_pattern_size_b, imagePosB.size);

--- a/src/shaders/fill_extrusion_pattern.fragment.glsl
+++ b/src/shaders/fill_extrusion_pattern.fragment.glsl
@@ -2,6 +2,7 @@ uniform vec2 u_pattern_tl_a;
 uniform vec2 u_pattern_br_a;
 uniform vec2 u_pattern_tl_b;
 uniform vec2 u_pattern_br_b;
+uniform vec2 u_texsize;
 uniform float u_mix;
 
 uniform sampler2D u_image;
@@ -18,11 +19,11 @@ void main() {
     #pragma mapbox: initialize lowp float height
 
     vec2 imagecoord = mod(v_pos_a, 1.0);
-    vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, imagecoord);
+    vec2 pos = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, imagecoord);
     vec4 color1 = texture2D(u_image, pos);
 
     vec2 imagecoord_b = mod(v_pos_b, 1.0);
-    vec2 pos2 = mix(u_pattern_tl_b, u_pattern_br_b, imagecoord_b);
+    vec2 pos2 = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, imagecoord_b);
     vec4 color2 = texture2D(u_image, pos2);
 
     vec4 mixedColor = mix(color1, color2, u_mix);

--- a/src/shaders/fill_outline_pattern.fragment.glsl
+++ b/src/shaders/fill_outline_pattern.fragment.glsl
@@ -2,6 +2,7 @@ uniform vec2 u_pattern_tl_a;
 uniform vec2 u_pattern_br_a;
 uniform vec2 u_pattern_tl_b;
 uniform vec2 u_pattern_br_b;
+uniform vec2 u_texsize;
 uniform float u_mix;
 
 uniform sampler2D u_image;
@@ -16,11 +17,11 @@ void main() {
     #pragma mapbox: initialize lowp float opacity
 
     vec2 imagecoord = mod(v_pos_a, 1.0);
-    vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, imagecoord);
+    vec2 pos = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, imagecoord);
     vec4 color1 = texture2D(u_image, pos);
 
     vec2 imagecoord_b = mod(v_pos_b, 1.0);
-    vec2 pos2 = mix(u_pattern_tl_b, u_pattern_br_b, imagecoord_b);
+    vec2 pos2 = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, imagecoord_b);
     vec4 color2 = texture2D(u_image, pos2);
 
     // find distance to outline for alpha interpolation

--- a/src/shaders/fill_pattern.fragment.glsl
+++ b/src/shaders/fill_pattern.fragment.glsl
@@ -2,6 +2,7 @@ uniform vec2 u_pattern_tl_a;
 uniform vec2 u_pattern_br_a;
 uniform vec2 u_pattern_tl_b;
 uniform vec2 u_pattern_br_b;
+uniform vec2 u_texsize;
 uniform float u_mix;
 
 uniform sampler2D u_image;
@@ -15,11 +16,11 @@ void main() {
     #pragma mapbox: initialize lowp float opacity
 
     vec2 imagecoord = mod(v_pos_a, 1.0);
-    vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, imagecoord);
+    vec2 pos = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, imagecoord);
     vec4 color1 = texture2D(u_image, pos);
 
     vec2 imagecoord_b = mod(v_pos_b, 1.0);
-    vec2 pos2 = mix(u_pattern_tl_b, u_pattern_br_b, imagecoord_b);
+    vec2 pos2 = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, imagecoord_b);
     vec4 color2 = texture2D(u_image, pos2);
 
     gl_FragColor = mix(color1, color2, u_mix) * opacity;

--- a/src/shaders/line_pattern.fragment.glsl
+++ b/src/shaders/line_pattern.fragment.glsl
@@ -4,6 +4,7 @@ uniform vec2 u_pattern_tl_a;
 uniform vec2 u_pattern_br_a;
 uniform vec2 u_pattern_tl_b;
 uniform vec2 u_pattern_br_b;
+uniform vec2 u_texsize;
 uniform float u_fade;
 
 uniform sampler2D u_image;
@@ -33,8 +34,8 @@ void main() {
     float x_b = mod(v_linesofar / u_pattern_size_b.x, 1.0);
     float y_a = 0.5 + (v_normal.y * v_width2.s / u_pattern_size_a.y);
     float y_b = 0.5 + (v_normal.y * v_width2.s / u_pattern_size_b.y);
-    vec2 pos_a = mix(u_pattern_tl_a, u_pattern_br_a, vec2(x_a, y_a));
-    vec2 pos_b = mix(u_pattern_tl_b, u_pattern_br_b, vec2(x_b, y_b));
+    vec2 pos_a = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, vec2(x_a, y_a));
+    vec2 pos_b = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, vec2(x_b, y_b));
 
     vec4 color = mix(texture2D(u_image, pos_a), texture2D(u_image, pos_b), u_fade);
 

--- a/src/symbol/sprite_atlas.js
+++ b/src/symbol/sprite_atlas.js
@@ -144,8 +144,8 @@ class SpriteAtlas extends Evented {
 
         return {
             size: [image.width, image.height],
-            tl: [(rect.x + padding)         / this.width, (rect.y + padding)          / this.height],
-            br: [(rect.x + padding + width) / this.width, (rect.y + padding + height) / this.height]
+            tl: [(rect.x + padding),         (rect.y + padding)],
+            br: [(rect.x + padding + width), (rect.y + padding + height)]
         };
     }
 


### PR DESCRIPTION
This makes pattern usage more like icons, and will be necessary for data-driven *-pattern properties (because the texture coordinates will be used in vertex attributes, and you don't want to have to regenerate those buffers when the texture needs to grow in size).

But mainly this is to enable https://github.com/mapbox/mapbox-gl-native/pull/9038.