### PR TITLE
Use polymorphism in feature querying

### DIFF
--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -5,7 +5,6 @@ const util = require('../util/util');
 import type CollisionBoxArray from '../symbol/collision_box';
 import type Style from '../style/style';
 import type StyleLayer from '../style/style_layer';
-import type {PaintPropertyStatistics} from './program_configuration';
 import type FeatureIndex from './feature_index';
 
 export type BucketParameters = {
@@ -58,7 +57,6 @@ export type IndexedFeature = {
  */
 export interface Bucket {
     populate(features: Array<IndexedFeature>, options: PopulateParameters): void;
-    getPaintPropertyStatistics(): PaintPropertyStatistics;
     isEmpty(): boolean;
     serialize(transferables?: Array<Transferable>): SerializedBucket;
 

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -72,7 +72,7 @@ class CircleBucket implements Bucket {
         if (options.layoutVertexArray) {
             this.layoutVertexBuffer = new Buffer(options.layoutVertexArray, LayoutVertexArrayType.serialize(), Buffer.BufferType.VERTEX);
             this.elementBuffer = new Buffer(options.elementArray, ElementArrayType.serialize(), Buffer.BufferType.ELEMENT);
-            this.programConfigurations = ProgramConfigurationSet.deserialize(circleInterface, options.layers, options.zoom, options.paintVertexArrays);
+            this.programConfigurations = ProgramConfigurationSet.deserialize(circleInterface, options.layers, options.zoom, options.programConfigurations);
             this.segments = new SegmentVector(options.segments);
             this.segments.createVAOs(options.layers);
         } else {
@@ -92,10 +92,6 @@ class CircleBucket implements Bucket {
         }
     }
 
-    getPaintPropertyStatistics() {
-        return this.programConfigurations.getPaintPropertyStatistics();
-    }
-
     isEmpty() {
         return this.layoutVertexArray.length === 0;
     }
@@ -106,7 +102,7 @@ class CircleBucket implements Bucket {
             layerIds: this.layers.map((l) => l.id),
             layoutVertexArray: this.layoutVertexArray.serialize(transferables),
             elementArray: this.elementArray.serialize(transferables),
-            paintVertexArrays: this.programConfigurations.serialize(transferables),
+            programConfigurations: this.programConfigurations.serialize(transferables),
             segments: this.segments.get(),
         };
     }

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -65,7 +65,7 @@ class FillBucket implements Bucket {
             this.layoutVertexBuffer = new Buffer(options.layoutVertexArray, LayoutVertexArrayType.serialize(), Buffer.BufferType.VERTEX);
             this.elementBuffer = new Buffer(options.elementArray, ElementArrayType.serialize(), Buffer.BufferType.ELEMENT);
             this.elementBuffer2 = new Buffer(options.elementArray2, ElementArrayType2.serialize(), Buffer.BufferType.ELEMENT);
-            this.programConfigurations = ProgramConfigurationSet.deserialize(fillInterface, options.layers, options.zoom, options.paintVertexArrays);
+            this.programConfigurations = ProgramConfigurationSet.deserialize(fillInterface, options.layers, options.zoom, options.programConfigurations);
             this.segments = new SegmentVector(options.segments);
             this.segments.createVAOs(options.layers);
             this.segments2 = new SegmentVector(options.segments2);
@@ -89,10 +89,6 @@ class FillBucket implements Bucket {
         }
     }
 
-    getPaintPropertyStatistics() {
-        return this.programConfigurations.getPaintPropertyStatistics();
-    }
-
     isEmpty() {
         return this.layoutVertexArray.length === 0;
     }
@@ -104,7 +100,7 @@ class FillBucket implements Bucket {
             layoutVertexArray: this.layoutVertexArray.serialize(transferables),
             elementArray: this.elementArray.serialize(transferables),
             elementArray2: this.elementArray2.serialize(transferables),
-            paintVertexArrays: this.programConfigurations.serialize(transferables),
+            programConfigurations: this.programConfigurations.serialize(transferables),
             segments: this.segments.get(),
             segments2: this.segments2.get()
         };

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -78,7 +78,7 @@ class FillExtrusionBucket implements Bucket {
         if (options.layoutVertexArray) {
             this.layoutVertexBuffer = new Buffer(options.layoutVertexArray, LayoutVertexArrayType.serialize(), Buffer.BufferType.VERTEX);
             this.elementBuffer = new Buffer(options.elementArray, ElementArrayType.serialize(), Buffer.BufferType.ELEMENT);
-            this.programConfigurations = ProgramConfigurationSet.deserialize(fillExtrusionInterface, options.layers, options.zoom, options.paintVertexArrays);
+            this.programConfigurations = ProgramConfigurationSet.deserialize(fillExtrusionInterface, options.layers, options.zoom, options.programConfigurations);
             this.segments = new SegmentVector(options.segments);
             this.segments.createVAOs(options.layers);
         } else {
@@ -98,10 +98,6 @@ class FillExtrusionBucket implements Bucket {
         }
     }
 
-    getPaintPropertyStatistics() {
-        return this.programConfigurations.getPaintPropertyStatistics();
-    }
-
     isEmpty() {
         return this.layoutVertexArray.length === 0;
     }
@@ -112,7 +108,7 @@ class FillExtrusionBucket implements Bucket {
             layerIds: this.layers.map((l) => l.id),
             layoutVertexArray: this.layoutVertexArray.serialize(transferables),
             elementArray: this.elementArray.serialize(transferables),
-            paintVertexArrays: this.programConfigurations.serialize(transferables),
+            programConfigurations: this.programConfigurations.serialize(transferables),
             segments: this.segments.get(),
         };
     }

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -123,7 +123,7 @@ class LineBucket implements Bucket {
         if (options.layoutVertexArray) {
             this.layoutVertexBuffer = new Buffer(options.layoutVertexArray, LayoutVertexArrayType.serialize(), Buffer.BufferType.VERTEX);
             this.elementBuffer = new Buffer(options.elementArray, ElementArrayType.serialize(), Buffer.BufferType.ELEMENT);
-            this.programConfigurations = ProgramConfigurationSet.deserialize(lineInterface, options.layers, options.zoom, options.paintVertexArrays);
+            this.programConfigurations = ProgramConfigurationSet.deserialize(lineInterface, options.layers, options.zoom, options.programConfigurations);
             this.segments = new SegmentVector(options.segments);
             this.segments.createVAOs(options.layers);
         } else {
@@ -143,10 +143,6 @@ class LineBucket implements Bucket {
         }
     }
 
-    getPaintPropertyStatistics() {
-        return this.programConfigurations.getPaintPropertyStatistics();
-    }
-
     isEmpty() {
         return this.layoutVertexArray.length === 0;
     }
@@ -157,7 +153,7 @@ class LineBucket implements Bucket {
             layerIds: this.layers.map((l) => l.id),
             layoutVertexArray: this.layoutVertexArray.serialize(transferables),
             elementArray: this.elementArray.serialize(transferables),
-            paintVertexArrays: this.programConfigurations.serialize(transferables),
+            programConfigurations: this.programConfigurations.serialize(transferables),
             segments: this.segments.get(),
         };
     }

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -39,7 +39,7 @@ type QueryParameters = {
     scale: number,
     bearing: number,
     tileSize: number,
-    queryGeometry: Array<Array<{x: number, y: number}>>,
+    queryGeometry: Array<Array<Point>>,
     params: {
         filter: FilterSpecification,
         layers: Array<string>,
@@ -183,11 +183,7 @@ class FeatureIndex {
             additionalRadius = Math.max(additionalRadius, styleLayerDistance * pixelsToTileUnits);
         }
 
-        const queryGeometry = args.queryGeometry.map((q) => {
-            return q.map((p) => {
-                return new Point(p.x, p.y);
-            });
-        });
+        const queryGeometry = args.queryGeometry;
 
         let minX = Infinity;
         let minY = Infinity;

--- a/src/source/query_features.js
+++ b/src/source/query_features.js
@@ -17,21 +17,18 @@ exports.rendered = function(sourceCache: SourceCache,
     tilesIn.sort(sortTilesIn);
 
     const renderedFeatureLayers = [];
-    for (let r = 0; r < tilesIn.length; r++) {
-        const tileIn = tilesIn[r];
-        const featureIndex = tileIn.tile.featureIndex;
-        if (!featureIndex) continue;
-
+    for (const tileIn of tilesIn) {
         renderedFeatureLayers.push({
             wrappedTileID: tileIn.coord.wrapped().id,
-            queryResults: featureIndex.query({
-                queryGeometry: tileIn.queryGeometry,
-                scale: tileIn.scale,
-                tileSize: tileIn.tile.tileSize,
-                bearing: bearing,
-                params: params
-            }, styleLayers)});
+            queryResults: tileIn.tile.queryRenderedFeatures(
+                styleLayers,
+                tileIn.queryGeometry,
+                tileIn.scale,
+                params,
+                bearing)
+        });
     }
+
     return mergeRenderedFeatureLayers(renderedFeatureLayers);
 };
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -8,6 +8,7 @@ const Cache = require('../util/lru_cache');
 const Coordinate = require('../geo/coordinate');
 const util = require('../util/util');
 const EXTENT = require('../data/extent');
+const Point = require('@mapbox/point-geometry');
 
 import type {Source} from './source';
 import type Map from '../ui/map';
@@ -609,16 +610,14 @@ SourceCache.maxUnderzooming = 3;
 
 /**
  * Convert a coordinate to a point in a tile's coordinate space.
- * @returns {Object} position
  * @private
  */
-function coordinateToTilePoint(tileCoord: TileCoord, sourceMaxZoom: number, coord: Coordinate) {
+function coordinateToTilePoint(tileCoord: TileCoord, sourceMaxZoom: number, coord: Coordinate): Point {
     const zoomedCoord = coord.zoomTo(Math.min(tileCoord.z, sourceMaxZoom));
-    return {
-        x: (zoomedCoord.column - (tileCoord.x + tileCoord.w * Math.pow(2, tileCoord.z))) * EXTENT,
-        y: (zoomedCoord.row - tileCoord.y) * EXTENT
-    };
-
+    return new Point(
+        (zoomedCoord.column - (tileCoord.x + tileCoord.w * Math.pow(2, tileCoord.z))) * EXTENT,
+        (zoomedCoord.row - tileCoord.y) * EXTENT
+    );
 }
 
 function compareKeyZoom(a, b) {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -252,7 +252,7 @@ class Tile {
         return this.buckets[layer.id];
     }
 
-    queryRenderedFeatures(styleLayers: {[string]: StyleLayer},
+    queryRenderedFeatures(layers: {[string]: StyleLayer},
                           queryGeometry: Array<Array<Point>>,
                           scale: number,
                           params: { filter: FilterSpecification, layers: Array<string> },
@@ -260,13 +260,23 @@ class Tile {
         if (!this.featureIndex)
             return {};
 
+        // Determine the additional radius needed factoring in property functions
+        let additionalRadius = 0;
+        for (const id in layers) {
+            const bucket = this.getBucket(layers[id]);
+            if (bucket) {
+                additionalRadius = Math.max(additionalRadius, layers[id].queryRadius(bucket));
+            }
+        }
+
         return this.featureIndex.query({
             queryGeometry,
             bearing,
             params,
             scale,
+            additionalRadius,
             tileSize: this.tileSize,
-        }, styleLayers);
+        }, layers);
     }
 
     querySourceFeatures(result: Array<GeoJSONFeature>, params: any) {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -18,6 +18,7 @@ import type {Bucket} from '../data/bucket';
 import type StyleLayer from '../style/style_layer';
 import type TileCoord from './tile_coord';
 import type {WorkerTileResult} from './worker_source';
+import type Point from '@mapbox/point-geometry';
 
 export type TileState =
     | 'loading'   // Tile data is in the process of loading.
@@ -249,6 +250,23 @@ class Tile {
 
     getBucket(layer: StyleLayer) {
         return this.buckets[layer.id];
+    }
+
+    queryRenderedFeatures(styleLayers: {[string]: StyleLayer},
+                          queryGeometry: Array<Array<Point>>,
+                          scale: number,
+                          params: { filter: FilterSpecification, layers: Array<string> },
+                          bearing: number): {[string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>} {
+        if (!this.featureIndex)
+            return {};
+
+        return this.featureIndex.query({
+            queryGeometry,
+            bearing,
+            params,
+            scale,
+            tileSize: this.tileSize,
+        }, styleLayers);
     }
 
     querySourceFeatures(result: Array<GeoJSONFeature>, params: any) {

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -119,12 +119,6 @@ class WorkerTile {
         const done = (collisionTile) => {
             this.status = 'done';
 
-            // collect data-driven paint property statistics from each bucket
-            featureIndex.paintPropertyStatistics = {};
-            for (const id in buckets) {
-                util.extend(featureIndex.paintPropertyStatistics, buckets[id].getPaintPropertyStatistics());
-            }
-
             const transferables = [];
 
             callback(null, {

--- a/src/style/query_utils.js
+++ b/src/style/query_utils.js
@@ -1,0 +1,51 @@
+// @flow
+
+const Point = require('@mapbox/point-geometry');
+
+import type StyleLayer from './style_layer';
+
+function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: *) {
+    if (layer.isPaintValueFeatureConstant(property)) {
+        return layer.paint[property];
+    } else {
+        return bucket.programConfigurations.get(layer.id)
+            .paintPropertyStatistics[property].max;
+    }
+}
+
+function translateDistance(translate: [number, number]) {
+    return Math.sqrt(translate[0] * translate[0] + translate[1] * translate[1]);
+}
+
+function translate(queryGeometry: Array<Array<Point>>,
+                   translate: [number, number],
+                   translateAnchor: 'viewport' | 'map',
+                   bearing: number,
+                   pixelsToTileUnits: number) {
+    if (!translate[0] && !translate[1]) {
+        return queryGeometry;
+    }
+
+    const pt = Point.convert(translate);
+
+    if (translateAnchor === "viewport") {
+        pt._rotate(-bearing);
+    }
+
+    const translated = [];
+    for (let i = 0; i < queryGeometry.length; i++) {
+        const ring = queryGeometry[i];
+        const translatedRing = [];
+        for (let k = 0; k < ring.length; k++) {
+            translatedRing.push(ring[k].sub(pt._mult(pixelsToTileUnits)));
+        }
+        translated.push(translatedRing);
+    }
+    return translated;
+}
+
+module.exports = {
+    getMaximumPaintValue,
+    translateDistance,
+    translate
+};

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -9,6 +9,7 @@ const parseColor = require('./../style-spec/util/parse_color');
 const Evented = require('../util/evented');
 
 import type {Bucket, BucketParameters} from '../data/bucket';
+import type Point from '@mapbox/point-geometry';
 
 export type GlobalProperties = {
     zoom: number
@@ -43,6 +44,13 @@ class StyleLayer extends Evented {
     _layoutFunctions: any;
 
     +createBucket: (parameters: BucketParameters) => Bucket;
+    +queryRadius: (bucket: Bucket) => number;
+    +queryIntersectsFeature: (queryGeometry: Array<Array<Point>>,
+                              feature: VectorTileFeature,
+                              geometry: Array<Array<Point>>,
+                              zoom: number,
+                              bearing: number,
+                              pixelsToTileUnits: number) => boolean;
 
     constructor(layer: LayerSpecification) {
         super();

--- a/src/style/style_layer/circle_style_layer.js
+++ b/src/style/style_layer/circle_style_layer.js
@@ -2,12 +2,35 @@
 
 const StyleLayer = require('../style_layer');
 const CircleBucket = require('../../data/bucket/circle_bucket');
+const {multiPolygonIntersectsBufferedMultiPoint} = require('../../util/intersection_tests');
+const {getMaximumPaintValue, translateDistance, translate} = require('../query_utils');
 
-import type {BucketParameters} from '../../data/bucket';
+import type {Bucket, BucketParameters} from '../../data/bucket';
+import type Point from '@mapbox/point-geometry';
 
 class CircleStyleLayer extends StyleLayer {
     createBucket(parameters: BucketParameters) {
         return new CircleBucket(parameters);
+    }
+
+    queryRadius(bucket: Bucket): number {
+        const circleBucket: CircleBucket = (bucket: any);
+        return getMaximumPaintValue('circle-radius', this, circleBucket) +
+            translateDistance(this.paint['circle-translate']);
+    }
+
+    queryIntersectsFeature(queryGeometry: Array<Array<Point>>,
+                           feature: VectorTileFeature,
+                           geometry: Array<Array<Point>>,
+                           zoom: number,
+                           bearing: number,
+                           pixelsToTileUnits: number): boolean {
+        const translatedPolygon = translate(queryGeometry,
+            this.getPaintValue('circle-translate', {zoom}, feature.properties),
+            this.getPaintValue('circle-translate-anchor', {zoom}, feature.properties),
+            bearing, pixelsToTileUnits);
+        const circleRadius = this.getPaintValue('circle-radius', {zoom}, feature.properties) * pixelsToTileUnits;
+        return multiPolygonIntersectsBufferedMultiPoint(translatedPolygon, geometry, circleRadius);
     }
 }
 

--- a/src/style/style_layer/line_style_layer.js
+++ b/src/style/style_layer/line_style_layer.js
@@ -1,14 +1,79 @@
 // @flow
 
+const Point = require('@mapbox/point-geometry');
+
 const StyleLayer = require('../style_layer');
 const LineBucket = require('../../data/bucket/line_bucket');
+const {multiPolygonIntersectsBufferedMultiLine} = require('../../util/intersection_tests');
+const {getMaximumPaintValue, translateDistance, translate} = require('../query_utils');
 
-import type {BucketParameters} from '../../data/bucket';
+import type {Bucket, BucketParameters} from '../../data/bucket';
 
 class LineStyleLayer extends StyleLayer {
     createBucket(parameters: BucketParameters) {
         return new LineBucket(parameters);
     }
+
+    queryRadius(bucket: Bucket): number {
+        const lineBucket: LineBucket = (bucket: any);
+        const width = getLineWidth(
+            getMaximumPaintValue('line-width', this, lineBucket),
+            getMaximumPaintValue('line-gap-width', this, lineBucket));
+        const offset = getMaximumPaintValue('line-offset', this, lineBucket);
+        return width / 2 + Math.abs(offset) + translateDistance(this.paint['line-translate']);
+    }
+
+    queryIntersectsFeature(queryGeometry: Array<Array<Point>>,
+                           feature: VectorTileFeature,
+                           geometry: Array<Array<Point>>,
+                           zoom: number,
+                           bearing: number,
+                           pixelsToTileUnits: number): boolean {
+        const translatedPolygon = translate(queryGeometry,
+            this.getPaintValue('line-translate', {zoom}, feature.properties),
+            this.getPaintValue('line-translate-anchor', {zoom}, feature.properties),
+            bearing, pixelsToTileUnits);
+        const halfWidth = pixelsToTileUnits / 2 * getLineWidth(
+            this.getPaintValue('line-width', {zoom}, feature.properties),
+            this.getPaintValue('line-gap-width', {zoom}, feature.properties));
+        const lineOffset = this.getPaintValue('line-offset', {zoom}, feature.properties);
+        if (lineOffset) {
+            geometry = offsetLine(geometry, lineOffset * pixelsToTileUnits);
+        }
+        return multiPolygonIntersectsBufferedMultiLine(translatedPolygon, geometry, halfWidth);
+    }
 }
 
 module.exports = LineStyleLayer;
+
+function getLineWidth(lineWidth, lineGapWidth) {
+    if (lineGapWidth > 0) {
+        return lineGapWidth + 2 * lineWidth;
+    } else {
+        return lineWidth;
+    }
+}
+
+function offsetLine(rings, offset) {
+    const newRings = [];
+    const zero = new Point(0, 0);
+    for (let k = 0; k < rings.length; k++) {
+        const ring = rings[k];
+        const newRing = [];
+        for (let i = 0; i < ring.length; i++) {
+            const a = ring[i - 1];
+            const b = ring[i];
+            const c = ring[i + 1];
+            const aToB = i === 0 ? zero : b.sub(a)._unit()._perp();
+            const bToC = i === ring.length - 1 ? zero : c.sub(b)._unit()._perp();
+            const extrude = aToB._add(bToC)._unit();
+
+            const cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;
+            extrude._mult(1 / cosHalfAngle);
+
+            newRing.push(extrude._mult(offset)._add(b));
+        }
+        newRings.push(newRing);
+    }
+    return newRings;
+}

--- a/src/style/style_layer/symbol_style_layer.js
+++ b/src/style/style_layer/symbol_style_layer.js
@@ -2,6 +2,7 @@
 
 const StyleLayer = require('../style_layer');
 const SymbolBucket = require('../../data/bucket/symbol_bucket');
+const assert = require('assert');
 
 import type {GlobalProperties, FeatureProperties} from '../style_layer';
 import type {BucketParameters} from '../../data/bucket';
@@ -31,6 +32,15 @@ class SymbolStyleLayer extends StyleLayer {
         // Eventually we need to make SymbolBucket conform to the Bucket interface.
         // Hack around it with casts for now.
         return (new SymbolBucket((parameters: any)): any);
+    }
+
+    queryRadius(): number {
+        return 0;
+    }
+
+    queryIntersectsFeature(): boolean {
+        assert(false); // Should take a different path in FeatureIndex
+        return false;
     }
 }
 

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -12,7 +12,6 @@ const GlyphAtlas = require('../../../src/symbol/glyph_atlas');
 const StyleLayer = require('../../../src/style/style_layer');
 const util = require('../../../src/util/util');
 const featureFilter = require('../../../src/style-spec/feature_filter');
-const AnimationLoop = require('../../../src/style/animation_loop');
 
 // Load a point feature from fixture tile.
 const vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
@@ -96,48 +95,6 @@ test('SymbolBucket redo placement', (t) => {
     bucket.prepare(stacks, {});
     bucket.place(collision);
     bucket.place(collision);
-
-    t.end();
-});
-
-
-test('SymbolBucket#getPaintPropertyStatistics()', (t) => {
-    const layer = new StyleLayer({
-        id: 'test',
-        type: 'symbol',
-        layout: {
-            'text-font': ['Test'],
-            'text-field': 'abcde',
-            'icon-image': 'dot',
-            'icon-allow-overlap': true,
-            'text-allow-overlap': true
-        },
-        paint: {
-            'text-halo-width': { property: 'scalerank', type: 'identity' },
-            'icon-halo-width': { property: 'foo', type: 'identity', default: 5 }
-        },
-        filter: featureFilter()
-    });
-
-    layer.updatePaintTransitions([], {}, { zoom: 5 }, new AnimationLoop(), {});
-
-    const bucket = new SymbolBucket({
-        overscaling: 1,
-        zoom: 0,
-        collisionBoxArray: collisionBoxArray,
-        layers: [layer]
-    });
-    const options = {iconDependencies: {}, glyphDependencies: {}};
-
-    bucket.populate([{feature}], options);
-    bucket.prepare(stacks, {
-        dot: { displaySize: () => [10, 10], textureRect: { x: 0, y: 0, w: 10, h: 10 }, pixelRatio: 1 }
-    });
-    bucket.place(collision);
-
-    const stats = bucket.getPaintPropertyStatistics().test;
-    t.deepEqual(stats['text-halo-width'], { max: 4 });
-    t.deepEqual(stats['icon-halo-width'], { max: 5 });
 
     t.end();
 });


### PR DESCRIPTION
Extract `StyleLayer#queryRadius` and `StyleLayer#queryIntersectsFeature` methods, replacing tightly coupled case-based dispatch in `FeatureIndex` with polymorphism.

This matches native* and allows statistics to be owned by `ProgramConfiguration` throughout their lifetime, rather than awkwardly transferred to `FeatureIndex` at the end of layout.

<sub>* Except that in native, `queryRadius` is on `Bucket` instead of `StyleLayer`. I think this is just a historic accident and having both methods on the same type is preferable.</sub>

benchmark | master bb31e67 | layer-query-polymorphism b18f0be
--- | --- | ---
**map-load** | 86 ms  | 74 ms 
**style-load** | 57 ms  | 48 ms 
**buffer** | 1,007 ms  | 986 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 6 ms, 0% > 16ms  | 5.6 ms, 0% > 16ms 
**query-point** | 0.79 ms  | 0.63 ms 
**query-box** | 43.51 ms  | 40.40 ms 
**geojson-setdata-small** | 2 ms  | 2 ms 
**geojson-setdata-large** | 109 ms  | 104 ms 
