### PR TITLE
Clear VAO binding before binding index buffer.

### DIFF
--- a/src/gl/index_buffer.js
+++ b/src/gl/index_buffer.js
@@ -15,15 +15,7 @@ class IndexBuffer {
         this.buffer = gl.createBuffer();
         this.dynamicDraw = Boolean(dynamicDraw);
 
-        // The bound index buffer is part of vertex array object state. We don't want to
-        // modify whatever VAO happens to be currently bound, so make sure the default
-        // vertex array provided by the context is bound instead.
-        if (gl.extVertexArrayObject === undefined) {
-            (gl: any).extVertexArrayObject = gl.getExtension("OES_vertex_array_object");
-        }
-        if (gl.extVertexArrayObject) {
-            (gl: any).extVertexArrayObject.bindVertexArrayOES(null);
-        }
+        this.unbindVAO();
 
         gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.buffer);
         gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, array.arrayBuffer, this.dynamicDraw ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW);
@@ -33,12 +25,27 @@ class IndexBuffer {
         }
     }
 
+    unbindVAO() {
+        // The bound index buffer is part of vertex array object state. We don't want to
+        // modify whatever VAO happens to be currently bound, so make sure the default
+        // vertex array provided by the context is bound instead.
+        if (this.gl.extVertexArrayObject === undefined) {
+            (this.gl: any).extVertexArrayObject = this.gl.getExtension("OES_vertex_array_object");
+        }
+        if (this.gl.extVertexArrayObject) {
+            (this.gl: any).extVertexArrayObject.bindVertexArrayOES(null);
+        }
+    }
+
     bind() {
         this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, this.buffer);
     }
 
     updateData(array: SerializedStructArray) {
         assert(this.dynamicDraw);
+        // The right VAO will get this buffer re-bound later in VertexArrayObject#bind
+        // See https://github.com/mapbox/mapbox-gl-js/issues/5620
+        this.unbindVAO();
         this.bind();
         this.gl.bufferSubData(this.gl.ELEMENT_ARRAY_BUFFER, 0, array.arrayBuffer);
     }


### PR DESCRIPTION
Fixes issue #5620.

I tried making a regression test that would exercise this by creating three different spatially overlapping symbol layers, two with `allow-overlap` and one without. I used `setBearing` followed by a `wait` operation to get the dynamic sorting operation to take place. The idea was that the VAO for the `allow-overlap: false` layer would get messed up by the sortable layers that followed it, and since it wouldn't re-bind, it could end up with some missing elements. If it worked, it didn't make any difference in the rendering output...

/cc @jfirebaugh @ansis @mourner 