### PR TITLE
Fix character detection for Zanabazar Square

### DIFF
--- a/src/util/is_char_in_unicode_block.js
+++ b/src/util/is_char_in_unicode_block.js
@@ -228,7 +228,7 @@ const unicodeBlockLookup: UnicodeBlockLookup = {
     // 'Takri': (char) => char >= 0x11680 && char <= 0x116CF,
     // 'Ahom': (char) => char >= 0x11700 && char <= 0x1173F,
     // 'Warang Citi': (char) => char >= 0x118A0 && char <= 0x118FF,
-    // 'Zanabazar Square': (char) => char >= 0x11A00 && char <= 0x11A00,
+    // 'Zanabazar Square': (char) => char >= 0x11A00 && char <= 0x11A4F,
     // 'Soyombo': (char) => char >= 0x11A50 && char <= 0x11AAF,
     // 'Pau Cin Hau': (char) => char >= 0x11AC0 && char <= 0x11AFF,
     // 'Bhaiksuki': (char) => char >= 0x11C00 && char <= 0x11C6F,


### PR DESCRIPTION
This PR is a followup to #4919 that fixes the “nominal” detection of Zanabazar Square characters, which is actually commented out pending #4001.

Disappointingly, there is no feature in OpenStreetMap named “Zanabazar Square”. If only [this museum](http://www.openstreetmap.org/way/219748545) had a square out front.

/ref https://github.com/mapbox/mapbox-gl-native/pull/9401#pullrequestreview-48186080