### PR TITLE
Expression kinds

### DIFF
--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -5,18 +5,18 @@ const accessToken = require('../lib/access_token');
 const spec = require('../../src/style-spec/reference/latest');
 const convertFunction = require('../../src/style-spec/function/convert');
 const {isFunction, createFunction} = require('../../src/style-spec/function');
-const {createExpression} = require('../../src/style-spec/expression');
+const {createPropertyExpression} = require('../../src/style-spec/expression');
 
 import type {StylePropertySpecification} from '../../src/style-spec/style-spec';
-import type {StyleExpression} from '../../src/style-spec/expression';
+import type {StylePropertyExpression} from '../../src/style-spec/expression';
 
 class ExpressionBenchmark extends Benchmark {
     data: Array<{
         propertySpec: StylePropertySpecification,
         rawValue: mixed,
         rawExpression: mixed,
-        compiledFunction: StyleExpression,
-        compiledExpression: StyleExpression
+        compiledFunction: StylePropertyExpression,
+        compiledExpression: StylePropertyExpression
     }>;
 
     setup() {
@@ -33,8 +33,8 @@ class ExpressionBenchmark extends Benchmark {
                     const expressionData = function(rawValue, propertySpec: StylePropertySpecification) {
                         const rawExpression = convertFunction(rawValue, propertySpec);
                         const compiledFunction = createFunction(rawValue, propertySpec);
-                        const compiledExpression = createExpression(rawExpression, propertySpec, 'property');
-                        if (compiledExpression.result !== 'success') {
+                        const compiledExpression = createPropertyExpression(rawExpression, propertySpec);
+                        if (compiledExpression.result === 'error') {
                             throw new Error(compiledExpression.errors.map(err => `${err.key}: ${err.message}`).join(', '));
                         }
                         return {
@@ -89,7 +89,7 @@ class FunctionConvert extends ExpressionBenchmark {
 class ExpressionCreate extends ExpressionBenchmark {
     bench() {
         for (const {rawExpression, propertySpec} of this.data) {
-            createExpression(rawExpression, propertySpec, 'property');
+            createPropertyExpression(rawExpression, propertySpec);
         }
     }
 }

--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -35,14 +35,14 @@ class ExpressionBenchmark extends Benchmark {
                         const compiledFunction = createFunction(rawValue, propertySpec);
                         const compiledExpression = createPropertyExpression(rawExpression, propertySpec);
                         if (compiledExpression.result === 'error') {
-                            throw new Error(compiledExpression.errors.map(err => `${err.key}: ${err.message}`).join(', '));
+                            throw new Error(compiledExpression.value.map(err => `${err.key}: ${err.message}`).join(', '));
                         }
                         return {
                             propertySpec,
                             rawValue,
                             rawExpression,
                             compiledFunction,
-                            compiledExpression
+                            compiledExpression: compiledExpression.value
                         };
                     };
 

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -104,24 +104,24 @@ function createExpression(expression: mixed,
 }
 
 type ConstantExpression = {
-    result: 'constant',
+    kind: 'constant',
     evaluate: (globals: GlobalProperties, feature?: Feature) => any
 };
 
 type SourceExpression = {
-    result: 'source',
+    kind: 'source',
     evaluate: (globals: GlobalProperties, feature?: Feature) => any,
 };
 
 type CameraExpression = {
-    result: 'camera',
+    kind: 'camera',
     evaluate: (globals: GlobalProperties, feature?: Feature) => any,
     interpolationFactor: (input: number, lower: number, upper: number) => number,
     zoomStops: Array<number>
 };
 
 type CompositeExpression = {
-    result: 'composite',
+    kind: 'composite',
     evaluate: (globals: GlobalProperties, feature?: Feature) => any,
     interpolationFactor: (input: number, lower: number, upper: number) => number,
     zoomStops: Array<number>
@@ -164,8 +164,8 @@ function createPropertyExpression(expression: mixed,
 
     if (!zoomCurve) {
         return success(isFeatureConstant ?
-            { result: 'constant', parsed, evaluate } :
-            { result: 'source', parsed, evaluate });
+            { kind: 'constant', parsed, evaluate } :
+            { kind: 'source', parsed, evaluate });
     }
 
     const interpolationFactor = zoomCurve instanceof Interpolate ?
@@ -174,8 +174,8 @@ function createPropertyExpression(expression: mixed,
     const zoomStops = zoomCurve.labels;
 
     return success(isFeatureConstant ?
-        { result: 'camera', parsed, evaluate, interpolationFactor, zoomStops } :
-        { result: 'composite', parsed, evaluate, interpolationFactor, zoomStops });
+        { kind: 'camera', parsed, evaluate, interpolationFactor, zoomStops } :
+        { kind: 'composite', parsed, evaluate, interpolationFactor, zoomStops });
 }
 
 module.exports = {

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -74,9 +74,9 @@ function createFilter(filter: any): FeatureFilter {
 
     const compiled = createExpression(filter, filterSpec);
     if (compiled.result === 'error') {
-        throw new Error(compiled.errors.map(err => `${err.key}: ${err.message}`).join(', '));
+        throw new Error(compiled.value.map(err => `${err.key}: ${err.message}`).join(', '));
     } else {
-        return compiled.evaluate;
+        return compiled.value.evaluate;
     }
 }
 

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -72,11 +72,11 @@ function createFilter(filter: any): FeatureFilter {
         return (new Function('g', 'f', `var p = (f && f.properties || {}); return ${compile(filter)}`): any);
     }
 
-    const compiled = createExpression(filter, filterSpec, 'filter');
-    if (compiled.result === 'success') {
-        return compiled.evaluate;
-    } else {
+    const compiled = createExpression(filter, filterSpec);
+    if (compiled.result === 'error') {
         throw new Error(compiled.errors.map(err => `${err.key}: ${err.message}`).join(', '));
+    } else {
+        return compiled.evaluate;
     }
 }
 

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -112,7 +112,7 @@ function createFunction(parameters, propertySpec) {
         }
 
         return {
-            result: 'composite',
+            kind: 'composite',
             interpolationFactor: Interpolate.interpolationFactor.bind(undefined, {name: 'linear'}),
             zoomStops: featureFunctionStops.map(s => s[0]),
             evaluate({zoom}, properties) {
@@ -124,7 +124,7 @@ function createFunction(parameters, propertySpec) {
         };
     } else if (zoomDependent) {
         return {
-            result: 'camera',
+            kind: 'camera',
             interpolationFactor: type === 'exponential' ?
                 Interpolate.interpolationFactor.bind(undefined, {name: 'exponential', base: parameters.base !== undefined ? parameters.base : 1}) :
                 () => 0,
@@ -133,7 +133,7 @@ function createFunction(parameters, propertySpec) {
         };
     } else {
         return {
-            result: 'source',
+            kind: 'source',
             evaluate(_, feature) {
                 const value = feature && feature.properties ? feature.properties[parameters.property] : undefined;
                 if (value === undefined) {

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -112,7 +112,7 @@ function createFunction(parameters, propertySpec) {
         }
 
         return {
-            isFeatureConstant: false,
+            result: 'composite',
             interpolationFactor: Interpolate.interpolationFactor.bind(undefined, {name: 'linear'}),
             zoomStops: featureFunctionStops.map(s => s[0]),
             evaluate({zoom}, properties) {
@@ -124,8 +124,7 @@ function createFunction(parameters, propertySpec) {
         };
     } else if (zoomDependent) {
         return {
-            isFeatureConstant: true,
-            isZoomConstant: false,
+            result: 'camera',
             interpolationFactor: type === 'exponential' ?
                 Interpolate.interpolationFactor.bind(undefined, {name: 'exponential', base: parameters.base !== undefined ? parameters.base : 1}) :
                 () => 0,
@@ -134,8 +133,7 @@ function createFunction(parameters, propertySpec) {
         };
     } else {
         return {
-            isFeatureConstant: false,
-            isZoomConstant: true,
+            result: 'source',
             evaluate(_, feature) {
                 const value = feature && feature.properties ? feature.properties[parameters.property] : undefined;
                 if (value === undefined) {

--- a/src/style-spec/util/result.js
+++ b/src/style-spec/util/result.js
@@ -1,0 +1,23 @@
+// @flow
+
+/**
+ * A type used for returning and propagating errors. The first element of the union
+ * represents success and contains a value, and the second represents an error and
+ * contains an error value.
+ */
+export type Result<T, E> =
+    | {| result: 'success', value: T |}
+    | {| result: 'error', value: E |};
+
+function success<T, E>(value: T): Result<T, E> {
+    return { result: 'success', value };
+}
+
+function error<T, E>(value: E): Result<T, E> {
+    return { result: 'error', value };
+}
+
+module.exports = {
+    success,
+    error
+};

--- a/src/style-spec/validate/validate_expression.js
+++ b/src/style-spec/validate/validate_expression.js
@@ -1,15 +1,16 @@
+// @flow
 
 const ValidationError = require('../error/validation_error');
 const {createExpression, createPropertyExpression} = require('../expression');
 const unbundle = require('../util/unbundle_jsonlint');
 
-module.exports = function validateExpression(options) {
+module.exports = function validateExpression(options: any) {
     const expression = (options.expressionContext === 'property' ? createPropertyExpression : createExpression)(unbundle.deep(options.value), options.valueSpec);
     if (expression.result !== 'error') {
         return [];
     }
 
-    return expression.errors.map((error) => {
+    return expression.value.map((error) => {
         return new ValidationError(`${options.key}${error.key}`, options.value, error.message);
     });
 };

--- a/src/style-spec/validate/validate_expression.js
+++ b/src/style-spec/validate/validate_expression.js
@@ -1,11 +1,11 @@
 
 const ValidationError = require('../error/validation_error');
-const {createExpression} = require('../expression');
+const {createExpression, createPropertyExpression} = require('../expression');
 const unbundle = require('../util/unbundle_jsonlint');
 
 module.exports = function validateExpression(options) {
-    const expression = createExpression(unbundle.deep(options.value), options.valueSpec, options.expressionContext);
-    if (expression.result === 'success') {
+    const expression = (options.expressionContext === 'property' ? createPropertyExpression : createExpression)(unbundle.deep(options.value), options.valueSpec);
+    if (expression.result !== 'error') {
         return [];
     }
 

--- a/src/style/style_declaration.js
+++ b/src/style/style_declaration.js
@@ -22,7 +22,7 @@ function normalizeToExpression(parameters, propertySpec): StylePropertyExpressio
             parameters = Color.parse(parameters);
         }
         return {
-            result: 'constant',
+            kind: 'constant',
             evaluate: () => parameters
         };
     }
@@ -49,11 +49,11 @@ class StyleDeclaration {
     }
 
     isFeatureConstant() {
-        return this.expression.result === 'constant' || this.expression.result === 'camera';
+        return this.expression.kind === 'constant' || this.expression.kind === 'camera';
     }
 
     isZoomConstant() {
-        return this.expression.result === 'constant' || this.expression.result === 'source';
+        return this.expression.kind === 'constant' || this.expression.kind === 'source';
     }
 
     calculate(globals: GlobalProperties, feature?: Feature) {
@@ -69,7 +69,7 @@ class StyleDeclaration {
      * zoom level.
      */
     interpolationFactor(zoom: number, lower: number, upper: number) {
-        if (this.expression.result === 'constant' || this.expression.result === 'source') {
+        if (this.expression.kind === 'constant' || this.expression.kind === 'source') {
             return 0;
         } else {
             return this.expression.interpolationFactor(zoom, lower, upper);

--- a/src/style/style_declaration.js
+++ b/src/style/style_declaration.js
@@ -14,9 +14,9 @@ function normalizeToExpression(parameters, propertySpec): StylePropertyExpressio
         const expression = createPropertyExpression(parameters, propertySpec);
         if (expression.result === 'error') {
             // this should have been caught in validation
-            throw new Error(expression.errors.map(err => `${err.key}: ${err.message}`).join(', '));
+            throw new Error(expression.value.map(err => `${err.key}: ${err.message}`).join(', '));
         }
-        return expression;
+        return expression.value;
     } else {
         if (typeof parameters === 'string' && propertySpec.type === 'color') {
             parameters = Color.parse(parameters);

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -125,7 +125,7 @@ class StyleLayer extends Evented {
         const declaration = this._layoutDeclarations[name];
 
         // Avoid attempting to calculate a value for data-driven properties if `feature` is undefined.
-        if (declaration && (declaration.expression.isFeatureConstant || feature)) {
+        if (declaration && (declaration.isFeatureConstant() || feature)) {
             return declaration.calculate(globals, feature);
         } else {
             return specification.default;
@@ -168,7 +168,7 @@ class StyleLayer extends Evented {
         const transition = this._paintTransitions[name];
 
         // Avoid attempting to calculate a value for data-driven properties if `feature` is undefined.
-        if (transition && (transition.declaration.expression.isFeatureConstant || feature)) {
+        if (transition && (transition.declaration.isFeatureConstant() || feature)) {
             return transition.calculate(globals, feature);
         } else if (specification.type === 'color' && specification.default) {
             return Color.parse(specification.default);
@@ -184,12 +184,12 @@ class StyleLayer extends Evented {
 
     isPaintValueFeatureConstant(name: string) {
         const declaration = this._paintDeclarations[name];
-        return !declaration || declaration.expression.isFeatureConstant;
+        return !declaration || declaration.isFeatureConstant();
     }
 
     isPaintValueZoomConstant(name: string) {
         const declaration = this._paintDeclarations[name];
-        return !declaration || declaration.expression.isZoomConstant;
+        return !declaration || declaration.isZoomConstant();
     }
 
     isHidden(zoom: number) {
@@ -292,7 +292,7 @@ class StyleLayer extends Evented {
     // update layout value if it's constant, or mark it as zoom-dependent
     _updateLayoutValue(name: string) {
         const declaration = this._layoutDeclarations[name];
-        if (!declaration || (declaration.expression.isZoomConstant && declaration.expression.isFeatureConstant)) {
+        if (!declaration || (declaration.isZoomConstant() && declaration.isFeatureConstant())) {
             delete this._layoutFunctions[name];
             this.layout[name] = this.getLayoutValue(name, {zoom: 0});
         } else {

--- a/src/style/style_layer/symbol_style_layer.js
+++ b/src/style/style_layer/symbol_style_layer.js
@@ -36,12 +36,12 @@ class SymbolStyleLayer extends StyleLayer {
 
     isLayoutValueFeatureConstant(name: string) {
         const declaration = this._layoutDeclarations[name];
-        return !declaration || declaration.expression.isFeatureConstant;
+        return !declaration || declaration.isFeatureConstant();
     }
 
     isLayoutValueZoomConstant(name: string) {
         const declaration = this._layoutDeclarations[name];
-        return !declaration || declaration.expression.isZoomConstant;
+        return !declaration || declaration.isZoomConstant();
     }
 
     getValueAndResolveTokens(name: 'text-field' | 'icon-image', globals: GlobalProperties, feature: Feature) {

--- a/src/symbol/symbol_size.js
+++ b/src/symbol/symbol_size.js
@@ -31,9 +31,9 @@ export type SizeData = {
 // the painter to set symbol-size-related uniforms
 function getSizeData(tileZoom: number, layer: SymbolStyleLayer, sizeProperty: string): SizeData {
     const declaration: StyleDeclaration = layer.getLayoutDeclaration(sizeProperty);
-    const isFeatureConstant = !declaration || declaration.expression.isFeatureConstant;
+    const isFeatureConstant = !declaration || declaration.isFeatureConstant();
 
-    if (!declaration || declaration.expression.isZoomConstant) {
+    if (!declaration || declaration.isZoomConstant()) {
         return isFeatureConstant ? {
             functionType: 'constant',
             layoutSize: layer.getLayoutValue(sizeProperty, {zoom: tileZoom + 1})
@@ -41,7 +41,7 @@ function getSizeData(tileZoom: number, layer: SymbolStyleLayer, sizeProperty: st
     }
 
     // calculate covering zoom stops for zoom-dependent values
-    const levels = declaration.expression.zoomStops;
+    const levels = (declaration.expression: any).zoomStops;
 
     let lower = 0;
     while (lower < levels.length && levels[lower] <= tileZoom) lower++;

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -2,7 +2,7 @@
 
 require('flow-remove-types/register');
 const expressionSuite = require('./integration').expression;
-const { createExpression } = require('../src/style-spec/expression');
+const { createPropertyExpression } = require('../src/style-spec/expression');
 const { toString } = require('../src/style-spec/expression/types');
 const ignores = require('./ignores.json');
 
@@ -17,7 +17,7 @@ expressionSuite.run('js', { ignores, tests }, (fixture) => {
     spec['function'] = true;
     spec['property-function'] = true;
 
-    const expression = createExpression(fixture.expression, spec, 'property', {handleErrors: false});
+    const expression = createPropertyExpression(fixture.expression, spec, {handleErrors: false});
     if (expression.result === 'error') {
         return {
             compiled: {
@@ -34,9 +34,9 @@ expressionSuite.run('js', { ignores, tests }, (fixture) => {
     const result = {
         outputs,
         compiled: {
-            result: expression.result,
-            isZoomConstant: expression.isZoomConstant,
-            isFeatureConstant: expression.isFeatureConstant,
+            result: expression.result === 'error' ? 'error' : 'success',
+            isZoomConstant: expression.result === 'constant' || expression.result === 'source',
+            isFeatureConstant: expression.result === 'constant' || expression.result === 'camera',
             type: toString(expression.parsed.type)
         }
     };

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -17,12 +17,12 @@ expressionSuite.run('js', { ignores, tests }, (fixture) => {
     spec['function'] = true;
     spec['property-function'] = true;
 
-    const expression = createPropertyExpression(fixture.expression, spec, {handleErrors: false});
+    let expression = createPropertyExpression(fixture.expression, spec, {handleErrors: false});
     if (expression.result === 'error') {
         return {
             compiled: {
-                result: expression.result,
-                errors: expression.errors.map((err) => ({
+                result: 'error',
+                errors: expression.value.map((err) => ({
                     key: err.key,
                     error: err.message
                 }))
@@ -30,11 +30,13 @@ expressionSuite.run('js', { ignores, tests }, (fixture) => {
         };
     }
 
+    expression = expression.value;
+
     const outputs = [];
     const result = {
         outputs,
         compiled: {
-            result: expression.result === 'error' ? 'error' : 'success',
+            result: 'success',
             isZoomConstant: expression.result === 'constant' || expression.result === 'source',
             isFeatureConstant: expression.result === 'constant' || expression.result === 'camera',
             type: toString(expression.parsed.type)

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -37,8 +37,8 @@ expressionSuite.run('js', { ignores, tests }, (fixture) => {
         outputs,
         compiled: {
             result: 'success',
-            isZoomConstant: expression.result === 'constant' || expression.result === 'source',
-            isFeatureConstant: expression.result === 'constant' || expression.result === 'camera',
+            isZoomConstant: expression.kind === 'constant' || expression.kind === 'source',
+            isFeatureConstant: expression.kind === 'constant' || expression.kind === 'camera',
             type: toString(expression.parsed.type)
         }
     };

--- a/test/unit/style-spec/expression.test.js
+++ b/test/unit/style-spec/expression.test.js
@@ -1,16 +1,16 @@
 'use strict';
 
 const test = require('mapbox-gl-js-test').test;
-const {createExpression} = require('../../../src/style-spec/expression');
+const {createPropertyExpression} = require('../../../src/style-spec/expression');
 
-test('createExpression', (t) => {
+test('createPropertyExpression', (t) => {
     test('prohibits piecewise-constant properties from using an "interpolate" expression', (t) => {
-        const expression = createExpression([
+        const expression = createPropertyExpression([
             'interpolate', ['linear'], ['zoom'], 0, 0, 10, 10
         ], {
             type: 'number',
             function: 'piecewise-constant'
-        }, 'property');
+        });
         t.equal(expression.result, 'error');
         t.equal(expression.errors.length, 1);
         t.equal(expression.errors[0].message, '"interpolate" expressions cannot be used with this property');
@@ -22,16 +22,16 @@ test('createExpression', (t) => {
 
 test('evaluate expression', (t) => {
     test('warns and falls back to default for invalid enum values', (t) => {
-        const expression = createExpression([ 'get', 'x' ], {
+        const expression = createPropertyExpression([ 'get', 'x' ], {
             type: 'enum',
             values: {a: {}, b: {}, c: {}},
             default: 'a',
             'property-function': true
-        }, 'property');
+        });
 
         t.stub(console, 'warn');
 
-        t.equal(expression.result, 'success');
+        t.equal(expression.result, 'source');
 
         t.equal(expression.evaluate({}, { properties: {x: 'b'} }), 'b');
         t.equal(expression.evaluate({}, { properties: {x: 'invalid'} }), 'a');

--- a/test/unit/style-spec/expression.test.js
+++ b/test/unit/style-spec/expression.test.js
@@ -5,15 +5,15 @@ const {createPropertyExpression} = require('../../../src/style-spec/expression')
 
 test('createPropertyExpression', (t) => {
     test('prohibits piecewise-constant properties from using an "interpolate" expression', (t) => {
-        const expression = createPropertyExpression([
+        const {result, value} = createPropertyExpression([
             'interpolate', ['linear'], ['zoom'], 0, 0, 10, 10
         ], {
             type: 'number',
             function: 'piecewise-constant'
         });
-        t.equal(expression.result, 'error');
-        t.equal(expression.errors.length, 1);
-        t.equal(expression.errors[0].message, '"interpolate" expressions cannot be used with this property');
+        t.equal(result, 'error');
+        t.equal(value.length, 1);
+        t.equal(value[0].message, '"interpolate" expressions cannot be used with this property');
         t.end();
     });
 
@@ -22,7 +22,7 @@ test('createPropertyExpression', (t) => {
 
 test('evaluate expression', (t) => {
     test('warns and falls back to default for invalid enum values', (t) => {
-        const expression = createPropertyExpression([ 'get', 'x' ], {
+        const {value} = createPropertyExpression([ 'get', 'x' ], {
             type: 'enum',
             values: {a: {}, b: {}, c: {}},
             default: 'a',
@@ -31,10 +31,10 @@ test('evaluate expression', (t) => {
 
         t.stub(console, 'warn');
 
-        t.equal(expression.result, 'source');
+        t.equal(value.result, 'source');
 
-        t.equal(expression.evaluate({}, { properties: {x: 'b'} }), 'b');
-        t.equal(expression.evaluate({}, { properties: {x: 'invalid'} }), 'a');
+        t.equal(value.evaluate({}, { properties: {x: 'b'} }), 'b');
+        t.equal(value.evaluate({}, { properties: {x: 'invalid'} }), 'a');
         t.ok(console.warn.calledWith(`Expected value to be one of "a", "b", "c", but found "invalid" instead.`));
 
         t.end();

--- a/test/unit/style-spec/expression.test.js
+++ b/test/unit/style-spec/expression.test.js
@@ -31,7 +31,7 @@ test('evaluate expression', (t) => {
 
         t.stub(console, 'warn');
 
-        t.equal(value.result, 'source');
+        t.equal(value.kind, 'source');
 
         t.equal(value.evaluate({}, { properties: {x: 'b'} }), 'b');
         t.equal(value.evaluate({}, { properties: {x: 'invalid'} }), 'a');

--- a/test/unit/style-spec/function.test.js
+++ b/test/unit/style-spec/function.test.js
@@ -993,19 +993,19 @@ test('unknown function', (t) => {
     t.end();
 });
 
-test('isConstant', (t) => {
-    t.test('zoom', (t) => {
+test('kind', (t) => {
+    t.test('camera', (t) => {
         const f = createFunction({
             stops: [[1, 1]]
         }, {
             type: 'number'
         });
 
-        t.equal(f.result, 'camera');
+        t.equal(f.kind, 'camera');
         t.end();
     });
 
-    t.test('property', (t) => {
+    t.test('source', (t) => {
         const f = createFunction({
             stops: [[1, 1]],
             property: 'mapbox'
@@ -1013,11 +1013,11 @@ test('isConstant', (t) => {
             type: 'number'
         });
 
-        t.equal(f.result, 'source');
+        t.equal(f.kind, 'source');
         t.end();
     });
 
-    t.test('zoom + property', (t) => {
+    t.test('composite', (t) => {
         const f = createFunction({
             stops: [[{ zoom: 1, value: 1 }, 1]],
             property: 'mapbox'
@@ -1025,7 +1025,7 @@ test('isConstant', (t) => {
             type: 'number'
         });
 
-        t.equal(f.result, 'composite');
+        t.equal(f.kind, 'composite');
         t.end();
     });
 

--- a/test/unit/style-spec/function.test.js
+++ b/test/unit/style-spec/function.test.js
@@ -1001,9 +1001,7 @@ test('isConstant', (t) => {
             type: 'number'
         });
 
-        t.notOk(f.isZoomConstant);
-        t.ok(f.isFeatureConstant);
-
+        t.equal(f.result, 'camera');
         t.end();
     });
 
@@ -1015,9 +1013,7 @@ test('isConstant', (t) => {
             type: 'number'
         });
 
-        t.ok(f.isZoomConstant);
-        t.notOk(f.isFeatureConstant);
-
+        t.equal(f.result, 'source');
         t.end();
     });
 
@@ -1029,9 +1025,7 @@ test('isConstant', (t) => {
             type: 'number'
         });
 
-        t.notOk(f.isZoomConstant);
-        t.notOk(f.isFeatureConstant);
-
+        t.equal(f.result, 'composite');
         t.end();
     });
 

--- a/test/unit/style/style_declaration.test.js
+++ b/test/unit/style/style_declaration.test.js
@@ -14,8 +14,8 @@ test('StyleDeclaration', (t) => {
     t.test('number constant', (t) => {
         const d = new StyleDeclaration({type: 'number'}, 1);
 
-        t.ok(d.expression.isZoomConstant);
-        t.ok(d.expression.isFeatureConstant);
+        t.ok(d.isZoomConstant());
+        t.ok(d.isFeatureConstant());
 
         t.equal(d.calculate({zoom: 0}), 1);
         t.equal(d.calculate({zoom: 1}), 1);
@@ -27,8 +27,8 @@ test('StyleDeclaration', (t) => {
     t.test('string constant', (t) => {
         const d = new StyleDeclaration({type: 'string'}, 'mapbox');
 
-        t.ok(d.expression.isZoomConstant);
-        t.ok(d.expression.isFeatureConstant);
+        t.ok(d.isZoomConstant());
+        t.ok(d.isFeatureConstant());
 
         t.equal(d.calculate({zoom: 0}), 'mapbox');
         t.equal(d.calculate({zoom: 1}), 'mapbox');
@@ -40,8 +40,8 @@ test('StyleDeclaration', (t) => {
     t.test('color constant', (t) => {
         const d = new StyleDeclaration({type: 'color'}, 'red');
 
-        t.ok(d.expression.isZoomConstant);
-        t.ok(d.expression.isFeatureConstant);
+        t.ok(d.isZoomConstant());
+        t.ok(d.isFeatureConstant());
 
         t.deepEqual(d.calculate({zoom: 0}), new Color(1, 0, 0, 1));
         t.deepEqual(d.calculate({zoom: 1}), new Color(1, 0, 0, 1));
@@ -53,8 +53,8 @@ test('StyleDeclaration', (t) => {
     t.test('array constant', (t) => {
         const d = new StyleDeclaration({type: 'array'}, [1]);
 
-        t.ok(d.expression.isZoomConstant);
-        t.ok(d.expression.isFeatureConstant);
+        t.ok(d.isZoomConstant());
+        t.ok(d.isFeatureConstant());
 
         t.deepEqual(d.calculate({zoom: 0}), [1]);
         t.deepEqual(d.calculate({zoom: 1}), [1]);


### PR DESCRIPTION
Introduce the same sort of discriminated union as is used in native: an expression (or function, or generally, any property value) has one of the following kinds: `constant`, `camera`, `source`, `composite`.

This is a prerequisite for #2739 / #3044.