### PR TITLE
Fix invalid css keyframes selector

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -132,7 +132,7 @@
     0% { -ms-transform: rotate(0deg); }
     100% { -ms-transform: rotate(360deg); }
 }
-@-keyframes mapboxgl-spin {
+@keyframes mapboxgl-spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }


### PR DESCRIPTION
The `mapboxgl-spin` keyframes selector currently has a hyphen before it i.e. `@-keyframes`, but that's not the correct syntax. It should be just `@keyframes`.