### PR TITLE
Add 'properties' to GeoJSON in render-test style

### DIFF
--- a/test/integration/render-tests/regressions/mapbox-gl-js#2929/style.json
+++ b/test/integration/render-tests/regressions/mapbox-gl-js#2929/style.json
@@ -19,7 +19,8 @@
         "geometry": {
           "type": "Point",
           "coordinates": [0, 0]
-        }
+        },
+        "properties": {}
       }
     }
   },


### PR DESCRIPTION
Fix for: https://github.com/mapbox/mapbox-gl-native/issues/9704
GL-Native cannot load this style, because the GeoJSON source does not have a 'properties' property on the feature object.

The more detailed fix in native is being tracked at: https://github.com/mapbox/mapbox-gl-native/issues/9076