### PR TITLE
anchor Markers at their center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+#### :warning: Breaking changes
+
+- Markers are now anchored at their center by default ([#4751](https://github.com/mapbox/mapbox-gl-js/pull/4751))
+
 ## 0.38.0 (June 9, 2017)
 
 #### New features :sparkles:

--- a/docs/_posts/examples/3400-01-24-custom-marker-icons.html
+++ b/docs/_posts/examples/3400-01-24-custom-marker-icons.html
@@ -88,7 +88,7 @@ geojson.features.forEach(function(marker) {
     });
 
     // add marker to map
-    new mapboxgl.Marker(el, {offset: [-marker.properties.iconSize[0] / 2, -marker.properties.iconSize[1] / 2]})
+    new mapboxgl.Marker(el)
         .setLngLat(marker.geometry.coordinates)
         .addTo(map);
 });

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -254,9 +254,7 @@ class GeolocateControl extends Evented {
         if (this.options.showUserLocation) {
             this._dotElement = DOM.create('div', 'mapboxgl-user-location-dot');
 
-            // until https://github.com/mapbox/mapbox-gl-js/issues/2900, the offset is used to ensure the Marker is centered at the
-            // user's location, half of the .mapboxgl-user-location-dot width (including border).
-            this._userLocationDotMarker = new Marker(this._dotElement, { offset: [-10, -10] });
+            this._userLocationDotMarker = new Marker(this._dotElement);
 
             if (this.options.trackUserLocation) this._watchState = 'OFF';
         }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -8,7 +8,7 @@ const smartWrap = require('../util/smart_wrap');
  * Creates a marker component
  * @param {HTMLElement=} element DOM element to use as a marker (creates a div element by default)
  * @param {Object=} options
- * @param {PointLike=} options.offset The offset in pixels as a {@link PointLike} object to apply relative to the element's top left corner. Negatives indicate left and up.
+ * @param {PointLike=} options.offset The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
  * @example
  * var marker = new mapboxgl.Marker()
  *   .setLngLat([30.5, 50.5])
@@ -158,7 +158,8 @@ class Marker {
         }
 
         this._pos = this._map.project(this._lngLat)
-            ._add(this._offset);
+            ._add(this._offset)
+            ._add({x: -this._element.offsetWidth / 2, y: -this._element.offsetHeight / 2});
 
         // because rounding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -114,6 +114,9 @@ class Marker {
         }
 
         if (popup) {
+            if (!('offset' in popup.options)) {
+                popup.options.offset = this._offset;
+            }
             this._popup = popup;
             this._popup.setLngLat(this._lngLat);
         }

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -57,5 +57,20 @@ test('Marker', (t) => {
         t.end();
     });
 
+    t.test('marker centered by default', (t) => {
+        const map = createMap();
+        const element = window.document.createElement('div');
+        // jsdom workaround for element.style.width = '10px';
+        //                      element.style.height = '10px';
+        //                      element.style.border = '6px solid black';
+        Object.defineProperty(element, 'offsetWidth', {value: 6 + 10 + 6, configurable: true});
+        Object.defineProperty(element, 'offsetHeight', {value: 6 + 10 + 6, configurable: true});
+
+        const marker = new Marker(element).setLngLat([0, 0]).addTo(map);
+        const translate = Math.round((map.getContainer().offsetWidth / 2) - ((6 + 10 + 6) / 2));
+        t.equal(marker.getElement().style.transform, `translate(${translate}px, ${translate}px)`, 'Marker centered');
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
Closes #2900 (breaking change!)

Not sure if this is the best approach (tweaking transform translate values) or a CSS approach is best.

Currently if you change the HTML Element's size, it will loose centering until the map camera changes and triggers `Marker._update`.

## Launch Checklist

 - [x] briefly describe the changes in this PR
anchor Markers at their center by default per #2900 
 - [ ] write tests for all new functionality
~~~Tests aren't working, needs more work.~~~ Not sure how to test due to DOM used for tests is not behaving the same as a browser.
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
Need to check this extra calculation at each camera change doesn't add much overhead.
 - [x] manually test the debug page
looks okay (including when the element has a border).
