### PR TITLE
Increase significantRotateThreshold, fix #4970

### DIFF
--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -8,7 +8,7 @@ const inertiaLinearity = 0.15,
     inertiaDeceleration = 12, // scale / s^2
     inertiaMaxSpeed = 2.5, // scale / s
     significantScaleThreshold = 0.15,
-    significantRotateThreshold = 4;
+    significantRotateThreshold = 10;
 
 /**
  * The `TouchZoomRotateHandler` allows the user to zoom and rotate the map by


### PR DESCRIPTION
Ref #4970 

From user testing and feedback I have found that the old threshold value of 4 is too low, causing map to rotate when users are trying to simply pinch zoom the map.

Tested with higher values than 10, but found that 10 is a good value.

Changed the `significantRotateThreshold` from `4` to `10`

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
