### PR TITLE
Avoid attempting to calculate a value for data-driven properties if feature is undefined

### DIFF
--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -120,7 +120,8 @@ class StyleLayer extends Evented {
         const specification = this._layoutSpecifications[name];
         const declaration = this._layoutDeclarations[name];
 
-        if (declaration) {
+        // Avoid attempting to calculate a value for data-driven properties if `feature` is undefined.
+        if (declaration && (declaration.expression.isFeatureConstant || feature)) {
             return declaration.calculate(globals, feature);
         } else {
             return specification.default;
@@ -162,7 +163,8 @@ class StyleLayer extends Evented {
         const specification = this._paintSpecifications[name];
         const transition = this._paintTransitions[name];
 
-        if (transition) {
+        // Avoid attempting to calculate a value for data-driven properties if `feature` is undefined.
+        if (transition && (transition.declaration.expression.isFeatureConstant || feature)) {
             return transition.calculate(globals, feature);
         } else if (specification.type === 'color' && specification.default) {
             return parseColor(specification.default);

--- a/test/unit/style/style_layer.test.js
+++ b/test/unit/style/style_layer.test.js
@@ -414,6 +414,37 @@ test('StyleLayer#serialize', (t) => {
     t.end();
 });
 
+test('StyleLayer#getPaintValue', (t) => {
+    t.test('returns property default if the value is data-driven and no feature is provided', (t) => {
+        const layer = StyleLayer.create({
+            "type": "circle",
+            "paint": {
+                "circle-opacity": ["get", "opacity"]
+            }
+        });
+        layer.updatePaintTransitions({});
+        t.deepEqual(layer.getPaintValue("circle-opacity"), 1);
+        t.end();
+    });
+
+    t.end();
+});
+
+test('StyleLayer#getLayoutValue', (t) => {
+    t.test('returns property default if the value is data-driven and no feature is provided', (t) => {
+        const layer = StyleLayer.create({
+            "type": "symbol",
+            "layout": {
+                "icon-rotate": ["get", "rotate"]
+            }
+        });
+        t.deepEqual(layer.getLayoutValue("icon-rotate"), 0);
+        t.end();
+    });
+
+    t.end();
+});
+
 test('StyleLayer#getLayoutValue (default exceptions)', (t) => {
     t.test('symbol-placement:point => *-rotation-alignment:viewport', (t) => {
         const layer = StyleLayer.create({


### PR DESCRIPTION
Fixes #5431 