### PR TITLE
More flow

### DIFF
--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -160,29 +160,3 @@ module.exports = function bindHandlers(map: Map, options: {}) {
         });
     }
 };
-
-/**
- * @typedef {Object} MapMouseEvent
- * @property {string} type The event type.
- * @property {Map} target The `Map` object that fired the event.
- * @property {MouseEvent} originalEvent
- * @property {Point} point The pixel coordinates of the mouse event target, relative to the map
- *   and measured from the top left corner.
- * @property {LngLat} lngLat The geographic location on the map of the mouse event target.
- */
-
-/**
- * @typedef {Object} MapTouchEvent
- * @property {string} type The event type.
- * @property {Map} target The `Map` object that fired the event.
- * @property {TouchEvent} originalEvent
- * @property {Point} point The pixel coordinates of the center of the touch event points, relative to the map
- *   and measured from the top left corner.
- * @property {LngLat} lngLat The geographic location on the map of the center of the touch event points.
- * @property {Array<Point>} points The array of pixel coordinates corresponding to
- *   a [touch event's `touches`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches)
- *   property.
- * @property {Array<LngLat>} lngLats The geographical locations on the map corresponding to
- *   a [touch event's `touches`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches)
- *   property.
- */

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -928,33 +928,4 @@ class Camera extends Evented {
     }
 }
 
-/**
- * Fired whenever the map's pitch (tilt) begins a change as
- * the result of either user interaction or methods such as {@link Map#flyTo} .
- *
- * @event pitchstart
- * @memberof Map
- * @instance
- * @property {MapEventData} data
- */
-
-/**
- * Fired whenever the map's pitch (tilt) changes as.
- * the result of either user interaction or methods such as {@link Map#flyTo}.
- *
- * @event pitch
- * @memberof Map
- * @instance
- * @property {MapEventData} data
- */
-
-/**
- * Fired immediately after the map's pitch (tilt) finishes changing as
- * the result of either user interaction or methods such as {@link Map#flyTo}.
- *
- * @event pitchend
- * @memberof Map
- * @instance
- * @property {MapEventData} data
- */
 module.exports = Camera;

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -162,8 +162,39 @@ export type MapEvent =
      */
     | 'dblclick'
 
+    /**
+     * Fired when a pointing device (usually a mouse) enters a visible portion of a specified layer from
+     * outside that layer or outside the map canvas. This event can only be listened for via the three-argument
+     * version of {@link Map#on}, where the second argument specifies the desired layer.
+     *
+     * @event mouseenter
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     */
     | 'mouseenter'
+
+    /**
+     * Fired when a pointing device (usually a mouse) leaves a visible portion of a specified layer, or leaves
+     * the map canvas. This event can only be listened for via the three-argument version of {@link Map#on},
+     * where the second argument specifies the desired layer.
+     *
+     * @event mouseleave
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
+     */
     | 'mouseleave'
+
+    /**
+     * Synonym for `mouseenter`.
+     *
+     * @event mouseover
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     */
     | 'mouseover'
 
     /**
@@ -173,7 +204,6 @@ export type MapEvent =
      * @memberof Map
      * @instance
      * @property {MapMouseEvent} data
-     * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
      */
     | 'mouseout'
 

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -1,0 +1,576 @@
+// @flow
+
+import type Map from './map';
+import type Point from '@mapbox/point-geometry';
+import type LngLat from '../geo/lng_lat';
+import type LngLatBounds from '../geo/lng_lat_bounds';
+
+/**
+ * @typedef {Object} MapMouseEvent
+ * @property {string} type The event type.
+ * @property {Map} target The `Map` object that fired the event.
+ * @property {MouseEvent} originalEvent
+ * @property {Point} point The pixel coordinates of the mouse event target, relative to the map
+ *   and measured from the top left corner.
+ * @property {LngLat} lngLat The geographic location on the map of the mouse event target.
+ */
+export type MapMouseEvent = {
+    type: 'mousedown'
+        | 'mouseup'
+        | 'click'
+        | 'dblclick'
+        | 'mousemove'
+        | 'mouseenter'
+        | 'mouseleave'
+        | 'mouseover'
+        | 'mouseout'
+        | 'contextmenu',
+    map: Map,
+    originalEvent: MouseEvent,
+    point: Point,
+    lngLat: LngLat
+};
+
+/**
+ * @typedef {Object} MapTouchEvent
+ * @property {string} type The event type.
+ * @property {Map} target The `Map` object that fired the event.
+ * @property {TouchEvent} originalEvent
+ * @property {Point} point The pixel coordinates of the center of the touch event points, relative to the map
+ *   and measured from the top left corner.
+ * @property {LngLat} lngLat The geographic location on the map of the center of the touch event points.
+ * @property {Array<Point>} points The array of pixel coordinates corresponding to
+ *   a [touch event's `touches`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches)
+ *   property.
+ * @property {Array<LngLat>} lngLats The geographical locations on the map corresponding to
+ *   a [touch event's `touches`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches)
+ *   property.
+ */
+export type MapTouchEvent = {
+    type: 'touchstart'
+        | 'touchend'
+        | 'touchcancel',
+    map: Map,
+    originalEvent: TouchEvent,
+    lngLat: LngLat,
+    points: Array<Point>,
+    lngLats: Array<LngLat>
+};
+
+/**
+ * @typedef {Object} MapBoxZoomEvent
+ * @property {MouseEvent} originalEvent
+ * @property {LngLatBounds} boxZoomBounds The bounding box of the "box zoom" interaction.
+ *   This property is only provided for `boxzoomend` events.
+ */
+export type MapBoxZoomEvent = {
+    type: 'boxzoomstart'
+        | 'boxzoomend'
+        | 'boxzoomcancel',
+    map: Map,
+    originalEvent: MouseEvent,
+    boxZoomBounds: LngLatBounds
+};
+
+/**
+ * A `MapDataEvent` object is emitted with the {@link Map.event:data}
+ * and {@link Map.event:dataloading} events. Possible values for
+ * `dataType`s are:
+ *
+ * - `'source'`: The non-tile data associated with any source
+ * - `'style'`: The [style](https://www.mapbox.com/mapbox-gl-style-spec/) used by the map
+ *
+ * @typedef {Object} MapDataEvent
+ * @property {string} type The event type.
+ * @property {string} dataType The type of data that has changed. One of `'source'`, `'style'`.
+ * @property {boolean} [isSourceLoaded] True if the event has a `dataType` of `source` and the source has no outstanding network requests.
+ * @property {Object} [source] The [style spec representation of the source](https://www.mapbox.com/mapbox-gl-style-spec/#sources) if the event has a `dataType` of `source`.
+ * @property {string} [sourceDataType] Included if the event has a `dataType` of `source` and the event signals
+ * that internal data has been received or changed. Possible values are `metadata` and `content`.
+ * @property {Object} [tile] The tile being loaded or changed, if the event has a `dataType` of `source` and
+ * the event is related to loading of a tile.
+ * @property {Coordinate} [coord] The coordinate of the tile if the event has a `dataType` of `source` and
+ * the event is related to loading of a tile.
+ */
+export type MapDataEvent = {
+    type: string,
+    dataType: string
+};
+
+export type MapContextEvent = {
+    type: 'webglcontextlost' | 'webglcontextrestored',
+    originalEvent: WebGLContextEvent
+}
+
+export type MapEvent =
+    /**
+     * Fired when a pointing device (usually a mouse) is pressed within the map.
+     *
+     * @event mousedown
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
+     * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     */
+    | 'mousedown'
+
+    /**
+     * Fired when a pointing device (usually a mouse) is released within the map.
+     *
+     * @event mouseup
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
+     * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     */
+    | 'mouseup'
+
+    /**
+     * Fired when a pointing device (usually a mouse) is moved within the map.
+     *
+     * @event mousemove
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
+     * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
+     * @see [Display a popup on hover](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
+     */
+    | 'mousemove'
+
+    /**
+     * Fired when a pointing device (usually a mouse) is pressed and released at the same point on the map.
+     *
+     * @event click
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     * @see [Measure distances](https://www.mapbox.com/mapbox-gl-js/example/measure/)
+     * @see [Center the map on a clicked symbol](https://www.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
+     */
+    | 'click'
+
+    /**
+     * Fired when a pointing device (usually a mouse) is clicked twice at the same point on the map.
+     *
+     * @event dblclick
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     */
+    | 'dblclick'
+
+    | 'mouseenter'
+    | 'mouseleave'
+    | 'mouseover'
+
+    /**
+     * Fired when a point device (usually a mouse) leaves the map's canvas.
+     *
+     * @event mouseout
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
+     */
+    | 'mouseout'
+
+    /**
+     * Fired when the right button of the mouse is clicked or the context menu key is pressed within the map.
+     *
+     * @event contextmenu
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent} data
+     */
+    | 'contextmenu'
+
+    /**
+     * Fired when a touch point is placed on the map.
+     *
+     * @event touchstart
+     * @memberof Map
+     * @instance
+     * @property {MapTouchEvent} data
+     */
+    | 'touchstart'
+
+    /**
+     * Fired when a touch point is removed from the map.
+     *
+     * @event touchend
+     * @memberof Map
+     * @instance
+     * @property {MapTouchEvent} data
+     */
+    | 'touchend'
+
+    /**
+     * Fired when a touch point is moved within the map.
+     *
+     * @event touchmove
+     * @memberof Map
+     * @instance
+     * @property {MapTouchEvent} data
+     */
+    | 'touchmove'
+
+    /**
+     * Fired when a touch point has been disrupted.
+     *
+     * @event touchcancel
+     * @memberof Map
+     * @instance
+     * @property {MapTouchEvent} data
+     */
+    | 'touchcancel'
+
+    /**
+     * Fired just before the map begins a transition from one
+     * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.
+     *
+     * @event movestart
+     * @memberof Map
+     * @instance
+     * @property {{originalEvent: DragEvent}} data
+     */
+    | 'movestart'
+
+    /**
+     * Fired repeatedly during an animated transition from one view to
+     * another, as the result of either user interaction or methods such as {@link Map#flyTo}.
+     *
+     * @event move
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent | MapTouchEvent} data
+     */
+    | 'move'
+
+    /**
+     * Fired just after the map completes a transition from one
+     * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.
+     *
+     * @event moveend
+     * @memberof Map
+     * @instance
+     * @property {{originalEvent: DragEvent}} data
+     * @see [Play map locations as a slideshow](https://www.mapbox.com/mapbox-gl-js/example/playback-locations/)
+     * @see [Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
+     */
+    | 'moveend'
+
+    /**
+     * Fired when a "drag to pan" interaction starts. See {@link DragPanHandler}.
+     *
+     * @event dragstart
+     * @memberof Map
+     * @instance
+     * @property {{originalEvent: DragEvent}} data
+     */
+    | 'dragstart'
+
+    /**
+     * Fired repeatedly during a "drag to pan" interaction. See {@link DragPanHandler}.
+     *
+     * @event drag
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent | MapTouchEvent} data
+     */
+    | 'drag'
+
+    /**
+     * Fired when a "drag to pan" interaction ends. See {@link DragPanHandler}.
+     *
+     * @event dragend
+     * @memberof Map
+     * @instance
+     * @property {{originalEvent: DragEvent}} data
+     */
+    | 'dragend'
+
+    /**
+     * Fired just before the map begins a transition from one zoom level to another,
+     * as the result of either user interaction or methods such as {@link Map#flyTo}.
+     *
+     * @event zoomstart
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent | MapTouchEvent} data
+     */
+    | 'zoomstart'
+
+    /**
+     * Fired repeatedly during an animated transition from one zoom level to another,
+     * as the result of either user interaction or methods such as {@link Map#flyTo}.
+     *
+     * @event zoom
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent | MapTouchEvent} data
+     * @see [Update a choropleth layer by zoom level](https://www.mapbox.com/mapbox-gl-js/example/updating-choropleth/)
+     */
+    | 'zoom'
+
+    /**
+     * Fired just after the map completes a transition from one zoom level to another,
+     * as the result of either user interaction or methods such as {@link Map#flyTo}.
+     *
+     * @event zoomend
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent | MapTouchEvent} data
+     */
+    | 'zoomend'
+
+    /**
+     * Fired when a "drag to rotate" interaction starts. See {@link DragRotateHandler}.
+     *
+     * @event rotatestart
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent | MapTouchEvent} data
+     */
+    | 'rotatestart'
+
+    /**
+     * Fired repeatedly during a "drag to rotate" interaction. See {@link DragRotateHandler}.
+     *
+     * @event rotate
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent | MapTouchEvent} data
+     */
+    | 'rotate'
+
+    /**
+     * Fired when a "drag to rotate" interaction ends. See {@link DragRotateHandler}.
+     *
+     * @event rotateend
+     * @memberof Map
+     * @instance
+     * @property {MapMouseEvent | MapTouchEvent} data
+     */
+    | 'rotateend'
+
+    /**
+     * Fired whenever the map's pitch (tilt) begins a change as
+     * the result of either user interaction or methods such as {@link Map#flyTo} .
+     *
+     * @event pitchstart
+     * @memberof Map
+     * @instance
+     * @property {MapEventData} data
+     */
+    | 'pitchstart'
+
+    /**
+     * Fired whenever the map's pitch (tilt) changes as.
+     * the result of either user interaction or methods such as {@link Map#flyTo}.
+     *
+     * @event pitch
+     * @memberof Map
+     * @instance
+     * @property {MapEventData} data
+     */
+    | 'pitch'
+
+    /**
+     * Fired immediately after the map's pitch (tilt) finishes changing as
+     * the result of either user interaction or methods such as {@link Map#flyTo}.
+     *
+     * @event pitchend
+     * @memberof Map
+     * @instance
+     * @property {MapEventData} data
+     */
+    | 'pitchend'
+
+    /**
+     * Fired when a "box zoom" interaction starts. See {@link BoxZoomHandler}.
+     *
+     * @event boxzoomstart
+     * @memberof Map
+     * @instance
+     * @property {MapBoxZoomEvent} data
+     */
+    | 'boxzoomstart'
+
+    /**
+     * Fired when a "box zoom" interaction ends.  See {@link BoxZoomHandler}.
+     *
+     * @event boxzoomend
+     * @memberof Map
+     * @instance
+     * @type {Object}
+     * @property {MapBoxZoomEvent} data
+     */
+    | 'boxzoomend'
+
+    /**
+     * Fired when the user cancels a "box zoom" interaction, or when the bounding box does not meet the minimum size threshold.
+     * See {@link BoxZoomHandler}.
+     *
+     * @event boxzoomcancel
+     * @memberof Map
+     * @instance
+     * @property {MapBoxZoomEvent} data
+     */
+    | 'boxzoomcancel'
+
+    /**
+     * Fired immediately after the map has been resized.
+     *
+     * @event resize
+     * @memberof Map
+     * @instance
+     */
+    | 'resize'
+
+    /**
+     * Fired when the WebGL context is lost.
+     *
+     * @event webglcontextlost
+     * @memberof Map
+     * @instance
+     */
+    | 'webglcontextlost'
+
+    /**
+     * Fired when the WebGL context is restored.
+     *
+     * @event webglcontextrestored
+     * @memberof Map
+     * @instance
+     */
+    | 'webglcontextrestored'
+
+    /**
+     * Fired immediately after all necessary resources have been downloaded
+     * and the first visually complete rendering of the map has occurred.
+     *
+     * @event load
+     * @memberof Map
+     * @instance
+     * @type {Object}
+     * @see [Draw GeoJSON points](https://www.mapbox.com/mapbox-gl-js/example/geojson-markers/)
+     * @see [Add live realtime data](https://www.mapbox.com/mapbox-gl-js/example/live-geojson/)
+     * @see [Animate a point](https://www.mapbox.com/mapbox-gl-js/example/animate-point-along-line/)
+     */
+    | 'load'
+
+    /**
+     * Fired whenever the map is drawn to the screen, as the result of
+     *
+     * - a change to the map's position, zoom, pitch, or bearing
+     * - a change to the map's style
+     * - a change to a GeoJSON source
+     * - the loading of a vector tile, GeoJSON file, glyph, or sprite
+     *
+     * @event render
+     * @memberof Map
+     * @instance
+     */
+    | 'render'
+
+    /**
+     * Fired immediately after the map has been removed with {@link Map.event:remove}.
+     *
+     * @event remove
+     * @memberof Map
+     * @instance
+     */
+    | 'remove'
+
+    /**
+     * Fired when an error occurs. This is GL JS's primary error reporting
+     * mechanism. We use an event instead of `throw` to better accommodate
+     * asyncronous operations. If no listeners are bound to the `error` event, the
+     * error will be printed to the console.
+     *
+     * @event error
+     * @memberof Map
+     * @instance
+     * @property {{error: {message: string}}} data
+     */
+    | 'error'
+
+    /**
+     * Fired when any map data loads or changes. See {@link MapDataEvent}
+     * for more information.
+     *
+     * @event data
+     * @memberof Map
+     * @instance
+     * @property {MapDataEvent} data
+     */
+    | 'data'
+
+    /**
+     * Fired when the map's style loads or changes. See
+     * {@link MapDataEvent} for more information.
+     *
+     * @event styledata
+     * @memberof Map
+     * @instance
+     * @property {MapDataEvent} data
+     */
+    | 'styledata'
+
+    /**
+     * Fired when one of the map's sources loads or changes, including if a tile belonging
+     * to a source loads or changes. See {@link MapDataEvent} for more information.
+     *
+     * @event sourcedata
+     * @memberof Map
+     * @instance
+     * @property {MapDataEvent} data
+     */
+    | 'sourcedata'
+
+    /**
+     * Fired when any map data (style, source, tile, etc) begins loading or
+     * changing asyncronously. All `dataloading` events are followed by a `data`
+     * or `error` event. See {@link MapDataEvent} for more information.
+     *
+     * @event dataloading
+     * @memberof Map
+     * @instance
+     * @property {MapDataEvent} data
+     */
+    | 'dataloading'
+
+    /**
+     * Fired when the map's style begins loading or changing asyncronously.
+     * All `styledataloading` events are followed by a `styledata`
+     * or `error` event. See {@link MapDataEvent} for more information.
+     *
+     * @event styledataloading
+     * @memberof Map
+     * @instance
+     * @property {MapDataEvent} data
+     */
+    | 'styledataloading'
+
+    /**
+     * Fired when one of the map's sources begins loading or changing asyncronously.
+     * All `sourcedataloading` events are followed by a `sourcedata` or `error` event.
+     * See {@link MapDataEvent} for more information.
+     *
+     * @event sourcedataloading
+     * @memberof Map
+     * @instance
+     * @property {MapDataEvent} data
+     */
+    | 'sourcedataloading'
+
+    /**
+     * @event style.load
+     * @memberof Map
+     * @instance
+     * @private
+     */
+    | 'style.load';

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -167,39 +167,3 @@ class BoxZoomHandler {
 }
 
 module.exports = BoxZoomHandler;
-
-/**
- * @typedef {Object} MapBoxZoomEvent
- * @property {MouseEvent} originalEvent
- * @property {LngLatBounds} boxZoomBounds The bounding box of the "box zoom" interaction.
- *   This property is only provided for `boxzoomend` events.
- */
-
-/**
- * Fired when a "box zoom" interaction starts. See {@link BoxZoomHandler}.
- *
- * @event boxzoomstart
- * @memberof Map
- * @instance
- * @property {MapBoxZoomEvent} data
- */
-
-/**
- * Fired when a "box zoom" interaction ends.  See {@link BoxZoomHandler}.
- *
- * @event boxzoomend
- * @memberof Map
- * @instance
- * @type {Object}
- * @property {MapBoxZoomEvent} data
- */
-
-/**
- * Fired when the user cancels a "box zoom" interaction, or when the bounding box does not meet the minimum size threshold.
- * See {@link BoxZoomHandler}.
- *
- * @event boxzoomcancel
- * @memberof Map
- * @instance
- * @property {MapBoxZoomEvent} data
- */

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -223,30 +223,3 @@ class DragPanHandler {
 }
 
 module.exports = DragPanHandler;
-
-/**
- * Fired when a "drag to pan" interaction starts. See {@link DragPanHandler}.
- *
- * @event dragstart
- * @memberof Map
- * @instance
- * @property {{originalEvent: DragEvent}} data
- */
-
-/**
- * Fired repeatedly during a "drag to pan" interaction. See {@link DragPanHandler}.
- *
- * @event drag
- * @memberof Map
- * @instance
- * @property {MapMouseEvent | MapTouchEvent} data
- */
-
-/**
- * Fired when a "drag to pan" interaction ends. See {@link DragPanHandler}.
- *
- * @event dragend
- * @memberof Map
- * @instance
- * @property {{originalEvent: DragEvent}} data
- */

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -249,30 +249,3 @@ class DragRotateHandler {
 }
 
 module.exports = DragRotateHandler;
-
-/**
- * Fired when a "drag to rotate" interaction starts. See {@link DragRotateHandler}.
- *
- * @event rotatestart
- * @memberof Map
- * @instance
- * @property {MapMouseEvent | MapTouchEvent} data
- */
-
-/**
- * Fired repeatedly during a "drag to rotate" interaction. See {@link DragRotateHandler}.
- *
- * @event rotate
- * @memberof Map
- * @instance
- * @property {MapMouseEvent | MapTouchEvent} data
- */
-
-/**
- * Fired when a "drag to rotate" interaction ends. See {@link DragRotateHandler}.
- *
- * @event rotateend
- * @memberof Map
- * @instance
- * @property {MapMouseEvent | MapTouchEvent} data
- */

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -164,34 +164,3 @@ class ScrollZoomHandler {
 }
 
 module.exports = ScrollZoomHandler;
-
-/**
- * Fired just before the map begins a transition from one zoom level to another,
- * as the result of either user interaction or methods such as {@link Map#flyTo}.
- *
- * @event zoomstart
- * @memberof Map
- * @instance
- * @property {MapMouseEvent | MapTouchEvent} data
- */
-
-/**
- * Fired repeatedly during an animated transition from one zoom level to another,
- * as the result of either user interaction or methods such as {@link Map#flyTo}.
- *
- * @event zoom
- * @memberof Map
- * @instance
- * @property {MapMouseEvent | MapTouchEvent} data
- * @see [Update a choropleth layer by zoom level](https://www.mapbox.com/mapbox-gl-js/example/updating-choropleth/)
- */
-
-/**
- * Fired just after the map completes a transition from one zoom level to another,
- * as the result of either user interaction or methods such as {@link Map#flyTo}.
- *
- * @event zoomend
- * @memberof Map
- * @instance
- * @property {MapMouseEvent | MapTouchEvent} data
- */

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -23,10 +23,13 @@ const AttributionControl = require('./control/attribution_control');
 const LogoControl = require('./control/logo_control');
 const isSupported = require('mapbox-gl-supported');
 
+require('./events'); // Pull in for documentation.js
+
 import type {LngLatLike} from '../geo/lng_lat';
 import type {LngLatBoundsLike} from '../geo/lng_lat_bounds';
 import type {RequestParameters} from '../util/ajax';
 import type {StyleOptions} from '../style/style';
+import type {MapEvent, MapDataEvent} from './events';
 
 import type ScrollZoomHandler from './handler/scroll_zoom';
 import type BoxZoomHandler from './handler/box_zoom';
@@ -80,40 +83,6 @@ type MapOptions = {
     maxTileCacheSize?: number,
     transformRequest?: RequestTransformFunction
 };
-
-type MapEvent =
-    | 'mousedown'
-    | 'mouseup'
-    | 'click'
-    | 'dblclick'
-    | 'mousemove'
-    | 'mouseenter'
-    | 'mouseleave'
-    | 'mouseover'
-    | 'mouseout'
-    | 'contextmenu'
-    | 'touchstart'
-    | 'touchend'
-    | 'touchcancel'
-    | 'mouseenter'
-    | 'mousemover'
-    | 'zoom'
-    | 'movestart'
-    | 'move'
-    | 'moveend'
-    | 'style.load'
-    | 'data'
-    | 'dataloading'
-    | 'rotate'
-    | 'pitch'
-    | 'resize'
-    | 'error'
-    | 'data'
-    | 'styledata'
-    | 'sourcedata'
-    | 'dataloading'
-    | 'styledataloading'
-    | 'sourcedataloading';
 
 const defaultMinZoom = 0;
 const defaultMaxZoom = 22;
@@ -1501,15 +1470,6 @@ class Map extends Camera {
         this.painter = new Painter(gl, this.transform);
     }
 
-    /**
-     * Fired when the WebGL context is lost.
-     *
-     * @event webglcontextlost
-     * @memberof Map
-     * @instance
-     * @type {Object}
-     * @property {WebGLContextEvent} originalEvent The original DOM event.
-     */
     _contextLost(event: Event) {
         event.preventDefault();
         if (this._frameId) {
@@ -1519,15 +1479,6 @@ class Map extends Camera {
         this.fire('webglcontextlost', {originalEvent: event});
     }
 
-    /**
-     * Fired when the WebGL context is restored.
-     *
-     * @event webglcontextrestored
-     * @memberof Map
-     * @instance
-     * @type {Object}
-     * @property {WebGLContextEvent} originalEvent The original DOM event.
-     */
     _contextRestored(event: Event) {
         this._setupPainter();
         this.resize();
@@ -1862,287 +1813,4 @@ function removeNode(node) {
  * A {@link Point} or an array of two numbers representing `x` and `y` screen coordinates in pixels.
  *
  * @typedef {(Point | Array<number>)} PointLike
- */
-
-/**
- * Fired whenever the map is drawn to the screen, as the result of
- *
- * - a change to the map's position, zoom, pitch, or bearing
- * - a change to the map's style
- * - a change to a GeoJSON source
- * - the loading of a vector tile, GeoJSON file, glyph, or sprite
- *
- * @event render
- * @memberof Map
- * @instance
- */
-
-/**
- * Fired when a point device (usually a mouse) leaves the map's canvas.
- *
- * @event mouseout
- * @memberof Map
- * @instance
- * @property {MapMouseEvent} data
- * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
- */
-
-/**
- * Fired when a pointing device (usually a mouse) is pressed within the map.
- *
- * @event mousedown
- * @memberof Map
- * @instance
- * @property {MapMouseEvent} data
- * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
- * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
- */
-
-/**
- * Fired when a pointing device (usually a mouse) is released within the map.
- *
- * @event mouseup
- * @memberof Map
- * @instance
- * @property {MapMouseEvent} data
- * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
- * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
- */
-
-/**
- * Fired when a pointing device (usually a mouse) is moved within the map.
- *
- * @event mousemove
- * @memberof Map
- * @instance
- * @property {MapMouseEvent} data
- * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
- * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
- * @see [Display a popup on hover](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
- */
-
-/**
- * Fired when a touch point is placed on the map.
- *
- * @event touchstart
- * @memberof Map
- * @instance
- * @property {MapTouchEvent} data
- */
-
-/**
- * Fired when a touch point is removed from the map.
- *
- * @event touchend
- * @memberof Map
- * @instance
- * @property {MapTouchEvent} data
- */
-
-/**
- * Fired when a touch point is moved within the map.
- *
- * @event touchmove
- * @memberof Map
- * @instance
- * @property {MapTouchEvent} data
- */
-
-/**
- * Fired when a touch point has been disrupted.
- *
- * @event touchcancel
- * @memberof Map
- * @instance
- * @property {MapTouchEvent} data
- */
-
-/**
- * Fired when a pointing device (usually a mouse) is pressed and released at the same point on the map.
- *
- * @event click
- * @memberof Map
- * @instance
- * @property {MapMouseEvent} data
- * @see [Measure distances](https://www.mapbox.com/mapbox-gl-js/example/measure/)
- * @see [Center the map on a clicked symbol](https://www.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
- */
-
-/**
- * Fired when a pointing device (usually a mouse) is clicked twice at the same point on the map.
- *
- * @event dblclick
- * @memberof Map
- * @instance
- * @property {MapMouseEvent} data
- */
-
-/**
- * Fired when the right button of the mouse is clicked or the context menu key is pressed within the map.
- *
- * @event contextmenu
- * @memberof Map
- * @instance
- * @property {MapMouseEvent} data
- */
-
-/**
- * Fired immediately after all necessary resources have been downloaded
- * and the first visually complete rendering of the map has occurred.
- *
- * @event load
- * @memberof Map
- * @instance
- * @type {Object}
- * @see [Draw GeoJSON points](https://www.mapbox.com/mapbox-gl-js/example/geojson-markers/)
- * @see [Add live realtime data](https://www.mapbox.com/mapbox-gl-js/example/live-geojson/)
- * @see [Animate a point](https://www.mapbox.com/mapbox-gl-js/example/animate-point-along-line/)
- */
-
-/**
- * Fired just before the map begins a transition from one
- * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.
- *
- * @event movestart
- * @memberof Map
- * @instance
- * @property {{originalEvent: DragEvent}} data
- */
-
-/**
- * Fired repeatedly during an animated transition from one view to
- * another, as the result of either user interaction or methods such as {@link Map#flyTo}.
- *
- * @event move
- * @memberof Map
- * @instance
- * @property {MapMouseEvent | MapTouchEvent} data
- */
-
-/**
- * Fired just after the map completes a transition from one
- * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.
- *
- * @event moveend
- * @memberof Map
- * @instance
- * @property {{originalEvent: DragEvent}} data
- * @see [Play map locations as a slideshow](https://www.mapbox.com/mapbox-gl-js/example/playback-locations/)
- * @see [Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
- */
-
-/**
- * Fired when an error occurs. This is GL JS's primary error reporting
- * mechanism. We use an event instead of `throw` to better accommodate
- * asyncronous operations. If no listeners are bound to the `error` event, the
- * error will be printed to the console.
- *
- * @event error
- * @memberof Map
- * @instance
- * @property {{error: {message: string}}} data
- */
-
-/**
- * Fired when any map data loads or changes. See {@link MapDataEvent}
- * for more information.
- *
- * @event data
- * @memberof Map
- * @instance
- * @property {MapDataEvent} data
- */
-
-/**
- * Fired when the map's style loads or changes. See
- * {@link MapDataEvent} for more information.
- *
- * @event styledata
- * @memberof Map
- * @instance
- * @property {MapDataEvent} data
- */
-
-/**
- * Fired when one of the map's sources loads or changes, including if a tile belonging
- * to a source loads or changes. See {@link MapDataEvent} for more information.
- *
- * @event sourcedata
- * @memberof Map
- * @instance
- * @property {MapDataEvent} data
- */
-
-/**
- * Fired when any map data (style, source, tile, etc) begins loading or
- * changing asyncronously. All `dataloading` events are followed by a `data`
- * or `error` event. See {@link MapDataEvent} for more information.
- *
- * @event dataloading
- * @memberof Map
- * @instance
- * @property {MapDataEvent} data
- */
-
-/**
- * Fired when the map's style begins loading or changing asyncronously.
- * All `styledataloading` events are followed by a `styledata`
- * or `error` event. See {@link MapDataEvent} for more information.
- *
- * @event styledataloading
- * @memberof Map
- * @instance
- * @property {MapDataEvent} data
- */
-
-/**
- * Fired when one of the map's sources begins loading or changing asyncronously.
- * All `sourcedataloading` events are followed by a `sourcedata` or `error` event.
- * See {@link MapDataEvent} for more information.
- *
- * @event sourcedataloading
- * @memberof Map
- * @instance
- * @property {MapDataEvent} data
- */
-
-/**
- * A `MapDataEvent` object is emitted with the {@link Map.event:data}
- * and {@link Map.event:dataloading} events. Possible values for
- * `dataType`s are:
- *
- * - `'source'`: The non-tile data associated with any source
- * - `'style'`: The [style](https://www.mapbox.com/mapbox-gl-style-spec/) used by the map
- *
- * @typedef {Object} MapDataEvent
- * @property {string} type The event type.
- * @property {string} dataType The type of data that has changed. One of `'source'`, `'style'`.
- * @property {boolean} [isSourceLoaded] True if the event has a `dataType` of `source` and the source has no outstanding network requests.
- * @property {Object} [source] The [style spec representation of the source](https://www.mapbox.com/mapbox-gl-style-spec/#sources) if the event has a `dataType` of `source`.
- * @property {string} [sourceDataType] Included if the event has a `dataType` of `source` and the event signals
- * that internal data has been received or changed. Possible values are `metadata` and `content`.
- * @property {Object} [tile] The tile being loaded or changed, if the event has a `dataType` of `source` and
- * the event is related to loading of a tile.
- * @property {Coordinate} [coord] The coordinate of the tile if the event has a `dataType` of `source` and
- * the event is related to loading of a tile.
- */
-type MapDataEvent = {
-    type: string,
-    dataType: string
-}
-
-/**
- * Fired immediately after the map has been removed with {@link Map.event:remove}.
- *
- * @event remove
- * @memberof Map
- * @instance
- */
-
-/**
- * Fired immediately after the map has been resized.
- *
- * @event resize
- * @memberof Map
- * @instance
  */

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -9,6 +9,7 @@ const {bindAll} = require('../util/util');
 import type Map from './map';
 import type Popup from './popup';
 import type {LngLatLike} from "../geo/lng_lat";
+import type {MapMouseEvent} from './events';
 
 /**
  * Creates a marker component
@@ -27,7 +28,7 @@ class Marker {
     _element: HTMLElement;
     _popup: ?Popup;
     _lngLat: LngLat;
-    _pos: Point;
+    _pos: ?Point;
 
     constructor(element: ?HTMLElement, options?: {offset: PointLike}) {
         this._offset = Point.convert(options && options.offset || [0, 0]);
@@ -74,7 +75,7 @@ class Marker {
             this._map.off('click', this._onMapClick);
             this._map.off('move', this._update);
             this._map.off('moveend', this._update);
-            this._map = (null: any);
+            delete this._map;
         }
         DOM.remove(this._element);
         if (this._popup) this._popup.remove();
@@ -100,7 +101,7 @@ class Marker {
      */
     setLngLat(lnglat: LngLatLike) {
         this._lngLat = LngLat.convert(lnglat);
-        this._pos = (null: any);
+        this._pos = null;
         if (this._popup) this._popup.setLngLat(this._lngLat);
         this._update();
         return this;
@@ -133,11 +134,11 @@ class Marker {
         return this;
     }
 
-    _onMapClick(event: any) {
+    _onMapClick(event: MapMouseEvent) {
         const targetElement = event.originalEvent.target;
         const element = this._element;
 
-        if (this._popup && (targetElement === element || element.contains(targetElement))) {
+        if (this._popup && (targetElement === element || element.contains((targetElement: any)))) {
             this.togglePopup();
         }
     }
@@ -162,7 +163,7 @@ class Marker {
         else popup.addTo(this._map);
     }
 
-    _update(e: any) {
+    _update(e?: {type: 'move' | 'moveend'}) {
         if (!this._map) return;
 
         if (this._map.transform.renderWorldCopies) {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -19,6 +19,13 @@ const defaultOptions = {
 export type Anchor = 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 export type Offset = number | PointLike | {[Anchor]: PointLike};
 
+export type PopupOptions = {
+    closeButton: boolean,
+    closeOnClick: boolean,
+    anchor: Anchor,
+    offset: Offset
+};
+
 /**
  * A popup component.
  *
@@ -61,15 +68,15 @@ export type Offset = number | PointLike | {[Anchor]: PointLike};
  */
 class Popup extends Evented {
     _map: Map;
-    options: any;
+    options: PopupOptions;
     _content: HTMLElement;
     _container: HTMLElement;
     _closeButton: HTMLElement;
     _tip: HTMLElement;
     _lngLat: LngLat;
-    _pos: Point;
+    _pos: ?Point;
 
-    constructor(options: any) {
+    constructor(options: PopupOptions) {
         super();
         this.options = util.extend(Object.create(defaultOptions), options);
         util.bindAll(['_update', '_onClickClose'], this);
@@ -157,7 +164,7 @@ class Popup extends Evented {
      */
     setLngLat(lnglat: LngLatLike) {
         this._lngLat = LngLat.convert(lnglat);
-        this._pos = (null: any);
+        this._pos = null;
         this._update();
         return this;
     }
@@ -255,7 +262,7 @@ class Popup extends Evented {
             this._lngLat = smartWrap(this._lngLat, this._pos, this._map.transform);
         }
 
-        this._pos = this._map.project(this._lngLat);
+        const pos = this._pos = this._map.project(this._lngLat);
 
         let anchor = this.options.anchor;
         const offset = normalizeOffset(this.options.offset);
@@ -264,17 +271,17 @@ class Popup extends Evented {
             const width = this._container.offsetWidth,
                 height = this._container.offsetHeight;
 
-            if (this._pos.y + offset.bottom.y < height) {
+            if (pos.y + offset.bottom.y < height) {
                 anchor = ['top'];
-            } else if (this._pos.y > this._map.transform.height - height) {
+            } else if (pos.y > this._map.transform.height - height) {
                 anchor = ['bottom'];
             } else {
                 anchor = [];
             }
 
-            if (this._pos.x < width / 2) {
+            if (pos.x < width / 2) {
                 anchor.push('left');
-            } else if (this._pos.x > this._map.transform.width - width / 2) {
+            } else if (pos.x > this._map.transform.width - width / 2) {
                 anchor.push('right');
             }
 
@@ -285,7 +292,7 @@ class Popup extends Evented {
             }
         }
 
-        const offsetedPos = this._pos.add(offset[anchor]).round();
+        const offsetedPos = pos.add(offset[anchor]).round();
 
         const anchorTranslate = {
             'top': 'translate(-50%,0)',

--- a/src/util/smart_wrap.js
+++ b/src/util/smart_wrap.js
@@ -18,13 +18,9 @@ import type Transform from '../geo/transform';
  * map center changes by ±360° due to automatic wrapping, and when about to go off screen,
  * should wrap just enough to avoid doing so.
  *
- * @param lngLat
- * @param {Point} priorPos
- * @param {Transform} transform
- * @return LngLat
  * @private
  */
-module.exports = function(lngLat: LngLat, priorPos: Point, transform: Transform) {
+module.exports = function(lngLat: LngLat, priorPos: ?Point, transform: Transform): LngLat {
     lngLat = new LngLat(lngLat.lng, lngLat.lat);
 
     // First, try shifting one world in either direction, and see if either is closer to the


### PR DESCRIPTION
I set out to remove as many `any`s as I could from popup.js and marker.js, and discovered that I needed a `MapMouseEvent` type first. So I reorganized map event types and docs, then did the original task.

What's nice about this organization is the documentation for each map event type is next to its entry in the `MapEvent` enum, so we can see where we're missing documentation (e.g. #4772), or missing enum values.