### PR TITLE
Add ['heatmap-density'] expression

### DIFF
--- a/src/style-spec/function/compile.js
+++ b/src/style-spec/function/compile.js
@@ -12,7 +12,7 @@ const definitions = require('./definitions');
 const evaluationContext = require('./evaluation_context');
 const {
     isFeatureConstant,
-    isZoomConstant
+    isGlobalPropertyConstant
 } = require('./is_constant');
 
 import type { Type } from './types.js';
@@ -76,7 +76,7 @@ function compileExpression(
         function: compiled,
         functionSource: compilationContext.getPrelude(),
         isFeatureConstant: isFeatureConstant(parsed),
-        isZoomConstant: isZoomConstant(parsed),
+        isZoomConstant: isGlobalPropertyConstant(parsed, ['zoom']),
         expression: parsed
     };
 }

--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -4,7 +4,7 @@ const extend = require('../util/extend');
 module.exports.function = convertFunction;
 module.exports.value = convertValue;
 
-function convertFunction(parameters, propertySpec) {
+function convertFunction(parameters, propertySpec, name) {
     let expression;
 
     parameters = extend({}, parameters);
@@ -31,7 +31,10 @@ function convertFunction(parameters, propertySpec) {
             throw new Error('Unimplemented');
         }
 
-        if (zoomAndFeatureDependent) {
+        if (name === 'heatmap-color') {
+            assert(zoomDependent);
+            expression = convertZoomFunction(parameters, propertySpec, stops, ['heatmap-density']);
+        } else if (zoomAndFeatureDependent) {
             expression = convertZoomAndPropertyFunction(parameters, propertySpec, stops, defaultExpression);
         } else if (zoomDependent) {
             expression = convertZoomFunction(parameters, propertySpec, stops);
@@ -178,16 +181,16 @@ function convertPropertyFunction(parameters, propertySpec, stops, defaultExpress
     return expression;
 }
 
-function convertZoomFunction(parameters, propertySpec, stops) {
+function convertZoomFunction(parameters, propertySpec, stops, input = ['zoom']) {
     const type = getFunctionType(parameters, propertySpec);
     let expression;
     let isStep = false;
     if (type === 'interval') {
-        expression = ['curve', ['step'], ['zoom']];
+        expression = ['curve', ['step'], input];
         isStep = true;
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
-        expression = ['curve', ['exponential', base], ['zoom']];
+        expression = ['curve', ['exponential', base], input];
     } else {
         throw new Error(`Unknown zoom function type "${type}"`);
     }

--- a/src/style-spec/function/definitions/index.js
+++ b/src/style-spec/function/definitions/index.js
@@ -102,7 +102,8 @@ CompoundExpression.register(expressions, {
     'id': [ ValueType, [], () =>
         `('id' in $feature) ? $feature.id : null`
     ],
-    'zoom': [ NumberType, [], () => '$globalProperties.zoom' ],
+    'zoom': [ NumberType, [], () => '$globalProperties.zoom || 0' ],
+    'heatmap-density': [ NumberType, [], () => '$globalProperties.heatmapDensity || 0' ],
     '+': defineBinaryMathOp('+', true),
     '*': defineBinaryMathOp('*', true),
     '-': {

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -49,7 +49,7 @@ type StylePropertySpecification = {
 type StylePropertyValue = null | string | number | Array<string> | Array<number>;
 type FunctionParameters = DataDrivenPropertyValueSpecification<StylePropertyValue>
 
-function createFunction(parameters: FunctionParameters, propertySpec: StylePropertySpecification): StyleFunction {
+function createFunction(parameters: FunctionParameters, propertySpec: StylePropertySpecification, name: string): StyleFunction {
     let expr;
 
     let defaultValue = propertySpec.default;
@@ -61,7 +61,7 @@ function createFunction(parameters: FunctionParameters, propertySpec: StylePrope
     } else if (typeof parameters === 'object' && parameters !== null && typeof parameters.expression !== 'undefined') {
         expr = parameters.expression;
     } else {
-        expr = convert.function(parameters, propertySpec);
+        expr = convert.function(parameters, propertySpec, name);
         if (parameters && typeof parameters.default !== 'undefined') {
             defaultValue = parameters.default;
         }

--- a/src/style-spec/function/is_constant.js
+++ b/src/style-spec/function/is_constant.js
@@ -26,16 +26,16 @@ function isFeatureConstant(e: Expression) {
     return result;
 }
 
-function isZoomConstant(e: Expression) {
-    if (e instanceof CompoundExpression && e.name === 'zoom') { return false; }
+function isGlobalPropertyConstant(e: Expression, properties: Array<string>) {
+    if (e instanceof CompoundExpression && properties.indexOf(e.name) >= 0) { return false; }
     let result = true;
     e.eachChild((arg) => {
-        if (result && !isZoomConstant(arg)) { result = false; }
+        if (result && !isGlobalPropertyConstant(arg, properties)) { result = false; }
     });
     return result;
 }
 
 module.exports = {
     isFeatureConstant,
-    isZoomConstant,
+    isGlobalPropertyConstant,
 };

--- a/src/style-spec/function/parse_expression.js
+++ b/src/style-spec/function/parse_expression.js
@@ -89,7 +89,7 @@ function parseExpression(expr: mixed, context: ParsingContext): ?Expression {
 function isConstant(expression: Expression) {
     // requires within function body to workaround circular dependency
     const {CompoundExpression} = require('./compound_expression');
-    const {isZoomConstant, isFeatureConstant} = require('./is_constant');
+    const {isGlobalPropertyConstant, isFeatureConstant} = require('./is_constant');
     const Var = require('./definitions/var');
 
     if (expression instanceof Var) {
@@ -106,7 +106,8 @@ function isConstant(expression: Expression) {
         return false;
     }
 
-    return isZoomConstant(expression) && isFeatureConstant(expression);
+    return isFeatureConstant(expression) &&
+        isGlobalPropertyConstant(expression, ['zoom', 'heatmap-density']);
 }
 
 module.exports = parseExpression;

--- a/src/style/light.js
+++ b/src/style/light.js
@@ -8,6 +8,7 @@ const StyleDeclaration = require('./style_declaration');
 const StyleTransition = require('./style_transition');
 
 import type AnimationLoop from './animation_loop';
+import type {GlobalProperties} from './style_layer';
 
 const TRANSITION_SUFFIX = '-transition';
 const properties = ['anchor', 'color', 'position', 'intensity'];
@@ -42,7 +43,7 @@ class Light extends Evented {
         }, lightOpts);
 
         for (const prop of properties) {
-            this._declarations[prop] = new StyleDeclaration(specifications[prop], lightOpts[prop]);
+            this._declarations[prop] = new StyleDeclaration(specifications[prop], lightOpts[prop], prop);
         }
 
         return this;
@@ -70,7 +71,7 @@ class Light extends Evented {
         }
     }
 
-    getLightValue(property: string, globalProperties: {zoom: number}) {
+    getLightValue(property: string, globalProperties: GlobalProperties) {
         if (property === 'position') {
             const calculated: any = this._transitions[property].calculate(globalProperties),
                 cartesian = util.sphericalToCartesian(calculated);
@@ -95,7 +96,7 @@ class Light extends Evented {
             } else if (value === null || value === undefined) {
                 delete this._declarations[key];
             } else {
-                this._declarations[key] = new StyleDeclaration(specifications[key], value);
+                this._declarations[key] = new StyleDeclaration(specifications[key], value, key);
             }
         }
     }
@@ -111,7 +112,7 @@ class Light extends Evented {
         const spec = specifications[property];
 
         if (declaration === null || declaration === undefined) {
-            declaration = new StyleDeclaration(spec, spec.default);
+            declaration = new StyleDeclaration(spec, spec.default, property);
         }
 
         if (oldTransition && oldTransition.declaration.json === declaration.json) return;

--- a/src/style/style_declaration.js
+++ b/src/style/style_declaration.js
@@ -21,7 +21,7 @@ class StyleDeclaration {
     stopZoomLevels: Array<number>;
     _zoomCurve: ?Curve;
 
-    constructor(reference: any, value: any) {
+    constructor(reference: any, value: any, name: string) {
         this.value = util.clone(value);
         this.isFunction = createFunction.isFunctionDefinition(value);
 
@@ -29,7 +29,7 @@ class StyleDeclaration {
         this.json = JSON.stringify(this.value);
 
         this.minimum = reference.minimum;
-        this.function = createFunction(this.value, reference);
+        this.function = createFunction(this.value, reference, name);
         this.isFeatureConstant = this.function.isFeatureConstant;
         this.isZoomConstant = this.function.isZoomConstant;
 

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -14,7 +14,8 @@ import type {Feature} from '../style-spec/function';
 import type RenderTexture from '../render/render_texture';
 
 export type GlobalProperties = {
-    zoom: number
+    zoom?: number,
+    heatmapDensity?: number
 };
 
 export type FeatureProperties = {
@@ -117,7 +118,7 @@ class StyleLayer extends Evented {
         } else {
             const key = `layers.${this.id}.layout.${name}`;
             if (this._validate(validateStyle.layoutProperty, key, name, value, options)) return;
-            this._layoutDeclarations[name] = new StyleDeclaration(this._layoutSpecifications[name], value);
+            this._layoutDeclarations[name] = new StyleDeclaration(this._layoutSpecifications[name], value, name);
         }
         this._updateLayoutValue(name);
     }
@@ -161,7 +162,7 @@ class StyleLayer extends Evented {
                 delete this._paintDeclarations[klass || ''][name];
             } else {
                 if (this._validate(validateStyle.paintProperty, validateStyleKey, name, value, options)) return;
-                this._paintDeclarations[klass || ''][name] = new StyleDeclaration(this._paintSpecifications[name], value);
+                this._paintDeclarations[klass || ''][name] = new StyleDeclaration(this._paintSpecifications[name], value, name);
             }
         }
     }
@@ -338,7 +339,7 @@ class StyleLayer extends Evented {
         const spec = this._paintSpecifications[name];
 
         if (declaration === null || declaration === undefined) {
-            declaration = new StyleDeclaration(spec, spec.default);
+            declaration = new StyleDeclaration(spec, spec.default, name);
         }
 
         if (oldTransition && oldTransition.declaration.json === declaration.json) return;

--- a/src/style/style_layer/heatmap_style_layer.js
+++ b/src/style/style_layer/heatmap_style_layer.js
@@ -3,6 +3,7 @@
 const StyleLayer = require('../style_layer');
 const HeatmapBucket = require('../../data/bucket/heatmap_bucket');
 const RGBAImage = require('../../util/image').RGBAImage;
+const util = require('../../util/util');
 
 import type Texture from '../../render/texture';
 
@@ -33,7 +34,7 @@ class HeatmapStyleLayer extends StyleLayer {
         if (name === 'heatmap-color') {
             const len = this.colorRampData.length;
             for (let i = 4; i < len; i += 4) {
-                const pxColor = this.getPaintValue('heatmap-color', {zoom: i / len});
+                const pxColor = this.getPaintValue('heatmap-color', {heatmapDensity: i / len});
                 const alpha = pxColor[3];
                 // the colors are being unpremultiplied because getPaintValue returns
                 // premultiplied values, and the Texture class expects unpremultiplied ones

--- a/src/style/style_layer/heatmap_style_layer.js
+++ b/src/style/style_layer/heatmap_style_layer.js
@@ -3,7 +3,6 @@
 const StyleLayer = require('../style_layer');
 const HeatmapBucket = require('../../data/bucket/heatmap_bucket');
 const RGBAImage = require('../../util/image').RGBAImage;
-const util = require('../../util/util');
 
 import type Texture from '../../render/texture';
 

--- a/src/style/style_transition.js
+++ b/src/style/style_transition.js
@@ -6,6 +6,7 @@ const interpolate = require('../style-spec/util/interpolate');
 
 import type StyleDeclaration from './style_declaration';
 import type {Feature} from '../style-spec/function';
+import type {GlobalProperties} from '../style/style_layer';
 
 const fakeZoomHistory = { lastIntegerZoom: 0, lastIntegerZoomTime: 0, lastZoom: 0 };
 
@@ -58,7 +59,7 @@ class StyleTransition {
     /*
      * Return the value of the transitioning property.
      */
-    calculate(globalProperties?: {zoom: number}, feature?: Feature, time?: number) {
+    calculate(globalProperties?: GlobalProperties, feature?: Feature, time?: number) {
         const value = this._calculateTargetValue(globalProperties, feature);
 
         if (this.instant())
@@ -74,7 +75,7 @@ class StyleTransition {
         return this.interp(oldValue, value, t);
     }
 
-    _calculateTargetValue(globalProperties?: {zoom: number}, feature?: Feature) {
+    _calculateTargetValue(globalProperties?: GlobalProperties, feature?: Feature) {
         if (!this.zoomTransitioned)
             return this.declaration.calculate(globalProperties, feature);
 


### PR DESCRIPTION
This adds a `["heatmap-density"]` expression and special-case handling when converting stop functions to use that instead of `["zoom"]` for the `heatmap-color` style property.