### PR TITLE
Workaround for example flickering documented in issue #5333.

### DIFF
--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -2,7 +2,7 @@
 layout: pages
 ---
 
-<div class='round doc clip fill-white keyline-all'>
+<div class='round doc fill-white keyline-all'>
 
 <style>
 .fill-white pre { background-color:transparent; }


### PR DESCRIPTION
Removes `overflow: hidden` from div containing the example iframe.
I don't have a clear theory for why this works, but my hypothesis is that it's some interaction with Chrome's throttling of animation for frames that it thinks aren't visible.

Running the docs locally, I no longer see the flicker documented in #5333.

@mollymerp I can't see any other change in the example page after removing the clipping for the example div, but I don't know why it was put there in the first place. Do you have any idea who might know?