### PR TITLE
Test that Popup#remove is idempotent

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -227,8 +227,8 @@ class Popup extends Evented {
     }
 
     _createContent() {
-        if (this._content && this._content.parentNode) {
-            this._content.parentNode.removeChild(this._content);
+        if (this._content) {
+            DOM.remove(this._content);
         }
 
         this._content = DOM.create('div', 'mapboxgl-popup-content', this._container);

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -419,3 +419,17 @@ test('Popup#addTo is idempotent (#1811)', (t) => {
     t.equal(map.getContainer().querySelector('.mapboxgl-popup-content').textContent, "Test");
     t.end();
 });
+
+test('Popup#remove is idempotent (#2395)', (t) => {
+    const map = createMap();
+
+    new Popup({closeButton: false})
+        .setText("Test")
+        .setLngLat([0, 0])
+        .addTo(map)
+        .remove()
+        .remove();
+
+    t.equal(map.getContainer().querySelectorAll('.mapboxgl-popup').length, 0);
+    t.end();
+});


### PR DESCRIPTION
Adds a test for https://github.com/mapbox/mapbox-gl-js/issues/2395. The issue itself was fixed in 65afc08ef02f5eb2081c2e3ee83f23e61722ac14.

While here, use `DOM.remove` in one more place.