### PR TITLE
Update vt-pbf

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "tinyqueue": "^1.1.0",
     "unassertify": "^2.0.0",
     "unflowify": "^1.0.0",
-    "vt-pbf": "^3.0.0",
+    "vt-pbf": "^3.0.1",
     "webworkify": "^1.4.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,7 @@
     mapbox-gl-styles "2.0.2"
     pixelmatch "^4.0.2"
     pngjs "^3.0.0"
+    shuffle-seed "^1.1.6"
     st "^1.1.0"
 
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
@@ -6842,9 +6843,9 @@ vm-browserify@~0.0.1:
   dependencies:
     indexof "0.0.1"
 
-vt-pbf@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.0.0.tgz#2e12b2ac447d52190e895d325ec39b293cc3a93b"
+vt-pbf@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.0.1.tgz#ff7ef598464da443a03dece7b6bca12998a64338"
   dependencies:
     "@mapbox/point-geometry" "0.1.0"
     "@mapbox/vector-tile" "^1.3.0"


### PR DESCRIPTION
https://github.com/mapbox/vt-pbf/releases/tag/v3.0.1

benchmark | master 0746808 | vt-pbf 8542c0b
--- | --- | ---
**map-load** | 122 ms  | 102 ms 
**style-load** | 117 ms  | 78 ms 
**buffer** | 1,084 ms  | 1,035 ms 
**tile_layout_dds** | 1,496 ms  | 1,525 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 7 ms, 1% > 16ms  | 6.9 ms, 1% > 16ms 
**query-point** | 0.88 ms  | 1.11 ms 
**query-box** | 69.01 ms  | 78.26 ms 
**geojson-setdata-small** | 8 ms  | 10 ms 
**geojson-setdata-large** | 142 ms  | 75 ms 
**filter** | n/a  | n/a 

(The `geojson-setdata-large` result is unfortunately an artifact. Rerunning shows it hasn't changed.)