### PR TITLE
document units for `icon-offset`

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1026,7 +1026,7 @@
     "icon-offset": {
       "type": "array",
       "value": "number",
-      "units": "pixels",
+      "units": "pixels multiplied by the value of \"icon-size\"",
       "length": 2,
       "default": [
         0,

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1026,6 +1026,7 @@
     "icon-offset": {
       "type": "array",
       "value": "number",
+      "units": "pixels",
       "length": 2,
       "default": [
         0,


### PR DESCRIPTION
Documents that the units for `icon-offset` are px. ~~`em` and explains what `1 em` is for an icon.~~

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [NA] write tests for all new functionality
 - [NA] document any changes to public APIs
 - [NA] post benchmark scores
 - [x] manually test the debug page

@ericdeveloper @mollymerp 