### PR TITLE
iOS/macOS lack canvas source support

### DIFF
--- a/docs/style-spec/_generate/index.html
+++ b/docs/style-spec/_generate/index.html
@@ -529,8 +529,8 @@ navigation:
               <td>basic functionality</td>
               <td>&gt;= 0.32.0</td>
               <td>Not supported</td>
-              <td>&gt;= 3.6.0</td>
-              <td>&gt;= 0.5.0</td>
+              <td>Not supported</td>
+              <td>Not supported</td>
             </tr>
             </tbody>
           </table>


### PR DESCRIPTION
The iOS and macOS SDKs lack `canvas` source support. I had been a little overzealous in finding and replacing in #4920.

/ref https://github.com/mapbox/mapbox-gl-js/pull/4921#discussion_r125073984