### PR TITLE
Fix release date of 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
 
-## 0.38.0 (May 9, 2017)
+## 0.38.0 (June 9, 2017)
 
 #### New features :sparkles:
 


### PR DESCRIPTION
As the title suggests, version `0.38.0` landed in June, not May 😛 