### PR TITLE
Update style of collision debug geometries

### DIFF
--- a/src/shaders/collision_box.fragment.glsl
+++ b/src/shaders/collision_box.fragment.glsl
@@ -9,7 +9,7 @@ void main() {
     // Red = collision, hide label
     gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0) * alpha;
 
-    // Blue = collision, label is showing
+    // Blue = no collision, label is showing
     if (v_placed > 0.5) {
         gl_FragColor = vec4(0.0, 0.0, 1.0, 0.5) * alpha;
     }

--- a/src/shaders/collision_box.fragment.glsl
+++ b/src/shaders/collision_box.fragment.glsl
@@ -6,12 +6,12 @@ void main() {
 
     float alpha = 0.5;
 
-    // Blue = collision, hide label
-    gl_FragColor = vec4(0.0, 0.0, 1.0, 1.0) * alpha;
+    // Red = collision, hide label
+    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0) * alpha;
 
-    // Black = collision, label is showing
+    // Blue = collision, label is showing
     if (v_placed > 0.5) {
-        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0) * alpha;
+        gl_FragColor = vec4(0.0, 0.0, 1.0, 0.5) * alpha;
     }
 
     if (v_notUsed > 0.5) {

--- a/src/shaders/collision_circle.fragment.glsl
+++ b/src/shaders/collision_circle.fragment.glsl
@@ -8,22 +8,22 @@ varying vec2 v_extrude_scale;
 void main() {
     float alpha = 0.5;
 
-    // Blue = collision, hide label
-    vec4 color = vec4(0.0, 0.0, 1.0, 1.0) * alpha;
+    // Red = collision, hide label
+    vec4 color = vec4(1.0, 0.0, 0.0, 1.0) * alpha;
 
-    // Black = no collision, label is showing
+    // Blue = no collision, label is showing
     if (v_placed > 0.5) {
-        color = vec4(0.0, 0.0, 0.0, 1.0) * alpha;
+        color = vec4(0.0, 0.0, 1.0, 0.5) * alpha;
     }
 
     if (v_notUsed > 0.5) {
         // This box not used, fade it out
-        color *= .1;
+        color *= .2;
     }
 
     float extrude_scale_length = length(v_extrude_scale);
     float extrude_length = length(v_extrude) * extrude_scale_length;
-    float stroke_width = 5.0;
+    float stroke_width = 3.0;
     float radius = v_radius * extrude_scale_length;
 
     float distance_to_edge = abs(extrude_length - radius);


### PR DESCRIPTION
@ChrisLoer This updates colors of collision debug geometries, and stroke width of collision debug circles:

![screen shot 2017-08-30 at 3 30 11 pm](https://user-images.githubusercontent.com/5607844/29892040-1aca0e1e-8d9b-11e7-9ed9-43cc68a64ccb.png)

- Geometries for non-visible labels are red, geometries for visible labels are blue (but lower opacity than the red). For legibility, especially in areas with a lot of collisions, I think it's best for the visible labels to have much lighter/more subtle collision geometries than non-visible labels.

- I reduced the stroke width of collision circles from `5.0` to `3.0`, which I think works best for non-retina screens. `2.0` would look better on retina screens, but would be too illegible on non-retina. I tried different values in the `smoothstep` function, as you suggested, but didn't seem to get better results. I think it may just be hard to find values that work equally well for retina and non-retina.

Please review! Does this work for your 👀  ?



