### PR TITLE
Fix texture#update

### DIFF
--- a/flow-typed/window.js
+++ b/flow-typed/window.js
@@ -116,8 +116,10 @@ declare interface Window extends EventTarget, IDBEnvironment {
     Blob: typeof Blob;
     HTMLImageElement: typeof HTMLImageElement;
     HTMLVideoElement: typeof HTMLVideoElement;
+    HTMLCanvasElement: typeof HTMLCanvasElement;
     Image: typeof Image;
     ImageData: typeof ImageData;
+    ImageBitmap: typeof ImageBitmap;
     URL: typeof URL;
     webkitURL: typeof URL;
     URLSearchParams: typeof URLSearchParams;

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -1,7 +1,7 @@
 // @flow
 
 const {RGBAImage, AlphaImage} = require('../util/image');
-const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageBitmap, ImageData} = require('../util/window');
+const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageData, ImageBitmap} = require('../util/window');
 
 export type TextureFormat =
     | $PropertyType<WebGLRenderingContext, 'RGBA'>
@@ -55,7 +55,7 @@ class Texture {
             gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, (true: any));
         }
 
-        if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof HTMLCanvasElement || image instanceof ImageData || image instanceof ImageBitmap) {
+        if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || image instanceof ImageBitmap) {
             gl.texImage2D(gl.TEXTURE_2D, 0, this.format, this.format, gl.UNSIGNED_BYTE, image);
         } else {
             gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, gl.UNSIGNED_BYTE, image.data);

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -1,7 +1,7 @@
 // @flow
 
 const {RGBAImage, AlphaImage} = require('../util/image');
-const {HTMLImageElement} = require('../util/window');
+const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageBitmap, ImageData} = require('../util/window');
 
 export type TextureFormat =
     | $PropertyType<WebGLRenderingContext, 'RGBA'>
@@ -55,10 +55,10 @@ class Texture {
             gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, (true: any));
         }
 
-        if (image instanceof RGBAImage || image instanceof AlphaImage) {
-            gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, gl.UNSIGNED_BYTE, image.data);
-        } else {
+        if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof HTMLCanvasElement || image instanceof ImageData || image instanceof ImageBitmap) {
             gl.texImage2D(gl.TEXTURE_2D, 0, this.format, this.format, gl.UNSIGNED_BYTE, image);
+        } else {
+            gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, gl.UNSIGNED_BYTE, image.data);
         }
     }
 

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -56,6 +56,8 @@ function restore(): Window {
     window.restore = restore;
 
     window.ImageData = window.ImageData || function() { return false; };
+    window.ImageBitmap = window.ImageBitmap || function () { return false; };
+    window.HTMLVideoElement = window.HTMLVideoElement || function () { return false; };
 
     util.extend(module.exports, window);
 

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -56,9 +56,7 @@ function restore(): Window {
     window.restore = restore;
 
     window.ImageData = window.ImageData || function() { return false; };
-    window.ImageBitmap = window.ImageBitmap || function () { return false; };
-    window.HTMLVideoElement = window.HTMLVideoElement || function () { return false; };
-
+    window.ImageBitmap = window.ImageBitmap || function() { return false; };
     util.extend(module.exports, window);
 
     return window;


### PR DESCRIPTION
fixes a problem introduced by #5406 because `RGBAImage` and `AlphaImage` are declared as `Classes` but not used as such so `image instanceof RGBAImage` was always returning false. 

benchmarks work again:
https://bl.ocks.org/anonymous/raw/6bf016e150a227d2f59703c816100e87/

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
