### PR TITLE
Revert CanvasSource intermediary image buffer fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mapbox-gl",
+  "name": "@3drobotics/mapbox-gl",
   "description": "A WebGL interactive maps library",
   "version": "0.40.1",
   "main": "dist/mapbox-gl.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@3drobotics/mapbox-gl",
+  "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
   "version": "0.40.1",
   "main": "dist/mapbox-gl.js",

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -97,12 +97,34 @@ class CanvasSource extends ImageSource {
         this.pause();
     }
 
+    /**
+     * Sets the canvas's coordinates and re-renders the map.
+     *
+     * @method setCoordinates
+     * @param {Array<Array<number>>} coordinates Four geographical coordinates,
+     *   represented as arrays of longitude and latitude numbers, which define the corners of the canvas.
+     *   The coordinates start at the top left corner of the canvas and proceed in clockwise order.
+     *   They do not have to represent a rectangle.
+     * @returns {CanvasSource} this
+     */
+    // setCoordinates inherited from ImageSource
+
     prepare() {
+        let resize = false;
+        if (this.canvas.width !== this.width) {
+            this.width = this.canvas.width;
+            resize = true;
+        }
+        if (this.canvas.height !== this.height) {
+            this.height = this.canvas.height;
+            resize = true;
+        }
+
         if (this._hasInvalidDimensions()) return;
 
         if (Object.keys(this.tiles).length === 0) return; // not enough data for current position
 
-        this._prepareImage(this.map.painter.gl, this.canvas, true);
+        this._prepareImage(this.map.painter.gl, this.canvas, resize);
     }
 
     serialize(): Object {

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -98,7 +98,6 @@ class CanvasSource extends ImageSource {
     }
 
     prepare() {
-        console.log('prepare');
         if (this._hasInvalidDimensions()) return;
 
         if (Object.keys(this.tiles).length === 0) return; // not enough data for current position

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -204,7 +204,7 @@ class ImageSource extends Evented implements Source {
             this.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
         } else if (resize) {
             this.texture.update(image);
-        } else if (image instanceof window.HTMLVideoElement || image instanceof window.ImageData) {
+        } else if (image instanceof window.HTMLVideoElement || image instanceof window.ImageData || image instanceof window.HTMLCanvasElement) {
             this.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, image);
         }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -302,25 +302,6 @@
       "type": "string",
       "required": true,
       "doc": "HTML ID of the canvas from which to read pixels."
-    },
-    "contextType": {
-      "required": true,
-      "type": "enum",
-      "values": {
-        "2d": {
-          "doc" : "Source canvas is associated with a `2d` drawing context."
-        },
-        "webgl": {
-          "doc": "Source canvas is associated with a `webgl` drawing context."
-        },
-        "experimental-webgl": {
-          "doc": "Source canvas is associated with an `experimental-webgl` drawing context."
-        },
-        "webgl2": {
-          "doc": "Source canvas is associated with a `webgl2` drawing context."
-        }
-      },
-      "doc": "The context identifier defining the drawing context associated to the source canvas (see HTMLCanvasElement.getContext() documentation)."
     }
   },
   "layer": {

--- a/test/unit/source/canvas_source.test.js
+++ b/test/unit/source/canvas_source.test.js
@@ -18,7 +18,6 @@ function createSource(options) {
     options = util.extend({
         canvas: 'id',
         coordinates: [[0, 0], [1, 0], [1, 1], [0, 1]],
-        contextType: '2d'
     }, options);
 
     const source = new CanvasSource('id', options, { send: function() {} }, options.eventedParent);


### PR DESCRIPTION
Moving #5448 here to 🚢 in time for the next release. Thanks so much @gpbmike!

⚠️ **BREAKING** ⚠️: awkwardly, this reverts the breaking change introduced in #5155 and canvas sources will no longer have a `contextType` parameter, which is ultimately for the better, but… 😬 

> A recent fix for GPU related bug introduced a large performance hit to animated canvas sources. The intermediary step of copying data to an `ImageData` object, particularly with large canvases (my use case is 3000x3000), caused an unacceptable frame drop for my users.
> 
> This PR removes the intermediate step. The result is a dramatic increase in performance, back to 60fps.
> 
> I have confirmed that the change works with previously affected broadwell line GPUs referenced here: #4262
> 
> `contextType` is no longer needed when creating a canvas source.
> 
> Tests do not need an update since there is not a good way to test rendering at the moment (see #5303).
> 
> I appreciate all the effort that was put into confirming and working around the GPU issue when it was first presented. It would seem as though the work around is not needed anymore. I don't know if that's the result of a change somewhere else in the mapbox codebase or something else entirely.

