### PR TITLE
Corrected lat/lng syntax on the Zoom-to Linestring example

### DIFF
--- a/docs/_posts/examples/3400-01-28-zoomto-linestring.html
+++ b/docs/_posts/examples/3400-01-28-zoomto-linestring.html
@@ -95,7 +95,7 @@ map.on('load', function() {
         // requires wrapping all the coordinates with the extend method.
         var bounds = coordinates.reduce(function(bounds, coord) {
             return bounds.extend(coord);
-        }, new mapboxgl.LngLatBounds(coordinates[0], coordinates[0]));
+        }, new mapboxgl.LngLatBounds(coordinates[0], coordinates[1]));
 
         map.fitBounds(bounds, {
             padding: 20


### PR DESCRIPTION
## Changes
When using this example online, I got hung up and kept getting an error about my `LatLngBounds` not being correct.

I got the example to work once I changed the example code to use `coordinates[0], coordinates[1]` instead of using the longitude twice.

## Tests
Didn't write any tests ... are there tests that I missed?

