### PR TITLE
Fix issue #5248: don't redo placement for zoom changes of low-pitch m…

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -226,17 +226,18 @@ class Tile {
         const cameraToTileDistance = source.map.transform.cameraToTileDistance(this);
         if (this.angle === source.map.transform.angle &&
             this.pitch === source.map.transform.pitch &&
-            this.cameraToCenterDistance === source.map.transform.cameraToCenterDistance &&
             this.showCollisionBoxes === source.map.showCollisionBoxes) {
-            if (this.cameraToTileDistance === cameraToTileDistance) {
+            if (this.cameraToTileDistance === cameraToTileDistance &&
+                this.cameraToCenterDistance === source.map.transform.cameraToCenterDistance) {
                 return;
             } else if (this.pitch < 25) {
                 // At low pitch tile distance doesn't affect placement very
                 // much, so we skip the cost of redoPlacement
                 // However, we might as well store the latest value of
-                // cameraToTileDistance in case a redoPlacement request
+                // cameraToTileDistance and cameraToCenterDistance in case a redoPlacement request
                 // is already queued.
                 this.cameraToTileDistance = cameraToTileDistance;
+                this.cameraToCenterDistance = source.map.transform.cameraToCenterDistance;
                 return;
             }
         }

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -194,6 +194,41 @@ test('Tile#redoPlacement', (t) => {
         });
     });
 
+    test('changing cameraToCenterDistance does not trigger placement for low pitch', (t)=>{
+        const tile = new Tile(new TileCoord(1, 1, 1));
+        tile.loadVectorData(createVectorData(), createPainter());
+        t.stub(tile, 'reloadSymbolData').returns(null);
+        const source1 = util.extend(new Evented(), {
+            type: 'vector',
+            dispatcher: {
+                send: (name, data, cb) => {
+                    cb();
+                }
+            },
+            map: {
+                transform: { cameraToCenterDistance: 1, pitch: 10, cameraToTileDistance: () => { return 1; } },
+                painter: { tileExtentVAO: {vao: 0}}
+            }
+        });
+
+        const source2 = util.extend(new Evented(), {
+            type: 'vector',
+            dispatcher: {
+                send: () => {}
+            },
+            map: {
+                transform: { cameraToCenterDistance: 2, pitch: 10, cameraToTileDistance: () => { return 1; } },
+                painter: { tileExtentVAO: {vao: 0}}
+            }
+        });
+
+        tile.redoPlacement(source1);
+        tile.redoPlacement(source2);
+
+        t.ok(tile.state === 'loaded');
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Fixes #5248.

https://github.com/mapbox/mapbox-gl-js/commit/aefb3ee1f7b3b3133c4e630356cfd7a1f35d7c2d introduced `redoPlacement` calls in response to any map move, since any movement could potentially affect collision detection with the new pitch-scaling behavior. To prevent incurring extra/unnecessary placement costs, I did a couple things:

- Don't trigger placement at all if none of the transform parameters had changed
- Don't trigger placement if the only thing that had changed was the relative position of the tile (i.e. a pan operation), and the pitch was low (at low pitch, pan operations have very small effects on collision detection).
- Trigger placement at most once per 300 ms: there's no point in maxing out the CPU on the worker threads to deliver placement faster than collisions are actually perceived, and in fact going too quickly can exacerbate some "flicker" problems.

However, I forgot that the transform parameter `cameraToCenterDistance` would be changing with every zoom change, and that zoom changes didn't previously trigger placement. While zoom changes (and anything else that affects `cameraToCenterDistance`, like changing the field of view) do affect collision detection, the effects are minimal at low pitch and can be safely ignored.

When the cost of placement is relatively low, this is not a very substantial difference, because the throttling limits placement to once every 300ms anyway. When placement is significantly more expensive (as in #5208), the placement can end up running continuously during zoom operations, which is a waste (we should only have to re-do placement when we cross integer zoom levels).

This PR fixes the oversight and introduces one unit test to verify that `redoPlacement` is actually being suppressed.

This will hopefully all be superseded soon by #5150.

## bench results
The benchmarks don't really exercise the use case this PR addresses, so this is just a sanity check.

benchmark | master 7d452ea | cloer_5248 6e2fbf4
--- | --- | ---
**map-load** | 125 ms  | 89 ms 
**style-load** | 127 ms  | 132 ms 
**buffer** | 1,147 ms  | 1,128 ms 
**tile_layout_dds** | 1,259 ms  | 1,258 ms 
**fps** | 60 fps  | 60 fps 
**frame-duration** | 6.2 ms, 0% > 16ms  | 6.4 ms, 1% > 16ms 
**query-point** | 0.84 ms  | 0.96 ms 
**query-box** | 72.64 ms  | 66.96 ms 
**geojson-setdata-small** | 9 ms  | 11 ms 
**geojson-setdata-large** | 130 ms  | 148 ms 
**filter** | n/a  | n/a 

/cc @jfirebaugh @ansis 