### PR TITLE
Simplify viewport fbo/texture caching and use

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -36,12 +36,7 @@ class Painter {
     constructor(gl, transform) {
         this.gl = gl;
         this.transform = transform;
-
-        this.reusableTextures = {
-            tiles: {},
-            viewport: null
-        };
-        this.preFbos = {};
+        this._tileTextures = {};
 
         this.frameHistory = new FrameHistory();
 
@@ -68,6 +63,15 @@ class Painter {
         this.width = width * browser.devicePixelRatio;
         this.height = height * browser.devicePixelRatio;
         gl.viewport(0, 0, this.width, this.height);
+
+        if (this.viewportTexture) {
+            this.gl.deleteTexture(this.viewportTexture);
+            this.viewportTexture = null;
+        }
+        if (this.viewportFbo) {
+            this.gl.deleteFramebuffer(this.viewportFbo);
+            this.viewportFbo = null;
+        }
     }
 
     setup() {
@@ -192,11 +196,6 @@ class Painter {
     // Overridden by headless tests.
     prepareBuffers() {}
 
-    bindDefaultFramebuffer() {
-        const gl = this.gl;
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    }
-
     render(style, options) {
         this.style = style;
         this.options = options;
@@ -317,34 +316,17 @@ class Painter {
     }
 
     saveTileTexture(texture) {
-        const textures = this.reusableTextures.tiles[texture.size];
+        const textures = this._tileTextures[texture.size];
         if (!textures) {
-            this.reusableTextures.tiles[texture.size] = [texture];
+            this._tileTextures[texture.size] = [texture];
         } else {
             textures.push(texture);
         }
     }
 
-    saveViewportTexture(texture) {
-        this.reusableTextures.viewport = texture;
-    }
-
     getTileTexture(size) {
-        const textures = this.reusableTextures.tiles[size];
+        const textures = this._tileTextures[size];
         return textures && textures.length > 0 ? textures.pop() : null;
-    }
-
-    getViewportTexture(width, height) {
-        const texture = this.reusableTextures.viewport;
-        if (!texture) return;
-
-        if (texture.width === width && texture.height === height) {
-            return texture;
-        } else {
-            this.gl.deleteTexture(texture);
-            this.reusableTextures.viewport = null;
-            return;
-        }
     }
 
     lineWidth(width) {


### PR DESCRIPTION
The PRs simplifies fbo/texture caching logic (which I'm going to reuse for heatmaps). Previously, the fbo cache would hold arrays of fbo objects hashed by their size (width/height). Now that we don't use differently sized fbos anywhere, we can get away with caching only a single fbo object and deleting it on resize.  Also note that previously, resizing a window would leave a ton of cached fbo objects hanging and never released — this PR fixes that too.

Viewport texture caching already had a similar logic, — I just did some renaming/cleanup to make the code simpler.

Also simplifies extrusion drawing code in the second commit (no need to have `ExtrusionTexture` class since we destroy the instance immediately after creation and only need the bound texture).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~ (seems to be no need to test)
 - [ ] ~~document any changes to public APIs~~ (no changes)
 - [ ] ~~post benchmark scores~~ (we don't benchmark extrusions yet)
 - [x] manually test the debug page
