### PR TITLE
Re-export Transform for external use

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const Marker = require('./ui/marker');
 const Style = require('./style/style');
 const LngLat = require('./geo/lng_lat');
 const LngLatBounds = require('./geo/lng_lat_bounds');
+const Transform = require('./geo/transform');
 const Point = require('@mapbox/point-geometry');
 const Evented = require('./util/evented');
 const config = require('./util/config');
@@ -40,6 +41,7 @@ module.exports = {
     Point,
     Evented,
     config,
+    Transform,
 
     /**
      * Gets and sets the map's [access token](https://www.mapbox.com/help/define-access-token/).


### PR DESCRIPTION
This simply exports the `Transform` class for external use. For apps with unidirectional data flow (such as a large React app), it's much cleaner to do these calculations at a higher level than a map component. This would allow a root component to, for example, calculate map bounds given a center/zoom/pitch from the URL and and window resolution.

This is especially important for server side rendering, where results of a geo-bounded query shouldn't have to wait for a map to be instantiated.