### PR TITLE
Add native ignore for regression 4860 test

### DIFF
--- a/test/integration/render-tests/regressions/mapbox-gl-js#4860/style.json
+++ b/test/integration/render-tests/regressions/mapbox-gl-js#4860/style.json
@@ -2,6 +2,9 @@
     "version": 8,
     "metadata": {
         "test": {
+            "ignored": {
+                "native": "https://github.com/mapbox/mapbox-gl-native/issues/8967"
+            },
             "width": 256,
             "height": 256
         }


### PR DESCRIPTION
This test depends on the label placement changes coming for https://github.com/mapbox/mapbox-gl-native/issues/8967.

/cc @jfirebaugh @ansis 