### PR TITLE
limit animation duration on flyTo with maxDuration option

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -665,6 +665,7 @@ class Camera extends Evented {
      *     It does not correspond to a fixed physical distance, but varies by zoom level.
      * @param {number} [options.screenSpeed] The average speed of the animation measured in screenfuls
      *     per second, assuming a linear timing curve. If `options.speed` is specified, this option is ignored.
+     * @param {number} [options.maxDuration] The animation's maximum duration, measured in milliseconds.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires zoomstart

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -803,6 +803,10 @@ class Camera extends Evented {
             options.duration = 1000 * S / V;
         }
 
+        if (options.maxDuration) {
+            options.duration = Math.min(options.duration, options.maxDuration);
+        }
+
         this.zooming = true;
         this.rotating = (startBearing !== bearing);
         this.pitching = (pitch !== startPitch);

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -666,6 +666,7 @@ class Camera extends Evented {
      * @param {number} [options.screenSpeed] The average speed of the animation measured in screenfuls
      *     per second, assuming a linear timing curve. If `options.speed` is specified, this option is ignored.
      * @param {number} [options.maxDuration] The animation's maximum duration, measured in milliseconds.
+     *     If duration exceeds maximum duration, it resets to 0.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires zoomstart

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -804,8 +804,8 @@ class Camera extends Evented {
             options.duration = 1000 * S / V;
         }
 
-        if (options.maxDuration) {
-            options.duration = Math.min(options.duration, options.maxDuration);
+        if (options.maxDuration && options.duration > options.maxDuration) {
+            options.duration = 0;
         }
 
         this.zooming = true;

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1201,6 +1201,22 @@ test('camera', (t) => {
             camera.flyTo(flyOptions);
         });
 
+        t.test('resets duration to 0 if it exceeds maxDuration', (t) => {
+            let startTime, endTime, timeDiff;
+            const camera = createCamera({ center: [37.63454, 55.75868], zoom: 18});
+
+            camera
+                .on('movestart', () => { startTime = new Date(); })
+                .on('moveend', () => {
+                    endTime = new Date();
+                    timeDiff = endTime - startTime;
+                    t.equalWithPrecision(timeDiff, 0, 1e-6);
+                    t.end();
+                });
+
+            camera.flyTo({ center: [-122.3998631, 37.7884307], maxDuration: 100 });
+        });
+
         t.end();
     });
 

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1210,7 +1210,7 @@ test('camera', (t) => {
                 .on('moveend', () => {
                     endTime = new Date();
                     timeDiff = endTime - startTime;
-                    t.equalWithPrecision(timeDiff, 0, 1e-6);
+                    t.equalWithPrecision(timeDiff, 0, 1e+1);
                     t.end();
                 });
 


### PR DESCRIPTION
Hi there! I've added the `maxDuration` option to limit animation duration on `flyTo` according to https://github.com/mapbox/mapbox-gl-js/issues/3904.

If this is the right way to do it, I'll add tests and documentation.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
