### PR TITLE
remove link to deprecated mapbox-gl repo

### DIFF
--- a/docs/_theme/index.hbs
+++ b/docs/_theme/index.hbs
@@ -82,7 +82,7 @@ category: api
           <p class='space-bottom2 pad1y'>Mapbox GL JS is a JavaScript library that uses WebGL to render interactive maps
             from <a href='{{site.url}}/help/define-vector-tiles'>vector tiles</a> and <a
                     href='{{site.baseurl}}/style-spec'>Mapbox styles</a>.
-            It is part of the <a href='https://github.com/mapbox/mapbox-gl'>Mapbox GL ecosystem</a>, which includes <a
+            It is part of the Mapbox GL ecosystem, which includes <a
                     href='{{site.url}}/mobile/'>Mapbox Mobile</a>, a compatible renderer written in C++ with bindings
             for desktop and mobile platforms. To see what new features our team is working on, take a look at our <a href='{{site.baseurl}}/roadmap'>roadmap</a>.</p>
           <div class='col12 fill-light round pad2 clearfix space-top2'>


### PR DESCRIPTION
At https://www.mapbox.com/mapbox-gl-js/api/ `Mapbox GL ecosystem` links to the deprecated repo https://github.com/mapbox/DEPRECATED-mapbox-gl.

I couldn't find a good landing page for `Mapbox GL ecosystem`, so might be better to simply remove the link? Mapbox Mobile is already linked to.
