### PR TITLE
Added 'recycleMap' as part of renderFn test suite params

### DIFF
--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -74,6 +74,7 @@ module.exports = function (directory, implementation, options, run) {
                 width: 512,
                 height: 512,
                 pixelRatio: 1,
+                recycleMap: options.recycleMap || false,
                 allowed: 0.00015
             }, style.metadata && style.metadata.test, {ignored});
 

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -59,6 +59,8 @@ function compare(path1, path2, diffPath, callback) {
  * disabled tests will be run, but not fail the test run if the result does not match the expected
  * result. If the value begins with "skip", the test will not be run at all -- use this for tests
  * that would crash the test harness entirely if they were run.
+ * @param {Object<boolean>} [options.recycleMap] - Boolean representing whether
+ * or not to recycle the Map object when running the tests.
  * @param {renderFn} render - a function that performs the rendering
  * @returns {undefined} terminates the process when testing is complete
  */
@@ -132,6 +134,7 @@ exports.run = function (implementation, options, render) {
  * @param {number} options.width - render this wide
  * @param {number} options.height - render this high
  * @param {number} options.pixelRatio - render with this pixel ratio
+ * @param {boolean} options.recycleMap - trigger map object recycling
  * @param {renderCallback} callback - callback to call with the results of rendering
  */
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -7,9 +7,15 @@ const suiteImplementation = require('./suite_implementation');
 const ignores = require('./ignores.json');
 
 let tests;
+let recycleMap = false;
 
 if (process.argv[1] === __filename && process.argv.length > 2) {
-    tests = process.argv.slice(2);
+    if (process.argv[2] === '--recycle-map') {
+        recycleMap = true;
+        tests = process.argv.slice(3);
+    } else {
+        tests = process.argv.slice(2);
+    }
 }
 
-renderSuite.run('js', {tests, ignores}, suiteImplementation);
+renderSuite.run('js', {tests, ignores, recycleMap}, suiteImplementation);


### PR DESCRIPTION
This is needed by GL native in order to enable render test executions that recycles the Map object.