### PR TITLE
Set cache size based on correct tile size rather than global map tile…

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -324,8 +324,8 @@ class SourceCache extends Evented {
      * the map is more important.
      */
     updateCacheSize(transform: Transform) {
-        const widthInTiles = Math.ceil(transform.width / transform.tileSize) + 1;
-        const heightInTiles = Math.ceil(transform.height / transform.tileSize) + 1;
+        const widthInTiles = Math.ceil(transform.width / this._source.tileSize) + 1;
+        const heightInTiles = Math.ceil(transform.height / this._source.tileSize) + 1;
         const approxTilesInView = widthInTiles * heightInTiles;
         const commonZoomRange = 5;
 
@@ -344,7 +344,6 @@ class SourceCache extends Evented {
         if (!this._sourceLoaded || this._paused) { return; }
 
         this.updateCacheSize(transform);
-
         // Covered is a list of retained tiles who's areas are fully covered by other,
         // better, retained tiles. They are not drawn separately.
         this._coveredTiles = {};

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -1372,3 +1372,37 @@ test('SourceCache reloads expiring tiles', (t) => {
 
     t.end();
 });
+
+test('SourceCache sets max cache size correctly', (t) => {
+    t.test('sets cache size based on 512 tiles', (t) => {
+        const sourceCache = createSourceCache({
+            tileSize: 256
+        });
+
+        const tr = new Transform();
+        tr.width = 512;
+        tr.height = 512;
+        sourceCache.updateCacheSize(tr);
+
+        // Expect max size to be ((512 / tileSize + 1) ^ 2) * 5 => 3 * 3 * 5
+        t.equal(sourceCache._cache.max, 45);
+        t.end();
+    });
+
+    t.test('sets cache size based on 256 tiles', (t) => {
+        const sourceCache = createSourceCache({
+            tileSize: 512
+        });
+
+        const tr = new Transform();
+        tr.width = 512;
+        tr.height = 512;
+        sourceCache.updateCacheSize(tr);
+
+        // Expect max size to be ((512 / tileSize + 1) ^ 2) * 5 => 2 * 2 * 5
+        t.equal(sourceCache._cache.max, 20);
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
This correctly sets source cache size based on a source's tile size, rather than a global 512 tile size. See https://github.com/mapbox/mapbox-gl-js/issues/4313 for extended description.

Fixes https://github.com/mapbox/mapbox-gl-js/issues/4313.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
