### PR TITLE
Enable tests for gl-native issues #9345 and #9456

### DIFF
--- a/test/integration/render-tests/icon-pitch-alignment/auto-rotation-alignment-map/style.json
+++ b/test/integration/render-tests/icon-pitch-alignment/auto-rotation-alignment-map/style.json
@@ -2,9 +2,6 @@
     "version": 8,
     "metadata": {
         "test": {
-            "ignored": {
-                "native": "https://github.com/mapbox/mapbox-gl-native/issues/9345"
-            },
             "width": 64,
             "height": 64
         }

--- a/test/integration/render-tests/icon-pitch-alignment/auto-rotation-alignment-viewport/style.json
+++ b/test/integration/render-tests/icon-pitch-alignment/auto-rotation-alignment-viewport/style.json
@@ -2,9 +2,6 @@
     "version": 8,
     "metadata": {
         "test": {
-            "ignored": {
-                "native": "https://github.com/mapbox/mapbox-gl-native/issues/9345"
-            },
             "width": 64,
             "height": 64
         }

--- a/test/integration/render-tests/icon-pitch-alignment/map-rotation-alignment-viewport/style.json
+++ b/test/integration/render-tests/icon-pitch-alignment/map-rotation-alignment-viewport/style.json
@@ -2,9 +2,6 @@
     "version": 8,
     "metadata": {
         "test": {
-            "ignored": {
-                "native": "https://github.com/mapbox/mapbox-gl-native/issues/9345"
-            },
             "width": 64,
             "height": 64
         }

--- a/test/integration/render-tests/icon-pitch-alignment/viewport-rotation-alignment-map/style.json
+++ b/test/integration/render-tests/icon-pitch-alignment/viewport-rotation-alignment-map/style.json
@@ -2,9 +2,6 @@
     "version": 8,
     "metadata": {
         "test": {
-            "ignored": {
-                "native": "https://github.com/mapbox/mapbox-gl-native/issues/9345"
-            },
             "width": 64,
             "height": 64
         }

--- a/test/integration/render-tests/regressions/mapbox-gl-js#4860/style.json
+++ b/test/integration/render-tests/regressions/mapbox-gl-js#4860/style.json
@@ -2,9 +2,6 @@
     "version": 8,
     "metadata": {
         "test": {
-            "ignored": {
-                "native": "https://github.com/mapbox/mapbox-gl-native/issues/9456"
-            },
             "width": 256,
             "height": 256
         }


### PR DESCRIPTION
This is support for 'icon-pitch-alignment' and the fix for GL JS regression #4860.

/cc @ansis @mollymerp 