### PR TITLE
Use old function code rather than converting to expressions

### DIFF
--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -62,9 +62,7 @@ type StylePropertySpecification = {
 type StylePropertyValue = null | string | number | Array<string> | Array<number>;
 type FunctionParameters = DataDrivenPropertyValueSpecification<StylePropertyValue>
 
-function createExpression(expression: mixed,
-                          propertySpec: StylePropertySpecification,
-                          options: { isConvertedFunction?: boolean, defaultValue?: any } = {}): StyleExpression {
+function createExpression(expression: mixed, propertySpec: StylePropertySpecification): StyleExpression {
     const expectedType = getExpectedType(propertySpec);
     const compiled = compileExpression(expression, expectedType);
 
@@ -73,7 +71,7 @@ function createExpression(expression: mixed,
         throw new Error(compiled.errors.map(err => `${err.key}: ${err.message}`).join(', '));
     }
 
-    let defaultValue = options.defaultValue || propertySpec.default;
+    let defaultValue = propertySpec.default;
     if (propertySpec.type === 'color') {
         defaultValue = parseColor((defaultValue: any));
     }
@@ -87,7 +85,7 @@ function createExpression(expression: mixed,
             }
             return val;
         } catch (e) {
-            if (!options.isConvertedFunction && !warningHistory[e.message]) {
+            if (!warningHistory[e.message]) {
                 warningHistory[e.message] = true;
                 if (typeof console !== 'undefined') {
                     console.warn(e.message);

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -121,7 +121,9 @@ function createFunction(parameters, propertySpec) {
         return {
             isFeatureConstant: true,
             isZoomConstant: false,
-            interpolation: {name: type === 'exponential' ? 'exponential' : 'step'},
+            interpolation: type === 'exponential' ?
+                {name: 'exponential', base: parameters.base !== undefined ? parameters.base : 1} :
+                {name: 'step'},
             zoomStops: parameters.stops.map(s => s[0]),
             evaluate({zoom}) {
                 return outputFunction(innerFun(parameters, propertySpec, zoom, hashedStops, categoricalKeyType));

--- a/src/style/style_declaration.js
+++ b/src/style/style_declaration.js
@@ -2,7 +2,7 @@
 
 const parseColor = require('../style-spec/util/parse_color');
 const createExpression = require('../style-spec/expression');
-const convertFunction = require('../style-spec/function/convert');
+const createFunction = require('../style-spec/function');
 const util = require('../util/util');
 const Curve = require('../style-spec/expression/definitions/curve');
 
@@ -29,10 +29,7 @@ function normalizeToExpression(parameters, propertySpec): StyleExpression {
     if (parameters.expression) {
         return createExpression(parameters.expression, propertySpec);
     } else {
-        return createExpression(convertFunction(parameters, propertySpec), propertySpec, {
-            defaultValue: parameters.default,
-            isConvertedFunction: true
-        });
+        return createFunction(parameters, propertySpec);
     }
 }
 

--- a/test/unit/style-spec/function.test.js
+++ b/test/unit/style-spec/function.test.js
@@ -1,15 +1,7 @@
 'use strict';
 
 const test = require('mapbox-gl-js-test').test;
-const createExpression = require('../../../src/style-spec/expression');
-const convertFunction = require('../../../src/style-spec/function/convert');
-
-function createFunction(parameters, propertySpec) {
-    return createExpression(convertFunction(parameters, propertySpec), propertySpec, {
-        defaultValue: parameters.default,
-        isConvertedFunction: true
-    });
-}
+const createFunction = require('../../../src/style-spec/function');
 
 test('binary search', (t) => {
     t.test('will eventually terminate.', (t) => {
@@ -996,7 +988,7 @@ test('unknown function', (t) => {
         type: 'nonesuch', stops: [[]]
     }, {
         type: 'string'
-    }), /Unknown zoom function type "nonesuch"/);
+    }), /Unknown function type "nonesuch"/);
     t.end();
 });
 


### PR DESCRIPTION
Fixes #5379.

Clear improvements on `LayoutDDS`, `Paint`, and `StyleLayerCreate`. `QueryBox` seems to be slightly slower (?). The benchmarks I added in #5384 turn out to be too micro to be effective (not that they should show any changes here).

![image](https://user-images.githubusercontent.com/98601/31038047-5c08bd26-a529-11e7-8249-671fd5309995.png)

