### PR TITLE
Add the ability to customize the tile cache size

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -60,7 +60,7 @@ class SourceCache extends Evented {
 
     onAdd(map) {
         this.map = map;
-        this._maxTileCacheSize = map._maxTileCacheSize
+        this._maxTileCacheSize = map._maxTileCacheSize;
         if (this._source && this._source.onAdd) {
             this._source.onAdd(map);
         }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -60,7 +60,7 @@ class SourceCache extends Evented {
 
     onAdd(map) {
         this.map = map;
-        this._maxTileCacheSize = map._maxTileCacheSize;
+        this._maxTileCacheSize = map ? map._maxTileCacheSize : null;
         if (this._source && this._source.onAdd) {
             this._source.onAdd(map);
         }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -53,14 +53,14 @@ class SourceCache extends Evented {
         this._cache = new Cache(0, this.unloadTile.bind(this));
         this._timers = {};
         this._cacheTimers = {};
-        this._tileCacheSize = null;
+        this._maxTileCacheSize = null;
 
         this._isIdRenderable = this._isIdRenderable.bind(this);
     }
 
     onAdd(map) {
         this.map = map;
-        this._tileCacheSize = map._tileCacheSize
+        this._maxTileCacheSize = map._maxTileCacheSize
         if (this._source && this._source.onAdd) {
             this._source.onAdd(map);
         }
@@ -281,7 +281,7 @@ class SourceCache extends Evented {
 
     /**
      * Resizes the tile cache based on the current viewport's size
-     * or the tileCacheSize option passed during map creation
+     * or the maxTileCacheSize option passed during map creation
      *
      * Larger viewports use more tiles and need larger caches. Larger viewports
      * are more likely to be found on devices with more memory and on pages where
@@ -295,7 +295,8 @@ class SourceCache extends Evented {
         const approxTilesInView = widthInTiles * heightInTiles;
         const commonZoomRange = 5;
 
-        const maxSize = this._tileCacheSize || Math.floor(approxTilesInView * commonZoomRange);
+        const viewDependentMaxSize = Math.floor(approxTilesInView * commonZoomRange);
+        const maxSize = typeof this._maxTileCacheSize === 'number' ? Math.min(this._maxTileCacheSize, viewDependentMaxSize) : viewDependentMaxSize;
 
         this._cache.setMaxSize(maxSize);
     }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -53,12 +53,14 @@ class SourceCache extends Evented {
         this._cache = new Cache(0, this.unloadTile.bind(this));
         this._timers = {};
         this._cacheTimers = {};
+        this._cacheSize = null;
 
         this._isIdRenderable = this._isIdRenderable.bind(this);
     }
 
     onAdd(map) {
         this.map = map;
+        this._cacheSize = map._cacheSize
         if (this._source && this._source.onAdd) {
             this._source.onAdd(map);
         }
@@ -278,7 +280,8 @@ class SourceCache extends Evented {
     }
 
     /**
-     * Resizes the tile cache based on the current viewport's size.
+     * Resizes the tile cache based on the current viewport's size
+     * or the cacheSize option passed during map creation
      *
      * Larger viewports use more tiles and need larger caches. Larger viewports
      * are more likely to be found on devices with more memory and on pages where
@@ -291,7 +294,10 @@ class SourceCache extends Evented {
         const heightInTiles = Math.ceil(transform.height / transform.tileSize) + 1;
         const approxTilesInView = widthInTiles * heightInTiles;
         const commonZoomRange = 5;
-        this._cache.setMaxSize(Math.floor(approxTilesInView * commonZoomRange));
+
+        const maxSize = this._cacheSize || Math.floor(approxTilesInView * commonZoomRange);
+
+        this._cache.setMaxSize(maxSize);
     }
 
     /**

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -53,14 +53,14 @@ class SourceCache extends Evented {
         this._cache = new Cache(0, this.unloadTile.bind(this));
         this._timers = {};
         this._cacheTimers = {};
-        this._cacheSize = null;
+        this._tileCacheSize = null;
 
         this._isIdRenderable = this._isIdRenderable.bind(this);
     }
 
     onAdd(map) {
         this.map = map;
-        this._cacheSize = map._cacheSize
+        this._tileCacheSize = map._tileCacheSize
         if (this._source && this._source.onAdd) {
             this._source.onAdd(map);
         }
@@ -281,7 +281,7 @@ class SourceCache extends Evented {
 
     /**
      * Resizes the tile cache based on the current viewport's size
-     * or the cacheSize option passed during map creation
+     * or the tileCacheSize option passed during map creation
      *
      * Larger viewports use more tiles and need larger caches. Larger viewports
      * are more likely to be found on devices with more memory and on pages where
@@ -295,7 +295,7 @@ class SourceCache extends Evented {
         const approxTilesInView = widthInTiles * heightInTiles;
         const commonZoomRange = 5;
 
-        const maxSize = this._cacheSize || Math.floor(approxTilesInView * commonZoomRange);
+        const maxSize = this._tileCacheSize || Math.floor(approxTilesInView * commonZoomRange);
 
         this._cache.setMaxSize(maxSize);
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -57,7 +57,9 @@ const defaultOptions = {
 
     renderWorldCopies: true,
 
-    refreshExpiredTiles: true
+    refreshExpiredTiles: true,
+
+    cacheSize: null
 };
 
 /**
@@ -122,6 +124,7 @@ const defaultOptions = {
  * @param {number} [options.bearing=0] The initial bearing (rotation) of the map, measured in degrees counter-clockwise from north. If `bearing` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {number} [options.pitch=0] The initial pitch (tilt) of the map, measured in degrees away from the plane of the screen (0-60). If `pitch` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {boolean} [options.renderWorldCopies=true]  If `true`, multiple copies of the world will be rendered, when zoomed out.
+  * @param {number} [options.cacheSize=null]  The number of tiles stored in the tile cache. If omitted, the cache will be dynamically sized based on the current viewport.
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',
@@ -145,6 +148,7 @@ class Map extends Camera {
         super(transform, options);
 
         this._interactive = options.interactive;
+        this._cacheSize = options.cacheSize;
         this._failIfMajorPerformanceCaveat = options.failIfMajorPerformanceCaveat;
         this._preserveDrawingBuffer = options.preserveDrawingBuffer;
         this._trackResize = options.trackResize;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -124,7 +124,7 @@ const defaultOptions = {
  * @param {number} [options.bearing=0] The initial bearing (rotation) of the map, measured in degrees counter-clockwise from north. If `bearing` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {number} [options.pitch=0] The initial pitch (tilt) of the map, measured in degrees away from the plane of the screen (0-60). If `pitch` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {boolean} [options.renderWorldCopies=true]  If `true`, multiple copies of the world will be rendered, when zoomed out.
-  * @param {number} [options.maxTileCacheSize=null]  The maxiumum number of tiles stored in the tile cache. If omitted, the cache will be dynamically sized based on the current viewport.
+  * @param {number} [options.maxTileCacheSize=null]  The maxiumum number of tiles stored in the tile cache for a given source. If omitted, the cache will be dynamically sized based on the current viewport.
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -59,7 +59,7 @@ const defaultOptions = {
 
     refreshExpiredTiles: true,
 
-    tileCacheSize: null
+    maxTileCacheSize: null
 };
 
 /**
@@ -124,7 +124,7 @@ const defaultOptions = {
  * @param {number} [options.bearing=0] The initial bearing (rotation) of the map, measured in degrees counter-clockwise from north. If `bearing` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {number} [options.pitch=0] The initial pitch (tilt) of the map, measured in degrees away from the plane of the screen (0-60). If `pitch` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {boolean} [options.renderWorldCopies=true]  If `true`, multiple copies of the world will be rendered, when zoomed out.
-  * @param {number} [options.tileCacheSize=null]  The number of tiles stored in the tile cache. If omitted, the cache will be dynamically sized based on the current viewport.
+  * @param {number} [options.maxTileCacheSize=null]  The maxiumum number of tiles stored in the tile cache. If omitted, the cache will be dynamically sized based on the current viewport.
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',
@@ -148,7 +148,7 @@ class Map extends Camera {
         super(transform, options);
 
         this._interactive = options.interactive;
-        this._tileCacheSize = options.tileCacheSize;
+        this._maxTileCacheSize = options.maxTileCacheSize;
         this._failIfMajorPerformanceCaveat = options.failIfMajorPerformanceCaveat;
         this._preserveDrawingBuffer = options.preserveDrawingBuffer;
         this._trackResize = options.trackResize;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -59,7 +59,7 @@ const defaultOptions = {
 
     refreshExpiredTiles: true,
 
-    cacheSize: null
+    tileCacheSize: null
 };
 
 /**
@@ -124,7 +124,7 @@ const defaultOptions = {
  * @param {number} [options.bearing=0] The initial bearing (rotation) of the map, measured in degrees counter-clockwise from north. If `bearing` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {number} [options.pitch=0] The initial pitch (tilt) of the map, measured in degrees away from the plane of the screen (0-60). If `pitch` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {boolean} [options.renderWorldCopies=true]  If `true`, multiple copies of the world will be rendered, when zoomed out.
-  * @param {number} [options.cacheSize=null]  The number of tiles stored in the tile cache. If omitted, the cache will be dynamically sized based on the current viewport.
+  * @param {number} [options.tileCacheSize=null]  The number of tiles stored in the tile cache. If omitted, the cache will be dynamically sized based on the current viewport.
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',
@@ -148,7 +148,7 @@ class Map extends Camera {
         super(transform, options);
 
         this._interactive = options.interactive;
-        this._cacheSize = options.cacheSize;
+        this._tileCacheSize = options.tileCacheSize;
         this._failIfMajorPerformanceCaveat = options.failIfMajorPerformanceCaveat;
         this._preserveDrawingBuffer = options.preserveDrawingBuffer;
         this._trackResize = options.trackResize;


### PR DESCRIPTION
This pull request addresses #4052. Currently the tile cache size is determined by the size of the viewport and there is no way for the user to manually override this size. This pull requests exposes a new option on the map, `cacheSize`, which can be used to explicitly set the tile cache size. 