### PR TITLE
Fixing padding issues in fitBounds

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -395,7 +395,7 @@ class Camera extends Evented {
         // (lateral and vertical padding), and the part that does (paddingOffset). We add the padding offset
         // to the options `offset` object where it can alter the map's center in the subsequent calls to
         // `easeTo` and `flyTo`.
-        const paddingOffset = [options.padding.left - options.padding.right, options.padding.top - options.padding.bottom],
+        const paddingOffset = [(options.padding.left - options.padding.right) / 2, (options.padding.top - options.padding.bottom) / 2],
             lateralPadding = Math.min(options.padding.right, options.padding.left),
             verticalPadding = Math.min(options.padding.top, options.padding.bottom);
         options.offset = [options.offset[0] + paddingOffset[0], options.offset[1] + paddingOffset[1]];

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1378,7 +1378,7 @@ test('camera', (t) => {
             const bb = [[-133, 16], [-68, 50]];
 
             camera.fitBounds(bb, { padding: {top: 10, right: 75, bottom: 50, left: 25}, duration:0 });
-            t.deepEqual(fixedLngLat(camera.getCenter(), 4), { lng: -91.5221, lat: 28.6089 }, 'pans to coordinates based on fitBounds with padding option as object applied');
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), { lng: -96.5558, lat: 32.0833 }, 'pans to coordinates based on fitBounds with padding option as object applied');
             t.end();
         });
 


### PR DESCRIPTION
This fixes #4846 where the offset from center was incorrectly calculated when there was a difference between top and bottom, or left and right padding. The offset should be half the difference between padding when finding the center.

The example from the original issue showing the error:
http://jsbin.com/nadukifexa/edit?html,output

Same example with this fix:
http://jsbin.com/rihunorico/edit?html,output

## Launch Checklist

 - [x] briefly describe the changes in this PR