### PR TITLE
display warning when missing css #5359

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -5,6 +5,10 @@
     -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
+.mapboxgl-missing-css {
+    display: none;
+}
+
 .mapboxgl-canvas-container.mapboxgl-interactive,
 .mapboxgl-ctrl-nav-compass {
     cursor: -webkit-grab;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1428,6 +1428,9 @@ class Map extends Camera {
         const container = this._container;
         container.classList.add('mapboxgl-map');
 
+        const missingCSSContainer = DOM.create('div', 'mapboxgl-missing-css', container);
+        missingCSSContainer.innerHTML = 'Missing Mapbox GL JS CSS';
+
         const canvasContainer = this._canvasContainer = DOM.create('div', 'mapboxgl-canvas-container', container);
         if (this._interactive) {
             canvasContainer.classList.add('mapboxgl-interactive');

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -223,6 +223,7 @@ class Map extends Camera {
 
     _classes: Array<string>;
     _container: HTMLElement;
+    _missingCSSContainer: HTMLElement;
     _canvasContainer: HTMLElement;
     _controlContainer: HTMLElement;
     _controlPositions: {[string]: HTMLElement};

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1428,7 +1428,7 @@ class Map extends Camera {
         const container = this._container;
         container.classList.add('mapboxgl-map');
 
-        const missingCSSContainer = DOM.create('div', 'mapboxgl-missing-css', container);
+        const missingCSSContainer = this._missingCSSContainer = DOM.create('div', 'mapboxgl-missing-css', container);
         missingCSSContainer.innerHTML = 'Missing Mapbox GL JS CSS';
 
         const canvasContainer = this._canvasContainer = DOM.create('div', 'mapboxgl-canvas-container', container);
@@ -1620,6 +1620,7 @@ class Map extends Camera {
         if (extension) extension.loseContext();
         removeNode(this._canvasContainer);
         removeNode(this._controlContainer);
+        removeNode(this._missingCSSContainer);
         this._container.classList.remove('mapboxgl-map');
         this.fire('remove');
     }

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -749,7 +749,7 @@ test('Map', (t) => {
 
     t.test('#remove', (t) => {
         const map = createMap();
-        t.equal(map.getContainer().childNodes.length, 2);
+        t.equal(map.getContainer().childNodes.length, 3);
         map.remove();
         t.equal(map.getContainer().childNodes.length, 0);
         t.end();


### PR DESCRIPTION
Display warning if mapbox-gl CSS is missing according to https://github.com/mapbox/mapbox-gl-js/issues/5359

![screenshot 2017-10-02 18 34 44](https://user-images.githubusercontent.com/533564/31085821-d9dd56c0-a7a0-11e7-8a6e-cd7962e3571b.png)

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page