### PR TITLE
Fix erroneous validation error caused by usage in environment with extended prototypes

### DIFF
--- a/src/style-spec/validate/validate_layer.js
+++ b/src/style-spec/validate/validate_layer.js
@@ -31,9 +31,9 @@ module.exports = function validateLayer(options) {
         }
     }
 
-    if ('ref' in layer) {
+    if (layer.hasOwnProperty('ref')) {
         ['type', 'source', 'source-layer', 'filter', 'layout'].forEach((p) => {
-            if (p in layer) {
+            if (layer.hasOwnProperty(p)) {
                 errors.push(new ValidationError(key, layer[p], '"%s" is prohibited for ref layers', p));
             }
         });


### PR DESCRIPTION
`a in b` returns `true` if `a` is defined as a key in object `b` or if it's defined as a key anywhere in `b`'s prototype chain.

This is probably not the intention here, and it is causing errors in my environment (where `Object.prototype.filter` is defined).

Please let me know if there's anywhere else this change should be made.