### PR TITLE
LogoControl cleanup

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -120,7 +120,7 @@ class Style extends Evented {
 
         this.on('data', (event) => {
             if (event.dataType === 'source' && event.sourceDataType === 'metadata') {
-                const source = this.sourceCaches[event.sourceId].getSource();
+                const source = !!this.sourceCaches[event.sourceId] && this.sourceCaches[event.sourceId].getSource();
                 if (source && source.vectorLayerIds) {
                     for (const layerId in this._layers) {
                         const layer = this._layers[layerId];
@@ -408,6 +408,7 @@ class Style extends Evented {
         const sourceCache = this.sourceCaches[id];
         delete this.sourceCaches[id];
         delete this._updatedSources[id];
+        sourceCache.fire('data', {sourceDataType: 'metadata', dataType:'source', sourceId: id});
         sourceCache.setEventedParent(null);
         sourceCache.clearTiles();
 

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -19,10 +19,16 @@ class LogoControl {
 
     onAdd(map) {
         this._map = map;
+        this._logoDisplayed = true;
+
         this._container = DOM.create('div', 'mapboxgl-ctrl');
+        const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
+        anchor.target = "_blank";
+        anchor.href = "https://www.mapbox.com/";
+        anchor.setAttribute("aria-label", "Mapbox logo");
+        this._container.appendChild(anchor);
 
         this._map.on('sourcedata', this._updateLogo);
-        this._updateLogo();
         return this._container;
     }
 
@@ -36,15 +42,10 @@ class LogoControl {
     }
 
     _updateLogo(e) {
-        if (e && e.sourceDataType === 'metadata') {
-            if (!this._container.childNodes.length && this._logoRequired()) {
-                const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
-                anchor.target = "_blank";
-                anchor.href = "https://www.mapbox.com/";
-                anchor.setAttribute("aria-label", "Mapbox logo");
-                this._container.appendChild(anchor);
-                this._map.off('data', this._updateLogo);
-            } else if (this._container.childNodes.length && !this._logoRequired()) {
+        if (!e || e.sourceDataType === 'metadata') {
+            if (!this._logoDisplayed && this._logoRequired()) {
+                this.onAdd(this._map);
+            } else if (this._container && !this._logoRequired()) {
                 this.onRemove();
             }
         }

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -27,8 +27,6 @@ class LogoControl {
         this._container.appendChild(anchor);
         this._container.style.display = 'none';
 
-
-        this._logoDisplay = false;
         this._map.on('sourcedata', this._updateLogo);
         return this._container;
     }
@@ -44,13 +42,7 @@ class LogoControl {
 
     _updateLogo(e) {
         if (e && e.sourceDataType === 'metadata') {
-            if (!this._logoDisplay && this._logoRequired()) {
-                this._container.style.display = 'block';
-                this._logoDisplay = true;
-            } else if (this._logoDisplay && !this._logoRequired()) {
-                this._container.style.display = 'none';
-                this._logoDisplay = false;
-            }
+            this._container.style.display = this._logoRequired() ? 'block' : 'none';
         }
     }
 

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -28,6 +28,7 @@ class LogoControl {
         this._container.style.display = 'none';
 
         this._map.on('sourcedata', this._updateLogo);
+        this._updateLogo();
         return this._container;
     }
 
@@ -41,7 +42,7 @@ class LogoControl {
     }
 
     _updateLogo(e) {
-        if (e && e.sourceDataType === 'metadata') {
+        if (!e || e.sourceDataType === 'metadata') {
             this._container.style.display = this._logoRequired() ? 'block' : 'none';
         }
     }

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -19,15 +19,16 @@ class LogoControl {
 
     onAdd(map) {
         this._map = map;
-        this._logoDisplayed = true;
-
         this._container = DOM.create('div', 'mapboxgl-ctrl');
         const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
         anchor.target = "_blank";
         anchor.href = "https://www.mapbox.com/";
         anchor.setAttribute("aria-label", "Mapbox logo");
         this._container.appendChild(anchor);
+        this._container.style.display = 'none';
 
+
+        this._logoDisplay = false;
         this._map.on('sourcedata', this._updateLogo);
         return this._container;
     }
@@ -42,11 +43,13 @@ class LogoControl {
     }
 
     _updateLogo(e) {
-        if (!e || e.sourceDataType === 'metadata') {
-            if (!this._logoDisplayed && this._logoRequired()) {
-                this.onAdd(this._map);
-            } else if (this._container && !this._logoRequired()) {
-                this.onRemove();
+        if (e && e.sourceDataType === 'metadata') {
+            if (!this._logoDisplay && this._logoRequired()) {
+                this._container.style.display = 'block';
+                this._logoDisplay = true;
+            } else if (this._logoDisplay && !this._logoRequired()) {
+                this._container.style.display = 'none';
+                this._logoDisplay = false;
             }
         }
     }

--- a/test/unit/ui/control/logo.test.js
+++ b/test/unit/ui/control/logo.test.js
@@ -58,10 +58,10 @@ test('LogoControl appears in the position specified by the position option', (t)
     });
 });
 
-test('LogoControl is not added when the mapbox_logo property is false', (t) => {
+test('LogoControl is not displayed when the mapbox_logo property is false', (t) => {
     const map = createMap('top-left', false);
     map.on('load', () => {
-        t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-top-left .mapboxgl-ctrl-logo').length, 0);
+        t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-top-left > .mapboxgl-ctrl')[0].style.display, 'none');
         t.end();
     });
 });


### PR DESCRIPTION
fix #4813 

This changes a couple things. 

I added a `sourcedata` event firing when a source is removed. This seems in line with the current description in our docs:
>Fired when one of the map's sources loads or changes

I also follow @jingsam's recommendation of hiding the LogoControl when no Mapbox sources are present instead of removing it from the DOM. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
