### PR TITLE
update locate the user example

### DIFF
--- a/docs/_posts/examples/3400-01-05-locate-user.html
+++ b/docs/_posts/examples/3400-01-05-locate-user.html
@@ -2,7 +2,7 @@
 layout: example
 category: example
 title: Locate the user
-description: Geolocate the user and then center the map on their current location
+description: Geolocate the user and then track their current location on the map
 tags: 
   - controls-and-overlays
 ---
@@ -16,5 +16,10 @@ var map = new mapboxgl.Map({
 });
 
 // Add geolocate control to the map.
-map.addControl(new mapboxgl.GeolocateControl());
+map.addControl(new mapboxgl.GeolocateControl({
+    positionOptions: {
+        enableHighAccuracy: true
+    },
+    trackUserLocation: true
+}));
 </script>


### PR DESCRIPTION
Change the "locate the user" example with better defaults for tracking a mobile user.

The original example (no options passed to the GeolocateControl) is good for desktop when you don't need to track their location or get an accurate GPS location.

However for mobile, there this PR gives better defaults to get an accurate GPS fix and track their movement. Without this PR it can be confusing how to get something more suited for mobile.

I'm not sure weather to turn this PR into a new example instead so we still have the current one. OR would that just create confusion? Thoughts?