### PR TITLE
Fix unbounded memory use in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
     docker:
       - image: mbgl/ci:r4-linux-gl-js
     working_directory: ~/mapbox-gl-js
-    resource_class: large
     steps:
       - checkout
       - restore_cache:
@@ -47,7 +46,6 @@ jobs:
     docker:
       - image: mbgl/ci:r4-linux-gl-js
     working_directory: ~/mapbox-gl-js
-    resource_class: large
     steps:
       - checkout
       - restore_cache:

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -42,7 +42,7 @@ function restore(): Window {
     };
 
     window.useFakeHTMLCanvasGetContext = function() {
-        this.HTMLCanvasElement.prototype.getContext = sinon.stub().returns('2d');
+        this.HTMLCanvasElement.prototype.getContext = function() { return '2d'; };
     };
 
     window.useFakeXMLHttpRequest = function() {
@@ -55,7 +55,7 @@ function restore(): Window {
 
     window.restore = restore;
 
-    window.ImageData = window.ImageData || sinon.stub().returns(false);
+    window.ImageData = window.ImageData || function() { return false; };
 
     util.extend(module.exports, window);
 

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const ajax =  require('../src/util/ajax');
-const sinon = require('sinon');
 const request = require('request');
 const PNG = require('pngjs').PNG;
 const Map = require('../src/ui/map');
@@ -126,7 +125,7 @@ function cached(data, callback) {
     });
 }
 
-sinon.stub(ajax, 'getJSON').callsFake(({ url }, callback) => {
+ajax.getJSON = function({ url }, callback) {
     if (cache[url]) return cached(cache[url], callback);
     return request(url, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
@@ -142,9 +141,9 @@ sinon.stub(ajax, 'getJSON').callsFake(({ url }, callback) => {
             callback(error || new Error(response.statusCode));
         }
     });
-});
+};
 
-sinon.stub(ajax, 'getArrayBuffer').callsFake(({ url }, callback) => {
+ajax.getArrayBuffer = function({ url }, callback) {
     if (cache[url]) return cached(cache[url], callback);
     return request({ url, encoding: null }, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
@@ -154,9 +153,9 @@ sinon.stub(ajax, 'getArrayBuffer').callsFake(({ url }, callback) => {
             callback(error || new Error(response.statusCode));
         }
     });
-});
+};
 
-sinon.stub(ajax, 'getImage').callsFake(({ url }, callback) => {
+ajax.getImage = function({ url }, callback) {
     if (cache[url]) return cached(cache[url], callback);
     return request({ url, encoding: null }, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
@@ -169,15 +168,15 @@ sinon.stub(ajax, 'getImage').callsFake(({ url }, callback) => {
             callback(error || new Error(response.statusCode));
         }
     });
-});
+};
 
-sinon.stub(browser, 'getImageData').callsFake((img) => {
+browser.getImageData = function(img) {
     return new Uint8Array(img.data);
-});
+};
 
 // Hack: since node doesn't have any good video codec modules, just grab a png with
 // the first frame and fake the video API.
-sinon.stub(ajax, 'getVideo').callsFake((urls, callback) => {
+ajax.getVideo = function(urls, callback) {
     return request({ url: urls[0], encoding: null }, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
             new PNG().parse(body, (err, png) => {
@@ -195,4 +194,4 @@ sinon.stub(ajax, 'getVideo').callsFake((urls, callback) => {
             callback(error || new Error(response.statusCode));
         }
     });
-});
+};


### PR DESCRIPTION
This was caused by the use of sinon's stubs. Stubs permanently record the arguments for every call, i.e. they leak memory. Don't use them unless you actually need to inspect the arguments or restore the original method.

Fixes #5163 and speeds up the render tests:

before:

```
real	1m59.662s
user	1m40.130s
sys	0m6.504s
```

after:

```
real	1m46.410s
user	1m25.947s
sys	0m5.938s
```
