### PR TITLE
Fix for infinite flight path length

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -785,7 +785,7 @@ class Camera extends Evented {
         let S = (r(1) - r0) / rho;
 
         // When u₀ = u₁, the optimal path doesn’t require both ascent and descent.
-        if (Math.abs(u1) < 0.000001 || isNaN(S)) {
+        if (Math.abs(u1) < 0.000001 || !isFinite(S)) {
             // Perform a more or less instantaneous transition if the path is too short.
             if (Math.abs(w0 - w1) < 0.000001) return this.easeTo(options, eventData);
 


### PR DESCRIPTION
The total flight path length can sometimes be infinite. Using `!isFinite(S)` handles `Infinity` and `NaN` values for `S`.