### PR TITLE
Stub out Map#_rerender in paint benchmarks

### DIFF
--- a/bench/benchmarks/layers.js
+++ b/bench/benchmarks/layers.js
@@ -13,6 +13,8 @@ class LayerBenchmark extends Benchmark {
             style: this.layerStyle
         }).then(map => {
             this.map = map;
+            // Stub out `_rerender`; we want to be the only trigger of `_render`.
+            this.map._rerender = () => {};
         });
     }
 

--- a/bench/benchmarks/paint.js
+++ b/bench/benchmarks/paint.js
@@ -16,7 +16,13 @@ module.exports = class Paint extends Benchmark {
                 center: [-77.032194, 38.912753],
                 style: 'mapbox://styles/mapbox/streets-v9'
             });
-        })).then(maps => { this.maps = maps; });
+        })).then(maps => {
+            this.maps = maps;
+            for (const map of this.maps) {
+                // Stub out `_rerender`; we want to be the only trigger of `_render`.
+                map._rerender = () => {};
+            }
+        });
     }
 
     bench() {


### PR DESCRIPTION
Fixes #5543. Internal rendering changes were causing one of the [conditions on the call to _rerender inside _render](https://github.com/mapbox/mapbox-gl-js/blob/b00d7e07c52a299190c2cd1c6c2d0cc6879e8e28/src/ui/map.js#L1500-L1502) to be true, whereas before it was apparently always false. _rerender caused an animation frame to be requested, but then the resulting frameId would be [reset](https://github.com/mapbox/mapbox-gl-js/blob/b00d7e07c52a299190c2cd1c6c2d0cc6879e8e28/src/ui/map.js#L1492) via the benchmark's own call to _render. The result was a backlog of animation frame requests, some of which completed after teardown.