### PR TITLE
Provide default element for Marker class per #3557

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -39,21 +39,21 @@ class Marker {
             element = DOM.create('div');
 
             // create svg marker icon based on the Maki icon marker-15
-            var svg = DOM.createNS('http://www.w3.org/2000/svg', 'svg');
+            const svg = DOM.createNS('http://www.w3.org/2000/svg', 'svg');
             svg.setAttributeNS(null, 'height', '30');
             svg.setAttributeNS(null, 'width', '30');
             svg.setAttributeNS(null, 'x', '0');
             svg.setAttributeNS(null, 'y', '0');
             svg.setAttributeNS(null, 'viewBox', '0 0 19 19');
 
-            var rect = DOM.createNS('http://www.w3.org/2000/svg', 'rect');
+            const rect = DOM.createNS('http://www.w3.org/2000/svg', 'rect');
             rect.setAttributeNS(null, 'fill', 'none');
             rect.setAttributeNS(null, 'x', '0');
             rect.setAttributeNS(null, 'y', '0');
             rect.setAttributeNS(null, 'width', '19');
             rect.setAttributeNS(null, 'height', '19');
 
-            var path = DOM.createNS('http://www.w3.org/2000/svg', 'path');
+            const path = DOM.createNS('http://www.w3.org/2000/svg', 'path');
             path.setAttributeNS(null, 'd', 'M7.5,0C5.0676,0,2.2297,1.4865,2.2297,5.2703 C2.2297,7.8378,6.2838,13.5135,7.5,15c1.0811-1.4865,5.2703-7.027,5.2703-9.7297C12.7703,1.4865,9.9324,0,7.5,0z');
             path.setAttributeNS(null, 'fill', '#4264FB');
             path.setAttributeNS(null, 'transform', 'translate(2 2)');

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -13,7 +13,7 @@ import type {MapMouseEvent} from './events';
 
 /**
  * Creates a marker component
- * @param element DOM element to use as a marker (creates a div element by default)
+ * @param element DOM element to use as a marker. If left unspecified a default SVG will be created as the DOM element to use.
  * @param options
  * @param options.offset The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
  * @example

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -35,7 +35,34 @@ class Marker {
 
         bindAll(['_update', '_onMapClick'], this);
 
-        if (!element) element = DOM.create('div');
+        if (!element) {
+            element = DOM.create('div');
+
+            // create svg marker icon based on the Maki icon marker-15
+            var svg = window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            svg.setAttributeNS(null, 'height', '30');
+            svg.setAttributeNS(null, 'width', '30');
+            svg.setAttributeNS(null, 'x', '0');
+            svg.setAttributeNS(null, 'y', '0');
+            svg.setAttributeNS(null, 'viewBox', '0 0 19 19');
+
+            var rect = window.document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            rect.setAttributeNS(null, 'fill', 'none');
+            rect.setAttributeNS(null, 'x', '0');
+            rect.setAttributeNS(null, 'y', '0');
+            rect.setAttributeNS(null, 'width', '19');
+            rect.setAttributeNS(null, 'height', '19');
+
+            var path = window.document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttributeNS(null, 'd', 'M7.5,0C5.0676,0,2.2297,1.4865,2.2297,5.2703 C2.2297,7.8378,6.2838,13.5135,7.5,15c1.0811-1.4865,5.2703-7.027,5.2703-9.7297C12.7703,1.4865,9.9324,0,7.5,0z');
+            path.setAttributeNS(null, 'fill', '#4264FB');
+            path.setAttributeNS(null, 'transform', 'translate(2 2)');
+
+            svg.appendChild(rect);
+            svg.appendChild(path);
+            element.appendChild(svg);
+        }
+
         element.classList.add('mapboxgl-marker');
         this._element = element;
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -38,28 +38,94 @@ class Marker {
         if (!element) {
             element = DOM.create('div');
 
-            // create svg marker icon based on the Maki icon marker-15
+            // create default map marker SVG
             const svg = DOM.createNS('http://www.w3.org/2000/svg', 'svg');
-            svg.setAttributeNS(null, 'height', '30');
-            svg.setAttributeNS(null, 'width', '30');
-            svg.setAttributeNS(null, 'x', '0');
-            svg.setAttributeNS(null, 'y', '0');
-            svg.setAttributeNS(null, 'viewBox', '0 0 19 19');
+            svg.setAttributeNS(null, 'height', '41px');
+            svg.setAttributeNS(null, 'width', '27px');
+            svg.setAttributeNS(null, 'viewBox', '0 0 27 41');
 
-            const rect = DOM.createNS('http://www.w3.org/2000/svg', 'rect');
-            rect.setAttributeNS(null, 'fill', 'none');
-            rect.setAttributeNS(null, 'x', '0');
-            rect.setAttributeNS(null, 'y', '0');
-            rect.setAttributeNS(null, 'width', '19');
-            rect.setAttributeNS(null, 'height', '19');
+            const markerLarge = DOM.createNS('http://www.w3.org/2000/svg', 'g');
+            markerLarge.setAttributeNS(null, 'stroke', 'none');
+            markerLarge.setAttributeNS(null, 'stroke-width', '1');
+            markerLarge.setAttributeNS(null, 'fill', 'none');
+            markerLarge.setAttributeNS(null, 'fill-rule', 'evenodd');
 
-            const path = DOM.createNS('http://www.w3.org/2000/svg', 'path');
-            path.setAttributeNS(null, 'd', 'M7.5,0C5.0676,0,2.2297,1.4865,2.2297,5.2703 C2.2297,7.8378,6.2838,13.5135,7.5,15c1.0811-1.4865,5.2703-7.027,5.2703-9.7297C12.7703,1.4865,9.9324,0,7.5,0z');
-            path.setAttributeNS(null, 'fill', '#4264FB');
-            path.setAttributeNS(null, 'transform', 'translate(2 2)');
+            const page1 = DOM.createNS('http://www.w3.org/2000/svg', 'g');
+            page1.setAttributeNS(null, 'fill-rule', 'nonzero');
 
-            svg.appendChild(rect);
-            svg.appendChild(path);
+            const shadow = DOM.createNS('http://www.w3.org/2000/svg', 'g');
+            shadow.setAttributeNS(null, 'transform', 'translate(3.0, 29.0)');
+            shadow.setAttributeNS(null, 'fill', '#000000');
+
+            const ellipses = [
+                {'rx': '10.5', 'ry': '5.25002273'},
+                {'rx': '10.5', 'ry': '5.25002273'},
+                {'rx': '9.5', 'ry': '4.77275007'},
+                {'rx': '8.5', 'ry': '4.29549936'},
+                {'rx': '7.5', 'ry': '3.81822308'},
+                {'rx': '6.5', 'ry': '3.34094679'},
+                {'rx': '5.5', 'ry': '2.86367051'},
+                {'rx': '4.5', 'ry': '2.38636864'}
+            ];
+
+            for (const data of ellipses) {
+                const ellipse = DOM.createNS('http://www.w3.org/2000/svg', 'ellipse');
+                ellipse.setAttributeNS(null, 'opacity', '0.04');
+                ellipse.setAttributeNS(null, 'cx', '10.5');
+                ellipse.setAttributeNS(null, 'cy', '5.80029008');
+                ellipse.setAttributeNS(null, 'rx', data['rx']);
+                ellipse.setAttributeNS(null, 'ry', data['ry']);
+                shadow.appendChild(ellipse);
+            }
+
+            const background = DOM.createNS('http://www.w3.org/2000/svg', 'g');
+            background.setAttributeNS(null, 'fill', '#3FB1CE');
+
+            const bgPath = DOM.createNS('http://www.w3.org/2000/svg', 'path');
+            bgPath.setAttributeNS(null, 'd', 'M27,13.5 C27,19.074644 20.250001,27.000002 14.75,34.500002 C14.016665,35.500004 12.983335,35.500004 12.25,34.500002 C6.7499993,27.000002 0,19.222562 0,13.5 C0,6.0441559 6.0441559,0 13.5,0 C20.955844,0 27,6.0441559 27,13.5 Z');
+
+            background.appendChild(bgPath);
+
+            const border = DOM.createNS('http://www.w3.org/2000/svg', 'g');
+            border.setAttributeNS(null, 'opacity', '0.25');
+            border.setAttributeNS(null, 'fill', '#000000');
+
+            const borderPath = DOM.createNS('http://www.w3.org/2000/svg', 'path');
+            borderPath.setAttributeNS(null, 'd', 'M13.5,0 C6.0441559,0 0,6.0441559 0,13.5 C0,19.222562 6.7499993,27 12.25,34.5 C13,35.522727 14.016664,35.500004 14.75,34.5 C20.250001,27 27,19.074644 27,13.5 C27,6.0441559 20.955844,0 13.5,0 Z M13.5,1 C20.415404,1 26,6.584596 26,13.5 C26,15.898657 24.495584,19.181431 22.220703,22.738281 C19.945823,26.295132 16.705119,30.142167 13.943359,33.908203 C13.743445,34.180814 13.612715,34.322738 13.5,34.441406 C13.387285,34.322738 13.256555,34.180814 13.056641,33.908203 C10.284481,30.127985 7.4148684,26.314159 5.015625,22.773438 C2.6163816,19.232715 1,15.953538 1,13.5 C1,6.584596 6.584596,1 13.5,1 Z');
+
+            border.appendChild(borderPath);
+
+            const maki = DOM.createNS('http://www.w3.org/2000/svg', 'g');
+            maki.setAttributeNS(null, 'transform', 'translate(6.0, 7.0)');
+            maki.setAttributeNS(null, 'fill', '#FFFFFF');
+
+            const circleContainer = DOM.createNS('http://www.w3.org/2000/svg', 'g');
+            circleContainer.setAttributeNS(null, 'transform', 'translate(8.0, 8.0)');
+
+            const circle1 = DOM.createNS('http://www.w3.org/2000/svg', 'circle');
+            circle1.setAttributeNS(null, 'fill', '#000000');
+            circle1.setAttributeNS(null, 'opacity', '0.25');
+            circle1.setAttributeNS(null, 'cx', '5.5');
+            circle1.setAttributeNS(null, 'cy', '5.5');
+            circle1.setAttributeNS(null, 'r', '5.4999962');
+
+            const circle2 = DOM.createNS('http://www.w3.org/2000/svg', 'circle');
+            circle2.setAttributeNS(null, 'fill', '#FFFFFF');
+            circle2.setAttributeNS(null, 'cx', '5.5');
+            circle2.setAttributeNS(null, 'cy', '5.5');
+            circle2.setAttributeNS(null, 'r', '5.4999962');
+
+            circleContainer.appendChild(circle1);
+            circleContainer.appendChild(circle2);
+
+            page1.appendChild(shadow);
+            page1.appendChild(background);
+            page1.appendChild(border);
+            page1.appendChild(maki);
+            page1.appendChild(circleContainer);
+
+            svg.appendChild(page1);
+
             element.appendChild(svg);
         }
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -39,21 +39,21 @@ class Marker {
             element = DOM.create('div');
 
             // create svg marker icon based on the Maki icon marker-15
-            var svg = window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            var svg = DOM.createNS('http://www.w3.org/2000/svg', 'svg');
             svg.setAttributeNS(null, 'height', '30');
             svg.setAttributeNS(null, 'width', '30');
             svg.setAttributeNS(null, 'x', '0');
             svg.setAttributeNS(null, 'y', '0');
             svg.setAttributeNS(null, 'viewBox', '0 0 19 19');
 
-            var rect = window.document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            var rect = DOM.createNS('http://www.w3.org/2000/svg', 'rect');
             rect.setAttributeNS(null, 'fill', 'none');
             rect.setAttributeNS(null, 'x', '0');
             rect.setAttributeNS(null, 'y', '0');
             rect.setAttributeNS(null, 'width', '19');
             rect.setAttributeNS(null, 'height', '19');
 
-            var path = window.document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            var path = DOM.createNS('http://www.w3.org/2000/svg', 'path');
             path.setAttributeNS(null, 'd', 'M7.5,0C5.0676,0,2.2297,1.4865,2.2297,5.2703 C2.2297,7.8378,6.2838,13.5135,7.5,15c1.0811-1.4865,5.2703-7.027,5.2703-9.7297C12.7703,1.4865,9.9324,0,7.5,0z');
             path.setAttributeNS(null, 'fill', '#4264FB');
             path.setAttributeNS(null, 'transform', 'translate(2 2)');

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -10,6 +10,11 @@ exports.create = function (tagName: *, className?: string, container?: HTMLEleme
     return el;
 };
 
+exports.createNS = function (namespaceURI: string, tagName: string) {
+    const el = window.document.createElementNS(namespaceURI, tagName);
+    return el;
+};
+
 const docStyle = (window.document.documentElement: any).style;
 
 function testProp(props) {

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -21,6 +21,12 @@ test('Marker', (t) => {
         t.end();
     });
 
+    t.test('default marker', (t) => {
+        const marker = new Marker();
+        t.ok(marker.getElement(), 'default marker is created');
+        t.end();
+    });
+
     t.test('marker is added to map', (t) => {
         const map = createMap();
         const marker = new Marker(window.document.createElement('div')).setLngLat([-77.01866, 38.888]);


### PR DESCRIPTION
This PR creates a basic html element for when the `element` parameter to the `Marker` class is null. The icon is pulled from https://www.mapbox.com/maki-icons/ (marker-15), so there shouldn't be any licensing issues.

If this is PR is a valid solution to #3557, maybe something in the docs could be added to show a default marker exists? I can add that if necessary.

Here is a sample `index.html` to test this:

```html
<!DOCTYPE html>
<html>
<head>
    <title>Mapbox GL JS debug page</title>
    <meta charset='utf-8'>
    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
    <style>
        body { margin: 0; padding: 0; }
        html, body, #map { height: 100%; }
    </style>
</head>

<body>
<div id='map'></div>

<script src='/dist/mapbox-gl-dev.js'></script>
<script src='/debug/access_token_generated.js'></script>
<script>

var map = window.map = new mapboxgl.Map({
    container: 'map',
    zoom: 2.5,
    center: [-77.01866, 38.888],
    style: 'mapbox://styles/mapbox/streets-v10',
    hash: true
});

map.on('load', function() {
    // default marker
    var marker = new mapboxgl.Marker()
    .setLngLat([30.5, 50.5])
    .addTo(map);

    // custom element marker
    var el = document.createElement('div');
    el.className = 'marker';
    el.style.backgroundImage = 'url(http://via.placeholder.com/25x25)';
    el.style.width = '25px';
    el.style.height = '25px';

    var marker2 = new mapboxgl.Marker(el)
    .setLngLat([41, 50.5])
    .addTo(map);
});

</script>
</body>
</html>
```


(Updated) Example of icon:
![marker](https://user-images.githubusercontent.com/1827631/32769484-e10476a8-c8d0-11e7-90e4-cb6739a8ea3c.png)


