### PR TITLE
Relax lint indent settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,15 @@
     "space-before-function-paren": "off",
     "template-curly-spacing": "error",
     "no-useless-escape": "off",
-    "indent": ["error", 4, {"flatTernaryExpressions": true}]
+    "indent": ["error", 4, {
+      "flatTernaryExpressions": true,
+      "FunctionDeclaration": {
+        "parameters": "off"
+      },
+      "FunctionExpression": {
+        "parameters": "off"
+      }
+    }]
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
Fixes build by allowing indentation like:

```
    addCurrentVertex(currentVertex: Point,
                     distance: number,
                     normal: Point,
                     endLeft: number,
                     endRight: number,
                     round: boolean,
                     segment: Segment) {
...
```