### PR TITLE
Pause animation loop when removing canvas source

### DIFF
--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -66,12 +66,16 @@ class CanvasSource extends ImageSource {
         let loopID;
 
         this.play = function() {
-            loopID = this.map.style.animationLoop.set(Infinity);
-            this.map._rerender();
+            if (!loopID) {
+                loopID = this.map.style.animationLoop.set(Infinity);
+                this.map._rerender();
+            }
         };
 
         this.pause = function() {
-            this.map.style.animationLoop.cancel(loopID);
+            if (loopID) {
+                loopID = this.map.style.animationLoop.cancel(loopID);
+            }
         };
 
         this._finishLoading();
@@ -93,6 +97,10 @@ class CanvasSource extends ImageSource {
         if (this.canvas) {
             if (this.animate) this.play();
         }
+    }
+
+    onRemove() {
+        this.pause();
     }
 
     /**

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -66,14 +66,14 @@ class CanvasSource extends ImageSource {
         let loopID;
 
         this.play = function() {
-            if (!loopID) {
+            if (loopID === undefined) {
                 loopID = this.map.style.animationLoop.set(Infinity);
                 this.map._rerender();
             }
         };
 
         this.pause = function() {
-            if (loopID) {
+            if (loopID !== undefined) {
                 loopID = this.map.style.animationLoop.cancel(loopID);
             }
         };
@@ -91,7 +91,6 @@ class CanvasSource extends ImageSource {
     }
 
     onAdd(map: Map) {
-        if (this.map) return;
         this.map = map;
         this.load();
         if (this.canvas) {

--- a/test/unit/source/canvas_source.test.js
+++ b/test/unit/source/canvas_source.test.js
@@ -3,6 +3,7 @@
 const test = require('mapbox-gl-js-test').test;
 const CanvasSource = require('../../../src/source/canvas_source');
 const Transform = require('../../../src/geo/transform');
+const AnimationLoop = require('../../../src/style/animation_loop');
 const Evented = require('../../../src/util/evented');
 const util = require('../../../src/util/util');
 const window = require('../../../src/util/window');
@@ -30,7 +31,7 @@ class StubMap extends Evented {
     constructor() {
         super();
         this.transform = new Transform();
-        this.style = { animationLoop: { set: function() {} } };
+        this.style = { animationLoop: new AnimationLoop() };
     }
 
     _rerender() {
@@ -92,6 +93,44 @@ test('CanvasSource', (t) => {
         });
 
         source.onAdd(map);
+    });
+
+    t.test('onRemove stops animation', (t) => {
+        const source = createSource();
+        const map = new StubMap();
+
+        source.onAdd(map);
+
+        t.equal(map.style.animationLoop.stopped(), false, 'should animate initally');
+
+        source.onRemove();
+
+        t.equal(map.style.animationLoop.stopped(), true, 'should stop animating');
+
+        source.onAdd(map);
+
+        t.equal(map.style.animationLoop.stopped(), false, 'should animate when added again');
+
+        t.end();
+    });
+
+    t.test('play and pause animation', (t) => {
+        const source = createSource();
+        const map = new StubMap();
+
+        source.onAdd(map);
+
+        t.equal(map.style.animationLoop.stopped(), false, 'initially animating');
+
+        source.pause();
+
+        t.equal(map.style.animationLoop.stopped(), true, 'can be paused');
+
+        source.play();
+
+        t.equal(map.style.animationLoop.stopped(), false, 'can be played');
+
+        t.end();
     });
 
     t.end();


### PR DESCRIPTION
### Problem

When removing a canvas source, the map can be left in a infinite animation loop. 

### Solution

When removing a canvas source, pause the animation.

### Additional Changes

Protect against setting more than more animation loop per canvas source.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page

fixes #5097