### PR TITLE
Increase minimum supercluster version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pbf": "^1.3.2",
     "point-geometry": "^0.0.0",
     "quickselect": "^1.0.0",
-    "supercluster": "^2.0.1",
+    "supercluster": "^2.3.0",
     "through2": "^2.0.3",
     "tinyqueue": "^1.1.0",
     "unassertify": "^2.0.0",


### PR DESCRIPTION
Please consider increasing the supercluster version to ^2.3.0. This version of supercluser populates a cluster_id property of all clusters that it generates. This property is a useful cross reference when using a second instance of the supercluster object to aggregate properties or explore cluster members. Such functionality appears to be planned for integration into mapbox-gl-js per discussion in #2412 at which point the newer supercluster release would become a requirement.

In any case, supercluster 2.0.1 lacks the large performance improvement in version 2.1.0, and the release version of mapbox-gl-js is built against 2.2.0. So this ought to be bumped for other reasons as well.

👀 @jfirebaugh