### PR TITLE
fix parent tile retention for overzoomed tiles

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -415,7 +415,6 @@ class SourceCache extends Evented {
 
     _updateRetainedTiles(idealTileCoords: Array<TileCoord>, zoom: number): { [string]: boolean} {
         let i, coord, tile, covered;
-
         const retain = {};
         const checked: {[number]: boolean } = {};
         const minCoveringZoom = Math.max(zoom - SourceCache.maxOverzooming, this._source.minzoom);
@@ -468,14 +467,13 @@ class SourceCache extends Evented {
                     // We couldn't find child tiles that entirely cover the ideal tile.
                     for (let overscaledZ = zoom - 1; overscaledZ >= minCoveringZoom; --overscaledZ) {
 
-                        const parentId = coord.scaledTo(overscaledZ);
+                        const parentId = coord.scaledTo(overscaledZ, this._source.maxzoom);
                         if (checked[parentId.id]) {
                             // Break parent tile ascent, this route has been previously checked by another child.
                             break;
                         } else {
                             checked[parentId.id] = true;
                         }
-
 
                         tile = this.getTile(parentId);
                         if (!tile && parentWasRequested) {

--- a/src/source/tile_coord.js
+++ b/src/source/tile_coord.js
@@ -95,7 +95,12 @@ class TileCoord {
         ];
     }
 
-    scaledTo(targetZ: number) {
+    scaledTo(targetZ: number, sourceMaxZoom: number) {
+        // the id represents an overscaled tile, return the same coordinates with a lower z
+        if (this.z > sourceMaxZoom) {
+            return new TileCoord(targetZ, this.x, this.y, this.w);
+        }
+
         if (targetZ <= this.z) {
             return new TileCoord(targetZ, this.x >> (this.z - targetZ), this.y >> (this.z - targetZ), this.w); // parent or same
         } else {

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -822,9 +822,9 @@ test('SourceCache#_updateRetainedTiles', (t)=> {
         ]);
 
         t.deepEqual(retained, {
-            // parent of ideal tile
+            // parent of ideal tile 0/0/0
             '0' : true,
-            // ideal tile id
+            // ideal tile id 1/0/1
             '65' : true
         }, 'retain ideal and parent tile when ideal tiles aren\'t loaded');
 
@@ -929,7 +929,7 @@ test('SourceCache#_updateRetainedTiles', (t)=> {
         ], 'doesn\'t request parent tiles bc they are lower than minzoom');
 
         t.deepEqual(retained, {
-            // ideal tile id (1, 0, 0)
+            // ideal tile id (2, 0, 0)
             '2' : true
         }, 'doesn\'t retain parent tiles below minzoom');
 
@@ -959,7 +959,7 @@ test('SourceCache#_updateRetainedTiles', (t)=> {
         ], 'doesn\'t request childtiles above maxzoom');
 
         t.deepEqual(retained, {
-            // ideal tile id (1, 0, 0)
+            // ideal tile id (2, 0, 0)
             '2' : true
         }, 'doesn\'t retain child tiles above maxzoom');
 
@@ -1031,6 +1031,34 @@ test('SourceCache#_updateRetainedTiles', (t)=> {
         getTileSpy.restore();
         t.end();
     });
+
+    t.test('adds correct leaded parent tiles for overzoomed tiles', (t)=>{
+        const sourceCache = createSourceCache({
+            loadTile: function(tile, callback) {
+                tile.state = 'loading';
+                callback();
+            },
+            maxzoom: 7
+        });
+        const loadedTiles = [new TileCoord(7, 0, 0), new TileCoord(7, 1, 0)];
+        loadedTiles.forEach((t)=>{
+            sourceCache._tiles[t.id] = new Tile(t);
+            sourceCache._tiles[t.id].state = 'loaded';
+        });
+
+        const idealTiles = [new TileCoord(8, 0, 0), new TileCoord(8, 1, 0)];
+        const retained = sourceCache._updateRetainedTiles(idealTiles, 8);
+
+        t.deepEqual(Object.keys(retained).map((k)=>{ return TileCoord.fromID(k); }), [
+            new TileCoord(7, 0, 0),
+            new TileCoord(8, 0, 0),
+            new TileCoord(7, 1, 0),
+            new TileCoord(8, 1, 0)
+        ]);
+
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
fix #5290 

the `scaledTo` function wasn't returning the correct values for parents of overzoomed tiles resulting in loaded parents not being retained and a flicker. 

cc @ryanbaumann 
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
