### PR TITLE
Introduce a Program class

### DIFF
--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -74,7 +74,6 @@ class CircleBucket implements Bucket {
             this.elementBuffer = new Buffer(options.elementArray, ElementArrayType.serialize(), Buffer.BufferType.ELEMENT);
             this.programConfigurations = ProgramConfigurationSet.deserialize(circleInterface, options.layers, options.zoom, options.programConfigurations);
             this.segments = new SegmentVector(options.segments);
-            this.segments.createVAOs(options.layers);
         } else {
             this.layoutVertexArray = new LayoutVertexArrayType();
             this.elementArray = new ElementArrayType();

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -67,9 +67,7 @@ class FillBucket implements Bucket {
             this.elementBuffer2 = new Buffer(options.elementArray2, ElementArrayType2.serialize(), Buffer.BufferType.ELEMENT);
             this.programConfigurations = ProgramConfigurationSet.deserialize(fillInterface, options.layers, options.zoom, options.programConfigurations);
             this.segments = new SegmentVector(options.segments);
-            this.segments.createVAOs(options.layers);
             this.segments2 = new SegmentVector(options.segments2);
-            this.segments2.createVAOs(options.layers);
         } else {
             this.layoutVertexArray = new LayoutVertexArrayType();
             this.elementArray = new ElementArrayType();

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -80,7 +80,6 @@ class FillExtrusionBucket implements Bucket {
             this.elementBuffer = new Buffer(options.elementArray, ElementArrayType.serialize(), Buffer.BufferType.ELEMENT);
             this.programConfigurations = ProgramConfigurationSet.deserialize(fillExtrusionInterface, options.layers, options.zoom, options.programConfigurations);
             this.segments = new SegmentVector(options.segments);
-            this.segments.createVAOs(options.layers);
         } else {
             this.layoutVertexArray = new LayoutVertexArrayType();
             this.elementArray = new ElementArrayType();

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -125,7 +125,6 @@ class LineBucket implements Bucket {
             this.elementBuffer = new Buffer(options.elementArray, ElementArrayType.serialize(), Buffer.BufferType.ELEMENT);
             this.programConfigurations = ProgramConfigurationSet.deserialize(lineInterface, options.layers, options.zoom, options.programConfigurations);
             this.segments = new SegmentVector(options.segments);
-            this.segments.createVAOs(options.layers);
         } else {
             this.layoutVertexArray = new LayoutVertexArrayType();
             this.elementArray = new ElementArrayType();

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -233,7 +233,6 @@ class SymbolBuffers {
             this.elementBuffer = new Buffer(arrays.elementArray, ElementArrayType.serialize(), Buffer.BufferType.ELEMENT);
             this.programConfigurations = ProgramConfigurationSet.deserialize(programInterface, layers, zoom, arrays.programConfigurations);
             this.segments = new SegmentVector(arrays.segments);
-            this.segments.createVAOs(layers);
         } else {
             this.layoutVertexArray = new LayoutVertexArrayType();
             this.elementArray = new ElementArrayType();

--- a/src/data/buffer.js
+++ b/src/data/buffer.js
@@ -7,7 +7,7 @@ import type {
     SerializedStructArrayType
 } from '../util/struct_array';
 
-import type {Program} from './program_configuration';
+import type {Program} from '../render/program';
 
 /**
  * @enum {string} AttributeType
@@ -96,7 +96,7 @@ class Buffer {
     enableAttributes(gl: WebGLRenderingContext, program: Program) {
         for (let j = 0; j < this.attributes.length; j++) {
             const member = this.attributes[j];
-            const attribIndex: number | void = program[member.name];
+            const attribIndex: number | void = program.attributes[member.name];
             if (attribIndex !== undefined) {
                 gl.enableVertexAttribArray(attribIndex);
             }
@@ -112,7 +112,7 @@ class Buffer {
     setVertexAttribPointers(gl: WebGLRenderingContext, program: Program, vertexOffset: number) {
         for (let j = 0; j < this.attributes.length; j++) {
             const member = this.attributes[j];
-            const attribIndex: number | void = program[member.name];
+            const attribIndex: number | void = program.attributes[member.name];
 
             if (attribIndex !== undefined) {
                 gl.vertexAttribPointer(

--- a/src/data/buffer.js
+++ b/src/data/buffer.js
@@ -7,7 +7,7 @@ import type {
     SerializedStructArrayType
 } from '../util/struct_array';
 
-import type {Program} from '../render/program';
+import type Program from '../render/program';
 
 /**
  * @enum {string} AttributeType

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -7,6 +7,7 @@ const Buffer = require('./buffer');
 
 import type StyleLayer from '../style/style_layer';
 import type {ViewType, StructArray, SerializedStructArray, SerializedStructArrayType} from '../util/struct_array';
+import type {Program} from '../render/program';
 
 type LayoutAttribute = {
     name: string,
@@ -30,10 +31,6 @@ export type ProgramInterface = {
     dynamicLayoutAttributes?: Array<LayoutAttribute>,
     paintAttributes?: Array<PaintAttribute>,
     elementArrayType2?: Class<StructArray>
-}
-
-export type Program = {
-    [string]: any
 }
 
 function packColor(color: [number, number, number, number]): [number, number] {
@@ -83,9 +80,9 @@ class ConstantBinder implements Binder {
     setUniforms(gl: WebGLRenderingContext, program: Program, layer: StyleLayer, {zoom}: { zoom: number }) {
         const value = layer.getPaintValue(this.property, { zoom: this.useIntegerZoom ? Math.floor(zoom) : zoom });
         if (this.type === 'color') {
-            gl.uniform4fv(program[`u_${this.name}`], value);
+            gl.uniform4fv(program.uniforms[`u_${this.name}`], value);
         } else {
-            gl.uniform1f(program[`u_${this.name}`], value);
+            gl.uniform1f(program.uniforms[`u_${this.name}`], value);
         }
     }
 }
@@ -132,7 +129,7 @@ class SourceFunctionBinder implements Binder {
     }
 
     setUniforms(gl: WebGLRenderingContext, program: Program) {
-        gl.uniform1f(program[`a_${this.name}_t`], 0);
+        gl.uniform1f(program.uniforms[`a_${this.name}_t`], 0);
     }
 }
 
@@ -188,7 +185,7 @@ class CompositeFunctionBinder implements Binder {
 
     setUniforms(gl: WebGLRenderingContext, program: Program, layer: StyleLayer, {zoom}: { zoom: number }) {
         const f = interpolationFactor(this.useIntegerZoom ? Math.floor(zoom) : zoom, 1, this.zoom, this.zoom + 1);
-        gl.uniform1f(program[`a_${this.name}_t`], f);
+        gl.uniform1f(program.uniforms[`a_${this.name}_t`], f);
     }
 }
 

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -7,7 +7,7 @@ const Buffer = require('./buffer');
 
 import type StyleLayer from '../style/style_layer';
 import type {ViewType, StructArray, SerializedStructArray, SerializedStructArrayType} from '../util/struct_array';
-import type {Program} from '../render/program';
+import type Program from '../render/program';
 
 type LayoutAttribute = {
     name: string,

--- a/src/data/segment.js
+++ b/src/data/segment.js
@@ -1,9 +1,7 @@
 // @flow
 
-const VertexArrayObject = require('../render/vertex_array_object');
-
+import type VertexArrayObject from '../render/vertex_array_object';
 import type {StructArray} from '../util/struct_array';
-import type StyleLayer from '../style/style_layer';
 
 export type Segment = {
     vertexOffset: number,
@@ -36,15 +34,6 @@ class SegmentVector {
 
     get() {
         return this.segments;
-    }
-
-    createVAOs(layers: Array<StyleLayer>) {
-        for (const segment of this.segments) {
-            segment.vaos = {};
-            for (const layer of layers) {
-                segment.vaos[layer.id] = new VertexArrayObject();
-            }
-        }
     }
 
     destroy() {

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -31,11 +31,11 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Style
         painter.tileExtentPatternVAO.bind(gl, program, painter.tileExtentBuffer);
     } else {
         program = painter.useProgram('fill', painter.basicFillProgramConfiguration);
-        gl.uniform4fv(program.u_color, color);
+        gl.uniform4fv(program.uniforms.u_color, color);
         painter.tileExtentVAO.bind(gl, program, painter.tileExtentBuffer);
     }
 
-    gl.uniform1f(program.u_opacity, opacity);
+    gl.uniform1f(program.uniforms.u_opacity, opacity);
 
     const coords = transform.coveringTiles({tileSize});
 
@@ -43,7 +43,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Style
         if (image) {
             pattern.setTile({coord, tileSize}, painter, program);
         }
-        gl.uniformMatrix4fv(program.u_matrix, false, painter.transform.calculatePosMatrix(coord));
+        gl.uniformMatrix4fv(program.uniforms.u_matrix, false, painter.transform.calculatePosMatrix(coord));
         gl.drawArrays(gl.TRIANGLE_STRIP, 0, painter.tileExtentBuffer.length);
     }
 }

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -34,20 +34,20 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
         const program = painter.useProgram('circle', programConfiguration);
         programConfiguration.setUniforms(gl, program, layer, {zoom: painter.transform.zoom});
 
-        gl.uniform1f(program.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);
-        gl.uniform1i(program.u_scale_with_map, layer.paint['circle-pitch-scale'] === 'map' ? 1 : 0);
+        gl.uniform1f(program.uniforms.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);
+        gl.uniform1i(program.uniforms.u_scale_with_map, layer.paint['circle-pitch-scale'] === 'map' ? 1 : 0);
         if (layer.paint['circle-pitch-alignment'] === 'map') {
-            gl.uniform1i(program.u_pitch_with_map, 1);
+            gl.uniform1i(program.uniforms.u_pitch_with_map, 1);
             const pixelRatio = pixelsToTileUnits(tile, 1, painter.transform.zoom);
-            gl.uniform2f(program.u_extrude_scale, pixelRatio, pixelRatio);
+            gl.uniform2f(program.uniforms.u_extrude_scale, pixelRatio, pixelRatio);
         } else {
-            gl.uniform1i(program.u_pitch_with_map, 0);
-            gl.uniform2fv(program.u_extrude_scale, painter.transform.pixelsToGLUnits);
+            gl.uniform1i(program.uniforms.u_pitch_with_map, 0);
+            gl.uniform2fv(program.uniforms.u_extrude_scale, painter.transform.pixelsToGLUnits);
         }
 
-        gl.uniform1f(program.u_devicepixelratio, browser.devicePixelRatio);
+        gl.uniform1f(program.uniforms.u_devicepixelratio, browser.devicePixelRatio);
 
-        gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
+        gl.uniformMatrix4fv(program.uniforms.u_matrix, false, painter.translatePosMatrix(
             coord.posMatrix,
             tile,
             layer.paint['circle-translate'],

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -54,9 +54,13 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
             layer.paint['circle-translate-anchor']
         ));
 
-        for (const segment of bucket.segments.get()) {
-            segment.vaos[layer.id].bind(gl, program, bucket.layoutVertexBuffer, bucket.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);
-            gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
-        }
+        program.draw(
+            gl,
+            gl.TRIANGLES,
+            layer.id,
+            bucket.layoutVertexBuffer,
+            bucket.elementBuffer,
+            bucket.segments,
+            programConfiguration);
     }
 }

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -37,9 +37,12 @@ function drawCollisionDebug(painter: Painter, sourceCache: SourceCache, layer: S
         gl.uniform1f(program.uniforms.u_pitch, painter.transform.pitch / 360 * 2 * Math.PI);
         gl.uniform1f(program.uniforms.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);
 
-        for (const segment of bucket.collisionBox.segments.get()) {
-            segment.vaos[layer.id].bind(gl, program, bucket.collisionBox.layoutVertexBuffer, bucket.collisionBox.elementBuffer, null, segment.vertexOffset);
-            gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);
-        }
+        program.draw(
+            gl,
+            gl.LINES,
+            layer.id,
+            bucket.collisionBox.layoutVertexBuffer,
+            bucket.collisionBox.elementBuffer,
+            bucket.collisionBox.segments);
     }
 }

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -15,7 +15,7 @@ function drawCollisionDebug(painter: Painter, sourceCache: SourceCache, layer: S
 
     gl.activeTexture(gl.TEXTURE1);
     painter.frameHistory.bind(gl);
-    gl.uniform1i(program.u_fadetexture, 1);
+    gl.uniform1i(program.uniforms.u_fadetexture, 1);
 
     for (let i = 0; i < coords.length; i++) {
         const coord = coords[i];
@@ -23,19 +23,19 @@ function drawCollisionDebug(painter: Painter, sourceCache: SourceCache, layer: S
         const bucket: ?SymbolBucket = (tile.getBucket(layer): any);
         if (!bucket) continue;
 
-        gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
+        gl.uniformMatrix4fv(program.uniforms.u_matrix, false, coord.posMatrix);
 
         painter.enableTileClippingMask(coord);
 
         painter.lineWidth(1);
-        gl.uniform1f(program.u_scale, Math.pow(2, painter.transform.zoom - tile.coord.z));
-        gl.uniform1f(program.u_zoom, painter.transform.zoom * 10);
+        gl.uniform1f(program.uniforms.u_scale, Math.pow(2, painter.transform.zoom - tile.coord.z));
+        gl.uniform1f(program.uniforms.u_zoom, painter.transform.zoom * 10);
         const maxZoom = Math.max(0, Math.min(25, tile.coord.z + Math.log((tile.collisionTile: any).maxScale) / Math.LN2));
-        gl.uniform1f(program.u_maxzoom, maxZoom * 10);
+        gl.uniform1f(program.uniforms.u_maxzoom, maxZoom * 10);
 
-        gl.uniform1f(program.u_collision_y_stretch, (tile.collisionTile: any).yStretch);
-        gl.uniform1f(program.u_pitch, painter.transform.pitch / 360 * 2 * Math.PI);
-        gl.uniform1f(program.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);
+        gl.uniform1f(program.uniforms.u_collision_y_stretch, (tile.collisionTile: any).yStretch);
+        gl.uniform1f(program.uniforms.u_pitch, painter.transform.pitch / 360 * 2 * Math.PI);
+        gl.uniform1f(program.uniforms.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);
 
         for (const segment of bucket.collisionBox.segments.get()) {
             segment.vaos[layer.id].bind(gl, program, bucket.collisionBox.layoutVertexBuffer, bucket.collisionBox.elementBuffer, null, segment.vertexOffset);

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -28,8 +28,8 @@ function drawDebugTile(painter, sourceCache, coord) {
     const posMatrix = coord.posMatrix;
     const program = painter.useProgram('debug');
 
-    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
-    gl.uniform4f(program.u_color, 1, 0, 0, 1);
+    gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
+    gl.uniform4f(program.uniforms.u_color, 1, 0, 0, 1);
     painter.debugVAO.bind(gl, program, painter.debugBuffer);
     gl.drawArrays(gl.LINE_STRIP, 0, painter.debugBuffer.length);
 
@@ -41,7 +41,7 @@ function drawDebugTile(painter, sourceCache, coord) {
     const debugTextBuffer = Buffer.fromStructArray(debugTextArray, Buffer.BufferType.VERTEX);
     const debugTextVAO = new VertexArrayObject();
     debugTextVAO.bind(gl, program, debugTextBuffer);
-    gl.uniform4f(program.u_color, 1, 1, 1, 1);
+    gl.uniform4f(program.uniforms.u_color, 1, 1, 1, 1);
 
     // Draw the halo with multiple 1px lines instead of one wider line because
     // the gl spec doesn't guarantee support for lines with width > 1.
@@ -50,12 +50,12 @@ function drawDebugTile(painter, sourceCache, coord) {
     const translations = [[-1, -1], [-1, 1], [1, -1], [1, 1]];
     for (let i = 0; i < translations.length; i++) {
         const translation = translations[i];
-        gl.uniformMatrix4fv(program.u_matrix, false, mat4.translate([], posMatrix, [onePixel * translation[0], onePixel * translation[1], 0]));
+        gl.uniformMatrix4fv(program.uniforms.u_matrix, false, mat4.translate([], posMatrix, [onePixel * translation[0], onePixel * translation[1], 0]));
         gl.drawArrays(gl.LINES, 0, debugTextBuffer.length);
     }
 
-    gl.uniform4f(program.u_color, 0, 0, 0, 1);
-    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
+    gl.uniform4f(program.uniforms.u_color, 0, 0, 0, 1);
+    gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
     gl.drawArrays(gl.LINES, 0, debugTextBuffer.length);
 }
 

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -80,7 +80,7 @@ function drawStrokeTile(painter, sourceCache, layer, tile, coord, bucket, firstT
     const usePattern = layer.paint['fill-pattern'] && !layer.getPaintProperty('fill-outline-color');
 
     const program = setFillProgram('fillOutline', usePattern, painter, programConfiguration, layer, tile, coord, firstTile);
-    gl.uniform2f(program.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
+    gl.uniform2f(program.uniforms.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
     for (const segment of bucket.segments2.get()) {
         segment.vaos[layer.id].bind(gl, program, bucket.layoutVertexBuffer, bucket.elementBuffer2, programConfiguration.paintVertexBuffer, segment.vertexOffset);
@@ -104,7 +104,7 @@ function setFillProgram(programId, usePattern, painter, programConfiguration, la
         }
         pattern.setTile(tile, painter, program);
     }
-    painter.gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
+    painter.gl.uniformMatrix4fv(program.uniforms.u_matrix, false, painter.translatePosMatrix(
         coord.posMatrix, tile,
         layer.paint['fill-translate'],
         layer.paint['fill-translate-anchor']

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -68,10 +68,14 @@ function drawFillTile(painter, sourceCache, layer, tile, coord, bucket, firstTil
 
     const program = setFillProgram('fill', layer.paint['fill-pattern'], painter, programConfiguration, layer, tile, coord, firstTile);
 
-    for (const segment of bucket.segments.get()) {
-        segment.vaos[layer.id].bind(gl, program, bucket.layoutVertexBuffer, bucket.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);
-        gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
-    }
+    program.draw(
+        gl,
+        gl.TRIANGLES,
+        layer.id,
+        bucket.layoutVertexBuffer,
+        bucket.elementBuffer,
+        bucket.segments,
+        programConfiguration);
 }
 
 function drawStrokeTile(painter, sourceCache, layer, tile, coord, bucket, firstTile) {
@@ -82,10 +86,14 @@ function drawStrokeTile(painter, sourceCache, layer, tile, coord, bucket, firstT
     const program = setFillProgram('fillOutline', usePattern, painter, programConfiguration, layer, tile, coord, firstTile);
     gl.uniform2f(program.uniforms.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
-    for (const segment of bucket.segments2.get()) {
-        segment.vaos[layer.id].bind(gl, program, bucket.layoutVertexBuffer, bucket.elementBuffer2, programConfiguration.paintVertexBuffer, segment.vertexOffset);
-        gl.drawElements(gl.LINES, segment.primitiveLength * 2, gl.UNSIGNED_SHORT, segment.primitiveOffset * 2 * 2);
-    }
+    program.draw(
+        gl,
+        gl.LINES,
+        layer.id,
+        bucket.layoutVertexBuffer,
+        bucket.elementBuffer2,
+        bucket.segments2,
+        programConfiguration);
 }
 
 function setFillProgram(programId, usePattern, painter, programConfiguration, layer, tile, coord, firstTile) {

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -84,16 +84,16 @@ function renderTextureToMap(gl, painter, layer, texture) {
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, texture);
 
-    gl.uniform1f(program.u_opacity, layer.paint['fill-extrusion-opacity']);
-    gl.uniform1i(program.u_image, 1);
+    gl.uniform1f(program.uniforms.u_opacity, layer.paint['fill-extrusion-opacity']);
+    gl.uniform1i(program.uniforms.u_image, 1);
 
     const matrix = mat4.create();
     mat4.ortho(matrix, 0, painter.width, painter.height, 0, 0, 1);
-    gl.uniformMatrix4fv(program.u_matrix, false, matrix);
+    gl.uniformMatrix4fv(program.uniforms.u_matrix, false, matrix);
 
     gl.disable(gl.DEPTH_TEST);
 
-    gl.uniform2f(program.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
+    gl.uniform2f(program.uniforms.u_world, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
     const array = new PosArray();
     array.emplaceBack(0, 0);
@@ -126,10 +126,10 @@ function drawExtrusion(painter, source, layer, coord) {
         if (pattern.isPatternMissing(image, painter)) return;
         pattern.prepare(image, painter, program);
         pattern.setTile(tile, painter, program);
-        gl.uniform1f(program.u_height_factor, -Math.pow(2, coord.z) / tile.tileSize / 8);
+        gl.uniform1f(program.uniforms.u_height_factor, -Math.pow(2, coord.z) / tile.tileSize / 8);
     }
 
-    painter.gl.uniformMatrix4fv(program.u_matrix, false, painter.translatePosMatrix(
+    painter.gl.uniformMatrix4fv(program.uniforms.u_matrix, false, painter.translatePosMatrix(
         coord.posMatrix,
         tile,
         layer.paint['fill-extrusion-translate'],
@@ -154,7 +154,7 @@ function setLight(program, painter) {
     if (light.calculated.anchor === 'viewport') mat3.fromRotation(lightMat, -painter.transform.angle);
     vec3.transformMat3(lightPos, lightPos, lightMat);
 
-    gl.uniform3fv(program.u_lightpos, lightPos);
-    gl.uniform1f(program.u_lightintensity, light.calculated.intensity);
-    gl.uniform3fv(program.u_lightcolor, light.calculated.color.slice(0, 3));
+    gl.uniform3fv(program.uniforms.u_lightpos, lightPos);
+    gl.uniform1f(program.uniforms.u_lightintensity, light.calculated.intensity);
+    gl.uniform3fv(program.uniforms.u_lightcolor, light.calculated.color.slice(0, 3));
 }

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -138,10 +138,14 @@ function drawExtrusion(painter, source, layer, coord) {
 
     setLight(program, painter);
 
-    for (const segment of bucket.segments.get()) {
-        segment.vaos[layer.id].bind(gl, program, bucket.layoutVertexBuffer, bucket.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);
-        gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
-    }
+    program.draw(
+        gl,
+        gl.TRIANGLES,
+        layer.id,
+        bucket.layoutVertexBuffer,
+        bucket.elementBuffer,
+        bucket.segments,
+        programConfiguration);
 }
 
 function setLight(program, painter) {

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -112,8 +112,12 @@ function drawLineTile(program, painter, tile, bucket, layer, coord, programConfi
 
     gl.uniform1f(program.uniforms.u_ratio, 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom));
 
-    for (const segment of bucket.segments.get()) {
-        segment.vaos[layer.id].bind(gl, program, bucket.layoutVertexBuffer, bucket.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);
-        gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
-    }
+    program.draw(
+        gl,
+        gl.TRIANGLES,
+        layer.id,
+        bucket.layoutVertexBuffer,
+        bucket.elementBuffer,
+        bucket.segments,
+        programConfiguration);
 }

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -64,53 +64,53 @@ function drawLineTile(program, painter, tile, bucket, layer, coord, programConfi
             const widthA = posA.width * dasharray.fromScale;
             const widthB = posB.width * dasharray.toScale;
 
-            gl.uniform2f(program.u_patternscale_a, tileRatio / widthA, -posA.height / 2);
-            gl.uniform2f(program.u_patternscale_b, tileRatio / widthB, -posB.height / 2);
-            gl.uniform1f(program.u_sdfgamma, painter.lineAtlas.width / (Math.min(widthA, widthB) * 256 * browser.devicePixelRatio) / 2);
+            gl.uniform2f(program.uniforms.u_patternscale_a, tileRatio / widthA, -posA.height / 2);
+            gl.uniform2f(program.uniforms.u_patternscale_b, tileRatio / widthB, -posB.height / 2);
+            gl.uniform1f(program.uniforms.u_sdfgamma, painter.lineAtlas.width / (Math.min(widthA, widthB) * 256 * browser.devicePixelRatio) / 2);
 
         } else if (image) {
             imagePosA = painter.spriteAtlas.getPattern(image.from);
             imagePosB = painter.spriteAtlas.getPattern(image.to);
             if (!imagePosA || !imagePosB) return;
 
-            gl.uniform2f(program.u_pattern_size_a, imagePosA.displaySize[0] * image.fromScale / tileRatio, imagePosB.displaySize[1]);
-            gl.uniform2f(program.u_pattern_size_b, imagePosB.displaySize[0] * image.toScale / tileRatio, imagePosB.displaySize[1]);
-            gl.uniform2fv(program.u_texsize, painter.spriteAtlas.getPixelSize());
+            gl.uniform2f(program.uniforms.u_pattern_size_a, imagePosA.displaySize[0] * image.fromScale / tileRatio, imagePosB.displaySize[1]);
+            gl.uniform2f(program.uniforms.u_pattern_size_b, imagePosB.displaySize[0] * image.toScale / tileRatio, imagePosB.displaySize[1]);
+            gl.uniform2fv(program.uniforms.u_texsize, painter.spriteAtlas.getPixelSize());
         }
 
-        gl.uniform2f(program.u_gl_units_to_pixels, 1 / painter.transform.pixelsToGLUnits[0], 1 / painter.transform.pixelsToGLUnits[1]);
+        gl.uniform2f(program.uniforms.u_gl_units_to_pixels, 1 / painter.transform.pixelsToGLUnits[0], 1 / painter.transform.pixelsToGLUnits[1]);
     }
 
     if (programChanged) {
 
         if (dasharray) {
-            gl.uniform1i(program.u_image, 0);
+            gl.uniform1i(program.uniforms.u_image, 0);
             gl.activeTexture(gl.TEXTURE0);
             painter.lineAtlas.bind(gl);
 
-            gl.uniform1f(program.u_tex_y_a, (posA: any).y);
-            gl.uniform1f(program.u_tex_y_b, (posB: any).y);
-            gl.uniform1f(program.u_mix, dasharray.t);
+            gl.uniform1f(program.uniforms.u_tex_y_a, (posA: any).y);
+            gl.uniform1f(program.uniforms.u_tex_y_b, (posB: any).y);
+            gl.uniform1f(program.uniforms.u_mix, dasharray.t);
 
         } else if (image) {
-            gl.uniform1i(program.u_image, 0);
+            gl.uniform1i(program.uniforms.u_image, 0);
             gl.activeTexture(gl.TEXTURE0);
             painter.spriteAtlas.bind(gl, true);
 
-            gl.uniform2fv(program.u_pattern_tl_a, (imagePosA: any).tl);
-            gl.uniform2fv(program.u_pattern_br_a, (imagePosA: any).br);
-            gl.uniform2fv(program.u_pattern_tl_b, (imagePosB: any).tl);
-            gl.uniform2fv(program.u_pattern_br_b, (imagePosB: any).br);
-            gl.uniform1f(program.u_fade, image.t);
+            gl.uniform2fv(program.uniforms.u_pattern_tl_a, (imagePosA: any).tl);
+            gl.uniform2fv(program.uniforms.u_pattern_br_a, (imagePosA: any).br);
+            gl.uniform2fv(program.uniforms.u_pattern_tl_b, (imagePosB: any).tl);
+            gl.uniform2fv(program.uniforms.u_pattern_br_b, (imagePosB: any).br);
+            gl.uniform1f(program.uniforms.u_fade, image.t);
         }
     }
 
     painter.enableTileClippingMask(coord);
 
     const posMatrix = painter.translatePosMatrix(coord.posMatrix, tile, layer.paint['line-translate'], layer.paint['line-translate-anchor']);
-    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
+    gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
 
-    gl.uniform1f(program.u_ratio, 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom));
+    gl.uniform1f(program.uniforms.u_ratio, 1 / pixelsToTileUnits(tile, 1, painter.transform.zoom));
 
     for (const segment of bucket.segments.get()) {
         segment.vaos[layer.id].bind(gl, program, bucket.layoutVertexBuffer, bucket.elementBuffer, programConfiguration.paintVertexBuffer, segment.vertexOffset);

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -44,14 +44,14 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     tile.registerFadeDuration(painter.style.animationLoop, layer.paint['raster-fade-duration']);
 
     const program = painter.useProgram('raster');
-    gl.uniformMatrix4fv(program.u_matrix, false, posMatrix);
+    gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
 
     // color parameters
-    gl.uniform1f(program.u_brightness_low, layer.paint['raster-brightness-min']);
-    gl.uniform1f(program.u_brightness_high, layer.paint['raster-brightness-max']);
-    gl.uniform1f(program.u_saturation_factor, saturationFactor(layer.paint['raster-saturation']));
-    gl.uniform1f(program.u_contrast_factor, contrastFactor(layer.paint['raster-contrast']));
-    gl.uniform3fv(program.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));
+    gl.uniform1f(program.uniforms.u_brightness_low, layer.paint['raster-brightness-min']);
+    gl.uniform1f(program.uniforms.u_brightness_high, layer.paint['raster-brightness-max']);
+    gl.uniform1f(program.uniforms.u_saturation_factor, saturationFactor(layer.paint['raster-saturation']));
+    gl.uniform1f(program.uniforms.u_contrast_factor, contrastFactor(layer.paint['raster-contrast']));
+    gl.uniform3fv(program.uniforms.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));
 
     const parentTile = tile.sourceCache && tile.sourceCache.findLoadedParent(coord, 0, {}),
         fade = getFadeValues(tile, parentTile, layer, painter.transform);
@@ -73,13 +73,13 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     }
 
     // cross-fade parameters
-    gl.uniform2fv(program.u_tl_parent, parentTL || [0, 0]);
-    gl.uniform1f(program.u_scale_parent, parentScaleBy || 1);
-    gl.uniform1f(program.u_buffer_scale, 1);
-    gl.uniform1f(program.u_fade_t, fade.mix);
-    gl.uniform1f(program.u_opacity, fade.opacity * layer.paint['raster-opacity']);
-    gl.uniform1i(program.u_image0, 0);
-    gl.uniform1i(program.u_image1, 1);
+    gl.uniform2fv(program.uniforms.u_tl_parent, parentTL || [0, 0]);
+    gl.uniform1f(program.uniforms.u_scale_parent, parentScaleBy || 1);
+    gl.uniform1f(program.uniforms.u_buffer_scale, 1);
+    gl.uniform1f(program.uniforms.u_fade_t, fade.mix);
+    gl.uniform1f(program.uniforms.u_opacity, fade.opacity * layer.paint['raster-opacity']);
+    gl.uniform1i(program.uniforms.u_image0, 0);
+    gl.uniform1i(program.uniforms.u_image1, 1);
 
     const buffer = tile.boundsBuffer || painter.rasterBoundsBuffer;
     const vao = tile.boundsVAO || painter.rasterBoundsVAO;

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -205,11 +205,13 @@ function drawTileSymbols(program, programConfiguration, painter, layer, tile, bu
 }
 
 function drawSymbolElements(buffers, layer, gl, program) {
-    const programConfiguration = buffers.programConfigurations.get(layer.id);
-    const paintVertexBuffer = programConfiguration && programConfiguration.paintVertexBuffer;
-
-    for (const segment of buffers.segments.get()) {
-        segment.vaos[layer.id].bind(gl, program, buffers.layoutVertexBuffer, buffers.elementBuffer, paintVertexBuffer, segment.vertexOffset, buffers.dynamicLayoutVertexBuffer);
-        gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
-    }
+    program.draw(
+        gl,
+        gl.TRIANGLES,
+        layer.id,
+        buffers.layoutVertexBuffer,
+        buffers.elementBuffer,
+        buffers.segments,
+        buffers.programConfigurations.get(layer.id),
+        buffers.dynamicLayoutVertexBuffer);
 }

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -29,7 +29,7 @@ const draw = {
 import type Transform from '../geo/transform';
 import type Tile from '../source/tile';
 import type TileCoord from '../source/tile_coord';
-import type {Program} from '../data/program_configuration';
+import type {Program} from './program';
 import type Style from '../style/style';
 import type StyleLayer from '../style/style_layer';
 import type LineAtlas from './line_atlas';
@@ -227,7 +227,7 @@ class Painter {
             gl.stencilFunc(gl.ALWAYS, id, 0xFF);
 
             const program = this.useProgram('fill', this.basicFillProgramConfiguration);
-            gl.uniformMatrix4fv(program.u_matrix, false, coord.posMatrix);
+            gl.uniformMatrix4fv(program.uniforms.u_matrix, false, coord.posMatrix);
 
             // Draw the clipping mask
             this.tileExtentVAO.bind(gl, program, this.tileExtentBuffer);
@@ -455,12 +455,17 @@ class Painter {
         assert(gl.getProgramParameter(program, gl.LINK_STATUS), (gl.getProgramInfoLog(program): any));
 
         const numAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
-        const result = {program, numAttributes};
+        const result = {
+            program,
+            numAttributes,
+            attributes: {},
+            uniforms: {}
+        };
 
         for (let i = 0; i < numAttributes; i++) {
             const attribute = gl.getActiveAttrib(program, i);
             if (attribute) {
-                result[attribute.name] = gl.getAttribLocation(program, attribute.name);
+                result.attributes[attribute.name] = gl.getAttribLocation(program, attribute.name);
             }
         }
 
@@ -468,7 +473,7 @@ class Painter {
         for (let i = 0; i < numUniforms; i++) {
             const uniform = gl.getActiveUniform(program, i);
             if (uniform) {
-                result[uniform.name] = gl.getUniformLocation(program, uniform.name);
+                result.uniforms[uniform.name] = gl.getUniformLocation(program, uniform.name);
             }
         }
 

--- a/src/render/pattern.js
+++ b/src/render/pattern.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 
 import type Painter from './painter';
-import type {Program} from './program';
+import type Program from './program';
 import type TileCoord from '../source/tile_coord';
 
 type CrossFaded<T> = {

--- a/src/render/pattern.js
+++ b/src/render/pattern.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 
 import type Painter from './painter';
-import type {Program} from '../data/program_configuration';
+import type {Program} from './program';
 import type TileCoord from '../source/tile_coord';
 
 type CrossFaded<T> = {
@@ -34,17 +34,17 @@ exports.prepare = function (image: CrossFaded<string>, painter: Painter, program
     const imagePosB = painter.spriteAtlas.getPattern(image.to);
     assert(imagePosA && imagePosB);
 
-    gl.uniform1i(program.u_image, 0);
-    gl.uniform2fv(program.u_pattern_tl_a, (imagePosA: any).tl);
-    gl.uniform2fv(program.u_pattern_br_a, (imagePosA: any).br);
-    gl.uniform2fv(program.u_pattern_tl_b, (imagePosB: any).tl);
-    gl.uniform2fv(program.u_pattern_br_b, (imagePosB: any).br);
-    gl.uniform2fv(program.u_texsize, painter.spriteAtlas.getPixelSize());
-    gl.uniform1f(program.u_mix, image.t);
-    gl.uniform2fv(program.u_pattern_size_a, (imagePosA: any).displaySize);
-    gl.uniform2fv(program.u_pattern_size_b, (imagePosB: any).displaySize);
-    gl.uniform1f(program.u_scale_a, image.fromScale);
-    gl.uniform1f(program.u_scale_b, image.toScale);
+    gl.uniform1i(program.uniforms.u_image, 0);
+    gl.uniform2fv(program.uniforms.u_pattern_tl_a, (imagePosA: any).tl);
+    gl.uniform2fv(program.uniforms.u_pattern_br_a, (imagePosA: any).br);
+    gl.uniform2fv(program.uniforms.u_pattern_tl_b, (imagePosB: any).tl);
+    gl.uniform2fv(program.uniforms.u_pattern_br_b, (imagePosB: any).br);
+    gl.uniform2fv(program.uniforms.u_texsize, painter.spriteAtlas.getPixelSize());
+    gl.uniform1f(program.uniforms.u_mix, image.t);
+    gl.uniform2fv(program.uniforms.u_pattern_size_a, (imagePosA: any).displaySize);
+    gl.uniform2fv(program.uniforms.u_pattern_size_b, (imagePosB: any).displaySize);
+    gl.uniform1f(program.uniforms.u_scale_a, image.fromScale);
+    gl.uniform1f(program.uniforms.u_scale_b, image.toScale);
 
     gl.activeTexture(gl.TEXTURE0);
     painter.spriteAtlas.bind(gl, true);
@@ -53,7 +53,7 @@ exports.prepare = function (image: CrossFaded<string>, painter: Painter, program
 exports.setTile = function (tile: {coord: TileCoord, tileSize: number}, painter: Painter, program: Program) {
     const gl = painter.gl;
 
-    gl.uniform1f(program.u_tile_units_to_pixels, 1 / pixelsToTileUnits(tile, 1, painter.transform.tileZoom));
+    gl.uniform1f(program.uniforms.u_tile_units_to_pixels, 1 / pixelsToTileUnits(tile, 1, painter.transform.tileZoom));
 
     const numTiles = Math.pow(2, tile.coord.z);
     const tileSizeAtNearestZoom = tile.tileSize * Math.pow(2, painter.transform.tileZoom) / numTiles;
@@ -62,6 +62,6 @@ exports.setTile = function (tile: {coord: TileCoord, tileSize: number}, painter:
     const pixelY = tileSizeAtNearestZoom * tile.coord.y;
 
     // split the pixel coord into two pairs of 16 bit numbers. The glsl spec only guarantees 16 bits of precision.
-    gl.uniform2f(program.u_pixel_coord_upper, pixelX >> 16, pixelY >> 16);
-    gl.uniform2f(program.u_pixel_coord_lower, pixelX & 0xFFFF, pixelY & 0xFFFF);
+    gl.uniform2f(program.uniforms.u_pixel_coord_upper, pixelX >> 16, pixelY >> 16);
+    gl.uniform2f(program.uniforms.u_pixel_coord_lower, pixelX & 0xFFFF, pixelY & 0xFFFF);
 };

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -1,0 +1,8 @@
+// @flow
+
+export type Program = {
+    program: WebGLProgram,
+    uniforms: {[string]: number},
+    attributes: {[string]: number},
+    numAttributes: number
+}

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -4,6 +4,7 @@ const browser = require('../util/browser');
 const shaders = require('../shaders');
 const assert = require('assert');
 const {ProgramConfiguration} = require('../data/program_configuration');
+const VertexArrayObject = require('./vertex_array_object');
 
 import type {SegmentVector} from '../data/segment';
 import type Buffer from '../data/buffer';
@@ -95,7 +96,10 @@ class Program {
         }[drawMode];
 
         for (const segment of segments.get()) {
-            segment.vaos[layerID].bind(
+            const vaos = segment.vaos || (segment.vaos = {});
+            const vao = vaos[layerID] || (vaos[layerID] = new VertexArrayObject());
+
+            vao.bind(
                 gl,
                 this,
                 layoutVertexBuffer,

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -1,8 +1,76 @@
 // @flow
 
-export type Program = {
-    program: WebGLProgram,
-    uniforms: {[string]: number},
-    attributes: {[string]: number},
-    numAttributes: number
+const browser = require('../util/browser');
+const shaders = require('../shaders');
+const assert = require('assert');
+
+const {ProgramConfiguration} = require('../data/program_configuration');
+
+class Program {
+    program: WebGLProgram;
+    uniforms: {[string]: WebGLUniformLocation};
+    attributes: {[string]: number};
+    numAttributes: number;
+
+    constructor(gl: WebGLRenderingContext,
+                source: {fragmentSource: string, vertexSource: string},
+                configuration: ProgramConfiguration,
+                showOverdrawInspector: boolean) {
+        this.program = gl.createProgram();
+
+        const defines = configuration.defines().concat(
+            `#define DEVICE_PIXEL_RATIO ${browser.devicePixelRatio.toFixed(1)}`);
+        if (showOverdrawInspector) {
+            defines.push('#define OVERDRAW_INSPECTOR;');
+        }
+
+        const fragmentSource = defines.concat(shaders.prelude.fragmentSource, source.fragmentSource).join('\n');
+        const vertexSource = defines.concat(shaders.prelude.vertexSource, source.vertexSource).join('\n');
+
+        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(fragmentShader, fragmentSource);
+        gl.compileShader(fragmentShader);
+        assert(gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS), (gl.getShaderInfoLog(fragmentShader): any));
+        gl.attachShader(this.program, fragmentShader);
+
+        const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vertexShader, vertexSource);
+        gl.compileShader(vertexShader);
+        assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), (gl.getShaderInfoLog(vertexShader): any));
+        gl.attachShader(this.program, vertexShader);
+
+        // Manually bind layout attributes in the order defined by their
+        // ProgramInterface so that we don't dynamically link an unused
+        // attribute at position 0, which can cause rendering to fail for an
+        // entire layer (see #4607, #4728)
+        const layoutAttributes = configuration.interface ? configuration.interface.layoutAttributes : [];
+        for (let i = 0; i < layoutAttributes.length; i++) {
+            gl.bindAttribLocation(this.program, i, layoutAttributes[i].name);
+        }
+
+        gl.linkProgram(this.program);
+        assert(gl.getProgramParameter(this.program, gl.LINK_STATUS), (gl.getProgramInfoLog(this.program): any));
+
+        this.numAttributes = gl.getProgramParameter(this.program, gl.ACTIVE_ATTRIBUTES);
+
+        this.attributes = {};
+        this.uniforms = {};
+
+        for (let i = 0; i < this.numAttributes; i++) {
+            const attribute = gl.getActiveAttrib(this.program, i);
+            if (attribute) {
+                this.attributes[attribute.name] = gl.getAttribLocation(this.program, attribute.name);
+            }
+        }
+
+        const numUniforms = gl.getProgramParameter(this.program, gl.ACTIVE_UNIFORMS);
+        for (let i = 0; i < numUniforms; i++) {
+            const uniform = gl.getActiveUniform(this.program, i);
+            if (uniform) {
+                this.uniforms[uniform.name] = gl.getUniformLocation(this.program, uniform.name);
+            }
+        }
+    }
 }
+
+module.exports = Program;

--- a/src/render/vertex_array_object.js
+++ b/src/render/vertex_array_object.js
@@ -2,13 +2,16 @@
 
 const assert = require('assert');
 
+import type Program from './program';
+import type Buffer from '../data/buffer';
+
 class VertexArrayObject {
-    boundProgram: any;
-    boundVertexBuffer: any;
-    boundVertexBuffer2: any;
-    boundElementBuffer: any;
-    boundVertexOffset: any;
-    boundDynamicVertexBuffer: any;
+    boundProgram: ?Program;
+    boundVertexBuffer: ?Buffer;
+    boundVertexBuffer2: ?Buffer;
+    boundElementBuffer: ?Buffer;
+    boundVertexOffset: ?number;
+    boundDynamicVertexBuffer: ?Buffer;
     vao: any;
     gl: WebGLRenderingContext;
 
@@ -23,12 +26,12 @@ class VertexArrayObject {
     }
 
     bind(gl: WebGLRenderingContext,
-         program: any,
-         layoutVertexBuffer: any,
-         elementBuffer: any,
-         vertexBuffer2: any,
-         vertexOffset: any,
-         dynamicVertexBuffer: any) {
+         program: Program,
+         layoutVertexBuffer: Buffer,
+         elementBuffer: ?Buffer,
+         vertexBuffer2: ?Buffer,
+         vertexOffset: ?number,
+         dynamicVertexBuffer: ?Buffer) {
 
         if (gl.extVertexArrayObject === undefined) {
             (gl: any).extVertexArrayObject = gl.getExtension("OES_vertex_array_object");


### PR DESCRIPTION
Bring another concept over from native. Here it improves flow coverage (by eliminating a `{[string]: any}` map) and removes `createVAOs` calls from bucket constructors (slowly reducing duplicated code).

benchmark | master b9d9ef2 | program-class afe8a8e
--- | --- | ---
**map-load** | 120 ms  | 130 ms 
**style-load** | 46 ms  | 54 ms 
**buffer** | 974 ms  | 967 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 5.8 ms, 0% > 16ms  | 6.4 ms, 0% > 16ms 
**query-point** | 0.74 ms  | 0.76 ms 
**query-box** | 40.80 ms  | 43.64 ms 
**geojson-setdata-small** | 2 ms  | 1 ms 
**geojson-setdata-large** | 108 ms  | 111 ms 
