### PR TITLE
attach onerror callback to the image used for ajax#getImage

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -125,6 +125,11 @@ exports.getImage = function(requestParameters: RequestParameters, callback: Call
                 callback(null, img);
                 URL.revokeObjectURL(img.src);
             };
+            img.onerror = function(domErr) {
+                const err = new Error('failed to load image. make sure the image is a png');
+                (err: any).domErr = domErr;
+                callback(err);
+            };
             const blob: Blob = new window.Blob([new Uint8Array(imgData.data)], { type: 'image/png' });
             (img: any).cacheControl = imgData.cacheControl;
             (img: any).expires = imgData.expires;

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -72,5 +72,40 @@ test('ajax', (t) => {
         window.server.respond();
     });
 
+    t.test('getImage, 404', (t) => {
+        window.server.respondWith(request => {
+            request.respond(404);
+        });
+        ajax.getImage({ url:'' }, (error) => {
+            t.equal(error.status, 404);
+            t.end();
+        });
+        window.server.respond();
+    });
+
+    t.test('getImage, no content error', (t) => {
+        window.server.respondWith(request => {
+            request.respond(200, {'Content-Type': 'image/png'}, '');
+        });
+        ajax.getImage({ url:'' }, (error) => {
+            t.pass('called getImage');
+            t.ok(error, 'should error when the status is 200 without content.');
+            t.end();
+        });
+        window.server.respond();
+    });
+
+    t.test('getImage, invalid image', (t) => {
+        window.server.respondWith(request => {
+            request.respond(200, {'Content-Type': 'image/svg'}, '<svg height="100" width="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" /></svg>');
+        });
+        ajax.getImage({ url:'' }, (error) => {
+            t.pass('called getImage');
+            t.ok(error, 'should error when the image is not a png.');
+            t.end();
+        });
+        window.server.respond();
+    });
+
     t.end();
 });


### PR DESCRIPTION
I ran into there being no error callback while trying to map#loadImage a url to an svg instead of a png.

The error message could probably be better, and I'm not sure how y'all feel about attaching the original error as the domErr property.

The `getImage, invalid image` test is currently failing with
```
Error: Fake server request processing threw exception: URL.createObjectURL is not a function
      at TypeError: URL.createObjectURL is not a function
      at     at exports.getArrayBuffer (src/util/ajax.js:136:53)
      at     at FakeXMLHttpRequest.xhr.onload (src/util/ajax.js:94:13)
      at     at Array.forEach (<anonymous>)
      at     at Object.window.server.respondWith.request [as response] (test/unit/util/ajax.test.js:100:21)
      at     at Array.forEach (<anonymous>)
      at     at Test.t.test (test/unit/util/ajax.test.js:107:23)
```

so I'm not sure why that wouldn't be there.
