### PR TITLE
add initial bounds as map constructor option #1970

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -196,6 +196,7 @@ const defaultOptions = {
  * @param {number} [options.zoom=0] The initial zoom level of the map. If `zoom` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {number} [options.bearing=0] The initial bearing (rotation) of the map, measured in degrees counter-clockwise from north. If `bearing` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
  * @param {number} [options.pitch=0] The initial pitch (tilt) of the map, measured in degrees away from the plane of the screen (0-60). If `pitch` is not specified in the constructor options, Mapbox GL JS will look for it in the map's style object. If it is not specified in the style, either, it will default to `0`.
+ * @param {LngLatBoundsLike} [options.bounds] The initial bounds of the map. If `bounds` is specified, it overrides `center` and `zoom` constructor options.
  * @param {boolean} [options.renderWorldCopies=true]  If `true`, multiple copies of the world will be rendered, when zoomed out.
  * @param {number} [options.maxTileCacheSize=null]  The maximum number of tiles stored in the tile cache for a given source. If omitted, the cache will be dynamically sized based on the current viewport.
  * @param {string} [options.localIdeographFontFamily=null] If specified, defines a CSS font-family
@@ -369,12 +370,17 @@ class Map extends Camera {
         this._hash = options.hash && (new Hash()).addTo(this);
         // don't set position from options if set through hash
         if (!this._hash || !this._hash._onHashChange()) {
-            this.jumpTo({
-                center: options.center,
-                zoom: options.zoom,
-                bearing: options.bearing,
-                pitch: options.pitch
-            });
+            if (options.bounds) {
+                this.resize();
+                this.fitBounds(options.bounds, { duration: 0 });
+            } else {
+                this.jumpTo({
+                    center: options.center,
+                    zoom: options.zoom,
+                    bearing: options.bearing,
+                    pitch: options.pitch
+                });
+            }
         }
 
         this.resize();

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -367,12 +367,11 @@ class Map extends Camera {
 
         bindHandlers(this, options);
 
-        this.resize();
-
         this._hash = options.hash && (new Hash()).addTo(this);
         // don't set position from options if set through hash
         if (!this._hash || !this._hash._onHashChange()) {
             if (options.bounds) {
+                this.resize();
                 this.fitBounds(options.bounds, { duration: 0 });
             } else {
                 this.jumpTo({
@@ -383,6 +382,8 @@ class Map extends Camera {
                 });
             }
         }
+
+        this.resize();
 
         if (options.style) this.setStyle(options.style, { localIdeographFontFamily: options.localIdeographFontFamily });
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -367,11 +367,12 @@ class Map extends Camera {
 
         bindHandlers(this, options);
 
+        this.resize();
+
         this._hash = options.hash && (new Hash()).addTo(this);
         // don't set position from options if set through hash
         if (!this._hash || !this._hash._onHashChange()) {
             if (options.bounds) {
-                this.resize();
                 this.fitBounds(options.bounds, { duration: 0 });
             } else {
                 this.jumpTo({
@@ -382,8 +383,6 @@ class Map extends Camera {
                 });
             }
         }
-
-        this.resize();
 
         if (options.style) this.setStyle(options.style, { localIdeographFontFamily: options.localIdeographFontFamily });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -62,7 +62,7 @@ test('Map', (t) => {
         const map = createMap(t, {container, bounds});
 
         t.deepEqual(fixedLngLat(map.getCenter(), 4), { lng: -100.5, lat: 34.7171 });
-        t.equal(fixedNum(map.getZoom(), 3), 2.469);
+        t.equal(fixedNum(map.getZoom(), 3), 2.113);
 
         t.end();
     });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -53,6 +53,16 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('initial bounds in constructor options', (t) => {
+        const bounds = [[-133, 16], [-68, 50]];
+        const map = createMap({bounds});
+
+        t.deepEqual(fixedLngLat(map.getCenter(), 4), { lng: -100.5, lat: 34.7171 });
+        t.equal(fixedNum(map.getZoom(), 3), 2.469);
+
+        t.end();
+    });
+
     t.test('disables handlers', (t) => {
         t.test('disables all handlers', (t) => {
             const map = createMap(t, {interactive: false});

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -54,8 +54,12 @@ test('Map', (t) => {
     });
 
     t.test('initial bounds in constructor options', (t) => {
+        const container = window.document.createElement('div');
+        Object.defineProperty(container, 'offsetWidth', {value: 512});
+        Object.defineProperty(container, 'offsetHeight', {value: 512});
+
         const bounds = [[-133, 16], [-68, 50]];
-        const map = createMap({bounds});
+        const map = createMap(t, {container, bounds});
 
         t.deepEqual(fixedLngLat(map.getCenter(), 4), { lng: -100.5, lat: 34.7171 });
         t.equal(fixedNum(map.getZoom(), 3), 2.469);


### PR DESCRIPTION
This PR will add initial bounds as map constructor option according to #1970.

I have a problem implementing the test for this case. Then I manually test new functionality using the debug page, I'm getting the expected result. But the same steps reproduced in test somehow outcomes with different zoom level in the result (`1.113` instead of `2.469`). What can cause this?

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
