### PR TITLE
Promote StylePropertySpecification

### DIFF
--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -7,10 +7,8 @@ const convertFunction = require('../../src/style-spec/function/convert');
 const {isFunction, createFunction} = require('../../src/style-spec/function');
 const {createExpression} = require('../../src/style-spec/expression');
 
-import type {
-    StyleExpression,
-    StylePropertySpecification
-} from '../../src/style-spec/expression';
+import type {StylePropertySpecification} from '../../src/style-spec/style-spec';
+import type {StyleExpression} from '../../src/style-spec/expression';
 
 class ExpressionBenchmark extends Benchmark {
     data: Array<{

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -15,6 +15,7 @@ const isConstant = require('./is_constant');
 import type {Type} from './types';
 import type {Value} from './values';
 import type {Expression} from './expression';
+import type {StylePropertySpecification} from '../style-spec';
 
 export type Feature = {
     +type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon',
@@ -64,41 +65,6 @@ export type StyleFilterExpression = ZoomConstantExpression | {
 };
 
 export type StyleExpression = StyleDeclarationExpression | StyleFilterExpression;
-
-export type StylePropertySpecification = {
-    type: 'number',
-    'function': boolean,
-    'property-function': boolean,
-    default?: number
-} | {
-    type: 'string',
-    'function': boolean,
-    'property-function': boolean,
-    default?: string
-} | {
-    type: 'boolean',
-    'function': boolean,
-    'property-function': boolean,
-    default?: boolean
-} | {
-    type: 'enum',
-    'function': boolean,
-    'property-function': boolean,
-    values: {[string]: {}},
-    default?: string
-} | {
-    type: 'array',
-    'function': boolean,
-    'property-function': boolean,
-    value: 'number' | 'string' | 'boolean',
-    length?: number,
-    default?: Array<Value>
-} | {
-    type: 'color',
-    'function': boolean,
-    'property-function': boolean,
-    default?: string
-};
 
 function isExpression(expression: mixed) {
     return Array.isArray(expression) && expression.length > 0 &&

--- a/src/style-spec/expression/values.js
+++ b/src/style-spec/expression/values.js
@@ -35,7 +35,7 @@ function validateRGBA(r: mixed, g: mixed, b: mixed, a?: mixed): ?string {
     return null;
 }
 
-export type Value = null | string | boolean | number | Color | Array<Value> | { [string]: Value }
+export type Value = null | string | boolean | number | Color | $ReadOnlyArray<Value> | { +[string]: Value }
 
 function isValue(mixed: mixed): boolean {
     if (mixed === null) {

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -1,3 +1,46 @@
+// @flow
+
+export type StylePropertySpecification = {
+    type: 'number',
+    'function': boolean,
+    'property-function': boolean,
+    default?: number
+} | {
+    type: 'string',
+    'function': boolean,
+    'property-function': boolean,
+    default?: string
+} | {
+    type: 'boolean',
+    'function': boolean,
+    'property-function': boolean,
+    default?: boolean
+} | {
+    type: 'enum',
+    'function': boolean,
+    'property-function': boolean,
+    values: {[string]: {}},
+    default?: string
+} | {
+    type: 'color',
+    'function': boolean,
+    'property-function': boolean,
+    default?: string
+} | {
+    type: 'array',
+    value: 'number',
+    'function': boolean,
+    'property-function': boolean,
+    length?: number,
+    default?: Array<number>
+} | {
+    type: 'array',
+    value: 'string',
+    'function': boolean,
+    'property-function': boolean,
+    length?: number,
+    default?: Array<string>
+};
 
 exports.v6 = require('./reference/v6.json');
 exports.v7 = require('./reference/v7.json');


### PR DESCRIPTION
It's useful outside of expressions.

Needed for property-related refactoring (#2739).