### PR TITLE
Align line vertex to 4-byte boundary

### DIFF
--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -9,7 +9,6 @@ const {TriangleIndexArray} = require('../index_array_type');
 const loadGeometry = require('../load_geometry');
 const EXTENT = require('../extent');
 const vectorTileFeatureTypes = require('@mapbox/vector-tile').VectorTileFeature.types;
-const {packUint8ToFloat} = require('../../shaders/encode_attribute');
 
 import type {Bucket, IndexedFeature, PopulateParameters, SerializedBucket} from '../bucket';
 import type {ProgramInterface} from '../program_configuration';
@@ -53,7 +52,7 @@ const MAX_LINE_DISTANCE = Math.pow(2, LINE_DISTANCE_BUFFER_BITS - 1) / LINE_DIST
 
 const lineInterface = {
     layoutAttributes: [
-        {name: 'a_pos_normal', components: 3, type: 'Int16'},
+        {name: 'a_pos_normal', components: 4, type: 'Int16'},
         {name: 'a_data', components: 4, type: 'Uint8'}
     ],
     paintAttributes: [
@@ -73,7 +72,8 @@ function addLineVertex(layoutVertexBuffer, point: Point, extrude: Point, round: 
         // a_pos_normal
         point.x,
         point.y,
-        packUint8ToFloat(round ? 1 : 0, up ? 1 : 0),
+        round ? 1 : 0,
+        up ? 1 : -1,
         // a_data
         // add 128 to store a byte in an unsigned byte
         Math.round(EXTRUDE_SCALE * extrude.x) + 128,

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -12,7 +12,7 @@
 // #define scale 63.0
 #define scale 0.015873016
 
-attribute vec3 a_pos_normal;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -43,12 +43,9 @@ void main() {
 
     vec2 pos = a_pos_normal.xy;
 
-    // transform y normal so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // x is 1 if it's a round cap, 0 otherwise
     // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = unpack_float(a_pos_normal.z);
-    normal.y = sign(normal.y - 0.5);
-
+    mediump vec2 normal = a_pos_normal.zw;
     v_normal = normal;
 
     // these transformations used to be applied in the JS and native code bases.

--- a/src/shaders/line_pattern.vertex.glsl
+++ b/src/shaders/line_pattern.vertex.glsl
@@ -14,7 +14,7 @@
 // Retina devices need a smaller distance to avoid aliasing.
 #define ANTIALIASING 1.0 / DEVICE_PIXEL_RATIO / 2.0
 
-attribute vec3 a_pos_normal;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -45,12 +45,9 @@ void main() {
 
     vec2 pos = a_pos_normal.xy;
 
-    // transform y normal so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // x is 1 if it's a round cap, 0 otherwise
     // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = unpack_float(a_pos_normal.z);
-    normal.y = sign(normal.y - 0.5);
-
+    mediump vec2 normal = a_pos_normal.zw;
     v_normal = normal;
 
     // these transformations used to be applied in the JS and native code bases.

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -14,7 +14,7 @@
 // Retina devices need a smaller distance to avoid aliasing.
 #define ANTIALIASING 1.0 / DEVICE_PIXEL_RATIO / 2.0
 
-attribute vec3 a_pos_normal;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -54,12 +54,9 @@ void main() {
 
     vec2 pos = a_pos_normal.xy;
 
-    // transform y normal so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // x is 1 if it's a round cap, 0 otherwise
     // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = unpack_float(a_pos_normal.z);
-    normal.y = sign(normal.y - 0.5);
-
+    mediump vec2 normal = a_pos_normal.zw;
     v_normal = normal;
 
     // these transformations used to be applied in the JS and native code bases.


### PR DESCRIPTION
10 byte vertices are heavily penalized by common GL implementations.

Refs https://github.com/mapbox/mapbox-gl-native/issues/9912.

benchmark | master db8d5c0 | line-vertex-alignment cdde1eb
--- | --- | ---
**map-load** | 94 ms  | 79 ms 
**style-load** | 102 ms  | 99 ms 
**buffer** | 953 ms  | 887 ms 
**tile_layout_dds** | 1,826 ms  | 1,718 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 6.9 ms, 0% > 16ms  | 6.8 ms, 1% > 16ms 
**query-point** | 0.81 ms  | 1.06 ms 
**query-box** | 66.03 ms  | 73.99 ms 
**geojson-setdata-small** | 9 ms  | 14 ms 
**geojson-setdata-large** | 75 ms  | 142 ms 
**filter** | n/a  | n/a 

