### PR TITLE
Support expressions in filters

### DIFF
--- a/bench/benchmarks/filter_evaluate.js
+++ b/bench/benchmarks/filter_evaluate.js
@@ -39,7 +39,7 @@ module.exports = class FilterEvaluate extends Benchmark {
         for (const layer of this.layers) {
             for (const filter of layer.filters) {
                 for (const feature of layer.features) {
-                    if (typeof filter(feature) !== 'boolean') {
+                    if (typeof filter({zoom: 0}, feature) !== 'boolean') {
                         assert(false, 'Expected boolean result from filter');
                     }
                 }

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -80,7 +80,7 @@ class CircleBucket implements Bucket {
 
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
         for (const {feature, index, sourceLayerIndex} of features) {
-            if (this.layers[0].filter(feature)) {
+            if (this.layers[0]._featureFilter({zoom: this.zoom}, feature)) {
                 const geometry = loadGeometry(feature);
                 this.addFeature(feature, geometry);
                 options.featureIndex.insert(feature, geometry, index, sourceLayerIndex, this.index);

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -72,7 +72,7 @@ class FillBucket implements Bucket {
 
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
         for (const {feature, index, sourceLayerIndex} of features) {
-            if (this.layers[0].filter(feature)) {
+            if (this.layers[0]._featureFilter({zoom: this.zoom}, feature)) {
                 const geometry = loadGeometry(feature);
                 this.addFeature(feature, geometry);
                 options.featureIndex.insert(feature, geometry, index, sourceLayerIndex, this.index);

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -85,7 +85,7 @@ class FillExtrusionBucket implements Bucket {
 
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
         for (const {feature, index, sourceLayerIndex} of features) {
-            if (this.layers[0].filter(feature)) {
+            if (this.layers[0]._featureFilter({zoom: this.zoom}, feature)) {
                 const geometry = loadGeometry(feature);
                 this.addFeature(feature, geometry);
                 options.featureIndex.insert(feature, geometry, index, sourceLayerIndex, this.index);

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -129,7 +129,7 @@ class LineBucket implements Bucket {
 
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
         for (const {feature, index, sourceLayerIndex} of features) {
-            if (this.layers[0].filter(feature)) {
+            if (this.layers[0]._featureFilter({zoom: this.zoom}, feature)) {
                 const geometry = loadGeometry(feature);
                 this.addFeature(feature, geometry);
                 options.featureIndex.insert(feature, geometry, index, sourceLayerIndex, this.index);

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -396,7 +396,7 @@ class SymbolBucket implements Bucket {
         const globalProperties =  {zoom: this.zoom};
 
         for (const {feature, index, sourceLayerIndex} of features) {
-            if (!layer.filter(feature)) {
+            if (!layer._featureFilter(globalProperties, feature)) {
                 continue;
             }
 

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -16,6 +16,7 @@ import type CollisionTile from '../symbol/collision_tile';
 import type TileCoord from '../source/tile_coord';
 import type StyleLayer from '../style/style_layer';
 import type {SerializedStructArray} from '../util/struct_array';
+import type {FeatureFilter} from '../style-spec/feature_filter';
 
 const FeatureIndexArray = createStructArrayType({
     members: [
@@ -178,7 +179,7 @@ class FeatureIndex {
         matching: Array<any>,
         array: any,
         queryGeometry: Array<Array<Point>>,
-        filter: any,
+        filter: FeatureFilter,
         filterLayerIDs: Array<string>,
         styleLayers: {[string]: StyleLayer},
         bearing: number,
@@ -201,7 +202,7 @@ class FeatureIndex {
             const sourceLayer = this.vtLayers[sourceLayerName];
             const feature = sourceLayer.feature(match.featureIndex);
 
-            if (!filter(feature)) continue;
+            if (!filter({zoom: this.coord.z}, feature)) continue;
 
             let geometry = null;
 

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -357,7 +357,7 @@ class Tile {
 
         for (let i = 0; i < layer.length; i++) {
             const feature = layer.feature(i);
-            if (filter(feature)) {
+            if (filter({zoom: this.coord.z}, feature)) {
                 const geojsonFeature = new GeoJSONFeature(feature, this.coord.z, this.coord.x, this.coord.y);
                 (geojsonFeature: any).tile = coord;
                 result.push(geojsonFeature);

--- a/src/style-spec/expression/compound_expression.js
+++ b/src/style-spec/expression/compound_expression.js
@@ -11,7 +11,7 @@ import type { Value } from './values';
 
 type Varargs = {| type: Type |};
 type Signature = Array<Type> | Varargs;
-type Evaluate = (EvaluationContext, Array<Expression>) => Value;
+type Evaluate = (EvaluationContext) => Value;
 type Definition = [Type, Signature, Evaluate] |
     {|type: Type, overloads: Array<[Signature, Evaluate]>|};
 
@@ -19,7 +19,7 @@ class CompoundExpression implements Expression {
     key: string;
     name: string;
     type: Type;
-    _evaluate: Evaluate;
+    evaluate: (ctx: EvaluationContext) => any;
     args: Array<Expression>;
 
     static definitions: { [string]: Definition };
@@ -28,12 +28,8 @@ class CompoundExpression implements Expression {
         this.key = key;
         this.name = name;
         this.type = type;
-        this._evaluate = evaluate;
+        this.evaluate = evaluate;
         this.args = args;
-    }
-
-    evaluate(ctx: EvaluationContext) {
-        return this._evaluate(ctx, this.args);
     }
 
     serialize() {

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -353,28 +353,44 @@ CompoundExpression.register(expressions, {
             [[StringType, StringType], lteq]
         ]
     },
-    'all': [
-        BooleanType,
-        varargs(BooleanType),
-        (ctx, args) => {
-            for (const arg of args) {
-                if (!arg.evaluate(ctx))
-                    return false;
-            }
-            return true;
-        }
-    ],
-    'any': [
-        BooleanType,
-        varargs(BooleanType),
-        (ctx, args) => {
-            for (const arg of args) {
-                if (arg.evaluate(ctx))
+    'all': {
+        type: BooleanType,
+        overloads: [
+            [
+                [BooleanType, BooleanType],
+                (ctx, [a, b]) => a.evaluate(ctx) && b.evaluate(ctx)
+            ],
+            [
+                varargs(BooleanType),
+                (ctx, args) => {
+                    for (const arg of args) {
+                        if (!arg.evaluate(ctx))
+                            return false;
+                    }
                     return true;
-            }
-            return false;
-        }
-    ],
+                }
+            ]
+        ]
+    },
+    'any': {
+        type: BooleanType,
+        overloads: [
+            [
+                [BooleanType, BooleanType],
+                (ctx, [a, b]) => a.evaluate(ctx) || b.evaluate(ctx)
+            ],
+            [
+                varargs(BooleanType),
+                (ctx, args) => {
+                    for (const arg of args) {
+                        if (arg.evaluate(ctx))
+                            return true;
+                    }
+                    return false;
+                }
+            ]
+        ]
+    },
     '!': [
         BooleanType,
         [BooleanType],

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -191,12 +191,24 @@ CompoundExpression.register(expressions, {
     '+': [
         NumberType,
         varargs(NumberType),
-        (ctx, args) => args.reduce((a, b) => a + b.evaluate(ctx), 0)
+        (ctx, args) => {
+            let result = 0;
+            for (const arg of args) {
+                result += arg.evaluate(ctx);
+            }
+            return result;
+        }
     ],
     '*': [
         NumberType,
         varargs(NumberType),
-        (ctx, args) => args.reduce((a, b) => a * b.evaluate(ctx), 1)
+        (ctx, args) => {
+            let result = 1;
+            for (const arg of args) {
+                result *= arg.evaluate(ctx);
+            }
+            return result;
+        }
     ],
     '-': {
         type: NumberType,
@@ -344,12 +356,24 @@ CompoundExpression.register(expressions, {
     'all': [
         BooleanType,
         varargs(BooleanType),
-        (ctx, args) => args.reduce((a, b) => a && b.evaluate(ctx), true)
+        (ctx, args) => {
+            for (const arg of args) {
+                if (!arg.evaluate(ctx))
+                    return false;
+            }
+            return true;
+        }
     ],
     'any': [
         BooleanType,
         varargs(BooleanType),
-        (ctx, args) => args.reduce((a, b) => a || b.evaluate(ctx), false)
+        (ctx, args) => {
+            for (const arg of args) {
+                if (arg.evaluate(ctx))
+                    return true;
+            }
+            return false;
+        }
     ],
     '!': [
         BooleanType,

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -306,5 +306,5 @@ function getDefaultValue(spec: StylePropertySpecification): Value | null {
         assert(Array.isArray(c));
         return new Color(c[0], c[1], c[2], c[3]);
     }
-    return defaultValue || null;
+    return defaultValue === undefined ? null : defaultValue;
 }

--- a/src/style-spec/expression/is_constant.js
+++ b/src/style-spec/expression/is_constant.js
@@ -13,7 +13,8 @@ function isFeatureConstant(e: Expression) {
         } else if (
             e.name === 'properties' ||
             e.name === 'geometry-type' ||
-            e.name === 'id'
+            e.name === 'id' ||
+            /^filter-/.test(e.name)
         ) {
             return false;
         }

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -49,7 +49,7 @@ const types = ['Unknown', 'Point', 'LineString', 'Polygon'];
  * @returns {Function} filter-evaluating function
  */
 function createFilter(filter) {
-    return new Function('f', `var p = (f && f.properties || {}); return ${compile(filter)}`);
+    return new Function('g', 'f', `var p = (f && f.properties || {}); return ${compile(filter)}`);
 }
 
 function compile(filter) {

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -1,4 +1,41 @@
 module.exports = createFilter;
+module.exports.isExpressionFilter = isExpressionFilter;
+
+function isExpressionFilter(filter) {
+    if (!Array.isArray(filter) || filter.length === 0) {
+        return false;
+    }
+    switch (filter[0]) {
+    case 'has':
+        return filter.length >= 2 && filter[1] !== '$id' && filter[1] !== '$type';
+
+    case 'in':
+    case '!in':
+    case '!has':
+    case 'none':
+        return false;
+
+    case '==':
+    case '!=':
+    case '>':
+    case '>=':
+    case '<':
+    case '<=':
+        return filter.length === 3 && (Array.isArray(filter[1]) || Array.isArray(filter[2]));
+
+    case 'any':
+    case 'all':
+        for (const f of filter.slice(1)) {
+            if (!isExpressionFilter(f)) {
+                return false;
+            }
+        }
+        return true;
+
+    default:
+        return true;
+    }
+}
 
 const types = ['Unknown', 'Point', 'LineString', 'Polygon'];
 

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -1,8 +1,11 @@
 
 const ValidationError = require('../error/validation_error');
+const validateExpression = require('./validate_expression');
 const validateEnum = require('./validate_enum');
 const getType = require('../util/get_type');
 const unbundle = require('../util/unbundle_jsonlint');
+const extend = require('../util/extend');
+const {isExpressionFilter} = require('../feature_filter');
 
 module.exports = function validateFilter(options) {
     const value = options.value;
@@ -14,6 +17,13 @@ module.exports = function validateFilter(options) {
 
     if (getType(value) !== 'array') {
         return [new ValidationError(key, value, 'array expected, %s found', getType(value))];
+    }
+
+    if (isExpressionFilter(unbundle.deep(value))) {
+        return validateExpression(extend({}, options, {
+            expressionContext: 'filter',
+            valueSpec: { value: 'boolean' }
+        }));
     }
 
     if (value.length < 1) {

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -13,6 +13,7 @@ import type Point from '@mapbox/point-geometry';
 import type {Feature, GlobalProperties} from '../style-spec/expression';
 import type RenderTexture from '../render/render_texture';
 import type AnimationLoop from './animation_loop';
+import type {FeatureFilter} from '../style-spec/feature_filter';
 
 const TRANSITION_SUFFIX = '-transition';
 
@@ -26,11 +27,12 @@ class StyleLayer extends Evented {
     sourceLayer: ?string;
     minzoom: ?number;
     maxzoom: ?number;
-    filter: any;
+    filter: mixed;
     paint: { [string]: any };
     layout: { [string]: any };
 
     viewportFrame: ?RenderTexture;
+    _featureFilter: FeatureFilter;
 
     _paintSpecifications: any;
     _layoutSpecifications: any;
@@ -66,6 +68,8 @@ class StyleLayer extends Evented {
 
         this.paint = {};
         this.layout = {};
+
+        this._featureFilter = () => true;
 
         this._paintSpecifications = styleSpec[`paint_${this.type}`];
         this._layoutSpecifications = styleSpec[`layout_${this.type}`];

--- a/src/style/style_layer_index.js
+++ b/src/style/style_layer_index.js
@@ -38,7 +38,7 @@ class StyleLayerIndex {
 
             const layer = this._layers[layerConfig.id] = StyleLayer.create(layerConfig);
             layer.updatePaintTransitions({transition: false});
-            layer.filter = featureFilter(layer.filter);
+            layer._featureFilter = featureFilter(layer.filter);
         }
         for (const id of removedIds) {
             delete this._layerConfigs[id];

--- a/test/integration/expression-tests/coalesce/null/test.json
+++ b/test/integration/expression-tests/coalesce/null/test.json
@@ -1,0 +1,21 @@
+{
+  "expectExpressionType": null,
+  "expression": [
+    "coalesce",
+    ["get", "z"],
+    0
+  ],
+  "inputs": [
+    [{}, {"properties": {"z": 1}}],
+    [{}, {"properties": {"z": null}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "Value"
+    },
+    "outputs": [1, 0]
+  }
+}

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -299,7 +299,7 @@ test('in, null', (t) => {
     t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
     t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
     t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.end();
 });
 
@@ -312,7 +312,23 @@ test('in, multiple', (t) => {
 });
 
 test('in, large_multiple', (t) => {
-    const f = filter(['in', 'foo'].concat(Array.apply(null, {length: 2000}).map(Number.call, Number)));
+    const values = Array.apply(null, {length: 2000}).map(Number.call, Number);
+    values.reverse();
+    const f = filter(['in', 'foo'].concat(values));
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 2000}}), false);
+    t.end();
+});
+
+test('in, large_multiple, heterogeneous', (t) => {
+    const values = Array.apply(null, {length: 2000}).map(Number.call, Number);
+    values.push('a');
+    values.unshift('b');
+    const f = filter(['in', 'foo'].concat(values));
+    t.equal(f({zoom: 0}, {properties: {foo: 'b'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 'a'}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);
@@ -364,7 +380,7 @@ test('!in, null', (t) => {
     t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
     t.end();
 });
 
@@ -449,7 +465,7 @@ test('has', (t) => {
     t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
     t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
@@ -462,7 +478,7 @@ test('!has', (t) => {
     t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
     t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
     t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.equal(f({zoom: 0}, {properties: {}}), true);
     t.end();
 });

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -12,418 +12,418 @@ test('degenerate', (t) => {
 
 test('==, string', (t) => {
     const f = filter(['==', 'foo', 'bar']);
-    t.equal(f({properties: {foo: 'bar'}}), true);
-    t.equal(f({properties: {foo: 'baz'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 'bar'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 'baz'}}), false);
     t.end();
 });
 
 test('==, number', (t) => {
     const f = filter(['==', 'foo', 0]);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
-    t.equal(f({properties: {}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
 
 test('==, null', (t) => {
     const f = filter(['==', 'foo', null]);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), true);
-    t.equal(f({properties: {foo: undefined}}), false);
-    t.equal(f({properties: {}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
 
 test('==, $type', (t) => {
     const f = filter(['==', '$type', 'LineString']);
-    t.equal(f({type: 1}), false);
-    t.equal(f({type: 2}), true);
+    t.equal(f({zoom: 0}, {type: 1}), false);
+    t.equal(f({zoom: 0}, {type: 2}), true);
     t.end();
 });
 
 test('==, $id', (t) => {
     const f = filter(['==', '$id', 1234]);
 
-    t.equal(f({id: 1234}), true);
-    t.equal(f({id: '1234'}), false);
-    t.equal(f({properties: {id: 1234}}), false);
+    t.equal(f({zoom: 0}, {id: 1234}), true);
+    t.equal(f({zoom: 0}, {id: '1234'}), false);
+    t.equal(f({zoom: 0}, {properties: {id: 1234}}), false);
 
     t.end();
 });
 
 test('!=, string', (t) => {
     const f = filter(['!=', 'foo', 'bar']);
-    t.equal(f({properties: {foo: 'bar'}}), false);
-    t.equal(f({properties: {foo: 'baz'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 'bar'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 'baz'}}), true);
     t.end();
 });
 
 test('!=, number', (t) => {
     const f = filter(['!=', 'foo', 0]);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), true);
-    t.equal(f({properties: {foo: '0'}}), true);
-    t.equal(f({properties: {foo: true}}), true);
-    t.equal(f({properties: {foo: false}}), true);
-    t.equal(f({properties: {foo: null}}), true);
-    t.equal(f({properties: {foo: undefined}}), true);
-    t.equal(f({properties: {}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {}}), true);
     t.end();
 });
 
 test('!=, null', (t) => {
     const f = filter(['!=', 'foo', null]);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: 1}}), true);
-    t.equal(f({properties: {foo: '0'}}), true);
-    t.equal(f({properties: {foo: true}}), true);
-    t.equal(f({properties: {foo: false}}), true);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), true);
-    t.equal(f({properties: {}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {}}), true);
     t.end();
 });
 
 test('!=, $type', (t) => {
     const f = filter(['!=', '$type', 'LineString']);
-    t.equal(f({type: 1}), true);
-    t.equal(f({type: 2}), false);
+    t.equal(f({zoom: 0}, {type: 1}), true);
+    t.equal(f({zoom: 0}, {type: 2}), false);
     t.end();
 });
 
 test('<, number', (t) => {
     const f = filter(['<', 'foo', 0]);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: -1}}), true);
-    t.equal(f({properties: {foo: '1'}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: '-1'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
-    t.equal(f({properties: {}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: -1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
 
 test('<, string', (t) => {
     const f = filter(['<', 'foo', '0']);
-    t.equal(f({properties: {foo: -1}}), false);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: '1'}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: '-1'}}), true);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.end();
 });
 
 test('<=, number', (t) => {
     const f = filter(['<=', 'foo', 0]);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: -1}}), true);
-    t.equal(f({properties: {foo: '1'}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: '-1'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
-    t.equal(f({properties: {}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: -1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
 
 test('<=, string', (t) => {
     const f = filter(['<=', 'foo', '0']);
-    t.equal(f({properties: {foo: -1}}), false);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: '1'}}), false);
-    t.equal(f({properties: {foo: '0'}}), true);
-    t.equal(f({properties: {foo: '-1'}}), true);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.end();
 });
 
 test('>, number', (t) => {
     const f = filter(['>', 'foo', 0]);
-    t.equal(f({properties: {foo: 1}}), true);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: -1}}), false);
-    t.equal(f({properties: {foo: '1'}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: '-1'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
-    t.equal(f({properties: {}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
 
 test('>, string', (t) => {
     const f = filter(['>', 'foo', '0']);
-    t.equal(f({properties: {foo: -1}}), false);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: '1'}}), true);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: '-1'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.end();
 });
 
 test('>=, number', (t) => {
     const f = filter(['>=', 'foo', 0]);
-    t.equal(f({properties: {foo: 1}}), true);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: -1}}), false);
-    t.equal(f({properties: {foo: '1'}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: '-1'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
-    t.equal(f({properties: {}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
 
 test('>=, string', (t) => {
     const f = filter(['>=', 'foo', '0']);
-    t.equal(f({properties: {foo: -1}}), false);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: '1'}}), true);
-    t.equal(f({properties: {foo: '0'}}), true);
-    t.equal(f({properties: {foo: '-1'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.end();
 });
 
 test('in, degenerate', (t) => {
     const f = filter(['in', 'foo']);
-    t.equal(f({properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
     t.end();
 });
 
 test('in, string', (t) => {
     const f = filter(['in', 'foo', '0']);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: '0'}}), true);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
-    t.equal(f({properties: {}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
 
 test('in, number', (t) => {
     const f = filter(['in', 'foo', 0]);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.end();
 });
 
 test('in, null', (t) => {
     const f = filter(['in', 'foo', null]);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: true}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), true);
-    t.equal(f({properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.end();
 });
 
 test('in, multiple', (t) => {
     const f = filter(['in', 'foo', 0, 1]);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: 1}}), true);
-    t.equal(f({properties: {foo: 3}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 3}}), false);
     t.end();
 });
 
 test('in, large_multiple', (t) => {
     const f = filter(['in', 'foo'].concat(Array.apply(null, {length: 2000}).map(Number.call, Number)));
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: 1}}), true);
-    t.equal(f({properties: {foo: 1999}}), true);
-    t.equal(f({properties: {foo: 2000}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 2000}}), false);
     t.end();
 });
 
 test('in, $type', (t) => {
     const f = filter(['in', '$type', 'LineString', 'Polygon']);
-    t.equal(f({type: 1}), false);
-    t.equal(f({type: 2}), true);
-    t.equal(f({type: 3}), true);
+    t.equal(f({zoom: 0}, {type: 1}), false);
+    t.equal(f({zoom: 0}, {type: 2}), true);
+    t.equal(f({zoom: 0}, {type: 3}), true);
 
     const f1 = filter(['in', '$type', 'Polygon', 'LineString', 'Point']);
-    t.equal(f1({type: 1}), true);
-    t.equal(f1({type: 2}), true);
-    t.equal(f1({type: 3}), true);
+    t.equal(f1({zoom: 0}, {type: 1}), true);
+    t.equal(f1({zoom: 0}, {type: 2}), true);
+    t.equal(f1({zoom: 0}, {type: 3}), true);
 
     t.end();
 });
 
 test('!in, degenerate', (t) => {
     const f = filter(['!in', 'foo']);
-    t.equal(f({properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
     t.end();
 });
 
 test('!in, string', (t) => {
     const f = filter(['!in', 'foo', '0']);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: null}}), true);
-    t.equal(f({properties: {foo: undefined}}), true);
-    t.equal(f({properties: {}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {}}), true);
     t.end();
 });
 
 test('!in, number', (t) => {
     const f = filter(['!in', 'foo', 0]);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: '0'}}), true);
-    t.equal(f({properties: {foo: null}}), true);
-    t.equal(f({properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
     t.end();
 });
 
 test('!in, null', (t) => {
     const f = filter(['!in', 'foo', null]);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: '0'}}), true);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
     t.end();
 });
 
 test('!in, multiple', (t) => {
     const f = filter(['!in', 'foo', 0, 1]);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: 3}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 3}}), true);
     t.end();
 });
 
 test('!in, large_multiple', (t) => {
     const f = filter(['!in', 'foo'].concat(Array.apply(null, {length: 2000}).map(Number.call, Number)));
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: 1999}}), false);
-    t.equal(f({properties: {foo: 2000}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1999}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 2000}}), true);
     t.end();
 });
 
 test('!in, $type', (t) => {
     const f = filter(['!in', '$type', 'LineString', 'Polygon']);
-    t.equal(f({type: 1}), true);
-    t.equal(f({type: 2}), false);
-    t.equal(f({type: 3}), false);
+    t.equal(f({zoom: 0}, {type: 1}), true);
+    t.equal(f({zoom: 0}, {type: 2}), false);
+    t.equal(f({zoom: 0}, {type: 3}), false);
     t.end();
 });
 
 test('any', (t) => {
     const f1 = filter(['any']);
-    t.equal(f1({properties: {foo: 1}}), false);
+    t.equal(f1({zoom: 0}, {properties: {foo: 1}}), false);
 
     const f2 = filter(['any', ['==', 'foo', 1]]);
-    t.equal(f2({properties: {foo: 1}}), true);
+    t.equal(f2({zoom: 0}, {properties: {foo: 1}}), true);
 
     const f3 = filter(['any', ['==', 'foo', 0]]);
-    t.equal(f3({properties: {foo: 1}}), false);
+    t.equal(f3({zoom: 0}, {properties: {foo: 1}}), false);
 
     const f4 = filter(['any', ['==', 'foo', 0], ['==', 'foo', 1]]);
-    t.equal(f4({properties: {foo: 1}}), true);
+    t.equal(f4({zoom: 0}, {properties: {foo: 1}}), true);
 
     t.end();
 });
 
 test('all', (t) => {
     const f1 = filter(['all']);
-    t.equal(f1({properties: {foo: 1}}), true);
+    t.equal(f1({zoom: 0}, {properties: {foo: 1}}), true);
 
     const f2 = filter(['all', ['==', 'foo', 1]]);
-    t.equal(f2({properties: {foo: 1}}), true);
+    t.equal(f2({zoom: 0}, {properties: {foo: 1}}), true);
 
     const f3 = filter(['all', ['==', 'foo', 0]]);
-    t.equal(f3({properties: {foo: 1}}), false);
+    t.equal(f3({zoom: 0}, {properties: {foo: 1}}), false);
 
     const f4 = filter(['all', ['==', 'foo', 0], ['==', 'foo', 1]]);
-    t.equal(f4({properties: {foo: 1}}), false);
+    t.equal(f4({zoom: 0}, {properties: {foo: 1}}), false);
 
     t.end();
 });
 
 test('none', (t) => {
     const f1 = filter(['none']);
-    t.equal(f1({properties: {foo: 1}}), true);
+    t.equal(f1({zoom: 0}, {properties: {foo: 1}}), true);
 
     const f2 = filter(['none', ['==', 'foo', 1]]);
-    t.equal(f2({properties: {foo: 1}}), false);
+    t.equal(f2({zoom: 0}, {properties: {foo: 1}}), false);
 
     const f3 = filter(['none', ['==', 'foo', 0]]);
-    t.equal(f3({properties: {foo: 1}}), true);
+    t.equal(f3({zoom: 0}, {properties: {foo: 1}}), true);
 
     const f4 = filter(['none', ['==', 'foo', 0], ['==', 'foo', 1]]);
-    t.equal(f4({properties: {foo: 1}}), false);
+    t.equal(f4({zoom: 0}, {properties: {foo: 1}}), false);
 
     t.end();
 });
 
 test('has', (t) => {
     const f = filter(['has', 'foo']);
-    t.equal(f({properties: {foo: 0}}), true);
-    t.equal(f({properties: {foo: 1}}), true);
-    t.equal(f({properties: {foo: '0'}}), true);
-    t.equal(f({properties: {foo: true}}), true);
-    t.equal(f({properties: {foo: false}}), true);
-    t.equal(f({properties: {foo: null}}), true);
-    t.equal(f({properties: {foo: undefined}}), true);
-    t.equal(f({properties: {}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
 
 test('!has', (t) => {
     const f = filter(['!has', 'foo']);
-    t.equal(f({properties: {foo: 0}}), false);
-    t.equal(f({properties: {foo: 1}}), false);
-    t.equal(f({properties: {foo: '0'}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: false}}), false);
-    t.equal(f({properties: {foo: null}}), false);
-    t.equal(f({properties: {foo: undefined}}), false);
-    t.equal(f({properties: {}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {}}), true);
     t.end();
 });

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -3,6 +3,45 @@
 const test = require('mapbox-gl-js-test').test;
 const filter = require('../../../src/style-spec').featureFilter;
 
+test('expression, zoom', (t) => {
+    const f = filter(['>=', ['number', ['get', 'x']], ['zoom']]);
+    t.equal(f({zoom: 1}, {properties: {x: 0}}), false);
+    t.equal(f({zoom: 1}, {properties: {x: 1.5}}), true);
+    t.equal(f({zoom: 1}, {properties: {x: 2.5}}), true);
+    t.equal(f({zoom: 2}, {properties: {x: 0}}), false);
+    t.equal(f({zoom: 2}, {properties: {x: 1.5}}), false);
+    t.equal(f({zoom: 2}, {properties: {x: 2.5}}), true);
+    t.end();
+});
+
+test('expression, compare two properties', (t) => {
+    t.stub(console, 'warn');
+    const f = filter(['==', ['string', ['get', 'x']], ['string', ['get', 'y']]]);
+    t.equal(f({zoom: 0}, {properties: {x: 1, y: 1}}), false);
+    t.equal(f({zoom: 0}, {properties: {x: '1', y: '1'}}), true);
+    t.equal(f({zoom: 0}, {properties: {x: 'same', y: 'same'}}), true);
+    t.equal(f({zoom: 0}, {properties: {x: null}}), false);
+    t.equal(f({zoom: 0}, {properties: {x: undefined}}), false);
+    t.end();
+});
+
+test('expression, type error', (t) => {
+    t.throws(() => {
+        filter(['==', ['number', ['get', 'x']], ['string', ['get', 'y']]]);
+    });
+
+    t.throws(() => {
+        filter(['number', ['get', 'x']]);
+    });
+
+    t.doesNotThrow(() => {
+        filter(['boolean', ['get', 'x']]);
+    });
+
+    t.end();
+});
+
+
 test('degenerate', (t) => {
     t.equal(filter()(), true);
     t.equal(filter(undefined)(), true);
@@ -260,7 +299,7 @@ test('in, null', (t) => {
     t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
     t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
     t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
     t.end();
 });
 
@@ -325,7 +364,7 @@ test('!in, null', (t) => {
     t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.end();
 });
 
@@ -410,7 +449,7 @@ test('has', (t) => {
     t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
     t.equal(f({zoom: 0}, {properties: {}}), false);
     t.end();
 });
@@ -423,7 +462,7 @@ test('!has', (t) => {
     t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
     t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
     t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
     t.equal(f({zoom: 0}, {properties: {}}), true);
     t.end();
 });

--- a/test/unit/style-spec/fixture/filters.output.json
+++ b/test/unit/style-spec/fixture/filters.output.json
@@ -8,8 +8,8 @@
     "line": 22
   },
   {
-    "message": "layers[2].filter[0]: expected one of [==, !=, >, >=, <, <=, in, !in, all, any, none, has, !has], \"=\" found",
-    "line": 30
+    "message": "layers[2].filter[0]: Unknown expression \"=\". If you wanted a literal array, use [\"literal\", [...]].",
+    "line": 29
   },
   {
     "message": "layers[3].filter: filter array for operator \"==\" must have 3 elements",
@@ -24,8 +24,8 @@
     "line": 59
   },
   {
-    "message": "layers[6].filter[2]: string, number, or boolean expected, array found",
-    "line": 71
+    "message": "layers[6].filter[2]: Expected an array with at least one element. If you wanted a literal array, use [\"literal\", []].",
+    "line": 68
   },
   {
     "message": "layers[7].filter[2]: expected one of [Point, LineString, Polygon], \"value\" found",
@@ -44,11 +44,11 @@
     "line": 103
   },
   {
-    "message": "layers[12].filter: filter array for \"has\" operator must have 2 elements",
+    "message": "layers[12].filter: Expected arguments of type (String) | (String, Object), but found (String, String) instead.",
     "line": 131
   },
   {
-    "message": "layers[13].filter[1]: string expected, object found",
-    "line": 144
+    "message": "layers[13].filter[1]: Bare objects invalid. Use [\"literal\", {...}] instead.",
+    "line": 142
   }
 ]


### PR DESCRIPTION
Closes #4077
Closes #4410

- Converts classic filters to expressions under the hood
 - Also accepts `{expression: [...]}`, requiring that the given
 expression be of type Boolean
 - [ ] Benchmark to assess performance impact acainst classic filters
 - [ ] Add fixtures for `validation.test.js`
 - [ ] Manually test debug page
 - [ ] Add some kind of partial string matching? ( https://github.com/mapbox/mapbox-gl-js/issues/4089 / https://github.com/mapbox/mapbox-gl-js/issues/4113 )

 cc @jfirebaugh @aparlato