### PR TITLE
Fixed #2784

### DIFF
--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -46,7 +46,7 @@ module.exports = function bindHandlers(map: Map, options: {}) {
     }
 
     function onMouseDown(e: MouseEvent) {
-        if (!map._isUserDoubleClick) {
+        if (!map.doubleClickZoom.isActive()) {
             map.stop();
         }
 

--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -46,7 +46,10 @@ module.exports = function bindHandlers(map: Map, options: {}) {
     }
 
     function onMouseDown(e: MouseEvent) {
-        map.stop();
+        if (!map._isUserDoubleClick) {
+            map.stop();
+        }
+
         startPos = DOM.mousePos(el, e);
         fireMouseEvent('mousedown', e);
 

--- a/src/ui/handler/dblclick_zoom.js
+++ b/src/ui/handler/dblclick_zoom.js
@@ -19,6 +19,7 @@ class DoubleClickZoomHandler {
 
         util.bindAll([
             '_onDblClick',
+            '_onZoomEnd'
         ], this);
     }
 
@@ -56,11 +57,18 @@ class DoubleClickZoomHandler {
     }
 
     _onDblClick(e: any) {
+        this._map._isUserDoubleClick = true;
+        this._map.on('zoomend', this._onZoomEnd);
         this._map.zoomTo(
             this._map.getZoom() + (e.originalEvent.shiftKey ? -1 : 1),
             {around: e.lngLat},
             e
         );
+    }
+
+    _onZoomEnd() {
+        this._map._isUserDoubleClick = false;
+        this._map.off('zoomend', this._onZoomEnd);
     }
 }
 

--- a/src/ui/handler/dblclick_zoom.js
+++ b/src/ui/handler/dblclick_zoom.js
@@ -13,6 +13,7 @@ import type Map from '../map';
 class DoubleClickZoomHandler {
     _map: Map;
     _enabled: boolean;
+    _active: boolean;
 
     constructor(map: Map) {
         this._map = map;
@@ -30,6 +31,15 @@ class DoubleClickZoomHandler {
      */
     isEnabled() {
         return !!this._enabled;
+    }
+
+    /**
+     * Returns a Boolean indicating whether the "double click to zoom" interaction is active, i.e. currently being used.
+     *
+     * @returns {boolean} `true` if the "double click to zoom" interaction is active.
+     */
+    isActive() {
+        return !!this._active;
     }
 
     /**
@@ -57,7 +67,7 @@ class DoubleClickZoomHandler {
     }
 
     _onDblClick(e: any) {
-        this._map._isUserDoubleClick = true;
+        this._active = true;
         this._map.on('zoomend', this._onZoomEnd);
         this._map.zoomTo(
             this._map.getZoom() + (e.originalEvent.shiftKey ? -1 : 1),
@@ -67,7 +77,7 @@ class DoubleClickZoomHandler {
     }
 
     _onZoomEnd() {
-        this._map._isUserDoubleClick = false;
+        this._active = false;
         this._map.off('zoomend', this._onZoomEnd);
     }
 }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -244,7 +244,6 @@ class Map extends Camera {
     _refreshExpiredTiles: boolean;
     _hash: Hash;
     _delegatedListeners: any;
-    _isUserDoubleClick: boolean;
 
     scrollZoom: ScrollZoomHandler;
     boxZoom: BoxZoomHandler;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -244,6 +244,7 @@ class Map extends Camera {
     _refreshExpiredTiles: boolean;
     _hash: Hash;
     _delegatedListeners: any;
+    _isUserDoubleClick: boolean;
 
     scrollZoom: ScrollZoomHandler;
     boxZoom: BoxZoomHandler;


### PR DESCRIPTION
Previously, a zoom initiated by a double tap on a touchscreen device would stop as soon as the user lifted his/her finger from the second tap. This was due to the map's mousedown handler calling `map.stop()`.

This PR sets a flag when the user initiates a double click/tap, which is then checked before calling `map.stop()` in the map's mousedown handler.

mousedown events are still received and passed to any handlers during a user-initiated zoom animation, but they will not stop the zoom.