### PR TITLE
Remove fast-stable-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "bubleify": "^0.7.0",
     "csscolorparser": "~1.0.2",
     "earcut": "^2.0.3",
-    "fast-stable-stringify": "^0.1.1",
     "geojson-rewind": "^0.2.0",
     "geojson-vt": "^2.4.0",
     "grid-index": "^1.0.0",

--- a/src/style-spec/group_by_layout.js
+++ b/src/style-spec/group_by_layout.js
@@ -1,11 +1,34 @@
 
-const refProperties = require('./util/ref_properties'),
-    stringify = require('fast-stable-stringify');
+const refProperties = require('./util/ref_properties');
 
-function key(layer) {
-    return stringify(refProperties.map((k) => {
-        return layer[k];
-    }));
+function stringify(obj) {
+    const type = typeof obj;
+    if (type === 'number' || type === 'string' || obj === undefined || obj === null)
+        return JSON.stringify(obj);
+
+    if (Array.isArray(obj)) {
+        let str = '[';
+        for (const val of obj) {
+            str += `${stringify(val)},`;
+        }
+        return `${str}]`;
+    }
+
+    const keys = Object.keys(obj).sort();
+
+    let str = '{';
+    for (let i = 0; i < keys.length; i++) {
+        str += `${JSON.stringify(keys[i])}:${stringify(obj[keys[i]])},`;
+    }
+    return `${str}}`;
+}
+
+function getKey(layer) {
+    let key = '';
+    for (const k of refProperties) {
+        key += `/${stringify(layer[k])}`;
+    }
+    return key;
 }
 
 module.exports = groupByLayout;
@@ -28,7 +51,7 @@ function groupByLayout(layers) {
     const groups = {};
 
     for (let i = 0; i < layers.length; i++) {
-        const k = key(layers[i]);
+        const k = getKey(layers[i]);
         let group = groups[k];
         if (!group) {
             group = groups[k] = [];

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "csscolorparser": "~1.0.2",
-    "fast-stable-stringify": "^0.1.1",
     "jsonlint-lines-primitives": "~1.6.0",
     "lodash.isequal": "^3.0.4",
     "minimist": "0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,10 +2577,6 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fast-stable-stringify@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/fast-stable-stringify/-/fast-stable-stringify-0.1.1.tgz#ce758dce1cb40fb2bf0c8aef4f93e792d195b491"
-
 faye-websocket@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
@@ -2989,7 +2985,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.3:
+glob@^5.0.14, glob@^5.0.3:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:


### PR DESCRIPTION
Closes #5152 by implementing a simpler key generation for layer specifications. Input is pre-validated so we don't have to worry about circular links or weird objects, and the output doesn't have to be valid JSON, just good enough to be used as a unique key.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~ covered by `group_by_layout.test.js`
 - [x] post benchmark scores
 - [x] manually test the debug page
