### PR TITLE
StyleDeclaration / SymbolLayer cleanup

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -36,7 +36,7 @@ import type {
     StructArray,
     SerializedStructArray
 } from '../../util/struct_array';
-import type StyleLayer from '../../style/style_layer';
+import type SymbolStyleLayer from '../../style/style_layer/symbol_style_layer';
 import type {Shaping, PositionedIcon} from '../../symbol/shaping';
 import type {SymbolQuad} from '../../symbol/quads';
 import type {SizeData} from '../../symbol/symbol_size';
@@ -231,7 +231,7 @@ class SymbolBuffers {
     dynamicLayoutVertexArray: StructArray;
     dynamicLayoutVertexBuffer: VertexBuffer;
 
-    constructor(programInterface: ProgramInterface, layers: Array<StyleLayer>, zoom: number, arrays?: SerializedSymbolBuffer) {
+    constructor(programInterface: ProgramInterface, layers: Array<SymbolStyleLayer>, zoom: number, arrays?: SerializedSymbolBuffer) {
         this.programInterface = programInterface;
 
         const LayoutVertexArrayType = createVertexArrayType(programInterface.layoutAttributes);
@@ -323,7 +323,7 @@ class SymbolBucket implements Bucket {
     collisionBoxArray: CollisionBoxArray;
     zoom: number;
     overscaling: number;
-    layers: Array<StyleLayer>;
+    layers: Array<SymbolStyleLayer>;
     index: number;
     sdfIcons: boolean;
     iconsNeedLinear: boolean;
@@ -376,7 +376,7 @@ class SymbolBucket implements Bucket {
     }
 
     populate(features: Array<IndexedFeature>, options: PopulateParameters) {
-        const layer: StyleLayer = this.layers[0];
+        const layer: SymbolStyleLayer = this.layers[0];
         const layout = layer.layout;
         const textFont = layout['text-font'];
 
@@ -996,7 +996,7 @@ class SymbolBucket implements Bucket {
                       line: Array<Point>,
                       shapedTextOrientations: ShapedTextOrientations,
                       shapedIcon: PositionedIcon | void,
-                      layer: StyleLayer,
+                      layer: SymbolStyleLayer,
                       addToBuffers: boolean,
                       collisionBoxArray: CollisionBoxArray,
                       featureIndex: number,
@@ -1094,7 +1094,7 @@ class SymbolBucket implements Bucket {
 
 // For {text,icon}-size, get the bucket-level data that will be needed by
 // the painter to set symbol-size-related uniforms
-function getSizeData(tileZoom: number, layer: StyleLayer, sizeProperty: string): SizeData {
+function getSizeData(tileZoom: number, layer: SymbolStyleLayer, sizeProperty: string): SizeData {
     const isFeatureConstant = layer.isLayoutValueFeatureConstant(sizeProperty);
     const isZoomConstant = layer.isLayoutValueZoomConstant(sizeProperty);
 
@@ -1140,7 +1140,7 @@ function getSizeData(tileZoom: number, layer: StyleLayer, sizeProperty: string):
     }
 }
 
-function getSizeVertexData(layer: StyleLayer, tileZoom: number, sizeData: SizeData, sizeProperty, feature) {
+function getSizeVertexData(layer: SymbolStyleLayer, tileZoom: number, sizeData: SizeData, sizeProperty, feature) {
     if (sizeData.functionType === 'source') {
         return [
             10 * layer.getLayoutValue(sizeProperty, ({}: any), feature)

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -26,6 +26,7 @@ const classifyRings = require('../../util/classify_rings');
 const vectorTileFeatureTypes = require('@mapbox/vector-tile').VectorTileFeature.types;
 const createStructArrayType = require('../../util/struct_array');
 const verticalizePunctuation = require('../../util/verticalize_punctuation');
+const {getSizeData} = require('../../symbol/symbol_size');
 
 import type {Feature as ExpressionFeature} from '../../style-spec/function';
 import type {Bucket, BucketParameters, IndexedFeature, PopulateParameters} from '../bucket';
@@ -1089,54 +1090,6 @@ class SymbolBucket implements Bucket {
             feature,
             writingModes
         });
-    }
-}
-
-// For {text,icon}-size, get the bucket-level data that will be needed by
-// the painter to set symbol-size-related uniforms
-function getSizeData(tileZoom: number, layer: SymbolStyleLayer, sizeProperty: string): SizeData {
-    const isFeatureConstant = layer.isLayoutValueFeatureConstant(sizeProperty);
-    const isZoomConstant = layer.isLayoutValueZoomConstant(sizeProperty);
-
-    if (isZoomConstant && !isFeatureConstant) {
-        return { functionType: 'source' };
-    }
-
-    if (isZoomConstant && isFeatureConstant) {
-        return {
-            functionType: 'constant',
-            layoutSize: layer.getLayoutValue(sizeProperty, {zoom: tileZoom + 1})
-        };
-    }
-
-    // calculate covering zoom stops for zoom-dependent values
-    const levels = layer.getLayoutValueStopZoomLevels(sizeProperty);
-    let lower = 0;
-    while (lower < levels.length && levels[lower] <= tileZoom) lower++;
-    lower = Math.max(0, lower - 1);
-    let upper = lower;
-    while (upper < levels.length && levels[upper] < tileZoom + 1) upper++;
-    upper = Math.min(levels.length - 1, upper);
-
-    const coveringZoomRange: [number, number] = [levels[lower], levels[upper]];
-
-    if (!isFeatureConstant) {
-        return {
-            functionType: 'composite',
-            coveringZoomRange
-        };
-    } else {
-        // for camera functions, also save off the function values
-        // evaluated at the covering zoom levels
-        return {
-            functionType: 'camera',
-            layoutSize: layer.getLayoutValue(sizeProperty, {zoom: tileZoom + 1}),
-            coveringZoomRange,
-            coveringStopValues: [
-                layer.getLayoutValue(sizeProperty, {zoom: levels[lower]}),
-                layer.getLayoutValue(sizeProperty, {zoom: levels[upper]})
-            ]
-        };
     }
 }
 

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -362,7 +362,7 @@ class ProgramConfiguration {
 class ProgramConfigurationSet {
     programConfigurations: {[string]: ProgramConfiguration};
 
-    constructor(programInterface: ProgramInterface, layers: Array<StyleLayer>, zoom: number, arrays?: {+[string]: ?SerializedProgramConfiguration}) {
+    constructor(programInterface: ProgramInterface, layers: $ReadOnlyArray<StyleLayer>, zoom: number, arrays?: {+[string]: ?SerializedProgramConfiguration}) {
         this.programConfigurations = {};
         if (arrays) {
             for (const layer of layers) {

--- a/src/style/style_declaration.js
+++ b/src/style/style_declaration.js
@@ -13,13 +13,9 @@ import type {StyleFunction, Feature} from '../style-spec/function';
 class StyleDeclaration {
     value: any;
     isFunction: boolean;
-    isFeatureConstant: boolean;
-    isZoomConstant: boolean;
     json: mixed;
     minimum: number;
     function: StyleFunction;
-    stopZoomLevels: Array<number>;
-    _zoomCurve: ?Curve;
 
     constructor(reference: any, value: any) {
         this.value = util.clone(value);
@@ -30,16 +26,6 @@ class StyleDeclaration {
 
         this.minimum = reference.minimum;
         this.function = createFunction(this.value, reference);
-        this.isFeatureConstant = this.function.isFeatureConstant;
-        this.isZoomConstant = this.function.isZoomConstant;
-
-        if (!this.function.isZoomConstant) {
-            this._zoomCurve = this.function.zoomCurve;
-            this.stopZoomLevels = [];
-            for (const stop of this.function.zoomCurve.stops) {
-                this.stopZoomLevels.push(stop[0]);
-            }
-        }
     }
 
     calculate(globalProperties: {+zoom?: number} = {}, feature?: Feature) {
@@ -53,18 +39,18 @@ class StyleDeclaration {
     /**
      * Calculate the interpolation factor for the given zoom stops and current
      * zoom level.
-     *
-     * Only valid for composite functions.
-     * @private
      */
     interpolationFactor(zoom: number, lower: number, upper: number) {
-        if (!this._zoomCurve) return 0;
-        return Curve.interpolationFactor(
-            this._zoomCurve.interpolation,
-            zoom,
-            lower,
-            upper
-        );
+        if (this.function.isZoomConstant) {
+            return 0;
+        } else {
+            return Curve.interpolationFactor(
+                this.function.zoomCurve.interpolation,
+                zoom,
+                lower,
+                upper
+            );
+        }
     }
 }
 

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -195,15 +195,6 @@ class StyleLayer extends Evented {
         }
     }
 
-    getPaintValueStopZoomLevels(name: string) {
-        const transition = this._paintTransitions[name];
-        if (transition) {
-            return transition.declaration.stopZoomLevels;
-        } else {
-            return [];
-        }
-    }
-
     getLayoutValueStopZoomLevels(name: string) {
         const declaration = this._layoutDeclarations[name];
 

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -195,24 +195,9 @@ class StyleLayer extends Evented {
         }
     }
 
-    getLayoutValueStopZoomLevels(name: string) {
-        const declaration = this._layoutDeclarations[name];
-
-        if (declaration) {
-            return declaration.stopZoomLevels;
-        } else {
-            return [];
-        }
-    }
-
     getPaintInterpolationFactor(name: string, input: number, lower: number, upper: number) {
         const transition = this._paintTransitions[name];
         return transition.declaration.interpolationFactor(input, lower, upper);
-    }
-
-    getLayoutInterpolationFactor(name: string, input: number, lower: number, upper: number) {
-        const declaration = this._layoutDeclarations[name];
-        return declaration.interpolationFactor(input, lower, upper);
     }
 
     isPaintValueFeatureConstant(name: string) {
@@ -225,31 +210,11 @@ class StyleLayer extends Evented {
         }
     }
 
-    isLayoutValueFeatureConstant(name: string) {
-        const declaration = this._layoutDeclarations[name];
-
-        if (declaration) {
-            return declaration.isFeatureConstant;
-        } else {
-            return true;
-        }
-    }
-
     isPaintValueZoomConstant(name: string) {
         const transition = this._paintTransitions[name];
 
         if (transition) {
             return transition.declaration.isZoomConstant;
-        } else {
-            return true;
-        }
-    }
-
-    isLayoutValueZoomConstant(name: string) {
-        const declaration = this._layoutDeclarations[name];
-
-        if (declaration) {
-            return declaration.isZoomConstant;
         } else {
             return true;
         }

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -202,22 +202,12 @@ class StyleLayer extends Evented {
 
     isPaintValueFeatureConstant(name: string) {
         const transition = this._paintTransitions[name];
-
-        if (transition) {
-            return transition.declaration.isFeatureConstant;
-        } else {
-            return true;
-        }
+        return !transition || transition.declaration.function.isFeatureConstant;
     }
 
     isPaintValueZoomConstant(name: string) {
         const transition = this._paintTransitions[name];
-
-        if (transition) {
-            return transition.declaration.isZoomConstant;
-        } else {
-            return true;
-        }
+        return !transition || transition.declaration.function.isZoomConstant;
     }
 
     isHidden(zoom: number) {

--- a/src/style/style_layer/fill_style_layer.js
+++ b/src/style/style_layer/fill_style_layer.js
@@ -39,14 +39,6 @@ class FillStyleLayer extends StyleLayer {
         return super.getPaintValue(name, globalProperties, feature);
     }
 
-    getPaintValueStopZoomLevels(name: string) {
-        if (name === 'fill-outline-color' && this.getPaintProperty('fill-outline-color') === undefined) {
-            return super.getPaintValueStopZoomLevels('fill-color');
-        } else {
-            return super.getPaintValueStopZoomLevels(name);
-        }
-    }
-
     getPaintInterpolationFactor(name: string, ...args: *) {
         if (name === 'fill-outline-color' && this.getPaintProperty('fill-outline-color') === undefined) {
             return super.getPaintInterpolationFactor('fill-color', ...args);

--- a/src/style/style_layer/symbol_style_layer.js
+++ b/src/style/style_layer/symbol_style_layer.js
@@ -10,7 +10,7 @@ import type {BucketParameters} from '../../data/bucket';
 
 class SymbolStyleLayer extends StyleLayer {
 
-    getLayoutValue(name: string, globalProperties?: GlobalProperties, feature?: Feature) {
+    getLayoutValue(name: string, globalProperties?: GlobalProperties, feature?: Feature): any {
         const value = super.getLayoutValue(name, globalProperties, feature);
         if (value !== 'auto') {
             return value;
@@ -26,6 +26,38 @@ class SymbolStyleLayer extends StyleLayer {
             return this.getLayoutValue('icon-rotation-alignment', globalProperties, feature);
         default:
             return value;
+        }
+    }
+
+    getLayoutValueStopZoomLevels(name: string) {
+        const declaration = this._layoutDeclarations[name];
+        if (declaration) {
+            return declaration.stopZoomLevels;
+        } else {
+            return [];
+        }
+    }
+
+    getLayoutInterpolationFactor(name: string, input: number, lower: number, upper: number) {
+        const declaration = this._layoutDeclarations[name];
+        return declaration.interpolationFactor(input, lower, upper);
+    }
+
+    isLayoutValueFeatureConstant(name: string) {
+        const declaration = this._layoutDeclarations[name];
+        if (declaration) {
+            return declaration.isFeatureConstant;
+        } else {
+            return true;
+        }
+    }
+
+    isLayoutValueZoomConstant(name: string) {
+        const declaration = this._layoutDeclarations[name];
+        if (declaration) {
+            return declaration.isZoomConstant;
+        } else {
+            return true;
         }
     }
 

--- a/src/style/style_layer/symbol_style_layer.js
+++ b/src/style/style_layer/symbol_style_layer.js
@@ -29,36 +29,18 @@ class SymbolStyleLayer extends StyleLayer {
         }
     }
 
-    getLayoutValueStopZoomLevels(name: string) {
-        const declaration = this._layoutDeclarations[name];
-        if (declaration) {
-            return declaration.stopZoomLevels;
-        } else {
-            return [];
-        }
-    }
-
-    getLayoutInterpolationFactor(name: string, input: number, lower: number, upper: number) {
-        const declaration = this._layoutDeclarations[name];
-        return declaration.interpolationFactor(input, lower, upper);
+    getLayoutDeclaration(name: string) {
+        return this._layoutDeclarations[name];
     }
 
     isLayoutValueFeatureConstant(name: string) {
         const declaration = this._layoutDeclarations[name];
-        if (declaration) {
-            return declaration.isFeatureConstant;
-        } else {
-            return true;
-        }
+        return !declaration || declaration.function.isFeatureConstant;
     }
 
     isLayoutValueZoomConstant(name: string) {
         const declaration = this._layoutDeclarations[name];
-        if (declaration) {
-            return declaration.isZoomConstant;
-        } else {
-            return true;
-        }
+        return !declaration || declaration.function.isZoomConstant;
     }
 
     createBucket(parameters: BucketParameters) {

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -6,7 +6,7 @@ const symbolSize = require('./symbol_size');
 const {addDynamicAttributes} = require('../data/bucket/symbol_bucket');
 
 import type Painter from '../render/painter';
-import type StyleLayer from '../style/style_layer';
+import type SymbolStyleLayer from '../style/style_layer/symbol_style_layer';
 import type Transform from '../geo/transform';
 import type SymbolBucket from '../data/bucket/symbol_bucket';
 
@@ -144,7 +144,7 @@ function updateLineLabels(bucket: SymbolBucket,
                           pitchWithMap: boolean,
                           keepUpright: boolean,
                           pixelsToTileUnits: number,
-                          layer: StyleLayer) {
+                          layer: SymbolStyleLayer) {
 
     const sizeData = isText ? bucket.textSizeData : bucket.iconSizeData;
     const partiallyEvaluatedSize = symbolSize.evaluateSizeForZoom(sizeData, painter.transform, layer, isText);

--- a/src/symbol/symbol_size.js
+++ b/src/symbol/symbol_size.js
@@ -3,7 +3,7 @@
 const interpolate = require('../style-spec/util/interpolate');
 const util = require('../util/util');
 
-import type StyleLayer from '../style/style_layer';
+import type SymbolStyleLayer from '../style/style_layer/symbol_style_layer';
 
 module.exports = {
     evaluateSizeForFeature,
@@ -40,7 +40,7 @@ function evaluateSizeForFeature(sizeData: SizeData,
 
 function evaluateSizeForZoom(sizeData: SizeData,
                              tr: { zoom: number },
-                             layer: StyleLayer,
+                             layer: SymbolStyleLayer,
                              isText: boolean) {
     const sizeUniforms = {};
     if (sizeData.functionType === 'composite') {

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -8,7 +8,7 @@ const VectorTile = require('@mapbox/vector-tile').VectorTile;
 const SymbolBucket = require('../../../src/data/bucket/symbol_bucket');
 const CollisionTile = require('../../../src/symbol/collision_tile');
 const CollisionBoxArray = require('../../../src/symbol/collision_box');
-const StyleLayer = require('../../../src/style/style_layer');
+const SymbolStyleLayer = require('../../../src/style/style_layer/symbol_style_layer');
 const util = require('../../../src/util/util');
 const featureFilter = require('../../../src/style-spec/feature_filter');
 
@@ -24,7 +24,7 @@ const collision = new CollisionTile(0, 0, 1, 1, collisionBoxArray);
 const stacks = { 'Test': glyphs };
 
 function bucketSetup() {
-    const layer = new StyleLayer({
+    const layer = new SymbolStyleLayer({
         id: 'test',
         type: 'symbol',
         layout: { 'text-font': ['Test'], 'text-field': 'abcde' },

--- a/test/unit/style/style_declaration.test.js
+++ b/test/unit/style/style_declaration.test.js
@@ -4,14 +4,6 @@ const test = require('mapbox-gl-js-test').test;
 const StyleDeclaration = require('../../../src/style/style_declaration');
 
 test('StyleDeclaration', (t) => {
-    t.test('constant', (t) => {
-        t.equal((new StyleDeclaration({type: "number"}, 5)).calculate({zoom: 0}), 5);
-        t.equal((new StyleDeclaration({type: "number"}, 5)).calculate({zoom: 100}), 5);
-        t.ok((new StyleDeclaration({type: "number"}, 5)).isFeatureConstant);
-        t.ok((new StyleDeclaration({type: "number"}, 5)).isZoomConstant);
-        t.end();
-    });
-
     t.test('with minimum value', (t) => {
         t.equal((new StyleDeclaration({type: "number", minimum: -2}, -5)).calculate({zoom: 0}), -2);
         t.equal((new StyleDeclaration({type: "number", minimum: -2}, 5)).calculate({zoom: 0}), 5);
@@ -28,26 +20,12 @@ test('StyleDeclaration', (t) => {
         t.equal((new StyleDeclaration(reference, { stops: [[0, 0], [1, 10], [2, 20]] })).calculate({zoom: 2}), 20);
         t.equal((new StyleDeclaration(reference, { stops: [[0, 0], [1, 10], [2, 20]] })).calculate({zoom: 1}), 10);
         t.equal((new StyleDeclaration(reference, { stops: [[0, 0]] })).calculate({zoom: 6}), 0);
-        t.ok((new StyleDeclaration(reference, { stops: [[0, 1]] })).isFeatureConstant);
-        t.notOk((new StyleDeclaration(reference, { stops: [[0, 1]] })).isZoomConstant);
         t.end();
     });
 
     t.test('piecewise-constant function', (t) => {
         const decl = new StyleDeclaration({type: "array", function: "piecewise-constant"}, {stops: [[0, [0, 10, 5]]]});
         t.deepEqual(decl.calculate({zoom: 0}), [0, 10, 5]);
-        t.end();
-    });
-
-    t.test('property functions', (t) => {
-        const declaration = new StyleDeclaration(
-            {type: "number", function: "interpolated"},
-            { stops: [[0, 1]], property: 'mapbox' }
-        );
-
-        t.notOk(declaration.isFeatureConstant);
-        t.ok(declaration.isZoomConstant);
-
         t.end();
     });
 

--- a/test/unit/style/style_layer.test.js
+++ b/test/unit/style/style_layer.test.js
@@ -317,28 +317,6 @@ test('StyleLayer#setPaintProperty', (t) => {
         t.end();
     });
 
-    test('StyleLayer#getPaintValueStopZoomLevels', (t) => {
-        t.test('get undefined paint value stop zoom levels', (t) => {
-            const layer = StyleLayer.create({
-                "id": "background",
-                "type": "fill",
-                "paint.blue": {
-                    "fill-color": "#8ccbf7",
-                    "fill-opacity": 1
-                },
-                "paint": {
-                    "fill-opacity": 0
-                }
-            });
-
-            t.deepEqual(layer.getPaintValueStopZoomLevels('background-color'), []);
-
-            t.end();
-        });
-
-        t.end();
-    });
-
     test('StyleLayer#isPaintValueZoomConstant', (t) => {
         t.test('is paint value zoom constant undefined', (t) => {
             const layer = StyleLayer.create({


### PR DESCRIPTION
Some of the properties in `StyleDeclaration` are only needed for `icon-size`/`text-size` related calculations. Localize those special cases better and eliminate redundant computed properties.