### PR TITLE
Skip debug integration tests for all non-debug build types in GL native

### DIFF
--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -52,7 +52,7 @@ module.exports = function (directory, implementation, options, run) {
                 return;
             }
 
-            if (implementation === 'native' && process.env.BUILDTYPE === 'Release' && group === 'debug') {
+            if (implementation === 'native' && process.env.BUILDTYPE !== 'Debug' && group === 'debug') {
                 console.log(colors.gray(`* skipped ${group} ${test}`));
                 return;
             }


### PR DESCRIPTION
This is needed in GL native in order to skip `debug` integration tests in build types such as `RelWithDebInfo`.

Ref: https://github.com/mapbox/mapbox-gl-native/pull/9497