### PR TITLE
Remove diff handicap for text-pitch-{alignment,scaling} render tests

### DIFF
--- a/test/ignores.json
+++ b/test/ignores.json
@@ -15,5 +15,8 @@
   "render-tests/raster-masking/overlapping": "https://github.com/mapbox/mapbox-gl-js/issues/5003",
   "render-tests/regressions/mapbox-gl-js#3682": "skip - true",
   "render-tests/runtime-styling/image-update-icon": "skip - https://github.com/mapbox/mapbox-gl-js/issues/4804",
-  "render-tests/runtime-styling/image-update-pattern": "skip - https://github.com/mapbox/mapbox-gl-js/issues/4804"
+  "render-tests/runtime-styling/image-update-pattern": "skip - https://github.com/mapbox/mapbox-gl-js/issues/4804",
+  "render-tests/text-pitch-alignment/auto-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-js/issues/5118",
+  "render-tests/text-pitch-alignment/map-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-js/issues/5118",
+  "render-tests/text-pitch-scaling/line-half": "https://github.com/mapbox/mapbox-gl-js/issues/5118"
 }

--- a/test/integration/render-tests/text-pitch-alignment/auto-text-rotation-alignment-map/style.json
+++ b/test/integration/render-tests/text-pitch-alignment/auto-text-rotation-alignment-map/style.json
@@ -2,7 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "allowed": 0.005,
       "height": 256
     }
   },

--- a/test/integration/render-tests/text-pitch-alignment/auto-text-rotation-alignment-viewport/style.json
+++ b/test/integration/render-tests/text-pitch-alignment/auto-text-rotation-alignment-viewport/style.json
@@ -2,7 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "allowed": 0.005,
       "height": 256
     }
   },

--- a/test/integration/render-tests/text-pitch-alignment/map-text-rotation-alignment-map/style.json
+++ b/test/integration/render-tests/text-pitch-alignment/map-text-rotation-alignment-map/style.json
@@ -2,7 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "allowed": 0.005,
       "height": 256
     }
   },

--- a/test/integration/render-tests/text-pitch-alignment/map-text-rotation-alignment-viewport/style.json
+++ b/test/integration/render-tests/text-pitch-alignment/map-text-rotation-alignment-viewport/style.json
@@ -2,7 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "allowed": 0.005,
       "height": 256
     }
   },

--- a/test/integration/render-tests/text-pitch-alignment/viewport-text-rotation-alignment-map/style.json
+++ b/test/integration/render-tests/text-pitch-alignment/viewport-text-rotation-alignment-map/style.json
@@ -2,7 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "allowed": 0.005,
       "height": 256
     }
   },

--- a/test/integration/render-tests/text-pitch-alignment/viewport-text-rotation-alignment-viewport/style.json
+++ b/test/integration/render-tests/text-pitch-alignment/viewport-text-rotation-alignment-viewport/style.json
@@ -2,7 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "allowed": 0.005,
       "height": 256
     }
   },

--- a/test/integration/render-tests/text-pitch-scaling/line-half/style.json
+++ b/test/integration/render-tests/text-pitch-scaling/line-half/style.json
@@ -2,7 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {  
-      "allowed": 0.005,
       "height": 512
     }
   },


### PR DESCRIPTION
These tests should fail in GL native, as per https://github.com/mapbox/mapbox-gl-native/issues/9732.