### PR TITLE
Introduce an explicit "upload" step to rendering

### DIFF
--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -60,6 +60,9 @@ export interface Bucket {
     isEmpty(): boolean;
     serialize(transferables?: Array<Transferable>): SerializedBucket;
 
+    upload(gl: WebGLRenderingContext): void;
+    uploaded: boolean;
+
     /**
      * Release the WebGL resources associated with the buffers. Note that because
      * buckets are shared between layers having the same layout properties, they

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -51,7 +51,6 @@ function addVertex(vertexArray, x, y, nx, ny, nz, t, e) {
 }
 
 const LayoutVertexArrayType = createVertexArrayType(fillExtrusionInterface.layoutAttributes);
-const IndexArrayType = fillExtrusionInterface.indexArrayType;
 
 class FillExtrusionBucket implements Bucket {
     static programInterface: ProgramInterface;
@@ -69,6 +68,7 @@ class FillExtrusionBucket implements Bucket {
 
     programConfigurations: ProgramConfigurationSet;
     segments: SegmentVector;
+    uploaded: boolean;
 
     constructor(options: any) {
         this.zoom = options.zoom;
@@ -76,17 +76,10 @@ class FillExtrusionBucket implements Bucket {
         this.layers = options.layers;
         this.index = options.index;
 
-        if (options.layoutVertexArray) {
-            this.layoutVertexBuffer = new VertexBuffer(options.layoutVertexArray, LayoutVertexArrayType.serialize());
-            this.indexBuffer = new IndexBuffer(options.indexArray);
-            this.programConfigurations = ProgramConfigurationSet.deserialize(fillExtrusionInterface, options.layers, options.zoom, options.programConfigurations);
-            this.segments = new SegmentVector(options.segments);
-        } else {
-            this.layoutVertexArray = new LayoutVertexArrayType();
-            this.indexArray = new IndexArrayType();
-            this.programConfigurations = new ProgramConfigurationSet(fillExtrusionInterface, options.layers, options.zoom);
-            this.segments = new SegmentVector();
-        }
+        this.layoutVertexArray = new LayoutVertexArrayType(options.layoutVertexArray);
+        this.indexArray = new TriangleIndexArray(options.indexArray);
+        this.programConfigurations = new ProgramConfigurationSet(fillExtrusionInterface, options.layers, options.zoom, options.programConfigurations);
+        this.segments = new SegmentVector(options.segments);
     }
 
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
@@ -113,7 +106,14 @@ class FillExtrusionBucket implements Bucket {
         };
     }
 
+    upload(gl: WebGLRenderingContext) {
+        this.layoutVertexBuffer = new VertexBuffer(gl, this.layoutVertexArray);
+        this.indexBuffer = new IndexBuffer(gl, this.indexArray);
+        this.programConfigurations.upload(gl);
+    }
+
     destroy() {
+        if (!this.layoutVertexBuffer) return;
         this.layoutVertexBuffer.destroy();
         this.indexBuffer.destroy();
         this.programConfigurations.destroy();

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -38,7 +38,7 @@ function drawDebugTile(painter, sourceCache, coord) {
     for (let v = 0; v < vertices.length; v += 2) {
         debugTextArray.emplaceBack(vertices[v], vertices[v + 1]);
     }
-    const debugTextBuffer = VertexBuffer.fromStructArray(debugTextArray);
+    const debugTextBuffer = new VertexBuffer(gl, debugTextArray);
     const debugTextVAO = new VertexArrayObject();
     debugTextVAO.bind(gl, program, debugTextBuffer);
     gl.uniform4f(program.uniforms.u_color, 1, 1, 1, 1);

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -100,7 +100,7 @@ function renderTextureToMap(gl, painter, layer, texture) {
     array.emplaceBack(1, 0);
     array.emplaceBack(0, 1);
     array.emplaceBack(1, 1);
-    const buffer = VertexBuffer.fromStructArray(array);
+    const buffer = new VertexBuffer(gl, array);
 
     const vao = new VertexArrayObject();
     vao.bind(gl, program, buffer);

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -14,86 +14,78 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: StyleLaye
     if (painter.isOpaquePass) return;
 
     const gl = painter.gl;
+    const source = sourceCache.getSource();
+    const program = painter.useProgram('raster');
 
     gl.enable(gl.DEPTH_TEST);
     painter.depthMask(true);
 
     // Change depth function to prevent double drawing in areas where tiles overlap.
     gl.depthFunc(gl.LESS);
-
-    const minTileZ = coords.length && coords[0].z;
-
-    for (let i = 0; i < coords.length; i++) {
-        const coord = coords[i];
-        // set the lower zoom level to sublayer 0, and higher zoom levels to higher sublayers
-        painter.setDepthSublayer(coord.z - minTileZ);
-        drawRasterTile(painter, sourceCache, layer, coord);
-    }
-
-    gl.depthFunc(gl.LEQUAL);
-}
-
-function drawRasterTile(painter, sourceCache, layer, coord) {
-
-    const gl = painter.gl;
-
     gl.disable(gl.STENCIL_TEST);
 
-    const tile = sourceCache.getTile(coord);
-    const posMatrix = painter.transform.calculatePosMatrix(coord, sourceCache.getSource().maxzoom);
-
-    tile.registerFadeDuration(painter.style.animationLoop, layer.paint['raster-fade-duration']);
-
-    const program = painter.useProgram('raster');
-    gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
-
-    // color parameters
+    // Constant parameters.
     gl.uniform1f(program.uniforms.u_brightness_low, layer.paint['raster-brightness-min']);
     gl.uniform1f(program.uniforms.u_brightness_high, layer.paint['raster-brightness-max']);
     gl.uniform1f(program.uniforms.u_saturation_factor, saturationFactor(layer.paint['raster-saturation']));
     gl.uniform1f(program.uniforms.u_contrast_factor, contrastFactor(layer.paint['raster-contrast']));
     gl.uniform3fv(program.uniforms.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));
-
-    const parentTile = sourceCache.findLoadedParent(coord, 0, {}),
-        fade = getFadeValues(tile, parentTile, sourceCache, layer, painter.transform);
-
-    let parentScaleBy, parentTL;
-
-    gl.activeTexture(gl.TEXTURE0);
-    gl.bindTexture(gl.TEXTURE_2D, tile.texture);
-
-    gl.activeTexture(gl.TEXTURE1);
-
-    if (parentTile) {
-        gl.bindTexture(gl.TEXTURE_2D, parentTile.texture);
-        parentScaleBy = Math.pow(2, parentTile.coord.z - tile.coord.z);
-        parentTL = [tile.coord.x * parentScaleBy % 1, tile.coord.y * parentScaleBy % 1];
-
-    } else {
-        gl.bindTexture(gl.TEXTURE_2D, tile.texture);
-    }
-
-    // cross-fade parameters
-    gl.uniform2fv(program.uniforms.u_tl_parent, parentTL || [0, 0]);
-    gl.uniform1f(program.uniforms.u_scale_parent, parentScaleBy || 1);
     gl.uniform1f(program.uniforms.u_buffer_scale, 1);
-    gl.uniform1f(program.uniforms.u_fade_t, fade.mix);
-    gl.uniform1f(program.uniforms.u_opacity, fade.opacity * layer.paint['raster-opacity']);
     gl.uniform1i(program.uniforms.u_image0, 0);
     gl.uniform1i(program.uniforms.u_image1, 1);
 
-    const source = sourceCache.getSource();
-    if (source instanceof ImageSource) {
-        const buffer = source.boundsBuffer;
-        const vao = source.boundsVAO;
-        vao.bind(gl, program, buffer);
-        gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
-    } else {
-        const buffer = painter.rasterBoundsBuffer;
-        const vao = painter.rasterBoundsVAO;
-        vao.bind(gl, program, buffer);
-        gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+    const minTileZ = coords.length && coords[0].z;
+
+    for (const coord of coords) {
+        // set the lower zoom level to sublayer 0, and higher zoom levels to higher sublayers
+        painter.setDepthSublayer(coord.z - minTileZ);
+
+        const tile = sourceCache.getTile(coord);
+        const posMatrix = painter.transform.calculatePosMatrix(coord, sourceCache.getSource().maxzoom);
+
+        tile.registerFadeDuration(painter.style.animationLoop, layer.paint['raster-fade-duration']);
+
+        gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
+
+        const parentTile = sourceCache.findLoadedParent(coord, 0, {}),
+            fade = getFadeValues(tile, parentTile, sourceCache, layer, painter.transform);
+
+        let parentScaleBy, parentTL;
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, tile.texture);
+
+        gl.activeTexture(gl.TEXTURE1);
+
+        if (parentTile) {
+            gl.bindTexture(gl.TEXTURE_2D, parentTile.texture);
+            parentScaleBy = Math.pow(2, parentTile.coord.z - tile.coord.z);
+            parentTL = [tile.coord.x * parentScaleBy % 1, tile.coord.y * parentScaleBy % 1];
+
+        } else {
+            gl.bindTexture(gl.TEXTURE_2D, tile.texture);
+        }
+
+        // cross-fade parameters
+        gl.uniform2fv(program.uniforms.u_tl_parent, parentTL || [0, 0]);
+        gl.uniform1f(program.uniforms.u_scale_parent, parentScaleBy || 1);
+        gl.uniform1f(program.uniforms.u_fade_t, fade.mix);
+        gl.uniform1f(program.uniforms.u_opacity, fade.opacity * layer.paint['raster-opacity']);
+
+        if (source instanceof ImageSource) {
+            const buffer = source.boundsBuffer;
+            const vao = source.boundsVAO;
+            vao.bind(gl, program, buffer);
+            gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+        } else {
+            const buffer = painter.rasterBoundsBuffer;
+            const vao = painter.rasterBoundsVAO;
+            vao.bind(gl, program, buffer);
+            gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+        }
     }
+
+    gl.depthFunc(gl.LEQUAL);
 }
 
 function spinWeights(angle) {

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -1,6 +1,7 @@
 // @flow
 
 const util = require('../util/util');
+const ImageSource = require('../source/image_source');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -81,10 +82,18 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     gl.uniform1i(program.uniforms.u_image0, 0);
     gl.uniform1i(program.uniforms.u_image1, 1);
 
-    const buffer = tile.boundsBuffer || painter.rasterBoundsBuffer;
-    const vao = tile.boundsVAO || painter.rasterBoundsVAO;
-    vao.bind(gl, program, buffer);
-    gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+    const source = sourceCache.getSource();
+    if (source instanceof ImageSource) {
+        const buffer = source.boundsBuffer;
+        const vao = source.boundsVAO;
+        vao.bind(gl, program, buffer);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+    } else {
+        const buffer = painter.rasterBoundsBuffer;
+        const vao = painter.rasterBoundsVAO;
+        vao.bind(gl, program, buffer);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+    }
 }
 
 function spinWeights(angle) {

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -53,8 +53,8 @@ function drawRasterTile(painter, sourceCache, layer, coord) {
     gl.uniform1f(program.uniforms.u_contrast_factor, contrastFactor(layer.paint['raster-contrast']));
     gl.uniform3fv(program.uniforms.u_spin_weights, spinWeights(layer.paint['raster-hue-rotate']));
 
-    const parentTile = tile.sourceCache && tile.sourceCache.findLoadedParent(coord, 0, {}),
-        fade = getFadeValues(tile, parentTile, layer, painter.transform);
+    const parentTile = sourceCache.findLoadedParent(coord, 0, {}),
+        fade = getFadeValues(tile, parentTile, sourceCache, layer, painter.transform);
 
     let parentScaleBy, parentTL;
 
@@ -110,15 +110,15 @@ function saturationFactor(saturation) {
         -saturation;
 }
 
-function getFadeValues(tile, parentTile, layer, transform) {
+function getFadeValues(tile, parentTile, sourceCache, layer, transform) {
     const fadeDuration = layer.paint['raster-fade-duration'];
 
-    if (tile.sourceCache && fadeDuration > 0) {
+    if (fadeDuration > 0) {
         const now = Date.now();
         const sinceTile = (now - tile.timeAdded) / fadeDuration;
         const sinceParent = parentTile ? (now - parentTile.timeAdded) / fadeDuration : -1;
 
-        const source = tile.sourceCache.getSource();
+        const source = sourceCache.getSource();
         const idealZ = transform.coveringZoomLevel({
             tileSize: source.tileSize,
             roundZoom: source.roundZoom

--- a/src/render/vertex_array_object.js
+++ b/src/render/vertex_array_object.js
@@ -56,7 +56,7 @@ class VertexArrayObject {
 
             if (dynamicVertexBuffer) {
                 // The buffer may have been updated. Rebind to upload data.
-                dynamicVertexBuffer.bind(gl);
+                dynamicVertexBuffer.bind();
             }
         }
     }
@@ -106,18 +106,18 @@ class VertexArrayObject {
             dynamicVertexBuffer.enableAttributes(gl, program);
         }
 
-        layoutVertexBuffer.bind(gl);
+        layoutVertexBuffer.bind();
         layoutVertexBuffer.setVertexAttribPointers(gl, program, vertexOffset);
         if (vertexBuffer2) {
-            vertexBuffer2.bind(gl);
+            vertexBuffer2.bind();
             vertexBuffer2.setVertexAttribPointers(gl, program, vertexOffset);
         }
         if (dynamicVertexBuffer) {
-            dynamicVertexBuffer.bind(gl);
+            dynamicVertexBuffer.bind();
             dynamicVertexBuffer.setVertexAttribPointers(gl, program, vertexOffset);
         }
         if (indexBuffer) {
-            indexBuffer.bind(gl);
+            indexBuffer.bind();
         }
 
         (gl: any).currentNumAttributes = numNextAttributes;

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -67,6 +67,8 @@ class ImageSource extends Evented implements Source {
     centerCoord: Coordinate;
     coord: TileCoord;
     _tileCoords: Array<Point>;
+    boundsBuffer: VertexBuffer;
+    boundsVAO: VertexArrayObject;
 
     constructor(id: string, options: ImageSourceSpecification | VideoSourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
@@ -159,22 +161,22 @@ class ImageSource extends Evented implements Source {
                 Math.round((zoomedCoord.row - centerCoord.row) * EXTENT));
         });
 
-        this.fire('data', {dataType:'source', sourceDataType: 'content'});
-        return this;
-    }
-
-    _setTile(tile: Tile) {
-        this.tiles[String(tile.coord.w)] = tile;
         const array = new RasterBoundsArray();
         array.emplaceBack(this._tileCoords[0].x, this._tileCoords[0].y, 0, 0);
         array.emplaceBack(this._tileCoords[1].x, this._tileCoords[1].y, EXTENT, 0);
         array.emplaceBack(this._tileCoords[3].x, this._tileCoords[3].y, 0, EXTENT);
         array.emplaceBack(this._tileCoords[2].x, this._tileCoords[2].y, EXTENT, EXTENT);
 
-        tile.buckets = {};
+        this.boundsBuffer = VertexBuffer.fromStructArray(array);
+        this.boundsVAO = new VertexArrayObject();
 
-        tile.boundsBuffer = VertexBuffer.fromStructArray(array);
-        tile.boundsVAO = new VertexArrayObject();
+        this.fire('data', {dataType:'source', sourceDataType: 'content'});
+        return this;
+    }
+
+    _setTile(tile: Tile) {
+        this.tiles[String(tile.coord.w)] = tile;
+        tile.buckets = {};
     }
 
     prepare() {

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -174,11 +174,6 @@ class ImageSource extends Evented implements Source {
         return this;
     }
 
-    _setTile(tile: Tile) {
-        this.tiles[String(tile.coord.w)] = tile;
-        tile.buckets = {};
-    }
-
     prepare() {
         if (Object.keys(this.tiles).length === 0 || !this.image) return;
         this._prepareImage(this.map.painter.gl, this.image);
@@ -218,7 +213,8 @@ class ImageSource extends Evented implements Source {
         // If the world wraps, we may have multiple "wrapped" copies of the
         // single tile.
         if (this.coord && this.coord.toString() === tile.coord.toString()) {
-            this._setTile(tile);
+            this.tiles[String(tile.coord.w)] = tile;
+            tile.buckets = {};
             callback(null);
         } else {
             tile.state = 'errored';

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -211,7 +211,6 @@ class SourceCache extends Evented {
             return;
         }
 
-        tile.sourceCache = this;
         tile.timeAdded = new Date().getTime();
         if (previousState === 'expired') tile.refreshedUponExpiration = true;
         this._setTileReloadTimer(id, tile);

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -152,10 +152,14 @@ class SourceCache extends Evented {
         return this._source.serialize();
     }
 
+    prepare(gl: WebGLRenderingContext) {
+        if  (this._source.prepare) {
+            this._source.prepare();
+        }
 
-    prepare() {
-        if (this._sourceLoaded && this._source.prepare)
-            return this._source.prepare();
+        for (const i in this._tiles) {
+            this._tiles[i].upload(gl);
+        }
     }
 
     /**

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -249,6 +249,16 @@ class Tile {
         return this.buckets[layer.id];
     }
 
+    upload(gl: WebGLRenderingContext) {
+        for (const id in this.buckets) {
+            const bucket = this.buckets[id];
+            if (!bucket.uploaded) {
+                bucket.upload(gl);
+                bucket.uploaded = true;
+            }
+        }
+    }
+
     queryRenderedFeatures(layers: {[string]: StyleLayer},
                           queryGeometry: Array<Array<Point>>,
                           scale: number,

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -63,8 +63,6 @@ class Tile {
     vtLayers: {[string]: VectorTileLayer};
 
     aborted: ?boolean;
-    boundsBuffer: any;
-    boundsVAO: any;
     request: any;
     texture: any;
     refreshedUponExpiration: boolean;

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -67,7 +67,6 @@ class Tile {
     boundsVAO: any;
     request: any;
     texture: any;
-    sourceCache: any;
     refreshedUponExpiration: boolean;
     reloadCallback: any;
 

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -69,13 +69,7 @@ export type SerializedStructArray = {
     arrayBuffer: ArrayBuffer
 };
 
-export type SerializedStructArrayType = {
-    members: Array<StructArrayMember>,
-    alignment: number,
-    bytesPerElement: number
-};
-
-type StructArrayTypeParameters = {
+export type StructArrayTypeParameters = {
     members: $ReadOnlyArray<{
         name: string,
         type: ViewType,
@@ -131,11 +125,10 @@ class StructArray {
     /**
      * Serialize the StructArray type. This serializes the *type* not an instance of the type.
      */
-    static serialize(): SerializedStructArrayType {
+    static serialize(): StructArrayTypeParameters {
         return {
             members: this.prototype.members,
-            alignment: this.prototype.StructType.prototype.alignment,
-            bytesPerElement: this.prototype.bytesPerElement
+            alignment: this.prototype.StructType.prototype.alignment
         };
     }
 

--- a/test/unit/data/vertex_buffer.test.js
+++ b/test/unit/data/vertex_buffer.test.js
@@ -16,12 +16,13 @@ test('VertexBuffer', (t) => {
 
 
     t.test('constructs itself', (t) => {
+        const gl = require('gl')(10, 10);
         const array = new TestArray();
         array.emplaceBack(1, 1, 1);
         array.emplaceBack(1, 1, 1);
         array.emplaceBack(1, 1, 1);
 
-        const buffer = VertexBuffer.fromStructArray(array);
+        const buffer = new VertexBuffer(gl, array);
 
         t.deepEqual(buffer.attributes, [
             {
@@ -38,7 +39,6 @@ test('VertexBuffer', (t) => {
 
         t.deepEqual(buffer.itemSize, 8);
         t.deepEqual(buffer.length, 3);
-        t.ok(buffer.arrayBuffer);
         t.end();
     });
 

--- a/test/unit/util/struct_array.test.js
+++ b/test/unit/util/struct_array.test.js
@@ -27,7 +27,6 @@ test('StructArray', (t) => {
                 type: 'Int16',
                 offset: 4
             }],
-            bytesPerElement: 8,
             alignment: 4
         });
 


### PR DESCRIPTION
In this step, all pending vertex and index buffers are uploaded, rather than them being uploaded in the course of rendering. This brings gl-js closer to the native behavior, and in theory is more efficient.

benchmark | master b203a40 | upload e386312
--- | --- | ---
**map-load** | 221 ms  | 105 ms 
**style-load** | 85 ms  | 84 ms 
**buffer** | 1,033 ms  | 1,022 ms 
**fps** | 59 fps  | 60 fps 
**frame-duration** | 5.3 ms, 0% > 16ms  | 5 ms, 0% > 16ms 
**query-point** | 0.68 ms  | 0.69 ms 
**query-box** | 46.08 ms  | 41.86 ms 
**geojson-setdata-small** | 3 ms  | 4 ms 
**geojson-setdata-large** | 129 ms  | 111 ms 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
