### PR TITLE
Re-enable gl-native keep-upright test in pitched views.

### DIFF
--- a/test/integration/render-tests/text-keep-upright/line-placement-true-pitched/style.json
+++ b/test/integration/render-tests/text-keep-upright/line-placement-true-pitched/style.json
@@ -2,10 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/9457"
-      }
+      "height": 256
     }
   },
   "center": [


### PR DESCRIPTION
This should go in before the expected-soon fix for https://github.com/mapbox/mapbox-gl-native/issues/9457.

/cc @ansis @mollymerp 