### PR TITLE
Fix bug in multi-signature expression type inference

### DIFF
--- a/src/style-spec/expression/compound_expression.js
+++ b/src/style-spec/expression/compound_expression.js
@@ -51,12 +51,14 @@ class CompoundExpression implements Expression {
         const type = Array.isArray(definition) ?
             definition[0] : definition.type;
 
-        const overloads = Array.isArray(definition) ?
+        const availableOverloads = Array.isArray(definition) ?
             [[definition[1], definition[2]]] :
-            definition.overloads.filter(([signature]) => (
-                !Array.isArray(signature) || // varags
-                signature.length === args.length - 1 // correct param count
-            ));
+            definition.overloads;
+
+        const overloads = availableOverloads.filter(([signature]) => (
+            !Array.isArray(signature) || // varags
+            signature.length === args.length - 1 // correct param count
+        ));
 
         // First parse all the args
         const parsedArgs: Array<Expression> = [];
@@ -104,7 +106,8 @@ class CompoundExpression implements Expression {
         if (overloads.length === 1) {
             context.errors.push.apply(context.errors, signatureContext.errors);
         } else {
-            const signatures = overloads
+            const expected = overloads.length ? overloads : availableOverloads;
+            const signatures = expected
                 .map(([params]) => stringifySignature(params))
                 .join(' | ');
             const actualTypes = parsedArgs

--- a/src/style-spec/expression/compound_expression.js
+++ b/src/style-spec/expression/compound_expression.js
@@ -53,9 +53,9 @@ class CompoundExpression implements Expression {
 
         const overloads = Array.isArray(definition) ?
             [[definition[1], definition[2]]] :
-            definition.overloads.filter(overload => (
-                !Array.isArray(overload[0][0]) || // varags
-                overload[0][0].length === args.length - 1 // correct param count
+            definition.overloads.filter(([signature]) => (
+                !Array.isArray(signature) || // varags
+                signature.length === args.length - 1 // correct param count
             ));
 
         // First parse all the args
@@ -99,7 +99,7 @@ class CompoundExpression implements Expression {
             }
         }
 
-        assert(signatureContext.errors.length > 0);
+        assert(!signatureContext || signatureContext.errors.length > 0);
 
         if (overloads.length === 1) {
             context.errors.push.apply(context.errors, signatureContext.errors);

--- a/test/integration/expression-tests/minus/inference-arity-2/test.json
+++ b/test/integration/expression-tests/minus/inference-arity-2/test.json
@@ -1,0 +1,13 @@
+{
+  "expression": ["-", ["get", "x"], 7],
+  "inputs": [[{}, {"properties": {"x": 0}}]],
+  "expected": {
+    "outputs": [-7],
+    "compiled": {
+      "result": "success",
+      "isZoomConstant": true,
+      "isFeatureConstant": false,
+      "type": "number"
+    }
+  }
+}

--- a/test/unit/style-spec/fixture/filters.output.json
+++ b/test/unit/style-spec/fixture/filters.output.json
@@ -44,7 +44,7 @@
     "line": 103
   },
   {
-    "message": "layers[12].filter: Expected arguments of type (string) | (string, object), but found (string, string) instead.",
+    "message": "layers[12].filter[2]: Expected object but found string instead.",
     "line": 131
   },
   {


### PR DESCRIPTION
`overload[0][0]` was one level too deep; since `overload[0][0]` actually referred to the first parameter of the first signature, `Array.isArray(overload[0][0])` was always true, so we checked both the 1-ary and 2-ary versions of of `"-"` even when there were two arguments.