### PR TITLE
Symbol layer order no longer matters to the worker

### DIFF
--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -63,8 +63,8 @@ class Worker {
         callback();
     }
 
-    updateLayers(mapId: string, params: {layers: Array<LayerSpecification>, removedIds: Array<string>, symbolOrder: ?Array<string>}, callback: WorkerTileCallback) {
-        this.getLayerIndex(mapId).update(params.layers, params.removedIds, params.symbolOrder);
+    updateLayers(mapId: string, params: {layers: Array<LayerSpecification>, removedIds: Array<string>}, callback: WorkerTileCallback) {
+        this.getLayerIndex(mapId).update(params.layers, params.removedIds);
         callback();
     }
 

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -34,7 +34,6 @@ class WorkerTile {
     status: 'parsing' | 'done';
     data: VectorTile;
     collisionBoxArray: CollisionBoxArray;
-    symbolBuckets: Array<SymbolBucket>;
 
     abort: ?() => void;
     reloadCallback: WorkerTileCallback;
@@ -114,16 +113,6 @@ class WorkerTile {
             }
         }
 
-        // Symbol buckets must be placed in reverse order.
-        this.symbolBuckets = [];
-        for (let i = layerIndex.symbolOrder.length - 1; i >= 0; i--) {
-            const bucket = buckets[layerIndex.symbolOrder[i]];
-            if (bucket) {
-                assert(bucket instanceof SymbolBucket);
-                this.symbolBuckets.push(((bucket: any): SymbolBucket));
-            }
-        }
-
         let error: ?Error;
         let glyphMap: ?{[string]: {[number]: ?StyleGlyph}};
         let imageMap: ?{[string]: StyleImage};
@@ -163,10 +152,12 @@ class WorkerTile {
                 const glyphAtlas = makeGlyphAtlas(glyphMap);
                 const imageAtlas = makeImageAtlas(imageMap);
 
-                for (const bucket of this.symbolBuckets) {
-                    recalculateLayers(bucket, this.zoom);
-
-                    performSymbolLayout(bucket, glyphMap, glyphAtlas.positions, imageMap, imageAtlas.positions, this.showCollisionBoxes);
+                for (const key in buckets) {
+                    const bucket = buckets[key];
+                    if (bucket instanceof SymbolBucket) {
+                        recalculateLayers(bucket, this.zoom);
+                        performSymbolLayout(bucket, glyphMap, glyphAtlas.positions, imageMap, imageAtlas.positions, this.showCollisionBoxes);
+                    }
                 }
 
                 this.status = 'done';

--- a/src/style/style_layer_index.js
+++ b/src/style/style_layer_index.js
@@ -8,7 +8,6 @@ const groupByLayout = require('../style-spec/group_by_layout');
 export type LayerConfigs = { [string]: LayerSpecification };
 
 class StyleLayerIndex {
-    symbolOrder: Array<string>;
     familiesBySource: { [string]: { [string]: Array<Array<StyleLayer>> } };
 
     _layerConfigs: LayerConfigs;
@@ -21,18 +20,12 @@ class StyleLayerIndex {
     }
 
     replace(layerConfigs: Array<LayerSpecification>) {
-        this.symbolOrder = [];
-        for (const layerConfig of layerConfigs) {
-            if (layerConfig.type === 'symbol') {
-                this.symbolOrder.push(layerConfig.id);
-            }
-        }
         this._layerConfigs = {};
         this._layers = {};
         this.update(layerConfigs, []);
     }
 
-    update(layerConfigs: Array<LayerSpecification>, removedIds: Array<string>, symbolOrder: ?Array<string>) {
+    update(layerConfigs: Array<LayerSpecification>, removedIds: Array<string>) {
         for (const layerConfig of layerConfigs) {
             this._layerConfigs[layerConfig.id] = layerConfig;
 
@@ -43,9 +36,6 @@ class StyleLayerIndex {
         for (const id of removedIds) {
             delete this._layerConfigs[id];
             delete this._layers[id];
-        }
-        if (symbolOrder) {
-            this.symbolOrder = symbolOrder;
         }
 
         this.familiesBySource = {};


### PR DESCRIPTION
With viewport label placement, the ordering dependency is handled during foreground placement. The worker no longer needs to be concerned about layer order, and relayout doesn't need to happen just because symbol layers are reordered.