### PR TITLE
Update query tests for viewport collision detection.

### DIFF
--- a/test/ignores.json
+++ b/test/ignores.json
@@ -1,7 +1,5 @@
 {
   "query-tests/regressions/mapbox-gl-js#4494": "https://github.com/mapbox/mapbox-gl-js/issues/2716",
-  "query-tests/symbol/panned-after-insert": "https://github.com/mapbox/mapbox-gl-js/issues/3346",
-  "query-tests/symbol/rotated-after-insert": "https://github.com/mapbox/mapbox-gl-js/issues/3346",
   "render-tests/fill-extrusion-pattern/@2x": "https://github.com/mapbox/mapbox-gl-js/issues/3327",
   "render-tests/fill-extrusion-pattern/function-2": "https://github.com/mapbox/mapbox-gl-js/issues/3327",
   "render-tests/fill-extrusion-pattern/function": "https://github.com/mapbox/mapbox-gl-js/issues/3327",

--- a/test/integration/query-tests/symbol/panned-after-insert/expected.json
+++ b/test/integration/query-tests/symbol/panned-after-insert/expected.json
@@ -1,5326 +1,1333 @@
 [
   {
     "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         0.9997051308419742
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         1.9991059831233287
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         4.001260305845264
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         4.997922089609858
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         0.9997051308419742
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         1.9991059831233287
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         4.001260305845264
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         4.997922089609858
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         0.9997051308419742
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         1.9991059831233287
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         4.001260305845264
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         4.997922089609858
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         0.9997051308419742
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         1.9991059831233287
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         4.001260305845264
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         4.997922089609858
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
+        0,
+        -0.99970513084196
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
+        0,
+        0
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
+        0.999755859375,
+        -4.997922089609844
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
+        0.999755859375,
+        -4.00126030584525
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
+        0.999755859375,
+        -2.9978987411030573
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
   }
 ]

--- a/test/integration/query-tests/symbol/rotated-after-insert/expected.json
+++ b/test/integration/query-tests/symbol/rotated-after-insert/expected.json
@@ -1,5326 +1,1333 @@
 [
   {
     "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         0.9997051308419742
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         1.9991059831233287
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         4.001260305845264
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         4.997922089609858
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         0.9997051308419742
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         1.9991059831233287
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         4.001260305845264
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         4.997922089609858
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         0.9997051308419742
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         1.9991059831233287
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         4.001260305845264
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         4.997922089609858
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         0.9997051308419742
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         1.9991059831233287
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         4.001260305845264
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         4.997922089609858
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -4.998779296875,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         -3.9990234375,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         0.999755859375,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         1.99951171875,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         2.999267578125,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         3.9990234375,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        -0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         0,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
-      "coordinates": [
-        0,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        0.999755859375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        2.999267578125,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.997922089609844
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -4.00126030584525
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -1.9991059831233144
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        -0.99970513084196
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        0.9997051308419742
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        1.9991059831233287
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        2.9978987411030573
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.001260305845264
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
-      "coordinates": [
-        3.9990234375,
-        4.997922089609858
-      ],
-      "type": "Point"
-    },
-    "properties": {},
-    "type": "Feature"
-  },
-  {
-    "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -4.997922089609844
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -4.00126030584525
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -2.9978987411030573
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -1.9991059831233144
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         -0.99970513084196
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
         4.998779296875,
         0
-      ],
-      "type": "Point"
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        0.9997051308419742
-      ],
-      "type": "Point"
+        0,
+        -0.99970513084196
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        1.9991059831233287
-      ],
-      "type": "Point"
+        0,
+        0
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        2.9978987411030573
-      ],
-      "type": "Point"
+        0.999755859375,
+        -4.997922089609844
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        4.001260305845264
-      ],
-      "type": "Point"
+        0.999755859375,
+        -4.00126030584525
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
   },
   {
     "geometry": {
+      "type": "Point",
       "coordinates": [
-        4.998779296875,
-        4.997922089609858
-      ],
-      "type": "Point"
+        0.999755859375,
+        -2.9978987411030573
+      ]
     },
-    "properties": {},
-    "type": "Feature"
+    "type": "Feature",
+    "properties": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
   }
 ]


### PR DESCRIPTION
Defining correct behavior for these two tests has gotten easier: in both cases it's just all 121 points from 121points.geojson.

Earlier versions of this test included duplicates in expected.json because the same point would end up in results from multiple tiles.

Fixes issue #3346

/cc @ansis @jfirebaugh 