### PR TITLE
Remove gl.lineWidth

### DIFF
--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -7,7 +7,7 @@ import DepthMode from './depth_mode';
 import StencilMode from './stencil_mode';
 import ColorMode from './color_mode';
 import { deepEqual } from '../util/util';
-import { ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, Program, LineWidth, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha } from './value';
+import { ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, Program, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha } from './value';
 
 
 import type {TriangleIndexArray, LineIndexArray} from '../data/index_array_type';
@@ -28,7 +28,6 @@ class Context {
     gl: WebGLRenderingContext;
     extVertexArrayObject: any;
     currentNumAttributes: ?number;
-    lineWidthRange: [number, number];
 
     clearColor: ClearColor;
     clearDepth: ClearDepth;
@@ -46,7 +45,6 @@ class Context {
     blendFunc: BlendFunc;
     blendColor: BlendColor;
     program: Program;
-    lineWidth: LineWidth;
     activeTexture: ActiveTextureUnit;
     viewport: Viewport;
     bindFramebuffer: BindFramebuffer;
@@ -65,7 +63,6 @@ class Context {
     constructor(gl: WebGLRenderingContext) {
         this.gl = gl;
         this.extVertexArrayObject = this.gl.getExtension('OES_vertex_array_object');
-        this.lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
 
         this.clearColor = new ClearColor(this);
         this.clearDepth = new ClearDepth(this);
@@ -83,7 +80,6 @@ class Context {
         this.blendFunc = new BlendFunc(this);
         this.blendColor = new BlendColor(this);
         this.program = new Program(this);
-        this.lineWidth = new LineWidth(this);
         this.activeTexture = new ActiveTextureUnit(this);
         this.viewport = new Viewport(this);
         this.bindFramebuffer = new BindFramebuffer(this);

--- a/src/gl/value.js
+++ b/src/gl/value.js
@@ -2,8 +2,6 @@
 
 import Color from '../style-spec/util/color';
 
-import { clamp } from '../util/util';
-
 import type Context from './context';
 import type {
     BlendFuncType,
@@ -351,27 +349,6 @@ export class Program implements Value<?WebGLProgram> {
     set(v: ?WebGLProgram): void {
         if (this.current !== v) {
             this.context.gl.useProgram(v);
-            this.current = v;
-        }
-    }
-}
-
-export class LineWidth implements Value<number> {
-    context: Context;
-    current: number;
-
-    constructor(context: Context) {
-        this.context = context;
-        this.current = 1;
-    }
-
-    get(): number { return this.current; }
-
-    set(v: number): void {
-        const range = this.context.lineWidthRange;
-        const clamped = clamp(v, range[0], range[1]);
-        if (this.current !== clamped) {
-            this.context.gl.lineWidth(clamped);
             this.current = v;
         }
     }

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -31,10 +31,6 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
 
         gl.uniformMatrix4fv(program.uniforms.u_matrix, false, coord.posMatrix);
 
-        if (!drawCircles) {
-            context.lineWidth.set(1);
-        }
-
         gl.uniform1f(program.uniforms.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);
         const pixelRatio = pixelsToTileUnits(tile, 1, painter.transform.zoom);
         const scale = Math.pow(2, painter.transform.zoom - tile.tileID.overscaledZ);

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -1,7 +1,5 @@
 // @flow
 
-import browser from '../util/browser';
-
 import { mat4 } from 'gl-matrix';
 import EXTENT from '../data/extent';
 import VertexArrayObject from './vertex_array_object';
@@ -25,8 +23,6 @@ function drawDebug(painter: Painter, sourceCache: SourceCache, coords: Array<Ove
 function drawDebugTile(painter, sourceCache, coord) {
     const context = painter.context;
     const gl = context.gl;
-
-    context.lineWidth.set(1 * browser.devicePixelRatio);
 
     const posMatrix = coord.posMatrix;
     const program = painter.useProgram('debug');

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -43,7 +43,6 @@ function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLa
 
     // Draw stroke
     if (painter.renderPass === 'translucent' && layer.paint.get('fill-antialias')) {
-        context.lineWidth.set(2);
 
         // If we defined a different color for the fill outline, we are
         // going to ignore the bits in 0x07 and just care about the global

--- a/test/unit/gl/state.test.js
+++ b/test/unit/gl/state.test.js
@@ -1,11 +1,10 @@
 import { test } from 'mapbox-gl-js-test';
-import { ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, Program, LineWidth, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha } from '../../../src/gl/value';
+import { ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, Program, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha } from '../../../src/gl/value';
 import Context from '../../../src/gl/context';
 import Color from '../../../src/style-spec/util/color';
 import { deepEqual } from '../../../src/util/util';
 
 const context = new Context(require('gl')(10, 10));
-context.lineWidthRange = [0, 1];
 
 function ValueTest(Constructor, options, t) {
     t.test('#constructor', (t) => {
@@ -95,10 +94,6 @@ test('BlendColor', ValueTest.bind(ValueTest, BlendColor, {
 test('Program', ValueTest.bind(ValueTest, Program, {
     equality: (a, b) => a === b,
     setValue: context.gl.createProgram()
-}));
-
-test('LineWidth', ValueTest.bind(ValueTest, LineWidth, {
-    setValue: 0.5
 }));
 
 test('ActiveTextureUnit', ValueTest.bind(ValueTest, ActiveTextureUnit, {


### PR DESCRIPTION
This PR removes the use of `gl.lineWidth` in the few places where we use it: the [MDN doc for `WebGLRenderingContext.lineWidth()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/lineWidth) states

> `gl.lineWidth()` has no effect in common modern browsers. The corresponding [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=60124) and [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=634506) are closed as Won't Fix and the WebGL specification now defines that `gl.lineWidth()` does not change the line width anymore. If you need lines of any width other than 1px, consider drawing a narrow strip of triangles.