### PR TITLE
use translate3d replace translate

### DIFF
--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -111,7 +111,7 @@ class BoxZoomHandler {
             minY = Math.min(p0.y, p1.y),
             maxY = Math.max(p0.y, p1.y);
 
-        DOM.setTransform(this._box, `translate(${minX}px,${minY}px)`);
+        DOM.setTransform(this._box, `translate3d(${minX}px,${minY}px,0px)`);
 
         this._box.style.width = `${maxX - minX}px`;
         this._box.style.height = `${maxY - minY}px`;


### PR DESCRIPTION
For my app,when map container is scaled, box will dispear when it is out of the origin bounds,this is caused by map container's css `overflow:hidden`,so i replace `translate` to `translate3d`.