### PR TITLE
Refactor fill extrusion texture/fbo cache

### DIFF
--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -33,7 +33,7 @@ function draw(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLa
 }
 
 function drawExtrusionTexture(painter, layer) {
-    const renderedTexture = painter.prerenderedFrames[layer.id];
+    const renderedTexture = layer.viewportFrame;
     if (!renderedTexture) return;
 
     const gl = painter.gl;
@@ -56,10 +56,6 @@ function drawExtrusionTexture(painter, layer) {
 
     renderedTexture.vao.bind(gl, program, renderedTexture.buffer);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
-
-    // Since this texture has been rendered, make it available for reuse in the next frame.
-    painter.viewportFrames.push(renderedTexture);
-    delete painter.prerenderedFrames[layer.id];
 }
 
 function drawExtrusion(painter, source, layer, coord) {

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -11,6 +11,7 @@ const Evented = require('../util/evented');
 import type {Bucket, BucketParameters} from '../data/bucket';
 import type Point from '@mapbox/point-geometry';
 import type {Feature} from '../style-spec/function';
+import type RenderTexture from '../render/render_texture';
 
 export type GlobalProperties = {
     zoom: number
@@ -35,6 +36,8 @@ class StyleLayer extends Evented {
     filter: any;
     paint: { [string]: any };
     layout: { [string]: any };
+
+    viewportFrame: ?RenderTexture;
 
     _paintSpecifications: any;
     _layoutSpecifications: any;
@@ -75,7 +78,7 @@ class StyleLayer extends Evented {
         this._layoutSpecifications = styleSpec[`layout_${this.type}`];
 
         this._paintTransitions = {}; // {[propertyName]: StyleTransition}
-        this._paintTransitionOptions = {}; // 
+        this._paintTransitionOptions = {}; //
         this._paintDeclarations = {}; // {[className]: {[propertyName]: StyleDeclaration}}
         this._layoutDeclarations = {}; // {[propertyName]: StyleDeclaration}
         this._layoutFunctions = {}; // {[propertyName]: Boolean}
@@ -385,6 +388,10 @@ class StyleLayer extends Evented {
 
     has3DPass() {
         return false;
+    }
+
+    resize(gl: WebGLRenderingContext) { // eslint-disable-line
+        // noop
     }
 }
 

--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -44,6 +44,15 @@ class FillExtrusionStyleLayer extends StyleLayer {
     has3DPass() {
         return this.paint['fill-extrusion-opacity'] !== 0 && this.layout['visibility'] !== 'none';
     }
+
+    resize(gl: WebGLRenderingContext) {
+        if (this.viewportFrame) {
+            const {texture, fbo} = this.viewportFrame;
+            gl.deleteTexture(texture);
+            gl.deleteFramebuffer(fbo);
+            this.viewportFrame = null;
+        }
+    }
 }
 
 module.exports = FillExtrusionStyleLayer;


### PR DESCRIPTION
@lbud @jfirebaugh this is just a quick exploration of how caching textures in style layer objects would look. I would highly benefit from something like this in #5253 because I need to cache two types of textures that differ from the fill extrusion use case — a half-float screen-sized texture downscaled by 4, and a 256x1 RGBA color ramp texture. 

Heatmap-specific caching logic in `painter.js` would look really bad, and while I agree it's awkward to cache render-specific stuff in style layers and look forward to `RenderLayer`-introducing refactor, for now this seems like a lesser evil than writing lots of layer-specific code in `painter.js`.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~ (covered by render tests)
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~ there are no benchmarks with extrusions
 - [x] manually test the debug page
