### PR TITLE
Upgrade to flow 0.57.3

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,4 +13,4 @@
 unsafe.enable_getters_and_setters=true
 
 [version]
-0.54.1
+0.57.3

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-react": "^7.3.0",
     "execcommand-copy": "^1.1.0",
-    "flow-bin": "^0.54.1",
+    "flow-bin": "^0.57.3",
     "flow-coverage-report": "^0.3.0",
     "flow-remove-types": "^1.0.4",
     "github-slugger": "^1.1.1",

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -19,7 +19,7 @@ const OpacityState = require('../../symbol/opacity_state');
 const {getSizeData} = require('../../symbol/symbol_size');
 
 import type {Feature as ExpressionFeature} from '../../style-spec/expression';
-import type {Bucket, BucketParameters, IndexedFeature, PopulateParameters} from '../bucket';
+import type {Bucket, IndexedFeature, PopulateParameters} from '../bucket';
 import type {ProgramInterface, SerializedProgramConfiguration} from '../program_configuration';
 import type CollisionBoxArray, {CollisionBox} from '../../symbol/collision_box';
 import type {
@@ -28,18 +28,6 @@ import type {
 } from '../../util/struct_array';
 import type SymbolStyleLayer from '../../style/style_layer/symbol_style_layer';
 import type {SymbolQuad} from '../../symbol/quads';
-
-type SymbolBucketParameters = BucketParameters & {
-    sdfIcons: boolean,
-    iconsNeedLinear: boolean,
-    fontstack: string,
-    textSizeData: any,
-    iconSizeData: any,
-    placedGlyphArray: StructArray,
-    placedIconArray: StructArray,
-    glyphOffsetArray: StructArray,
-    lineVertexArray: StructArray,
-}
 
 export type SingleCollisionBox = {
     x1: number;
@@ -399,7 +387,7 @@ class SymbolBucket implements Bucket {
     uploaded: boolean;
     collisionCircle: SymbolBuffers;
 
-    constructor(options: SymbolBucketParameters) {
+    constructor(options: any) {
         this.collisionBoxArray = options.collisionBoxArray;
         this.zoom = options.zoom;
         this.overscaling = options.overscaling;

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -52,8 +52,6 @@ export interface Source {
     reparseOverscaled?: boolean,
     vectorLayerIds?: Array<string>,
 
-    constructor(id: string, source: SourceSpecification, dispatcher: Dispatcher, eventedParent: Evented): Source;
-
     fire(type: string, data: Object): mixed;
 
     +onAdd?: (map: Map) => void;
@@ -75,7 +73,7 @@ export interface Source {
     +prepare?: () => void;
 }
 
-const sourceTypes: {[string]: Class<Source>} = {
+const sourceTypes = {
     'vector': require('../source/vector_tile_source'),
     'raster': require('../source/raster_tile_source'),
     'geojson': require('../source/geojson_source'),
@@ -95,7 +93,7 @@ const sourceTypes: {[string]: Class<Source>} = {
  * @returns {Source}
  */
 exports.create = function(id: string, specification: SourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
-    const source = new sourceTypes[specification.type](id, specification, dispatcher, eventedParent);
+    const source = new sourceTypes[specification.type](id, (specification: any), dispatcher, eventedParent);
 
     if (source.id !== id) {
         throw new Error(`Expected Source id to be ${id} instead of ${source.id}`);

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -146,7 +146,7 @@ class Worker {
                 }
             };
 
-            this.workerSources[mapId][type] = new this.workerSourceTypes[type]((actor: any), this.getLayerIndex(mapId));
+            this.workerSources[mapId][type] = new (this.workerSourceTypes[type]: any)((actor: any), this.getLayerIndex(mapId));
         }
 
         return this.workerSources[mapId][type];

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -1,8 +1,6 @@
 // @flow
 
 import type TileCoord from './tile_coord';
-import type Actor from '../util/actor';
-import type StyleLayerIndex from '../style/style_layer_index';
 import type {SerializedBucket} from '../data/bucket';
 import type {SerializedFeatureIndex} from '../data/feature_index';
 import type {SerializedStructArray} from '../util/struct_array';
@@ -51,7 +49,8 @@ export type WorkerTileCallback = (error: ?Error, result: ?WorkerTileResult, tran
  * @param layerIndex
  */
 export interface WorkerSource {
-    constructor(actor: Actor, layerIndex: StyleLayerIndex): WorkerSource;
+    // Disabled due to https://github.com/facebook/flow/issues/5208
+    // constructor(actor: Actor, layerIndex: StyleLayerIndex): WorkerSource;
 
     /**
      * Loads a tile from the given params and parse it into buckets ready to send

--- a/yarn.lock
+++ b/yarn.lock
@@ -4072,9 +4072,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.54.1:
-  version "0.54.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.1.tgz#7101bcccf006dc0652714a8aef0c72078a760510"
+flow-bin@^0.57.3:
+  version "0.57.3"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
 
 flow-coverage-report@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Disable type checking in two places where flow became smart enough to detect unsoundness that it didn't before. Figuring out how to properly type these cases would be a better fix, but they are both difficult (bucket deserialization and JSON conversions).

Disable type checking in one place where flow regressed. Upstream issue is https://github.com/facebook/flow/issues/5208.