### PR TITLE
Clone LngLats when setting LngLatBounds' corners

### DIFF
--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -39,7 +39,7 @@ class LngLatBounds {
      * @returns {LngLatBounds} `this`
      */
     setNorthEast(ne) {
-        this._ne = LngLat.convert(ne);
+        this._ne = ne instanceof LngLat ? new LngLat(ne.lng, ne.lat) : LngLat.convert(ne);
         return this;
     }
 
@@ -50,7 +50,7 @@ class LngLatBounds {
      * @returns {LngLatBounds} `this`
      */
     setSouthWest(sw) {
-        this._sw = LngLat.convert(sw);
+        this._sw = sw instanceof LngLat ? new LngLat(sw.lng, sw.lat) : LngLat.convert(sw);
         return this;
     }
 

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -113,6 +113,20 @@ test('LngLatBounds', (t) => {
         t.end();
     });
 
+    t.test('#extend same LngLat instance', (t) => {
+        const point = new LngLat(0, 0);
+        const bounds = new LngLatBounds(point, point);
+
+        bounds.extend(new LngLat(15, 15));
+
+        t.equal(bounds.getSouth(), 0);
+        t.equal(bounds.getWest(), 0);
+        t.equal(bounds.getNorth(), 15);
+        t.equal(bounds.getEast(), 15);
+
+        t.end();
+    });
+
     t.test('accessors', (t) => {
         const sw = new LngLat(0, 0);
         const ne = new LngLat(-10, -20);


### PR DESCRIPTION

Fixes #4814 by cloning `LngLat`s when setting the corners of a `LngLatBounds`. Added one more unit test, which mimics the conditions of #4818 and fails without this fix.
