### PR TITLE
update gl draw example to use events

### DIFF
--- a/docs/_posts/examples/3400-01-25-mapbox-gl-draw.html
+++ b/docs/_posts/examples/3400-01-25-mapbox-gl-draw.html
@@ -8,25 +8,14 @@ tags:
 ---
 <style>
     .calculation-box {
-        height: 140px;
+        height: 75px;
         width: 150px;
         position: absolute;
-        top: 210px;
+        bottom: 40px;
         left: 10px;
         background-color: rgba(255, 255, 255, .9);
         padding: 15px;
         text-align: center;
-    }
-
-    #calculate {
-        min-height: 20px;
-        background-color: #3887be;
-        color: #fff;
-        font-family: 'Open Sans';
-        border-radius: 5px;
-        padding: 10px;
-        cursor: pointer;
-        margin: 10px 0;
     }
 
     p {
@@ -42,7 +31,6 @@ tags:
 <div id='map'></div>
 <div class='calculation-box'>
     <p>Draw a polygon using the draw tools.</p>
-    <div id='calculate' class='button button'>Calculate area</div>
     <div id='calculated-area'></div>
 </div>
 
@@ -64,18 +52,22 @@ var draw = new MapboxDraw({
 });
 map.addControl(draw);
 
-var calcButton = document.getElementById('calculate');
-calcButton.onclick = function() {
+map.on('draw.create', updateArea);
+map.on('draw.delete', updateArea);
+map.on('draw.update', updateArea);
+
+function updateArea() {
     var data = draw.getAll();
+    var answer = document.getElementById('calculated-area');
     if (data.features.length > 0) {
         var area = turf.area(data);
         // restrict to area to 2 decimal points
         var rounded_area = Math.round(area*100)/100;
-        var answer = document.getElementById('calculated-area');
         answer.innerHTML = '<p><strong>' + rounded_area + '</strong></p><p>square meters</p>';
     } else {
+        answer.innerHTML = '';
         alert("Use the draw tools to draw a polygon!");
     }
-};
+}
 
 </script>

--- a/docs/_posts/examples/3400-01-25-mapbox-gl-draw.html
+++ b/docs/_posts/examples/3400-01-25-mapbox-gl-draw.html
@@ -56,7 +56,7 @@ map.on('draw.create', updateArea);
 map.on('draw.delete', updateArea);
 map.on('draw.update', updateArea);
 
-function updateArea() {
+function updateArea(e) {
     var data = draw.getAll();
     var answer = document.getElementById('calculated-area');
     if (data.features.length > 0) {
@@ -66,7 +66,7 @@ function updateArea() {
         answer.innerHTML = '<p><strong>' + rounded_area + '</strong></p><p>square meters</p>';
     } else {
         answer.innerHTML = '';
-        alert("Use the draw tools to draw a polygon!");
+        if (e.type !== 'draw.delete') alert("Use the draw tools to draw a polygon!");
     }
 }
 


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

Updating the gl-draw example to use draw events to update the area automatically. The advantage here is it shows how you can use events which based on [this](https://github.com/mapbox/mapbox-gl-draw/issues/669) and [this](https://gis.stackexchange.com/questions/244155/how-to-center-a-mapbox-gl-js-map-at-the-point-coordinates-from-a-point-edited-wi) we could do a bit better.

 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

/cc @colleenmcginnis @mcwhittemore 