### PR TITLE
Remove Expression#key

### DIFF
--- a/src/style-spec/expression/compound_expression.js
+++ b/src/style-spec/expression/compound_expression.js
@@ -16,7 +16,6 @@ type Definition = [Type, Signature, Evaluate] |
     {|type: Type, overloads: Array<[Signature, Evaluate]>|};
 
 class CompoundExpression implements Expression {
-    key: string;
     name: string;
     type: Type;
     _evaluate: Evaluate;
@@ -24,8 +23,7 @@ class CompoundExpression implements Expression {
 
     static definitions: { [string]: Definition };
 
-    constructor(key: string, name: string, type: Type, evaluate: Evaluate, args: Array<Expression>) {
-        this.key = key;
+    constructor(name: string, type: Type, evaluate: Evaluate, args: Array<Expression>) {
         this.name = name;
         this.type = type;
         this._evaluate = evaluate;
@@ -97,7 +95,7 @@ class CompoundExpression implements Expression {
             }
 
             if (signatureContext.errors.length === 0) {
-                return new CompoundExpression(context.key, op, type, evaluate, parsedArgs);
+                return new CompoundExpression(op, type, evaluate, parsedArgs);
             }
         }
 

--- a/src/style-spec/expression/definitions/array.js
+++ b/src/style-spec/expression/definitions/array.js
@@ -25,12 +25,10 @@ const types = {
 };
 
 class ArrayAssertion implements Expression {
-    key: string;
     type: ArrayType;
     input: Expression;
 
-    constructor(key: string, type: ArrayType, input: Expression) {
-        this.key = key;
+    constructor(type: ArrayType, input: Expression) {
         this.type = type;
         this.input = input;
     }
@@ -66,7 +64,7 @@ class ArrayAssertion implements Expression {
         const input = context.parse(args[args.length - 1], args.length - 1, ValueType);
         if (!input) return null;
 
-        return new ArrayAssertion(context.key, type, input);
+        return new ArrayAssertion(type, input);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/assertion.js
+++ b/src/style-spec/expression/definitions/assertion.js
@@ -26,12 +26,10 @@ const types = {
 };
 
 class Assertion implements Expression {
-    key: string;
     type: Type;
     args: Array<Expression>;
 
-    constructor(key: string, type: Type, args: Array<Expression>) {
-        this.key = key;
+    constructor(type: Type, args: Array<Expression>) {
         this.type = type;
         this.args = args;
     }
@@ -52,7 +50,7 @@ class Assertion implements Expression {
             parsed.push(input);
         }
 
-        return new Assertion(context.key, type, parsed);
+        return new Assertion(type, parsed);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/at.js
+++ b/src/style-spec/expression/definitions/at.js
@@ -15,13 +15,11 @@ import type { Type, ArrayType } from '../types';
 import type { Value } from '../values';
 
 class At implements Expression {
-    key: string;
     type: Type;
     index: Expression;
     input: Expression;
 
-    constructor(key: string, type: Type, index: Expression, input: Expression) {
-        this.key = key;
+    constructor(type: Type, index: Expression, input: Expression) {
         this.type = type;
         this.index = index;
         this.input = input;
@@ -37,7 +35,7 @@ class At implements Expression {
         if (!index || !input) return null;
 
         const t: ArrayType = (input.type: any);
-        return new At(context.key, t.itemType, index, input);
+        return new At(t.itemType, index, input);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/case.js
+++ b/src/style-spec/expression/definitions/case.js
@@ -11,14 +11,12 @@ import type { Type } from '../types';
 type Branches = Array<[Expression, Expression]>;
 
 class Case implements Expression {
-    key: string;
     type: Type;
 
     branches: Branches;
     otherwise: Expression;
 
-    constructor(key: string, type: Type, branches: Branches, otherwise: Expression) {
-        this.key = key;
+    constructor(type: Type, branches: Branches, otherwise: Expression) {
         this.type = type;
         this.branches = branches;
         this.otherwise = otherwise;
@@ -52,7 +50,7 @@ class Case implements Expression {
         if (!otherwise) return null;
 
         assert(outputType);
-        return new Case(context.key, (outputType: any), branches, otherwise);
+        return new Case((outputType: any), branches, otherwise);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/coalesce.js
+++ b/src/style-spec/expression/definitions/coalesce.js
@@ -8,12 +8,10 @@ import type EvaluationContext from '../evaluation_context';
 import type { Type } from '../types';
 
 class Coalesce implements Expression {
-    key: string;
     type: Type;
     args: Array<Expression>;
 
-    constructor(key: string, type: Type, args: Array<Expression>) {
-        this.key = key;
+    constructor(type: Type, args: Array<Expression>) {
         this.type = type;
         this.args = args;
     }
@@ -34,7 +32,7 @@ class Coalesce implements Expression {
             parsedArgs.push(parsed);
         }
         assert(outputType);
-        return new Coalesce(context.key, (outputType: any), parsedArgs);
+        return new Coalesce((outputType: any), parsedArgs);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/coercion.js
+++ b/src/style-spec/expression/definitions/coercion.js
@@ -28,12 +28,10 @@ const types = {
  * @private
  */
 class Coercion implements Expression {
-    key: string;
     type: Type;
     args: Array<Expression>;
 
-    constructor(key: string, type: Type, args: Array<Expression>) {
-        this.key = key;
+    constructor(type: Type, args: Array<Expression>) {
         this.type = type;
         this.args = args;
     }
@@ -54,7 +52,7 @@ class Coercion implements Expression {
             parsed.push(input);
         }
 
-        return new Coercion(context.key, type, parsed);
+        return new Coercion(type, parsed);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/curve.js
+++ b/src/style-spec/expression/definitions/curve.js
@@ -5,7 +5,6 @@ import type ParsingContext from '../parsing_context';
 import type { Type } from '../types';
 
 class Curve implements Expression {
-    key: string;
     type: Type;
 
     static parse(args: Array<mixed>, context: ParsingContext) {

--- a/src/style-spec/expression/definitions/interpolate.js
+++ b/src/style-spec/expression/definitions/interpolate.js
@@ -17,7 +17,6 @@ export type InterpolationType =
     { name: 'cubic-bezier', controlPoints: [number, number, number, number] };
 
 class Interpolate implements Expression {
-    key: string;
     type: Type;
 
     interpolation: InterpolationType;
@@ -25,8 +24,7 @@ class Interpolate implements Expression {
     labels: Array<number>;
     outputs: Array<Expression>;
 
-    constructor(key: string, type: Type, interpolation: InterpolationType, input: Expression, stops: Stops) {
-        this.key = key;
+    constructor(type: Type, interpolation: InterpolationType, input: Expression, stops: Stops) {
         this.type = type;
         this.interpolation = interpolation;
         this.input = input;
@@ -137,7 +135,7 @@ class Interpolate implements Expression {
             return context.error(`Type ${toString(outputType)} is not interpolatable.`);
         }
 
-        return new Interpolate(context.key, outputType, interpolation, input, stops);
+        return new Interpolate(outputType, interpolation, input, stops);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/let.js
+++ b/src/style-spec/expression/definitions/let.js
@@ -6,13 +6,11 @@ import type ParsingContext from '../parsing_context';
 import type EvaluationContext  from '../evaluation_context';
 
 class Let implements Expression {
-    key: string;
     type: Type;
     bindings: Array<[string, Expression]>;
     result: Expression;
 
-    constructor(key: string, bindings: Array<[string, Expression]>, result: Expression) {
-        this.key = key;
+    constructor(bindings: Array<[string, Expression]>, result: Expression) {
         this.type = result.type;
         this.bindings = [].concat(bindings);
         this.result = result;
@@ -57,7 +55,7 @@ class Let implements Expression {
         const result = context.parse(args[args.length - 1], args.length - 1, undefined, bindings);
         if (!result) return null;
 
-        return new Let(context.key, bindings, result);
+        return new Let(bindings, result);
     }
 }
 

--- a/src/style-spec/expression/definitions/literal.js
+++ b/src/style-spec/expression/definitions/literal.js
@@ -8,12 +8,10 @@ import type { Expression } from '../expression';
 import type ParsingContext from '../parsing_context';
 
 class Literal implements Expression {
-    key: string;
     type: Type;
     value: Value;
 
-    constructor(key: *, type: Type, value: Value) {
-        this.key = key;
+    constructor(type: Type, value: Value) {
         this.type = type;
         this.value = value;
     }
@@ -40,7 +38,7 @@ class Literal implements Expression {
             type = expected;
         }
 
-        return new Literal(context.key, type, value);
+        return new Literal(type, value);
     }
 
     evaluate() {

--- a/src/style-spec/expression/definitions/match.js
+++ b/src/style-spec/expression/definitions/match.js
@@ -12,7 +12,6 @@ import type { Type } from '../types';
 type Cases = {[number | string]: number};
 
 class Match implements Expression {
-    key: string;
     type: Type;
     inputType: Type;
 
@@ -21,8 +20,7 @@ class Match implements Expression {
     outputs: Array<Expression>;
     otherwise: Expression;
 
-    constructor(key: string, inputType: Type, outputType: Type, input: Expression, cases: Cases, outputs: Array<Expression>, otherwise: Expression) {
-        this.key = key;
+    constructor(inputType: Type, outputType: Type, input: Expression, cases: Cases, outputs: Array<Expression>, otherwise: Expression) {
         this.inputType = inputType;
         this.type = outputType;
         this.input = input;
@@ -92,7 +90,7 @@ class Match implements Expression {
         if (!otherwise) return null;
 
         assert(inputType && outputType);
-        return new Match(context.key, (inputType: any), (outputType: any), input, cases, outputs, otherwise);
+        return new Match((inputType: any), (outputType: any), input, cases, outputs, otherwise);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/step.js
+++ b/src/style-spec/expression/definitions/step.js
@@ -10,15 +10,13 @@ import type EvaluationContext from '../evaluation_context';
 import type { Type } from '../types';
 
 class Step implements Expression {
-    key: string;
     type: Type;
 
     input: Expression;
     labels: Array<number>;
     outputs: Array<Expression>;
 
-    constructor(key: string, type: Type, input: Expression, stops: Stops) {
-        this.key = key;
+    constructor(type: Type, input: Expression, stops: Stops) {
         this.type = type;
         this.input = input;
 
@@ -74,7 +72,7 @@ class Step implements Expression {
             stops.push([label, parsed]);
         }
 
-        return new Step(context.key, outputType, input, stops);
+        return new Step(outputType, input, stops);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/var.js
+++ b/src/style-spec/expression/definitions/var.js
@@ -6,12 +6,10 @@ import type ParsingContext from '../parsing_context';
 import type EvaluationContext  from '../evaluation_context';
 
 class Var implements Expression {
-    key: string;
     type: Type;
     name: string;
 
-    constructor(key: string, name: string, type: Type) {
-        this.key = key;
+    constructor(name: string, type: Type) {
         this.type = type;
         this.name = name;
     }
@@ -25,7 +23,7 @@ class Var implements Expression {
             return context.error(`Unknown variable "${name}". Make sure "${name}" has been bound in an enclosing "let" expression before using it.`, 1);
         }
 
-        return new Var(context.key, name, context.scope.get(name).type);
+        return new Var(name, context.scope.get(name).type);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/expression.js
+++ b/src/style-spec/expression/expression.js
@@ -5,7 +5,6 @@ import type ParsingContext from './parsing_context';
 import type EvaluationContext from './evaluation_context';
 
 export interface Expression {
-    key: string;
     +type: Type;
 
     static parse(args: Array<mixed>, context: ParsingContext): ?Expression;

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -179,7 +179,7 @@ function createExpression(expression: mixed,
     } else if (zoomCurve instanceof Interpolate && propertySpec['function'] === 'piecewise-constant') {
         return {
             result: 'error',
-            errors: [new ParsingError(zoomCurve.key, '"interpolate" expressions cannot be used with this property')]
+            errors: [new ParsingError('', '"interpolate" expressions cannot be used with this property')]
         };
     }
 
@@ -236,9 +236,9 @@ function findZoomCurve(expression: Expression): Step | Interpolate | ParsingErro
         if (childResult instanceof ParsingError) {
             result = childResult;
         } else if (!result && childResult) {
-            result = new ParsingError(childResult.key, '"zoom" expression may only be used as input to a top-level "step" or "interpolate" expression.');
+            result = new ParsingError('', '"zoom" expression may only be used as input to a top-level "step" or "interpolate" expression.');
         } else if (result && childResult && result !== childResult) {
-            result = new ParsingError(childResult.key, 'Only one zoom-based "step" or "interpolate" subexpression may be used in an expression.');
+            result = new ParsingError('', 'Only one zoom-based "step" or "interpolate" subexpression may be used in an expression.');
         }
     });
 

--- a/src/style-spec/expression/parsing_context.js
+++ b/src/style-spec/expression/parsing_context.js
@@ -78,10 +78,10 @@ class ParsingContext {
 
                     if (canAssert && actual.kind === 'value') {
                         const Assertion = require('./definitions/assertion');
-                        parsed = new Assertion(parsed.key, expected, [parsed]);
+                        parsed = new Assertion(expected, [parsed]);
                     } else if (expected.kind === 'color' && (actual.kind === 'value' || actual.kind === 'string')) {
                         const Coercion = require('./definitions/coercion');
-                        parsed = new Coercion(parsed.key, expected, [parsed]);
+                        parsed = new Coercion(expected, [parsed]);
                     }
 
                     if (context.checkSubtype(expected, parsed.type)) {
@@ -95,7 +95,7 @@ class ParsingContext {
                 if (!(parsed instanceof Literal) && isConstant(parsed)) {
                     const ec = new (require('./evaluation_context'))();
                     try {
-                        parsed = new Literal(parsed.key, parsed.type, parsed.evaluate(ec));
+                        parsed = new Literal(parsed.type, parsed.evaluate(ec));
                     } catch (e) {
                         context.error(e.message);
                         return null;

--- a/test/integration/expression-tests/zoom/invalid-nested-1/test.json
+++ b/test/integration/expression-tests/zoom/invalid-nested-1/test.json
@@ -6,7 +6,7 @@
       "result": "error",
       "errors": [
         {
-          "key": "[2]",
+          "key": "",
           "error": "\"zoom\" expression may only be used as input to a top-level \"step\" or \"interpolate\" expression."
         }
       ]

--- a/test/integration/expression-tests/zoom/invalid-nested-2/test.json
+++ b/test/integration/expression-tests/zoom/invalid-nested-2/test.json
@@ -14,7 +14,7 @@
       "result": "error",
       "errors": [
         {
-          "key": "[6]",
+          "key": "",
           "error": "Only one zoom-based \"step\" or \"interpolate\" subexpression may be used in an expression."
         }
       ]

--- a/test/integration/expression-tests/zoom/invalid-nested-3/test.json
+++ b/test/integration/expression-tests/zoom/invalid-nested-3/test.json
@@ -11,7 +11,7 @@
       "result": "error",
       "errors": [
         {
-          "key": "[3]",
+          "key": "",
           "error": "Only one zoom-based \"step\" or \"interpolate\" subexpression may be used in an expression."
         }
       ]

--- a/test/integration/expression-tests/zoom/invalid-nested-4/test.json
+++ b/test/integration/expression-tests/zoom/invalid-nested-4/test.json
@@ -10,7 +10,7 @@
       "result": "error",
       "errors": [
         {
-          "key": "[2]",
+          "key": "",
           "error": "Only one zoom-based \"step\" or \"interpolate\" subexpression may be used in an expression."
         }
       ]

--- a/test/integration/expression-tests/zoom/invalid-nested-5/test.json
+++ b/test/integration/expression-tests/zoom/invalid-nested-5/test.json
@@ -11,7 +11,7 @@
       "result": "error",
       "errors": [
         {
-          "key": "[2]",
+          "key": "",
           "error": "\"zoom\" expression may only be used as input to a top-level \"step\" or \"interpolate\" expression."
         }
       ]

--- a/test/unit/style-spec/fixture/functions.output.json
+++ b/test/unit/style-spec/fixture/functions.output.json
@@ -172,7 +172,7 @@
     "line": 907
   },
   {
-    "message": "layers[49].paint.fill-opacity[2]: \"zoom\" expression may only be used as input to a top-level \"step\" or \"interpolate\" expression.",
+    "message": "layers[49].paint.fill-opacity: \"zoom\" expression may only be used as input to a top-level \"step\" or \"interpolate\" expression.",
     "line": 916
   },
   {


### PR DESCRIPTION
This was only being used to add a key to the errors produced by findZoomCurve.