### PR TITLE
Add tooltips to function icons, fix function links in docs

### DIFF
--- a/docs/style-spec/_generate/index.html
+++ b/docs/style-spec/_generate/index.html
@@ -703,8 +703,8 @@ navigation:
         layer can have independent paint properties. Paint properties appear in the layer's <code>"paint"</code> object.
       </p>
       <p class='space-bottom4 quiet small'>Key:
-        <a class='icon smooth-ramp quiet micro space-right inline' href='#function' title='Supports interpolated functions'>supports interpolated functions</a>
-        <a class='icon step-ramp quiet micro space-right inline' href='#function' title='Supports piecewise constant functions'>supports piecewise constant functions</a>
+        <a class='icon smooth-ramp quiet micro space-right inline' href='#types-function' title='Supports interpolated functions'>supports interpolated functions</a>
+        <a class='icon step-ramp quiet micro space-right inline' href='#types-function' title='Supports piecewise constant functions'>supports piecewise constant functions</a>
         <span class='icon opacity quiet micro space-right inline' title='Transitionable'>transitionable</span>
       </p>
 

--- a/docs/style-spec/_generate/item.html
+++ b/docs/style-spec/_generate/item.html
@@ -1,9 +1,9 @@
 <div class='col12 clearfix pad0y pad2x'>
   <div>
     <span class='code space-right'><a id='<%= id %>' href='#<%= id %>'><%= name %></a></span>
-    <% if (prop.function == "interpolated" ) { %><span class='icon smooth-ramp inline quiet'></span><% } %>
-    <% if (prop.function == "piecewise-constant" ) { %><span class='icon step-ramp inline quiet'></span><% } %>
-    <% if (prop.transition) { %><span class='icon opacity inline quiet'></span><% } %>
+    <% if (prop.function == "interpolated" ) { %><span class='icon smooth-ramp inline quiet' title='Supports interpolated functions'></span><% } %>
+    <% if (prop.function == "piecewise-constant" ) { %><span class='icon step-ramp inline quiet' title='Supports piecewise constant functions'></span><% } %>
+    <% if (prop.transition) { %><span class='icon opacity inline quiet' title='Transitionable'></span><% } %>
   </div>
   <div>
     <em class='inline quiet'>


### PR DESCRIPTION
This PR makes a couple minor changes to documentation:

- Fixes the links in the function icon key (`#function` -> `#types-function`)
- Adds `title` tooltips to the function icons:
  <img width="378" src="https://cloud.githubusercontent.com/assets/15995/26470883/54fb6986-416d-11e7-8c07-73e66f664ddb.png" />


## Launch Checklist

 - [x] briefly describe the changes in this PR
