### PR TITLE
URL Transform callback as a Map option

### DIFF
--- a/bench/benchmarks/buffer.js
+++ b/bench/benchmarks/buffer.js
@@ -24,7 +24,7 @@ module.exports = function run() {
     const evented = new Evented();
 
     const stylesheetURL = `https://api.mapbox.com/styles/v1/mapbox/streets-v9?access_token=${accessToken}`;
-    ajax.getJSON(stylesheetURL, (err, stylesheet) => {
+    ajax.getJSON({ url: stylesheetURL }, (err, stylesheet) => {
         if (err) return evented.fire('error', {error: err});
 
         evented.fire('log', {
@@ -82,6 +82,12 @@ module.exports = function run() {
     return evented;
 };
 
+class StubMap extends Evented {
+    _transformRequest(url) {
+        return { url };
+    }
+}
+
 function preloadAssets(stylesheet, callback) {
     const assets = {
         glyphs: {},
@@ -89,7 +95,7 @@ function preloadAssets(stylesheet, callback) {
         tiles: {}
     };
 
-    const style = new Style(stylesheet);
+    const style = new Style(stylesheet, new StubMap());
 
     style.on('style.load', () => {
         function getGlyphs(params, callback) {
@@ -107,7 +113,7 @@ function preloadAssets(stylesheet, callback) {
         }
 
         function getTile(url, callback) {
-            ajax.getArrayBuffer(url, (err, response) => {
+            ajax.getArrayBuffer({ url }, (err, response) => {
                 assets.tiles[url] = response.data;
                 callback(err, response.data);
             });

--- a/bench/benchmarks/geojson_setdata_large.js
+++ b/bench/benchmarks/geojson_setdata_large.js
@@ -14,7 +14,7 @@ module.exports = function() {
         evented.fire('log', {message: 'downloading large geojson'});
     }, 0);
 
-    ajax.getJSON('http://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_land.geojson', (err, data) => {
+    ajax.getJSON({ url: 'http://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_land.geojson' }, (err, data) => {
         evented.fire('log', {message: 'starting test'});
 
         if (err) return evented.fire('error', {error: err});

--- a/bench/benchmarks/style_load.js
+++ b/bench/benchmarks/style_load.js
@@ -12,8 +12,13 @@ module.exports = function() {
 
     const evented = new Evented();
 
+    class StubMap extends Evented {
+        _transformRequest(url) {
+            return { url };
+        }
+    }
     const stylesheetURL = `https://api.mapbox.com/styles/v1/mapbox/streets-v9?access_token=${accessToken}`;
-    ajax.getJSON(stylesheetURL, (err, json) => {
+    ajax.getJSON({ url: stylesheetURL }, (err, json) => {
         if (err) {
             return evented.fire('error', {error: err});
         }
@@ -23,7 +28,7 @@ module.exports = function() {
 
         asyncTimesSeries(20, (callback) => {
             const timeStart = performance.now();
-            new Style(json)
+            new Style(json, new StubMap())
                 .on('error', (err) => {
                     evented.fire('error', { error: err });
                 })

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -4,6 +4,7 @@ const Evented = require('../util/evented');
 const util = require('../util/util');
 const window = require('../util/window');
 const EXTENT = require('../data/extent');
+const ResourceType = require('../util/ajax').ResourceType;
 
 import type {Source} from './source';
 import type Map from '../ui/map';
@@ -138,8 +139,8 @@ class GeoJSONSource extends Evented implements Source {
     }
 
     onAdd(map: Map) {
-        this.load();
         this.map = map;
+        this.load();
     }
 
     /**
@@ -170,7 +171,7 @@ class GeoJSONSource extends Evented implements Source {
         const options = util.extend({}, this.workerOptions);
         const data = this._data;
         if (typeof data === 'string') {
-            options.url = resolveURL(data);
+            options.request = this.map._transformRequest(resolveURL(data), ResourceType.Source);
         } else {
             options.data = JSON.stringify(data);
         }

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -18,11 +18,12 @@ import type {Actor} from '../util/actor';
 import type StyleLayerIndex from '../style/style_layer_index';
 
 import type {LoadVectorDataCallback} from './vector_tile_worker_source';
+import type {RequestParameters} from '../util/ajax';
 
 export type GeoJSON = Object;
 
 export type LoadGeoJSONParameters = {
-    url?: string,
+    request?: RequestParameters,
     data?: string,
     source: string,
     superclusterOptions?: Object,
@@ -164,8 +165,8 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
         // origin or absolute path.
         // ie: /foo/bar.json or http://example.com/bar.json
         // but not ../foo/bar.json
-        if (params.url) {
-            ajax.getJSON(params.url, callback);
+        if (params.request) {
+            ajax.getJSON(params.request, callback);
         } else if (typeof params.data === 'string') {
             try {
                 return callback(null, JSON.parse(params.data));

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -91,7 +91,7 @@ class ImageSource extends Evented implements Source {
 
         this.url = this.options.url;
 
-        ajax.getImage(this.options.url, (err, image) => {
+        ajax.getImage(this.map._transformRequest(this.url, ajax.ResourceType.Image), (err, image) => {
             if (err) {
                 this.fire('error', {error: err});
             } else if (image) {
@@ -109,11 +109,8 @@ class ImageSource extends Evented implements Source {
     }
 
     onAdd(map: Map) {
-        this.load();
         this.map = map;
-        if (this.image) {
-            this.setCoordinates(this.coordinates);
-        }
+        this.load();
     }
 
     /**
@@ -181,7 +178,7 @@ class ImageSource extends Evented implements Source {
     }
 
     prepare() {
-        if (Object.keys(this.tiles).length === 0 === 0 || !this.image) return;
+        if (Object.keys(this.tiles).length === 0 || !this.image) return;
         this._prepareImage(this.map.painter.gl, this.image);
     }
 
@@ -230,7 +227,7 @@ class ImageSource extends Evented implements Source {
     serialize(): Object {
         return {
             type: 'image',
-            urls: this.url,
+            urls: this.options.url,
             coordinates: this.coordinates
         };
     }

--- a/src/source/load_tilejson.js
+++ b/src/source/load_tilejson.js
@@ -5,7 +5,9 @@ const ajax = require('../util/ajax');
 const browser = require('../util/browser');
 const normalizeURL = require('../util/mapbox').normalizeSourceURL;
 
-module.exports = function(options: any, callback: Callback<TileJSON>) {
+import type {RequestTransformFunction} from '../ui/map';
+
+module.exports = function(options: any, requestTransformFn: RequestTransformFunction, callback: Callback<TileJSON>) {
     const loaded = function(err, tileJSON: any) {
         if (err) {
             return callback(err);
@@ -22,7 +24,7 @@ module.exports = function(options: any, callback: Callback<TileJSON>) {
     };
 
     if (options.url) {
-        ajax.getJSON(normalizeURL(options.url), loaded);
+        ajax.getJSON(requestTransformFn(normalizeURL(options.url), ajax.ResourceType.Source), loaded);
     } else {
         browser.frame(() => loaded(null, options));
     }

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -52,7 +52,7 @@ class RasterTileSource extends Evented implements Source {
 
     load() {
         this.fire('dataloading', {dataType: 'source'});
-        loadTileJSON(this._options, (err, tileJSON) => {
+        loadTileJSON(this._options, this.map._transformRequest, (err, tileJSON) => {
             if (err) {
                 this.fire('error', err);
             } else if (tileJSON) {
@@ -69,8 +69,8 @@ class RasterTileSource extends Evented implements Source {
     }
 
     onAdd(map: Map) {
-        this.load();
         this.map = map;
+        this.load();
     }
 
     setBounds(bounds?: [number, number, number, number]) {
@@ -91,7 +91,7 @@ class RasterTileSource extends Evented implements Source {
     loadTile(tile: Tile, callback: Callback<void>) {
         const url = normalizeURL(tile.coord.url(this.tiles, null, this.scheme), this.url, this.tileSize);
 
-        tile.request = ajax.getImage(url, (err, img) => {
+        tile.request = ajax.getImage(this.map._transformRequest(url, ajax.ResourceType.Tile), (err, img) => {
             delete tile.request;
 
             if (tile.aborted) {

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -38,7 +38,7 @@ module.exports.setRTLTextPlugin = function(pluginURL: string, callback: ErrorCal
     }
     pluginRequested = true;
     module.exports.errorCallback = callback;
-    ajax.getArrayBuffer(pluginURL, (err, response) => {
+    ajax.getArrayBuffer({ url: pluginURL }, (err, response) => {
         if (err) {
             callback(err);
         } else if (response) {

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -5,6 +5,7 @@ const util = require('../util/util');
 const loadTileJSON = require('./load_tilejson');
 const normalizeURL = require('../util/mapbox').normalizeTileURL;
 const TileBounds = require('./tile_bounds');
+const ResourceType = require('../util/ajax').ResourceType;
 
 import type {Source} from './source';
 import type TileCoord from './tile_coord';
@@ -56,7 +57,7 @@ class VectorTileSource extends Evented implements Source {
     load() {
         this.fire('dataloading', {dataType: 'source'});
 
-        loadTileJSON(this._options, (err, tileJSON) => {
+        loadTileJSON(this._options, this.map._transformRequest, (err, tileJSON) => {
             if (err) {
                 this.fire('error', err);
             } else if (tileJSON) {
@@ -84,8 +85,8 @@ class VectorTileSource extends Evented implements Source {
     }
 
     onAdd(map: Map) {
-        this.load();
         this.map = map;
+        this.load();
     }
 
     serialize() {
@@ -94,8 +95,9 @@ class VectorTileSource extends Evented implements Source {
 
     loadTile(tile: Tile, callback: Callback<void>) {
         const overscaling = tile.coord.z > this.maxzoom ? Math.pow(2, tile.coord.z - this.maxzoom) : 1;
+        const url = normalizeURL(tile.coord.url(this.tiles, this.maxzoom, this.scheme), this.url);
         const params = {
-            url: normalizeURL(tile.coord.url(this.tiles, this.maxzoom, this.scheme), this.url),
+            request: this.map._transformRequest(url, ResourceType.Tile),
             uid: tile.uid,
             coord: tile.coord,
             zoom: tile.coord.z,

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -40,7 +40,7 @@ export type LoadVectorData = (params: WorkerTileParameters, callback: LoadVector
  * @private
  */
 function loadVectorTile(params: WorkerTileParameters, callback: LoadVectorDataCallback) {
-    const xhr = ajax.getArrayBuffer(params.url, (err, response) => {
+    const xhr = ajax.getArrayBuffer(params.request, (err, response) => {
         if (err) {
             callback(err);
         } else if (response) {

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -96,8 +96,8 @@ class VideoSource extends ImageSource {
 
     onAdd(map: Map) {
         if (this.map) return;
-        this.load();
         this.map = map;
+        this.load();
         if (this.video) {
             this.video.play();
             this.setCoordinates(this.coordinates);

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -108,7 +108,7 @@ class Worker {
      * function taking `(name, workerSourceObject)`.
      *  @private
      */
-    loadWorkerSource(map: string, params: {url: string}, callback: Callback<void>) {
+    loadWorkerSource(map: string, params: { url: string }, callback: Callback<void>) {
         try {
             this.self.importScripts(params.url);
             callback();

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -7,6 +7,7 @@ import type {SerializedBucket} from '../data/bucket';
 import type {SerializedFeatureIndex} from '../data/feature_index';
 import type {SerializedCollisionTile} from '../symbol/collision_tile';
 import type {SerializedStructArray} from '../util/struct_array';
+import type {RequestParameters} from '../util/ajax';
 
 export type TileParameters = {
     source: string,
@@ -23,7 +24,7 @@ export type PlacementConfig = {
 
 export type WorkerTileParameters = TileParameters & {
     coord: TileCoord,
-    url: string,
+    request: RequestParameters,
     zoom: number,
     maxZoom: number,
     tileSize: number,

--- a/src/style/image_sprite.js
+++ b/src/style/image_sprite.js
@@ -5,6 +5,8 @@ const ajax = require('../util/ajax');
 const browser = require('../util/browser');
 const normalizeURL = require('../util/mapbox').normalizeSpriteURL;
 
+import type {RequestTransformFunction} from '../ui/map';
+
 class SpritePosition {
     x: number;
     y: number;
@@ -27,19 +29,22 @@ class ImageSprite extends Evented {
     base: string;
     retina: boolean;
 
+    transformRequestFn: RequestTransformFunction;
     data: ?{[string]: SpritePosition};
     imgData: ?Uint8ClampedArray;
     width: ?number;
 
-    constructor(base: string, eventedParent?: Evented) {
+    constructor(base: string, transformRequestCallback: RequestTransformFunction, eventedParent?: Evented) {
         super();
         this.base = base;
         this.retina = browser.devicePixelRatio > 1;
         this.setEventedParent(eventedParent);
+        this.transformRequestFn = transformRequestCallback;
 
         const format = this.retina ? '@2x' : '';
-
-        ajax.getJSON(normalizeURL(base, format, '.json'), (err, data) => {
+        let url = normalizeURL(base, format, '.json');
+        const jsonRequest = transformRequestCallback(url, ajax.ResourceType.SpriteJSON);
+        ajax.getJSON(jsonRequest, (err, data) => {
             if (err) {
                 this.fire('error', {error: err});
             } else if (data) {
@@ -47,8 +52,9 @@ class ImageSprite extends Evented {
                 if (this.imgData) this.fire('data', {dataType: 'style'});
             }
         });
-
-        ajax.getImage(normalizeURL(base, format, '.png'), (err, img) => {
+        url = normalizeURL(base, format, '.png');
+        const imageRequest = transformRequestCallback(url, ajax.ResourceType.SpriteImage);
+        ajax.getImage(imageRequest, (err, img) => {
             if (err) {
                 this.fire('error', {error: err});
             } else if (img) {
@@ -71,7 +77,7 @@ class ImageSprite extends Evented {
 
     resize(/*gl*/) {
         if (browser.devicePixelRatio > 1 !== this.retina) {
-            const newSprite = new ImageSprite(this.base);
+            const newSprite = new ImageSprite(this.base, this.transformRequestFn);
             newSprite.on('data', () => {
                 this.data = newSprite.data;
                 this.imgData = newSprite.imgData;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -85,6 +85,10 @@ class Style extends Evented {
             }
         });
 
+        const transformRequest = (url, resourceType) => {
+            return  this.map ? this.map._transformRequest(url, resourceType) : { url };
+        };
+
         const stylesheetLoaded = (err, stylesheet) => {
             if (err) {
                 this.fire('error', {error: err});
@@ -103,17 +107,17 @@ class Style extends Evented {
             }
 
             if (stylesheet.sprite) {
-                this.sprite = new ImageSprite(stylesheet.sprite, this);
+                this.sprite = new ImageSprite(stylesheet.sprite, transformRequest, this);
             }
 
-            this.glyphSource = new GlyphSource(stylesheet.glyphs, options.localIdeographFontFamily, this);
+            this.glyphSource = new GlyphSource(stylesheet.glyphs, options.localIdeographFontFamily, transformRequest, this);
             this._resolve();
             this.fire('data', {dataType: 'style'});
             this.fire('style.load');
         };
 
         if (typeof stylesheet === 'string') {
-            ajax.getJSON(mapbox.normalizeStyleURL(stylesheet), stylesheetLoaded);
+            ajax.getJSON(transformRequest(mapbox.normalizeStyleURL(stylesheet), ajax.ResourceType.Style), stylesheetLoaded);
         } else {
             browser.frame(stylesheetLoaded.bind(this, null, stylesheet));
         }

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -126,7 +126,7 @@ function cached(data, callback) {
     });
 }
 
-sinon.stub(ajax, 'getJSON').callsFake((url, callback) => {
+sinon.stub(ajax, 'getJSON').callsFake(({ url }, callback) => {
     if (cache[url]) return cached(cache[url], callback);
     return request(url, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
@@ -144,9 +144,9 @@ sinon.stub(ajax, 'getJSON').callsFake((url, callback) => {
     });
 });
 
-sinon.stub(ajax, 'getArrayBuffer').callsFake((url, callback) => {
+sinon.stub(ajax, 'getArrayBuffer').callsFake(({ url }, callback) => {
     if (cache[url]) return cached(cache[url], callback);
-    return request({url: url, encoding: null}, (error, response, body) => {
+    return request({ url, encoding: null }, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
             cache[url] = {data: body};
             callback(null, {data: body});
@@ -156,9 +156,9 @@ sinon.stub(ajax, 'getArrayBuffer').callsFake((url, callback) => {
     });
 });
 
-sinon.stub(ajax, 'getImage').callsFake((url, callback) => {
+sinon.stub(ajax, 'getImage').callsFake(({ url }, callback) => {
     if (cache[url]) return cached(cache[url], callback);
-    return request({url: url, encoding: null}, (error, response, body) => {
+    return request({ url, encoding: null }, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
             new PNG().parse(body, (err, png) => {
                 if (err) return callback(err);
@@ -178,7 +178,7 @@ sinon.stub(browser, 'getImageData').callsFake((img) => {
 // Hack: since node doesn't have any good video codec modules, just grab a png with
 // the first frame and fake the video API.
 sinon.stub(ajax, 'getVideo').callsFake((urls, callback) => {
-    return request({url: urls[0], encoding: null}, (error, response, body) => {
+    return request({ url: urls[0], encoding: null }, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
             new PNG().parse(body, (err, png) => {
                 if (err) return callback(err);

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -139,6 +139,17 @@ test('GeoJSONSource#update', (t) => {
         }, mockDispatcher).load();
     });
 
+    t.test('transforms url before making request', (t) => {
+        const mapStub = {
+            _transformRequest: (url) => { return { url }; }
+        };
+        const transformSpy = t.spy(mapStub, '_transformRequest');
+        const source = new GeoJSONSource('id', {data: 'https://example.com/data.geojson'}, mockDispatcher);
+        source.onAdd(mapStub);
+        t.ok(transformSpy.calledOnce);
+        t.equal(transformSpy.getCall(0).args[0], 'https://example.com/data.geojson');
+        t.end();
+    });
     t.test('fires event when metadata loads', (t) => {
         const mockDispatcher = {
             send: function(message, args, callback) {
@@ -202,9 +213,12 @@ test('GeoJSONSource#update', (t) => {
 });
 
 test('GeoJSONSource#serialize', (t) => {
-
+    const mapStub = {
+        _transformRequest: (url) => { return { url }; }
+    };
     t.test('serialize source with inline data', (t) => {
         const source = new GeoJSONSource('id', {data: hawkHill}, mockDispatcher);
+        source.map = mapStub;
         source.load();
         t.deepEqual(source.serialize(), {
             type: 'geojson',
@@ -215,6 +229,7 @@ test('GeoJSONSource#serialize', (t) => {
 
     t.test('serialize source with url', (t) => {
         const source = new GeoJSONSource('id', {data: 'local://data.json'}, mockDispatcher);
+        source.map = mapStub;
         source.load();
         t.deepEqual(source.serialize(), {
             type: 'geojson',
@@ -225,6 +240,7 @@ test('GeoJSONSource#serialize', (t) => {
 
     t.test('serialize source with updated data', (t) => {
         const source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
+        source.map = mapStub;
         source.load();
         source.setData(hawkHill);
         t.deepEqual(source.serialize(), {

--- a/test/unit/source/image_source.test.js
+++ b/test/unit/source/image_source.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const test = require('mapbox-gl-js-test').test;
+const ImageSource = require('../../../src/source/image_source');
+const Evented = require('../../../src/util/evented');
+const Transform = require('../../../src/geo/transform');
+const util = require('../../../src/util/util');
+const ajax = require('../../../src/util/ajax');
+
+function createSource(options) {
+    options = util.extend({
+        coordinates: [[0, 0], [1, 0], [1, 1], [0, 1]]
+    }, options);
+
+    const source = new ImageSource('id', options, { send: function() {} }, options.eventedParent);
+    return source;
+}
+
+class StubMap extends Evented {
+    constructor() {
+        super();
+        this.transform = new Transform();
+    }
+
+    _transformRequest(url) {
+        return { url };
+    }
+}
+
+test('ImageSource', (t) => {
+
+    t.stub(ajax, 'getImage').callsFake((params, callback) => { callback(null, new ArrayBuffer(1)); });
+
+    t.test('constructor', (t) => {
+        const source = createSource({ url : '/image.png' });
+
+        t.equal(source.minzoom, 0);
+        t.equal(source.maxzoom, 22);
+        t.equal(source.tileSize, 512);
+        t.end();
+    });
+
+    t.test('fires dataloading event', (t) => {
+        const source = createSource({ url : '/image.png' });
+        source.on('dataloading', (e) => {
+            t.equal(e.dataType, 'source');
+            t.end();
+        });
+        source.onAdd(new StubMap());
+    });
+
+    t.test('transforms url request', (t) => {
+        const source = createSource({ url : '/image.png' });
+        const map = new StubMap();
+        const spy = t.spy(map, '_transformRequest');
+        source.onAdd(map);
+        t.ok(spy.calledOnce);
+        t.equal(spy.getCall(0).args[0], '/image.png');
+        t.equal(spy.getCall(0).args[1], 'Image');
+        t.end();
+    });
+
+    t.test('fires data event when content is loaded', (t) => {
+        const source = createSource({ url : '/image.png' });
+        source.on('data', (e) => {
+            if (e.dataType === 'source' && e.sourceDataType === 'content') {
+                t.ok(typeof source.coord == 'object');
+                t.end();
+            }
+        });
+        source.onAdd(new StubMap());
+    });
+
+    t.test('fires data event when metadata is loaded', (t) => {
+        const source = createSource({ url : '/image.png' });
+        source.on('data', (e) => {
+            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+                t.end();
+            }
+        });
+        source.onAdd(new StubMap());
+    });
+
+    t.test('serialize url and coordinates', (t) => {
+        const source = createSource({ url: '/image.png' });
+
+        const serialized = source.serialize();
+        t.equal(serialized.type, 'image');
+        t.equal(serialized.urls, '/image.png');
+        t.deepEqual(serialized.coordinates, [[0, 0], [1, 0], [1, 1], [0, 1]]);
+
+        t.end();
+    });
+
+    t.end();
+});

--- a/test/unit/source/raster_tile_source.test.js
+++ b/test/unit/source/raster_tile_source.test.js
@@ -2,12 +2,13 @@
 const test = require('mapbox-gl-js-test').test;
 const RasterTileSource = require('../../../src/source/raster_tile_source');
 const window = require('../../../src/util/window');
+const TileCoord = require('../../../src/source/tile_coord');
 
-
-function createSource(options) {
+function createSource(options, transformCallback) {
     const source = new RasterTileSource('id', options, { send: function() {} }, options.eventedParent);
     source.onAdd({
-        transform: { angle: 0, pitch: 0, showCollisionBoxes: false }
+        transform: { angle: 0, pitch: 0, showCollisionBoxes: false },
+        _transformRequest: transformCallback ? transformCallback : (url) => { return { url }; }
     });
 
     source.on('error', (e) => {
@@ -26,6 +27,26 @@ test('RasterTileSource', (t) => {
     t.afterEach((callback) => {
         window.restore();
         callback();
+    });
+
+    t.test('transforms request for TileJSON URL', (t) => {
+        window.server.respondWith('/source.json', JSON.stringify({
+            minzoom: 0,
+            maxzoom: 22,
+            attribution: "Mapbox",
+            tiles: ["http://example.com/{z}/{x}/{y}.png"],
+            bounds: [-47, -7, -45, -5]
+        }));
+        const transformSpy = t.spy((url) => {
+            return { url };
+        });
+
+        createSource({ url: "/source.json" }, transformSpy);
+        window.server.respond();
+
+        t.equal(transformSpy.getCall(0).args[0], '/source.json');
+        t.equal(transformSpy.getCall(0).args[1], 'Source');
+        t.end();
     });
 
     t.test('respects TileJSON.bounds', (t)=>{
@@ -67,6 +88,34 @@ test('RasterTileSource', (t) => {
             if (e.sourceDataType === 'metadata') {
                 t.false(source.hasTile({z: 8, x:96, y: 132}), 'returns false for tiles outside bounds');
                 t.true(source.hasTile({z: 8, x:95, y: 132}), 'returns true for tiles inside bounds');
+                t.end();
+            }
+        });
+        window.server.respond();
+    });
+
+    t.test('transforms tile urls before requesting', (t) => {
+        window.server.respondWith('/source.json', JSON.stringify({
+            minzoom: 0,
+            maxzoom: 22,
+            attribution: "Mapbox",
+            tiles: ["http://example.com/{z}/{x}/{y}.png"],
+            bounds: [-47, -7, -45, -5]
+        }));
+        const source = createSource({ url: "/source.json" });
+        const transformSpy = t.spy(source.map, '_transformRequest');
+        source.on('data', (e) => {
+            if (e.sourceDataType === 'metadata') {
+                const tile = {
+                    coord: new TileCoord(10, 5, 5, 0),
+                    state: 'loading',
+                    loadVectorData: function () {},
+                    setExpiryData: function() {}
+                };
+                source.loadTile(tile, () => {});
+                t.ok(transformSpy.calledOnce);
+                t.equal(transformSpy.getCall(0).args[0], 'http://example.com/10/5/5.png');
+                t.equal(transformSpy.getCall(0).args[1], 'Tile');
                 t.end();
             }
         });

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -61,7 +61,7 @@ test('querySourceFeatures', (t) => {
         geojsonWrapper.name = '_geojsonTileLayer';
         tile.rawTileData = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
         result = [];
-        t.doesNotThrow(tile.querySourceFeatures(result));
+        t.doesNotThrow(() => { tile.querySourceFeatures(result); });
         t.equal(result.length, 0);
         t.end();
     });

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -6,10 +6,11 @@ const TileCoord = require('../../../src/source/tile_coord');
 const window = require('../../../src/util/window');
 const Evented = require('../../../src/util/evented');
 
-function createSource(options) {
+function createSource(options, transformCallback) {
     const source = new VectorTileSource('id', options, { send: function() {} }, options.eventedParent);
     source.onAdd({
-        transform: { angle: 0, pitch: 0, cameraToCenterDistance: 1, cameraToTileDistance: () => { return 1; }, showCollisionBoxes: false }
+        transform: { angle: 0, pitch: 0, cameraToCenterDistance: 1, cameraToTileDistance: () => { return 1; }, showCollisionBoxes: false },
+        _transformRequest: transformCallback ? transformCallback : (url) => { return { url }; }
     });
 
     source.on('error', (e) => {
@@ -66,6 +67,19 @@ test('VectorTileSource', (t) => {
         });
 
         window.server.respond();
+    });
+
+    t.test('transforms the request for TileJSON URL', (t) => {
+        window.server.respondWith('/source.json', JSON.stringify(require('../../fixtures/source')));
+        const transformSpy = t.spy((url) => {
+            return { url };
+        });
+
+        createSource({ url: "/source.json" }, transformSpy);
+        window.server.respond();
+        t.equal(transformSpy.getCall(0).args[0], '/source.json');
+        t.equal(transformSpy.getCall(0).args[1], 'Source');
+        t.end();
     });
 
     t.test('fires event with metadata property', (t) => {
@@ -134,7 +148,7 @@ test('VectorTileSource', (t) => {
 
             source.dispatcher.send = function(type, params) {
                 t.equal(type, 'loadTile');
-                t.equal(expectedURL, params.url);
+                t.equal(expectedURL, params.request.url);
                 t.end();
             };
 
@@ -146,6 +160,30 @@ test('VectorTileSource', (t) => {
 
     testScheme('xyz', 'http://example.com/10/5/5.png');
     testScheme('tms', 'http://example.com/10/5/1018.png');
+
+    t.test('transforms tile urls before requesting', (t) => {
+        window.server.respondWith('/source.json', JSON.stringify(require('../../fixtures/source')));
+
+        const source = createSource({ url: "/source.json" });
+        const transformSpy = t.spy(source.map, '_transformRequest');
+        source.on('data', (e) => {
+            if (e.sourceDataType === 'metadata') {
+                const tile = {
+                    coord: new TileCoord(10, 5, 5, 0),
+                    state: 'loading',
+                    loadVectorData: function () {},
+                    setExpiryData: function() {}
+                };
+                source.loadTile(tile, () => {});
+                t.ok(transformSpy.calledOnce);
+                t.equal(transformSpy.getCall(0).args[0], 'http://example.com/10/5/5.png');
+                t.equal(transformSpy.getCall(0).args[1], 'Tile');
+                t.end();
+            }
+        });
+
+        window.server.respond();
+    });
 
     t.test('reloads a loading tile properly', (t) => {
         const source = createSource({

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -11,7 +11,7 @@ test('abortTile', (t) => {
         source.loadTile({
             source: 'source',
             uid: 0,
-            url: 'http://localhost:2900/abort'
+            request: { url: 'http://localhost:2900/abort' }
         }, t.fail);
 
         source.abortTile({

--- a/test/unit/source/worker.test.js
+++ b/test/unit/source/worker.test.js
@@ -16,7 +16,7 @@ test('load tile', (t) => {
             type: 'vector',
             source: 'source',
             uid: 0,
-            url: '/error' // Sinon fake server gives 404 responses by default
+            request: { url: '/error' }// Sinon fake server gives 404 responses by default 
         }, (err) => {
             t.ok(err);
             window.restore();

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -19,7 +19,7 @@ test('ajax', (t) => {
         window.server.respondWith(request => {
             request.respond(200, {'Content-Type': 'image/png'}, '');
         });
-        ajax.getArrayBuffer('', (error) => {
+        ajax.getArrayBuffer({ url:'' }, (error) => {
             t.pass('called getArrayBuffer');
             t.ok(error, 'should error when the status is 200 without content.');
             t.end();
@@ -31,7 +31,7 @@ test('ajax', (t) => {
         window.server.respondWith(request => {
             request.respond(404);
         });
-        ajax.getArrayBuffer('', (error) => {
+        ajax.getArrayBuffer({ url:'' }, (error) => {
             t.equal(error.status, 404);
             t.end();
         });
@@ -42,7 +42,7 @@ test('ajax', (t) => {
         window.server.respondWith(request => {
             request.respond(200, {'Content-Type': 'application/json'}, '{"foo": "bar"}');
         });
-        ajax.getJSON('', (error, body) => {
+        ajax.getJSON({ url:'' }, (error, body) => {
             t.error(error);
             t.deepEqual(body, {foo: 'bar'});
             t.end();
@@ -54,7 +54,7 @@ test('ajax', (t) => {
         window.server.respondWith(request => {
             request.respond(200, {'Content-Type': 'application/json'}, 'how do i even');
         });
-        ajax.getJSON('', (error) => {
+        ajax.getJSON({ url:'' }, (error) => {
             t.ok(error);
             t.end();
         });
@@ -65,7 +65,7 @@ test('ajax', (t) => {
         window.server.respondWith(request => {
             request.respond(404);
         });
-        ajax.getJSON('', (error) => {
+        ajax.getJSON({ url:'' }, (error) => {
             t.equal(error.status, 404);
             t.end();
         });


### PR DESCRIPTION
We have quite a few tickets (#4740, #2918, #4917, and [gl-native/#7455](https://github.com/mapbox/mapbox-gl-native/issues/7455)) related to modifying XHR requests made by mapbox-gl-js for various resources. While these tickets are each slightly different, they all include an element of inspecting and modifying the XHR request before it is sent.  
The common use cases break down to:
- sending authentication headers/cookies with cross-origin requests
- adding custom headers to requests
- altering URLs dynamically

This PR addresses all these concerns by providing a per-map option for a `transformRequest` callback.

### Example usage
```
let Map = new Map({    
  style: 'mapbox://styles/mapbox/streets-v9',
  transformRequest: (url, resourceType) => { 
    if (url.startsWith('http://myHost') {
      return {
        url: url.replace('http:', 'https:'),
        headers: { 'my-custom-header': true},
        withCredentials: true
    }
});
```
----

benchmark | master 93a9922 | 4740-per-map-transform 0933fb7
--- | --- | ---
**map-load** | 160 ms  | 103 ms 
**style-load** | 91 ms  | 80 ms 
**buffer** | 937 ms  | 905 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 6 ms, 0% > 16ms  | 6 ms, 0% > 16ms 
**query-point** | 0.95 ms  | 0.98 ms 
**query-box** | 52.74 ms  | 53.28 ms 
**geojson-setdata-small** | 5 ms  | 4 ms 
**geojson-setdata-large** | 134 ms  | 131 ms 

### Checklist
 - [x] Allow transforming URLs before they are requested #4740 
 - [X] Allow adding custom headers (Similar to #2918, partial of #3123)
 - [x] Allow sending request with cookie/credentials #3874 
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page

// **cc** @anandthakker @jfirebaugh @kkaefer 