### PR TITLE
Redirects the old heatmap example link

### DIFF
--- a/docs/_posts/redirects/3400-01-05-heatmap.html
+++ b/docs/_posts/redirects/3400-01-05-heatmap.html
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /example/heatmap/
+redirect: /example/heatmap-layer/
+---


### PR DESCRIPTION
Redirects the old heatmap example link (/example/heatmap/) to the new [heatmap layer example](https://www.mapbox.com/mapbox-gl-js/example/heatmap-layer) (/example/heatmap-layer/).