### PR TITLE
Evaluate all curve stops to avoid closures

### DIFF
--- a/src/style-spec/function/definitions/curve.js
+++ b/src/style-spec/function/definitions/curve.js
@@ -154,7 +154,7 @@ class Curve implements Expression {
         const outputs = [];
         for (const [label, expression] of this.stops) {
             labels.push(label);
-            outputs.push(`function () { return ${expression.compile()}; }`);
+            outputs.push(`${expression.compile()}`);
         }
 
         const interpolationType = this.type.kind.toLowerCase();

--- a/src/style-spec/function/evaluation_context.js
+++ b/src/style-spec/function/evaluation_context.js
@@ -179,24 +179,24 @@ module.exports = () => ({
     },
 
     _unitBezierCache: ({}: {[string]: UnitBezier}),
-    evaluateCurve(input: number, stopInputs: Array<number>, stopOutputs: Array<Function>, interpolation: InterpolationType, resultType: string) {
+    evaluateCurve(input: number, stopInputs: Array<number>, stopOutputs: Array<any>, interpolation: InterpolationType, resultType: string) {
         const stopCount = stopInputs.length;
-        if (stopInputs.length === 1) return stopOutputs[0]();
-        if (input <= stopInputs[0]) return stopOutputs[0]();
-        if (input >= stopInputs[stopCount - 1]) return stopOutputs[stopCount - 1]();
+        if (stopInputs.length === 1) return stopOutputs[0];
+        if (input <= stopInputs[0]) return stopOutputs[0];
+        if (input >= stopInputs[stopCount - 1]) return stopOutputs[stopCount - 1];
 
         const index = findStopLessThanOrEqualTo(stopInputs, input);
 
         if (interpolation.name === 'step') {
-            return stopOutputs[index]();
+            return stopOutputs[index];
         }
 
         const lower = stopInputs[index];
         const upper = stopInputs[index + 1];
         const t = Curve.interpolationFactor(interpolation, input, lower, upper, this._unitBezierCache);
 
-        const outputLower = stopOutputs[index]();
-        const outputUpper = stopOutputs[index + 1]();
+        const outputLower = stopOutputs[index];
+        const outputUpper = stopOutputs[index + 1];
 
         if (resultType === 'color') {
             return new Color(...interpolate.color(outputLower.value, outputUpper.value, t));


### PR DESCRIPTION
Makes curves faster on common use cases by avoiding `function` closures inside expression call sources. `tile_dds_layout` bench:

![image](https://user-images.githubusercontent.com/25395/29969727-190024fc-8f2a-11e7-8327-7a0f1a76ec0a.png)
