### PR TITLE
Add global mapboxgl.setURLTransform

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,12 +25,12 @@ mapboxgl.Point = require('point-geometry');
 
 mapboxgl.Evented = require('./util/evented');
 mapboxgl.supported = require('./util/browser').supported;
+mapboxgl.setURLTransform = require('./util/mapbox.js').setURLTransform;
 
 const config = require('./util/config');
 mapboxgl.config = config;
 
 const rtlTextPlugin = require('./source/rtl_text_plugin');
-
 mapboxgl.setRTLTextPlugin = rtlTextPlugin.setRTLTextPlugin;
 
  /**
@@ -78,4 +78,20 @@ Object.defineProperty(mapboxgl, 'accessToken', {
  * @example
  * mapboxgl.supported() // = true
  * @see [Check for browser support](https://www.mapbox.com/mapbox-gl-js/example/check-for-support/)
+ */
+
+/**
+ * Sets the map's URL Transform callback function
+ * Call this method to set a callback to transform URLs before they are requested
+ * from the internet. The callback can be used to add or remove custom parameters, or reroute
+ * certain requests to other servers or endpoints.
+ *
+ * @function setURLTransform
+ * @param {Function} callback Callback function called with the original URL to be transformed. Return the transformed URL
+ * @example
+ * mapboxgl.setURLTransform( (url)=> {
+ *  if(url.startsWith('https://myHost') {
+ *   return url += `&_ts=${Date.now()}`;
+ *  }
+ * });
  */

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -2,8 +2,8 @@
 
 const Evented = require('../util/evented');
 const util = require('../util/util');
-const window = require('../util/window');
 const EXTENT = require('../data/extent');
+const resolveURL = require('../util/mapbox').resolveURL;
 
 /**
  * A source containing GeoJSON.
@@ -222,12 +222,6 @@ class GeoJSONSource extends Evented {
             data: this._data
         };
     }
-}
-
-function resolveURL(url) {
-    const a = window.document.createElement('a');
-    a.href = url;
-    return a.href;
 }
 
 module.exports = GeoJSONSource;

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -30,6 +30,18 @@ test("mapbox", (t) => {
             t.end();
         });
 
+        t.test('transforms urls after normalizing', (t) => {
+            mapbox.setURLTransform((url) => {
+                url = url.replace('http://', 'https://');
+                return `${url}&transformed=true`;
+            });
+            t.equal(mapbox.normalizeStyleURL('mapbox://styles/user/style'), 'https://api.mapbox.com/styles/v1/user/style?access_token=key&transformed=true');
+            t.equal(mapbox.normalizeStyleURL('mapbox://styles/user/style?fresh=true'), 'https://api.mapbox.com/styles/v1/user/style?fresh=true&access_token=key&transformed=true');
+            t.equal(mapbox.normalizeStyleURL('http://path'), 'https://path&transformed=true');
+            mapbox.setURLTransform();
+            t.end();
+        });
+
         t.end();
     });
 
@@ -73,6 +85,18 @@ test("mapbox", (t) => {
             t.end();
         });
 
+        t.test('transforms all urls after normalizing', (t) => {
+            mapbox.setURLTransform((url) => {
+                url = url.replace('http://', 'https://');
+                return `${url}&transformed=true`;
+            });
+            t.equal(mapbox.normalizeSourceURL(mapboxSource), 'https://api.mapbox.com/v4/user.map.json?secure&access_token=key&transformed=true');
+            t.equal(mapbox.normalizeSourceURL(`${mapboxSource}?fresh=true`, 'token'), 'https://api.mapbox.com/v4/user.map.json?fresh=true&secure&access_token=token&transformed=true');
+            t.equal(mapbox.normalizeSourceURL('http://path'), 'https://path&transformed=true');
+            mapbox.setURLTransform();
+            t.end();
+        });
+
         t.end();
     });
 
@@ -89,6 +113,18 @@ test("mapbox", (t) => {
 
         t.test('ignores non-mapbox:// scheme', (t) => {
             t.equal(mapbox.normalizeGlyphsURL('http://path'), 'http://path');
+            t.end();
+        });
+
+        t.test('transforms all urls after normalizing', (t) => {
+            mapbox.setURLTransform((url) => {
+                url = url.replace('http://', 'https://');
+                return `${url}&transformed=true`;
+            });
+            t.equal(mapbox.normalizeGlyphsURL('mapbox://fonts/boxmap/{fontstack}/{range}.pbf'), 'https://api.mapbox.com/fonts/v1/boxmap/{fontstack}/{range}.pbf?access_token=key&transformed=true');
+            t.equal(mapbox.normalizeGlyphsURL('mapbox://fonts/boxmap/{fontstack}/{range}.pbf?fresh=true'), 'https://api.mapbox.com/fonts/v1/boxmap/{fontstack}/{range}.pbf?fresh=true&access_token=key&transformed=true');
+            t.equal(mapbox.normalizeGlyphsURL('http://path'), 'https://path&transformed=true');
+            mapbox.setURLTransform();
             t.end();
         });
 
@@ -146,6 +182,18 @@ test("mapbox", (t) => {
 
         t.test('normalizes non-mapbox:// scheme when query string exists', (t) => {
             t.equal(mapbox.normalizeSpriteURL('http://www.foo.com/bar?fresh=true', '@2x', '.png'), 'http://www.foo.com/bar@2x.png?fresh=true');
+            t.end();
+        });
+
+        t.test('transforms all urls after normalizing', (t) => {
+            mapbox.setURLTransform((url) => {
+                url = url.replace('http://', 'https://');
+                return `${url}&transformed=true`;
+            });
+            t.equal(mapbox.normalizeSpriteURL('mapbox://sprites/mapbox/streets-v8', '', '.json'), 'https://api.mapbox.com/styles/v1/mapbox/streets-v8/sprite.json?access_token=key&transformed=true');
+            t.equal(mapbox.normalizeSpriteURL('mapbox://sprites/mapbox/streets-v8?fresh=true', '@2x', '.png'), 'https://api.mapbox.com/styles/v1/mapbox/streets-v8/sprite@2x.png?fresh=true&access_token=key&transformed=true');
+            t.equal(mapbox.normalizeSpriteURL('http://path/sprite', '', '.png'), 'https://path/sprite.png&transformed=true');
+            mapbox.setURLTransform();
             t.end();
         });
 
@@ -222,6 +270,18 @@ test("mapbox", (t) => {
             t.throws(() => {
                 mapbox.normalizeTileURL('', mapboxSource);
             }, new Error('Unable to parse URL object'));
+            t.end();
+        });
+
+        t.test('transforms all urls after normalizing', (t) => {
+            mapbox.setURLTransform((url) => {
+                url = url.replace('http://', 'https://');
+                return `${url}&transformed=true`;
+            });
+            t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'https://path.png/tile.png32&transformed=true');
+            t.equal(mapbox.normalizeTileURL('http://example.com/tile.png?access_token=tk.abc.123', mapboxSource), 'https://example.com/tile.png?access_token=key&transformed=true');
+            t.equal(mapbox.normalizeTileURL('http://path.png'), 'https://path.png&transformed=true');
+            mapbox.setURLTransform();
             t.end();
         });
 


### PR DESCRIPTION
This PR addresses #4740 by adding a global `mapboxgl.setURLTransform` method that allows setting a single callback to transform URLs before they are requested.

The callback needs to be set before a new Map object is created so that it can be applied to requests that are generated as part of Map initialization.

 - [X] briefly describe the changes in this PR
 - [X] write tests for all new functionality
 - [X] document any changes to public APIs
  ~post benchmark scores~
 - [X] manually test the debug page
