### PR TITLE
fix thrown exception with certain calls to flyTo

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -758,7 +758,7 @@ class Camera extends Evented {
             S = (r(1) - r0) / rho;
 
         // When u₀ = u₁, the optimal path doesn’t require both ascent and descent.
-        if (Math.abs(u1) < 0.000001) {
+        if (Math.abs(u1) < 0.000001 || isNaN(S)) {
             // Perform a more or less instantaneous transition if the path is too short.
             if (Math.abs(w0 - w1) < 0.000001) return this.easeTo(options, eventData);
 

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -784,6 +784,13 @@ test('camera', (t) => {
             t.end();
         });
 
+        t.test('does not throw when cameras current zoom is sufficiently greater than passed zoom option', (t)=>{
+            const camera = createCamera({zoom: 22, center:[0, 0]});
+            t.doesNotThrow(()=>camera.flyTo({zoom:10, center:[0, 0]}));
+            t.end();
+
+        });
+
         t.test('zooms to specified level', (t) => {
             const camera = createCamera();
             camera.flyTo({ zoom: 3.2, animate: false });


### PR DESCRIPTION
Fix #4753 

@mourner some cases where w0 and w1 were very similar, but w1 was zoomed out significantly from w0 were causing r() to return infinity, causing S to be initially set at NaN. 

Not sure if this fix is how you'd do it but it manages to avoid the thrown `Failed to Invert Matrix`. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
