### PR TITLE
reduce factor by which we are scaling texture coordinates

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -162,9 +162,9 @@ class Painter {
 
         const rasterBoundsArray = new RasterBoundsArray();
         rasterBoundsArray.emplaceBack(0, 0, 0, 0);
-        rasterBoundsArray.emplaceBack(EXTENT, 0, 32767, 0);
-        rasterBoundsArray.emplaceBack(0, EXTENT, 0, 32767);
-        rasterBoundsArray.emplaceBack(EXTENT, EXTENT, 32767, 32767);
+        rasterBoundsArray.emplaceBack(EXTENT, 0, EXTENT, 0);
+        rasterBoundsArray.emplaceBack(0, EXTENT, 0, EXTENT);
+        rasterBoundsArray.emplaceBack(EXTENT, EXTENT, EXTENT, EXTENT);
         this.rasterBoundsBuffer = Buffer.fromStructArray(rasterBoundsArray, Buffer.BufferType.VERTEX);
         this.rasterBoundsVAO = new VertexArrayObject();
 

--- a/src/shaders/debug.vertex.glsl
+++ b/src/shaders/debug.vertex.glsl
@@ -3,5 +3,10 @@ attribute vec2 a_pos;
 uniform mat4 u_matrix;
 
 void main() {
-    gl_Position = u_matrix * vec4(a_pos, step(32767.0, a_pos.x), 1);
+    // We are using Int16 for texture position coordinates to give us enough precision for
+    // fractional coordinates. We use 8192 to scale the texture coordinates in the buffer
+    // as an arbitrarily high number to preserve adequate precision when rendering.
+    // This is also the same value as the EXTENT we are using for our tile buffer pos coordinates,
+    // so math for modifying either is consistent.
+    gl_Position = u_matrix * vec4(a_pos, step(8192.0, a_pos.x), 1);
 }

--- a/src/shaders/raster.vertex.glsl
+++ b/src/shaders/raster.vertex.glsl
@@ -11,6 +11,11 @@ varying vec2 v_pos1;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
-    v_pos0 = (((a_texture_pos / 32767.0) - 0.5) / u_buffer_scale ) + 0.5;
+    // We are using Int16 for texture position coordinates to give us enough precision for
+    // fractional coordinates. We use 8192 to scale the texture coordinates in the buffer
+    // as an arbitrarily high number to preserve adequate precision when rendering.
+    // This is also the same value as the EXTENT we are using for our tile buffer pos coordinates,
+    // so math for modifying either is consistent.
+    v_pos0 = (((a_texture_pos / 8192.0) - 0.5) / u_buffer_scale ) + 0.5;
     v_pos1 = (v_pos0 * u_scale_parent) + u_tl_parent;
 }

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -168,12 +168,11 @@ class ImageSource extends Evented implements Source {
 
     _setTile(tile: Tile) {
         this.tiles[String(tile.coord.w)] = tile;
-        const maxInt16 = 32767;
         const array = new RasterBoundsArray();
         array.emplaceBack(this._tileCoords[0].x, this._tileCoords[0].y, 0, 0);
-        array.emplaceBack(this._tileCoords[1].x, this._tileCoords[1].y, maxInt16, 0);
-        array.emplaceBack(this._tileCoords[3].x, this._tileCoords[3].y, 0, maxInt16);
-        array.emplaceBack(this._tileCoords[2].x, this._tileCoords[2].y, maxInt16, maxInt16);
+        array.emplaceBack(this._tileCoords[1].x, this._tileCoords[1].y, EXTENT, 0);
+        array.emplaceBack(this._tileCoords[3].x, this._tileCoords[3].y, 0, EXTENT);
+        array.emplaceBack(this._tileCoords[2].x, this._tileCoords[2].y, EXTENT, EXTENT);
 
         tile.buckets = {};
 

--- a/src/symbol/collision_tile.js
+++ b/src/symbol/collision_tile.js
@@ -98,18 +98,17 @@ class CollisionTile {
             // tempCollisionBox
             collisionBoxArray.emplaceBack();
 
-            const maxInt16 = 32767;
             //left
-            collisionBoxArray.emplaceBack(0, 0, 0, 0, 0, -maxInt16, 0, maxInt16, Infinity, Infinity,
+            collisionBoxArray.emplaceBack(0, 0, 0, 0, 0, -EXTENT, 0, EXTENT, Infinity, Infinity,
                 0, 0, 0, 0, 0, 0, 0, 0, 0);
             // right
-            collisionBoxArray.emplaceBack(EXTENT, 0, 0, 0, 0, -maxInt16, 0, maxInt16, Infinity, Infinity,
+            collisionBoxArray.emplaceBack(EXTENT, 0, 0, 0, 0, -EXTENT, 0, EXTENT, Infinity, Infinity,
                 0, 0, 0, 0, 0, 0, 0, 0, 0);
             // top
-            collisionBoxArray.emplaceBack(0, 0, 0, 0, -maxInt16, 0, maxInt16, 0, Infinity, Infinity,
+            collisionBoxArray.emplaceBack(0, 0, 0, 0, -EXTENT, 0, EXTENT, 0, Infinity, Infinity,
                 0, 0, 0, 0, 0, 0, 0, 0, 0);
             // bottom
-            collisionBoxArray.emplaceBack(0, EXTENT, 0, 0, -maxInt16, 0, maxInt16, 0, Infinity, Infinity,
+            collisionBoxArray.emplaceBack(0, EXTENT, 0, 0, -EXTENT, 0, EXTENT, 0, Infinity, Infinity,
                 0, 0, 0, 0, 0, 0, 0, 0, 0);
         }
 


### PR DESCRIPTION
reduce factor by which we are scaling texture coordinates in the buffer to 8192 to match `EXTENT`

per chat w @kkaefer – he arbitrarily chose 32767 to scale texture coordinates back in 2013 and we don't really need that much precision. this makes some of the math we need to do for terrain rendering a lot easier and doesn't cause any rendering degradation ✌️ 

I'll put up the corresponding native PR ASAP.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
