### PR TITLE
Accept `samples:` data in benchmark results

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -66,19 +66,27 @@ These events have no machine-semantic meaning.
 Fire the `end` event to indicate the benchmark has finished running and report
 its results.
 
-These events have both human-readable results (`message`) and machine-readable results (`score`). Smaller `score`s are "better."
+These events have both human-readable results (`message`) and machine-readable results (`score`). Smaller `score`s are "better."  Optionally, an array of raw sample data (`samples`) may also be included.
 
 ```js
 {
     message: string;
     score: number;
+    ?samples: Array
 }
 ```
 
 ```js
 benchmark.fire('end', {
     message: 'Average time is ' + formatNumber(averageTime)) + 'ms',
-    score: averageTime
+    score: averageTime,
+    samples: [
+        ['sample', 'value'],
+        [1, sample1Time],
+        [2, sample2Time],
+        [3, sample3Time],
+        ...
+    ]
 });
 ```
 

--- a/bench/benchmarks/frame_duration.js
+++ b/bench/benchmarks/frame_duration.js
@@ -41,15 +41,20 @@ module.exports = function(options) {
         let sum = 0;
         let count = 0;
         let countAbove16 = 0;
+        const samples = [];
         for (let i = 0; i < results.length; i++) {
             const result = results[i];
             sum += result.sum;
             count += result.count;
             countAbove16 += result.countAbove16;
+            for (const value of result.samples) {
+                samples.push([zooms[i], value]);
+            }
         }
         evented.fire('end', {
             message: `${formatNumber(sum / count * 10) / 10} ms, ${formatNumber(countAbove16 / count * 100)}% > 16ms`,
-            score: sum / count
+            score: sum / count,
+            samples: [['zoom', 'frame']].concat(samples)
         });
     }
 
@@ -75,6 +80,7 @@ function measureFrameTime(options, zoom, callback) {
             let sum = 0;
             let count = 0;
             let countAbove16 = 0;
+            const samples = [];
             const start = performance.now();
 
             map._realrender = map._render;
@@ -87,6 +93,7 @@ function measureFrameTime(options, zoom, callback) {
                 const frameEnd = performance.now();
                 const duration = frameEnd - frameStart;
 
+                samples.push(duration);
                 sum += duration;
                 count++;
                 if (duration >= 16) countAbove16++;
@@ -98,7 +105,8 @@ function measureFrameTime(options, zoom, callback) {
                     callback(undefined, {
                         sum: sum,
                         count: count,
-                        countAbove16: countAbove16
+                        countAbove16: countAbove16,
+                        samples: samples
                     });
                 }
             };

--- a/bench/benchmarks_view.js
+++ b/bench/benchmarks_view.js
@@ -49,6 +49,7 @@ const BenchmarksView = React.createClass({
 
     renderBenchmarkVersion: function(name, version) {
         const results = this.state.results[name][version];
+        const sampleData = results.samples ? results.samples.map(row => row.join(',')).join('\n') : null;
         return (
             <td id={name + version}
                 key={version}
@@ -56,6 +57,16 @@ const BenchmarksView = React.createClass({
                 {results.logs.map((log, index) => {
                     return <div key={index} className={`pad1 dark fill-${log.color}`}>{log.message}</div>;
                 })}
+                {sampleData ? (
+                    <details>
+                        <summary className='pad1 dark fill-green'>
+                            Sample Data
+                            <a className='icon clipboard'
+                                data-clipboard-text={sampleData}>Copy</a>
+                        </summary>
+                        <pre>{sampleData}</pre>
+                    </details>
+                ) : ''}
             </td>
         );
     },
@@ -151,6 +162,7 @@ const BenchmarksView = React.createClass({
             emitter.on('end', (event) => {
                 results.message = event.message;
                 results.status = 'ended';
+                results.samples = event.samples;
                 log('green', event.message);
                 callback();
 


### PR DESCRIPTION
![bench](https://user-images.githubusercontent.com/4974151/29537274-26747582-868f-11e7-9a86-e7c8b2e3493d.gif)
