### PR TITLE
do not display fullscreen control on unsupported devices #4786

### DIFF
--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -4,6 +4,8 @@ const DOM = require('../../util/dom');
 const util = require('../../util/util');
 const window = require('../../util/window');
 
+const className = 'mapboxgl-ctrl';
+
 /**
  * A `FullscreenControl` control contains a button for toggling the map in and out of fullscreen mode.
  *
@@ -33,21 +35,38 @@ class FullscreenControl {
     }
 
     onAdd(map) {
-        const className = 'mapboxgl-ctrl';
-        const container = this._container = DOM.create('div', `${className} mapboxgl-ctrl-group`);
-        const button = this._fullscreenButton = DOM.create('button', (`${className}-icon ${className}-fullscreen`), this._container);
-        button.setAttribute("aria-label", "Toggle fullscreen");
-        button.type = 'button';
-        this._fullscreenButton.addEventListener('click', this._onClickFullscreen);
-        this._mapContainer = map.getContainer();
-        window.document.addEventListener(this._fullscreenchange, this._changeIcon);
-        return container;
+        this._map = map;
+        this._mapContainer = this._map.getContainer();
+        this._container = DOM.create('div', `${className} mapboxgl-ctrl-group`);
+        if (this._checkFullscreenSupport()) {
+            this._setupUI();
+        } else {
+            util.warnOnce('This device does not support fullscreen mode.');
+        }
+        return this._container;
     }
 
     onRemove() {
         this._container.parentNode.removeChild(this._container);
         this._map = null;
         window.document.removeEventListener(this._fullscreenchange, this._changeIcon);
+    }
+
+    _checkFullscreenSupport() {
+        return !!(
+            this._mapContainer.requestFullscreen ||
+            this._mapContainer.mozRequestFullScreen ||
+            this._mapContainer.msRequestFullscreen ||
+            this._mapContainer.webkitRequestFullscreen
+        );
+    }
+
+    _setupUI() {
+        const button = this._fullscreenButton = DOM.create('button', (`${className}-icon ${className}-fullscreen`), this._container);
+        button.setAttribute("aria-label", "Toggle fullscreen");
+        button.type = 'button';
+        this._fullscreenButton.addEventListener('click', this._onClickFullscreen);
+        window.document.addEventListener(this._fullscreenchange, this._changeIcon);
     }
 
     _isFullscreen() {
@@ -63,7 +82,6 @@ class FullscreenControl {
 
         if ((fullscreenElement === this._mapContainer) !== this._fullscreen) {
             this._fullscreen = !this._fullscreen;
-            const className = 'mapboxgl-ctrl';
             this._fullscreenButton.classList.toggle(`${className}-shrink`);
             this._fullscreenButton.classList.toggle(`${className}-fullscreen`);
         }

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -40,6 +40,7 @@ class FullscreenControl {
         if (this._checkFullscreenSupport()) {
             this._setupUI();
         } else {
+            this._container.style.display = 'none';
             util.warnOnce('This device does not support fullscreen mode.');
         }
         return this._container;
@@ -53,10 +54,11 @@ class FullscreenControl {
 
     _checkFullscreenSupport() {
         return !!(
-            this._mapContainer.requestFullscreen ||
-            this._mapContainer.mozRequestFullScreen ||
-            this._mapContainer.msRequestFullscreen ||
-            this._mapContainer.webkitRequestFullscreen
+            window.document.fullscreenEnabled ||
+            window.document.mozFullscreenEnabled ||
+            window.document.mozFullScreenEnabled ||
+            window.document.msFullscreenEnabled ||
+            window.document.webkitFullscreenEnabled
         );
     }
 

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -56,7 +56,6 @@ class FullscreenControl {
         return !!(
             window.document.fullscreenEnabled ||
             window.document.mozFullscreenEnabled ||
-            window.document.mozFullScreenEnabled ||
             window.document.msFullscreenEnabled ||
             window.document.webkitFullscreenEnabled
         );

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -4,8 +4,6 @@ const DOM = require('../../util/dom');
 const util = require('../../util/util');
 const window = require('../../util/window');
 
-const className = 'mapboxgl-ctrl';
-
 /**
  * A `FullscreenControl` control contains a button for toggling the map in and out of fullscreen mode.
  *
@@ -32,12 +30,13 @@ class FullscreenControl {
         } else if ('onmsfullscreenchange' in window.document) {
             this._fullscreenchange = 'MSFullscreenChange';
         }
+        this._className = 'mapboxgl-ctrl';
     }
 
     onAdd(map) {
         this._map = map;
         this._mapContainer = this._map.getContainer();
-        this._container = DOM.create('div', `${className} mapboxgl-ctrl-group`);
+        this._container = DOM.create('div', `${this._className} mapboxgl-ctrl-group`);
         if (this._checkFullscreenSupport()) {
             this._setupUI();
         } else {
@@ -62,7 +61,7 @@ class FullscreenControl {
     }
 
     _setupUI() {
-        const button = this._fullscreenButton = DOM.create('button', (`${className}-icon ${className}-fullscreen`), this._container);
+        const button = this._fullscreenButton = DOM.create('button', (`${this._className}-icon ${this._className}-fullscreen`), this._container);
         button.setAttribute("aria-label", "Toggle fullscreen");
         button.type = 'button';
         this._fullscreenButton.addEventListener('click', this._onClickFullscreen);
@@ -82,8 +81,8 @@ class FullscreenControl {
 
         if ((fullscreenElement === this._mapContainer) !== this._fullscreen) {
             this._fullscreen = !this._fullscreen;
-            this._fullscreenButton.classList.toggle(`${className}-shrink`);
-            this._fullscreenButton.classList.toggle(`${className}-fullscreen`);
+            this._fullscreenButton.classList.toggle(`${this._className}-shrink`);
+            this._fullscreenButton.classList.toggle(`${this._className}-fullscreen`);
         }
     }
 

--- a/test/unit/ui/control/fullscreen.test.js
+++ b/test/unit/ui/control/fullscreen.test.js
@@ -17,11 +17,24 @@ function createMap() {
     });
 }
 
-test('FullscreenControl with no options', (t) => {
-    t.plan(0);
+test('FullscreenControl appears then fullscreen enabled', (t) => {
+    window.document.fullscreenEnabled = true;
 
     const map = createMap();
     const fullscreen = new FullscreenControl();
     map.addControl(fullscreen);
+
+    t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-fullscreen').length, 1);
+    t.end();
+});
+
+test('FullscreenControl does not appears then fullscreen is not enabled', (t) => {
+    window.document.fullscreenEnabled = false;
+
+    const map = createMap();
+    const fullscreen = new FullscreenControl();
+    map.addControl(fullscreen);
+
+    t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-fullscreen').length, 0);
     t.end();
 });

--- a/test/unit/ui/control/fullscreen.test.js
+++ b/test/unit/ui/control/fullscreen.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const test = require('mapbox-gl-js-test').test;
+const window = require('../../../../src/util/window');
+const Map = require('../../../../src/ui/map');
+const FullscreenControl = require('../../../../src/ui/control/fullscreen_control');
+
+function createMap() {
+    const container = window.document.createElement('div');
+    return new Map({
+        container: container,
+        style: {
+            version: 8,
+            sources: {},
+            layers: []
+        }
+    });
+}
+
+test('FullscreenControl with no options', (t) => {
+    t.plan(0);
+
+    const map = createMap();
+    const fullscreen = new FullscreenControl();
+    map.addControl(fullscreen);
+    t.end();
+});


### PR DESCRIPTION
Do not display fullscreen control on unsupported devices according to #4786

I think, that it would be useful to warn the user if the device does not support fullscreen mode.