### PR TITLE
Switch to default tap test reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "test": "run-s lint lint-css test-flow test-unit",
     "test-suite": "run-s test-render test-query",
     "test-suite-clean": "find test/integration/{render,query}-tests -mindepth 2 -type d  -not \\( -exec test -e \"{}/style.json\" \\; \\) -print | xargs -t rm -r",
-    "test-unit": "tap --reporter dot --no-coverage test/unit",
+    "test-unit": "tap --no-coverage test/unit",
     "test-render": "node --max-old-space-size=2048 test/render.test.js",
     "test-query": "node test/query.test.js",
     "test-expressions": "node test/expression.test.js",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "test": "run-s lint lint-css test-flow test-unit",
     "test-suite": "run-s test-render test-query",
     "test-suite-clean": "find test/integration/{render,query}-tests -mindepth 2 -type d  -not \\( -exec test -e \"{}/style.json\" \\; \\) -print | xargs -t rm -r",
-    "test-unit": "tap --no-coverage test/unit",
+    "test-unit": "tap --reporter classic --no-coverage test/unit",
     "test-render": "node --max-old-space-size=2048 test/render.test.js",
     "test-query": "node test/query.test.js",
     "test-expressions": "node test/expression.test.js",


### PR DESCRIPTION
With 10164 tests, the `dot` reporter isn't very ergonomic. The default test reporter works much better.

![screen shot 2017-11-08 at 4 40 24 pm](https://user-images.githubusercontent.com/281306/32582419-982cc376-c4a3-11e7-8596-983179101750.png)
![screen shot 2017-11-08 at 4 38 40 pm](https://user-images.githubusercontent.com/281306/32582420-984b1704-c4a3-11e7-98a6-75b84c72de7a.png)
