### PR TITLE
Normal map (normal) layer type

### DIFF
--- a/src/render/draw_normal.js
+++ b/src/render/draw_normal.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const util = require('../util/util');
+const glMatrix = require('@mapbox/gl-matrix');
+
+module.exports = drawNormalMap;
+
+function setLight(program, painter) {
+    const gl = painter.gl;
+    const light = painter.style.light;
+    const mat3 = glMatrix.mat3;
+    const mat4 = glMatrix.mat4;
+    const vec3 = glMatrix.vec3;
+
+    const _lp = light.calculated.position,
+        lightPos = [_lp.x, _lp.y, _lp.z];
+    const lightMat = mat3.create();
+    if (light.calculated.anchor === 'viewport') mat3.fromRotation(lightMat, -painter.transform.angle);
+    vec3.transformMat3(lightPos, lightPos, lightMat);
+
+    gl.uniform3fv(program.u_lightpos, lightPos);
+    gl.uniform1f(program.u_lightintensity, light.calculated.intensity);
+    gl.uniform3fv(program.u_lightcolor, light.calculated.color.slice(0, 3));
+}
+
+function drawNormalMap(painter, sourceCache, layer, coords) {
+    if (painter.isOpaquePass) return;
+
+    const gl = painter.gl;
+
+    gl.enable(gl.DEPTH_TEST);
+    painter.depthMask(true);
+
+    // Change depth function to prevent double drawing in areas where tiles overlap.
+    gl.depthFunc(gl.LESS);
+
+    const minTileZ = coords.length && coords[0].z;
+
+    for (let i = 0; i < coords.length; i++) {
+        const coord = coords[i];
+        // set the lower zoom level to sublayer 0, and higher zoom levels to higher sublayers
+        painter.setDepthSublayer(coord.z - minTileZ);
+        drawNormalMappedTile(painter, sourceCache, layer, coord);
+    }
+
+    gl.depthFunc(gl.LEQUAL);
+}
+
+function drawNormalMappedTile(painter, sourceCache, layer, coord) {
+
+    const gl = painter.gl;
+
+    gl.disable(gl.STENCIL_TEST);
+
+    const tile = sourceCache.getTile(coord);
+    const posMatrix = painter.transform.calculatePosMatrix(coord, sourceCache.getSource().maxzoom);
+
+    tile.registerFadeDuration(painter.style.animationLoop, layer.paint['normal-fade-duration']);
+
+    const program = painter.useProgram('normal');
+
+    setLight(program, painter);
+    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
+
+    // color parameters
+    gl.uniform1f(program.u_brightness_low, layer.paint['normal-brightness-min']);
+    gl.uniform1f(program.u_brightness_high, layer.paint['normal-brightness-max']);
+    gl.uniform1f(program.u_saturation_factor, saturationFactor(layer.paint['normal-saturation']));
+    gl.uniform1f(program.u_contrast_factor, contrastFactor(layer.paint['normal-contrast']));
+    gl.uniform3fv(program.u_spin_weights, spinWeights(layer.paint['normal-hue-rotate']));
+
+    const parentTile = tile.sourceCache && tile.sourceCache.findLoadedParent(coord, 0, {}),
+        fade = getFadeValues(tile, parentTile, layer, painter.transform);
+
+    let parentScaleBy, parentTL;
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, tile.texture);
+
+    gl.activeTexture(gl.TEXTURE1);
+
+    if (parentTile) {
+        gl.bindTexture(gl.TEXTURE_2D, parentTile.texture);
+        parentScaleBy = Math.pow(2, parentTile.coord.z - tile.coord.z);
+        parentTL = [tile.coord.x * parentScaleBy % 1, tile.coord.y * parentScaleBy % 1];
+
+    } else {
+        gl.bindTexture(gl.TEXTURE_2D, tile.texture);
+    }
+
+    // cross-fade parameters
+    gl.uniform2fv(program.u_tl_parent, parentTL || [0, 0]);
+    gl.uniform1f(program.u_scale_parent, parentScaleBy || 1);
+    gl.uniform1f(program.u_buffer_scale, 1);
+    gl.uniform1f(program.u_fade_t, fade.mix);
+    gl.uniform1f(program.u_opacity, fade.opacity * layer.paint['normal-opacity']);
+    gl.uniform1i(program.u_image0, 0);
+    gl.uniform1i(program.u_image1, 1);
+
+    const buffer = tile.boundsBuffer || painter.rasterBoundsBuffer;
+    const vao = tile.boundsVAO || painter.rasterBoundsVAO;
+    vao.bind(gl, program, buffer);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+}
+
+function spinWeights(angle) {
+    angle *= Math.PI / 180;
+    const s = Math.sin(angle);
+    const c = Math.cos(angle);
+    return [
+        (2 * c + 1) / 3,
+        (-Math.sqrt(3) * s - c + 1) / 3,
+        (Math.sqrt(3) * s - c + 1) / 3
+    ];
+}
+
+function contrastFactor(contrast) {
+    return contrast > 0 ?
+        1 / (1 - contrast) :
+        1 + contrast;
+}
+
+function saturationFactor(saturation) {
+    return saturation > 0 ?
+        1 - 1 / (1.001 - saturation) :
+        -saturation;
+}
+
+function getFadeValues(tile, parentTile, layer, transform) {
+    const fadeDuration = layer.paint['normal-fade-duration'];
+
+    if (tile.sourceCache && fadeDuration > 0) {
+        const now = Date.now();
+        const sinceTile = (now - tile.timeAdded) / fadeDuration;
+        const sinceParent = parentTile ? (now - parentTile.timeAdded) / fadeDuration : -1;
+
+        const source = tile.sourceCache.getSource();
+        const idealZ = transform.coveringZoomLevel({
+            tileSize: source.tileSize,
+            roundZoom: source.roundZoom
+        });
+
+        // if no parent or parent is older, fade in; if parent is younger, fade out
+        const fadeIn = !parentTile || Math.abs(parentTile.coord.z - idealZ) > Math.abs(tile.coord.z - idealZ);
+
+        const childOpacity = (fadeIn && tile.refreshedUponExpiration) ? 1 : util.clamp(fadeIn ? sinceTile : 1 - sinceParent, 0, 1);
+
+        // we don't crossfade tiles that were just refreshed upon expiring:
+        // once they're old enough to pass the crossfading threshold
+        // (fadeDuration), unset the `refreshedUponExpiration` flag so we don't
+        // incorrectly fail to crossfade them when zooming
+        if (tile.refreshedUponExpiration && sinceTile >= 1) tile.refreshedUponExpiration = false;
+
+        if (parentTile) {
+            return {
+                opacity: 1,
+                mix: 1 - childOpacity
+            };
+        } else {
+            return {
+                opacity: childOpacity,
+                mix: 0
+            };
+        }
+    } else {
+        return {
+            opacity: 1,
+            mix: 0
+        };
+    }
+}

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -23,6 +23,7 @@ const draw = {
     'fill-extrusion': require('./draw_fill_extrusion'),
     raster: require('./draw_raster'),
     background: require('./draw_background'),
+    normal: require('./draw_normal'),
     debug: require('./draw_debug')
 };
 

--- a/src/render/shaders.js
+++ b/src/render/shaders.js
@@ -73,5 +73,9 @@ module.exports = {
     symbolSDF: {
         fragmentSource: fs.readFileSync(__dirname + '/../shaders/symbol_sdf.fragment.glsl', 'utf8'),
         vertexSource: fs.readFileSync(__dirname + '/../shaders/symbol_sdf.vertex.glsl', 'utf8')
+    },
+    normal: {
+        fragmentSource: fs.readFileSync(__dirname + '/../shaders/normal.fragment.glsl', 'utf8'),
+        vertexSource: fs.readFileSync(__dirname + '/../shaders/normal.vertex.glsl', 'utf8')
     }
 };

--- a/src/shaders/normal.fragment.glsl
+++ b/src/shaders/normal.fragment.glsl
@@ -1,0 +1,57 @@
+uniform float u_fade_t;
+uniform float u_opacity;
+uniform sampler2D u_image0;
+uniform sampler2D u_image1;
+varying vec2 v_pos0;
+varying vec2 v_pos1;
+
+uniform float u_brightness_low;
+uniform float u_brightness_high;
+
+uniform float u_saturation_factor;
+uniform float u_contrast_factor;
+uniform vec3 u_spin_weights;
+
+uniform vec3 u_lightcolor;
+uniform lowp vec3 u_lightpos;
+uniform lowp float u_lightintensity;
+
+void main() {
+
+    // read and cross-fade colors from the main and parent tiles
+    vec4 color0 = texture2D(u_image0, v_pos0);
+    vec4 color1 = texture2D(u_image1, v_pos1);
+    vec3 normalC = mix(color0, color1, u_fade_t).xyz;
+    vec3 normal = (normalC * 2.) - 1.;
+    
+    vec4 v_lighting = vec4(0.0, 0.0, 0.0, 1.0);
+    float directional = clamp(dot(normal, u_lightpos), 0.0, 1.0);
+    directional = mix((1.0 - u_lightintensity), max((0.5 + u_lightintensity), 1.0), directional);
+    v_lighting.rgb += clamp(directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));
+
+    vec4 color = vec4(v_lighting.rgb, u_opacity);
+    vec3 rgb = v_lighting.rgb;
+
+    // spin
+    rgb = vec3(
+        dot(rgb, u_spin_weights.xyz),
+        dot(rgb, u_spin_weights.zxy),
+        dot(rgb, u_spin_weights.yzx));
+
+    // saturation
+    float average = (color.r + color.g + color.b) / 3.0;
+    rgb += (average - rgb) * u_saturation_factor;
+
+    // contrast
+    rgb = (rgb - 0.5) * u_contrast_factor + 0.5;
+
+    // brightness
+    vec3 u_high_vec = vec3(u_brightness_low, u_brightness_low, u_brightness_low);
+    vec3 u_low_vec = vec3(u_brightness_high, u_brightness_high, u_brightness_high);
+
+    gl_FragColor = vec4(mix(u_high_vec, u_low_vec, rgb) * color.a, color.a);
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
+}

--- a/src/shaders/normal.vertex.glsl
+++ b/src/shaders/normal.vertex.glsl
@@ -1,0 +1,16 @@
+uniform mat4 u_matrix;
+uniform vec2 u_tl_parent;
+uniform float u_scale_parent;
+uniform float u_buffer_scale;
+
+attribute vec2 a_pos;
+attribute vec2 a_texture_pos;
+
+varying vec2 v_pos0;
+varying vec2 v_pos1;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    v_pos0 = (((a_texture_pos / 32767.0) - 0.5) / u_buffer_scale ) + 0.5;
+    v_pos1 = (v_pos0 * u_scale_parent) + u_tl_parent;
+}

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -602,7 +602,7 @@ function compareKeyZoom(a, b) {
 }
 
 function isRasterType(type) {
-    return type === 'raster' || type === 'image' || type === 'video';
+    return type === 'raster' || type === 'image' || type === 'video' || type === 'normal';
 }
 
 module.exports = SourceCache;

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -369,6 +369,17 @@
             }
           }
         },
+        "normal": {
+          "doc": "Normal mapping textures",
+          "sdk-support": {
+            "basic functionality": {
+              "js": "0.10.0",
+              "android": "2.0.1",
+              "ios": "2.0.0",
+              "macos": "0.1.0"
+            }
+          }
+        },
         "background": {
           "doc": "The background color or pattern of the map.",
           "sdk-support": {
@@ -3058,6 +3069,141 @@
       }
     },
     "raster-fade-duration": {
+      "type": "number",
+      "default": 300,
+      "minimum": 0,
+      "function": "interpolated",
+      "zoom-function": true,
+      "transition": true,
+      "units": "milliseconds",
+      "doc": "Fade duration when a new tile is added.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.10.0",
+          "android": "2.0.1",
+          "ios": "2.0.0",
+          "macos": "0.1.0"
+        },
+        "data-driven styling": {}
+      }
+    }
+  },
+  "paint_normal": {
+    "normal-opacity": {
+      "type": "number",
+      "doc": "The opacity at which the image will be drawn.",
+      "default": 1,
+      "minimum": 0,
+      "maximum": 1,
+      "function": "interpolated",
+      "zoom-function": true,
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.10.0",
+          "android": "2.0.1",
+          "ios": "2.0.0",
+          "macos": "0.1.0"
+        },
+        "data-driven styling": {}
+      }
+    },
+    "normal-hue-rotate": {
+      "type": "number",
+      "default": 0,
+      "period": 360,
+      "function": "interpolated",
+      "zoom-function": true,
+      "transition": true,
+      "units": "degrees",
+      "doc": "Rotates hues around the color wheel.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.10.0",
+          "android": "2.0.1",
+          "ios": "2.0.0",
+          "macos": "0.1.0"
+        },
+        "data-driven styling": {}
+      }
+    },
+    "normal-brightness-min": {
+      "type": "number",
+      "function": "interpolated",
+      "zoom-function": true,
+      "doc": "Increase or reduce the brightness of the image. The value is the minimum brightness.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 1,
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.10.0",
+          "android": "2.0.1",
+          "ios": "2.0.0",
+          "macos": "0.1.0"
+        },
+        "data-driven styling": {}
+      }
+    },
+    "normal-brightness-max": {
+      "type": "number",
+      "function": "interpolated",
+      "zoom-function": true,
+      "doc": "Increase or reduce the brightness of the image. The value is the maximum brightness.",
+      "default": 1,
+      "minimum": 0,
+      "maximum": 1,
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.10.0",
+          "android": "2.0.1",
+          "ios": "2.0.0",
+          "macos": "0.1.0"
+        },
+        "data-driven styling": {}
+      }
+    },
+    "normal-saturation": {
+      "type": "number",
+      "doc": "Increase or reduce the saturation of the image.",
+      "default": 0,
+      "minimum": -1,
+      "maximum": 1,
+      "function": "interpolated",
+      "zoom-function": true,
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.10.0",
+          "android": "2.0.1",
+          "ios": "2.0.0",
+          "macos": "0.1.0"
+        },
+        "data-driven styling": {}
+      }
+    },
+    "normal-contrast": {
+      "type": "number",
+      "doc": "Increase or reduce the contrast of the image.",
+      "default": 0,
+      "minimum": -1,
+      "maximum": 1,
+      "function": "interpolated",
+      "zoom-function": true,
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.10.0",
+          "android": "2.0.1",
+          "ios": "2.0.0",
+          "macos": "0.1.0"
+        },
+        "data-driven styling": {}
+      }
+    },
+    "normal-fade-duration": {
       "type": "number",
       "default": 300,
       "minimum": 0,

--- a/src/style-spec/validate/validate_layer.js
+++ b/src/style-spec/validate/validate_layer.js
@@ -62,7 +62,7 @@ module.exports = function validateLayer(options) {
                 errors.push(new ValidationError(key, layer.source, 'source "%s" not found', layer.source));
             } else if (sourceType === 'vector' && type === 'raster') {
                 errors.push(new ValidationError(key, layer.source, 'layer "%s" requires a raster source', layer.id));
-            } else if (sourceType === 'raster' && type !== 'raster') {
+            } else if (sourceType === 'raster' && type !== 'raster' && type !== 'normal') {
                 errors.push(new ValidationError(key, layer.source, 'layer "%s" requires a vector source', layer.id));
             } else if (sourceType === 'vector' && !layer['source-layer']) {
                 errors.push(new ValidationError(key, layer, 'layer "%s" must specify a "source-layer"', layer.id));


### PR DESCRIPTION
Adds a new layer type called _normal_ that given a source layer with raster type pointing to a normal map pyramid, is shaded with the light defined on the style object.

I've created a new draw_normal.js where the webgl initialization is done and two files: normal.fragment.js and normal.vertex.js with the normal mapping shader. The remaining files are modified to update the spec to support the new type and its parameters (the same as a raster layer)
