### PR TITLE
Check if parentNode exists before trying to removechild.

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -95,7 +95,7 @@ class Popup extends Evented {
             this._content.parentNode.removeChild(this._content);
         }
 
-        if (this._container) {
+        if (this._container && this._container.parentNode) {
             this._container.parentNode.removeChild(this._container);
             delete this._container;
         }


### PR DESCRIPTION
Fixes bug relating to popup removal if popup has already been removed. 

Popups include an option to closeOnClick. If the user manually removes the popup by some other method (a timeout, clicking a clear button etc,), and then clicks the map, the console logs an error because the popup has already been removed:

```
popup.js:99 Uncaught TypeError: Cannot read property 'removeChild' of null
    at o.remove (popup.js:99)
    at o._onClickClose (popup.js:295)
    at e.Evented.fire (evented.js:94)
    at h (bind_handlers.js:138)
    at HTMLDivElement.s (bind_handlers.js:113)
```

Corresponds to #2395 

@jfirebaugh - I tested this locally and it fixed the problem in my code and popups behaved normally otherwise. I'm not familiar enough with the code to know if there's any other functionality that this might interfere with, but seems unlikely given that anything that didn't pass that if statement would error anyways. 