### PR TITLE
Don't request vertical glyphs for labels that can't be verticalized.

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -22,6 +22,7 @@ const findPoleOfInaccessibility = require('../../util/find_pole_of_inaccessibili
 const classifyRings = require('../../util/classify_rings');
 const vectorTileFeatureTypes = require('vector-tile').VectorTileFeature.types;
 const createStructArrayType = require('../../util/struct_array');
+const verticalizePunctuation = require('../../util/verticalize_punctuation');
 
 const shapeText = Shaping.shapeText;
 const shapeIcon = Shaping.shapeIcon;
@@ -323,8 +324,16 @@ class SymbolBucket {
             }
 
             if (text) {
+                const textAlongLine = layout['text-rotation-alignment'] === 'map' && layout['symbol-placement'] === 'line';
+                const allowsVerticalWritingMode = scriptDetection.allowsVerticalWritingMode(text);
                 for (let i = 0; i < text.length; i++) {
                     stack[text.charCodeAt(i)] = true;
+                    if (textAlongLine && allowsVerticalWritingMode) {
+                        const verticalChar = verticalizePunctuation.lookup[text.charAt(i)];
+                        if (verticalChar) {
+                            stack[verticalChar.charCodeAt(0)] = true;
+                        }
+                    }
                 }
             }
         }

--- a/src/symbol/glyph_source.js
+++ b/src/symbol/glyph_source.js
@@ -1,7 +1,6 @@
 
 const normalizeURL = require('../util/mapbox').normalizeGlyphsURL;
 const ajax = require('../util/ajax');
-const verticalizePunctuation = require('../util/verticalize_punctuation');
 const Glyphs = require('../util/glyphs');
 const GlyphAtlas = require('../symbol/glyph_atlas');
 const Protobuf = require('pbf');
@@ -88,12 +87,7 @@ class GlyphSource {
         };
 
         for (let i = 0; i < glyphIDs.length; i++) {
-            const glyphID = glyphIDs[i];
-            const string = String.fromCharCode(glyphID);
-            getGlyph(glyphID);
-            if (verticalizePunctuation.lookup[string]) {
-                getGlyph(verticalizePunctuation.lookup[string].charCodeAt(0));
-            }
+            getGlyph(glyphIDs[i]);
         }
 
         if (!remaining) callback(undefined, glyphs, fontstack);


### PR DESCRIPTION
Fixes issue #4720 -- avoids network traffic requesting vertical versions of glyphs that won't be needed.

/cc @1ec5