### PR TITLE
GeoJSON and VectorTile types

### DIFF
--- a/flow-typed/geojson.js
+++ b/flow-typed/geojson.js
@@ -1,0 +1,39 @@
+type Position = [number, number] | [number, number, number];
+type Geometry<T, C> = { type: T, coordinates: C }
+
+declare type      GeoJSONPoint = Geometry<     'Point',       Position>;
+declare type GeoJSONMultiPoint = Geometry<'MultiPoint', Array<Position>>;
+
+declare type      GeoJSONLineString = Geometry<     'LineString',       Array<Position>>;
+declare type GeoJSONMultiLineString = Geometry<'MultiLineString', Array<Array<Position>>>;
+
+declare type      GeoJSONPolygon = Geometry<     'Polygon',       Array<Array<Position>>>;
+declare type GeoJSONMultiPolygon = Geometry<'MultiPolygon', Array<Array<Array<Position>>>>;
+
+declare type GeoJSONGeometry =
+    | GeoJSONPoint
+    | GeoJSONMultiPoint
+    | GeoJSONLineString
+    | GeoJSONMultiLineString
+    | GeoJSONPolygon
+    | GeoJSONMultiPolygon
+    | GeoJSONGeometryCollection;
+
+declare type GeoJSONGeometryCollection = {
+    type: 'GeometryCollection',
+    geometries: Array<GeoJSONGeometry>
+};
+
+declare type GeoJSONFeature = {
+    type: 'Feature',
+    geometry: ?GeoJSONGeometry,
+    properties: {},
+    id?: number | string
+};
+
+declare type GeoJSONFeatureCollection = {
+    type: 'FeatureCollection',
+    features: Array<GeoJSONFeature>
+};
+
+declare type GeoJSON = GeoJSONGeometry | GeoJSONFeature | GeoJSONFeatureCollection;

--- a/flow-typed/pbf.js
+++ b/flow-typed/pbf.js
@@ -1,0 +1,7 @@
+declare module "pbf" {
+    declare class Pbf {
+        constructor(ArrayBuffer | $ArrayBufferView): Pbf;
+    }
+
+    declare module.exports: typeof Pbf
+}

--- a/flow-typed/vector-tile.js
+++ b/flow-typed/vector-tile.js
@@ -1,0 +1,36 @@
+declare interface VectorTile {
+    layers: {[string]: VectorTileLayer};
+}
+
+declare interface VectorTileLayer {
+    name: string;
+    extent: number;
+    length: number;
+    feature(i: number): VectorTileFeature;
+}
+
+declare interface VectorTileFeature {
+    extent: number;
+    type: 1 | 2 | 3;
+    id: number;
+    properties: {[string]: string | number | boolean};
+
+    loadGeometry(): Array<Array<Point>>;
+    bbox(): [number, number, number, number];
+    toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
+}
+
+declare module "vector-tile" {
+    declare class VectorTileImpl {
+        constructor(pbf: Pbf): VectorTile;
+    }
+
+    declare class VectorTileFeatureImpl {
+        toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
+    }
+
+    declare module.exports: {
+        VectorTile: typeof VectorTileImpl;
+        VectorTileFeature: typeof VectorTileFeatureImpl;
+    }
+}

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -47,18 +47,21 @@ function loadGeoJSONTile(params: WorkerTileParameters, callback: LoadVectorDataC
         return callback(null, null); // nothing in the given tile
     }
 
+    const geojsonWrapper = new GeoJSONWrapper(geoJSONTile.features);
+
     // Encode the geojson-vt tile into binary vector tile form form.  This
     // is a convenience that allows `FeatureIndex` to operate the same way
     // across `VectorTileSource` and `GeoJSONSource` data.
-    const geojsonWrapper = new GeoJSONWrapper(geoJSONTile.features);
-    geojsonWrapper.name = '_geojsonTileLayer';
-    let pbf = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
+    let pbf = vtpbf(geojsonWrapper);
     if (pbf.byteOffset !== 0 || pbf.byteLength !== pbf.buffer.byteLength) {
         // Compatibility with node Buffer (https://github.com/mapbox/pbf/issues/35)
         pbf = new Uint8Array(pbf);
     }
-    geojsonWrapper.rawData = pbf.buffer;
-    callback(null, geojsonWrapper);
+
+    callback(null, {
+        vectorTile: geojsonWrapper,
+        rawData: pbf.buffer
+    });
 }
 
 /**

--- a/src/source/geojson_wrapper.js
+++ b/src/source/geojson_wrapper.js
@@ -1,11 +1,33 @@
+// @flow
 
 const Point = require('point-geometry');
-const VectorTileFeature = require('vector-tile').VectorTileFeature;
+const toGeoJSON = require('vector-tile').VectorTileFeature.prototype.toGeoJSON;
 const EXTENT = require('../data/extent');
 
-class FeatureWrapper {
+// The feature type used by geojson-vt and supercluster. Should be extracted to
+// global type and used in module definitions for those two modules.
+type Feature = {
+    type: 1,
+    id: mixed,
+    tags: {[string]: string | number | boolean},
+    geometry: Array<[number, number]>,
+} | {
+    type: 2 | 3,
+    id: mixed,
+    tags: {[string]: string | number | boolean},
+    geometry: Array<Array<[number, number]>>,
+}
 
-    constructor(feature) {
+class FeatureWrapper implements VectorTileFeature {
+    extent: number;
+    type: 1 | 2 | 3;
+    id: number;
+    properties: {[string]: string | number | boolean};
+
+    geometry: Array<Array<Point>>;
+    rawGeometry: Array<Array<[number, number]>>;
+
+    constructor(feature: Feature) {
         this.type = feature.type;
         if (feature.type === 1) {
             this.rawGeometry = [];
@@ -70,21 +92,27 @@ class FeatureWrapper {
     }
 
     toGeoJSON() {
-        VectorTileFeature.prototype.toGeoJSON.call(this);
+        return toGeoJSON.apply(this, arguments);
     }
 }
 
-// conform to vectortile api
-class GeoJSONWrapper {
+class GeoJSONWrapper implements VectorTile, VectorTileLayer {
+    layers: {[string]: VectorTileLayer};
+    name: string;
+    extent: number;
+    length: number;
+    _features: Array<any>;
 
-    constructor(features) {
-        this.features = features;
-        this.length = features.length;
+    constructor(features: Array<Feature>) {
+        this.layers = { '_geojsonTileLayer': this };
+        this.name = '_geojsonTileLayer';
         this.extent = EXTENT;
+        this.length = features.length;
+        this._features = features;
     }
 
-    feature(i) {
-        return new FeatureWrapper(this.features[i]);
+    feature(i: number): VectorTileFeature {
+        return new FeatureWrapper(this._features[i]);
     }
 }
 

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -196,24 +196,3 @@ export interface WorkerSource {
     redoPlacement(params: RedoPlacementParameters, callback: RedoPlacementCallback): void;
     removeSource?: (params: {source: string}) => void;
 }
-
-export interface VectorTile {
-    layers: any;
-}
-
-/**
- * The result passed to the `loadVectorData` callback must conform to the interface established
- * by the `VectorTile` class from the [vector-tile](https://www.npmjs.com/package/vector-tile)
- * npm package. In addition, it must have a `rawData` property containing an `ArrayBuffer`
- * with protobuf data conforming to the
- * [Mapbox Vector Tile specification](https://github.com/mapbox/vector-tile-spec).
- *
- * @class AugmentedVectorTile
- * @property {ArrayBuffer} rawData
- * @private
- */
-export type AugmentedVectorTile = VectorTile & {
-     rawData: any;
-     expires?: any;
-     cacheControl?: any;
-};

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -50,7 +50,7 @@ class Tile {
     showCollisionBoxes: boolean;
     placementSource: any;
     workerID: number;
-    vtLayers: any;
+    vtLayers: {[string]: VectorTileLayer};
 
     /**
      * @param {TileCoord} coord
@@ -238,7 +238,7 @@ class Tile {
             this.vtLayers = new vt.VectorTile(new Protobuf(this.rawTileData)).layers;
         }
 
-        const sourceLayer = params ? params.sourceLayer : undefined;
+        const sourceLayer = params ? params.sourceLayer : '';
         const layer = this.vtLayers._geojsonTileLayer || this.vtLayers[sourceLayer];
 
         if (!layer) return;

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -14,7 +14,6 @@ import type {StyleLayerIndex} from '../style/style_layer_index';
 import type {
     WorkerTileParameters,
     WorkerTileCallback,
-    VectorTile
 } from '../source/source';
 
 class WorkerTile {
@@ -54,11 +53,6 @@ class WorkerTile {
     }
 
     parse(data: VectorTile, layerIndex: StyleLayerIndex, actor: Actor, callback: WorkerTileCallback) {
-        // Normalize GeoJSON data.
-        if (!data.layers) {
-            data = { layers: { '_geojsonTileLayer': data } };
-        }
-
         this.status = 'parsing';
         this.data = data;
 
@@ -95,8 +89,8 @@ class WorkerTile {
             const features = [];
             for (let i = 0; i < sourceLayer.length; i++) {
                 const feature = sourceLayer.feature(i);
-                feature.index = i;
-                feature.sourceLayerIndex = sourceLayerIndex;
+                (feature: any).index = i;
+                (feature: any).sourceLayerIndex = sourceLayerIndex;
                 features.push(feature);
             }
 


### PR DESCRIPTION
Includes some code changes to support the type annotations:

* `GeoJSONWrapper` implements the `VectorTile` interface as well as the `VectorTileLayer` interface. This eliminates special `_geojsonTileLayer` cases from `GeoJSONWorkerSource` and `WorkerTile`.
* Use composition instead of augmenting vector tile objects with `rawData`, `expires`, and `cacheControl` properties. (We still augment individual features with `index` and `sourceLayerIndex`; this should be cleaned up in a subsequent refactor.)