### PR TITLE
light.anchor: zoom (piecewise-constant) functions supported

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1705,6 +1705,9 @@
         }
       },
       "transition": false,
+      "zoom-function": true,
+      "property-function": false,
+      "function": "piecewise-constant",
       "doc": "Whether extruded geometries are lit relative to the map or viewport.",
       "example": "map",
       "sdk-support": {


### PR DESCRIPTION
Fixes #4743 by adding appropriate key/value pairs to `light.anchor` documentation .