### PR TITLE
Support for all test result files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ flow-coverage
 .nyc_output
 *_generated.js
 *-generated.js
-test/integration/**/index.html
+test/integration/**/index*.html
 test/integration/**/actual.png
 test/integration/**/diff.png
 .eslintcache


### PR DESCRIPTION
Avoids git complaining about `test/integration/render-tests/index-recycle-map.html`.