### PR TITLE
Don't do extrusion rendering work during opaque pass

### DIFF
--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -12,7 +12,9 @@ const vec3 = glMatrix.vec3;
 module.exports = draw;
 
 function draw(painter, source, layer, coords) {
+    if (painter.isOpaquePass) return;
     if (layer.paint['fill-extrusion-opacity'] === 0) return;
+
     const gl = painter.gl;
     gl.disable(gl.STENCIL_TEST);
     gl.enable(gl.DEPTH_TEST);
@@ -102,8 +104,6 @@ function renderTextureToMap(gl, painter, layer, texture) {
 }
 
 function drawExtrusion(painter, source, layer, coord) {
-    if (painter.isOpaquePass) return;
-
     const tile = source.getTile(coord);
     const bucket = tile.getBucket(layer);
     if (!bucket) return;


### PR DESCRIPTION
Previously, the code bound, cleared, and copied a transparent texture during the opaque pass. Fixing this roughly doubles the FPS of https://www.mapbox.com/bites/00351/.