### PR TITLE
Debug shader has step(8192.0, a_pos.x)

### DIFF
--- a/src/shaders/debug.vertex.glsl
+++ b/src/shaders/debug.vertex.glsl
@@ -3,10 +3,5 @@ attribute vec2 a_pos;
 uniform mat4 u_matrix;
 
 void main() {
-    // We are using Int16 for texture position coordinates to give us enough precision for
-    // fractional coordinates. We use 8192 to scale the texture coordinates in the buffer
-    // as an arbitrarily high number to preserve adequate precision when rendering.
-    // This is also the same value as the EXTENT we are using for our tile buffer pos coordinates,
-    // so math for modifying either is consistent.
-    gl_Position = u_matrix * vec4(a_pos, step(8192.0, a_pos.x), 1);
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
 }


### PR DESCRIPTION
This leads to us rendering incorrect tile boundaries in debug mode. Not sure why we have this (probably a historical artifact), but it works fine with just `vec4(a_pos, 0, 1)`.

Especially when zooming in, the z of 1 is pretty apparent:

![mapbox gl streets 2017-09-27 11-12-58](https://user-images.githubusercontent.com/52399/30905360-d879b16e-a374-11e7-961d-c3d68c00268e.png)

After:

![mapbox gl streets 2017-09-27 11-13-31](https://user-images.githubusercontent.com/52399/30905380-eabd2bbc-a374-11e7-95f8-2fa61c6fb650.png)
