### PR TITLE
Fix geojson serialize to include all option keys.

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -72,6 +72,7 @@ class GeoJSONSource extends Evented {
         this.setEventedParent(eventedParent);
 
         this._data = options.data;
+        this._options = util.extend({}, options);
 
         if (options.maxzoom !== undefined) this.maxzoom = options.maxzoom;
         if (options.type) this.type = options.type;
@@ -213,10 +214,10 @@ class GeoJSONSource extends Evented {
     }
 
     serialize() {
-        return {
+        return util.extend({}, this._options, {
             type: this.type,
             data: this._data
-        };
+        });
     }
 }
 

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -234,5 +234,15 @@ test('GeoJSONSource#serialize', (t) => {
         t.end();
     });
 
+    t.test('serialize source with additional options', (t) => {
+        const source = new GeoJSONSource('id', {data: {}, cluster: true}, mockDispatcher);
+        t.deepEqual(source.serialize(), {
+            type: 'geojson',
+            data: {},
+            cluster: true
+        });
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
This was causing style diffing to always fail when using additional
option keys, such as `cluster: true`.

There are probably other serialize functions that are insufficient in the same way. Serialization for all style types should probably be systematically tested for setStyle diffing friendliness.