### PR TITLE
Introduce Texture class to dry up code

### DIFF
--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -54,17 +54,17 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     let parentScaleBy, parentTL;
 
     gl.activeTexture(gl.TEXTURE0);
-    gl.bindTexture(gl.TEXTURE_2D, tile.texture);
+    gl.bindTexture(gl.TEXTURE_2D, tile.texture.texture);
 
     gl.activeTexture(gl.TEXTURE1);
 
     if (parentTile) {
-        gl.bindTexture(gl.TEXTURE_2D, parentTile.texture);
+        gl.bindTexture(gl.TEXTURE_2D, parentTile.texture.texture);
         parentScaleBy = Math.pow(2, parentTile.coord.z - tile.coord.z);
         parentTL = [tile.coord.x * parentScaleBy % 1, tile.coord.y * parentScaleBy % 1];
 
     } else {
-        gl.bindTexture(gl.TEXTURE_2D, tile.texture);
+        gl.bindTexture(gl.TEXTURE_2D, tile.texture.texture);
     }
 
     // cross-fade parameters

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -130,7 +130,7 @@ function setSymbolDrawState(program, painter, layer, tileZoom, isText, isSDF, ro
         const glyphAtlas = fontstack && painter.glyphSource.getGlyphAtlas(fontstack);
         if (!glyphAtlas) return;
 
-        glyphAtlas.updateTexture(gl);
+        glyphAtlas.bind(gl);
         gl.uniform2f(program.u_texsize, glyphAtlas.width, glyphAtlas.height);
     } else {
         const mapMoving = painter.options.rotating || painter.options.zooming;

--- a/src/render/frame_history.js
+++ b/src/render/frame_history.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Texture = require('./texture');
+
 class FrameHistory {
 
     constructor() {
@@ -10,6 +12,7 @@ class FrameHistory {
 
         this.previousZoom = 0;
         this.firstFrame = true;
+        this.dirty = true;
     }
 
     record(now, zoom, duration) {
@@ -43,26 +46,19 @@ class FrameHistory {
             }
         }
 
-        this.changed = true;
+        this.dirty = true;
         this.previousZoom = zoom;
     }
 
     bind(gl) {
         if (!this.texture) {
-            this.texture = gl.createTexture();
-            gl.bindTexture(gl.TEXTURE_2D, this.texture);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.ALPHA, 256, 1, 0, gl.ALPHA, gl.UNSIGNED_BYTE, this.array);
-
+            this.texture = new Texture(gl, gl.CLAMP_TO_EDGE, gl.LINEAR, gl.LINEAR);
         } else {
-            gl.bindTexture(gl.TEXTURE_2D, this.texture);
-            if (this.changed) {
-                gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 256, 1, gl.ALPHA, gl.UNSIGNED_BYTE, this.array);
-                this.changed = false;
-            }
+            this.texture.bind();
+        }
+        if (this.dirty) {
+            this.texture.setData(gl.ALPHA, 256, 1, this.array);
+            this.dirty = true;
         }
     }
 }

--- a/src/render/line_atlas.js
+++ b/src/render/line_atlas.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('../util/util');
+const Texture = require('../render/texture');
 
 /**
  * A LineAtlas lets us reuse rendered dashed lines
@@ -21,6 +22,7 @@ class LineAtlas {
         this.data = new Uint8Array(this.width * this.height * this.bytes);
 
         this.positions = {};
+        this.dirty = true;
     }
 
     setSprite(sprite) {
@@ -125,21 +127,13 @@ class LineAtlas {
 
     bind(gl) {
         if (!this.texture) {
-            this.texture = gl.createTexture();
-            gl.bindTexture(gl.TEXTURE_2D, this.texture);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, this.width, this.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, this.data);
-
+            this.texture = new Texture(gl, gl.REPEAT, gl.LINEAR, gl.LINEAR);
         } else {
-            gl.bindTexture(gl.TEXTURE_2D, this.texture);
-
-            if (this.dirty) {
-                this.dirty = false;
-                gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, this.width, this.height, gl.RGBA, gl.UNSIGNED_BYTE, this.data);
-            }
+            this.texture.bind();
+        }
+        if (this.dirty) {
+            this.texture.setData(gl.RGBA, this.width, this.height, this.data);
+            this.dirty = false;
         }
     }
 }

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -1,0 +1,48 @@
+'use strict';
+
+class Texture {
+
+    constructor(gl, wrap, filterMag, filterMin) {
+        this.gl = gl;
+        this.texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, this.texture);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrap);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrap);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filterMag);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filterMin);
+        this.dirty = true;
+    }
+
+    bind() {
+        this.gl.bindTexture(this.gl.TEXTURE_2D, this.texture);
+    }
+
+    setData(type, width, height, data) {
+        const gl = this.gl;
+        if (this.dirty) {
+            gl.texImage2D(gl.TEXTURE_2D, 0, type, width, height, 0, type, gl.UNSIGNED_BYTE, data);
+            this.dirty = false;
+        } else {
+            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, type, gl.UNSIGNED_BYTE, data);
+        }
+    }
+
+    setImage(image) {
+        const gl = this.gl;
+        if (this.dirty) {
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+            this.dirty = false;
+        } else {
+            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, image);
+        }
+    }
+
+    destroy() {
+        if (this.texture) {
+            this.gl.deleteTexture(this.texture);
+            this.texture = null;
+        }
+    }
+}
+
+module.exports = Texture;

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -6,6 +6,7 @@ const Evented = require('../util/evented');
 const loadTileJSON = require('./load_tilejson');
 const normalizeURL = require('../util/mapbox').normalizeTileURL;
 const TileBounds = require('./tile_bounds');
+const Texture = require('../render/texture');
 
 class RasterTileSource extends Evented {
 
@@ -94,25 +95,19 @@ class RasterTileSource extends Evented {
             delete img.expires;
 
             const gl = this.map.painter.gl;
-            tile.texture = this.map.painter.getTileTexture(img.width);
-            if (tile.texture) {
-                gl.bindTexture(gl.TEXTURE_2D, tile.texture);
-                gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, img);
-            } else {
-                tile.texture = gl.createTexture();
-                gl.bindTexture(gl.TEXTURE_2D, tile.texture);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
+            tile.texture = this.map.painter.getTileTexture(img.width);
+            if (!tile.texture) {
+                tile.texture = new Texture(gl, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_NEAREST, gl.LINEAR);
+                tile.texture.size = img.width;
                 if (this.map.painter.extTextureFilterAnisotropic) {
                     gl.texParameterf(gl.TEXTURE_2D, this.map.painter.extTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, this.map.painter.extTextureFilterAnisotropicMax);
                 }
-
-                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
-                tile.texture.size = img.width;
+            } else {
+                tile.texture.bind(gl);
             }
+
+            tile.texture.setImage(img);
             gl.generateMipmap(gl.TEXTURE_2D);
 
             tile.state = 'loaded';


### PR DESCRIPTION
Abstracts our texture logic (which was repeated in many places) in a `Texture` class, reducing the amount of code and the error surface. A work in progress — just wanted to get this out to show the direction this is going and get some feedback.

## Launch Checklist

 - [ ] fix a few render test failures
 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] ~~document any changes to public APIs~~
 - [ ] post benchmark scores
 - [x] manually test the debug page
