### PR TITLE
add aria-label to Popup close button

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -224,6 +224,7 @@ class Popup extends Evented {
         if (this.options.closeButton) {
             this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', this._content);
             this._closeButton.type = 'button';
+            this._closeButton.setAttribute('aria-label', 'Close popup');
             this._closeButton.innerHTML = '&#215;';
             this._closeButton.addEventListener('click', this._onClickClose);
         }


### PR DESCRIPTION
This change ensures screen readers etc. read this as a close popup button rather than a multiplication sign.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
