### PR TITLE
Fix 'icon-pitch-alignment' sdk support typo

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1041,10 +1041,7 @@
       ],
       "sdk-support": {
         "basic functionality": {
-          "js": "0.39.0",
-          "android": null,
-          "ios": null,
-          "macos": null
+          "js": "0.39.0"
         },
         "data-driven styling": {}
       }


### PR DESCRIPTION
Oops, I let these "nulls" sneak in to the style spec documentation.

/cc @nickidlugash 