### PR TITLE
Canvas Source Performance Increase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mapbox-gl",
+  "name": "@3drobotics/mapbox-gl",
   "description": "A WebGL interactive maps library",
   "version": "0.40.1",
   "main": "dist/mapbox-gl.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@3drobotics/mapbox-gl",
+  "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
   "version": "0.40.1",
   "main": "dist/mapbox-gl.js",

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -98,7 +98,6 @@ class CanvasSource extends ImageSource {
     }
 
     prepare() {
-        console.log('prepare');
         if (this._hasInvalidDimensions()) return;
 
         if (Object.keys(this.tiles).length === 0) return; // not enough data for current position

--- a/test/unit/source/canvas_source.test.js
+++ b/test/unit/source/canvas_source.test.js
@@ -18,7 +18,6 @@ function createSource(options) {
     options = util.extend({
         canvas: 'id',
         coordinates: [[0, 0], [1, 0], [1, 1], [0, 1]],
-        contextType: '2d'
     }, options);
 
     const source = new CanvasSource('id', options, { send: function() {} }, options.eventedParent);


### PR DESCRIPTION
A [recent fix](https://github.com/mapbox/mapbox-gl-js/pull/5155) for GPU related bug introduced a large performance hit to animated canvas sources. The intermediary step of copying data to an `ImageData` object, particularly with large canvases (my use case is 3000x3000), caused an unacceptable frame drop for my users.

This PR removes the intermediate step. The result is a dramatic increase in performance, back to 60fps.

I have confirmed that the change works with previously affected broadwell line GPUs referenced here: https://github.com/mapbox/mapbox-gl-js/issues/4262

`contextType` is no longer needed when creating a canvas source.

Tests do not need an update since there is not a good way to test rendering at the moment (see https://github.com/mapbox/mapbox-gl-js/pull/5303). 

I appreciate all the effort that was put into confirming and working around the GPU issue when it was first presented. It would seem as though the work around is not needed anymore. I don't know if that's the result of a change somewhere else in the mapbox codebase or something else entirely. 

Happy to answer questions.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] manually test the debug page

fixes https://github.com/mapbox/mapbox-gl-js/issues/5301