### PR TITLE
Throw an error when a used source is removed and not readded

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -510,7 +510,7 @@ class Style extends Evented {
         }
         for (const layerId in this._layers) {
             if (this._layers[layerId].source === id) {
-                throw new Error(`Source "${id}" cannot be removed while layer "${layerId}" is using it.`);
+                return this.fire('error', `Source "${id}" cannot be removed while layer "${layerId}" is using it.`);
             }
         }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -89,6 +89,7 @@ class Style extends Evented {
     _rtlTextPluginCallback: Function;
     _changed: boolean;
     _updatedSources: {[string]: 'clear' | 'reload'};
+    _removedUsedSources: {[string]: boolean};
     _updatedLayers: {[string]: true};
     _removedLayers: {[string]: StyleLayer};
     _updatedPaintProps: {[layer: string]: {[class: string]: true}};
@@ -381,6 +382,12 @@ class Style extends Evented {
             }
         }
 
+        for (const id in this._removedUsedSources) {
+            if (this._removedUsedSources[id]) {
+                throw new Error(`Source "${id}" was removed while there are still layers using it.`);
+            }
+        }
+
         this._applyPaintPropertyUpdates(options);
         this._resetUpdates();
 
@@ -405,6 +412,7 @@ class Style extends Evented {
         this._updatedSymbolOrder = false;
 
         this._updatedSources = {};
+        this._removedUsedSources = {};
 
         this._updatedPaintProps = {};
         this._updatedAllPaintProps = false;
@@ -495,6 +503,7 @@ class Style extends Evented {
 
         sourceCache.onAdd(this.map);
         this._changed = true;
+        this._removedUsedSources[id] = false;
     }
 
     /**
@@ -511,6 +520,7 @@ class Style extends Evented {
         const sourceCache = this.sourceCaches[id];
         delete this.sourceCaches[id];
         delete this._updatedSources[id];
+        this._removedUsedSources[id] = sourceCache.used;
         sourceCache.fire('data', {sourceDataType: 'metadata', dataType:'source', sourceId: id});
         sourceCache.setEventedParent(null);
         sourceCache.clearTiles();

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -510,7 +510,7 @@ class Style extends Evented {
         }
         for (const layerId in this._layers) {
             if (this._layers[layerId].source === id) {
-                return this.fire('error', `Source "${id}" cannot be removed while layer "${layerId}" is using it.`);
+                return this.fire('error', {error: new Error(`Source "${id}" cannot be removed while layer "${layerId}" is using it.`)});
             }
         }
 

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -693,6 +693,48 @@ test('Style#removeSource', (t) => {
         });
     });
 
+    function createStyle(callback) {
+        const style = new Style(new StubMap());
+        style.loadJSON(createStyleJSON({
+            'sources': {
+                'mapbox-source': createGeoJSONSource()
+            },
+            'layers': [{
+                'id': 'mapbox-layer',
+                'type': 'circle',
+                'source': 'mapbox-source',
+                'source-layer': 'whatever'
+            }]
+        }));
+        style.on('style.load', () => {
+            style.update();
+            style._recalculate(1);
+            callback(style);
+        });
+        return style;
+    }
+
+    t.test('does not throw is source is in use and readded', (t) => {
+        createStyle((style) => {
+            style.removeSource('mapbox-source');
+            style.addSource('mapbox-source', createSource());
+            t.doesNotThrow(() => {
+                style.update();
+            });
+            t.end();
+        });
+    });
+
+    t.test('throws if source is in use and not readded', (t) => {
+        createStyle((style) => {
+            style.removeSource('mapbox-source');
+            t.throws(() => {
+                style.update();
+            }, /\"mapbox\-source\"/);
+            t.end();
+        });
+    });
+
     t.test('tears down source event forwarding', (t) => {
         const style = new Style(new StubMap());
         style.loadJSON(createStyleJSON());

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -314,12 +314,7 @@ test('Style#loadJSON', (t) => {
             sources: {
                 '-source-id-': { type: "vector", tiles: [] }
             },
-            layers: [{
-                'id': '-layer-id-',
-                'type': 'circle',
-                'source': '-source-id-',
-                'source-layer': '-source-layer-'
-            }]
+            layers: []
         }));
 
         style.on('style.load', () => {
@@ -328,6 +323,12 @@ test('Style#loadJSON', (t) => {
             const source = createSource();
             source['vector_layers'] = [{ id: 'green' }];
             style.addSource('-source-id-', source);
+            style.addLayer({
+                'id': '-layer-id-',
+                'type': 'circle',
+                'source': '-source-id-',
+                'source-layer': '-source-layer-'
+            });
             style.update();
         });
 
@@ -714,22 +715,20 @@ test('Style#removeSource', (t) => {
         return style;
     }
 
-    t.test('does not throw is source is in use and readded', (t) => {
+    t.test('throws if source is in use', (t) => {
         createStyle((style) => {
-            style.removeSource('mapbox-source');
-            style.addSource('mapbox-source', createSource());
-            t.doesNotThrow(() => {
-                style.update();
-            });
+            t.throws(() => {
+                style.removeSource('mapbox-source');
+            }, /\"mapbox\-source\"/);
             t.end();
         });
     });
 
-    t.test('throws if source is in use and not readded', (t) => {
+    t.test('does not throw if source is not in use', (t) => {
         createStyle((style) => {
-            style.removeSource('mapbox-source');
-            t.throws(() => {
-                style.update();
+            style.removeLayer('mapbox-layer');
+            t.doesNotThrow(() => {
+                style.removeSource('mapbox-source');
             }, /\"mapbox\-source\"/);
             t.end();
         });

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -718,6 +718,8 @@ test('Style#removeSource', (t) => {
     t.test('throws if source is in use', (t) => {
         createStyle((style) => {
             style.on('error', (event) => {
+                t.ok(event.error.message.includes('"mapbox-source"'));
+                t.ok(event.error.message.includes('"mapbox-layer"'));
                 t.end();
             });
             style.removeSource('mapbox-source');
@@ -726,7 +728,7 @@ test('Style#removeSource', (t) => {
 
     t.test('does not throw if source is not in use', (t) => {
         createStyle((style) => {
-            style.on('error', (event) => {
+            style.on('error', () => {
                 t.fail();
             });
             style.removeLayer('mapbox-layer');

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -717,19 +717,20 @@ test('Style#removeSource', (t) => {
 
     t.test('throws if source is in use', (t) => {
         createStyle((style) => {
-            t.throws(() => {
-                style.removeSource('mapbox-source');
-            }, /\"mapbox\-source\"/);
-            t.end();
+            style.on('error', (event) => {
+                t.end();
+            });
+            style.removeSource('mapbox-source');
         });
     });
 
     t.test('does not throw if source is not in use', (t) => {
         createStyle((style) => {
+            style.on('error', (event) => {
+                t.fail();
+            });
             style.removeLayer('mapbox-layer');
-            t.doesNotThrow(() => {
-                style.removeSource('mapbox-source');
-            }, /\"mapbox\-source\"/);
+            style.removeSource('mapbox-source');
             t.end();
         });
     });


### PR DESCRIPTION
Currently, the below code does not throw an error. Instead it quietly fails to render `mapbox-layer`.

```js
map.setStyle({
  'version': 8,
  'sources': {
    'mapbox-source': {...}
  },
  'layers': [{
    'id': 'mapbox-layer',
    'source': 'mapbox-source',
    'type': 'circle'
  }]
});

map.removeSource('mapbox-source');
// THROWS
```

This PR causes an error to be fired in the above case while still allowing the below case where a source is removed and then re-added before the next call to `Style#update`

```js
map.removeSource('mapbox-source');
map.addSource('mapbox-source', {...});
// DOES NOT THROW
```

fixes #1711 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
