### PR TITLE
Adjust queryRenderedSymbols with tile perspective approximation

### DIFF
--- a/src/symbol/collision_tile.js
+++ b/src/symbol/collision_tile.js
@@ -236,8 +236,14 @@ class CollisionTile {
             features.push(ignoredFeatures[i]);
         }
 
+        // "perspectiveRatio" is a tile-based approximation of how much larger symbols will
+        // be in the distance. It won't line up exactly with the actually rendered symbols
+        // Being exact would require running the collision detection logic in symbol_sdf.vertex
+        // in the CPU
+        const perspectiveScale = scale / this.perspectiveRatio;
+
         // Account for the rounding done when updating symbol shader variables.
-        const roundedScale = Math.pow(2, Math.ceil(Math.log(scale) / Math.LN2 * 10) / 10);
+        const roundedScale = Math.pow(2, Math.ceil(Math.log(perspectiveScale) / Math.LN2 * 10) / 10);
 
         for (let i = 0; i < features.length; i++) {
             const blocking = collisionBoxArray.get(features[i]);
@@ -255,10 +261,10 @@ class CollisionTile {
 
             // Check if query intersects with the feature box at current scale.
             const anchor = blocking.anchorPoint.matMult(rotationMatrix);
-            const x1 = anchor.x + blocking.x1 / scale;
-            const y1 = anchor.y + blocking.y1 / scale * yStretch;
-            const x2 = anchor.x + blocking.x2 / scale;
-            const y2 = anchor.y + blocking.y2 / scale * yStretch;
+            const x1 = anchor.x + blocking.x1 / perspectiveScale;
+            const y1 = anchor.y + blocking.y1 / perspectiveScale * yStretch;
+            const x2 = anchor.x + blocking.x2 / perspectiveScale;
+            const y2 = anchor.y + blocking.y2 / perspectiveScale * yStretch;
             const bbox = [
                 new Point(x1, y1),
                 new Point(x2, y1),

--- a/test/integration/query-tests/symbol-features-in/pitched-screen/expected.json
+++ b/test/integration/query-tests/symbol-features-in/pitched-screen/expected.json
@@ -1,90 +1,189 @@
 [
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        4.000053405761719,
-        4.000061604283047
-      ]
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                2.9999542236328125,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
     },
-    "type": "Feature",
-    "properties": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        4.000053405761719,
-        4.000061604283047
-      ]
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                4.999974190748432
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
     },
-    "type": "Feature",
-    "properties": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        2.9999542236328125,
-        2.999955856573024
-      ]
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                2.9999542236328125,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
     },
-    "type": "Feature",
-    "properties": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        2.9999542236328125,
-        2.999955856573024
-      ]
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
     },
-    "type": "Feature",
-    "properties": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        4.000053405761719,
-        4.000061604283047
-      ]
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.999980926513672,
+                4.999974190748432
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
     },
-    "type": "Feature",
-    "properties": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        4.000053405761719,
-        4.000061604283047
-      ]
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
     },
-    "type": "Feature",
-    "properties": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        2.9999542236328125,
-        2.999955856573024
-      ]
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                4.999974190748432
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
     },
-    "type": "Feature",
-    "properties": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        2.9999542236328125,
-        2.999955856573024
-      ]
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.999980926513672,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
     },
-    "type": "Feature",
-    "properties": {}
-  }
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                2.9999542236328125,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    },
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    },
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                2.9999542236328125,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    },
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                2.999955856573024
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    },
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.999980926513672,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    },
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                2.999955856573024
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    },
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                4.000061604283047
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    },
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                2.999955856573024
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    },
+    {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                4.000053405761719,
+                2.999955856573024
+            ]
+        },
+        "type": "Feature",
+        "properties": {}
+    }
 ]

--- a/test/integration/query-tests/symbol-features-in/pitched-screen/style.json
+++ b/test/integration/query-tests/symbol-features-in/pitched-screen/style.json
@@ -2,17 +2,21 @@
   "version": 8,
   "metadata": {
     "test": {
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/8967"
+      },
       "collisionDebug": true,
-      "width": 500,
-      "height": 500,
+      "debug": true,
+      "width": 1000,
+      "height": 1000,
       "queryGeometry": [
           [
-              0,
-              0
+              100,
+              85
           ],
           [
-              500,
-              500
+              850,
+              400
           ]
       ]
     }
@@ -30,6 +34,7 @@
       "data": "local://data/121points.geojson"
     }
   },
+  "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
   "sprite": "local://sprites/sprite",
   "layers": [
     {
@@ -38,7 +43,13 @@
       "source": "geojson",
       "layout": {
         "symbol-placement": "point",
-        "icon-image": "bicycle-12"
+        "icon-image": "bicycle-12",
+        "text-field": "A lot of test text so that the collision box is big",
+        "text-max-width": 10,
+        "text-font": [
+          "Open Sans Semibold",
+          "Arial Unicode MS Bold"
+        ]
       },
       "interactive": true
     }


### PR DESCRIPTION
This is a back-port from https://github.com/mapbox/mapbox-gl-native/pull/9009. Although `queryRenderedSymbols` won't match collision boxes exactly (because they're partially calculated in the GPU), this change gets the results of `queryRenderedSymbols` closer to what's shown on the screen by using the tile-based approximation of the pitch-scaling ratio.

To get an idea for what this changes, look at the `actual.png` generated for `query/symbol-features-in/pitched-screen`. Before the change, the top symbol wouldn't be included in the results (even though you can see the rendered collision box overlaps with the query geometry).

@ansis