### PR TITLE
Fold compound expressions with literal arguments into literals

### DIFF
--- a/flow-typed/visitor.js
+++ b/flow-typed/visitor.js
@@ -1,3 +1,0 @@
-declare type Visitor<T> = {
-    visit: (T) => void
-};

--- a/src/style-spec/function/compile.js
+++ b/src/style-spec/function/compile.js
@@ -8,9 +8,12 @@ const {
     CompilationContext
 } = require('./expression');
 const parseExpression = require('./parse_expression');
-const { CompoundExpression } = require('./compound_expression');
 const definitions = require('./definitions');
 const evaluationContext = require('./evaluation_context');
+const {
+    isFeatureConstant,
+    isZoomConstant
+} = require('./is_constant');
 
 import type { Type } from './types.js';
 import type { Expression, ParsingError } from './expression.js';
@@ -78,33 +81,3 @@ function compileExpression(
     };
 }
 
-function isFeatureConstant(e: Expression) {
-    if (e instanceof CompoundExpression) {
-        if (e.name === 'get' && e.args.length === 1) {
-            return false;
-        } else if (e.name === 'has' && e.args.length === 1) {
-            return false;
-        } else if (
-            e.name === 'properties' ||
-            e.name === 'geometry-type' ||
-            e.name === 'id'
-        ) {
-            return false;
-        }
-    }
-
-    let result = true;
-    e.eachChild(arg => {
-        if (result && !isFeatureConstant(arg)) { result = false; }
-    });
-    return result;
-}
-
-function isZoomConstant(e: Expression) {
-    if (e instanceof CompoundExpression && e.name === 'zoom') { return false; }
-    let result = true;
-    e.eachChild((arg) => {
-        if (result && !isZoomConstant(arg)) { result = false; }
-    });
-    return result;
-}

--- a/src/style-spec/function/compile.js
+++ b/src/style-spec/function/compile.js
@@ -79,33 +79,32 @@ function compileExpression(
 }
 
 function isFeatureConstant(e: Expression) {
-    let result = true;
-    e.accept({
-        visit: (expression) => {
-            if (expression instanceof CompoundExpression) {
-                if (expression.name === 'get') {
-                    result = result && (expression.args.length > 1);
-                } else if (expression.name === 'has') {
-                    result = result && (expression.args.length > 1);
-                } else {
-                    result = result && !(
-                        expression.name === 'properties' ||
-                        expression.name === 'geometry-type' ||
-                        expression.name === 'id'
-                    );
-                }
-            }
+    if (e instanceof CompoundExpression) {
+        if (e.name === 'get' && e.args.length === 1) {
+            return false;
+        } else if (e.name === 'has' && e.args.length === 1) {
+            return false;
+        } else if (
+            e.name === 'properties' ||
+            e.name === 'geometry-type' ||
+            e.name === 'id'
+        ) {
+            return false;
         }
+    }
+
+    let result = true;
+    e.eachChild(arg => {
+        if (result && !isFeatureConstant(arg)) { result = false; }
     });
     return result;
 }
 
 function isZoomConstant(e: Expression) {
+    if (e instanceof CompoundExpression && e.name === 'zoom') { return false; }
     let result = true;
-    e.accept({
-        visit: (expression) => {
-            if (expression.name === 'zoom') result = false;
-        }
+    e.eachChild((arg) => {
+        if (result && !isZoomConstant(arg)) { result = false; }
     });
     return result;
 }

--- a/src/style-spec/function/compound_expression.js
+++ b/src/style-spec/function/compound_expression.js
@@ -41,9 +41,8 @@ class CompoundExpression implements Expression {
         return [ name ].concat(args);
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
-        this.args.forEach(a => a.accept(visitor));
+    eachChild(fn: (Expression) => void) {
+        this.args.forEach(fn);
     }
 
     static parse(args: Array<mixed>, context: ParsingContext): ?Expression {

--- a/src/style-spec/function/definitions/array.js
+++ b/src/style-spec/function/definitions/array.js
@@ -78,9 +78,8 @@ class ArrayAssertion implements Expression {
         }
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
-        this.input.accept(visitor);
+    eachChild(fn: (Expression) => void) {
+        fn(this.input);
     }
 }
 

--- a/src/style-spec/function/definitions/at.js
+++ b/src/style-spec/function/definitions/at.js
@@ -44,10 +44,9 @@ class At implements Expression {
         return [ 'at', this.index.serialize(), this.input.serialize() ];
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
-        this.index.accept(visitor);
-        this.input.accept(visitor);
+    eachChild(fn: (Expression) => void) {
+        fn(this.index);
+        fn(this.input);
     }
 }
 

--- a/src/style-spec/function/definitions/case.js
+++ b/src/style-spec/function/definitions/case.js
@@ -73,13 +73,12 @@ class Case implements Expression {
         return result;
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
+    eachChild(fn: (Expression) => void) {
         for (const [test, expression] of this.branches) {
-            test.accept(visitor);
-            expression.accept(visitor);
+            fn(test);
+            fn(expression);
         }
-        this.otherwise.accept(visitor);
+        fn(this.otherwise);
     }
 }
 

--- a/src/style-spec/function/definitions/coalesce.js
+++ b/src/style-spec/function/definitions/coalesce.js
@@ -50,11 +50,8 @@ class Coalesce implements Expression {
         return ['coalesce'].concat(this.args.map(a => a.serialize()));
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
-        for (const arg of this.args) {
-            arg.accept(visitor);
-        }
+    eachChild(fn: (Expression) => void) {
+        this.args.forEach(fn);
     }
 }
 

--- a/src/style-spec/function/definitions/contains.js
+++ b/src/style-spec/function/definitions/contains.js
@@ -50,10 +50,9 @@ class Contains implements Expression {
         return [ 'contains', this.value.serialize(), this.array.serialize() ];
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
-        this.array.accept(visitor);
-        this.value.accept(visitor);
+    eachChild(fn: (Expression) => void) {
+        fn(this.array);
+        fn(this.value);
     }
 }
 

--- a/src/style-spec/function/definitions/curve.js
+++ b/src/style-spec/function/definitions/curve.js
@@ -113,8 +113,8 @@ class Curve implements Expression {
             const label = rest[i];
             const value = rest[i + 1];
 
-            const labelKey = isStep ? i + 4 : i + 3;
-            const valueKey = isStep ? i + 5 : i + 4;
+            const labelKey = isStep ? i + 2 : i + 3;
+            const valueKey = isStep ? i + 3 : i + 4;
 
             if (typeof label !== 'number') {
                 return context.error('Input/output pairs for "curve" expressions must be defined using literal numeric values (not computed expressions) for the input values.', labelKey);

--- a/src/style-spec/function/definitions/curve.js
+++ b/src/style-spec/function/definitions/curve.js
@@ -176,11 +176,10 @@ class Curve implements Expression {
         return result;
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
-        this.input.accept(visitor);
+    eachChild(fn: (Expression) => void) {
+        fn(this.input);
         for (const [ , expression] of this.stops) {
-            expression.accept(visitor);
+            fn(expression);
         }
     }
 }

--- a/src/style-spec/function/definitions/let.js
+++ b/src/style-spec/function/definitions/let.js
@@ -33,12 +33,11 @@ class Let implements Expression {
         return serialized;
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
+    eachChild(fn: (Expression) => void) {
         for (const binding of this.bindings) {
-            binding[1].accept(visitor);
+            fn(binding[1]);
         }
-        this.result.accept(visitor);
+        fn(this.result);
     }
 
     static parse(args: Array<mixed>, context: ParsingContext) {

--- a/src/style-spec/function/definitions/literal.js
+++ b/src/style-spec/function/definitions/literal.js
@@ -4,7 +4,7 @@ const { Color, isValue, typeOf } = require('../values');
 
 import type { Type } from '../types';
 import type { Value }  from '../values';
-import type { Expression, ParsingContext }  from '../expression';
+import type { Expression, ParsingContext, CompilationContext }  from '../expression';
 
 const u2028 = /\u2028/g;
 const u2029 = /\u2029/g;
@@ -45,9 +45,19 @@ class Literal implements Expression {
         return new Literal(context.key, type, value);
     }
 
-    compile() {
-        const value = Literal.compile(this.value);
-        return typeof this.value === 'object' ?  `(${value})` : value;
+    compile(ctx: CompilationContext) {
+        let value;
+        if (this.type.kind === 'Color') {
+            value = `(new $this.Color(${(this.value: any).join(', ')}))`;
+        } else {
+            value = Literal.compile(this.value);
+        }
+
+        if (typeof this.value === 'object' && this.value !== null) {
+            return ctx.addVariable(value);
+        } else {
+            return value;
+        }
     }
 
     static compile(value: Value) {

--- a/src/style-spec/function/definitions/literal.js
+++ b/src/style-spec/function/definitions/literal.js
@@ -72,7 +72,7 @@ class Literal implements Expression {
         }
     }
 
-    accept(visitor: Visitor<Expression>) { visitor.visit(this); }
+    eachChild() {}
 }
 
 module.exports = Literal;

--- a/src/style-spec/function/definitions/match.js
+++ b/src/style-spec/function/definitions/match.js
@@ -135,13 +135,10 @@ class Match implements Expression {
         return result;
     }
 
-    accept(visitor: Visitor<Expression>) {
-        visitor.visit(this);
-        this.input.accept(visitor);
-        for (const output of this.outputs) {
-            output.accept(visitor);
-        }
-        this.otherwise.accept(visitor);
+    eachChild(fn: (Expression) => void) {
+        fn(this.input);
+        this.outputs.forEach(fn);
+        fn(this.otherwise);
     }
 }
 

--- a/src/style-spec/function/definitions/var.js
+++ b/src/style-spec/function/definitions/var.js
@@ -35,7 +35,7 @@ class Var implements Expression {
         return [this.name];
     }
 
-    accept(visitor: Visitor<Expression>) { visitor.visit(this); }
+    eachChild() {}
 }
 
 

--- a/src/style-spec/function/evaluation_context.js
+++ b/src/style-spec/function/evaluation_context.js
@@ -62,6 +62,7 @@ function ensure(condition: any, message: string) {
 module.exports = () => ({
     types: types,
 
+    Color: Color, // used for compiling color literals
     ensure: ensure,
     error: (msg: string) => ensure(false, msg),
 

--- a/src/style-spec/function/expression.js
+++ b/src/style-spec/function/expression.js
@@ -14,7 +14,7 @@ export interface Expression {
     compile(CompilationContext): string; // eslint-disable-line no-use-before-define
 
     serialize(): any;
-    accept(Visitor<Expression>): void;
+    eachChild(fn: Expression => void): void;
 }
 
 class ParsingError extends Error {

--- a/src/style-spec/function/is_constant.js
+++ b/src/style-spec/function/is_constant.js
@@ -1,0 +1,41 @@
+// @flow
+
+const { CompoundExpression } = require('./compound_expression');
+
+import type { Expression } from './expression.js';
+
+function isFeatureConstant(e: Expression) {
+    if (e instanceof CompoundExpression) {
+        if (e.name === 'get' && e.args.length === 1) {
+            return false;
+        } else if (e.name === 'has' && e.args.length === 1) {
+            return false;
+        } else if (
+            e.name === 'properties' ||
+            e.name === 'geometry-type' ||
+            e.name === 'id'
+        ) {
+            return false;
+        }
+    }
+
+    let result = true;
+    e.eachChild(arg => {
+        if (result && !isFeatureConstant(arg)) { result = false; }
+    });
+    return result;
+}
+
+function isZoomConstant(e: Expression) {
+    if (e instanceof CompoundExpression && e.name === 'zoom') { return false; }
+    let result = true;
+    e.eachChild((arg) => {
+        if (result && !isZoomConstant(arg)) { result = false; }
+    });
+    return result;
+}
+
+module.exports = {
+    isFeatureConstant,
+    isZoomConstant,
+};

--- a/test/integration/expression-tests/constant-folding/evaluation-error/test.json
+++ b/test/integration/expression-tests/constant-folding/evaluation-error/test.json
@@ -1,0 +1,28 @@
+{
+  "expectExpressionType": {"kind": "Color"},
+  "expression": [
+    "curve",
+    ["step"],
+    ["get", "x"],
+    "black",
+    0,
+    "invalid",
+    10,
+    "blue"
+  ],
+  "inputs": [
+    [{}, {"properties": {"x": -1}}],
+    [{}, {"properties": {"x": 0}}],
+    [{}, {"properties": {"x": 5}}],
+    [{}, {"properties": {"x": 10}}],
+    [{}, {"properties": {"x": 11}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [
+        {"key": "[5]", "error": "Could not parse color from value 'invalid'"}
+      ]
+    }
+  }
+}

--- a/test/integration/expression-tests/constant-folding/to-color/test.json
+++ b/test/integration/expression-tests/constant-folding/to-color/test.json
@@ -9,8 +9,6 @@
       "isZoomConstant": true,
       "type": "Color"
     },
-    "outputs": [
-      [1, 0, 0, 1]
-    ]
+    "outputs": [[1, 0, 0, 1]]
   }
 }

--- a/test/integration/expression-tests/constant-folding/to-color/test.json
+++ b/test/integration/expression-tests/constant-folding/to-color/test.json
@@ -1,0 +1,16 @@
+{
+  "expectExpressionType": null,
+  "expression": ["to-color", "red"],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "Color"
+    },
+    "outputs": [
+      [1, 0, 0, 1]
+    ]
+  }
+}

--- a/test/integration/expression-tests/get/from-literal--missing/test.json
+++ b/test/integration/expression-tests/get/from-literal--missing/test.json
@@ -4,13 +4,13 @@
   "inputs": [[{}, {}]],
   "expected": {
     "compiled": {
-      "result": "success",
-      "isFeatureConstant": true,
-      "isZoomConstant": true,
-      "type": "Number"
-    },
-    "outputs": [
-      {"error": "Expected value to be of type Number, but found Null instead."}
-    ]
+      "result": "error",
+      "errors": [
+        {
+          "key": "",
+          "error": "Expected value to be of type Number, but found Null instead."
+        }
+      ]
+    }
   }
 }

--- a/test/integration/lib/expression.js
+++ b/test/integration/lib/expression.js
@@ -5,7 +5,21 @@ const path = require('path');
 const harness = require('./harness');
 const diff = require('diff');
 const fs = require('fs');
-const stringify = require('json-stringify-pretty-compact');
+const compactStringify = require('json-stringify-pretty-compact');
+
+// we have to handle this edge case here because we have test fixtures for this
+// edge case, and we don't want UPDATE=1 to mess with them
+function stringify(v) {
+    let s = compactStringify(v);
+    // http://timelessrepo.com/json-isnt-a-javascript-subset
+    if (s.indexOf('\u2028') >= 0) {
+        s = s.replace(/\u2028/g, '\\u2028');
+    }
+    if (s.indexOf('\u2029') >= 0) {
+        s = s.replace(/\u2029/g, '\\u2029');
+    }
+    return s;
+}
 
 let linter;
 try {


### PR DESCRIPTION
When parsing an expression, if its arguments are all Literals, then evaluate it immediately and yield a Literal instead.

Yields a modest perf improvement in `tile_layout_dds`:
 - before: 51.37629 - 52.20937 ms / iteration
 - after: 47.81951 - 49.86712 ms / iteration

More importantly, this means we get validation errors at compile time rather than evaluation time for the common case of color curves defined like `[curve, [linear], [zoom], 0, "red", 10, "bleu mispelled"]`

benchmark | master 2200752 | expressions-fold-constant 0567a8f
--- | --- | ---
**map-load** | 111 ms  | 119 ms 
**style-load** | 128 ms  | 168 ms 
**buffer** | 1,167 ms  | 1,120 ms 
**tile_layout_dds** | 1,329 ms  | 1,255 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 7.1 ms, 1% > 16ms  | 6.9 ms, 2% > 16ms 
**query-point** | 0.98 ms  | 1.24 ms 
**query-box** | 73.43 ms  | 75.72 ms 
**geojson-setdata-small** | 17 ms  | 0 ms 
**geojson-setdata-large** | 88 ms  | 175 ms 
**filter** | Done  | Done 
