### PR TITLE
Manually bind a_data attribute to location 0 for symbol_icon shader

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -394,10 +394,10 @@ class Painter {
         gl.attachShader(program, vertexShader);
 
 
-        // For the symbol program, manually ensure the attrib bound to position 0 is always used (either a_data or a_pos_offset would work here).
+        // For the symbol programs, manually ensure the attrib bound to position 0 is always used (either a_data or a_pos_offset would work here).
         // This is needed to fix https://github.com/mapbox/mapbox-gl-js/issues/4607 — otherwise a_size can be bound first, causing rendering to fail.
         // All remaining attribs will be bound dynamically below.
-        if (name === 'symbolSDF') {
+        if (name === 'symbolSDF' || name === 'symbolIcon') {
             gl.bindAttribLocation(program, 0, 'a_data');
         }
 

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -1,3 +1,5 @@
+// NOTE: the a_data attribute in this shader is manually bound (see https://github.com/mapbox/mapbox-gl-js/issues/4607 / #4728).
+// If removing or renaming a_data, revisit the manual binding in painter.js accordingly.
 attribute vec4 a_pos_offset;
 attribute vec2 a_label_pos;
 attribute vec4 a_data;


### PR DESCRIPTION
Fixes #4728
Ref #4688 (that PR fixed this issue as we were seeing it in the symbol_sdf shader but overlooked the corresponding issue in the symbol_icon shader as it had not manifested in a previous bug report).