### PR TITLE
Require node 6; use more ES6 features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,11 +109,11 @@ See [`bench/README.md`](https://github.com/mapbox/mapbox-gl-js/blob/master/bench
   * Classes
   * Template strings
   * Computed and shorthand object properties
-* The following ES6 features are not to be used, in order to maintain support for Node 4.x, IE 11, and older mobile browsers. This may change in the future.
   * Default parameters
   * Rest parameters
-  * Spread (`...`) operator
   * Destructuring
+* The following ES6 features are not to be used, in order to maintain support for IE 11 and older mobile browsers. This may change in the future.
+  * Spread (`...`) operator (because it requires Object.assign)
   * Iterators and generators
   * "Library" features such as `Map`, `Set`, `array.find`, etc.
   * Modules

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/mapbox/mapbox-gl-js.git"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.4.0"
   },
   "dependencies": {
     "@mapbox/gl-matrix": "^0.0.1",

--- a/src/style-spec/error/validation_error.js
+++ b/src/style-spec/error/validation_error.js
@@ -2,11 +2,8 @@
 
 const format = require('util').format;
 
-function ValidationError(key, value /*, message, ...*/) {
-    this.message = (
-        (key ? `${key}: ` : '') +
-        format.apply(format, Array.prototype.slice.call(arguments, 2))
-    );
+function ValidationError(key, value, ...args) {
+    this.message = (key ? `${key}: ` : '') + format.apply(format, args);
 
     if (value !== null && value !== undefined && value.__line__) {
         this.line = value.__line__;

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -196,9 +196,9 @@ function evaluateExponentialFunction(parameters, propertySpec, input) {
     const interp = interpolate[propertySpec.type] || identityFunction;
 
     if (typeof outputLower === 'function') {
-        return function() {
-            const evaluatedLower = outputLower.apply(undefined, arguments);
-            const evaluatedUpper = outputUpper.apply(undefined, arguments);
+        return function(...args) {
+            const evaluatedLower = outputLower.apply(undefined, args);
+            const evaluatedUpper = outputUpper.apply(undefined, args);
             // Special case for fill-outline-color, which has no spec default.
             if (evaluatedLower === undefined || evaluatedUpper === undefined) {
                 return undefined;

--- a/src/style-spec/util/extend.js
+++ b/src/style-spec/util/extend.js
@@ -1,8 +1,7 @@
 'use strict';
 
-module.exports = function (output) {
-    for (let i = 1; i < arguments.length; i++) {
-        const input = arguments[i];
+module.exports = function (output, ...inputs) {
+    for (const input of inputs) {
         for (const k in input) {
             output[k] = input[k];
         }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -139,13 +139,11 @@ exports.keysDifference = function (obj: {[key: string]: mixed}, other: {[key: st
  * source objects.
  *
  * @param dest destination object
- * @param {...Object} sources sources from which properties are pulled
+ * @param sources sources from which properties are pulled
  * @private
  */
-// eslint-disable-next-line no-unused-vars
-exports.extend = function (dest: Object, source0: Object, source1?: Object, source2?: Object): Object {
-    for (let i = 1; i < arguments.length; i++) {
-        const src = arguments[i];
+exports.extend = function (dest: Object, ...sources: Array<Object>): Object {
+    for (const src of sources) {
         for (const k in src) {
             dest[k] = src[k];
         }

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -816,8 +816,8 @@ test('Style#addLayer', (t) => {
         };
 
         style.on('style.load', () => {
-            style.on('error', (e) => {
-                t.match(e.error.message, /does not exist on source/);
+            style.on('error', ({ error }) => {
+                t.match(error.message, /does not exist on source/);
                 t.end();
             });
             style.addLayer(layer);
@@ -882,8 +882,8 @@ test('Style#removeLayer', (t) => {
         const style = new Style(createStyleJSON());
 
         style.on('style.load', () => {
-            style.on('error', (e) => {
-                t.match(e.error.message, /does not exist in the map\'s style and cannot be removed/);
+            style.on('error', ({ error }) => {
+                t.match(error.message, /does not exist in the map\'s style and cannot be removed/);
                 t.end();
             });
             style.removeLayer('background');
@@ -961,8 +961,8 @@ test('Style#moveLayer', (t) => {
         const style = new Style(createStyleJSON());
 
         style.on('style.load', () => {
-            style.on('error', (e) => {
-                t.match(e.error.message, /does not exist in the map\'s style and cannot be moved/);
+            style.on('error', ({ error }) => {
+                t.match(error.message, /does not exist in the map\'s style and cannot be moved/);
                 t.end();
             });
             style.moveLayer('background');
@@ -1080,8 +1080,8 @@ test('Style#setFilter', (t) => {
         const style = createStyle();
 
         style.on('style.load', () => {
-            style.on('error', (e) => {
-                t.match(e.error.message, /does not exist in the map\'s style and cannot be filtered/);
+            style.on('error', ({ error }) => {
+                t.match(error.message, /does not exist in the map\'s style and cannot be filtered/);
                 t.end();
             });
             style.setFilter('non-existant', ['==', 'id', 1]);
@@ -1135,8 +1135,8 @@ test('Style#setLayerZoomRange', (t) => {
     t.test('fires an error if layer not found', (t) => {
         const style = createStyle();
         style.on('style.load', () => {
-            style.on('error', (e) => {
-                t.match(e.error.message, /does not exist in the map\'s style and cannot have zoom extent/);
+            style.on('error', ({ error }) => {
+                t.match(error.message, /does not exist in the map\'s style and cannot have zoom extent/);
                 t.end();
             });
             style.setLayerZoomRange('non-existant', 5, 12);

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1156,9 +1156,9 @@ test('camera', (t) => {
 
             camera.on('moveend', () => {
                 t.equalWithPrecision(camera.getZoom(), 10, 1e-10);
-                const center = camera.getCenter();
-                t.equalWithPrecision(center.lng, 12, 1e-10);
-                t.equalWithPrecision(center.lat, 34, 1e-10);
+                const { lng, lat } = camera.getCenter();
+                t.equalWithPrecision(lng, 12, 1e-10);
+                t.equalWithPrecision(lat, 34, 1e-10);
 
                 t.end();
             });
@@ -1176,9 +1176,9 @@ test('camera', (t) => {
 
             camera.on('moveend', () => {
                 t.equalWithPrecision(camera.getZoom(), 2, 1e-10);
-                const center = camera.getCenter();
-                t.equalWithPrecision(center.lng, 12, 1e-10);
-                t.equalWithPrecision(center.lat, 34, 1e-10);
+                const { lng, lat } = camera.getCenter();
+                t.equalWithPrecision(lng, 12, 1e-10);
+                t.equalWithPrecision(lat, 34, 1e-10);
 
                 t.end();
             });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -351,8 +351,8 @@ test('Map', (t) => {
             const map = createMap({style: style});
 
             map.on('load', () => {
-                map.on('error', (e) => {
-                    t.match(e.error.message, /There is no source with ID/);
+                map.on('error', ({ error }) => {
+                    t.match(error.message, /There is no source with ID/);
                     t.end();
                 });
                 map.isSourceLoaded('geojson');
@@ -964,8 +964,8 @@ test('Map', (t) => {
             });
 
             map.on('style.load', () => {
-                map.style.on('error', (e) => {
-                    t.match(e.error.message, /does not exist in the map\'s style and cannot be styled/);
+                map.style.on('error', ({ error }) => {
+                    t.match(error.message, /does not exist in the map\'s style and cannot be styled/);
                     t.end();
                 });
                 map.setLayoutProperty('non-existant', 'text-transform', 'lowercase');
@@ -1170,8 +1170,8 @@ test('Map', (t) => {
             });
 
             map.on('style.load', () => {
-                map.style.on('error', (e) => {
-                    t.match(e.error.message, /does not exist in the map\'s style and cannot be styled/);
+                map.style.on('error', ({ error }) => {
+                    t.match(error.message, /does not exist in the map\'s style and cannot be styled/);
                     t.end();
                 });
                 map.setPaintProperty('non-existant', 'background-color', 'red');


### PR DESCRIPTION
Require node 6, allowing us to permit use of additional ES6 features:

* default parameters
* rest parameters
* destructuring