### PR TITLE
Avoid intermediate representation of geometry in FeatureWrapper

### DIFF
--- a/flow-typed/vector-tile.js
+++ b/flow-typed/vector-tile.js
@@ -16,7 +16,6 @@ declare interface VectorTileFeature {
     properties: {[string]: string | number | boolean};
 
     loadGeometry(): Array<Array<Point>>;
-    bbox(): [number, number, number, number];
     toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
 }
 

--- a/src/source/geojson_wrapper.js
+++ b/src/source/geojson_wrapper.js
@@ -64,29 +64,6 @@ class FeatureWrapper implements VectorTileFeature {
         }
     }
 
-    bbox() {
-        const rings = this.loadGeometry();
-        let x1 = Infinity,
-            x2 = -Infinity,
-            y1 = Infinity,
-            y2 = -Infinity;
-
-        for (let i = 0; i < rings.length; i++) {
-            const ring = rings[i];
-
-            for (let j = 0; j < ring.length; j++) {
-                const coord = ring[j];
-
-                x1 = Math.min(x1, coord.x);
-                x2 = Math.max(x2, coord.x);
-                y1 = Math.min(y1, coord.y);
-                y2 = Math.max(y2, coord.y);
-            }
-        }
-
-        return [x1, y1, x2, y2];
-    }
-
     toGeoJSON(x: number, y: number, z: number) {
         return toGeoJSON.call(this, x, y, z);
     }

--- a/test/unit/source/geojson_wrapper.test.js
+++ b/test/unit/source/geojson_wrapper.test.js
@@ -16,7 +16,7 @@ test('geojsonwrapper', (t) => {
         const feature = wrap.feature(0);
 
         t.ok(feature, 'gets a feature');
-        t.deepEqual(feature.bbox(), [0, 0, 10, 10], 'bbox');
+        t.deepEqual(feature.loadGeometry(), [[{x: 0, y: 0}, {x: 10, y: 10}]]);
         t.equal(feature.type, 2, 'type');
         t.deepEqual(feature.properties, {hello:'world'}, 'properties');
 
@@ -32,7 +32,7 @@ test('geojsonwrapper', (t) => {
 
         const wrap = new Wrapper(features);
         const feature = wrap.feature(0);
-        t.deepEqual(feature.bbox(), [0, 1, 0, 1], 'bbox');
+        t.deepEqual(feature.loadGeometry(), [[{x: 0, y: 1}]]);
         t.end();
     });
 


### PR DESCRIPTION
Less GC, better performance on https://github.com/mapbox/mapbox-gl-js/issues/5208.

benchmark | master 78e8e74 | perf-5208 1dc290b
--- | --- | ---
**map-load** | 86 ms  | 89 ms 
**style-load** | 87 ms  | 89 ms 
**buffer** | 1,008 ms  | 988 ms 
**tile_layout_dds** | 1,376 ms  | 1,386 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 6.6 ms, 1% > 16ms  | 6.7 ms, 2% > 16ms 
**query-point** | 1.10 ms  | 1.05 ms 
**query-box** | 69.43 ms  | 80.24 ms 
**geojson-setdata-small** | 12 ms  | 11 ms 
**geojson-setdata-large** | 159 ms  | 127 ms 
**filter** | n/a  | n/a 
