### PR TITLE
fix flow-typed style-spec generator

### DIFF
--- a/build/generate-flow-typed-style-spec.js
+++ b/build/generate-flow-typed-style-spec.js
@@ -87,11 +87,11 @@ function flowLayer(key) {
     delete layer['paint.*'];
 
     layer.paint.type = () => {
-        return flowObject(spec[`layout_${key}`], '    ', '|');
+        return flowObject(spec[`paint_${key}`], '    ', '|');
     };
 
     layer.layout.type = () => {
-        return flowObject(spec[`paint_${key}`], '    ', '|');
+        return flowObject(spec[`layout_${key}`], '    ', '|');
     };
 
     if (key === 'background') {

--- a/flow-typed/style-spec.js
+++ b/flow-typed/style-spec.js
@@ -131,6 +131,9 @@ declare type FillLayerSpecification = {|
     "maxzoom"?: number,
     "filter"?: FilterSpecification,
     "layout"?: {|
+        "visibility"?: "visible" | "none"
+    |},
+    "paint"?: {|
         "fill-antialias"?: PropertyValueSpecification<boolean>,
         "fill-opacity"?: DataDrivenPropertyValueSpecification<number>,
         "fill-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
@@ -138,9 +141,6 @@ declare type FillLayerSpecification = {|
         "fill-translate"?: PropertyValueSpecification<[number, number]>,
         "fill-translate-anchor"?: PropertyValueSpecification<"map" | "viewport">,
         "fill-pattern"?: PropertyValueSpecification<string>
-    |},
-    "paint"?: {|
-        "visibility"?: "visible" | "none"
     |}
 |}
 
@@ -154,6 +154,13 @@ declare type LineLayerSpecification = {|
     "maxzoom"?: number,
     "filter"?: FilterSpecification,
     "layout"?: {|
+        "line-cap"?: PropertyValueSpecification<"butt" | "round" | "square">,
+        "line-join"?: DataDrivenPropertyValueSpecification<"bevel" | "round" | "miter">,
+        "line-miter-limit"?: PropertyValueSpecification<number>,
+        "line-round-limit"?: PropertyValueSpecification<number>,
+        "visibility"?: "visible" | "none"
+    |},
+    "paint"?: {|
         "line-opacity"?: DataDrivenPropertyValueSpecification<number>,
         "line-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
         "line-translate"?: PropertyValueSpecification<[number, number]>,
@@ -164,13 +171,6 @@ declare type LineLayerSpecification = {|
         "line-blur"?: DataDrivenPropertyValueSpecification<number>,
         "line-dasharray"?: PropertyValueSpecification<Array<number>>,
         "line-pattern"?: PropertyValueSpecification<string>
-    |},
-    "paint"?: {|
-        "line-cap"?: PropertyValueSpecification<"butt" | "round" | "square">,
-        "line-join"?: DataDrivenPropertyValueSpecification<"bevel" | "round" | "miter">,
-        "line-miter-limit"?: PropertyValueSpecification<number>,
-        "line-round-limit"?: PropertyValueSpecification<number>,
-        "visibility"?: "visible" | "none"
     |}
 |}
 
@@ -184,22 +184,6 @@ declare type SymbolLayerSpecification = {|
     "maxzoom"?: number,
     "filter"?: FilterSpecification,
     "layout"?: {|
-        "icon-opacity"?: DataDrivenPropertyValueSpecification<number>,
-        "icon-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
-        "icon-halo-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
-        "icon-halo-width"?: DataDrivenPropertyValueSpecification<number>,
-        "icon-halo-blur"?: DataDrivenPropertyValueSpecification<number>,
-        "icon-translate"?: PropertyValueSpecification<[number, number]>,
-        "icon-translate-anchor"?: PropertyValueSpecification<"map" | "viewport">,
-        "text-opacity"?: DataDrivenPropertyValueSpecification<number>,
-        "text-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
-        "text-halo-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
-        "text-halo-width"?: DataDrivenPropertyValueSpecification<number>,
-        "text-halo-blur"?: DataDrivenPropertyValueSpecification<number>,
-        "text-translate"?: PropertyValueSpecification<[number, number]>,
-        "text-translate-anchor"?: PropertyValueSpecification<"map" | "viewport">
-    |},
-    "paint"?: {|
         "symbol-placement"?: PropertyValueSpecification<"point" | "line">,
         "symbol-spacing"?: PropertyValueSpecification<number>,
         "symbol-avoid-edges"?: PropertyValueSpecification<boolean>,
@@ -237,6 +221,22 @@ declare type SymbolLayerSpecification = {|
         "text-ignore-placement"?: PropertyValueSpecification<boolean>,
         "text-optional"?: PropertyValueSpecification<boolean>,
         "visibility"?: "visible" | "none"
+    |},
+    "paint"?: {|
+        "icon-opacity"?: DataDrivenPropertyValueSpecification<number>,
+        "icon-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
+        "icon-halo-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
+        "icon-halo-width"?: DataDrivenPropertyValueSpecification<number>,
+        "icon-halo-blur"?: DataDrivenPropertyValueSpecification<number>,
+        "icon-translate"?: PropertyValueSpecification<[number, number]>,
+        "icon-translate-anchor"?: PropertyValueSpecification<"map" | "viewport">,
+        "text-opacity"?: DataDrivenPropertyValueSpecification<number>,
+        "text-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
+        "text-halo-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
+        "text-halo-width"?: DataDrivenPropertyValueSpecification<number>,
+        "text-halo-blur"?: DataDrivenPropertyValueSpecification<number>,
+        "text-translate"?: PropertyValueSpecification<[number, number]>,
+        "text-translate-anchor"?: PropertyValueSpecification<"map" | "viewport">
     |}
 |}
 
@@ -250,6 +250,9 @@ declare type CircleLayerSpecification = {|
     "maxzoom"?: number,
     "filter"?: FilterSpecification,
     "layout"?: {|
+        "visibility"?: "visible" | "none"
+    |},
+    "paint"?: {|
         "circle-radius"?: DataDrivenPropertyValueSpecification<number>,
         "circle-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
         "circle-blur"?: DataDrivenPropertyValueSpecification<number>,
@@ -261,9 +264,6 @@ declare type CircleLayerSpecification = {|
         "circle-stroke-width"?: DataDrivenPropertyValueSpecification<number>,
         "circle-stroke-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
         "circle-stroke-opacity"?: DataDrivenPropertyValueSpecification<number>
-    |},
-    "paint"?: {|
-        "visibility"?: "visible" | "none"
     |}
 |}
 
@@ -277,14 +277,14 @@ declare type HeatmapLayerSpecification = {|
     "maxzoom"?: number,
     "filter"?: FilterSpecification,
     "layout"?: {|
+        "visibility"?: "visible" | "none"
+    |},
+    "paint"?: {|
         "heatmap-radius"?: PropertyValueSpecification<number>,
         "heatmap-weight"?: DataDrivenPropertyValueSpecification<number>,
         "heatmap-intensity"?: PropertyValueSpecification<number>,
         "heatmap-color"?: PropertyValueSpecification<ColorSpecification>,
         "heatmap-opacity"?: PropertyValueSpecification<number>
-    |},
-    "paint"?: {|
-        "visibility"?: "visible" | "none"
     |}
 |}
 
@@ -298,6 +298,9 @@ declare type FillExtrusionLayerSpecification = {|
     "maxzoom"?: number,
     "filter"?: FilterSpecification,
     "layout"?: {|
+        "visibility"?: "visible" | "none"
+    |},
+    "paint"?: {|
         "fill-extrusion-opacity"?: PropertyValueSpecification<number>,
         "fill-extrusion-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
         "fill-extrusion-translate"?: PropertyValueSpecification<[number, number]>,
@@ -305,9 +308,6 @@ declare type FillExtrusionLayerSpecification = {|
         "fill-extrusion-pattern"?: PropertyValueSpecification<string>,
         "fill-extrusion-height"?: DataDrivenPropertyValueSpecification<number>,
         "fill-extrusion-base"?: DataDrivenPropertyValueSpecification<number>
-    |},
-    "paint"?: {|
-        "visibility"?: "visible" | "none"
     |}
 |}
 
@@ -321,6 +321,9 @@ declare type RasterLayerSpecification = {|
     "maxzoom"?: number,
     "filter"?: FilterSpecification,
     "layout"?: {|
+        "visibility"?: "visible" | "none"
+    |},
+    "paint"?: {|
         "raster-opacity"?: PropertyValueSpecification<number>,
         "raster-hue-rotate"?: PropertyValueSpecification<number>,
         "raster-brightness-min"?: PropertyValueSpecification<number>,
@@ -328,9 +331,6 @@ declare type RasterLayerSpecification = {|
         "raster-saturation"?: PropertyValueSpecification<number>,
         "raster-contrast"?: PropertyValueSpecification<number>,
         "raster-fade-duration"?: PropertyValueSpecification<number>
-    |},
-    "paint"?: {|
-        "visibility"?: "visible" | "none"
     |}
 |}
 
@@ -341,12 +341,12 @@ declare type BackgroundLayerSpecification = {|
     "minzoom"?: number,
     "maxzoom"?: number,
     "layout"?: {|
+        "visibility"?: "visible" | "none"
+    |},
+    "paint"?: {|
         "background-color"?: PropertyValueSpecification<ColorSpecification>,
         "background-pattern"?: PropertyValueSpecification<string>,
         "background-opacity"?: PropertyValueSpecification<number>
-    |},
-    "paint"?: {|
-        "visibility"?: "visible" | "none"
     |}
 |}
 


### PR DESCRIPTION
It seems that `generate-flow-typed-style-spec.js` script mixes up `layout` and `paint` properties, so generated flow types are not consistent with the actual `style-spec`.
