### PR TITLE
Accommodate microbenchmarks

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -14,6 +14,8 @@ To run all benchmarks, open [the benchmark page, `http://localhost:9966/bench`](
 
 To run a specific benchmark, add its name to the url hash, for example [`http://localhost:9966/bench/#Layout`](http://localhost:9966/bench/#Layout).
 
+In either case, if you want to run only benchmarks from your local branch, without also running the current master branch build, then include a `no-master` query parameter, i.e. [localhost:9966/bench?no-master](http://localhost:9966/bench?no-master) or [localhost:9966/bench?no-master#Layout](http://localhost:9966/bench?no-master#Layout).
+
 ## Writing a Benchmark
 
 Good benchmarks

--- a/bench/benchmarks_view.js
+++ b/bench/benchmarks_view.js
@@ -43,7 +43,7 @@ class StatisticsPlot extends React.Component {
             name: v.name,
             samples: v.samples,
             summary: v.summary,
-            density: kde(v.samples, t.ticks(50))
+            density: kde(v.samples, v.summary, t.ticks(50))
         }));
 
         const p = d3.scaleLinear()

--- a/bench/benchmarks_view.js
+++ b/bench/benchmarks_view.js
@@ -382,11 +382,14 @@ for (const name in window.mapboxglBenchmarks) {
             update();
 
             return window.mapboxglBenchmarks[name][ver].run()
-                .then(samples => {
+                .then(measurements => {
+                    // scale measurements down by iteration count, so that
+                    // they represent (average) time for a single iteration
+                    const samples = measurements.map(({time, iterations}) => time / iterations);
                     version.status = 'ended';
                     version.samples = samples;
                     version.summary = summaryStatistics(samples);
-                    version.regression = regression(samples);
+                    version.regression = regression(measurements);
                     update();
                 })
                 .catch(error => {

--- a/bench/benchmarks_view.js
+++ b/bench/benchmarks_view.js
@@ -90,6 +90,7 @@ class StatisticsPlot extends React.Component {
 
                         const {
                             mean,
+                            trimmedMean,
                             q1,
                             q2,
                             q3,
@@ -98,6 +99,8 @@ class StatisticsPlot extends React.Component {
                             argmin,
                             argmax
                         } = v.summary;
+
+                        const tMax = t.domain()[1];
 
                         return <g key={i}>
                             <path
@@ -148,18 +151,20 @@ class StatisticsPlot extends React.Component {
                                     stroke={color}
                                     strokeWidth={bandwidth}
                                     strokeOpacity={1} />
-                                <line // mean
-                                    x1={bandwidth / 2}
-                                    x2={bandwidth / 2}
-                                    y1={t(mean) - 0.5}
-                                    y2={t(mean) + 0.5}
-                                    stroke='white'
-                                    strokeWidth={bandwidth}
-                                    strokeOpacity={1} />
-                                {[mean].map((d, i) =>
+                                <use href="#up-arrow" // mean
+                                    style={{ stroke: color, fill: color, fillOpacity: 0.4 }}
+                                    transform={mean >= tMax ? 'translate(-10, 0)' : `translate(-5, ${t(mean)}) rotate(90)`}
+                                    x={0}
+                                    y={0} />
+                                <use href="#up-arrow" // trimmed mean
+                                    style={{ stroke: color, fill: color }}
+                                    transform={`translate(-5, ${t(trimmedMean)}) rotate(90)`}
+                                    x={0}
+                                    y={0} />
+                                {[mean, trimmedMean].map(d =>
                                     <text // left
                                         key={i}
-                                        dx={-6}
+                                        dx={-16}
                                         dy='.3em'
                                         x={0}
                                         y={t(d)}

--- a/bench/index.html
+++ b/bench/index.html
@@ -15,7 +15,13 @@
     <script src="https://unpkg.com/react@next/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@next/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/d3@4"></script>
-    <script src="https://s3.amazonaws.com/mapbox-gl-js/master/benchmarks.js"></script>
+    <script>
+        // Unless the URL contains a no-master query parameter, include the
+        // current master-branch build of benchmarks.js for comparison
+        if (!/no-master/.test(window.location.search)) {
+            document.write(`<script src="https://s3.amazonaws.com/mapbox-gl-js/master/benchmarks.js"><` + `/script>`);
+        }
+    </script>
     <script src="/bench/benchmarks_generated.js"></script>
     <script src="/bench/benchmarks_view_generated.js"></script>
 </body>

--- a/bench/lib/statistics.js
+++ b/bench/lib/statistics.js
@@ -70,10 +70,14 @@ function summaryStatistics(data) {
     };
 }
 
-function regression(samples) {
+function regression(measurements) {
     const result = [];
-    for (let i = 0, n = 1; i + n < samples.length; i += n, n++) {
-        result.push([n, samples.slice(i, i + n).reduce(((sum, sample) => sum + sample), 0)]);
+    for (let i = 0, n = 1; i + n < measurements.length; i += n, n++) {
+        const subset = measurements.slice(i, i + n);
+        result.push([
+            subset.reduce((sum, measurement) => sum + measurement.iterations, 0),
+            subset.reduce((sum, measurement) => sum + measurement.time, 0)
+        ]);
     }
     return leastSquaresRegression(result);
 }

--- a/bench/lib/statistics.js
+++ b/bench/lib/statistics.js
@@ -99,14 +99,14 @@ function leastSquaresRegression(data) {
     return { correlation, slope, intercept, data };
 }
 
-function kde(samples, ticks) {
+function kde(samples, summary, ticks) {
     const kernel = kernelEpanechnikov;
 
     if (samples.length === 0) {
         return [];
     }
     // https://en.wikipedia.org/wiki/Kernel_density_estimation#A_rule-of-thumb_bandwidth_estimator
-    const bandwidth = 1.06 * d3.deviation(samples) * Math.pow(samples.length, -0.2);
+    const bandwidth = 1.06 * summary.windsorizedDeviation * Math.pow(samples.length, -0.2);
     return ticks.map((x) => {
         return [x, d3.mean(samples, (v) => kernel((x - v) / bandwidth)) / bandwidth];
     });

--- a/bench/lib/statistics.js
+++ b/bench/lib/statistics.js
@@ -63,6 +63,7 @@ function summaryStatistics(data) {
         q1,
         q2,
         q3,
+        iqr: q3 - q1,
         argmin: min[0], // index of minimum value
         min: min[1],
         argmax: max[0], // index of maximum value


### PR DESCRIPTION
Accommodate microbenchmarks by (possibly) running >1 iteration per measurement.

Attached a couple riders, since they address issues that are particularly prevalent with microbenchmarks
 - Clamp the t-axis of the statistics plot to prevent outliers from scaling away much of the detail in KDE / scatter plots
 - Visualize both mean and trimmed mean