### PR TITLE
Enable ImageSource integration tests for Native

### DIFF
--- a/test/integration/render-tests/image/default/style.json
+++ b/test/integration/render-tests/image/default/style.json
@@ -2,14 +2,8 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/601"
-      },
       "width": 512,
-      "height": 512,
-      "skipped": {
-        "native": "needs issue"
-      }
+      "height": 512
     }
   },
   "center": [

--- a/test/integration/render-tests/image/raster-brightness/style.json
+++ b/test/integration/render-tests/image/raster-brightness/style.json
@@ -2,14 +2,8 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/601"
-      },
       "width": 512,
-      "height": 512,
-      "skipped": {
-        "native": "needs issue"
-      }
+      "height": 512
     }
   },
   "center": [

--- a/test/integration/render-tests/image/raster-contrast/style.json
+++ b/test/integration/render-tests/image/raster-contrast/style.json
@@ -2,14 +2,8 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/601"
-      },
       "width": 512,
-      "height": 512,
-      "skipped": {
-        "native": "needs issue"
-      }
+      "height": 512
     }
   },
   "center": [

--- a/test/integration/render-tests/image/raster-hue-rotate/style.json
+++ b/test/integration/render-tests/image/raster-hue-rotate/style.json
@@ -2,14 +2,8 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/601"
-      },
       "width": 512,
-      "height": 512,
-      "skipped": {
-        "native": "needs issue"
-      }
+      "height": 512
     }
   },
   "center": [

--- a/test/integration/render-tests/image/raster-opacity/style.json
+++ b/test/integration/render-tests/image/raster-opacity/style.json
@@ -2,14 +2,8 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/601"
-      },
       "width": 512,
-      "height": 512,
-      "skipped": {
-        "native": "needs issue"
-      }
+      "height": 512
     }
   },
   "center": [

--- a/test/integration/render-tests/image/raster-saturation/style.json
+++ b/test/integration/render-tests/image/raster-saturation/style.json
@@ -2,14 +2,8 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/601"
-      },
       "width": 512,
-      "height": 512,
-      "skipped": {
-        "native": "needs issue"
-      }
+      "height": 512
     }
   },
   "center": [

--- a/test/integration/render-tests/image/raster-visibility/style.json
+++ b/test/integration/render-tests/image/raster-visibility/style.json
@@ -2,14 +2,8 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/601"
-      },
       "width": 512,
-      "height": 512,
-      "skipped": {
-        "native": "needs issue"
-      }
+      "height": 512
     }
   },
   "center": [


### PR DESCRIPTION
In support of [gl-native#8968](https://github.com/mapbox/mapbox-gl-native/pull/8968)