### PR TITLE
Fix typo in style spec

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1947,7 +1947,7 @@
         "group": "Color"
       },
       "get": {
-        "doc": "Retrieves an the object property value.  If it's not provided, the object argument defaults to [\"properties\"].  Returns null if the requested property is missing from the object.",
+        "doc": "Retrieves an object property value.  If it's not provided, the object argument defaults to [\"properties\"].  Returns null if the requested property is missing from the object.",
         "group": "Lookup"
       },
       "has": {


### PR DESCRIPTION
Removes unnecessary `"the"`.