### PR TITLE
Prevent tests from outputting to console.error or console.warn

### DIFF
--- a/bench/lib/create_style.js
+++ b/bench/lib/create_style.js
@@ -13,7 +13,8 @@ class StubMap extends Evented {
 
 module.exports = function (styleJSON: StyleSpecification): Promise<Style> {
     return new Promise((resolve, reject) => {
-        const style = new Style(styleJSON, (new StubMap(): any), {});
+        const style = new Style((new StubMap(): any));
+        style.loadJSON(styleJSON);
 
         style
             .on('style.load', () => resolve(style))

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -53,6 +53,7 @@ function createFunction(parameters: FunctionParameters, propertySpec: StylePrope
     let expr;
 
     let defaultValue = propertySpec.default;
+    let isConvertedStopFunction = false;
     if (!isFunctionDefinition(parameters)) {
         expr = convert.value(parameters, propertySpec);
         if (expr === null) {
@@ -62,6 +63,7 @@ function createFunction(parameters: FunctionParameters, propertySpec: StylePrope
         expr = parameters.expression;
     } else {
         expr = convert.function(parameters, propertySpec);
+        isConvertedStopFunction = true;
         if (parameters && typeof parameters.default !== 'undefined') {
             defaultValue = parameters.default;
         }
@@ -90,7 +92,7 @@ function createFunction(parameters: FunctionParameters, propertySpec: StylePrope
                     }
                     return val;
                 } catch (e) {
-                    if (!warningHistory[e.message]) {
+                    if (!isConvertedStopFunction && !warningHistory[e.message]) {
                         warningHistory[e.message] = true;
                         if (typeof console !== 'undefined') {
                             console.warn(e.message);

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -56,9 +56,6 @@ function createFunction(parameters: FunctionParameters, propertySpec: StylePrope
     let isConvertedStopFunction = false;
     if (!isFunctionDefinition(parameters)) {
         expr = convert.value(parameters, propertySpec);
-        if (expr === null) {
-            expr = getDefaultValue(propertySpec);
-        }
     } else if (typeof parameters === 'object' && parameters !== null && typeof parameters.expression !== 'undefined') {
         expr = parameters.expression;
     } else {
@@ -177,12 +174,6 @@ function isFunctionDefinition(value: FunctionParameters): boolean {
         return Array.isArray(value.stops) ||
             (typeof value.type === 'string' && value.type === 'identity');
     }
-}
-
-function getDefaultValue(propertySpec) {
-    return (typeof propertySpec.default !== 'undefined') ?
-        convert.value(propertySpec.default, propertySpec) :
-        ['error', 'No default property value available'];
 }
 
 function getExpectedType(spec) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1002,13 +1002,19 @@ class Map extends Camera {
         }
 
         if (!style) {
-            this.style = (null: any);
+            delete this.style;
             return this;
         } else {
-            this.style = new Style(style, this, options || {});
+            this.style = new Style(this, options || {});
         }
 
         this.style.setEventedParent(this, {style: this.style});
+
+        if (typeof style === 'string') {
+            this.style.loadURL(style);
+        } else {
+            this.style.loadJSON(style);
+        }
 
         this.on('rotate', this.style._redoPlacement);
         this.on('pitch', this.style._redoPlacement);

--- a/test/node_modules/mapbox-gl-js-test.js
+++ b/test/node_modules/mapbox-gl-js-test.js
@@ -3,6 +3,7 @@
 require('flow-remove-types/register');
 const tap = module.exports = require('tap');
 const sinon = require('sinon');
+const util = require('../../src/util/util');
 
 tap.Test.prototype.addAssert('equalWithPrecision', 3, assertEqualWithPrecision);
 
@@ -19,10 +20,25 @@ tap.beforeEach(function (done) {
         injectInto: this,
         properties: ['spy', 'stub', 'mock']
     });
+
+    const consoleError = console.error;
+    console.error = () => {
+        this.fail(`console.error called -- please adjust your test (maybe stub console.error?)`);
+    };
+    console.error.previous = consoleError;
+
+    const consoleWarn = console.warn;
+    console.warn = () => {
+        this.fail(`console.warn called -- please adjust your test (maybe stub console.warn?)`);
+    };
+    console.warn.previous = consoleWarn;
+
     done();
 });
 
 tap.afterEach(function (done) {
+    console.error = console.error.previous;
+    console.warn = console.warn.previous;
     this.sandbox.restore();
     done();
 });

--- a/test/unit/data/fill_bucket.test.js
+++ b/test/unit/data/fill_bucket.test.js
@@ -51,10 +51,11 @@ test('FillBucket segmentation', (t) => {
         id: 'test',
         type: 'fill',
         layout: {},
-        paint: { 'fill-color': {
-            stops: [[0, 'red'], [1, 'blue']],
-            property: 'foo'
-        } }
+        paint: {
+            'fill-color': {
+                expression: ['to-color', ['get', 'foo'], '#000']
+            }
+        }
     });
 
     // this, plus the style function, sets things up so that

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1663,7 +1663,6 @@ test('Style#addSourceType', (t) => {
 
     t.test('adds factory function', (t) => {
         const style = new Style(new StubMap());
-        style.loadJSON(createStyleJSON());
         const SourceType = function () {};
 
         // expect no call to load worker source
@@ -1681,7 +1680,6 @@ test('Style#addSourceType', (t) => {
 
     t.test('triggers workers to load worker source code', (t) => {
         const style = new Style(new StubMap());
-        style.loadJSON(createStyleJSON());
         const SourceType = function () {};
         SourceType.workerSourceURL = 'worker-source.js';
 
@@ -1699,7 +1697,6 @@ test('Style#addSourceType', (t) => {
 
     t.test('refuses to add new type over existing name', (t) => {
         const style = new Style(new StubMap());
-        style.loadJSON(createStyleJSON());
         style.addSourceType('existing', () => {}, (err) => {
             t.ok(err);
             t.end();

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const test = require('mapbox-gl-js-test').test;
-const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const Style = require('../../../src/style/style');
 const SourceCache = require('../../../src/source/source_cache');
@@ -1165,7 +1164,7 @@ test('Style#setPaintProperty', (t) => {
             source.on('data', (e) => setImmediate(() => {
                 if (!begun && sourceCache.loaded()) {
                     begun = true;
-                    sinon.stub(sourceCache, 'reload').callsFake(() => {
+                    t.stub(sourceCache, 'reload').callsFake(() => {
                         t.ok(styleUpdateCalled, 'loadTile called before layer data broadcast');
                         t.end();
                     });

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -387,12 +387,8 @@ test('Style#_resolve', (t) => {
 test('Style#setState', (t) => {
     t.test('throw before loaded', (t) => {
         const style = new Style(createStyleJSON());
-        t.throws(() => {
-            style.setState(style.serialize());
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
+        t.throws(() => style.setState(createStyleJSON()), /load/i);
+        t.end();
     });
 
     t.test('do nothing if there are no changes', (t) => {
@@ -505,14 +501,9 @@ test('Style#setState', (t) => {
 
 test('Style#addSource', (t) => {
     t.test('throw before loaded', (t) => {
-        const style = new Style(createStyleJSON(), new StubMap()),
-            source = createSource();
-        t.throws(() => {
-            style.addSource('source-id', source);
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
+        const style = new Style(createStyleJSON());
+        t.throws(() => style.addSource('source-id', createSource()), /load/i);
+        t.end();
     });
 
     t.test('throw if missing source type', (t) => {
@@ -522,9 +513,7 @@ test('Style#addSource', (t) => {
         delete source.type;
 
         style.on('style.load', () => {
-            t.throws(() => {
-                style.addSource('source-id', source);
-            }, Error, /type/i);
+            t.throws(() => style.addSource('source-id', source), /type/i);
             t.end();
         });
     });
@@ -610,12 +599,8 @@ test('Style#removeSource', (t) => {
                 }
             }
         }), new StubMap());
-        t.throws(() => {
-            style.removeSource('source-id');
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
+        t.throws(() => style.removeSource('source-id'), /load/i);
+        t.end();
     });
 
     t.test('fires "data" event', (t) => {
@@ -688,35 +673,21 @@ test('Style#removeSource', (t) => {
     t.end();
 });
 
-test('Style#setData', (t) => {
+test('Style#setGeoJSONSourceData', (t) => {
+    const geoJSON = {type: "FeatureCollection", features: []};
+
     t.test('throws before loaded', (t) => {
         const style = new Style(createStyleJSON({
             "sources": { "source-id": createGeoJSONSource() }
         }), new StubMap());
-        const geoJSONSourceData = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": { "type": "Point", "coordinates": [125.6, 10.1] }
-                }
-            ]
-        };
-        t.throws(() => {
-            style.setGeoJSONSourceData('source-id', geoJSONSourceData);
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
+        t.throws(() => style.setGeoJSONSourceData('source-id', geoJSON), /load/i);
+        t.end();
     });
 
     t.test('throws on non-existence', (t) => {
-        const style = new Style(createStyleJSON(), new StubMap()),
-            geoJSONSourceData = { type: "FeatureCollection", "features": [] };
+        const style = new Style(createStyleJSON(), new StubMap());
         style.on('style.load', () => {
-            t.throws(() => {
-                style.setGeoJSONSourceData('source-id', geoJSONSourceData);
-            }, Error, /There is no source with this ID/);
+            t.throws(() => style.setGeoJSONSourceData('source-id', geoJSON), /There is no source with this ID/);
             t.end();
         });
     });
@@ -726,14 +697,9 @@ test('Style#setData', (t) => {
 
 test('Style#addLayer', (t) => {
     t.test('throw before loaded', (t) => {
-        const style = new Style(createStyleJSON(), new StubMap()),
-            layer = {id: 'background', type: 'background'};
-        t.throws(() => {
-            style.addLayer(layer);
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
+        const style = new Style(createStyleJSON(), new StubMap());
+        t.throws(() => style.addLayer({id: 'background', type: 'background'}), /load/i);
+        t.end();
     });
 
     t.test('sets up layer event forwarding', (t) => {
@@ -1019,12 +985,8 @@ test('Style#removeLayer', (t) => {
         const style = new Style(createStyleJSON({
             "layers": [{id: 'background', type: 'background'}]
         }), new StubMap());
-        t.throws(() => {
-            style.removeLayer('background');
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
+        t.throws(() => style.removeLayer('background'), /load/i);
+        t.end();
     });
 
     t.test('fires "data" event', (t) => {
@@ -1122,12 +1084,8 @@ test('Style#moveLayer', (t) => {
         const style = new Style(createStyleJSON({
             "layers": [{id: 'background', type: 'background'}]
         }));
-        t.throws(() => {
-            style.moveLayer('background');
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
+        t.throws(() => style.moveLayer('background'), /load/i);
+        t.end();
     });
 
     t.test('fires "data" event', (t) => {
@@ -1302,11 +1260,7 @@ test('Style#setFilter', (t) => {
 
     t.test('throws if style is not loaded', (t) => {
         const style = createStyle();
-
-        t.throws(() => {
-            style.setFilter('symbol', ['==', 'id', 1]);
-        }, Error, /load/i);
-
+        t.throws(() => style.setFilter('symbol', ['==', 'id', 1]), /load/i);
         t.end();
     });
 
@@ -1369,12 +1323,8 @@ test('Style#setLayerZoomRange', (t) => {
 
     t.test('throw before loaded', (t) => {
         const style = createStyle();
-        t.throws(() => {
-            style.setLayerZoomRange('symbol', 5, 12);
-        }, Error, /load/i);
-        style.on('style.load', () => {
-            t.end();
-        });
+        t.throws(() => style.setLayerZoomRange('symbol', 5, 12), /load/i);
+        t.end();
     });
 
     t.test('fires an error if layer not found', (t) => {

--- a/test/unit/ui/control/fullscreen.test.js
+++ b/test/unit/ui/control/fullscreen.test.js
@@ -17,7 +17,7 @@ function createMap() {
     });
 }
 
-test('FullscreenControl appears then fullscreen enabled', (t) => {
+test('FullscreenControl appears when fullscreen is enabled', (t) => {
     window.document.fullscreenEnabled = true;
 
     const map = createMap();
@@ -28,13 +28,16 @@ test('FullscreenControl appears then fullscreen enabled', (t) => {
     t.end();
 });
 
-test('FullscreenControl does not appears then fullscreen is not enabled', (t) => {
+test('FullscreenControl does not appears when fullscreen is not enabled', (t) => {
     window.document.fullscreenEnabled = false;
+
+    const consoleWarn = t.stub(console, 'warn');
 
     const map = createMap();
     const fullscreen = new FullscreenControl();
     map.addControl(fullscreen);
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-fullscreen').length, 0);
+    t.equal(consoleWarn.getCall(0).args[0], 'This device does not support fullscreen mode.');
     t.end();
 });


### PR DESCRIPTION
* Prevent current tests from outputting to `console.{error,warn}`. Fixes #5352.
* Fail future tests that do so. Fixes #3900.
* Various other test cleanups; see commits for details.