### PR TITLE
Fix bug with rerendering map after webglcontexlost

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1461,6 +1461,7 @@ class Map extends Camera {
     remove() {
         if (this._hash) this._hash.remove();
         browser.cancelFrame(this._frameId);
+        this._frameId = null;
         this.setStyle(null);
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1328,6 +1328,7 @@ class Map extends Camera {
         event.preventDefault();
         if (this._frameId) {
             browser.cancelFrame(this._frameId);
+            this._frameId = null;
         }
         this.fire('webglcontextlost', {originalEvent: event});
     }


### PR DESCRIPTION
On IE 11 and Edge map sometimes stops refreshing (loading new content).

It is caused by _webglcontextlost_ event being fired while frame is rendered. (easiest way to reproduce is to run frame-duration benchmark several times on IE)
After _webglcontextrestored_ event is fired map tries to rerender itself by calling `resize()` and then _move_ event fires which calls `_rerender()`.
Hovewer it hits condition `if (this.style && !this._frameId)` and stops.
`this._frameId` is not cleared, map cannot rerender and stops rendering new content.

This pull request cleares `map._frameId` when _webglcontextlost_ event is fired so it enables proper rendering restoration after losing webgl context.

## Launch Checklist


 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
