### PR TITLE
Bind depth attachment to RenderTextures only once

### DIFF
--- a/src/render/render_texture.js
+++ b/src/render/render_texture.js
@@ -12,6 +12,7 @@ class RenderTexture {
     fbo: WebGLFramebuffer;
     buffer: VertexBuffer;
     vao: VertexArrayObject;
+    boundAttachment: ?WebGLRenderbuffer;
 
     constructor(painter: Painter) {
         const gl = this.gl = painter.gl;
@@ -42,12 +43,14 @@ class RenderTexture {
     bindWithDepth(depthRbo: WebGLRenderbuffer) {
         const gl = this.gl;
         gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo);
-        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthRbo);
+        if (this.boundAttachment !== depthRbo) {
+            gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthRbo);
+            this.boundAttachment = depthRbo;
+        }
     }
 
     unbind() {
         const gl = this.gl;
-        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, null);
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     }
 }

--- a/src/render/render_texture.js
+++ b/src/render/render_texture.js
@@ -12,7 +12,7 @@ class RenderTexture {
     fbo: WebGLFramebuffer;
     buffer: VertexBuffer;
     vao: VertexArrayObject;
-    boundAttachment: ?WebGLRenderbuffer;
+    attachedRbo: ?WebGLRenderbuffer;
 
     constructor(painter: Painter) {
         const gl = this.gl = painter.gl;
@@ -43,9 +43,9 @@ class RenderTexture {
     bindWithDepth(depthRbo: WebGLRenderbuffer) {
         const gl = this.gl;
         gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo);
-        if (this.boundAttachment !== depthRbo) {
+        if (this.attachedRbo !== depthRbo) {
             gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthRbo);
-            this.boundAttachment = depthRbo;
+            this.attachedRbo = depthRbo;
         }
     }
 


### PR DESCRIPTION
Because I'm continually figuring out more about how GL works 🤓/🤦‍♀️ : 

This removes the detaching of the shared depth renderbuffer from the individual extrusion RenderTextures (framebuffers), and stores a reference to the attached depth RBO so that we only attach it once at the beginning, which will avoid expensive framebuffer validations on subsequent calls. (I think @kkaefer suggested this last week and I misinterpreted it.)

If we use the `RenderTexture` class later for other purposes we can slightly rework this to store more specific information about attachment state (type + attachment point).