### PR TITLE
Fix redoPlacement race condition

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -235,6 +235,8 @@ class Tile {
             cameraToTileDistance: this.cameraToTileDistance,
             showCollisionBoxes: this.showCollisionBoxes
         }, (_, data) => {
+            if (this.state !== 'reloading') return;
+
             this.state = 'loaded';
             this.reloadSymbolData(data, this.placementSource.map.style);
             this.placementSource.fire('data', {tile: this, coord: this.coord, dataType: 'source'});
@@ -242,6 +244,7 @@ class Tile {
             if (this.placementSource.map) this.placementSource.map.painter.tileExtentVAO.vao = null;
 
             if (this.redoWhenDone) {
+                this.state = 'reloading';
                 this.redoWhenDone = false;
                 this._immediateRedoPlacement();
             }


### PR DESCRIPTION
Closes #3700. The condition occurred when a tile requested redoPlacement (which sent a redoPlacement request to the worker) and then shortly got removed (before getting response to redoPlacement back from the worker)  — `stopPlacementThrottler` did not prevent redoPlacement from running in this case because it was past the throttling phase.

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
