### PR TITLE
Make compass and zoom controls optional

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -67,18 +67,18 @@
     padding: 0;
     outline: none;
     border: none;
-    border-bottom: 1px solid #ddd;
     box-sizing: border-box;
     background-color: rgba(0,0,0,0);
     cursor: pointer;
+}
+
+.mapboxgl-ctrl-group > button + button {
+    border-top: 1px solid #ddd;
 }
 /* https://bugzilla.mozilla.org/show_bug.cgi?id=140562 */
 .mapboxgl-ctrl > button::-moz-focus-inner {
     border: 0;
     padding: 0;
-}
-.mapboxgl-ctrl > button:last-child {
-    border-bottom: 0;
 }
 .mapboxgl-ctrl > button:hover {
     background-color: rgba(0,0,0,0.05);

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -7,7 +7,8 @@ const DragRotateHandler = require('../handler/drag_rotate');
 import type Map from '../map';
 
 const defaultOptions = {
-    showCompass: true
+    showCompass: true,
+    showZoom: true
 };
 
 /**
@@ -39,9 +40,10 @@ class NavigationControl {
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-group');
         this._container.addEventListener('contextmenu', (e) => e.preventDefault());
 
-        this._zoomInButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-in', 'Zoom In', () => this._map.zoomIn());
-        this._zoomOutButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-out', 'Zoom Out', () => this._map.zoomOut());
-
+        if (this.options.showZoom) {
+            this._zoomInButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-in', 'Zoom In', () => this._map.zoomIn());
+            this._zoomOutButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-out', 'Zoom Out', () => this._map.zoomOut());
+        }
         if (this.options.showCompass) {
             this._compass = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-compass', 'Reset North', () => this._map.resetNorth());
             this._compassArrow = DOM.create('span', 'mapboxgl-ctrl-compass-arrow', this._compass);

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -16,8 +16,8 @@ const defaultOptions = {
  *
  * @implements {IControl}
  * @param {Object} [options]
- * @param {Object} [options.showCompass=true] If `false` will omit the compass button from the Navigation Control. The default is `true` to show a compass button.
- * @param {Object} [options.showZoom=true] If `false` will omit the zoom-in/out buttons from the Navigation Control. The default is `true` to show zoom buttons.
+ * @param {Boolean} [options.showCompass=true] If `true` the compass button is included.
+ * @param {Boolean} [options.showZoom=true] If `true` the zoom-in and zoom-out buttons are included.
  * @example
  * var nav = new mapboxgl.NavigationControl();
  * map.addControl(nav, 'top-left');

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -36,9 +36,6 @@ class NavigationControl {
 
     constructor(options: any) {
         this.options = util.extend({}, defaultOptions, options);
-        util.bindAll([
-            '_rotateCompassArrow'
-        ], this);
 
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-group');
         this._container.addEventListener('contextmenu', (e) => e.preventDefault());
@@ -48,34 +45,39 @@ class NavigationControl {
             this._zoomOutButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-out', 'Zoom Out', () => this._map.zoomOut());
         }
         if (this.options.showCompass) {
+            util.bindAll([
+                '_rotateCompassArrow'
+            ], this);
             this._compass = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-compass', 'Reset North', () => this._map.resetNorth());
             this._compassArrow = DOM.create('span', 'mapboxgl-ctrl-compass-arrow', this._compass);
         }
     }
 
     _rotateCompassArrow() {
-        if (this.options.showCompass) {
-            const rotate = `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
-            this._compassArrow.style.transform = rotate;
-        }
+        const rotate = `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
+        this._compassArrow.style.transform = rotate;
     }
 
     onAdd(map: Map) {
         this._map = map;
-        this._map.on('rotate', this._rotateCompassArrow);
-        this._rotateCompassArrow();
-        this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass});
-        this._handler.enable();
+        if (this.options.showCompass) {
+            this._map.on('rotate', this._rotateCompassArrow);
+            this._rotateCompassArrow();
+            this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass});
+            this._handler.enable();
+        }
         return this._container;
     }
 
     onRemove() {
         DOM.remove(this._container);
-        this._map.off('rotate', this._rotateCompassArrow);
-        delete this._map;
+        if (this.options.showCompass) {
+            this._map.off('rotate', this._rotateCompassArrow);
+            this._handler.disable();
+            delete this._handler;
+        }
 
-        this._handler.disable();
-        delete this._handler;
+        delete this._map;
     }
 
     _createButton(className: string, ariaLabel: string, fn: () => mixed) {

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -15,6 +15,9 @@ const defaultOptions = {
  * A `NavigationControl` control contains zoom buttons and a compass.
  *
  * @implements {IControl}
+ * @param {Object} [options]
+ * @param {Object} [options.showCompass=true] If `false` will omit the compass button from the Navigation Control. The default is `true` to show a compass button.
+ * @param {Object} [options.showZoom=true] If `false` will omit the zoom-in/out buttons from the Navigation Control. The default is `true` to show zoom buttons.
  * @example
  * var nav = new mapboxgl.NavigationControl();
  * map.addControl(nav, 'top-left');

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -6,6 +6,10 @@ const DragRotateHandler = require('../handler/drag_rotate');
 
 import type Map from '../map';
 
+const defaultOptions = {
+    showCompass: true
+};
+
 /**
  * A `NavigationControl` control contains zoom buttons and a compass.
  *
@@ -18,6 +22,7 @@ import type Map from '../map';
  */
 class NavigationControl {
     _map: Map;
+    options: any;
     _container: HTMLElement;
     _zoomInButton: HTMLElement;
     _zoomOutButton: HTMLElement;
@@ -25,7 +30,8 @@ class NavigationControl {
     _compassArrow: HTMLElement;
     _handler: DragRotateHandler;
 
-    constructor() {
+    constructor(options: any) {
+        this.options = util.extend({}, defaultOptions, options);
         util.bindAll([
             '_rotateCompassArrow'
         ], this);
@@ -35,13 +41,18 @@ class NavigationControl {
 
         this._zoomInButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-in', 'Zoom In', () => this._map.zoomIn());
         this._zoomOutButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-out', 'Zoom Out', () => this._map.zoomOut());
-        this._compass = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-compass', 'Reset North', () => this._map.resetNorth());
-        this._compassArrow = DOM.create('span', 'mapboxgl-ctrl-compass-arrow', this._compass);
+
+        if (this.options.showCompass) {
+            this._compass = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-compass', 'Reset North', () => this._map.resetNorth());
+            this._compassArrow = DOM.create('span', 'mapboxgl-ctrl-compass-arrow', this._compass);
+        }
     }
 
     _rotateCompassArrow() {
-        const rotate = `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
-        this._compassArrow.style.transform = rotate;
+        if (this.options.showCompass) {
+            const rotate = `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
+            this._compassArrow.style.transform = rotate;
+        }
     }
 
     onAdd(map: Map) {


### PR DESCRIPTION
Add options to `NavigationControl`. `showZoom` and `showCompass` both default to `true` can be used to hide either the zoom buttons or the compass button from the Navigation Control.

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] manually test the debug page
- [x] conditionally add dragRotateHandler

Fixes #1554
  