### PR TITLE
3D buildings example: labels on top, hash option

### DIFF
--- a/docs/_posts/examples/3400-01-30-3d-buildings.html
+++ b/docs/_posts/examples/3400-01-30-3d-buildings.html
@@ -14,6 +14,7 @@ var map = new mapboxgl.Map({
     zoom: 15,
     pitch: 45,
     bearing: -17.6,
+    hash: true,
     container: 'map'
 });
 

--- a/docs/_posts/examples/3400-01-30-3d-buildings.html
+++ b/docs/_posts/examples/3400-01-30-3d-buildings.html
@@ -17,8 +17,12 @@ var map = new mapboxgl.Map({
     container: 'map'
 });
 
-// the 'building' layer in the mapbox-streets vector source contains building-height
-// data from OpenStreetMap.
+// The 'building' layer in the mapbox-streets vector source contains building-height
+// data from OpenStreetMap. Insert the layer beneath any symbol layer.
+var layers = map.getStyle().layers.reverse();
+var labelLayerIdx = layers.findIndex(function (layer) {
+    return layer.type !== 'symbol';
+});
 map.on('load', function() {
     map.addLayer({
         'id': '3d-buildings',
@@ -39,6 +43,6 @@ map.on('load', function() {
             },
             'fill-extrusion-opacity': .6
         }
-    });
+    }, labelLayerId);
 });
 </script>

--- a/docs/_posts/examples/3400-01-30-3d-buildings.html
+++ b/docs/_posts/examples/3400-01-30-3d-buildings.html
@@ -24,6 +24,7 @@ var layers = map.getStyle().layers.reverse();
 var labelLayerIdx = layers.findIndex(function (layer) {
     return layer.type !== 'symbol';
 });
+var labelLayerId = labelLayerIdx !== -1 ? layers[labelLayerIdx].id : undefined;
 map.on('load', function() {
     map.addLayer({
         'id': '3d-buildings',


### PR DESCRIPTION
This PR makes two modifications to the “[Display buildings in 3D](https://www.mapbox.com/mapbox-gl-js/example/3d-buildings/)” example based on [this gist](https://gist.github.com/1ec5/09234e60976ad968dc3fd499fb893717):

* The extrusion layer is added beneath any symbol layers that are currently on top – that is, any labels, icons, and shields.
* The `hash` option is set, so that the “[Simple 3D buildings](https://wiki.openstreetmap.org/wiki/Simple_3D_buildings#Demo_areas)” page on the OpenStreetMap Wiki can link to this example page instead of my gist. The wiki page needs to link to specific places on the map, and I think this example page would be more effective than pointing people to [this block](https://bl.ocks.org/1ec5/raw/09234e60976ad968dc3fd499fb893717/) that asks for an access token on the first visit.

/cc @lbud @mourner