### PR TITLE
Fix initialization of CollisionTile causing exception

### DIFF
--- a/src/symbol/collision_tile.js
+++ b/src/symbol/collision_tile.js
@@ -4,6 +4,7 @@ const Point = require('@mapbox/point-geometry');
 const EXTENT = require('../data/extent');
 const Grid = require('grid-index');
 const intersectionTests = require('../util/intersection_tests');
+const CollisionBoxArray = require('../symbol/collision_box');
 
 import type CollisionBoxArray, {CollisionBox} from './collision_box';
 

--- a/src/symbol/collision_tile.js
+++ b/src/symbol/collision_tile.js
@@ -92,6 +92,10 @@ class CollisionTile {
         // boxes at render time.
         this.yStretch = Math.max(1, cameraToTileDistance / (cameraToCenterDistance * Math.cos(pitch / 180 * Math.PI)));
 
+        if (!collisionBoxArray) {
+            // If collisionBoxArray was not initialize, create a new object
+            collisionBoxArray = new CollisionBoxArray();
+        }
         this.collisionBoxArray = collisionBoxArray;
         if (collisionBoxArray.length === 0) {
             // the first time collisionBoxArray is passed to a CollisionTile


### PR DESCRIPTION
In the constructor for a CollisionTile, if the collisionBoxArray parameter passed in was null or undefined, the constructor will throw an exception of length is not defined for null.  Since the code is later initializing to a temporary CollisionBox, create a temporary collisionBoxArray so code can continue without exception.

The problem I was running into is that a javascript exception was being thrown, although the code continued to appear to work.  The source of the problem was the Tile.loadVectorData() function.  The Tile object can be created without a collisionBoxArray member, which is only later initialized when loadVectorData() is called.  The slightly strange thing is in Tile.js:119, a Tile can be set this.state = 'loaded' even though the this.collisionTitle and this.collisionBoxArray parameters are never initialized.  (in the case the data parameter passed in is null/undefined).  It would seem better to initialize these members to default values in the constructor or not allow the state to be loaded if these are not set.  Otherwise, all functions/objects have to handle the case where the values may be null/undefined (such as I pointed out above).

Since this is a very minor change and could not really cause a side-effect, I did not run all your build checks and unit tests.  My apologies.
