### PR TITLE
Allow Markdown (but not arbitrary HTML) in example descriptions

### DIFF
--- a/docs/components/example.js
+++ b/docs/components/example.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {prefixUrl} from '@mapbox/batfish/modules/prefix-url';
 import urls from './urls';
+import md from './md';
 import PageShell from './page_shell';
 import LeftNav from './left_nav';
 import TopNav from './top_nav';
@@ -111,7 +112,7 @@ ${html}
                                 `}</style>
 
                                 <div className='prose'>
-                                    <div className='pad2'><strong>{frontMatter.title}</strong><br/>{frontMatter.description}</div>
+                                    <div className='pad2'><strong>{frontMatter.title}</strong><br/>{md(frontMatter.description)}</div>
 
                                     {!supported() &&
                                         <div id='unsupported' className='pad2 hidden dark'>

--- a/docs/components/md.js
+++ b/docs/components/md.js
@@ -1,0 +1,6 @@
+import remark from 'remark';
+import reactRenderer from 'remark-react';
+
+export default function md(str) {
+    return remark().use(reactRenderer).processSync(str).contents;
+}

--- a/docs/pages/example/animate-point-along-route.js
+++ b/docs/pages/example/animate-point-along-route.js
@@ -1,8 +1,7 @@
 /*---
 title: Animate a point along a route
 description: >-
-  Use <a target='_blank' href='http://turfjs.org/'>Turf</a> to smoothly animate
-  a point along the distance of a line.
+  Use [Turf](http://turfjs.org/) to smoothly animate a point along the distance of a line.
 tags:
   - animate
   - camera

--- a/docs/pages/example/attribution-position.js
+++ b/docs/pages/example/attribution-position.js
@@ -1,8 +1,7 @@
 /*---
 title: Change the default position for attribution
 description: >-
-  Place attribution in the <code>top-left</code> position when initializing a
-  map.
+  Place attribution in the `top-left` position when initializing a map.
 tags:
   - controls-and-overlays
 pathname: /mapbox-gl-js/example/attribution-position/

--- a/docs/pages/example/mapbox-gl-compare.js
+++ b/docs/pages/example/mapbox-gl-compare.js
@@ -1,9 +1,7 @@
 /*---
 title: Swipe between maps
 description: >-
-  Use <a target="_blank"
-  href="https://github.com/mapbox/mapbox-gl-compare">mapbox-gl-compare</a> to
-  swipe between map instances &amp; sync their movement.
+  Use [mapbox-gl-compare](https://github.com/mapbox/mapbox-gl-compare) to swipe between and synchronize two maps.
 tags:
   - controls-and-overlays
 pathname: /mapbox-gl-js/example/mapbox-gl-compare/

--- a/docs/pages/example/mapbox-gl-directions.js
+++ b/docs/pages/example/mapbox-gl-directions.js
@@ -1,8 +1,7 @@
 /*---
 title: Display driving directions
 description: >-
-  Use the <a target="_blank"
-  href="https://github.com/mapbox/mapbox-gl-directions">mapbox-gl-directions</a>
+  Use the [mapbox-gl-directions](https://github.com/mapbox/mapbox-gl-directions)
   plugin to show results from the Mapbox Directions API. Click the map to add an
   origin and destination.
 tags:

--- a/docs/pages/example/mapbox-gl-geocoder.js
+++ b/docs/pages/example/mapbox-gl-geocoder.js
@@ -1,8 +1,7 @@
 /*---
 title: Add a geocoder
 description: >-
-  Use the <a target="_blank"
-  href="https://github.com/mapbox/mapbox-gl-geocoder">mapbox-gl-geocoder</a>
+  Use the [mapbox-gl-geocoder](https://github.com/mapbox/mapbox-gl-geocoder)
   control to search for places using Mapbox Geocoding API.
 tags:
   - controls-and-overlays

--- a/docs/pages/example/mapbox-gl-rtl-text.js
+++ b/docs/pages/example/mapbox-gl-rtl-text.js
@@ -1,8 +1,7 @@
 /*---
 title: Add support for right-to-left scripts
 description: >-
-  Use the <a target="_blank"
-  href="https://github.com/mapbox/mapbox-gl-rtl-text">mapbox-gl-rtl-text</a>
+  Use the [mapbox-gl-rtl-text](https://github.com/mapbox/mapbox-gl-rtl-text)
   plugin to support scripts that use right-to-left layout (such as Arabic or
   Hebrew). Note that Studio does not yet support RTL text.
 tags:

--- a/docs/pages/example/measure.js
+++ b/docs/pages/example/measure.js
@@ -1,8 +1,8 @@
 /*---
 title: Measure distances
 description: >-
-  Click points on a map to create lines that measure distanced using <a
-  href="http://turfjs.org/static/docs/module-turf_line-distance.html">turf.lineDistance</a>.
+  Click points on a map to create lines that measure distanced using
+  [turf.lineDistance](http://turfjs.org/static/docs/module-turf_line-distance.html).
 tags:
   - user-interaction
 pathname: /mapbox-gl-js/example/measure/

--- a/docs/pages/example/point-from-geocoder-result.js
+++ b/docs/pages/example/point-from-geocoder-result.js
@@ -1,8 +1,7 @@
 /*---
 title: Set a point after Geocoder result
 description: >-
-  Listen to the <code>geocoder.input</code> event from the <a target="_blank"
-  href="https://github.com/mapbox/mapbox-gl-geocoder">Geocoder plugin</a> and
+  Listen to the `geocoder.input` event from the [Geocoder plugin](https://github.com/mapbox/mapbox-gl-geocoder) and
   place a point on the coordinate results.
 tags:
   - controls-and-overlays

--- a/docs/pages/example/queryrenderedfeatures-around-point.js
+++ b/docs/pages/example/queryrenderedfeatures-around-point.js
@@ -1,6 +1,6 @@
 /*---
 title: Select features around a clicked point
-description: Click on the map to query features using <code>queryRenderedFeatures</code>.
+description: Click on the map to query features using [`queryRenderedFeatures`](https://www.mapbox.com/mapbox-gl-js/api#map#queryrenderedfeatures).
 tags:
   - user-interaction
 pathname: /mapbox-gl-js/example/queryrenderedfeatures-around-point/

--- a/docs/pages/example/restrict-bounds.js
+++ b/docs/pages/example/restrict-bounds.js
@@ -1,8 +1,7 @@
 /*---
 title: Restrict map panning to an area
 description: >-
-  Prevent a map from being panned to a different place by setting
-  <code>maxBounds</code>.
+  Prevent a map from being panned to a different place by setting [`maxBounds`](https://www.mapbox.com/mapbox-gl-js/api#map#setmaxbounds).
 tags:
   - user-interaction
 pathname: /mapbox-gl-js/example/restrict-bounds/

--- a/docs/pages/example/third-party.js
+++ b/docs/pages/example/third-party.js
@@ -1,8 +1,7 @@
 /*---
 title: Add a third party vector tile source
 description: >-
-  Render a map using an external vector source of OpenStreetMap data provided by
-  <a target="_blank" href="http://mapzen.com/vector/">Mapzen</a>.
+  Render a map using an external vector source of OpenStreetMap data provided by [Mapzen](http://mapzen.com/vector/).
 tags:
   - sources
 pathname: /mapbox-gl-js/example/third-party/

--- a/docs/pages/example/using-box-queryrenderedfeatures.js
+++ b/docs/pages/example/using-box-queryrenderedfeatures.js
@@ -1,8 +1,7 @@
 /*---
 title: Highlight features within a bounding box
 description: >-
-  Hold <kbd>Shift</kbd> &amp; drag the map to query features using
-  <code>queryRenderedFeatures</code>.
+  Hold the Shift key and drag the map to query features using `queryRenderedFeatures`.
 tags:
   - user-interaction
 pathname: /mapbox-gl-js/example/using-box-queryrenderedfeatures/

--- a/docs/pages/example/zoomto-linestring.js
+++ b/docs/pages/example/zoomto-linestring.js
@@ -1,10 +1,9 @@
 /*---
 title: Fit to the bounds of a LineString
 description: >-
-  Get the bounds of a LineString by passing it's first coordinates to <a
-  href='https://www.mapbox.com/mapbox-gl-js/api/#LngLatBounds'>mapboxgl.LngLatBounds</a>
-  and chaining <a
-  href='https://www.mapbox.com/mapbox-gl-js/api/#LngLatBounds#extend'>extend</a>
+  Get the bounds of a LineString by passing its first coordinates to
+  [`LngLatBounds`](https://www.mapbox.com/mapbox-gl-js/api/#lnglatbounds)
+  and chaining [`extend`](https://www.mapbox.com/mapbox-gl-js/api/#lnglatbounds#extend)
   to include the last coordinates.
 tags:
   - user-interaction

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import slug from 'slugg';
 import assert from 'assert';
-import remark from 'remark';
-import reactRenderer from 'remark-react';
+import md from '../components/md';
 import PageShell from '../components/page_shell';
 import LeftNav from '../components/left_nav';
 import TopNav from '../components/top_nav';
@@ -221,10 +220,6 @@ const navigation = [
         ]
     }
 ];
-
-function md(str) {
-    return remark().use(reactRenderer).processSync(str).contents;
-}
 
 const sourceTypes = ['vector', 'raster', 'geojson', 'image', 'video', 'canvas'];
 const layerTypes = ['background', 'fill', 'line', 'symbol', 'raster', 'circle', 'fill-extrusion', 'heatmap'];


### PR DESCRIPTION
Fixes https://www.mapbox.com/mapbox-gl-js/example/zoomto-linestring/ and other pages that used markup in the description.