### PR TITLE
queryRenderedFeatures: Return empty array on errors

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -756,7 +756,7 @@ class Style extends Evented {
         if (params && params.layers) {
             if (!Array.isArray(params.layers)) {
                 this.fire('error', {error: 'parameters.layers must be an Array.'});
-                return;
+                return [];
             }
             for (const layerId of params.layers) {
                 const layer = this._layers[layerId];
@@ -764,7 +764,7 @@ class Style extends Evented {
                     // this layer is not in the style.layers array
                     this.fire('error', {error: `The layer '${layerId}' does not exist ` +
                         `in the map's style and cannot be queried for features.`});
-                    return;
+                    return [];
                 }
                 includedSources[layer.source] = true;
             }

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1411,8 +1411,9 @@ test('Style#queryRenderedFeatures', (t) => {
             t.stub(style, 'fire').callsFake((type, data) => {
                 if (data.error && data.error.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
             });
-            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']});
+            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']});
             t.equals(errors, 1);
+            t.equals(results.length, 0);
             t.end();
         });
 


### PR DESCRIPTION
Else, there will be an exception in map.js as it expects an array to be
returned.
