### PR TITLE
Link to mapbox-gl-language

### DIFF
--- a/docs/_data/plugins.yml
+++ b/docs/_data/plugins.yml
@@ -20,9 +20,13 @@ User Interface Plugins:
     example: mapbox-gl-directions
 
 Map Rendering Plugins:
+  mapbox-gl-language:
+    website: https://github.com/mapbox/mapbox-gl-language/
+    description: automatically localizes the map into the user’s language
   mapbox-gl-rtl-text:
     website: https://github.com/mapbox/mapbox-gl-rtl-text
     description: adds right-to-left text support to Mapbox GL JS
+    example: mapbox-gl-rtl-text
   deck.gl:
     website: https://github.com/uber/deck.gl
     description: adds advanced WebGL visualization layers to Mapbox GL JS


### PR DESCRIPTION
Link to [Mapbox GL Language](https://github.com/mapbox/mapbox-gl-language/) from the plugins page. Also link to the mapbox-gl-rtl-text example.

After merging, this change can be cherry-picked into the mb-pages branch to go live immediately instead of waiting until the next GL JS release.

/cc @lukasmartinelli