### PR TITLE
Remove unpremultiply from Raster buckets. 

### DIFF
--- a/src/shaders/raster.fragment.glsl
+++ b/src/shaders/raster.fragment.glsl
@@ -17,6 +17,12 @@ void main() {
     // read and cross-fade colors from the main and parent tiles
     vec4 color0 = texture2D(u_image0, v_pos0);
     vec4 color1 = texture2D(u_image1, v_pos1);
+    if (color0.a > 0.0) {
+        color0.rgb = color0.rgb / color0.a;
+    }
+    if (color1.a > 0.0) {
+        color1.rgb = color1.rgb / color1.a;
+    }
     vec4 color = mix(color0, color1, u_fade_t);
     color.a *= u_opacity;
     vec3 rgb = color.rgb;

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -105,7 +105,7 @@ class RasterTileSource extends Evented {
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
+                gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
                 if (this.map.painter.extTextureFilterAnisotropic) {
                     gl.texParameterf(gl.TEXTURE_2D, this.map.painter.extTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, this.map.painter.extTextureFilterAnisotropicMax);
                 }


### PR DESCRIPTION
This supports [gl-native/#9070](https://github.com/mapbox/mapbox-gl-native/issues/9070)

On native platforms, image bytes are decoded using platform APIs and, by default, return bitmaps with alpha premultiplied. The current shader setup required that these be un-premultiplied before being passed to the shaders. On some Android devices, the un-premultiply is very expensive and is slowing down interactivity for raster tile sources and animated image sources. 

The fix here is to make gl-js request pre-multiplication of the image data while uploading to the gl texture. This is done on the CPU, but seems to have negligible performance impact on the benchmarks (I added a raster benchmark locally to verify).

Side benefit is that it also fixes a bug with darker edges on images with alpha. This was reported [here](https://github.com/mapbox/labs/issues/1194#issuecomment-309972799)

### Background
#3846 changed the shaders to fix #3723. This change was ported to `gl-native` in [gl-native#7533](https://github.com/mapbox/mapbox-gl-native/pull/7533)

### Benchmarks

benchmark | master 7b803b6 | remove-unpremultiply dbeaeca
--- | --- | ---
**map-load** | 148 ms  | 104 ms 
**style-load** | 93 ms  | 88 ms 
**buffer** | 929 ms  | 940 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 4.4 ms, 0% > 16ms  | 4.5 ms, 0% > 16ms 
**query-point** | 1.25 ms  | 1.19 ms 
**query-box** | 73.59 ms  | 74.23 ms 
**geojson-setdata-small** | 6 ms  | 5 ms 
**geojson-setdata-large** | 89 ms  | 101 ms 
**raster-frame-duration** | 5.1 ms, 0% > 16ms  | 5.4 ms, 3% > 16ms 

*Note* raster-frame-duration has not been added to the benchmarks in this PR. It needs more work

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page

/cc @kkaefer @ansis  