### PR TITLE
remove ImageBitmap from flow types to fix maps in Safari and IE

### DIFF
--- a/flow-typed/window.js
+++ b/flow-typed/window.js
@@ -119,7 +119,6 @@ declare interface Window extends EventTarget, IDBEnvironment {
     HTMLCanvasElement: typeof HTMLCanvasElement;
     Image: typeof Image;
     ImageData: typeof ImageData;
-    ImageBitmap: typeof ImageBitmap;
     URL: typeof URL;
     webkitURL: typeof URL;
     URLSearchParams: typeof URLSearchParams;

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -1,7 +1,9 @@
 // @flow
 
-const {RGBAImage, AlphaImage} = require('../util/image');
-const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageData, ImageBitmap} = require('../util/window');
+const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageData} = require('../util/window');
+
+import type {RGBAImage, AlphaImage} from '../util/image';
+import type {ImageTextureSource} from '../source/image_source';
 
 export type TextureFormat =
     | $PropertyType<WebGLRenderingContext, 'RGBA'>
@@ -18,11 +20,7 @@ export type TextureWrap =
 export type TextureImage =
     | RGBAImage
     | AlphaImage
-    | HTMLImageElement
-    | HTMLCanvasElement
-    | HTMLVideoElement
-    | ImageData
-    | ImageBitmap;
+    | ImageTextureSource;
 
 class Texture {
     gl: WebGLRenderingContext;
@@ -55,7 +53,7 @@ class Texture {
             gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, (true: any));
         }
 
-        if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || image instanceof ImageBitmap) {
+        if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData) {
             gl.texImage2D(gl.TEXTURE_2D, 0, this.format, this.format, gl.UNSIGNED_BYTE, image);
         } else {
             gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, gl.UNSIGNED_BYTE, image.data);

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -20,6 +20,12 @@ import type Dispatcher from '../util/dispatcher';
 import type Tile from './tile';
 import type Coordinate from '../geo/coordinate';
 
+export type ImageTextureSource =
+  ImageData |
+  HTMLImageElement |
+  HTMLCanvasElement |
+  HTMLVideoElement;
+
 /**
  * A data source containing an image.
  * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-image) for detailed documentation of options.)
@@ -183,7 +189,7 @@ class ImageSource extends Evented implements Source {
         this._prepareImage(this.map.painter.gl, this.image);
     }
 
-    _prepareImage(gl: WebGLRenderingContext, image: TexImageSource, resize?: boolean) {
+    _prepareImage(gl: WebGLRenderingContext, image: ImageTextureSource, resize?: boolean) {
         if (!this.boundsBuffer) {
             this.boundsBuffer = new VertexBuffer(gl, this._boundsArray);
         }


### PR DESCRIPTION
Safari and IE don't support ImageBitmap so #5414 broke the maps on Safari and IE (with error: `right hand side of instanceof is not an object`) . 

it was only being included in the flow checks because we were using the default Flow def for [`TexImageSource`](https://github.com/facebook/flow/blob/v0.56.0/lib/dom.js#L1611). This PR removes its use so we don't have to deal with special casing for Safari and IE. 


# Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
