### PR TITLE
don't call `_render()` directly, fix #5543

### DIFF
--- a/bench/benchmarks/paint.js
+++ b/bench/benchmarks/paint.js
@@ -23,7 +23,7 @@ module.exports = class Paint extends Benchmark {
         for (const map of this.maps) {
             map._styleDirty = true;
             map._sourcesDirty = true;
-            map._render();
+            map._rerender();
         }
     }
 


### PR DESCRIPTION
`_rerender()` requests a deduped animation frame. `_render()` does the actual rendering. Using the non-deduped version resulted in overwriting the `_frameId` which prevented the frames from being cancelled.

I'm not sure *exactly* how the placement changes made this bug visible, but I'm guessing some extra rerendering made it more likely.