### PR TITLE
Don't enforce ascending order for categorical function stops

### DIFF
--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -168,7 +168,7 @@ module.exports = function validateFunction(options) {
             return [new ValidationError(options.key, options.value, 'integer expected, found %s', value)];
         }
 
-        if (type === 'number' && previousStopDomainValue !== undefined && value < previousStopDomainValue) {
+        if (functionType !== 'categorical' && type === 'number' && previousStopDomainValue !== undefined && value < previousStopDomainValue) {
             return [new ValidationError(options.key, options.value, 'stop domain values must appear in ascending order')];
         } else {
             previousStopDomainValue = value;

--- a/test/unit/style-spec/fixture/functions.input.json
+++ b/test/unit/style-spec/fixture/functions.input.json
@@ -839,6 +839,46 @@
           "default": "invalid"
         }
       }
+    },
+    {
+      "id": "invalid interval property function non-ascending stop values",
+      "type": "fill",
+      "source": "source",
+      "source-layer": "layer",
+      "paint": {
+        "fill-opacity": {
+          "property": "mapbox",
+          "type": "interval",
+          "stops": [
+            [
+              1, 1
+            ],
+            [
+              0, 0
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "valid categorical property function non-ascending stop values",
+      "type": "fill",
+      "source": "source",
+      "source-layer": "layer",
+      "paint": {
+        "fill-opacity": {
+          "property": "mapbox",
+          "type": "categorical",
+          "stops": [
+            [
+              1, 1
+            ],
+            [
+              0, 0
+            ]
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/unit/style-spec/fixture/functions.output.json
+++ b/test/unit/style-spec/fixture/functions.output.json
@@ -157,5 +157,9 @@
   {
     "message": "layers[43].paint.fill-color.default: color expected, \"invalid\" found",
     "line": 839
+  },
+  {
+    "message": "layers[44].paint.fill-opacity.stops[1][0]: stop domain values must appear in ascending order",
+    "line": 857
   }
 ]


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/4980.