### PR TITLE
Separate fill-extrusion segments if necessary

### DIFF
--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -209,6 +209,7 @@ class FillExtrusionBucket implements Bucket {
             }
 
             segment.primitiveLength += indices.length / 3;
+            segment.vertexLength += numVertices;
         }
 
         this.programConfigurations.populatePaintArrays(this.layoutVertexArray.length, feature);

--- a/src/data/segment.js
+++ b/src/data/segment.js
@@ -1,7 +1,11 @@
 // @flow
 
+const {warnOnce} = require('../util/util');
+
 import type VertexArrayObject from '../render/vertex_array_object';
 import type {StructArray} from '../util/struct_array';
+
+const MAX_VERTEX_ARRAY_LENGTH = Math.pow(2, 16) - 1;
 
 export type Segment = {
     vertexOffset: number,
@@ -20,6 +24,7 @@ class SegmentVector {
 
     prepareSegment(numVertices: number, layoutVertexArray: StructArray, indexArray: StructArray): Segment {
         let segment: Segment = this.segments[this.segments.length - 1];
+        if (numVertices > MAX_VERTEX_ARRAY_LENGTH) warnOnce(`Max vertices per segment is ${MAX_VERTEX_ARRAY_LENGTH}: bucket requested ${numVertices}`);
         if (!segment || segment.vertexLength + numVertices > module.exports.MAX_VERTEX_ARRAY_LENGTH) {
             segment = ({
                 vertexOffset: layoutVertexArray.length,
@@ -54,5 +59,5 @@ module.exports = {
      * @private
      * @readonly
      */
-    MAX_VERTEX_ARRAY_LENGTH: Math.pow(2, 16) - 1
+    MAX_VERTEX_ARRAY_LENGTH: MAX_VERTEX_ARRAY_LENGTH
 };


### PR DESCRIPTION
This PR
* Separates fill-extrusion vertex/element creation into two separate loops: once for the footprint and once for the walls. In this way a segment needs to prepare at most `numVertices`, rather than, as it was previously, `numVertices * 5`, and then additional segments can be prepared as needed during wall creation. (I think we _could_ be really tricky about this and try to keep everything in the same loop by maintaining separate cursors for the footprint and walls, but this seems too much unnecessary complication.)
* Adds a warning to `prepareSegment` when a segment of length > 65535 is requested.

Fixes #5214.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
