### PR TITLE
Export createFilters from style-spec

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const Point = require('@mapbox/point-geometry');
 const Evented = require('./util/evented');
 const config = require('./util/config');
 const rtlTextPlugin = require('./source/rtl_text_plugin');
+const createFilter = require('./style-spec/feature_filter');
 
 module.exports = {
     version,
@@ -40,6 +41,7 @@ module.exports = {
     Point,
     Evented,
     config,
+    createFilter,
 
     /**
      * Gets and sets the map's [access token](https://www.mapbox.com/help/define-access-token/).


### PR DESCRIPTION
## Launch Checklist

Address #5481

It now exports `createFilters` from `style-spec` to the global `mapboxgl object`.

It is now possible to create custom filters for a GeoJSON collection to be used outside the map using the same powerful style-spec filter language.

### Example

```javascript
const filterDef = ['==', 'type', 'bar'];
const filterFunction = mapboxgl.createFilter(filterDef).bind(null, null); // see comments below
const filteredFeature = myGeoJSONData.features.filter(filterFunction); // will hold only features of type bar
```

#### Why bind(null, null)
I have to set thisArg null and the first param null, because now the compiled filter has a first parameter 'g' which is not clear to me, but wasn't present in v0.40.1, but perhaps has something to do with the new expression filters syntax.

## Possible use cases for this API

An application where I want to show or make available for download only the features visible on the map, by filtering the original data source, using the same filter definition, even in a page that does not display the map.