### PR TITLE
Fix geojson Position element issue (3rd element)

### DIFF
--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -107,7 +107,7 @@ class LngLat {
         if (input instanceof LngLat) {
             return input;
         }
-        if (Array.isArray(input) && input.length === 2) {
+        if (Array.isArray(input) && (input.length === 2 || input.length === 3)) {
             return new LngLat(Number(input[0]), Number(input[1]));
         }
         if (!Array.isArray(input) && typeof input === 'object' && input !== null) {

--- a/test/unit/geo/lng_lat.test.js
+++ b/test/unit/geo/lng_lat.test.js
@@ -23,8 +23,13 @@ test('LngLat', (t) => {
 
     t.test('#convert', (t) => {
         t.ok(LngLat.convert([0, 10]) instanceof LngLat, 'convert creates a LngLat instance');
+        t.ok(LngLat.convert([0, 10, 0]) instanceof LngLat, 'convert creates a LngLat instance (Elevation)');
+        t.throw(() => {
+            LngLat.convert([0, 10, 0, 5]);
+        }, "LngLat must not accept an array size bigger than 3'", 'detects and throws on invalid input');
         t.ok(LngLat.convert({lng: 0, lat: 10}) instanceof LngLat, 'convert creates a LngLat instance');
         t.ok(LngLat.convert({lng: 0, lat: 0}) instanceof LngLat, 'convert creates a LngLat instance');
+        t.ok(LngLat.convert({lng: 0, lat: 0, elev: 0}) instanceof LngLat, 'convert creates a LngLat instance');
         t.ok(LngLat.convert(new LngLat(0, 0)) instanceof LngLat, 'convert creates a LngLat instance');
         t.throws(() => {
             LngLat.convert(0, 10);


### PR DESCRIPTION
Following RFC 7946, position is an array of number with two OR MORE
elements (Implementations SHOULD NOT extend positions beyond three
elements). The 3rd element is usually Altitude. We could ignore it
but we must not fail.
This small fix allows well-formed geojson file to be fully processed

Signed-off-by: Olivier Guiter <oguiter@free.fr>

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
