### PR TITLE
Shuffle render tests via `--shuffle`

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "remark": "^6.0.1",
     "remark-html": "^5.0.1",
     "request": "^2.79.0",
+    "shuffle-array": "^1.0.1",
     "sinon": "^2.1.0",
     "st": "^1.2.0",
     "stylelint": "^7.10.1",

--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -20,6 +20,7 @@ module.exports = function (directory, implementation, options, run) {
     fs.readdirSync(directory).forEach((group) => {
         if (
             group === 'index.html' ||
+            group === 'index-recycle-map.html' ||
             group === 'results.html.tmpl' ||
             group === 'result_item.html.tmpl' ||
             group[0] === '.'
@@ -216,7 +217,7 @@ module.exports = function (directory, implementation, options, run) {
         const resultsShell = resultsTemplate({ failed })
             .split('<!-- results go here -->');
 
-        const p = path.join(directory, 'index.html');
+        const p = path.join(directory, options.recycleMap ? 'index-recycle-map.html' : 'index.html');
         const out = fs.createWriteStream(p);
 
         const q = queue(1);

--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -214,7 +214,7 @@ module.exports = function (directory, implementation, options, run) {
         const itemTemplate = template(fs.readFileSync(path.join(directory, 'result_item.html.tmpl'), 'utf8'));
 
         const failed = results.filter(r => /failed/.test(r.status));
-        const resultsShell = resultsTemplate({ failed })
+        const resultsShell = resultsTemplate({ failed, sequence })
             .split('<!-- results go here -->');
 
         const p = path.join(directory, options.recycleMap ? 'index-recycle-map.html' : 'index.html');

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -59,6 +59,8 @@ function compare(path1, path2, diffPath, callback) {
  * disabled tests will be run, but not fail the test run if the result does not match the expected
  * result. If the value begins with "skip", the test will not be run at all -- use this for tests
  * that would crash the test harness entirely if they were run.
+ * @param {Object<boolean>} [options.shuffle] - Boolean representing whether
+ * or not to shuffle the render tests sequence.
  * @param {Object<boolean>} [options.recycleMap] - Boolean representing whether
  * or not to recycle the Map object when running the tests.
  * @param {renderFn} render - a function that performs the rendering
@@ -134,6 +136,7 @@ exports.run = function (implementation, options, render) {
  * @param {number} options.width - render this wide
  * @param {number} options.height - render this high
  * @param {number} options.pixelRatio - render with this pixel ratio
+ * @param {boolean} options.shuffle - shuffle tests sequence
  * @param {boolean} options.recycleMap - trigger map object recycling
  * @param {renderCallback} callback - callback to call with the results of rendering
  */

--- a/test/integration/results.html.tmpl
+++ b/test/integration/results.html.tmpl
@@ -1,5 +1,6 @@
 <style>
     body { font-family: Helvetica; }
+    div { color: black; }
     h2 { text-align: center; margin-bottom: 10px; padding: 2px 5px; font-weight: normal; }
     h2 a { color: white; text-decoration: none; }
     table td { vertical-align: top; }
@@ -27,14 +28,27 @@
 <% } else { %>
 <div><strong style="color: darkgreen;">All tests passed!</div>
 <% } %>
+<% if (sequence.length) { %>
+<button id='toggle-sequence'>Toggle showing test sequence</button>
+<div id='test-sequence' style='display:none'>
+    <strong style="color: black;">Test sequence:</strong>
+    <% for (const r of sequence) { %><%- r.params.group %>/<%- r.params.test %> <% } %>
+</div>
+<% } %>
 <button id='toggle-passed'>Toggle showing passed tests</button>
 <script>
-const btn = document.getElementById('toggle-passed')
-btn.addEventListener('click', function (e) {
+const passedButton = document.getElementById('toggle-passed');
+passedButton.addEventListener('click', function (e) {
   const passed = document.querySelectorAll('tr.passed');
   for (const row of passed) {
     row.classList.toggle('hide');
   }
+});
+
+const sequenceButton = document.getElementById('toggle-sequence');
+sequenceButton.addEventListener('click', function (e) {
+    const sequence = document.getElementById('test-sequence');
+    sequence.style.display = sequence.style.display == "none" ? "block" : "none";
 });
 </script>
 <table>

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -7,15 +7,21 @@ const suiteImplementation = require('./suite_implementation');
 const ignores = require('./ignores.json');
 
 let tests;
+let shuffle = false;
 let recycleMap = false;
 
-if (process.argv[1] === __filename && process.argv.length > 2) {
-    if (process.argv[2] === '--recycle-map') {
-        recycleMap = true;
-        tests = process.argv.slice(3);
-    } else {
-        tests = process.argv.slice(2);
-    }
+function checkParameter(param) {
+    const index = tests.indexOf(param);
+    if (index === -1)
+        return false;
+    tests.splice(index, 1);
+    return true;
 }
 
-renderSuite.run('js', {tests, ignores, recycleMap}, suiteImplementation);
+if (process.argv[1] === __filename && process.argv.length > 2) {
+    tests = process.argv.slice(2).filter((value, index, self) => { return self.indexOf(value) === index; });
+    shuffle = checkParameter('--shuffle');
+    recycleMap = checkParameter('--recycle-map');
+}
+
+renderSuite.run('js', { tests, ignores, shuffle, recycleMap }, suiteImplementation);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5756,6 +5756,10 @@ shellsubstitute@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shellsubstitute/-/shellsubstitute-1.2.0.tgz#e4f702a50c518b0f6fe98451890d705af29b6b70"
 
+shuffle-array@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/shuffle-array/-/shuffle-array-1.0.1.tgz#c4ff3cfe74d16f93730592301b25e6577b12898b"
+
 signal-exit@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-2.1.2.tgz#375879b1f92ebc3b334480d038dc546a6d558564"


### PR DESCRIPTION
This PR adds a new parameter `--shuffle` that causes the render tests sequence to be shuffled. Also, it was not previously possible to force a specific test run sequence because all tests would end up being run in alphabetical file system sequence. This PR also enables a specific test run sequence to be specified - which is great in cases you want to repeat a shuffled test sequence.

Shuffling among specified tests:
```
$ node test/render.test.js --shuffle "icon-visibility" "text-visibility"
* passed text-visibility visible
* passed icon-visibility visible
* passed icon-visibility none
* passed text-visibility none
```

Shuffling all available tests:
```
$ node test/render.test.js --shuffle
```

Specified tests are now run in the same sequence they are specified via parameters:
```
$ node test/render.test.js "text-visibility"
* passed text-visibility none
* passed text-visibility visible
2 passed (100.0%)

$ node test/render.test.js "text-visibility/visible" "text-visibility/none"
* passed text-visibility visible
* passed text-visibility none
2 passed (100.0%)
```
