### PR TITLE
Added style field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A WebGL interactive maps library",
   "version": "0.37.0",
   "main": "dist/mapbox-gl.js",
+  "style": "dist/mapbox-gl.css",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Many modules in npm are starting to expose their css entry files in their package.json files. This allows tools like npm-css or rework-npm to import `mapbox-gl.css` from the node_modules directory and not from the cdn