### PR TITLE
Filter symbol query results by source ID.

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -40,7 +40,8 @@ type QueryParameters = {
         layers: Array<string>,
     },
     tileSourceMaxZoom: number,
-    collisionBoxArray: any
+    collisionBoxArray: any,
+    sourceID: string
 }
 
 export type SerializedFeatureIndex = {
@@ -170,7 +171,7 @@ class FeatureIndex {
         this.filterMatching(result, matching, this.featureIndexArray, queryGeometry, filter, params.layers, styleLayers, args.bearing, pixelsToTileUnits);
 
         const matchingSymbols = this.collisionIndex ?
-            this.collisionIndex.queryRenderedSymbols(queryGeometry, this.coord, args.tileSourceMaxZoom, EXTENT / args.tileSize, args.collisionBoxArray) :
+            this.collisionIndex.queryRenderedSymbols(queryGeometry, this.coord, args.tileSourceMaxZoom, EXTENT / args.tileSize, args.collisionBoxArray, args.sourceID) :
             [];
         matchingSymbols.sort();
         this.filterMatching(result, matchingSymbols, args.collisionBoxArray, queryGeometry, filter, params.layers, styleLayers, args.bearing, pixelsToTileUnits);

--- a/src/source/query_features.js
+++ b/src/source/query_features.js
@@ -25,7 +25,8 @@ exports.rendered = function(sourceCache: SourceCache,
                 tileIn.queryGeometry,
                 tileIn.scale,
                 params,
-                bearing)
+                bearing,
+                sourceCache.id)
         });
     }
 

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -206,7 +206,7 @@ class Tile {
         }
     }
 
-    placeLayer(showCollisionBoxes: boolean, collisionIndex: CollisionIndex, layer: any) {
+    placeLayer(showCollisionBoxes: boolean, collisionIndex: CollisionIndex, layer: any, sourceID: string) {
         const bucket = this.getBucket(layer);
         const collisionBoxArray = this.collisionBoxArray;
 
@@ -218,7 +218,7 @@ class Tile {
             const pixelRatio = pixelsToTileUnits(this, 1, collisionIndex.transform.zoom);
 
             const labelPlaneMatrix = projection.getLabelPlaneMatrix(posMatrix, pitchWithMap, true, collisionIndex.transform, pixelRatio);
-            performSymbolPlacement(bucket, collisionIndex, showCollisionBoxes, collisionIndex.transform.zoom, textPixelRatio, posMatrix, labelPlaneMatrix, this.coord.id, collisionBoxArray);
+            performSymbolPlacement(bucket, collisionIndex, showCollisionBoxes, collisionIndex.transform.zoom, textPixelRatio, posMatrix, labelPlaneMatrix, this.coord.id, sourceID, collisionBoxArray);
         }
     }
 
@@ -267,7 +267,8 @@ class Tile {
                           queryGeometry: Array<Array<Point>>,
                           scale: number,
                           params: { filter: FilterSpecification, layers: Array<string> },
-                          bearing: number): {[string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>} {
+                          bearing: number,
+                          sourceID: string): {[string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>} {
         if (!this.featureIndex)
             return {};
 
@@ -288,7 +289,8 @@ class Tile {
             params: params,
             additionalRadius: additionalRadius,
             tileSourceMaxZoom: this.sourceMaxZoom,
-            collisionBoxArray: this.collisionBoxArray
+            collisionBoxArray: this.collisionBoxArray,
+            sourceID: sourceID
         }, layers);
     }
 

--- a/src/style/placement.js
+++ b/src/style/placement.js
@@ -32,7 +32,7 @@ class LayerPlacement {
     continuePlacement(sourceCache, collisionIndex, showCollisionBoxes: boolean, layer, shouldPausePlacement) {
         while (this._currentTileIndex < this._tileIDs.length) {
             const tile = sourceCache.getTileByID(this._tileIDs[this._currentTileIndex]);
-            tile.placeLayer(showCollisionBoxes, collisionIndex, layer);
+            tile.placeLayer(showCollisionBoxes, collisionIndex, layer, sourceCache.id);
 
             this._currentTileIndex++;
             if (shouldPausePlacement()) {

--- a/src/symbol/collision_index.js
+++ b/src/symbol/collision_index.js
@@ -220,7 +220,7 @@ class CollisionIndex {
      *
      * @private
      */
-    queryRenderedSymbols(queryGeometry: any, tileCoord: TileCoord, tileSourceMaxZoom: number, textPixelRatio: number, collisionBoxArray: any) {
+    queryRenderedSymbols(queryGeometry: any, tileCoord: TileCoord, tileSourceMaxZoom: number, textPixelRatio: number, collisionBoxArray: any, sourceID: string) {
         const sourceLayerFeatures = {};
         const result = [];
 
@@ -252,13 +252,13 @@ class CollisionIndex {
         const thisTileFeatures = [];
         const features = this.grid.query(minX, minY, maxX, maxY);
         for (let i = 0; i < features.length; i++) {
-            if (features[i].tileID === tileID) {
+            if (features[i].sourceID === sourceID && features[i].tileID === tileID) {
                 thisTileFeatures.push(features[i].boxIndex);
             }
         }
         const ignoredFeatures = this.ignoredGrid.query(minX, minY, maxX, maxY);
         for (let i = 0; i < ignoredFeatures.length; i++) {
-            if (ignoredFeatures[i].tileID === tileID) {
+            if (ignoredFeatures[i].sourceID === sourceID && ignoredFeatures[i].tileID === tileID) {
                 thisTileFeatures.push(ignoredFeatures[i].boxIndex);
             }
         }
@@ -301,18 +301,18 @@ class CollisionIndex {
         return result;
     }
 
-    insertCollisionBox(collisionBox: Array<number>, ignorePlacement: boolean, tileID: number, boxStartIndex: number) {
+    insertCollisionBox(collisionBox: Array<number>, ignorePlacement: boolean, tileID: number, sourceID: string, boxStartIndex: number) {
         const grid = ignorePlacement ? this.ignoredGrid : this.grid;
 
-        const key = { tileID: tileID, boxIndex: boxStartIndex };
+        const key = { tileID: tileID, sourceID: sourceID, boxIndex: boxStartIndex };
         grid.insert(key, collisionBox[0], collisionBox[1], collisionBox[2], collisionBox[3]);
     }
 
-    insertCollisionCircles(collisionCircles: Array<number>, ignorePlacement: boolean, tileID: number, boxStartIndex: number) {
+    insertCollisionCircles(collisionCircles: Array<number>, ignorePlacement: boolean, tileID: number, sourceID: string, boxStartIndex: number) {
         const grid = ignorePlacement ? this.ignoredGrid : this.grid;
 
         for (let k = 0; k < collisionCircles.length; k += 4) {
-            const key = { tileID: tileID, boxIndex: boxStartIndex + collisionCircles[k + 3] };
+            const key = { tileID: tileID, sourceID: sourceID, boxIndex: boxStartIndex + collisionCircles[k + 3] };
             grid.insertCircle(key, collisionCircles[k], collisionCircles[k + 1], collisionCircles[k + 2]);
         }
     }

--- a/src/symbol/symbol_placement.js
+++ b/src/symbol/symbol_placement.js
@@ -133,7 +133,7 @@ function updateCollisionCircles(collisionVertexArray: StructArray, collisionCirc
     }
 }
 
-function performSymbolPlacement(bucket: SymbolBucket, collisionIndex: CollisionIndex, showCollisionBoxes: boolean, zoom: number, textPixelRatio: number, posMatrix: mat4, labelPlaneMatrix: mat4, tileID: number, collisionBoxArray: CollisionBoxArray) {
+function performSymbolPlacement(bucket: SymbolBucket, collisionIndex: CollisionIndex, showCollisionBoxes: boolean, zoom: number, textPixelRatio: number, posMatrix: mat4, labelPlaneMatrix: mat4, tileID: number, sourceID: string, collisionBoxArray: CollisionBoxArray) {
     const layer = bucket.layers[0];
     const layout = layer.layout;
 
@@ -234,7 +234,7 @@ function performSymbolPlacement(bucket: SymbolBucket, collisionIndex: CollisionI
                 updateCollisionBox(collisionDebugBoxArray, placeGlyph);
             }
             if (placeGlyph) {
-                collisionIndex.insertCollisionBox(placedGlyphBox, layout['text-ignore-placement'], tileID, symbolInstance.textBoxStartIndex);
+                collisionIndex.insertCollisionBox(placedGlyphBox, layout['text-ignore-placement'], tileID, sourceID, symbolInstance.textBoxStartIndex);
             }
         }
         if (symbolInstance.collisionArrays.iconBox) {
@@ -242,7 +242,7 @@ function performSymbolPlacement(bucket: SymbolBucket, collisionIndex: CollisionI
                 updateCollisionBox(collisionDebugBoxArray, placeIcon);
             }
             if (placeIcon) {
-                collisionIndex.insertCollisionBox(placedIconBox, layout['icon-ignore-placement'], tileID, symbolInstance.iconBoxStartIndex);
+                collisionIndex.insertCollisionBox(placedIconBox, layout['icon-ignore-placement'], tileID, sourceID, symbolInstance.iconBoxStartIndex);
             }
         }
         if (symbolInstance.collisionArrays.textCircles) {
@@ -250,7 +250,7 @@ function performSymbolPlacement(bucket: SymbolBucket, collisionIndex: CollisionI
                 updateCollisionCircles(collisionDebugCircleArray, symbolInstance.collisionArrays.textCircles, placeGlyph, symbolInstance.isDuplicate);
             }
             if (placeGlyph) {
-                collisionIndex.insertCollisionCircles(placedGlyphCircles, layout['text-ignore-placement'], tileID, symbolInstance.textBoxStartIndex);
+                collisionIndex.insertCollisionCircles(placedGlyphCircles, layout['text-ignore-placement'], tileID, sourceID, symbolInstance.textBoxStartIndex);
             }
         }
 

--- a/test/integration/query-tests/regressions/mapbox-gl-js#5554/expected.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#5554/expected.json
@@ -1,0 +1,15 @@
+[
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        5.003394345022144
+      ]
+    },
+    "type": "Feature",
+    "properties": {
+      "identifier": "secondSource"
+    }
+  }
+]

--- a/test/integration/query-tests/regressions/mapbox-gl-js#5554/style.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#5554/style.json
@@ -1,0 +1,95 @@
+{
+    "version": 8,
+    "metadata": {
+        "test": {
+            "width": 128,
+            "height": 128,
+            "queryGeometry": [
+                64,
+                64
+            ]
+        }
+    },
+    "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
+    "sources": {
+        "firstSource": {
+            "type": "geojson",
+            "data": {
+              "type": "FeatureCollection",
+              "features": [
+                {
+                  "type": "Feature",
+                  "properties": {
+                    "identifier": "firstSource"
+                  },
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                      0,
+                      0
+                    ]
+                  }
+                }
+            ]
+            }
+        },
+        "secondSource": {
+            "type": "geojson",
+            "data": {
+              "type": "FeatureCollection",
+              "features": [
+                {
+                  "type": "Feature",
+                  "properties": {
+                    "identifier": "secondSource"
+                  },
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                      0,
+                      5
+                    ]
+                  }
+                }
+            ]
+            }
+        }
+    },
+    "layers": [
+        {
+          "id": "background",
+          "type": "background",
+          "paint": {
+            "background-color": "white"
+          }
+        },
+        {
+            "id": "firstLabel",
+            "source": "firstSource",
+            "type": "symbol",
+            "layout": {
+                "text-field": "First Source",
+                "text-size": 11,
+                "text-font": [
+                    "Open Sans Semibold",
+                    "Arial Unicode MS Bold"
+                ],
+                "symbol-placement": "point"
+            }
+        },
+        {
+            "id": "secondLabel",
+            "source": "secondSource",
+            "type": "symbol",
+            "layout": {
+                "text-field": "Second Source",
+                "text-size": 11,
+                "text-font": [
+                    "Open Sans Semibold",
+                    "Arial Unicode MS Bold"
+                ],
+                "symbol-placement": "point"
+            }
+        }
+    ]
+}

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -37,6 +37,7 @@ const showCollisionBoxes = false;
 const zoom = 0;
 const pixelRatio = 1;
 const tileID = 0;
+const sourceID = "source";
 
 const stacks = { 'Test': glyphs };
 
@@ -65,7 +66,7 @@ test('SymbolBucket', (t) => {
     const a = collision.grid.keysLength();
     bucketA.populate([{feature}], options);
     performSymbolLayout(bucketA, stacks, {});
-    performSymbolPlacement(bucketA, collision, showCollisionBoxes, zoom, pixelRatio, labelPlaneMatrix, labelPlaneMatrix, tileID, collisionBoxArray);
+    performSymbolPlacement(bucketA, collision, showCollisionBoxes, zoom, pixelRatio, labelPlaneMatrix, labelPlaneMatrix, tileID, sourceID, collisionBoxArray);
 
     const b = collision.grid.keysLength();
     t.notEqual(a, b, 'places feature');
@@ -74,7 +75,7 @@ test('SymbolBucket', (t) => {
     const a2 = collision.grid.keysLength();
     bucketB.populate([{feature}], options);
     performSymbolLayout(bucketB, stacks, {});
-    performSymbolPlacement(bucketB, collision, showCollisionBoxes, zoom, pixelRatio, labelPlaneMatrix, labelPlaneMatrix, tileID, collisionBoxArray);
+    performSymbolPlacement(bucketB, collision, showCollisionBoxes, zoom, pixelRatio, labelPlaneMatrix, labelPlaneMatrix, tileID, sourceID, collisionBoxArray);
     const b2 = collision.grid.keysLength();
     t.equal(b2, a2, 'detects collision and does not place feature');
     t.end();
@@ -102,8 +103,8 @@ test('SymbolBucket redo placement', (t) => {
 
     bucket.populate([{feature}], options);
     performSymbolLayout(bucket, stacks, {});
-    performSymbolPlacement(bucket, collision, showCollisionBoxes, zoom, pixelRatio, labelPlaneMatrix, labelPlaneMatrix, tileID, collisionBoxArray);
-    performSymbolPlacement(bucket, collision, showCollisionBoxes, zoom, pixelRatio, labelPlaneMatrix, labelPlaneMatrix, tileID, collisionBoxArray);
+    performSymbolPlacement(bucket, collision, showCollisionBoxes, zoom, pixelRatio, labelPlaneMatrix, labelPlaneMatrix, tileID, sourceID, collisionBoxArray);
+    performSymbolPlacement(bucket, collision, showCollisionBoxes, zoom, pixelRatio, labelPlaneMatrix, labelPlaneMatrix, tileID, sourceID, collisionBoxArray);
 
     t.end();
 });


### PR DESCRIPTION
Fixes issue #5554, in which unrelated symbols from source B could be returned in a query that returned symbols from source A.

This requires passing a source ID into all the placement calls so we can track which source a given entry refers to, and also passing the source ID into the query calls. It seems awkward to be passing this string all over the place, like maybe it would make sense for it to live in something like `TileCoord` -- I'm open to any suggestions there.

Benchmarks: https://bl.ocks.org/anonymous/raw/45bafc08e9463c751998d6ca10a4a43f/

`QueryBox` seems to get a little slower -- maybe just the overhead of inserting the strings into the grid and then filtering on the way out? `QueryPoint` seems to get a bit faster -- I don't have an explanation for that (although the values jumped around a lot between the three runs I did, so maybe it's just not that stable a benchmark). If the benchmark used multiple sources, it might have been erroneously returning too many results before, but it doesn't look like that's the case.

Before this fix, the regression test I added would correctly return the item from the second source, but also incorrectly return an item from the first source (which shouldn't show because it's collided out).

/cc @ansis @anandthakker @jfirebaugh 
