### PR TITLE
ignore symbol-features-in/tilted-outside query test

### DIFF
--- a/test/integration/query-tests/symbol-features-in/tilted-outside/style.json
+++ b/test/integration/query-tests/symbol-features-in/tilted-outside/style.json
@@ -2,16 +2,20 @@
   "version": 8,
   "metadata": {
     "test": {
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/9435",
+        "js": "https://github.com/mapbox/mapbox-gl-js/issues/4945"
+      },
       "collisionDebug": true,
       "width": 500,
       "height": 500,
       "queryGeometry": [
         [
           230,
-          275
+          250
         ],
         [
-          280,
+          300,
           300
         ]
       ]


### PR DESCRIPTION
This ignores a tilted symbol query test failure. It should be fixed as part of the global label placement implementation.

This also reverts the *queryGeometry* to a stricter box.

relevant issues:
https://github.com/mapbox/mapbox-gl-js/issues/4945
https://github.com/mapbox/mapbox-gl-native/issues/9435