### PR TITLE
Ensure worker callbacks are cleaned up

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -223,11 +223,11 @@ class GeoJSONSource extends Evented implements Source {
 
     unloadTile(tile: Tile) {
         tile.unloadVectorData();
-        this.dispatcher.send('removeTile', { uid: tile.uid, type: this.type, source: this.id }, () => {}, tile.workerID);
+        this.dispatcher.send('removeTile', { uid: tile.uid, type: this.type, source: this.id }, null, tile.workerID);
     }
 
     onRemove() {
-        this.dispatcher.broadcast('removeSource', { type: this.type, source: this.id }, () => {});
+        this.dispatcher.broadcast('removeSource', { type: this.type, source: this.id });
     }
 
     serialize() {

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -204,8 +204,9 @@ class GeoJSONSource extends Evented implements Source {
         tile.workerID = this.dispatcher.send(message, params, (err, data) => {
             tile.unloadVectorData();
 
-            if (tile.aborted)
-                return;
+            if (tile.aborted) {
+                return callback(null);
+            }
 
             if (err) {
                 return callback(err);

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -178,10 +178,11 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
         }
     }
 
-    removeSource(params: {source: string}) {
+    removeSource(params: {source: string}, callback: Callback<mixed>) {
         if (this._geoJSONIndexes[params.source]) {
             delete this._geoJSONIndexes[params.source];
         }
+        callback();
     }
 }
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -120,15 +120,17 @@ class RasterTileSource extends Evented implements Source {
         });
     }
 
-    abortTile(tile: Tile) {
+    abortTile(tile: Tile, callback: Callback<void>) {
         if (tile.request) {
             tile.request.abort();
             delete tile.request;
         }
+        callback();
     }
 
-    unloadTile(tile: Tile) {
+    unloadTile(tile: Tile, callback: Callback<void>) {
         if (tile.texture) this.map.painter.saveTileTexture(tile.texture);
+        callback();
     }
 }
 

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -60,8 +60,8 @@ export interface Source {
 
     loadTile(tile: Tile, callback: Callback<void>): void;
     +hasTile?: (coord: TileCoord) => boolean;
-    +abortTile?: (tile: Tile) => void;
-    +unloadTile?: (tile: Tile) => void;
+    +abortTile?: (tile: Tile, callback: Callback<void>) => void;
+    +unloadTile?: (tile: Tile, callback: Callback<void>) => void;
 
     /**
      * @returns A plain (stringifiable) JS object representing the current state of the source.

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -148,12 +148,12 @@ class SourceCache extends Evented {
 
     _unloadTile(tile: Tile) {
         if (this._source.unloadTile)
-            return this._source.unloadTile(tile);
+            return this._source.unloadTile(tile, () => {});
     }
 
     _abortTile(tile: Tile) {
         if (this._source.abortTile)
-            return this._source.abortTile(tile);
+            return this._source.abortTile(tile, () => {});
     }
 
     serialize() {

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -114,7 +114,7 @@ class VectorTileSource extends Evented implements Source {
 
         function done(err, data) {
             if (tile.aborted)
-                return;
+                return callback(null);
 
             if (err) {
                 return callback(err);

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -163,13 +163,14 @@ class VectorTileWorkerSource implements WorkerSource {
      * @param params.source The id of the source for which we're loading this tile.
      * @param params.uid The UID for this tile.
      */
-    abortTile(params: TileParameters) {
+    abortTile(params: TileParameters, callback: WorkerTileCallback) {
         const loading = this.loading[params.source],
             uid = params.uid;
         if (loading && loading[uid] && loading[uid].abort) {
             loading[uid].abort();
             delete loading[uid];
         }
+        callback();
     }
 
     /**
@@ -179,12 +180,13 @@ class VectorTileWorkerSource implements WorkerSource {
      * @param params.source The id of the source for which we're loading this tile.
      * @param params.uid The UID for this tile.
      */
-    removeTile(params: TileParameters) {
+    removeTile(params: TileParameters, callback: WorkerTileCallback) {
         const loaded = this.loaded[params.source],
             uid = params.uid;
         if (loaded && loaded[uid]) {
             delete loaded[uid];
         }
+        callback();
     }
 }
 

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -50,7 +50,10 @@ function loadVectorTile(params: WorkerTileParameters, callback: LoadVectorDataCa
             });
         }
     });
-    return () => { xhr.abort(); };
+    return () => {
+        xhr.abort();
+        callback();
+    };
 }
 
 /**

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -58,12 +58,14 @@ class Worker {
         };
     }
 
-    setLayers(mapId: string, layers: Array<LayerSpecification>) {
+    setLayers(mapId: string, layers: Array<LayerSpecification>, callback: WorkerTileCallback) {
         this.getLayerIndex(mapId).replace(layers);
+        callback();
     }
 
-    updateLayers(mapId: string, params: {layers: Array<LayerSpecification>, removedIds: Array<string>, symbolOrder: ?Array<string>}) {
+    updateLayers(mapId: string, params: {layers: Array<LayerSpecification>, removedIds: Array<string>, symbolOrder: ?Array<string>}, callback: WorkerTileCallback) {
         this.getLayerIndex(mapId).update(params.layers, params.removedIds, params.symbolOrder);
+        callback();
     }
 
     loadTile(mapId: string, params: WorkerTileParameters & {type: string}, callback: WorkerTileCallback) {
@@ -76,21 +78,23 @@ class Worker {
         this.getWorkerSource(mapId, params.type).reloadTile(params, callback);
     }
 
-    abortTile(mapId: string, params: TileParameters & {type: string}) {
+    abortTile(mapId: string, params: TileParameters & {type: string}, callback: WorkerTileCallback) {
         assert(params.type);
-        this.getWorkerSource(mapId, params.type).abortTile(params);
+        this.getWorkerSource(mapId, params.type).abortTile(params, callback);
     }
 
-    removeTile(mapId: string, params: TileParameters & {type: string}) {
+    removeTile(mapId: string, params: TileParameters & {type: string}, callback: WorkerTileCallback) {
         assert(params.type);
-        this.getWorkerSource(mapId, params.type).removeTile(params);
+        this.getWorkerSource(mapId, params.type).removeTile(params, callback);
     }
 
-    removeSource(mapId: string, params: {source: string} & {type: string}) {
+    removeSource(mapId: string, params: {source: string} & {type: string}, callback: WorkerTileCallback) {
         assert(params.type);
         const worker = this.getWorkerSource(mapId, params.type);
         if (worker.removeSource !== undefined) {
-            worker.removeSource(params);
+            worker.removeSource(params, callback);
+        } else {
+            callback();
         }
     }
 

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -69,12 +69,12 @@ export interface WorkerSource {
     /**
      * Aborts loading a tile that is in progress.
      */
-    abortTile(params: TileParameters): void;
+    abortTile(params: TileParameters, callback: WorkerTileCallback): void;
 
     /**
      * Removes this tile from any local caches.
      */
-    removeTile(params: TileParameters): void;
+    removeTile(params: TileParameters, callback: WorkerTileCallback): void;
 
-    removeSource?: (params: {source: string}) => void;
+    removeSource?: (params: {source: string}, callback: WorkerTileCallback) => void;
 }

--- a/src/util/dispatcher.js
+++ b/src/util/dispatcher.js
@@ -36,10 +36,15 @@ class Dispatcher {
      * Broadcast a message to all Workers.
      */
     broadcast(type: string, data: mixed, cb?: Function) {
-        cb = cb || function () {};
-        util.asyncAll(this.actors, (actor, done) => {
-            actor.send(type, data, done);
-        }, cb);
+        if (cb) {
+            util.asyncAll(this.actors, (actor, done) => {
+                actor.send(type, data, done);
+            }, cb);
+        } else {
+            this.actors.forEach(actor => {
+                actor.send(type, data);
+            });
+        }
     }
 
     /**

--- a/src/util/dispatcher.js
+++ b/src/util/dispatcher.js
@@ -52,7 +52,7 @@ class Dispatcher {
      * @param targetID The ID of the Worker to which to send this message. Omit to allow the dispatcher to choose.
      * @returns The ID of the worker to which the message was sent.
      */
-    send(type: string, data: mixed, callback?: Function, targetID?: number, buffers?: Array<Transferable>): number {
+    send(type: string, data: mixed, callback?: ?Function, targetID?: number, buffers?: Array<Transferable>): number {
         if (typeof targetID !== 'number' || isNaN(targetID)) {
             // Use round robin to send requests to web workers.
             targetID = this.currentActor = (this.currentActor + 1) % this.actors.length;

--- a/src/util/dispatcher.js
+++ b/src/util/dispatcher.js
@@ -36,15 +36,10 @@ class Dispatcher {
      * Broadcast a message to all Workers.
      */
     broadcast(type: string, data: mixed, cb?: Function) {
-        if (cb) {
-            util.asyncAll(this.actors, (actor, done) => {
-                actor.send(type, data, done);
-            }, cb);
-        } else {
-            this.actors.forEach(actor => {
-                actor.send(type, data);
-            });
-        }
+        cb = cb || function () {};
+        util.asyncAll(this.actors, (actor, done) => {
+            actor.send(type, data, done);
+        }, cb);
     }
 
     /**

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -82,7 +82,7 @@ test('GeoJSONSource#onRemove', (t) => {
     t.test('broadcasts "removeSource" event', (t) => {
         const source = new GeoJSONSource('id', {data: {}}, {
             broadcast: function (type, data, callback) {
-                callback();
+                t.false(callback);
                 t.equal(type, 'removeSource');
                 t.deepEqual(data, { type: 'geojson', source: 'id' });
                 t.end();

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -38,7 +38,10 @@ test('removeSource', (t) => {
         addData(() => {
             loadTile((vectorTile) => {
                 t.notEqual(vectorTile, null);
-                source.removeSource({ source: 'source' });
+                source.removeSource({ source: 'source' }, (err, res) => {
+                    t.false(err);
+                    t.false(res);
+                });
                 loadTile((vectorTile) => {
                     t.equal(vectorTile, null);
                     t.end();

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -20,6 +20,9 @@ test('abortTile', (t) => {
         source.abortTile({
             source: 'source',
             uid: 0
+        }, (err, res) => {
+            t.false(err);
+            t.false(res);
         });
 
         t.deepEqual(source.loading, { source: {} });
@@ -42,6 +45,9 @@ test('removeTile', (t) => {
         source.removeTile({
             source: 'source',
             uid: 0
+        }, (err, res) => {
+            t.false(err);
+            t.false(res);
         });
 
         t.deepEqual(source.loaded, { source: {} });

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -12,7 +12,10 @@ test('abortTile', (t) => {
             source: 'source',
             uid: 0,
             request: { url: 'http://localhost:2900/abort' }
-        }, t.fail);
+        }, (err, res) => {
+            t.false(err);
+            t.false(res);
+        });
 
         source.abortTile({
             source: 'source',

--- a/test/unit/source/worker.test.js
+++ b/test/unit/source/worker.test.js
@@ -33,12 +33,12 @@ test('isolates different instances\' data', (t) => {
 
     worker.setLayers(0, [
         { id: 'one', type: 'circle' }
-    ]);
+    ], () => {});
 
     worker.setLayers(1, [
         { id: 'one', type: 'circle' },
         { id: 'two', type: 'circle' },
-    ]);
+    ], () => {});
 
     t.notEqual(worker.layerIndexes[0], worker.layerIndexes[1]);
     t.end();


### PR DESCRIPTION
Fix for #5443 

The main change is adding a no callback path to `Dispatcher.broadcast`. I originally started to do this in `util.asyncAll`, but the required type changes were rippling further than I was comfortable with.

My primary testing method was to run this from the console: `map.style.dispatcher.actors.reduce((total, actor) => Object.keys(actor.callbacks).length + total, 0)`

With this set of fixes, the count always settled back down to zero across a variety of layer types.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
