### PR TITLE
fix Map#areTilesLoading from not returning true on final sourcedata event 

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -228,7 +228,6 @@ class Tile {
             cameraToTileDistance: this.cameraToTileDistance,
             showCollisionBoxes: this.showCollisionBoxes
         }, (_, data) => {
-            console.log('reloaded');
             this.state = 'loaded';
             this.reloadSymbolData(data, this.placementSource.map.style);
             this.placementSource.fire('data', {tile: this, coord: this.coord, dataType: 'source'});

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -228,12 +228,12 @@ class Tile {
             cameraToTileDistance: this.cameraToTileDistance,
             showCollisionBoxes: this.showCollisionBoxes
         }, (_, data) => {
+            console.log('reloaded');
+            this.state = 'loaded';
             this.reloadSymbolData(data, this.placementSource.map.style);
-            if (this.placementSource.map.showCollisionBoxes) this.placementSource.fire('data', {tile: this, coord: this.coord, dataType: 'source'});
+            this.placementSource.fire('data', {tile: this, coord: this.coord, dataType: 'source'});
             // HACK this is nescessary to fix https://github.com/mapbox/mapbox-gl-js/issues/2986
             if (this.placementSource.map) this.placementSource.map.painter.tileExtentVAO.vao = null;
-
-            this.state = 'loaded';
 
             if (this.redoWhenDone) {
                 this.redoWhenDone = false;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1049,7 +1049,7 @@ class Map extends Camera {
             const tiles = source._tiles;
             for (const t in tiles) {
                 const tile = tiles[t];
-                if (!(tile.state === 'loaded' || tile.state === 'errored' || tile.state === 'reloading')) return false;
+                if (!(tile.state === 'loaded' || tile.state === 'errored')) return false;
             }
         }
         return true;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1049,7 +1049,7 @@ class Map extends Camera {
             const tiles = source._tiles;
             for (const t in tiles) {
                 const tile = tiles[t];
-                if (!(tile.state === 'loaded' || tile.state === 'errored')) return false;
+                if (!(tile.state === 'loaded' || tile.state === 'errored' || tile.state === 'reloading')) return false;
             }
         }
         return true;

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -175,7 +175,7 @@ test('Tile#redoPlacement', (t) => {
         const tile = new Tile(new TileCoord(1, 1, 1));
         tile.loadVectorData(createVectorData(), createPainter());
         t.stub(tile, 'reloadSymbolData').returns(null);
-        const options = util.extend(new Evented(), {
+        const source = util.extend(new Evented(), {
             type: 'vector',
             dispatcher: {
                 send: (name, data, cb) => {
@@ -188,7 +188,7 @@ test('Tile#redoPlacement', (t) => {
             }
         });
 
-        tile.redoPlacement(options);
+        tile.redoPlacement(source);
         tile.placementSource.on('data', ()=>{
             if (tile.state === 'loaded') t.end();
         });

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -11,6 +11,7 @@ const FeatureIndex = require('../../../src/data/feature_index');
 const CollisionTile = require('../../../src/symbol/collision_tile');
 const CollisionBoxArray = require('../../../src/symbol/collision_box');
 const util = require('../../../src/util/util');
+const Evented = require('../../../src/util/evented');
 
 test('querySourceFeatures', (t) => {
     const features = [{
@@ -168,6 +169,29 @@ test('Tile#redoPlacement', (t) => {
 
         t.ok(tile.redoWhenDone);
         t.end();
+    });
+
+    test('reloaded tile fires a data event on completion', (t)=>{
+        const tile = new Tile(new TileCoord(1, 1, 1));
+        tile.loadVectorData(createVectorData(), createPainter());
+        t.stub(tile, 'reloadSymbolData').returns(null);
+        const options = util.extend(new Evented(), {
+            type: 'vector',
+            dispatcher: {
+                send: (name, data, cb) => {
+                    if (name === 'redoPlacement') setTimeout(cb, 300);
+                }
+            },
+            map: {
+                transform: { cameraToCenterDistance: 1, cameraToTileDistance: () => { return 1; } },
+                painter: { tileExtentVAO: {vao: 0}}
+            }
+        });
+
+        tile.redoPlacement(options);
+        tile.placementSource.on('data', ()=>{
+            if (tile.state === 'loaded') t.end();
+        });
     });
 
     t.end();


### PR DESCRIPTION
Fixes #4975 

When tiles are `reloading` they don't fire a `sourcedata` event when they finish loading unless debug collision boxes are enabled (https://github.com/mapbox/mapbox-gl-js/blob/master/src/source/tile.js#L232 🤔 )

this approach changes the `areTilesLoaded` check to accept `reloading` tiles as loaded, but an alternative approach could be removing the conditional in `tile.js` linked above so that a sourcedata event would be fired when all `reloading` tiles switch back to `loaded`. 

cc @ksummerill  
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
