### PR TITLE
include MouseEvents polyfill to allow map rotation via compass button on IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "brfs": "^1.4.0",
     "bubleify": "^0.7.0",
     "earcut": "^2.0.3",
+    "events-polyfill": "^1.1.9",
     "geojson-rewind": "^0.1.0",
     "geojson-vt": "^2.4.0",
     "grid-index": "^1.0.0",

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -6,6 +6,8 @@ const util = require('../../util/util');
 
 const className = 'mapboxgl-ctrl';
 
+require('events-polyfill');
+
 /**
  * A `NavigationControl` control contains zoom buttons and a compass.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,6 +2395,10 @@ event-stream@~3.3.0:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
+events-polyfill@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/events-polyfill/-/events-polyfill-1.1.9.tgz#07d5788da4a151042be8b68f6e387b58e310e50c"
+
 events-to-array@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.0.2.tgz#b3484465534fe4ff66fbdd1a83b777713ba404aa"


### PR DESCRIPTION
Closes #4784 

## Launch Checklist

 - [x] briefly describe the changes in this PR
This PR include a MouseEvents polyfill to fix #4784. What's the feeling towards using polyfills in GL JS to maintain support for older browsers?

 - [ ] write tests for all new functionality
This change seems to break a whole lot of tests, I can look into that once I get feedback on if this approach will be accepted or not.

 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
tested before and after on IE11.
