### PR TITLE
Rewrite ProgramConfiguration

### DIFF
--- a/src/data/array_group.js
+++ b/src/data/array_group.js
@@ -140,7 +140,6 @@ class ArrayGroup {
                 layerData.paintVertexArray,
                 layerData.paintPropertyStatistics,
                 this.layoutVertexArray.length,
-                this.globalProperties,
                 featureProperties);
         }
     }

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -15,13 +15,13 @@ const circleInterface = {
     elementArrayType: createElementArrayType(),
 
     paintAttributes: [
-        {property: 'circle-color',          type: 'Uint8'},
-        {property: 'circle-radius',         type: 'Uint16', multiplier: 10},
-        {property: 'circle-blur',           type: 'Uint16', multiplier: 10},
-        {property: 'circle-opacity',        type: 'Uint8',  multiplier: 255},
-        {property: 'circle-stroke-color',   type: 'Uint8'},
-        {property: 'circle-stroke-width',   type: 'Uint16', multiplier: 10},
-        {property: 'circle-stroke-opacity', type: 'Uint8',  multiplier: 255}
+        {property: 'circle-color'},
+        {property: 'circle-radius'},
+        {property: 'circle-blur'},
+        {property: 'circle-opacity'},
+        {property: 'circle-stroke-color'},
+        {property: 'circle-stroke-width'},
+        {property: 'circle-stroke-opacity'}
     ]
 };
 

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -19,9 +19,9 @@ const fillInterface = {
     elementArrayType2: createElementArrayType(2),
 
     paintAttributes: [
-        {property: 'fill-color',         type: 'Uint8'},
-        {property: 'fill-outline-color', type: 'Uint8'},
-        {property: 'fill-opacity',       type: 'Uint8', multiplier: 255}
+        {property: 'fill-color'},
+        {property: 'fill-outline-color'},
+        {property: 'fill-opacity'}
     ]
 };
 

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -21,9 +21,9 @@ const fillExtrusionInterface = {
     elementArrayType: createElementArrayType(3),
 
     paintAttributes: [
-        {property: 'fill-extrusion-base',   type: 'Uint16'},
-        {property: 'fill-extrusion-height', type: 'Uint16'},
-        {property: 'fill-extrusion-color',  type: 'Uint8'}
+        {property: 'fill-extrusion-base'},
+        {property: 'fill-extrusion-height'},
+        {property: 'fill-extrusion-color'}
     ]
 };
 

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -50,13 +50,13 @@ const lineInterface = {
         {name: 'a_data', components: 4, type: 'Uint8'}
     ],
     paintAttributes: [
-        {property: 'line-color', type: 'Uint8'},
-        {property: 'line-blur', multiplier: 10, type: 'Uint8'},
-        {property: 'line-opacity', multiplier: 10, type: 'Uint8'},
-        {property: 'line-gap-width', multiplier: 10, type: 'Uint8', name: 'a_gapwidth'},
-        {property: 'line-offset', multiplier: 1, type: 'Int8'},
-        {property: 'line-width', multiplier: 10, type: 'Uint8', name: 'a_width'},
-        {property: 'line-width', multiplier: 10, type: 'Uint8', name: 'a_floorwidth', useIntegerZoom: true},
+        {property: 'line-color'},
+        {property: 'line-blur'},
+        {property: 'line-opacity'},
+        {property: 'line-gap-width', name: 'gapwidth'},
+        {property: 'line-offset'},
+        {property: 'line-width'},
+        {property: 'line-width', name: 'floorwidth', useIntegerZoom: true},
     ],
     elementArrayType: createElementArrayType()
 };

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -92,11 +92,11 @@ const symbolInterfaces = {
         dynamicLayoutAttributes: dynamicLayoutAttributes,
         elementArrayType: elementArrayType,
         paintAttributes: [
-            {name: 'a_fill_color', property: 'text-color', type: 'Uint8'},
-            {name: 'a_halo_color', property: 'text-halo-color', type: 'Uint8'},
-            {name: 'a_halo_width', property: 'text-halo-width', type: 'Uint16', multiplier: 10},
-            {name: 'a_halo_blur', property: 'text-halo-blur', type: 'Uint16', multiplier: 10},
-            {name: 'a_opacity', property: 'text-opacity', type: 'Uint8', multiplier: 255}
+            {property: 'text-color', name: 'fill_color'},
+            {property: 'text-halo-color', name: 'halo_color'},
+            {property: 'text-halo-width', name: 'halo_width'},
+            {property: 'text-halo-blur', name: 'halo_blur'},
+            {property: 'text-opacity', name: 'opacity'}
         ]
     },
     icon: {
@@ -104,11 +104,11 @@ const symbolInterfaces = {
         dynamicLayoutAttributes: dynamicLayoutAttributes,
         elementArrayType: elementArrayType,
         paintAttributes: [
-            {name: 'a_fill_color', property: 'icon-color', type: 'Uint8'},
-            {name: 'a_halo_color', property: 'icon-halo-color', type: 'Uint8'},
-            {name: 'a_halo_width', property: 'icon-halo-width', type: 'Uint16', multiplier: 10},
-            {name: 'a_halo_blur', property: 'icon-halo-blur', type: 'Uint16', multiplier: 10},
-            {name: 'a_opacity', property: 'icon-opacity', type: 'Uint8', multiplier: 255}
+            {property: 'icon-color', name: 'fill_color'},
+            {property: 'icon-halo-color', name: 'halo_color'},
+            {property: 'icon-halo-width', name: 'halo_width'},
+            {property: 'icon-halo-blur', name: 'halo_blur'},
+            {property: 'icon-opacity', name: 'opacity'}
         ]
     },
     collisionBox: { // used to render collision boxes for debugging purposes

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -16,25 +16,6 @@ precision highp float;
 
 #endif
 
-float evaluate_zoom_function_1(const vec4 values, const float t) {
-    if (t < 1.0) {
-        return mix(values[0], values[1], t);
-    } else if (t < 2.0) {
-        return mix(values[1], values[2], t - 1.0);
-    } else {
-        return mix(values[2], values[3], t - 2.0);
-    }
-}
-vec4 evaluate_zoom_function_4(const vec4 value0, const vec4 value1, const vec4 value2, const vec4 value3, const float t) {
-    if (t < 1.0) {
-        return mix(value0, value1, t);
-    } else if (t < 2.0) {
-        return mix(value1, value2, t - 1.0);
-    } else {
-        return mix(value2, value3, t - 2.0);
-    }
-}
-
 // Unpack a pair of values that have been packed into a single float.
 // The packed values are assumed to be 8-bit unsigned integers, and are
 // packed like so:
@@ -46,8 +27,8 @@ vec2 unpack_float(const float packedValue) {
 }
 
 
-// To minimize the number of attributes needed in the mapbox-gl-native shaders,
-// we encode a 4-component color into a pair of floats (i.e. a vec2) as follows:
+// To minimize the number of attributes needed, we encode a 4-component
+// color into a pair of floats (i.e. a vec2) as follows:
 // [ floor(color.r * 255) * 256 + color.g * 255,
 //   floor(color.b * 255) * 256 + color.g * 255 ]
 vec4 decode_color(const vec2 encodedColor) {

--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -75,3 +75,75 @@ module.exports = {
         vertexSource: fs.readFileSync(__dirname + '/../shaders/symbol_sdf.vertex.glsl', 'utf8')
     }
 };
+
+// Expand #pragmas to #ifdefs.
+
+const re = /#pragma mapbox: ([\w]+) ([\w]+) ([\w]+) ([\w]+)/g;
+
+for (const programName in module.exports) {
+    const program = module.exports[programName];
+    const fragmentPragmas = {};
+
+    program.fragmentSource = program.fragmentSource.replace(re, (match, operation, precision, type, name) => {
+        fragmentPragmas[name] = true;
+        if (operation === 'define') {
+            return `
+#ifndef HAS_UNIFORM_u_${name}
+varying ${precision} ${type} ${name};
+#else
+uniform ${precision} ${type} u_${name};
+#endif
+`;
+        } else if (operation === 'initialize') {
+            return `
+#ifdef HAS_UNIFORM_u_${name}
+    ${precision} ${type} ${name} = u_${name};
+#endif
+`;
+        }
+    });
+
+    program.vertexSource = program.vertexSource.replace(re, (match, operation, precision, type, name) => {
+        const attrType = type === 'float' ? 'vec2' : 'vec4';
+        if (fragmentPragmas[name]) {
+            if (operation === 'define') {
+                return `
+#ifndef HAS_UNIFORM_u_${name}
+uniform lowp float a_${name}_t;
+attribute ${precision} ${attrType} a_${name};
+varying ${precision} ${type} ${name};
+#else
+uniform ${precision} ${type} u_${name};
+#endif
+`;
+            } else if (operation === 'initialize') {
+                return `
+#ifndef HAS_UNIFORM_u_${name}
+    ${name} = unpack_mix_${attrType}(a_${name}, a_${name}_t);
+#else
+    ${precision} ${type} ${name} = u_${name};
+#endif
+`;
+            }
+        } else {
+            if (operation === 'define') {
+                return `
+#ifndef HAS_UNIFORM_u_${name}
+uniform lowp float a_${name}_t;
+attribute ${precision} ${attrType} a_${name};
+#else
+uniform ${precision} ${type} u_${name};
+#endif
+`;
+            } else if (operation === 'initialize') {
+                return `
+#ifndef HAS_UNIFORM_u_${name}
+    ${precision} ${type} ${name} = unpack_mix_${attrType}(a_${name}, a_${name}_t);
+#else
+    ${precision} ${type} ${name} = u_${name};
+#endif
+`;
+            }
+        }
+    });
+}

--- a/test/unit/data/bucket.test.js
+++ b/test/unit/data/bucket.test.js
@@ -41,10 +41,7 @@ test('Bucket', (t) => {
             elementArrayType: createElementArrayType(),
             elementArrayType2: createElementArrayType(2),
 
-            paintAttributes: options.paintAttributes || [{
-                property: 'circle-opacity',
-                type: 'Int16'
-            }]
+            paintAttributes: options.paintAttributes || [{ property: 'circle-opacity' }]
         };
 
         class Class extends Bucket {
@@ -91,6 +88,7 @@ test('Bucket', (t) => {
         const v0 = testVertex.get(0);
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
+
         const paintVertex = bucket.arrays.layerData.layerid.paintVertexArray;
         t.equal(paintVertex.length, 1);
         const p0 = paintVertex.get(0);
@@ -133,10 +131,7 @@ test('Bucket', (t) => {
 
     t.test('add features, disabled attribute', (t) => {
         const bucket = create({
-            paintAttributes: [{
-                property: 'circle-opacity',
-                type: 'Int16'
-            }],
+            paintAttributes: [{ property: 'circle-opacity' }],
             layoutAttributes: [],
             layers: [
                 { id: 'one', type: 'circle', paint: constantPaint }

--- a/test/unit/data/fill_bucket.test.js
+++ b/test/unit/data/fill_bucket.test.js
@@ -104,16 +104,5 @@ test('FillBucket segmentation', (t) => {
         primitiveLength: 126
     });
 
-    t.equal(arrays.layerData.test.paintVertexArray.length, 266);
-    for (let i = 0; i < arrays.layerData.test.paintVertexArray.length; i++) {
-        const vertex = arrays.layerData.test.paintVertexArray.get(i);
-        t.deepEqual([
-            vertex['a_color0'],
-            vertex['a_color1'],
-            vertex['a_color2'],
-            vertex['a_color3']
-        ], [0, 0, 255, 255]);
-    }
-
     t.end();
 });

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -135,12 +135,9 @@ test('SymbolBucket#getPaintPropertyStatistics()', (t) => {
     });
     bucket.place(collision);
 
-    t.deepEqual(bucket.getPaintPropertyStatistics(), {
-        test: {
-            'text-halo-width': { max: 4 },
-            'icon-halo-width': { max: 5 }
-        }
-    });
+    const stats = bucket.getPaintPropertyStatistics().test;
+    t.deepEqual(stats['text-halo-width'], { max: 4 });
+    t.deepEqual(stats['icon-halo-width'], { max: 5 });
 
     t.end();
 });


### PR DESCRIPTION
* Expand `#pragma`s to `#ifndef`s early on. This is written in such a way that it can be reused by gl-native's generate-shaders.js. It also avoids generating unnecessary `varying`s (#4542).
* Binder interface for paint properties, with a concrete implementation for each binding strategy.
* Always use floats for paint property attributes, without a multiplication factor. (Fixes #4438. Fixes #3954.)
* When binding composite functions, interpolate between two stop values only: zoom and zoom + 1.

benchmark | master 83fb52d | rewrite-program-configuration 96e5fb8
--- | --- | ---
**map-load** | 99 ms  | 83 ms 
**style-load** | 67 ms  | 60 ms 
**buffer** | 1,002 ms  | 945 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 5.1 ms, 0% > 16ms  | 5.4 ms, 0% > 16ms 
**query-point** | 0.78 ms  | 0.87 ms 
**query-box** | 50.73 ms  | 50.52 ms 
**geojson-setdata-small** | 4 ms  | 4 ms 
**geojson-setdata-large** | 129 ms  | 130 ms 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page

