### PR TITLE
Fix issue #5516: layers with multiple SDF icons wouldn't load.

### DIFF
--- a/src/symbol/symbol_layout.js
+++ b/src/symbol/symbol_layout.js
@@ -85,7 +85,7 @@ function performSymbolLayout(bucket: SymbolBucket,
                     bucket.layers[0].getLayoutValue('icon-anchor', {zoom: bucket.zoom}, feature));
                 if (bucket.sdfIcons === undefined) {
                     bucket.sdfIcons = image.sdf;
-                } else if (this.sdfIcons !== image.sdf) {
+                } else if (bucket.sdfIcons !== image.sdf) {
                     util.warnOnce('Style sheet warning: Cannot mix SDF and non-SDF icons in one buffer');
                 }
                 if (image.pixelRatio !== bucket.pixelRatio) {


### PR DESCRIPTION
Fixes issue #5516: a typo in the refactoring for #5150 made it so that layers with multiple SDF icons would error out during tile loading trying to dereference `this$1.sdfIcons`.

I haven't figured out a useful regression test for this case. This code is exercised by many of the render tests, but within the test suite it just generates a warning (and only shows it once, so it's easy to miss), and otherwise renders fine. We could try to do something like `eval` the results of a `WebWorkify` call in the test suite version of `web_worker`? That seems like a really heavy solution...

/cc @jfirebaugh 