### PR TITLE
Expose the actor parent (Worker) on wrapped actor.

### DIFF
--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -141,6 +141,7 @@ class Worker {
             // use a wrapped actor so that we can attach a target mapId param
             // to any messages invoked by the WorkerSource
             const actor = {
+                parent: this.actor.parent,
                 send: (type, data, callback, buffers) => {
                     this.actor.send(type, data, callback, buffers, mapId);
                 }


### PR DESCRIPTION
Worker sources are created with a wrapped actor with a send() that has the last argument bound to the mapId.  The wrapper is just a raw object literal that didn't have any of the normal Actor properties on it.  Add the actor parent to the object so that the worker source has access to it.