### PR TITLE
Avoid reusing variable names in the HTML test result template

### DIFF
--- a/test/integration/results.html.tmpl
+++ b/test/integration/results.html.tmpl
@@ -32,7 +32,7 @@
 <button id='toggle-sequence'>Toggle showing test sequence</button>
 <div id='test-sequence' style='display:none'>
     <strong style="color: black;">Test sequence:</strong>
-    <% for (const r of sequence) { %><%- r.params.group %>/<%- r.params.test %> <% } %>
+    <% for (const s of sequence) { %><%- s.params.group %>/<%- s.params.test %> <% } %>
 </div>
 <% } %>
 <button id='toggle-passed'>Toggle showing passed tests</button>


### PR DESCRIPTION
Node v4 doesn't like it - captured in https://circleci.com/gh/mapbox/mapbox-gl-native/20296:
```
lodash.templateSources[0]:4
return function(obj) {
               ^

SyntaxError: Identifier 'r' has already been declared
    at eval (lodash.templateSources[0]:4:16)
    at Queue._call (/src/mapbox-gl-js/test/integration/lib/harness.js:217:30)
    at maybeNotify (/src/mapbox-gl-js/test/integration/node_modules/d3-queue/build/d3-queue.js:120:7)
    at Server.<anonymous> (/src/mapbox-gl-js/test/integration/node_modules/d3-queue/build/d3-queue.js:91:12)
    at Server.g (events.js:260:16)
    at emitNone (events.js:67:13)
    at Server.emit (events.js:166:7)
    at emitCloseNT (net.js:1540:8)
    at nextTickCallbackWith1Arg (node.js:500:9)
    at process._tickCallback (node.js:422:17)
apitrace: unloaded from /usr/bin/nodejs```