### PR TITLE
Remove maximum from fill-extrusion-height

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2211,7 +2211,6 @@
       "property-function": true,
       "default": 0,
       "minimum": 0,
-      "maximum": 65535,
       "units": "meters",
       "doc": "The height with which to extrude this layer.",
       "transition": true,


### PR DESCRIPTION
The previous value was due to using a 16-bit unsigned integer for the attribute. In #4934, we switched to floats, removing the limitation.

Refs https://github.com/mapbox/mapbox-gl-js/issues/3954#issuecomment-330063218.