### PR TITLE
Eliminate LayerData type

### DIFF
--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -119,7 +119,7 @@ class Bucket {
     }
 
     getPaintPropertyStatistics() {
-        return util.mapObject(this.arrays.layerData, data => data.paintPropertyStatistics);
+        return util.mapObject(this.arrays.programConfigurations, config => config.paintPropertyStatistics);
     }
 
     isEmpty() {

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -389,8 +389,8 @@ class SymbolBucket {
         const statistics = {};
         for (const layer of this.layers) {
             statistics[layer.id] = util.extend({},
-                this.arrays.icon.layerData[layer.id].paintPropertyStatistics,
-                this.arrays.glyph.layerData[layer.id].paintPropertyStatistics
+                this.arrays.icon.programConfigurations[layer.id].paintPropertyStatistics,
+                this.arrays.glyph.programConfigurations[layer.id].paintPropertyStatistics
             );
         }
         return statistics;

--- a/src/data/buffer_group.js
+++ b/src/data/buffer_group.js
@@ -23,10 +23,7 @@ class BufferGroup {
     dynamicLayoutVertexBuffer: Buffer;
     elementBuffer: Buffer;
     elementBuffer2: Buffer;
-    layerData: {[string]: {
-        programConfiguration: ProgramConfiguration,
-        paintVertexBuffer: ?Buffer
-    }};
+    programConfigurations: {[string]: ProgramConfiguration};
     segments: Array<any>;
     segments2: Array<any>;
 
@@ -52,12 +49,12 @@ class BufferGroup {
                 programInterface.elementArrayType2.serialize(), Buffer.BufferType.ELEMENT);
         }
 
-        this.layerData = {};
+        this.programConfigurations = {};
         for (const layer of layers) {
             const array = arrays.paintVertexArrays && arrays.paintVertexArrays[layer.id];
             const programConfiguration = ProgramConfiguration.createDynamic(programInterface, layer, zoom);
-            const paintVertexBuffer = array ? new Buffer(array.array, array.type, Buffer.BufferType.VERTEX) : null;
-            this.layerData[layer.id] = {programConfiguration, paintVertexBuffer};
+            programConfiguration.paintVertexBuffer = array ? new Buffer(array.array, array.type, Buffer.BufferType.VERTEX) : null;
+            this.programConfigurations[layer.id] = programConfiguration;
         }
 
         this.segments = arrays.segments;
@@ -65,7 +62,7 @@ class BufferGroup {
 
         for (const segments of [this.segments, this.segments2]) {
             for (const segment of segments || []) {
-                segment.vaos = util.mapObject(this.layerData, () => new VertexArrayObject());
+                segment.vaos = util.mapObject(this.programConfigurations, () => new VertexArrayObject());
             }
         }
     }
@@ -82,8 +79,8 @@ class BufferGroup {
         if (this.elementBuffer2) {
             this.elementBuffer2.destroy();
         }
-        for (const layerId in this.layerData) {
-            const paintVertexBuffer = this.layerData[layerId].paintVertexBuffer;
+        for (const layerId in this.programConfigurations) {
+            const paintVertexBuffer = this.programConfigurations[layerId].paintVertexBuffer;
             if (paintVertexBuffer) {
                 paintVertexBuffer.destroy();
             }

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -30,8 +30,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
         if (!bucket) continue;
 
         const buffers = bucket.buffers;
-        const layerData = buffers.layerData[layer.id];
-        const programConfiguration = layerData.programConfiguration;
+        const programConfiguration = buffers.programConfigurations[layer.id];
         const program = painter.useProgram('circle', programConfiguration);
         programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
 
@@ -56,7 +55,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
         ));
 
         for (const segment of buffers.segments) {
-            segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
+            segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);
             gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
         }
     }

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -63,42 +63,42 @@ function drawFillTiles(painter, sourceCache, layer, coords, drawFn) {
 
 function drawFillTile(painter, sourceCache, layer, tile, coord, buffers, firstTile) {
     const gl = painter.gl;
-    const layerData = buffers.layerData[layer.id];
+    const programConfiguration = buffers.programConfigurations[layer.id];
 
-    const program = setFillProgram('fill', layer.paint['fill-pattern'], painter, layerData, layer, tile, coord, firstTile);
+    const program = setFillProgram('fill', layer.paint['fill-pattern'], painter, programConfiguration, layer, tile, coord, firstTile);
 
     for (const segment of buffers.segments) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }
 
 function drawStrokeTile(painter, sourceCache, layer, tile, coord, buffers, firstTile) {
     const gl = painter.gl;
-    const layerData = buffers.layerData[layer.id];
+    const programConfiguration = buffers.programConfigurations[layer.id];
     const usePattern = layer.paint['fill-pattern'] && !layer.getPaintProperty('fill-outline-color');
 
-    const program = setFillProgram('fillOutline', usePattern, painter, layerData, layer, tile, coord, firstTile);
+    const program = setFillProgram('fillOutline', usePattern, painter, programConfiguration, layer, tile, coord, firstTile);
     gl.uniform2f(program.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
     for (const segment of buffers.segments2) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer2, layerData.paintVertexBuffer, segment.vertexOffset);
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer2, programConfiguration.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);
     }
 }
 
-function setFillProgram(programId, usePattern, painter, layerData, layer, tile, coord, firstTile) {
+function setFillProgram(programId, usePattern, painter, programConfiguration, layer, tile, coord, firstTile) {
     let program;
     const prevProgram = painter.currentProgram;
     if (!usePattern) {
-        program = painter.useProgram(programId, layerData.programConfiguration);
+        program = painter.useProgram(programId, programConfiguration);
         if (firstTile || program !== prevProgram) {
-            layerData.programConfiguration.setUniforms(painter.gl, program, layer, {zoom: painter.transform.zoom});
+            programConfiguration.setUniforms(painter.gl, program, layer, {zoom: painter.transform.zoom});
         }
     } else {
-        program = painter.useProgram(`${programId}Pattern`, layerData.programConfiguration);
+        program = painter.useProgram(`${programId}Pattern`, programConfiguration);
         if (firstTile || program !== prevProgram) {
-            layerData.programConfiguration.setUniforms(painter.gl, program, layer, {zoom: painter.transform.zoom});
+            programConfiguration.setUniforms(painter.gl, program, layer, {zoom: painter.transform.zoom});
             pattern.prepare(layer.paint['fill-pattern'], painter, program);
         }
         pattern.setTile(tile, painter, program);

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -118,8 +118,7 @@ function drawExtrusion(painter, source, layer, coord) {
 
     const image = layer.paint['fill-extrusion-pattern'];
 
-    const layerData = buffers.layerData[layer.id];
-    const programConfiguration = layerData.programConfiguration;
+    const programConfiguration = buffers.programConfigurations[layer.id];
     const program = painter.useProgram(image ? 'fillExtrusionPattern' : 'fillExtrusion', programConfiguration);
     programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
 
@@ -140,7 +139,7 @@ function drawExtrusion(painter, source, layer, coord) {
     setLight(program, painter);
 
     for (const segment of buffers.segments) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -31,22 +31,22 @@ module.exports = function drawLine(painter: Painter, sourceCache: SourceCache, l
         const bucket = tile.getBucket(layer);
         if (!bucket) continue;
 
-        const layerData = bucket.buffers.layerData[layer.id];
+        const programConfiguration = bucket.buffers.programConfigurations[layer.id];
         const prevProgram = painter.currentProgram;
-        const program = painter.useProgram(programId, layerData.programConfiguration);
+        const program = painter.useProgram(programId, programConfiguration);
         const programChanged = firstTile || program !== prevProgram;
         const tileRatioChanged = prevTileZoom !== tile.coord.z;
 
         if (programChanged) {
-            layerData.programConfiguration.setUniforms(painter.gl, program, layer, {zoom: painter.transform.zoom});
+            programConfiguration.setUniforms(painter.gl, program, layer, {zoom: painter.transform.zoom});
         }
-        drawLineTile(program, painter, tile, bucket.buffers, layer, coord, layerData, programChanged, tileRatioChanged);
+        drawLineTile(program, painter, tile, bucket.buffers, layer, coord, programConfiguration, programChanged, tileRatioChanged);
         prevTileZoom = tile.coord.z;
         firstTile = false;
     }
 };
 
-function drawLineTile(program, painter, tile, buffers, layer, coord, layerData, programChanged, tileRatioChanged) {
+function drawLineTile(program, painter, tile, buffers, layer, coord, programConfiguration, programChanged, tileRatioChanged) {
     const gl = painter.gl;
     const dasharray = layer.paint['line-dasharray'];
     const image = layer.paint['line-pattern'];
@@ -112,7 +112,7 @@ function drawLineTile(program, painter, tile, buffers, layer, coord, layerData, 
     gl.uniform1f(program.u_ratio, 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom));
 
     for (const segment of buffers.segments) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, layerData.paintVertexBuffer, segment.vertexOffset);
+        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);
         gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
     }
 }

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -93,8 +93,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         if (!bucket) continue;
         const buffers = isText ? bucket.buffers.glyph : bucket.buffers.icon;
         if (!buffers || !buffers.segments.length) continue;
-        const layerData = buffers.layerData[layer.id];
-        const programConfiguration = layerData.programConfiguration;
+        const programConfiguration = buffers.programConfigurations[layer.id];
 
         const isSDF = isText || bucket.sdfIcons;
 
@@ -206,8 +205,8 @@ function drawTileSymbols(program, programConfiguration, painter, layer, tile, bu
 }
 
 function drawSymbolElements(buffers, layer, gl, program) {
-    const layerData = buffers.layerData[layer.id];
-    const paintVertexBuffer = layerData && layerData.paintVertexBuffer;
+    const programConfiguration = buffers.programConfigurations[layer.id];
+    const paintVertexBuffer = programConfiguration && programConfiguration.paintVertexBuffer;
 
     for (const segment of buffers.segments) {
         segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, paintVertexBuffer, segment.vertexOffset, buffers.dynamicLayoutVertexBuffer);

--- a/test/unit/data/bucket.test.js
+++ b/test/unit/data/bucket.test.js
@@ -89,7 +89,7 @@ test('Bucket', (t) => {
         t.equal(v0.a_box0, 34);
         t.equal(v0.a_box1, 84);
 
-        const paintVertex = bucket.arrays.layerData.layerid.paintVertexArray;
+        const paintVertex = bucket.arrays.programConfigurations.layerid.paintVertexArray;
         t.equal(paintVertex.length, 1);
         const p0 = paintVertex.get(0);
         t.equal(p0.a_opacity, 17);
@@ -119,8 +119,8 @@ test('Bucket', (t) => {
         bucket.populate([{feature: createFeature(17, 42)}], createOptions());
 
         const v0 = bucket.arrays.layoutVertexArray.get(0);
-        const a0 = bucket.arrays.layerData.one.paintVertexArray.get(0);
-        const b0 = bucket.arrays.layerData.two.paintVertexArray.get(0);
+        const a0 = bucket.arrays.programConfigurations.one.paintVertexArray.get(0);
+        const b0 = bucket.arrays.programConfigurations.two.paintVertexArray.get(0);
         t.equal(a0.a_opacity, 17);
         t.equal(b0.a_opacity, 17);
         t.equal(v0.a_box0, 34);
@@ -182,7 +182,7 @@ test('Bucket', (t) => {
         t.equal(bucket.arrays.layoutVertexArray.arrayBuffer, transferables[0]);
         t.equal(bucket.arrays.elementArray.arrayBuffer, transferables[1]);
         t.equal(bucket.arrays.elementArray2.arrayBuffer, transferables[2]);
-        t.equal(bucket.arrays.layerData.layerid.paintVertexArray.arrayBuffer, transferables[3]);
+        t.equal(bucket.arrays.programConfigurations.layerid.paintVertexArray.arrayBuffer, transferables[3]);
 
         t.end();
     });


### PR DESCRIPTION
Its non-`ProgramConfiguration` members are better suited as properties of `ProgramConfiguration` itself.