### PR TITLE
serialize use url not urls

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -236,7 +236,7 @@ class ImageSource extends Evented implements Source {
     serialize(): Object {
         return {
             type: 'image',
-            urls: this.options.url,
+            url: this.options.url,
             coordinates: this.coordinates
         };
     }

--- a/test/unit/source/image_source.test.js
+++ b/test/unit/source/image_source.test.js
@@ -88,7 +88,7 @@ test('ImageSource', (t) => {
 
         const serialized = source.serialize();
         t.equal(serialized.type, 'image');
-        t.equal(serialized.urls, '/image.png');
+        t.equal(serialized.url, '/image.png');
         t.deepEqual(serialized.coordinates, [[0, 0], [1, 0], [1, 1], [0, 1]]);
 
         t.end();


### PR DESCRIPTION
`serialize` use `url` not `urls`
