### PR TITLE
Fix for webgl-based canvas sources rendering flipped in 0.40.0 + non-animated optimization

### DIFF
--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -129,7 +129,7 @@ class CanvasSource extends ImageSource {
             const imageData = this.secondaryContext.createImageData(this.width, this.height);
             const flipped = new Uint8Array(this.width * this.height * 4);
             for (let i = this.height - 1, j = 0; i >= 0; i--, j++) {
-                flipped.set(data.slice(i * this.width * 4, (i + 1) * this.width * 4), j * this.width * 4);
+                flipped.set(data.subarray(i * this.width * 4, (i + 1) * this.width * 4), j * this.width * 4);
             }
             imageData.data.set(flipped);
             return imageData;

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -45,6 +45,7 @@ class CanvasSource extends ImageSource {
     secondaryContext: ?CanvasRenderingContext2D;
     width: number;
     height: number;
+    canvasData: ?ImageData;
     play: () => void;
     pause: () => void;
 
@@ -114,25 +115,29 @@ class CanvasSource extends ImageSource {
      */
     // setCoordinates inherited from ImageSource
 
-    readCanvas() {
+    readCanvas(resize: boolean) {
         // We *should* be able to use a pure HTMLCanvasElement in
         // texImage2D/texSubImage2D (in ImageSource#_prepareImage), but for
         // some reason this breaks the map on certain GPUs (see #4262).
 
         if (this.context instanceof CanvasRenderingContext2D) {
-            return this.context.getImageData(0, 0, this.width, this.height);
+            this.canvasData = this.context.getImageData(0, 0, this.width, this.height);
         } else if (this.context instanceof WebGLRenderingContext) {
             const gl = this.context;
             const data = new Uint8Array(this.width * this.height * 4);
             gl.readPixels(0, 0, this.width, this.height, gl.RGBA, gl.UNSIGNED_BYTE, data);
+
             if (!this.secondaryContext) this.secondaryContext = window.document.createElement('canvas').getContext('2d');
-            const imageData = this.secondaryContext.createImageData(this.width, this.height);
+            if (!this.canvasData || resize) {
+                this.canvasData = this.secondaryContext.createImageData(this.width, this.height);
+            }
+
+            // WebGL reads pixels bottom to top, but for our ImageData object we need top to bottom: flip here
             const flipped = new Uint8Array(this.width * this.height * 4);
             for (let i = this.height - 1, j = 0; i >= 0; i--, j++) {
                 flipped.set(data.subarray(i * this.width * 4, (i + 1) * this.width * 4), j * this.width * 4);
             }
-            imageData.data.set(flipped);
-            return imageData;
+            this.canvasData.data.set(flipped);
         }
     }
 
@@ -149,12 +154,17 @@ class CanvasSource extends ImageSource {
         if (this._hasInvalidDimensions()) return;
 
         if (Object.keys(this.tiles).length === 0) return; // not enough data for current position
-        const canvasData = this.readCanvas();
-        if (!canvasData) {
+
+        const reread = this.animate || !this.canvasData || resize;
+        if (reread) {
+            this.readCanvas(resize);
+        }
+
+        if (!this.canvasData) {
             this.fire('error', new Error('Could not read canvas data.'));
             return;
         }
-        this._prepareImage(this.map.painter.gl, canvasData, resize);
+        this._prepareImage(this.map.painter.gl, this.canvasData, resize);
     }
 
     serialize(): Object {

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -127,7 +127,11 @@ class CanvasSource extends ImageSource {
             gl.readPixels(0, 0, this.width, this.height, gl.RGBA, gl.UNSIGNED_BYTE, data);
             if (!this.secondaryContext) this.secondaryContext = window.document.createElement('canvas').getContext('2d');
             const imageData = this.secondaryContext.createImageData(this.width, this.height);
-            imageData.data.set(data);
+            const flipped = new Uint8Array(this.width * this.height * 4);
+            for (let i = this.height - 1, j = 0; i >= 0; i--, j++) {
+                flipped.set(data.slice(i * this.width * 4, (i + 1) * this.width * 4), j * this.width * 4);
+            }
+            imageData.data.set(flipped);
             return imageData;
         }
     }

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -133,11 +133,9 @@ class CanvasSource extends ImageSource {
             }
 
             // WebGL reads pixels bottom to top, but for our ImageData object we need top to bottom: flip here
-            const flipped = new Uint8Array(this.width * this.height * 4);
             for (let i = this.height - 1, j = 0; i >= 0; i--, j++) {
-                flipped.set(data.subarray(i * this.width * 4, (i + 1) * this.width * 4), j * this.width * 4);
+                this.canvasData.data.set(data.subarray(i * this.width * 4, (i + 1) * this.width * 4), j * this.width * 4);
             }
-            this.canvasData.data.set(flipped);
         }
     }
 


### PR DESCRIPTION
WebGL APIs and Canvas APIs are vertically flipped (gl reads from the lower left, canvas from the upper left), so I introduced https://github.com/mapbox/mapbox-gl-js/issues/5300 in #5155. Eventually we should try to write render tests with a secondary webgl canvas 🤔 to catch bugs like this, but in the meantime this should make it into the 0.40.1 patch release.

Edit: this PR also modifies the intermediary read step to only reread if a canvas is supposed to be animated, if it hasn't been read yet, or if it is resized, to mitigate performance concerns for non-animated canvases (see https://github.com/mapbox/mapbox-gl-js/issues/5301).

Fixes #5300.
Refs #5301.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
