### PR TITLE
Added diffs caused by GL driver implementation

### DIFF
--- a/test/integration/render-tests/fill-outline-color/fill/style.json
+++ b/test/integration/render-tests/fill-outline-color/fill/style.json
@@ -3,7 +3,8 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64
+      "height": 64,
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/fill-outline-color/function/style.json
+++ b/test/integration/render-tests/fill-outline-color/function/style.json
@@ -3,7 +3,8 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64
+      "height": 64,
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/fill-outline-color/literal/style.json
+++ b/test/integration/render-tests/fill-outline-color/literal/style.json
@@ -3,7 +3,8 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64
+      "height": 64,
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/fill-outline-color/opacity/style.json
+++ b/test/integration/render-tests/fill-outline-color/opacity/style.json
@@ -3,7 +3,8 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64
+      "height": 64,
+      "diff": 0.00075
     }
   },
   "sources": {

--- a/test/integration/render-tests/fill-outline-color/zoom-and-property-function/style.json
+++ b/test/integration/render-tests/fill-outline-color/zoom-and-property-function/style.json
@@ -3,7 +3,8 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64
+      "height": 64,
+      "diff": 0.00075
     }
   },
   "zoom": 0.1,

--- a/test/integration/render-tests/regressions/mapbox-gl-js#4647/style.json
+++ b/test/integration/render-tests/regressions/mapbox-gl-js#4647/style.json
@@ -4,6 +4,7 @@
     "test": {
       "height": 64,
       "width": 64,
+      "diff": 0.001,
       "collisionDebug":true
     }
   },


### PR DESCRIPTION
Affected render tests:

| Render test | Diff | Diff (Image) |
|-----------------|------|------------------|
| fill-outline-color/fill | 0.000244140625 | ![diff](https://user-images.githubusercontent.com/76133/29068105-0ab27f2a-7c3e-11e7-9d5e-f8b6e470d7c3.png) |
| fill-outline-color/function | 0.00048828125 | ![diff](https://user-images.githubusercontent.com/76133/29068150-38de2570-7c3e-11e7-8c5f-01c9c38f1154.png) |
| fill-outline-color/literal | 0.00048828125 | ![diff](https://user-images.githubusercontent.com/76133/29068193-6124a630-7c3e-11e7-9e58-7f3fa4327c39.png) |
| fill-outline-color/opacity | 0.000488281252 | ![diff](https://user-images.githubusercontent.com/76133/29068222-7ceae802-7c3e-11e7-80c9-cfeccde3460c.png) |
| fill-outline-color/zoom-and-property-function | 0.00048828125 | ![diff](https://user-images.githubusercontent.com/76133/29068235-8efc2196-7c3e-11e7-9379-0f758ba64b17.png) |
| regressions/mapbox-gl-js#4647 | 0.0009765625 | ![diff](https://user-images.githubusercontent.com/76133/29068342-049b6aec-7c3f-11e7-9339-5cfc259eb717.png) |



