### PR TITLE
Update docs and test to newer version of mapbox-gl-rtl-text plugin

### DIFF
--- a/docs/_posts/examples/3400-01-31-mapbox-gl-rtl-text.html
+++ b/docs/_posts/examples/3400-01-31-mapbox-gl-rtl-text.html
@@ -9,7 +9,7 @@ tags:
 <div id='map'></div>
 
 <script>
-mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.0/mapbox-gl-rtl-text.js');
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.1/mapbox-gl-rtl-text.js');
 
 var map = new mapboxgl.Map({
     container: 'map',

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "webworkify": "^1.4.0"
   },
   "devDependencies": {
-    "@mapbox/mapbox-gl-rtl-text": "^0.1.0",
+    "@mapbox/mapbox-gl-rtl-text": "^0.1.1",
     "@mapbox/mapbox-gl-test-suite": "file:test/integration",
     "babel-eslint": "^7.0.0",
     "benchmark": "~2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ mapboxgl.setRTLTextPlugin = rtlTextPlugin.setRTLTextPlugin;
   * @param {string} pluginURL URL pointing to the Mapbox RTL text plugin source.
   * @param {Function} callback Called with an error argument if there is an error.
   * @example
-  * mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.0/mapbox-gl-rtl-text.js');
+  * mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.1/mapbox-gl-rtl-text.js');
   * @see [Add support for right-to-left scripts](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-rtl-text/)
   */
 


### PR DESCRIPTION
Upgrade to `mapbox-gl-rtl-text` v0.1.1 to take advantage of smaller package size due to newer version of Emscripten (1.37) stripping more out of the runtime.

I've done sanity checks of the example page, and the Arabic unit tests pass with the new build. I've also tested "time to first tile load" by logging a timestamp from `VectorTileSource#done`, and don't see a noticeable performance change. The plugin isn't used by our benchmarks, so they're unaffected.