### PR TITLE
split placement control into separate file

### DIFF
--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -42,9 +42,8 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
             buffers.indexBuffer,
             buffers.segments,
             null,
-            null,
-            null,
-            buffers.collisionVertexBuffer);
+            buffers.collisionVertexBuffer,
+            null);
     }
 }
 

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -90,8 +90,7 @@ class Program {
          segments: SegmentVector,
          configuration: ?ProgramConfiguration,
          dynamicLayoutBuffer: ?VertexBuffer,
-         opacityVertexBuffer: ?VertexBuffer,
-         collisionVertexBuffer: ?VertexBuffer) {
+         dynamicLayoutBuffer2: ?VertexBuffer) {
 
         const primitiveSize = {
             [gl.LINES]: 2,
@@ -110,8 +109,7 @@ class Program {
                 configuration && configuration.paintVertexBuffer,
                 segment.vertexOffset,
                 dynamicLayoutBuffer,
-                opacityVertexBuffer,
-                collisionVertexBuffer
+                dynamicLayoutBuffer2
             );
 
             gl.drawElements(

--- a/src/render/vertex_array_object.js
+++ b/src/render/vertex_array_object.js
@@ -13,8 +13,7 @@ class VertexArrayObject {
     boundIndexBuffer: ?IndexBuffer;
     boundVertexOffset: ?number;
     boundDynamicVertexBuffer: ?VertexBuffer;
-    boundOpacityVertexBuffer: ?VertexBuffer;
-    boundCollisionVertexBuffer: ?VertexBuffer;
+    boundDynamicVertexBuffer2: ?VertexBuffer;
     vao: any;
     gl: WebGLRenderingContext;
 
@@ -35,8 +34,7 @@ class VertexArrayObject {
          vertexBuffer2: ?VertexBuffer,
          vertexOffset: ?number,
          dynamicVertexBuffer: ?VertexBuffer,
-         opacityVertexBuffer: ?VertexBuffer,
-         collisionVertexBuffer: ?VertexBuffer) {
+         dynamicVertexBuffer2: ?VertexBuffer) {
 
         if (gl.extVertexArrayObject === undefined) {
             (gl: any).extVertexArrayObject = gl.getExtension("OES_vertex_array_object");
@@ -50,12 +48,11 @@ class VertexArrayObject {
             this.boundIndexBuffer !== indexBuffer ||
             this.boundVertexOffset !== vertexOffset ||
             this.boundDynamicVertexBuffer !== dynamicVertexBuffer ||
-            this.boundOpacityVertexBuffer !== opacityVertexBuffer ||
-            this.boundCollisionVertexBuffer !== collisionVertexBuffer
+            this.boundDynamicVertexBuffer2 !== dynamicVertexBuffer2
         );
 
         if (!gl.extVertexArrayObject || isFreshBindRequired) {
-            this.freshBind(gl, program, layoutVertexBuffer, indexBuffer, vertexBuffer2, vertexOffset, dynamicVertexBuffer, opacityVertexBuffer, collisionVertexBuffer);
+            this.freshBind(gl, program, layoutVertexBuffer, indexBuffer, vertexBuffer2, vertexOffset, dynamicVertexBuffer, dynamicVertexBuffer2);
             this.gl = gl;
         } else {
             (gl: any).extVertexArrayObject.bindVertexArrayOES(this.vao);
@@ -69,12 +66,8 @@ class VertexArrayObject {
                 indexBuffer.bind();
             }
 
-            if (opacityVertexBuffer) {
-                opacityVertexBuffer.bind();
-            }
-
-            if (collisionVertexBuffer) {
-                collisionVertexBuffer.bind();
+            if (dynamicVertexBuffer2) {
+                dynamicVertexBuffer2.bind();
             }
         }
     }
@@ -86,8 +79,7 @@ class VertexArrayObject {
               vertexBuffer2: ?VertexBuffer,
               vertexOffset: ?number,
               dynamicVertexBuffer: ?VertexBuffer,
-              opacityVertexBuffer: ?VertexBuffer,
-              collisionVertexBuffer: ?VertexBuffer) {
+              dynamicVertexBuffer2: ?VertexBuffer) {
         let numPrevAttributes;
         const numNextAttributes = program.numAttributes;
 
@@ -104,8 +96,7 @@ class VertexArrayObject {
             this.boundIndexBuffer = indexBuffer;
             this.boundVertexOffset = vertexOffset;
             this.boundDynamicVertexBuffer = dynamicVertexBuffer;
-            this.boundOpacityVertexBuffer = opacityVertexBuffer;
-            this.boundCollisionVertexBuffer = collisionVertexBuffer;
+            this.boundDynamicVertexBuffer2 = dynamicVertexBuffer2;
 
         } else {
             numPrevAttributes = (gl: any).currentNumAttributes || 0;
@@ -127,11 +118,8 @@ class VertexArrayObject {
         if (dynamicVertexBuffer) {
             dynamicVertexBuffer.enableAttributes(gl, program);
         }
-        if (opacityVertexBuffer) {
-            opacityVertexBuffer.enableAttributes(gl, program);
-        }
-        if (collisionVertexBuffer) {
-            collisionVertexBuffer.enableAttributes(gl, program);
+        if (dynamicVertexBuffer2) {
+            dynamicVertexBuffer2.enableAttributes(gl, program);
         }
 
         layoutVertexBuffer.bind();
@@ -147,13 +135,9 @@ class VertexArrayObject {
         if (indexBuffer) {
             indexBuffer.bind();
         }
-        if (opacityVertexBuffer) {
-            opacityVertexBuffer.bind();
-            opacityVertexBuffer.setVertexAttribPointers(gl, program, vertexOffset);
-        }
-        if (collisionVertexBuffer) {
-            collisionVertexBuffer.bind();
-            collisionVertexBuffer.setVertexAttribPointers(gl, program, vertexOffset);
+        if (dynamicVertexBuffer2) {
+            dynamicVertexBuffer2.bind();
+            dynamicVertexBuffer2.setVertexAttribPointers(gl, program, vertexOffset);
         }
 
         (gl: any).currentNumAttributes = numNextAttributes;

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -46,8 +46,6 @@ class SourceCache extends Evented {
     _paused: boolean;
     _shouldReloadOnResume: boolean;
     _needsFullPlacement: boolean;
-    _placementIDs: Array<number>;
-    _placementIndex: number;
     _coveredTiles: {[any]: boolean};
     transform: Transform;
     _isIdRenderable: (id: string) => boolean;
@@ -90,9 +88,6 @@ class SourceCache extends Evented {
         this._maxTileCacheSize = null;
 
         this._isIdRenderable = this._isIdRenderable.bind(this);
-
-        this._placementIndex = 0;
-        this._placementIDs = [];
 
         this._coveredTiles = {};
     }
@@ -611,8 +606,6 @@ class SourceCache extends Evented {
 
     _updatePlacement() {
         this._needsFullPlacement = true;
-        this._placementIDs = this.getRenderableIds();
-        this._placementIndex = 0;
     }
 
     /**
@@ -679,20 +672,6 @@ class SourceCache extends Evented {
         }
 
         return tileResults;
-    }
-
-    placeLayer(collisionIndex: CollisionIndex, showCollisionBoxes: boolean, layer: any, shouldPausePlacement: any) {
-        while (this._placementIndex < this._placementIDs.length) {
-            const tile = this.getTileByID(this._placementIDs[this._placementIndex]);
-            tile.placeLayer(showCollisionBoxes, collisionIndex, layer);
-
-            this._placementIndex++;
-            if (shouldPausePlacement()) {
-                return true;
-            }
-        }
-        this._placementIndex = 0; // Start over at the first tile
-        return false;
     }
 
     commitPlacement(collisionIndex: CollisionIndex, collisionFadeTimes: any) {

--- a/src/style/placement.js
+++ b/src/style/placement.js
@@ -1,0 +1,119 @@
+// @flow
+
+const browser = require('../util/browser');
+const CollisionIndex = require('../symbol/collision_index');
+
+import type Transform from '../geo/transform';
+import type StyleLayer from './style_layer';
+import type SourceCache from '../source/source_cache';
+
+class LayerPlacement {
+    _currentTileIndex: number;
+    _tileIDs: Array<number>;
+
+    constructor(sourceCache) {
+        this._currentTileIndex = 0;
+        this._tileIDs = sourceCache.getRenderableIds();
+    }
+
+    continuePlacement(sourceCache, collisionIndex, showCollisionBoxes: boolean, layer, shouldPausePlacement) {
+        while (this._currentTileIndex < this._tileIDs.length) {
+            const tile = sourceCache.getTileByID(this._tileIDs[this._currentTileIndex]);
+            tile.placeLayer(showCollisionBoxes, collisionIndex, layer);
+
+            this._currentTileIndex++;
+            if (shouldPausePlacement()) {
+                return true;
+            }
+        }
+    }
+}
+
+class Placement {
+    collisionIndex: CollisionIndex;
+    _done: number;
+    _currentPlacementIndex: number;
+    _forceFullPlacement: boolean;
+    _showCollisionBoxes: boolean;
+    _delayUntil: number;
+    _collisionFadeTimes: any;
+    _inProgressLayer: ?LayerPlacement;
+
+    constructor(transform: Transform, order: Array<string>,
+            forceFullPlacement: boolean, showCollisionBoxes: boolean, fadeDuration: number,
+            previousPlacement: ?Placement) {
+
+        this.collisionIndex = new CollisionIndex(transform.clone());
+        this._currentPlacementIndex = order.length - 1;
+        this._forceFullPlacement = forceFullPlacement;
+        this._showCollisionBoxes = showCollisionBoxes;
+
+        if (forceFullPlacement || !previousPlacement) {
+            this._delayUntil = browser.now();
+        } else {
+            this._delayUntil = previousPlacement._delayUntil + 300;
+        }
+
+        if (previousPlacement) {
+            this._collisionFadeTimes = previousPlacement._collisionFadeTimes;
+        } else {
+            this._collisionFadeTimes = {
+                latestStart: 0,
+                duration: fadeDuration
+            };
+        }
+    }
+
+    isDone() {
+        return Boolean(this._done);
+    }
+
+    continuePlacement(order: Array<string>, layers: {[string]: StyleLayer}, sourceCaches: {[string]: SourceCache}) {
+        const startTime = browser.now();
+
+        if (startTime < this._delayUntil) return true;
+
+        const shouldPausePlacement = () => {
+            const elapsedTime = browser.now() - startTime;
+            return this._forceFullPlacement ? false : elapsedTime > 2;
+        };
+
+        while (this._currentPlacementIndex >= 0) {
+            const layerId = order[this._currentPlacementIndex];
+            const layer = layers[layerId];
+            if (layer.type === 'symbol') {
+                const sourceCache = sourceCaches[layer.source];
+
+                if (!this._inProgressLayer) {
+                    this._inProgressLayer = new LayerPlacement(sourceCache);
+                }
+
+                const pausePlacement = this._inProgressLayer.continuePlacement(sourceCache, this.collisionIndex, this._showCollisionBoxes, layer, shouldPausePlacement);
+
+                if (pausePlacement) {
+                    // We didn't finish placing all layers within 2ms,
+                    // but we can keep rendering with a partial placement
+                    // We'll resume here on the next frame
+                    return;
+                }
+
+                delete this._inProgressLayer;
+            }
+
+            this._currentPlacementIndex--;
+        }
+
+        for (const id in sourceCaches) {
+            sourceCaches[id].commitPlacement(this.collisionIndex, this._collisionFadeTimes);
+        }
+
+        this._done = browser.now();
+    }
+
+    stillFading() {
+        return Date.now() < this._collisionFadeTimes.latestStart + this._collisionFadeTimes.duration;
+    }
+
+}
+
+module.exports = Placement;


### PR DESCRIPTION
#### Background

A single round of global symbol placement sometimes gets split over multiple frames for performance reasons. This means we need to keep track of how far into the placement we got in the previous step. es6 generators would be ideal for managing this control flow but unfortunately we can't use them. Instead we need to manually keep track of the progress.

#### Changes
The first commit separates the placement stuff into a separate file so that it's less intertwined with `Map` and `Style`.

The second commit is unrelated cleanup that generalizes dynamic VAO buffer binding. We don't need an arg for each type of dynamic buffer because to the VAO they all look the same. This removes the `collisionVertexBuffer` arg from VAOs and renames `opacityVertexBuffer` to make it more general.

@ChrisLoer 