### PR TITLE
Handle configured API_URLs that have a path:

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -17,6 +17,10 @@ function makeAPIURL(urlObject: UrlObject, accessToken: string | null | void): st
     urlObject.protocol = apiUrlObject.protocol;
     urlObject.authority = apiUrlObject.authority;
 
+    if (apiUrlObject.path !== '/') {
+        urlObject.authority = `${urlObject.authority}${apiUrlObject.path}`;
+    }
+
     if (!config.REQUIRE_ACCESS_TOKEN) return formatUrl(urlObject);
 
     accessToken = accessToken || config.ACCESS_TOKEN;

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -18,7 +18,7 @@ function makeAPIURL(urlObject: UrlObject, accessToken: string | null | void): st
     urlObject.authority = apiUrlObject.authority;
 
     if (apiUrlObject.path !== '/') {
-        urlObject.authority = `${urlObject.authority}${apiUrlObject.path}`;
+        urlObject.path = `${apiUrlObject.path}${urlObject.path}`;
     }
 
     if (!config.REQUIRE_ACCESS_TOKEN) return formatUrl(urlObject);

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -30,6 +30,17 @@ test("mapbox", (t) => {
             t.end();
         });
 
+        t.test('handles custom API_URLs with paths', (t) => {
+            const previousUrl = config.API_URL;
+            config.API_URL = 'https://test.example.com/api.mapbox.com';
+            t.equal(
+                mapbox.normalizeStyleURL('mapbox://styles/foo/bar'),
+                'https://test.example.com/api.mapbox.com/styles/v1/foo/bar?access_token=key'
+            );
+            config.API_URL = previousUrl;
+            t.end();
+        });
+
         t.end();
     });
 
@@ -73,6 +84,17 @@ test("mapbox", (t) => {
             t.end();
         });
 
+        t.test('handles custom API_URLs with paths', (t) => {
+            const previousUrl = config.API_URL;
+            config.API_URL = 'https://test.example.com/api.mapbox.com';
+            t.equal(
+                mapbox.normalizeSourceURL('mapbox://one.a'),
+                'https://test.example.com/api.mapbox.com/v4/one.a.json?secure&access_token=key'
+            );
+            config.API_URL = previousUrl;
+            t.end();
+        });
+
         t.end();
     });
 
@@ -89,6 +111,17 @@ test("mapbox", (t) => {
 
         t.test('ignores non-mapbox:// scheme', (t) => {
             t.equal(mapbox.normalizeGlyphsURL('http://path'), 'http://path');
+            t.end();
+        });
+
+        t.test('handles custom API_URLs with paths', (t) => {
+            const previousUrl = config.API_URL;
+            config.API_URL = 'https://test.example.com/api.mapbox.com';
+            t.equal(
+                mapbox.normalizeGlyphsURL('mapbox://fonts/boxmap/{fontstack}/{range}.pbf'),
+                'https://test.example.com/api.mapbox.com/fonts/v1/boxmap/{fontstack}/{range}.pbf?access_token=key'
+            );
+            config.API_URL = previousUrl;
             t.end();
         });
 
@@ -146,6 +179,17 @@ test("mapbox", (t) => {
 
         t.test('normalizes non-mapbox:// scheme when query string exists', (t) => {
             t.equal(mapbox.normalizeSpriteURL('http://www.foo.com/bar?fresh=true', '@2x', '.png'), 'http://www.foo.com/bar@2x.png?fresh=true');
+            t.end();
+        });
+
+        t.test('handles custom API_URLs with paths', (t) => {
+            const previousUrl = config.API_URL;
+            config.API_URL = 'https://test.example.com/api.mapbox.com';
+            t.equal(
+                mapbox.normalizeSpriteURL('mapbox://sprites/mapbox/streets-v8', '', '.json'),
+                'https://test.example.com/api.mapbox.com/styles/v1/mapbox/streets-v8/sprite.json?access_token=key'
+            );
+            config.API_URL = previousUrl;
             t.end();
         });
 


### PR DESCRIPTION
For the case when a user has modified `mapboxgl.config.API_URL` that
includes a path such as http://test.example.com/api.mapbox.com the
path was getting removed when building the full URL as it was being
overwritten by the original path from the request.

This pull request checks if the generation of the `apiUrlObject` has a
path other than `'/'` (which is the default), and if so we need to prepend it to the
original `urlObject` path.

This fixes the case where users using a reverse proxy to mapbox have
filtered on the specific path set in their API_URL, and when it has been
removed the lack of a match causes the proxy to not forward the requests
.

Debug page:

<img width="1788" alt="screen shot 2017-07-19 at 9 34 43 pm" src="https://user-images.githubusercontent.com/9030/28387702-6daa963a-6cd0-11e7-87b8-ecb8c8d48344.png">

Benchmarks:

```shell
benchmark | master 8567504 | api-url-with-path d0feffa
--- | --- | ---
**map-load** | 298 ms  | 304 ms 
**style-load** | 1,048 ms  | 95 ms 
**buffer** | 1,173 ms  | 1,163 ms 
**fps** | 57 fps  | 60 fps 
**frame-duration** | 8.1 ms, 2% > 16ms  | 7.9 ms, 1% > 16ms 
**query-point** | 1.15 ms  | 1.24 ms 
**query-box** | 86.21 ms  | 95.22 ms 
**geojson-setdata-small** | 7 ms  | 4 ms 
**geojson-setdata-large** | 170 ms  | 167 ms 

```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
