### PR TITLE
make sure fullscreen works on webkit browsers

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -4,6 +4,10 @@
     position: relative;
     -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
+.mapboxgl-map:-webkit-full-screen {
+    width: 100%;
+    height: 100%;
+}
 
 .mapboxgl-missing-css {
     display: none;


### PR DESCRIPTION
fix #5492 

fullscreen wasn't working in webkit browsers if the map container's width was not explicitly set
https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
