### PR TITLE
Avoid calling loadGeometry twice for every feature

### DIFF
--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -13,6 +13,7 @@ import type {Bucket, IndexedFeature, PopulateParameters, SerializedBucket} from 
 import type {ProgramInterface} from '../program_configuration';
 import type StyleLayer from '../../style/style_layer';
 import type {StructArray} from '../../util/struct_array';
+import type Point from '@mapbox/point-geometry';
 
 const circleInterface = {
     layoutAttributes: [
@@ -79,8 +80,9 @@ class CircleBucket implements Bucket {
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
         for (const {feature, index, sourceLayerIndex} of features) {
             if (this.layers[0].filter(feature)) {
-                this.addFeature(feature);
-                options.featureIndex.insert(feature, index, sourceLayerIndex, this.index);
+                const geometry = loadGeometry(feature);
+                this.addFeature(feature, geometry);
+                options.featureIndex.insert(feature, geometry, index, sourceLayerIndex, this.index);
             }
         }
     }
@@ -114,8 +116,8 @@ class CircleBucket implements Bucket {
         this.segments.destroy();
     }
 
-    addFeature(feature: VectorTileFeature) {
-        for (const ring of loadGeometry(feature)) {
+    addFeature(feature: VectorTileFeature, geometry: Array<Array<Point>>) {
+        for (const ring of geometry) {
             for (const point of ring) {
                 const x = point.x;
                 const y = point.y;

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -17,6 +17,7 @@ import type {Bucket, IndexedFeature, PopulateParameters, SerializedBucket} from 
 import type {ProgramInterface} from '../program_configuration';
 import type StyleLayer from '../../style/style_layer';
 import type {StructArray} from '../../util/struct_array';
+import type Point from '@mapbox/point-geometry';
 
 const fillExtrusionInterface = {
     layoutAttributes: [
@@ -85,8 +86,9 @@ class FillExtrusionBucket implements Bucket {
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
         for (const {feature, index, sourceLayerIndex} of features) {
             if (this.layers[0].filter(feature)) {
-                this.addFeature(feature);
-                options.featureIndex.insert(feature, index, sourceLayerIndex, this.index);
+                const geometry = loadGeometry(feature);
+                this.addFeature(feature, geometry);
+                options.featureIndex.insert(feature, geometry, index, sourceLayerIndex, this.index);
             }
         }
     }
@@ -120,8 +122,8 @@ class FillExtrusionBucket implements Bucket {
         this.segments.destroy();
     }
 
-    addFeature(feature: VectorTileFeature) {
-        for (const polygon of classifyRings(loadGeometry(feature), EARCUT_MAX_RINGS)) {
+    addFeature(feature: VectorTileFeature, geometry: Array<Array<Point>>) {
+        for (const polygon of classifyRings(geometry, EARCUT_MAX_RINGS)) {
             let numVertices = 0;
             for (const ring of polygon) {
                 numVertices += ring.length;

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -172,7 +172,7 @@ class LineBucket implements Bucket {
         const miterLimit = layout['line-miter-limit'];
         const roundLimit = layout['line-round-limit'];
 
-        for (const line of loadGeometry(feature, LINE_DISTANCE_BUFFER_BITS)) {
+        for (const line of loadGeometry(feature)) {
             this.addLine(line, feature, join, cap, miterLimit, roundLimit);
         }
     }

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -130,8 +130,9 @@ class LineBucket implements Bucket {
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
         for (const {feature, index, sourceLayerIndex} of features) {
             if (this.layers[0].filter(feature)) {
-                this.addFeature(feature);
-                options.featureIndex.insert(feature, index, sourceLayerIndex, this.index);
+                const geometry = loadGeometry(feature);
+                this.addFeature(feature, geometry);
+                options.featureIndex.insert(feature, geometry, index, sourceLayerIndex, this.index);
             }
         }
     }
@@ -165,14 +166,14 @@ class LineBucket implements Bucket {
         this.segments.destroy();
     }
 
-    addFeature(feature: VectorTileFeature) {
+    addFeature(feature: VectorTileFeature, geometry: Array<Array<Point>>) {
         const layout = this.layers[0].layout;
         const join = this.layers[0].getLayoutValue('line-join', {zoom: this.zoom}, feature);
         const cap = layout['line-cap'];
         const miterLimit = layout['line-miter-limit'];
         const roundLimit = layout['line-round-limit'];
 
-        for (const line of loadGeometry(feature)) {
+        for (const line of geometry) {
             this.addLine(line, feature, join, cap, miterLimit, roundLimit);
         }
     }

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -93,10 +93,9 @@ class FeatureIndex {
         this.featureIndexArray = featureIndexArray || new FeatureIndexArray();
     }
 
-    insert(feature: VectorTileFeature, featureIndex: number, sourceLayerIndex: number, bucketIndex: number) {
+    insert(feature: VectorTileFeature, geometry: Array<Array<Point>>, featureIndex: number, sourceLayerIndex: number, bucketIndex: number) {
         const key = this.featureIndexArray.length;
         this.featureIndexArray.emplaceBack(featureIndex, sourceLayerIndex, bucketIndex);
-        const geometry = loadGeometry(feature);
 
         for (let r = 0; r < geometry.length; r++) {
             const ring = geometry[r];

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -2,7 +2,6 @@
 
 const util = require('../util/util');
 const EXTENT = require('./extent');
-const assert = require('assert');
 
 import type Point from '@mapbox/point-geometry';
 
@@ -17,24 +16,15 @@ function createBounds(bits) {
     };
 }
 
-const boundsLookup = {
-    '15': createBounds(15),
-    '16': createBounds(16)
-};
+const bounds = createBounds(16);
 
 /**
  * Loads a geometry from a VectorTileFeature and scales it to the common extent
  * used internally.
  * @param {VectorTileFeature} feature
- * @param {number} [bits=16] The number of signed integer bits available to store
- *   each coordinate. A warning will be issued if any coordinate will not fits
- *   in the specified number of bits.
  * @private
  */
-module.exports = function loadGeometry(feature: VectorTileFeature, bits?: number): Array<Array<Point>> {
-    const bounds = boundsLookup[bits || 16];
-    assert(bounds);
-
+module.exports = function loadGeometry(feature: VectorTileFeature): Array<Array<Point>> {
     const scale = EXTENT / feature.extent;
     const geometry = feature.loadGeometry();
     for (let r = 0; r < geometry.length; r++) {

--- a/test/unit/data/fill_bucket.test.js
+++ b/test/unit/data/fill_bucket.test.js
@@ -14,21 +14,10 @@ const StyleLayer = require('../../../src/style/style_layer');
 const vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
 const feature = vt.layers.water.feature(0);
 
-function createFeature(points) {
-    return {
-        properties: {
-            'foo': 1
-        },
-        loadGeometry: function() {
-            return points;
-        }
-    };
-}
-
 function createPolygon(numPoints) {
     const points = [];
     for (let i = 0; i < numPoints; i++) {
-        points.push(new Point(i / numPoints, i / numPoints));
+        points.push(new Point(2048 + 256 * Math.cos(i / numPoints * 2 * Math.PI, 2048 + 256 * Math.sin(i / numPoints * 2 * Math.PI))));
     }
     return points;
 }
@@ -37,18 +26,18 @@ test('FillBucket', (t) => {
     const layer = new StyleLayer({ id: 'test', type: 'fill', layout: {} });
     const bucket = new FillBucket({ layers: [layer] });
 
-    bucket.addFeature(createFeature([[
+    bucket.addFeature({}, [[
         new Point(0, 0),
         new Point(10, 10)
-    ]]));
+    ]]);
 
-    bucket.addFeature(createFeature([[
+    bucket.addFeature({}, [[
         new Point(0, 0),
         new Point(10, 10),
         new Point(10, 20)
-    ]]));
+    ]]);
 
-    bucket.addFeature(feature);
+    bucket.addFeature(feature, feature.loadGeometry());
 
     t.end();
 });
@@ -76,13 +65,13 @@ test('FillBucket segmentation', (t) => {
 
     // first add an initial, small feature to make sure the next one starts at
     // a non-zero offset
-    bucket.addFeature(createFeature([createPolygon(10)]));
+    bucket.addFeature({}, [createPolygon(10)]);
 
     // add a feature that will break across the group boundary
-    bucket.addFeature(createFeature([
+    bucket.addFeature({}, [
         createPolygon(128),
         createPolygon(128)
-    ]));
+    ]);
 
     // Each polygon must fit entirely within a segment, so we expect the
     // first segment to include the first feature and the first polygon

--- a/test/unit/data/line_bucket.test.js
+++ b/test/unit/data/line_bucket.test.js
@@ -14,14 +14,6 @@ const StyleLayer = require('../../../src/style/style_layer');
 const vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
 const feature = vt.layers.road.feature(0);
 
-function createFeature(points) {
-    return {
-        loadGeometry: function() {
-            return points;
-        }
-    };
-}
-
 function createLine(numPoints) {
     const points = [];
     for (let i = 0; i < numPoints; i++) {
@@ -100,7 +92,7 @@ test('LineBucket', (t) => {
         new Point(0, 0)
     ], polygon);
 
-    bucket.addFeature(feature);
+    bucket.addFeature(feature, feature.loadGeometry());
 
     t.end();
 });
@@ -115,10 +107,10 @@ test('LineBucket segmentation', (t) => {
 
     // first add an initial, small feature to make sure the next one starts at
     // a non-zero offset
-    bucket.addFeature(createFeature([createLine(10)]));
+    bucket.addFeature({}, [createLine(10)]);
 
     // add a feature that will break across the group boundary
-    bucket.addFeature(createFeature([createLine(128)]));
+    bucket.addFeature({}, [createLine(128)]);
 
     // Each polygon must fit entirely within a segment, so we expect the
     // first segment to include the first feature and the first polygon

--- a/test/unit/data/load_geometry.test.js
+++ b/test/unit/data/load_geometry.test.js
@@ -21,7 +21,7 @@ test('loadGeometry', (t) => {
 
 test('loadGeometry extent error', (t) => {
     const feature = vt.layers.road.feature(0);
-    feature.extent = 2048;
+    feature.extent = 1024;
 
     let numWarnings = 0;
 
@@ -33,7 +33,7 @@ test('loadGeometry extent error', (t) => {
         }
     };
 
-    loadGeometry(feature, 15);
+    loadGeometry(feature);
 
     t.equal(numWarnings, 1);
 


### PR DESCRIPTION
This ports an optimization that we've had in native for a long time. Should help with #5208.

benchmark | master 2a9381a | perf-5208 f8a9f58
--- | --- | ---
**map-load** | 96 ms  | 92 ms 
**style-load** | 110 ms  | 106 ms 
**buffer** | 1,119 ms  | 1,072 ms 
**tile_layout_dds** | 1,648 ms  | 1,620 ms 
**fps** | 60 fps  | 59 fps 
**frame-duration** | 6.6 ms, 2% > 16ms  | 6.7 ms, 2% > 16ms 
**query-point** | 0.96 ms  | 1.12 ms 
**query-box** | 81.39 ms  | 82.65 ms 
**geojson-setdata-small** | 9 ms  | 9 ms 
**geojson-setdata-large** | 146 ms  | 78 ms 
**filter** | n/a  | n/a 
