### PR TITLE
Android SDK 5.1.0

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -355,6 +355,7 @@
           "sdk-support": {
             "basic functionality": {
               "js": "0.27.0",
+              "android": "5.1.0",
               "ios": "3.6.0",
               "macos": "0.5.0"
             }
@@ -524,6 +525,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -829,6 +831,7 @@
         },
         "data-driven styling": {
           "js": "0.35.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -919,6 +922,7 @@
         },
         "data-driven styling": {
           "js": "0.35.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1163,6 +1167,7 @@
         },
         "data-driven styling": {
           "js": "0.35.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1351,6 +1356,7 @@
         },
         "data-driven styling": {
           "js": "0.35.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1463,6 +1469,7 @@
         },
         "data-driven styling": {
           "js": "0.35.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1728,6 +1735,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1747,6 +1755,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1763,6 +1772,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1781,6 +1791,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1977,6 +1988,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -1998,11 +2010,13 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         },
         "data-driven styling": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -2024,6 +2038,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         },
@@ -2050,6 +2065,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         },
@@ -2065,6 +2081,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         },
@@ -2085,11 +2102,13 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         },
         "data-driven styling": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
@@ -2112,11 +2131,13 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         },
         "data-driven styling": {
           "js": "0.27.0",
+          "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
         }


### PR DESCRIPTION
Android SDK equivalent of https://github.com/mapbox/mapbox-gl-js/pull/4920,

Refs https://github.com/mapbox/mapbox-gl-native/issues/9404

This PR updates the style specification JSON and documentation to indicate support for additional features in Android SDK 5.1.0. After these changes land in master, they’ll need to be cherry-picked or merged into the mb-pages branch.