### PR TITLE
document Marker#getElement and add Popup#getElement

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -107,6 +107,10 @@ class Marker {
         return this;
     }
 
+    /**
+     * Returns the `Marker`'s HTML element.
+     * @returns {HTMLElement} element
+     */
     getElement() {
         return this._element;
     }


### PR DESCRIPTION
per a question on stackoverflow, `Marker#getElement` was not documented, and I also noticed `Popup` did not have an equivalent function.
 
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
