### PR TITLE
Flow type workers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "array-bracket-spacing": "off",
     "block-scoped-var": "error",
     "consistent-return": "off",
+    "flowtype/define-flow-type": 1,
     "global-require": "off",
     "key-spacing": "off",
     "no-eq-null": "off",

--- a/flow-interfaces/callback.js
+++ b/flow-interfaces/callback.js
@@ -1,0 +1,17 @@
+
+// Flow can't perfectly type Node-style callbacks yet; it does not have a way to
+// express that if the first parameter is null, the second is not, so for the time
+// being, both parameters must be optional. Use the following convention when defining
+// a callback:
+//
+//    asyncFunction((error, result) => {
+//        if (error) {
+//            // handle error
+//        } else if (result) {
+//            // handle success
+//        }
+//    });
+//
+// See https://github.com/facebook/flow/issues/2123 for more.
+
+declare type Callback<T> = (error: ?Error, result: ?T) => void;

--- a/flow-interfaces/transferable.js
+++ b/flow-interfaces/transferable.js
@@ -1,0 +1,1 @@
+declare type Transferable = ArrayBuffer | MessagePort | ImageBitmap;

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
       "package-json-versionify",
       "unassertify",
       "brfs",
-      "./src/style-spec/minifyify_style_spec"
+      "./src/build/minifyify_style_spec",
+      "./src/build/strictify"
     ]
   },
   "browser": {

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module",
+  }
+}

--- a/src/build/minifyify_style_spec.js
+++ b/src/build/minifyify_style_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const through = require('through2');
 
 function replacer(k, v) {

--- a/src/build/strictify.js
+++ b/src/build/strictify.js
@@ -1,0 +1,17 @@
+const through = require('through2');
+const path = require('path');
+
+module.exports = (file) => {
+    if (path.extname(file) === '.json') {
+        return through();
+    }
+    let first = true;
+    return through(function (chunk, encoding, callback) {
+        if (first) {
+            this.push("'use strict';");
+            first = false;
+        }
+        this.push(chunk);
+        callback();
+    });
+};

--- a/src/data/array_group.js
+++ b/src/data/array_group.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ProgramConfiguration = require('./program_configuration');
 const createVertexArrayType = require('./vertex_array_type');

--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ArrayGroup = require('./array_group');
 const BufferGroup = require('./buffer_group');

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Bucket = require('../bucket');
 const createElementArrayType = require('../element_array_type');

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Bucket = require('../bucket');
 const createElementArrayType = require('../element_array_type');

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Bucket = require('../bucket');
 const createElementArrayType = require('../element_array_type');

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Bucket = require('../bucket');
 const createElementArrayType = require('../element_array_type');

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Point = require('point-geometry');
 const ArrayGroup = require('../array_group');

--- a/src/data/buffer.js
+++ b/src/data/buffer.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /**
  * @enum {string} AttributeType

--- a/src/data/buffer_group.js
+++ b/src/data/buffer_group.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const Buffer = require('./buffer');

--- a/src/data/element_array_type.js
+++ b/src/data/element_array_type.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const createStructArrayType = require('../util/struct_array');
 

--- a/src/data/extent.js
+++ b/src/data/extent.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /**
  * The maximum value of a coordinate in the internal tile coordinate system. Coordinates of

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const assert = require('assert');
 const Point = require('point-geometry');

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const EXTENT = require('./extent');

--- a/src/data/pos_array.js
+++ b/src/data/pos_array.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const createStructArrayType = require('../util/struct_array');
 

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const assert = require('assert');
 const createVertexArrayType = require('./vertex_array_type');

--- a/src/data/raster_bounds_array.js
+++ b/src/data/raster_bounds_array.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const createStructArrayType = require('../util/struct_array');
 

--- a/src/data/vertex_array_type.js
+++ b/src/data/vertex_array_type.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const createStructArrayType = require('../util/struct_array');
 

--- a/src/geo/coordinate.js
+++ b/src/geo/coordinate.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 /**

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 const wrap = require('../util/util').wrap;

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const LngLat = require('./lng_lat');
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 const LngLat = require('./lng_lat'),

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 const browser = require('./util/browser');

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const pattern = require('./pattern');
 

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const browser = require('../util/browser');
 

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = drawCollisionDebug;
 

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const browser = require('../util/browser');
 const mat4 = require('@mapbox/gl-matrix').mat4;

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const pattern = require('./pattern');
 

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const glMatrix = require('@mapbox/gl-matrix');
 const Buffer = require('../data/buffer');

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const browser = require('../util/browser');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const drawCollisionDebug = require('./draw_collision_debug');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');

--- a/src/render/frame_history.js
+++ b/src/render/frame_history.js
@@ -1,4 +1,3 @@
-'use strict';
 
 class FrameHistory {
 

--- a/src/render/line_atlas.js
+++ b/src/render/line_atlas.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const browser = require('../util/browser');
 const mat4 = require('@mapbox/gl-matrix').mat4;

--- a/src/render/pattern.js
+++ b/src/render/pattern.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const assert = require('assert');
 

--- a/src/render/shaders.js
+++ b/src/render/shaders.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const fs = require('fs');
 

--- a/src/render/vertex_array_object.js
+++ b/src/render/vertex_array_object.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const assert = require('assert');
 

--- a/src/shaders/encode_attribute.js
+++ b/src/shaders/encode_attribute.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ImageSource = require('./image_source');
 const window = require('../util/window');

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Evented = require('../util/evented');
 const util = require('../util/util');

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -29,8 +29,7 @@ export type LoadGeoJSONParameters = {
     geojsonVtOptions?: Object
 };
 
-export type LoadGeoJSONCallback = (error: ?Error, result: ?GeoJSON) => void;
-export type LoadGeoJSON = (params: LoadGeoJSONParameters, callback: LoadGeoJSONCallback) => void;
+export type LoadGeoJSON = (params: LoadGeoJSONParameters, callback: Callback<GeoJSON>) => void;
 
 export interface GeoJSONIndex {
 }
@@ -102,7 +101,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * @param params.source The id of the source.
      * @param callback
      */
-    loadData(params: LoadGeoJSONParameters, callback: (error: ?Error) => void) {
+    loadData(params: LoadGeoJSONParameters, callback: Callback<void>) {
         this.loadGeoJSON(params, (err, data) => {
             if (err || !data) {
                 return callback(err);
@@ -157,7 +156,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * @param [params.url] A URL to the remote GeoJSON data.
      * @param [params.data] Literal GeoJSON data. Must be provided if `params.url` is not.
      */
-    loadGeoJSON(params: LoadGeoJSONParameters, callback: LoadGeoJSONCallback) {
+    loadGeoJSON(params: LoadGeoJSONParameters, callback: Callback<GeoJSON>) {
         // Because of same origin issues, urls must either include an explicit
         // origin or absolute path.
         // ie: /foo/bar.json or http://example.com/bar.json

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -1,3 +1,4 @@
+// @flow
 
 const ajax = require('../util/ajax');
 const rewind = require('geojson-rewind');
@@ -8,56 +9,85 @@ const geojsonvt = require('geojson-vt');
 
 const VectorTileWorkerSource = require('./vector_tile_worker_source');
 
+import type {
+    WorkerTileParameters,
+    WorkerTileCallback,
+} from '../source/source';
+
+import type {Actor} from '../util/actor';
+import type {StyleLayerIndex} from '../style/style_layer_index';
+
+import type {LoadVectorDataCallback} from './vector_tile_worker_source';
+
+export type GeoJSON = Object;
+
+export type LoadGeoJSONParameters = {
+    url?: string,
+    data?: string,
+    source: string,
+    superclusterOptions?: Object,
+    geojsonVtOptions?: Object
+};
+
+export type LoadGeoJSONCallback = (error: ?Error, result: ?GeoJSON) => void;
+export type LoadGeoJSON = (params: LoadGeoJSONParameters, callback: LoadGeoJSONCallback) => void;
+
+export interface GeoJSONIndex {
+}
+
+function loadGeoJSONTile(params: WorkerTileParameters, callback: LoadVectorDataCallback) {
+    const source = params.source,
+        coord = params.coord;
+
+    if (!this._geoJSONIndexes[source]) {
+        return callback(null, null);  // we couldn't load the file
+    }
+
+    const geoJSONTile = this._geoJSONIndexes[source].getTile(Math.min(coord.z, params.maxZoom), coord.x, coord.y);
+    if (!geoJSONTile) {
+        return callback(null, null); // nothing in the given tile
+    }
+
+    // Encode the geojson-vt tile into binary vector tile form form.  This
+    // is a convenience that allows `FeatureIndex` to operate the same way
+    // across `VectorTileSource` and `GeoJSONSource` data.
+    const geojsonWrapper = new GeoJSONWrapper(geoJSONTile.features);
+    geojsonWrapper.name = '_geojsonTileLayer';
+    let pbf = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
+    if (pbf.byteOffset !== 0 || pbf.byteLength !== pbf.buffer.byteLength) {
+        // Compatibility with node Buffer (https://github.com/mapbox/pbf/issues/35)
+        pbf = new Uint8Array(pbf);
+    }
+    geojsonWrapper.rawData = pbf.buffer;
+    callback(null, geojsonWrapper);
+}
+
 /**
  * The {@link WorkerSource} implementation that supports {@link GeoJSONSource}.
  * This class is designed to be easily reused to support custom source types
  * for data formats that can be parsed/converted into an in-memory GeoJSON
  * representation.  To do so, create it with
- * `new GeoJSONWorkerSource(actor, layerIndex, customLoadGeoJSONFunction)`.  For a full example, see [mapbox-gl-topojson](https://github.com/developmentseed/mapbox-gl-topojson).
+ * `new GeoJSONWorkerSource(actor, layerIndex, customLoadGeoJSONFunction)`.
+ * For a full example, see [mapbox-gl-topojson](https://github.com/developmentseed/mapbox-gl-topojson).
  *
  * @private
  */
 class GeoJSONWorkerSource extends VectorTileWorkerSource {
+    _geoJSONIndexes: { [string]: GeoJSONIndex };
+    loadGeoJSON: LoadGeoJSON;
+
     /**
-     * @param {Function} [loadGeoJSON] Optional method for custom loading/parsing of GeoJSON based on parameters passed from the main-thread Source.  See {@link GeoJSONWorkerSource#loadGeoJSON}.
+     * @param [loadGeoJSON] Optional method for custom loading/parsing of
+     * GeoJSON based on parameters passed from the main-thread Source.
+     * See {@link GeoJSONWorkerSource#loadGeoJSON}.
      */
-    constructor (actor, layerIndex, loadGeoJSON) {
-        super(actor, layerIndex);
+    constructor(actor: Actor, layerIndex: StyleLayerIndex, loadGeoJSON: ?LoadGeoJSON) {
+        super(actor, layerIndex, loadGeoJSONTile);
         if (loadGeoJSON) {
             this.loadGeoJSON = loadGeoJSON;
         }
         // object mapping source ids to geojson-vt-like tile indexes
         this._geoJSONIndexes = {};
-    }
-
-    /**
-     * See {@link VectorTileWorkerSource#loadTile}.
-     */
-    loadVectorData(params, callback) {
-        const source = params.source,
-            coord = params.coord;
-
-        if (!this._geoJSONIndexes[source]) {
-            return callback(null, null);  // we couldn't load the file
-        }
-
-        const geoJSONTile = this._geoJSONIndexes[source].getTile(Math.min(coord.z, params.maxZoom), coord.x, coord.y);
-        if (!geoJSONTile) {
-            return callback(null, null); // nothing in the given tile
-        }
-
-        // Encode the geojson-vt tile into binary vector tile form form.  This
-        // is a convenience that allows `FeatureIndex` to operate the same way
-        // across `VectorTileSource` and `GeoJSONSource` data.
-        const geojsonWrapper = new GeoJSONWrapper(geoJSONTile.features);
-        geojsonWrapper.name = '_geojsonTileLayer';
-        let pbf = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
-        if (pbf.byteOffset !== 0 || pbf.byteLength !== pbf.buffer.byteLength) {
-            // Compatibility with node Buffer (https://github.com/mapbox/pbf/issues/35)
-            pbf = new Uint8Array(pbf);
-        }
-        geojsonWrapper.rawData = pbf.buffer;
-        callback(null, geojsonWrapper);
     }
 
     /**
@@ -68,32 +98,30 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * Defers to {@link GeoJSONWorkerSource#loadGeoJSON} for the fetching/parsing,
      * expecting `callback(error, data)` to be called with either an error or a
      * parsed GeoJSON object.
-     * @param {Object} params
-     * @param {string} params.source The id of the source.
-     * @param {Function} callback
+     * @param params
+     * @param params.source The id of the source.
+     * @param callback
      */
-    loadData(params, callback) {
+    loadData(params: LoadGeoJSONParameters, callback: (error: ?Error) => void) {
         this.loadGeoJSON(params, (err, data) => {
-            if (err) {
+            if (err || !data) {
                 return callback(err);
-            }
-
-            if (typeof data !== 'object') {
+            } else if (typeof data !== 'object') {
                 return callback(new Error("Input data is not a valid GeoJSON object."));
+            } else {
+                rewind(data, true);
+
+                try {
+                    this._geoJSONIndexes[params.source] = params.cluster ?
+                        supercluster(params.superclusterOptions).load(data.features) :
+                        geojsonvt(data, params.geojsonVtOptions);
+                } catch (err) {
+                    return callback(err);
+                }
+
+                this.loaded[params.source] = {};
+                callback(null);
             }
-
-            rewind(data, true);
-
-            try {
-                this._geoJSONIndexes[params.source] = params.cluster ?
-                    supercluster(params.superclusterOptions).load(data.features) :
-                    geojsonvt(data, params.geojsonVtOptions);
-            } catch (err) {
-                return callback(err);
-            }
-
-            this.loaded[params.source] = {};
-            callback(null);
         });
     }
 
@@ -103,11 +131,11 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     * If the tile is loaded, uses the implementation in VectorTileWorkerSource.
     * Otherwise, such as after a setData() call, we load the tile fresh.
     *
-    * @param {Object} params
-    * @param {string} params.source The id of the source for which we're loading this tile.
-    * @param {string} params.uid The UID for this tile.
+    * @param params
+    * @param params.source The id of the source for which we're loading this tile.
+    * @param params.uid The UID for this tile.
     */
-    reloadTile(params, callback) {
+    reloadTile(params: WorkerTileParameters, callback: WorkerTileCallback) {
         const loaded = this.loaded[params.source],
             uid = params.uid;
 
@@ -125,11 +153,11 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * GeoJSON is loaded and parsed from `params.url` if it exists, or else
      * expected as a literal (string or object) `params.data`.
      *
-     * @param {Object} params
-     * @param {string} [params.url] A URL to the remote GeoJSON data.
-     * @param {Object} [params.data] Literal GeoJSON data. Must be provided if `params.url` is not.
+     * @param params
+     * @param [params.url] A URL to the remote GeoJSON data.
+     * @param [params.data] Literal GeoJSON data. Must be provided if `params.url` is not.
      */
-    loadGeoJSON(params, callback) {
+    loadGeoJSON(params: LoadGeoJSONParameters, callback: LoadGeoJSONCallback) {
         // Because of same origin issues, urls must either include an explicit
         // origin or absolute path.
         // ie: /foo/bar.json or http://example.com/bar.json
@@ -147,7 +175,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
         }
     }
 
-    removeSource(params) {
+    removeSource(params: {source: string}) {
         if (this._geoJSONIndexes[params.source]) {
             delete this._geoJSONIndexes[params.source];
         }

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ajax = require('../util/ajax');
 const rewind = require('geojson-rewind');

--- a/src/source/geojson_wrapper.js
+++ b/src/source/geojson_wrapper.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Point = require('point-geometry');
 const VectorTileFeature = require('vector-tile').VectorTileFeature;

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const window = require('../util/window');

--- a/src/source/load_tilejson.js
+++ b/src/source/load_tilejson.js
@@ -1,4 +1,3 @@
-'use strict';
 const util = require('../util/util');
 const ajax = require('../util/ajax');
 const browser = require('../util/browser');

--- a/src/source/pixels_to_tile_units.js
+++ b/src/source/pixels_to_tile_units.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const EXTENT = require('../data/extent');
 

--- a/src/source/query_features.js
+++ b/src/source/query_features.js
@@ -1,4 +1,3 @@
-'use strict';
 const TileCoord = require('./tile_coord');
 
 exports.rendered = function(sourceCache, styleLayers, queryGeometry, params, zoom, bearing) {

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const ajax = require('../util/ajax');

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 const ajax = require('../util/ajax');

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -47,3 +47,6 @@ module.exports.setRTLTextPlugin = function(pluginURL: string, callback: ErrorCal
         }
     });
 };
+
+module.exports.applyArabicShaping = (null : ?Function);
+module.exports.processBidirectionalText = (null : ?Function);

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Source = require('./source');
 const Tile = require('./tile');

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -114,7 +114,7 @@ class Tile {
         }
 
         this.collisionBoxArray = new CollisionBoxArray(data.collisionBoxArray);
-        this.collisionTile = new CollisionTile(data.collisionTile, this.collisionBoxArray);
+        this.collisionTile = CollisionTile.deserialize(data.collisionTile, this.collisionBoxArray);
         this.featureIndex = new FeatureIndex(data.featureIndex, this.rawTileData, this.collisionTile);
         this.buckets = Bucket.deserialize(data.buckets, painter.style);
     }
@@ -129,7 +129,7 @@ class Tile {
     reloadSymbolData(data: any, style: any) {
         if (this.state === 'unloaded') return;
 
-        this.collisionTile = new CollisionTile(data.collisionTile, this.collisionBoxArray);
+        this.collisionTile = CollisionTile.deserialize(data.collisionTile, this.collisionBoxArray);
         this.featureIndex.setCollisionTile(this.collisionTile);
 
         for (const id in this.buckets) {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const Bucket = require('../data/bucket');

--- a/src/source/tile_bounds.js
+++ b/src/source/tile_bounds.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const LngLatBounds = require('../geo/lng_lat_bounds');
 const clamp = require('../util/util').clamp;

--- a/src/source/tile_coord.js
+++ b/src/source/tile_coord.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const assert = require('assert');
 const WhooTS = require('@mapbox/whoots-js');

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Evented = require('../util/evented');
 const util = require('../util/util');

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -25,7 +25,7 @@ import type {StyleLayerIndex} from '../style/style_layer_index';
  * @param vectorTile
  * @private
  */
-export type LoadVectorDataCallback = (error: ?Error, result: ?AugmentedVectorTile) => void;
+export type LoadVectorDataCallback = Callback<?AugmentedVectorTile>;
 
 export type AbortVectorData = () => void;
 export type LoadVectorData = (params: WorkerTileParameters, callback: LoadVectorDataCallback) => ?AbortVectorData;

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -1,4 +1,3 @@
-'use strict';
 const ajax = require('../util/ajax');
 const vt = require('vector-tile');
 const Protobuf = require('pbf');

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -1,8 +1,49 @@
+// @flow
+
 const ajax = require('../util/ajax');
 const vt = require('vector-tile');
 const Protobuf = require('pbf');
 const WorkerTile = require('./worker_tile');
 const util = require('../util/util');
+
+import type {
+    WorkerSource,
+    WorkerTileParameters,
+    WorkerTileCallback,
+    TileParameters,
+    RedoPlacementParameters,
+    RedoPlacementCallback,
+    AugmentedVectorTile
+} from '../source/source';
+
+import type {Actor} from '../util/actor';
+import type {StyleLayerIndex} from '../style/style_layer_index';
+
+/**
+ * @callback LoadVectorDataCallback
+ * @param error
+ * @param vectorTile
+ * @private
+ */
+export type LoadVectorDataCallback = (error: ?Error, result: ?AugmentedVectorTile) => void;
+
+export type AbortVectorData = () => void;
+export type LoadVectorData = (params: WorkerTileParameters, callback: LoadVectorDataCallback) => ?AbortVectorData;
+
+/**
+ * @private
+ */
+function loadVectorTile(params: WorkerTileParameters, callback: LoadVectorDataCallback) {
+    const xhr = ajax.getArrayBuffer(params.url, (err, response) => {
+        if (err) { return callback(err); }
+        const vectorTile = new vt.VectorTile(new Protobuf(response.data));
+        vectorTile.rawData = response.data;
+        vectorTile.cacheControl = response.cacheControl;
+        vectorTile.expires = response.expires;
+        callback(err, vectorTile);
+    });
+    return () => { xhr.abort(); };
+}
 
 /**
  * The {@link WorkerSource} implementation that supports {@link VectorTileSource}.
@@ -13,36 +54,33 @@ const util = require('../util/util');
  *
  * @private
  */
-class VectorTileWorkerSource {
+class VectorTileWorkerSource implements WorkerSource {
+    actor: Actor;
+    layerIndex: number;
+    loadVectorData: LoadVectorData;
+    loading: { [string]: { [string]: WorkerTile } };
+    loaded: { [string]: { [string]: WorkerTile } };
+
     /**
-     * @param {Function} [loadVectorData] Optional method for custom loading of a VectorTile object based on parameters passed from the main-thread Source.  See {@link VectorTileWorkerSource#loadTile}.  The default implementation simply loads the pbf at `params.url`.
+     * @param [loadVectorData] Optional method for custom loading of a VectorTile
+     * object based on parameters passed from the main-thread Source. See
+     * {@link VectorTileWorkerSource#loadTile}. The default implementation simply
+     * loads the pbf at `params.url`.
      */
-    constructor(actor, layerIndex, loadVectorData) {
+    constructor(actor: Actor, layerIndex: StyleLayerIndex, loadVectorData: ?LoadVectorData) {
         this.actor = actor;
         this.layerIndex = layerIndex;
-
-        if (loadVectorData) { this.loadVectorData = loadVectorData; }
-
+        this.loadVectorData = loadVectorData || loadVectorTile;
         this.loading = {};
         this.loaded = {};
     }
 
     /**
-     * Implements {@link WorkerSource#loadTile}.  Delegates to {@link VectorTileWorkerSource#loadVectorData} (which by default expects a `params.url` property) for fetching and producing a VectorTile object.
-     *
-     * @param {Object} params
-     * @param {string} params.source The id of the source for which we're loading this tile.
-     * @param {string} params.uid The UID for this tile.
-     * @param {TileCoord} params.coord
-     * @param {number} params.zoom
-     * @param {number} params.overscaling
-     * @param {number} params.angle
-     * @param {number} params.pitch
-     * @param {number} params.cameraToCenterDistance
-     * @param {number} params.cameraToTileDistance
-     * @param {boolean} params.showCollisionBoxes
+     * Implements {@link WorkerSource#loadTile}. Delegates to
+     * {@link VectorTileWorkerSource#loadVectorData} (which by default expects
+     * a `params.url` property) for fetching and producing a VectorTile object.
      */
-    loadTile(params, callback) {
+    loadTile(params: WorkerTileParameters, callback: WorkerTileCallback) {
         const source = params.source,
             uid = params.uid;
 
@@ -50,41 +88,37 @@ class VectorTileWorkerSource {
             this.loading[source] = {};
 
         const workerTile = this.loading[source][uid] = new WorkerTile(params);
-        workerTile.abort = this.loadVectorData(params, done.bind(this));
-
-        function done(err, vectorTile) {
+        workerTile.abort = this.loadVectorData(params, (err, vectorTile) => {
             delete this.loading[source][uid];
 
-            if (err) return callback(err);
-            if (!vectorTile) return callback(null, null);
+            if (err || !vectorTile) {
+                return callback(err);
+            }
+
+            const rawTileData = vectorTile.rawData;
+            const cacheControl = {};
+            if (vectorTile.expires) cacheControl.expires = vectorTile.expires;
+            if (vectorTile.cacheControl) cacheControl.cacheControl = vectorTile.cacheControl;
 
             workerTile.vectorTile = vectorTile;
             workerTile.parse(vectorTile, this.layerIndex, this.actor, (err, result, transferrables) => {
-                if (err) return callback(err);
-
-                const cacheControl = {};
-                if (vectorTile.expires) cacheControl.expires = vectorTile.expires;
-                if (vectorTile.cacheControl) cacheControl.cacheControl = vectorTile.cacheControl;
+                if (err || !result) return callback(err);
 
                 // Not transferring rawTileData because the worker needs to retain its copy.
                 callback(null,
-                    util.extend({rawTileData: vectorTile.rawData}, result, cacheControl),
+                    util.extend({rawTileData}, result, cacheControl),
                     transferrables);
             });
 
             this.loaded[source] = this.loaded[source] || {};
             this.loaded[source][uid] = workerTile;
-        }
+        });
     }
 
     /**
      * Implements {@link WorkerSource#reloadTile}.
-     *
-     * @param {Object} params
-     * @param {string} params.source The id of the source for which we're loading this tile.
-     * @param {string} params.uid The UID for this tile.
      */
-    reloadTile(params, callback) {
+    reloadTile(params: WorkerTileParameters, callback: WorkerTileCallback) {
         const loaded = this.loaded[params.source],
             uid = params.uid,
             vtSource = this;
@@ -113,11 +147,11 @@ class VectorTileWorkerSource {
     /**
      * Implements {@link WorkerSource#abortTile}.
      *
-     * @param {Object} params
-     * @param {string} params.source The id of the source for which we're loading this tile.
-     * @param {string} params.uid The UID for this tile.
+     * @param params
+     * @param params.source The id of the source for which we're loading this tile.
+     * @param params.uid The UID for this tile.
      */
-    abortTile(params) {
+    abortTile(params: TileParameters) {
         const loading = this.loading[params.source],
             uid = params.uid;
         if (loading && loading[uid] && loading[uid].abort) {
@@ -129,11 +163,11 @@ class VectorTileWorkerSource {
     /**
      * Implements {@link WorkerSource#removeTile}.
      *
-     * @param {Object} params
-     * @param {string} params.source The id of the source for which we're loading this tile.
-     * @param {string} params.uid The UID for this tile.
+     * @param params
+     * @param params.source The id of the source for which we're loading this tile.
+     * @param params.uid The UID for this tile.
      */
-    removeTile(params) {
+    removeTile(params: TileParameters) {
         const loaded = this.loaded[params.source],
             uid = params.uid;
         if (loaded && loaded[uid]) {
@@ -141,44 +175,7 @@ class VectorTileWorkerSource {
         }
     }
 
-    /**
-     * The result passed to the `loadVectorData` callback must conform to the interface established
-     * by the `VectorTile` class from the [vector-tile](https://www.npmjs.com/package/vector-tile)
-     * npm package. In addition, it must have a `rawData` property containing an `ArrayBuffer`
-     * with protobuf data conforming to the
-     * [Mapbox Vector Tile specification](https://github.com/mapbox/vector-tile-spec).
-     *
-     * @class VectorTile
-     * @property {ArrayBuffer} rawData
-     * @private
-     */
-
-    /**
-     * @callback LoadVectorDataCallback
-     * @param {Error?} error
-     * @param {VectorTile?} vectorTile
-     * @private
-     */
-
-    /**
-     * @param {Object} params
-     * @param {string} params.url The URL of the tile PBF to load.
-     * @param {LoadVectorDataCallback} callback
-     */
-    loadVectorData(params, callback) {
-        const xhr = ajax.getArrayBuffer(params.url, done.bind(this));
-        return function abort () { xhr.abort(); };
-        function done(err, response) {
-            if (err) { return callback(err); }
-            const vectorTile = new vt.VectorTile(new Protobuf(response.data));
-            vectorTile.rawData = response.data;
-            vectorTile.cacheControl = response.cacheControl;
-            vectorTile.expires = response.expires;
-            callback(err, vectorTile);
-        }
-    }
-
-    redoPlacement(params, callback) {
+    redoPlacement(params: RedoPlacementParameters, callback: RedoPlacementCallback) {
         const loaded = this.loaded[params.source],
             loading = this.loading[params.source],
             uid = params.uid;

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ajax = require('../util/ajax');
 const ImageSource = require('./image_source');

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -122,7 +122,7 @@ class Worker {
             if (!globalRTLTextPlugin.applyArabicShaping && !globalRTLTextPlugin.processBidirectionalText) {
                 this.self.importScripts(pluginURL);
                 if (!globalRTLTextPlugin.applyArabicShaping || !globalRTLTextPlugin.processBidirectionalText) {
-                    callback(`RTL Text Plugin failed to import scripts from ${pluginURL}`);
+                    callback(new Error(`RTL Text Plugin failed to import scripts from ${pluginURL}`));
                 }
             }
         } catch (e) {

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -108,7 +108,7 @@ class Worker {
      * function taking `(name, workerSourceObject)`.
      *  @private
      */
-    loadWorkerSource(map: string, params: {url: string}, callback: Function) {
+    loadWorkerSource(map: string, params: {url: string}, callback: Callback<void>) {
         try {
             this.self.importScripts(params.url);
             callback();
@@ -117,7 +117,7 @@ class Worker {
         }
     }
 
-    loadRTLTextPlugin(map: string, pluginURL: string, callback: Function) {
+    loadRTLTextPlugin(map: string, pluginURL: string, callback: Callback<void>) {
         try {
             if (!globalRTLTextPlugin.applyArabicShaping && !globalRTLTextPlugin.processBidirectionalText) {
                 this.self.importScripts(pluginURL);

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Actor = require('../util/actor');
 const StyleLayerIndex = require('../style/style_layer_index');

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const FeatureIndex = require('../data/feature_index');
 const CollisionTile = require('../symbol/collision_tile');

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -1,3 +1,4 @@
+// @flow
 
 const FeatureIndex = require('../data/feature_index');
 const CollisionTile = require('../symbol/collision_tile');
@@ -6,8 +7,39 @@ const DictionaryCoder = require('../util/dictionary_coder');
 const util = require('../util/util');
 const assert = require('assert');
 
+import type {TileCoord} from './tile_coord';
+import type {SymbolBucket} from '../data/bucket/symbol_bucket';
+import type {Actor} from '../util/actor';
+import type {StyleLayerIndex} from '../style/style_layer_index';
+import type {
+    WorkerTileParameters,
+    WorkerTileCallback,
+    VectorTile
+} from '../source/source';
+
 class WorkerTile {
-    constructor(params) {
+    coord: TileCoord;
+    uid: string;
+    zoom: number;
+    tileSize: number;
+    source: string;
+    overscaling: number;
+    angle: number;
+    pitch: number;
+    cameraToCenterDistance: number;
+    cameraToTileDistance: number;
+    showCollisionBoxes: boolean;
+
+    status: 'parsing' | 'done';
+    data: VectorTile;
+    collisionBoxArray: CollisionBoxArray;
+    symbolBuckets: Array<SymbolBucket>;
+
+    abort: ?() => void;
+    reloadCallback: WorkerTileCallback;
+    vectorTile: VectorTile;
+
+    constructor(params: WorkerTileParameters) {
         this.coord = params.coord;
         this.uid = params.uid;
         this.zoom = params.zoom;
@@ -21,7 +53,7 @@ class WorkerTile {
         this.showCollisionBoxes = params.showCollisionBoxes;
     }
 
-    parse(data, layerIndex, actor, callback) {
+    parse(data: VectorTile, layerIndex: StyleLayerIndex, actor: Actor, callback: WorkerTileCallback) {
         // Normalize GeoJSON data.
         if (!data.layers) {
             data = { layers: { '_geojsonTileLayer': data } };
@@ -174,7 +206,7 @@ class WorkerTile {
         }
     }
 
-    redoPlacement(angle, pitch, cameraToCenterDistance, cameraToTileDistance, showCollisionBoxes) {
+    redoPlacement(angle: number, pitch: number, cameraToCenterDistance: number, cameraToTileDistance: number, showCollisionBoxes: boolean) {
         this.angle = angle;
         this.pitch = pitch;
         this.cameraToCenterDistance = cameraToCenterDistance;

--- a/src/style-spec/bin/gl-style-composite
+++ b/src/style-spec/bin/gl-style-composite
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-'use strict';
 
 var fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2)),

--- a/src/style-spec/bin/gl-style-format
+++ b/src/style-spec/bin/gl-style-format
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-'use strict';
 
 var fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2)),

--- a/src/style-spec/bin/gl-style-migrate
+++ b/src/style-spec/bin/gl-style-migrate
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-'use strict';
 
 var fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2)),

--- a/src/style-spec/bin/gl-style-validate
+++ b/src/style-spec/bin/gl-style-validate
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-'use strict';
 
 var argv = require('minimist')(process.argv.slice(2), {
         boolean: 'json'

--- a/src/style-spec/composite.js
+++ b/src/style-spec/composite.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = function (style) {
     const styleIDs = [];

--- a/src/style-spec/declass.js
+++ b/src/style-spec/declass.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const extend = require('./util/extend');
 

--- a/src/style-spec/deref.js
+++ b/src/style-spec/deref.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const refProperties = require('./util/ref_properties');
 

--- a/src/style-spec/diff.js
+++ b/src/style-spec/diff.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const isEqual = require('lodash.isequal');
 

--- a/src/style-spec/error/parsing_error.js
+++ b/src/style-spec/error/parsing_error.js
@@ -1,4 +1,3 @@
-'use strict';
 
 function ParsingError(error) {
     this.error = error;

--- a/src/style-spec/error/validation_error.js
+++ b/src/style-spec/error/validation_error.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const format = require('util').format;
 

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = createFilter;
 

--- a/src/style-spec/format.js
+++ b/src/style-spec/format.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const reference = require('./reference/latest.js');
 const sortObject = require('sort-object');

--- a/src/style-spec/function/color_spaces.js
+++ b/src/style-spec/function/color_spaces.js
@@ -1,4 +1,3 @@
-'use strict';
 
 // Constants
 const Xn = 0.950470, // D65 standard referent

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const colorSpaces = require('./color_spaces');
 const parseColor = require('../util/parse_color');

--- a/src/style-spec/group_by_layout.js
+++ b/src/style-spec/group_by_layout.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const refProperties = require('./util/ref_properties'),
     stringify = require('fast-stable-stringify');

--- a/src/style-spec/index.js
+++ b/src/style-spec/index.js
@@ -1,4 +1,3 @@
-'use strict';
 
 exports.v6 = require('./reference/v6.json');
 exports.v7 = require('./reference/v7.json');

--- a/src/style-spec/migrate.js
+++ b/src/style-spec/migrate.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /**
  * Migrate a Mapbox GL Style to the latest version.

--- a/src/style-spec/migrate/v7.js
+++ b/src/style-spec/migrate/v7.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ref = require('../reference/v7.json');
 

--- a/src/style-spec/migrate/v8.js
+++ b/src/style-spec/migrate/v8.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Reference = require('../reference/v8.json');
 const URL = require('url');

--- a/src/style-spec/migrate/v9.js
+++ b/src/style-spec/migrate/v9.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const deref = require('../deref');
 

--- a/src/style-spec/reference/latest.js
+++ b/src/style-spec/reference/latest.js
@@ -1,3 +1,2 @@
-'use strict';
 
 module.exports = require('./v8.json');

--- a/src/style-spec/util/extend.js
+++ b/src/style-spec/util/extend.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = function (output, ...inputs) {
     for (const input of inputs) {

--- a/src/style-spec/util/get_type.js
+++ b/src/style-spec/util/get_type.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = function getType(val) {
     if (val instanceof Number) {

--- a/src/style-spec/util/interpolate.js
+++ b/src/style-spec/util/interpolate.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = interpolate;
 

--- a/src/style-spec/util/parse_color.js
+++ b/src/style-spec/util/parse_color.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const parseColorString = require('csscolorparser').parseCSSColor;
 

--- a/src/style-spec/util/ref_properties.js
+++ b/src/style-spec/util/ref_properties.js
@@ -1,3 +1,2 @@
-'use strict';
 
 module.exports = ['type', 'source', 'source-layer', 'minzoom', 'maxzoom', 'filter', 'layout'];

--- a/src/style-spec/util/unbundle_jsonlint.js
+++ b/src/style-spec/util/unbundle_jsonlint.js
@@ -1,4 +1,3 @@
-'use strict';
 
 // Turn jsonlint-lines-primitives objects into primitive objects
 module.exports = function unbundle(value) {

--- a/src/style-spec/validate/latest.js
+++ b/src/style-spec/validate/latest.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /*
  * Validate a style against the latest specification. This method is optimized

--- a/src/style-spec/validate/validate.js
+++ b/src/style-spec/validate/validate.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const getType = require('../util/get_type');

--- a/src/style-spec/validate/validate_array.js
+++ b/src/style-spec/validate/validate_array.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const getType = require('../util/get_type');
 const validate = require('./validate');

--- a/src/style-spec/validate/validate_boolean.js
+++ b/src/style-spec/validate/validate_boolean.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const getType = require('../util/get_type');
 const ValidationError = require('../error/validation_error');

--- a/src/style-spec/validate/validate_color.js
+++ b/src/style-spec/validate/validate_color.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const getType = require('../util/get_type');

--- a/src/style-spec/validate/validate_constants.js
+++ b/src/style-spec/validate/validate_constants.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const getType = require('../util/get_type');

--- a/src/style-spec/validate/validate_enum.js
+++ b/src/style-spec/validate/validate_enum.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const unbundle = require('../util/unbundle_jsonlint');

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const validateEnum = require('./validate_enum');

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const getType = require('../util/get_type');

--- a/src/style-spec/validate/validate_glyphs_url.js
+++ b/src/style-spec/validate/validate_glyphs_url.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const validateString = require('./validate_string');

--- a/src/style-spec/validate/validate_layer.js
+++ b/src/style-spec/validate/validate_layer.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const unbundle = require('../util/unbundle_jsonlint');

--- a/src/style-spec/validate/validate_layout_property.js
+++ b/src/style-spec/validate/validate_layout_property.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const validateProperty = require('./validate_property');
 

--- a/src/style-spec/validate/validate_light.js
+++ b/src/style-spec/validate/validate_light.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const getType = require('../util/get_type');

--- a/src/style-spec/validate/validate_number.js
+++ b/src/style-spec/validate/validate_number.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const getType = require('../util/get_type');
 const ValidationError = require('../error/validation_error');

--- a/src/style-spec/validate/validate_object.js
+++ b/src/style-spec/validate/validate_object.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const getType = require('../util/get_type');

--- a/src/style-spec/validate/validate_paint_property.js
+++ b/src/style-spec/validate/validate_paint_property.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const validateProperty = require('./validate_property');
 

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const validate = require('./validate');
 const ValidationError = require('../error/validation_error');

--- a/src/style-spec/validate/validate_source.js
+++ b/src/style-spec/validate/validate_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ValidationError = require('../error/validation_error');
 const unbundle = require('../util/unbundle_jsonlint');

--- a/src/style-spec/validate/validate_string.js
+++ b/src/style-spec/validate/validate_string.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const getType = require('../util/get_type');
 const ValidationError = require('../error/validation_error');

--- a/src/style-spec/validate_style.js
+++ b/src/style-spec/validate_style.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const validateStyleMin = require('./validate_style.min');
 const ParsingError = require('./error/parsing_error');

--- a/src/style-spec/validate_style.min.js
+++ b/src/style-spec/validate_style.min.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const validateConstants = require('./validate/validate_constants');
 const validate = require('./validate/validate');

--- a/src/style/animation_loop.js
+++ b/src/style/animation_loop.js
@@ -1,4 +1,3 @@
-'use strict';
 
 class AnimationLoop {
     constructor() {

--- a/src/style/image_sprite.js
+++ b/src/style/image_sprite.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Evented = require('../util/evented');
 const ajax = require('../util/ajax');

--- a/src/style/light.js
+++ b/src/style/light.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const styleSpec = require('../style-spec/reference/latest');
 const util = require('../util/util');

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const assert = require('assert');
 const Evented = require('../util/evented');

--- a/src/style/style_declaration.js
+++ b/src/style/style_declaration.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const createFunction = require('../style-spec/function');
 const util = require('../util/util');

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const StyleTransition = require('./style_transition');

--- a/src/style/style_layer/circle_style_layer.js
+++ b/src/style/style_layer/circle_style_layer.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const StyleLayer = require('../style_layer');
 const CircleBucket = require('../../data/bucket/circle_bucket');

--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const StyleLayer = require('../style_layer');
 const FillExtrusionBucket = require('../../data/bucket/fill_extrusion_bucket');

--- a/src/style/style_layer/fill_style_layer.js
+++ b/src/style/style_layer/fill_style_layer.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const StyleLayer = require('../style_layer');
 const FillBucket = require('../../data/bucket/fill_bucket');

--- a/src/style/style_layer/line_style_layer.js
+++ b/src/style/style_layer/line_style_layer.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const StyleLayer = require('../style_layer');
 const LineBucket = require('../../data/bucket/line_bucket');

--- a/src/style/style_layer/symbol_style_layer.js
+++ b/src/style/style_layer/symbol_style_layer.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const StyleLayer = require('../style_layer');
 const SymbolBucket = require('../../data/bucket/symbol_bucket');

--- a/src/style/style_layer_index.js
+++ b/src/style/style_layer_index.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const StyleLayer = require('./style_layer');
 const util = require('../util/util');

--- a/src/style/style_transition.js
+++ b/src/style/style_transition.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const interpolate = require('../style-spec/util/interpolate');

--- a/src/style/validate_style.js
+++ b/src/style/validate_style.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = require('../style-spec/validate_style.min');
 

--- a/src/symbol/anchor.js
+++ b/src/symbol/anchor.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Point = require('point-geometry');
 

--- a/src/symbol/check_max_angle.js
+++ b/src/symbol/check_max_angle.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = checkMaxAngle;
 

--- a/src/symbol/clip_line.js
+++ b/src/symbol/clip_line.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Point = require('point-geometry');
 

--- a/src/symbol/collision_box.js
+++ b/src/symbol/collision_box.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const createStructArrayType = require('../util/struct_array');
 const Point = require('point-geometry');

--- a/src/symbol/collision_feature.js
+++ b/src/symbol/collision_feature.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /**
  * A CollisionFeature represents the area of the tile covered by a single label.

--- a/src/symbol/collision_tile.js
+++ b/src/symbol/collision_tile.js
@@ -39,27 +39,32 @@ class CollisionTile {
     tempCollisionBox: any;
     edges: Array<any>;
 
-    constructor(angle: number | SerializedCollisionTile, pitch: any, cameraToCenterDistance: any, cameraToTileDistance: any, collisionBoxArray: any) {
-        if (typeof angle === 'object') {
-            const serialized = angle;
-            collisionBoxArray = pitch;
+    static deserialize(serialized: SerializedCollisionTile, collisionBoxArray: any) {
+        return new CollisionTile(
+            serialized.angle,
+            serialized.pitch,
+            serialized.cameraToCenterDistance,
+            serialized.cameraToTileDistance,
+            collisionBoxArray,
+            new Grid(serialized.grid),
+            new Grid(serialized.ignoredGrid)
+        );
+    }
 
-            this.angle = serialized.angle;
-            this.pitch = serialized.pitch;
-            this.cameraToCenterDistance = serialized.cameraToCenterDistance;
-            this.cameraToTileDistance = serialized.cameraToTileDistance;
+    constructor(angle: number,
+                pitch: number,
+                cameraToCenterDistance: number,
+                cameraToTileDistance: number,
+                collisionBoxArray: any,
+                grid: any = new Grid(EXTENT, 12, 6),
+                ignoredGrid: any = new Grid(EXTENT, 12, 0)) {
+        this.angle = angle;
+        this.pitch = pitch;
+        this.cameraToCenterDistance = cameraToCenterDistance;
+        this.cameraToTileDistance = cameraToTileDistance;
 
-            this.grid = new Grid(serialized.grid);
-            this.ignoredGrid = new Grid(serialized.ignoredGrid);
-        } else {
-            this.angle = angle;
-            this.pitch = pitch;
-            this.cameraToCenterDistance = cameraToCenterDistance;
-            this.cameraToTileDistance = cameraToTileDistance;
-
-            this.grid = new Grid(EXTENT, 12, 6);
-            this.ignoredGrid = new Grid(EXTENT, 12, 0);
-        }
+        this.grid = grid;
+        this.ignoredGrid = ignoredGrid;
 
         this.perspectiveRatio = 1 + 0.5 * ((cameraToTileDistance / cameraToCenterDistance) - 1);
 

--- a/src/symbol/collision_tile.js
+++ b/src/symbol/collision_tile.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Point = require('point-geometry');
 const EXTENT = require('../data/extent');

--- a/src/symbol/get_anchors.js
+++ b/src/symbol/get_anchors.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const interpolate = require('../style-spec/util/interpolate');
 const Anchor = require('../symbol/anchor');

--- a/src/symbol/glyph_atlas.js
+++ b/src/symbol/glyph_atlas.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ShelfPack = require('@mapbox/shelf-pack');
 const util = require('../util/util');

--- a/src/symbol/glyph_source.js
+++ b/src/symbol/glyph_source.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const normalizeURL = require('../util/mapbox').normalizeGlyphsURL;
 const ajax = require('../util/ajax');

--- a/src/symbol/mergelines.js
+++ b/src/symbol/mergelines.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = function (features) {
     const leftIndex = {};

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Point = require('point-geometry');
 const mat4 = require('@mapbox/gl-matrix').mat4;

--- a/src/symbol/quads.js
+++ b/src/symbol/quads.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Point = require('point-geometry');
 

--- a/src/symbol/shaping.js
+++ b/src/symbol/shaping.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const scriptDetection = require('../util/script_detection');
 const verticalizePunctuation = require('../util/verticalize_punctuation');

--- a/src/symbol/sprite_atlas.js
+++ b/src/symbol/sprite_atlas.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const ShelfPack = require('@mapbox/shelf-pack');
 const browser = require('../util/browser');

--- a/src/symbol/symbol_size.js
+++ b/src/symbol/symbol_size.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const interpolate = require('../style-spec/util/interpolate');
 const util = require('../util/util');

--- a/src/symbol/transform_text.js
+++ b/src/symbol/transform_text.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const rtlTextPlugin = require('../source/rtl_text_plugin');
 

--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../util/dom');
 const Point = require('point-geometry');

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const interpolate = require('../style-spec/util/interpolate');

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Evented = require('../../util/evented');
 const DOM = require('../../util/dom');

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const window = require('../../util/window');

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const LngLatBounds = require('../../geo/lng_lat_bounds');

--- a/src/ui/handler/dblclick_zoom.js
+++ b/src/ui/handler/dblclick_zoom.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /**
  * The `DoubleClickZoomHandler` allows the user to zoom the map at a point by

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const panStep = 100,
     bearingStep = 15,

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../../util/dom');
 const util = require('../../util/util');

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const window = require('../util/window');

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const browser = require('../util/browser');

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const DOM = require('../util/dom');
 const LngLat = require('../geo/lng_lat');

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('../util/util');
 const Evented = require('../util/evented');

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -65,7 +65,11 @@ class Actor {
         if (data.type === '<response>') {
             callback = this.callbacks[data.id];
             delete this.callbacks[data.id];
-            if (callback) callback(data.error || null, data.data);
+            if (callback && data.error) {
+                callback(new Error(data.error));
+            } else if (callback) {
+                callback(null, data.data);
+            }
         } else if (typeof data.id !== 'undefined' && this.parent[data.type]) {
             // data.type == 'loadTile', 'removeTile', etc.
             this.parent[data.type](data.sourceMapId, data.data, done);

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /**
  * An implementation of the [Actor design pattern](http://en.wikipedia.org/wiki/Actor_model)

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const window = require('./window');
 

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /**
  * @module browser

--- a/src/util/browser/web_worker.js
+++ b/src/util/browser/web_worker.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const WebWorkify = require('webworkify');
 const window = require('../window');

--- a/src/util/browser/window.js
+++ b/src/util/browser/window.js
@@ -1,4 +1,3 @@
-'use strict';
 
 /* eslint-env browser */
 module.exports = self;

--- a/src/util/classify_rings.js
+++ b/src/util/classify_rings.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const quickselect = require('quickselect');
 const calculateSignedArea = require('./util').calculateSignedArea;

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 type Config = {|

--- a/src/util/dictionary_coder.js
+++ b/src/util/dictionary_coder.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const assert = require('assert');
 

--- a/src/util/dispatcher.js
+++ b/src/util/dispatcher.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('./util');
 const Actor = require('./actor');

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Point = require('point-geometry');
 const window = require('./window');

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const util = require('./util');
 

--- a/src/util/find_pole_of_inaccessibility.js
+++ b/src/util/find_pole_of_inaccessibility.js
@@ -1,4 +1,3 @@
-'use strict';
 const Queue = require('tinyqueue');
 const Point = require('point-geometry');
 const distToSegmentSquared = require('./intersection_tests').distToSegmentSquared;

--- a/src/util/global_worker_pool.js
+++ b/src/util/global_worker_pool.js
@@ -1,4 +1,3 @@
-'use strict';
 const WorkerPool = require('./worker_pool');
 
 let globalWorkerPool;

--- a/src/util/glyphs.js
+++ b/src/util/glyphs.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = Glyphs;
 

--- a/src/util/intersection_tests.js
+++ b/src/util/intersection_tests.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const isCounterClockwise = require('./util').isCounterClockwise;
 

--- a/src/util/is_char_in_unicode_block.js
+++ b/src/util/is_char_in_unicode_block.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 // The following table comes from <http://www.unicode.org/Public/9.0.0/ucd/Blocks.txt>.

--- a/src/util/lru_cache.js
+++ b/src/util/lru_cache.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 /**

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 const config = require('./config');

--- a/src/util/script_detection.js
+++ b/src/util/script_detection.js
@@ -1,4 +1,3 @@
-'use strict';
 /* eslint-disable new-cap */
 
 const isChar = require('./is_char_in_unicode_block');

--- a/src/util/smart_wrap.js
+++ b/src/util/smart_wrap.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const LngLat = require('../geo/lng_lat');
 

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 // Note: all "sizes" are measured in bytes

--- a/src/util/throttler.js
+++ b/src/util/throttler.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const browser = require('./browser');
 

--- a/src/util/token.js
+++ b/src/util/token.js
@@ -1,4 +1,3 @@
-'use strict';
 
 // @flow
 

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,4 +1,3 @@
-'use strict';
 // @flow
 
 const UnitBezier = require('@mapbox/unitbezier');

--- a/src/util/vectortile_to_geojson.js
+++ b/src/util/vectortile_to_geojson.js
@@ -1,4 +1,3 @@
-'use strict';
 
 class Feature {
     constructor(vectorTileFeature, z, x, y) {

--- a/src/util/verticalize_punctuation.js
+++ b/src/util/verticalize_punctuation.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const scriptDetection = require('./script_detection');
 

--- a/src/util/web_worker.js
+++ b/src/util/web_worker.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Worker = require('../source/worker');
 

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const jsdom = require('jsdom');
 const gl = require('gl');

--- a/src/util/worker_pool.js
+++ b/src/util/worker_pool.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const assert = require('assert');
 const WebWorker = require('./web_worker');

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -84,7 +84,7 @@ test('Style', (t) => {
             // Getting this error message shows the bogus URL was succesfully passed to the worker
             // We'll get the error from all workers, only pay attention to the first one
             if (firstError) {
-                t.deepEquals(error, 'RTL Text Plugin failed to import scripts from data:text/javascript;base64,abc');
+                t.deepEquals(error, new Error('RTL Text Plugin failed to import scripts from data:text/javascript;base64,abc'));
                 t.end();
                 firstError = false;
             }


### PR DESCRIPTION
This adds flow annotations to the majority of the `Worker`-related code. I started on #4876, wanted to make some refactors, and realized that it would be better to have the safety of some static type checking as I did.

The first commit here switches the eslint `sourceType` option to `module`, so that we can use [module types](https://flow.org/en/docs/types/modules/) without resorting to flow comments.

Q: Why not use flow comments?
A: They're ugly, and they're not as good as native type annotations: not syntax highlighted, not linted (e.g. no warnings if you import something and don't use it), no documentation.js support, no IDE integration.

Q: What are the side effects of `"sourceType": "module"`?
A: AFAICT, it doesn't force us to actually use non-type `import`/`export` rather than CommonJS `require`, it just means that we can't `'use strict'` in each file -- this is enforced by eslint because modules are always strict. I worked around this by writing a simple `strictify` transform that puts them back in. (I didn't use the published one because it's [buggy and unmaintained](https://github.com/jsdf/strictify/pull/4).)

Q: Shouldn't you be able to use `import type` without requiring `"sourceType": "module"`?
A: Yes, I think you should be. If you agree, 👍  [this bug](https://github.com/babel/babel-eslint/issues/474).

Beyond that, the eslint + flow combo pretty much works. The only issue I've found is that eslint chokes on unnamed parameters in function types. So just name them:

**Works**
```
type Callback = (error: ?Error, result: ?Result) => void;
```

**Doesn't Work**
```
type Callback = (?Error, ?Result) => void;
```