### PR TITLE
Bump mapbox-gl-geocoder version in geocoder examples

### DIFF
--- a/docs/_posts/examples/3400-01-12-mapbox-gl-geocoder.html
+++ b/docs/_posts/examples/3400-01-12-mapbox-gl-geocoder.html
@@ -6,8 +6,8 @@ description: 'Use the <a target="_blank" href="https://github.com/mapbox/mapbox-
 tags:
   - controls-and-overlays
 ---
-<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.0/mapbox-gl-geocoder.min.js'></script>
-<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.0/mapbox-gl-geocoder.css' type='text/css' />
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.1/mapbox-gl-geocoder.min.js'></script>
+<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.1/mapbox-gl-geocoder.css' type='text/css' />
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/3400-01-16-point-from-geocoder-result.html
+++ b/docs/_posts/examples/3400-01-16-point-from-geocoder-result.html
@@ -6,8 +6,8 @@ description: 'Listen to the <code>geocoder.input</code> event from the <a target
 tags:
   - controls-and-overlays
 ---
-<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.0/mapbox-gl-geocoder.min.js'></script>
-<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.0/mapbox-gl-geocoder.css' type='text/css' />
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.1/mapbox-gl-geocoder.min.js'></script>
+<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.1.1/mapbox-gl-geocoder.css' type='text/css' />
 <style>
 #geocoder-container > div {
     min-width:50%;


### PR DESCRIPTION
Updates the mapbox-gl-geocoder plugin version number in the two examples that use the mapbox-gl-geocoder plugin.


 - [x] briefly describe the changes in this PR
 - ~~[ ] write tests for all new functionality~~
 - ~~[ ] document any changes to public APIs~~
 - ~~[ ] post benchmark scores~~
 - [x] manually test the ~~debug page~~ examples
