### PR TITLE
Use separate attribute elements for line normals

### DIFF
--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -5,6 +5,7 @@ const createElementArrayType = require('../element_array_type');
 const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
 const vectorTileFeatureTypes = require('@mapbox/vector-tile').VectorTileFeature.types;
+const {packUint8ToFloat} = require('../../shaders/encode_attribute');
 
 import type {BucketParameters} from '../bucket';
 import type {ProgramInterface} from '../program_configuration';
@@ -46,7 +47,7 @@ const MAX_LINE_DISTANCE = Math.pow(2, LINE_DISTANCE_BUFFER_BITS - 1) / LINE_DIST
 
 const lineInterface = {
     layoutAttributes: [
-        {name: 'a_pos_normal', components: 4, type: 'Int16'},
+        {name: 'a_pos_normal', components: 3, type: 'Int16'},
         {name: 'a_data', components: 4, type: 'Uint8'}
     ],
     paintAttributes: [
@@ -66,8 +67,7 @@ function addLineVertex(layoutVertexBuffer, point: Point, extrude: Point, round: 
         // a_pos_normal
         point.x,
         point.y,
-        round ? 1 : 0,
-        up ? 1 : -1,
+        packUint8ToFloat(round ? 1 : 0, up ? 1 : 0),
         // a_data
         // add 128 to store a byte in an unsigned byte
         Math.round(EXTRUDE_SCALE * extrude.x) + 128,

--- a/src/data/extent.js
+++ b/src/data/extent.js
@@ -8,7 +8,8 @@
  *
  * * Vertex buffer store positions as signed 16 bit integers.
  * * One bit is lost for signedness to support tile buffers.
- * * One bit is lost because the line vertex buffer packs 1 bit of other data into the int.
+ * * One bit is lost because the line vertex buffer used to pack 1 bit of other data into the int.
+ *   This is no longer the case but we're reserving this bit anyway.
  * * One bit is lost to support features extending past the extent on the right edge of the tile.
  * * This leaves us with 2^13 = 8192
  *

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -12,7 +12,7 @@
 // #define scale 63.0
 #define scale 0.015873016
 
-attribute vec4 a_pos_normal;
+attribute vec3 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -42,7 +42,12 @@ void main() {
     float a_direction = mod(a_data.z, 4.0) - 1.0;
 
     vec2 pos = a_pos_normal.xy;
-    vec2 normal = a_pos_normal.zw;
+
+    // transform y normal so that 0 => -1 and 1 => 1
+    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // y is 1 if the normal points up, and -1 if it points down
+    mediump vec2 normal = unpack_float(a_pos_normal.z);
+    normal.y = sign(normal.y - 0.5);
 
     v_normal = normal;
 

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -12,7 +12,7 @@
 // #define scale 63.0
 #define scale 0.015873016
 
-attribute vec2 a_pos;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -41,20 +41,16 @@ void main() {
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
 
-    // We store the texture normals in the most insignificant bit
-    // transform y so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
-    // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = mod(a_pos, 2.0);
-    normal.y = sign(normal.y - 0.5);
+    vec2 pos = a_pos_normal.xy;
+    vec2 normal = a_pos_normal.zw;
+
     v_normal = normal;
 
-
-    // these transformations used to be applied in the JS and native code bases. 
-    // moved them into the shader for clarity and simplicity. 
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
     gapwidth = gapwidth / 2.0;
     float halfwidth = width / 2.0;
-    offset = -1.0 * offset; 
+    offset = -1.0 * offset;
 
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
     float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
@@ -70,9 +66,6 @@ void main() {
     mediump float u = 0.5 * a_direction;
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
-
-    // Remove the texture normal bit to get the position
-    vec2 pos = floor(a_pos * 0.5);
 
     vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
     gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;

--- a/src/shaders/line_pattern.vertex.glsl
+++ b/src/shaders/line_pattern.vertex.glsl
@@ -14,7 +14,7 @@
 // Retina devices need a smaller distance to avoid aliasing.
 #define ANTIALIASING 1.0 / DEVICE_PIXEL_RATIO / 2.0
 
-attribute vec2 a_pos;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -43,19 +43,16 @@ void main() {
     float a_direction = mod(a_data.z, 4.0) - 1.0;
     float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
 
-    // We store the texture normals in the most insignificant bit
-    // transform y so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
-    // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = mod(a_pos, 2.0);
-    normal.y = sign(normal.y - 0.5);
+    vec2 pos = a_pos_normal.xy;
+    vec2 normal = a_pos_normal.zw;
+
     v_normal = normal;
 
-    // these transformations used to be applied in the JS and native code bases. 
-    // moved them into the shader for clarity and simplicity. 
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
     gapwidth = gapwidth / 2.0;
     float halfwidth = width / 2.0;
-    offset = -1.0 * offset; 
+    offset = -1.0 * offset;
 
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
     float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
@@ -71,9 +68,6 @@ void main() {
     mediump float u = 0.5 * a_direction;
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
-
-    // Remove the texture normal bit to get the position
-    vec2 pos = floor(a_pos * 0.5);
 
     vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
     gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;

--- a/src/shaders/line_pattern.vertex.glsl
+++ b/src/shaders/line_pattern.vertex.glsl
@@ -14,7 +14,7 @@
 // Retina devices need a smaller distance to avoid aliasing.
 #define ANTIALIASING 1.0 / DEVICE_PIXEL_RATIO / 2.0
 
-attribute vec4 a_pos_normal;
+attribute vec3 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -44,7 +44,12 @@ void main() {
     float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
 
     vec2 pos = a_pos_normal.xy;
-    vec2 normal = a_pos_normal.zw;
+
+    // transform y normal so that 0 => -1 and 1 => 1
+    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // y is 1 if the normal points up, and -1 if it points down
+    mediump vec2 normal = unpack_float(a_pos_normal.z);
+    normal.y = sign(normal.y - 0.5);
 
     v_normal = normal;
 

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -14,7 +14,7 @@
 // Retina devices need a smaller distance to avoid aliasing.
 #define ANTIALIASING 1.0 / DEVICE_PIXEL_RATIO / 2.0
 
-attribute vec2 a_pos;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -52,20 +52,17 @@ void main() {
     float a_direction = mod(a_data.z, 4.0) - 1.0;
     float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
 
-    // We store the texture normals in the most insignificant bit
-    // transform y so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
-    // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = mod(a_pos, 2.0);
-    normal.y = sign(normal.y - 0.5);
+    vec2 pos = a_pos_normal.xy;
+    vec2 normal = a_pos_normal.zw;
+
     v_normal = normal;
 
-    // these transformations used to be applied in the JS and native code bases. 
-    // moved them into the shader for clarity and simplicity. 
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
     gapwidth = gapwidth / 2.0;
     float halfwidth = width / 2.0;
     offset = -1.0 * offset;
- 
+
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
     float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
 
@@ -80,9 +77,6 @@ void main() {
     mediump float u = 0.5 * a_direction;
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
-
-    // Remove the texture normal bit to get the position
-    vec2 pos = floor(a_pos * 0.5);
 
     vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
     gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -14,7 +14,7 @@
 // Retina devices need a smaller distance to avoid aliasing.
 #define ANTIALIASING 1.0 / DEVICE_PIXEL_RATIO / 2.0
 
-attribute vec4 a_pos_normal;
+attribute vec3 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -53,7 +53,12 @@ void main() {
     float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
 
     vec2 pos = a_pos_normal.xy;
-    vec2 normal = a_pos_normal.zw;
+
+    // transform y normal so that 0 => -1 and 1 => 1
+    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // y is 1 if the normal points up, and -1 if it points down
+    mediump vec2 normal = unpack_float(a_pos_normal.z);
+    normal.y = sign(normal.y - 0.5);
 
     v_normal = normal;
 


### PR DESCRIPTION
Broadcom GPUs don't cope well with using the least significant bit for this.

Refs https://github.com/mapbox/mapbox-gl-native/issues/7583.