### PR TITLE
Add json-stringify-pretty-compact to integration test dependencies

### DIFF
--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -8,6 +8,7 @@
     "colors": "^1.1.2",
     "d3-queue": "^3.0.3",
     "diff": "^3.0.0",
+    "json-stringify-pretty-compact": "^1.0.4",
     "lodash": "^4.17.4",
     "mapbox-gl-styles": "2.0.2",
     "pixelmatch": "^4.0.2",


### PR DESCRIPTION
Fixes gl-native build.