### PR TITLE
Avoid use of 'new Function' when it is prohibited by CSP

### DIFF
--- a/bench/index.html
+++ b/bench/index.html
@@ -12,6 +12,7 @@
 
 <body>
     <div id="benchmarks"></div>
+    <script src="/bench/benchmarks_generated-v0.43.0.js"></script>
     <script>
         // Unless the URL contains a no-master query parameter, include the
         // current master-branch build of benchmarks.js for comparison

--- a/debug/csp.html
+++ b/debug/csp.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta http-equiv="Content-Security-Policy" content="worker-src blob: ; img-src data: blob: ; script-src http: 'nonce-dummy' 'unsafe-eval'; connect-src https://*.tiles.mapbox.com https://api.mapbox.com">
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script nonce="dummy">
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-77.01866, 38.888],
+    style: 'mapbox://styles/mapbox/streets-v10',
+    hash: true
+});
+
+</script>
+</body>
+</html>

--- a/debug/csp.html
+++ b/debug/csp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Mapbox GL JS debug page</title>
-    <meta http-equiv="Content-Security-Policy" content="worker-src blob: ; img-src data: blob: ; script-src http: 'nonce-dummy' 'unsafe-eval'; connect-src https://*.tiles.mapbox.com https://api.mapbox.com">
+    <meta http-equiv="Content-Security-Policy" content="worker-src blob: ; img-src data: blob: ; script-src http: 'nonce-dummy'; connect-src https://*.tiles.mapbox.com https://api.mapbox.com">
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='/dist/mapbox-gl.css' />

--- a/docs/components/quickstart.js
+++ b/docs/components/quickstart.js
@@ -136,7 +136,7 @@ export default class extends React.Component {
                             a <a href='https://developer.mozilla.org/en-US/docs/Web/Security/CSP'>Content Security Policy (CSP)</a> to
                             specify security policies for your website. If you do, Mapbox GL JS requires the following CSP
                             directives:</p>
-                        <pre><code>{`child-src blob: ;\nimg-src data: blob: ;\nscript-src 'unsafe-eval' ;`}</code></pre>
+                        <pre><code>{`child-src blob: ;\nimg-src data: blob: ;`}</code></pre>
 
                         <p>Requesting styles from Mapbox or other services will require additional
                             directives. For Mapbox, you can use this <code>connect-src</code> directive:</p>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "unassertify": "^2.0.0",
     "unflowify": "^1.0.0",
     "vt-pbf": "^3.0.1",
-    "webworkify": "^1.4.0"
+    "webworkify": "^1.5.0"
   },
   "devDependencies": {
     "@mapbox/batfish": "^0.13.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "brfs": "^1.4.0",
     "bubleify": "^0.7.0",
     "csscolorparser": "~1.0.2",
-    "earcut": "^2.0.3",
+    "earcut": "^2.1.3",
     "geojson-rewind": "^0.3.0",
     "geojson-vt": "^3.0.0",
     "gray-matter": "^3.0.8",

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -332,100 +332,94 @@ CompoundExpression.register(expressions, {
     'filter-==': [
         BooleanType,
         [StringType, ValueType],
-        function (ctx) {
-            return ctx.properties()[this.args[0].value] === this.args[1].value;
-        }
+        (ctx, [k, v]) => ctx.properties()[(k: any).value] === (v: any).value
     ],
     'filter-id-==': [
         BooleanType,
         [ValueType],
-        function (ctx) {
-            return ctx.id() === this.args[0].value;
-        }
+        (ctx, [v]) => ctx.id() === (v: any).value
     ],
     'filter-type-==': [
         BooleanType,
         [StringType],
-        function (ctx) {
-            return ctx.geometryType() === this.args[0].value;
-        }
+        (ctx, [v]) => ctx.geometryType() === (v: any).value
     ],
     'filter-<': [
         BooleanType,
         [StringType, ValueType],
-        function (ctx) {
-            const v = ctx.properties()[this.args[0].value];
-            const b = this.args[1];
-            return typeof v === typeof b.value && v < b.value;
+        (ctx, [k, v]) => {
+            const a = ctx.properties()[(k: any).value];
+            const b = (v: any).value;
+            return typeof a === typeof b && a < b;
         }
     ],
     'filter-id-<': [
         BooleanType,
         [ValueType],
-        function (ctx) {
-            const v = ctx.id();
-            const b = this.args[0];
-            return typeof v === typeof b.value && v < b.value;
+        (ctx, [v]) => {
+            const a = ctx.id();
+            const b = (v: any).value;
+            return typeof a === typeof b && a < b;
         }
     ],
     'filter->': [
         BooleanType,
         [StringType, ValueType],
-        function (ctx) {
-            const v = ctx.properties()[this.args[0].value];
-            const b = this.args[1];
-            return typeof v === typeof b.value && v > b.value;
+        (ctx, [k, v]) => {
+            const a = ctx.properties()[(k: any).value];
+            const b = (v: any).value;
+            return typeof a === typeof b && a > b;
         }
     ],
     'filter-id->': [
         BooleanType,
         [ValueType],
-        function (ctx) {
-            const v = ctx.id();
-            const b = this.args[0];
-            return typeof v === typeof b.value && v > b.value;
+        (ctx, [v]) => {
+            const a = ctx.id();
+            const b = (v: any).value;
+            return typeof a === typeof b && a > b;
         }
     ],
     'filter-<=': [
         BooleanType,
         [StringType, ValueType],
-        function (ctx) {
-            const v = ctx.properties()[this.args[0].value];
-            const b = this.args[1];
-            return typeof v === typeof b.value && v <= b.value;
+        (ctx, [k, v]) => {
+            const a = ctx.properties()[(k: any).value];
+            const b = (v: any).value;
+            return typeof a === typeof b && a <= b;
         }
     ],
     'filter-id-<=': [
         BooleanType,
         [ValueType],
-        function (ctx) {
-            const v = ctx.id();
-            const b = this.args[0];
-            return typeof v === typeof b.value && v <= b.value;
+        (ctx, [v]) => {
+            const a = ctx.id();
+            const b = (v: any).value;
+            return typeof a === typeof b && a <= b;
         }
     ],
     'filter->=': [
         BooleanType,
         [StringType, ValueType],
-        function (ctx) {
-            const v = ctx.properties()[this.args[0].value];
-            const b = this.args[1];
-            return typeof v === typeof b.value && v >= b.value;
+        (ctx, [k, v]) => {
+            const a = ctx.properties()[(k: any).value];
+            const b = (v: any).value;
+            return typeof a === typeof b && a >= b;
         }
     ],
     'filter-id->=': [
         BooleanType,
         [ValueType],
-        function (ctx) {
-            const v = ctx.id();
-            const b = this.args[0];
-            return typeof v === typeof b.value && v >= b.value;
+        (ctx, [v]) => {
+            const a = ctx.id();
+            const b = (v: any).value;
+            return typeof a === typeof b && a >= b;
         }
     ],
     'filter-has': [
         BooleanType,
         [ValueType],
-        function (ctx) { return this.args[0].value in ctx.properties(); }
+        (ctx, [k]) => (k: any).value in ctx.properties()
     ],
     'filter-has-id': [
         BooleanType,
@@ -435,33 +429,24 @@ CompoundExpression.register(expressions, {
     'filter-type-in': [
         BooleanType,
         [array(StringType)],
-        function (ctx) { return this.args[0].value.indexOf(ctx.geometryType()) >= 0; }
+        (ctx, [v]) => (v: any).value.indexOf(ctx.geometryType()) >= 0
     ],
     'filter-id-in': [
         BooleanType,
         [array(ValueType)],
-        function (ctx) { return this.args[0].value.indexOf(ctx.id()) >= 0; }
+        (ctx, [v]) => (v: any).value.indexOf(ctx.id()) >= 0
     ],
     'filter-in-small': [
         BooleanType,
         [StringType, array(ValueType)],
-        function (ctx) {
-            // assumes this.args[1] is an array Literal
-            const value = ctx.properties()[this.args[0].value];
-            const array = this.args[1].value;
-            return array.indexOf(value) >= 0;
-        }
+        // assumes v is an array literal
+        (ctx, [k, v]) => (v: any).value.indexOf(ctx.properties()[(k: any).value]) >= 0
     ],
     'filter-in-large': [
         BooleanType,
         [StringType, array(ValueType)],
-        function (ctx) {
-            // assumes this.args[1] is a array Literal with values
-            // sorted in ascending order and of a single type
-            const value = ctx.properties()[this.args[0].value];
-            const array = this.args[1].value;
-            return binarySearch(value, array, 0, array.length - 1);
-        }
+        // assumes v is a array literal with values sorted in ascending order and of a single type
+        (ctx, [k, v]) => binarySearch(ctx.properties()[(k: any).value], (v: any).value, 0, (v: any).value.length - 1)
     ],
     '>': {
         type: BooleanType,

--- a/src/style-spec/expression/is_constant.js
+++ b/src/style-spec/expression/is_constant.js
@@ -16,6 +16,8 @@ function isFeatureConstant(e: Expression) {
             e.name === 'id'
         ) {
             return false;
+        } else if (e.name.startsWith('filter-')) {
+            return false;
         }
     }
 

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -126,7 +126,7 @@ function compileInOp(property, values) {
     const left = JSON.stringify(values.sort(compare));
     const right = compilePropertyReference(property);
 
-    if (values.length <= 200) return `${left}.indexOf(${right}) !== -1`;
+    if (values.length <= 200 || values.some(v => typeof v !== typeof values[0])) return `${left}.indexOf(${right}) !== -1`;
 
     return `${'function(v, a, i, j) {' +
         'while (i <= j) { var m = (i + j) >> 1;' +

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -44,8 +44,6 @@ function isExpressionFilter(filter) {
     }
 }
 
-const types = ['Unknown', 'Point', 'LineString', 'Polygon'];
-
 const filterSpec = {
     'type': 'boolean',
     'default': false,
@@ -69,7 +67,7 @@ function createFilter(filter: any): FeatureFilter {
     }
 
     if (!isExpressionFilter(filter)) {
-        return (new Function('g', 'f', `var p = (f && f.properties || {}); return ${compile(filter)}`): any);
+        filter = convertFilter(filter);
     }
 
     const compiled = createExpression(filter, filterSpec);
@@ -80,70 +78,76 @@ function createFilter(filter: any): FeatureFilter {
     }
 }
 
-function compile(filter) {
-    if (!filter) return 'true';
-    const op = filter[0];
-    if (filter.length <= 1) return op === 'any' ? 'false' : 'true';
-    const str =
-        op === '==' ? compileComparisonOp(filter[1], filter[2], '===', false) :
-        op === '!=' ? compileComparisonOp(filter[1], filter[2], '!==', false) :
-        op === '<' ||
-        op === '>' ||
-        op === '<=' ||
-        op === '>=' ? compileComparisonOp(filter[1], filter[2], op, true) :
-        op === 'any' ? compileLogicalOp(filter.slice(1), '||') :
-        op === 'all' ? compileLogicalOp(filter.slice(1), '&&') :
-        op === 'none' ? compileNegation(compileLogicalOp(filter.slice(1), '||')) :
-        op === 'in' ? compileInOp(filter[1], filter.slice(2)) :
-        op === '!in' ? compileNegation(compileInOp(filter[1], filter.slice(2))) :
-        op === 'has' ? compileHasOp(filter[1]) :
-        op === '!has' ? compileNegation(compileHasOp(filter[1])) :
-        'true';
-    return `(${str})`;
-}
-
-function compilePropertyReference(property) {
-    const ref =
-        property === '$type' ? 'f.type' :
-        property === '$id' ? 'f.id' : `p[${JSON.stringify(property)}]`;
-    return ref;
-}
-
-function compileComparisonOp(property, value, op, checkType) {
-    const left = compilePropertyReference(property);
-    const right = property === '$type' ? types.indexOf(value) : JSON.stringify(value);
-    return (checkType ? `typeof ${left}=== typeof ${right}&&` : '') + left + op + right;
-}
-
-function compileLogicalOp(expressions, op) {
-    return expressions.map(compile).join(op);
-}
-
-function compileInOp(property, values) {
-    if (property === '$type') values = values.map((value) => {
-        return types.indexOf(value);
-    });
-    const left = JSON.stringify(values.sort(compare));
-    const right = compilePropertyReference(property);
-
-    if (values.length <= 200 || values.some(v => typeof v !== typeof values[0])) return `${left}.indexOf(${right}) !== -1`;
-
-    return `${'function(v, a, i, j) {' +
-        'while (i <= j) { var m = (i + j) >> 1;' +
-        '    if (a[m] === v) return true; if (a[m] > v) j = m - 1; else i = m + 1;' +
-        '}' +
-    'return false; }('}${right}, ${left},0,${values.length - 1})`;
-}
-
-function compileHasOp(property) {
-    return property === '$id' ? '"id" in f' : `${JSON.stringify(property)} in p`;
-}
-
-function compileNegation(expression) {
-    return `!(${expression})`;
-}
-
 // Comparison function to sort numbers and strings
 function compare(a, b) {
     return a < b ? -1 : a > b ? 1 : 0;
 }
+
+function convertFilter(filter: ?Array<any>): mixed {
+    if (!filter) return true;
+    const op = filter[0];
+    if (filter.length <= 1) return (op !== 'any');
+    const converted =
+        op === '==' ? convertComparisonOp(filter[1], filter[2], '==') :
+        op === '!=' ? convertNegation(convertComparisonOp(filter[1], filter[2], '==')) :
+        op === '<' ||
+        op === '>' ||
+        op === '<=' ||
+        op === '>=' ? convertComparisonOp(filter[1], filter[2], op) :
+        op === 'any' ? convertDisjunctionOp(filter.slice(1)) :
+        op === 'all' ? ['all'].concat(filter.slice(1).map(convertFilter)) :
+        op === 'none' ? ['all'].concat(filter.slice(1).map(convertFilter).map(convertNegation)) :
+        op === 'in' ? convertInOp(filter[1], filter.slice(2)) :
+        op === '!in' ? convertNegation(convertInOp(filter[1], filter.slice(2))) :
+        op === 'has' ? convertHasOp(filter[1]) :
+        op === '!has' ? convertNegation(convertHasOp(filter[1])) :
+        true;
+    return converted;
+}
+
+function convertComparisonOp(property: string, value: any, op: string) {
+    switch (property) {
+    case '$type':
+        return [`filter-type-${op}`, value];
+    case '$id':
+        return [`filter-id-${op}`, value];
+    default:
+        return [`filter-${op}`, property, value];
+    }
+}
+
+function convertDisjunctionOp(filters: Array<Array<any>>) {
+    return ['any'].concat(filters.map(convertFilter));
+}
+
+function convertInOp(property: string, values: Array<any>) {
+    if (values.length === 0) { return false; }
+    switch (property) {
+    case '$type':
+        return [`filter-type-in`, ['literal', values]];
+    case '$id':
+        return [`filter-id-in`, ['literal', values]];
+    default:
+        if (values.length > 200 && !values.some(v => typeof v !== typeof values[0])) {
+            return ['filter-in-large', property, ['literal', values.sort(compare)]];
+        } else {
+            return ['filter-in-small', property, ['literal', values]];
+        }
+    }
+}
+
+function convertHasOp(property: string) {
+    switch (property) {
+    case '$type':
+        return true;
+    case '$id':
+        return [`filter-has-id`];
+    default:
+        return [`filter-has`, property];
+    }
+}
+
+function convertNegation(filter: mixed) {
+    return ['!', filter];
+}
+

--- a/src/style-spec/util/eval_support.js
+++ b/src/style-spec/util/eval_support.js
@@ -1,0 +1,10 @@
+// @flow
+
+module.exports = (function () {
+    try {
+        new Function('');
+        return true;
+    } catch (e) {
+        return false;
+    }
+})();

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -1,496 +1,507 @@
 'use strict';
 
 const test = require('mapbox-gl-js-test').test;
-const filter = require('../../../src/style-spec/feature_filter');
+const proxyquire = require('proxyquire');
 
-test('expression, zoom', (t) => {
-    const f = filter(['>=', ['number', ['get', 'x']], ['zoom']]);
-    t.equal(f({zoom: 1}, {properties: {x: 0}}), false);
-    t.equal(f({zoom: 1}, {properties: {x: 1.5}}), true);
-    t.equal(f({zoom: 1}, {properties: {x: 2.5}}), true);
-    t.equal(f({zoom: 2}, {properties: {x: 0}}), false);
-    t.equal(f({zoom: 2}, {properties: {x: 1.5}}), false);
-    t.equal(f({zoom: 2}, {properties: {x: 2.5}}), true);
-    t.end();
-});
-
-test('expression, compare two properties', (t) => {
-    t.stub(console, 'warn');
-    const f = filter(['==', ['string', ['get', 'x']], ['string', ['get', 'y']]]);
-    t.equal(f({zoom: 0}, {properties: {x: 1, y: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {x: '1', y: '1'}}), true);
-    t.equal(f({zoom: 0}, {properties: {x: 'same', y: 'same'}}), true);
-    t.equal(f({zoom: 0}, {properties: {x: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {x: undefined}}), false);
-    t.end();
-});
-
-test('expression, any/all', (t) => {
-    t.equal(filter(['all'])(), true);
-    t.equal(filter(['all', true])(), true);
-    t.equal(filter(['all', true, false])(), false);
-    t.equal(filter(['all', true, true])(), true);
-    t.equal(filter(['any'])(), false);
-    t.equal(filter(['any', true])(), true);
-    t.equal(filter(['any', true, false])(), true);
-    t.equal(filter(['any', false, false])(), false);
-    t.end();
-});
-
-test('expression, type error', (t) => {
-    t.throws(() => {
-        filter(['==', ['number', ['get', 'x']], ['string', ['get', 'y']]]);
+const filterTests = (isEvalSupported) => (t) => {
+    const filter = proxyquire('../../../src/style-spec/feature_filter', {
+        '../util/eval_support': isEvalSupported
     });
 
-    t.throws(() => {
-        filter(['number', ['get', 'x']]);
+    t.test('expression, zoom', (t) => {
+        const f = filter(['>=', ['number', ['get', 'x']], ['zoom']]);
+        t.equal(f({zoom: 1}, {properties: {x: 0}}), false);
+        t.equal(f({zoom: 1}, {properties: {x: 1.5}}), true);
+        t.equal(f({zoom: 1}, {properties: {x: 2.5}}), true);
+        t.equal(f({zoom: 2}, {properties: {x: 0}}), false);
+        t.equal(f({zoom: 2}, {properties: {x: 1.5}}), false);
+        t.equal(f({zoom: 2}, {properties: {x: 2.5}}), true);
+        t.end();
     });
 
-    t.doesNotThrow(() => {
-        filter(['boolean', ['get', 'x']]);
+    t.test('expression, compare two properties', (t) => {
+        t.stub(console, 'warn');
+        const f = filter(['==', ['string', ['get', 'x']], ['string', ['get', 'y']]]);
+        t.equal(f({zoom: 0}, {properties: {x: 1, y: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {x: '1', y: '1'}}), true);
+        t.equal(f({zoom: 0}, {properties: {x: 'same', y: 'same'}}), true);
+        t.equal(f({zoom: 0}, {properties: {x: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {x: undefined}}), false);
+        t.end();
+    });
+
+    t.test('expression, any/all', (t) => {
+        t.equal(filter(['all'])(), true);
+        t.equal(filter(['all', true])(), true);
+        t.equal(filter(['all', true, false])(), false);
+        t.equal(filter(['all', true, true])(), true);
+        t.equal(filter(['any'])(), false);
+        t.equal(filter(['any', true])(), true);
+        t.equal(filter(['any', true, false])(), true);
+        t.equal(filter(['any', false, false])(), false);
+        t.end();
+    });
+
+    t.test('expression, type error', (t) => {
+        t.throws(() => {
+            filter(['==', ['number', ['get', 'x']], ['string', ['get', 'y']]]);
+        });
+
+        t.throws(() => {
+            filter(['number', ['get', 'x']]);
+        });
+
+        t.doesNotThrow(() => {
+            filter(['boolean', ['get', 'x']]);
+        });
+
+        t.end();
+    });
+
+
+    t.test('degenerate', (t) => {
+        t.equal(filter()(), true);
+        t.equal(filter(undefined)(), true);
+        t.equal(filter(null)(), true);
+        t.end();
+    });
+
+    t.test('==, string', (t) => {
+        const f = filter(['==', 'foo', 'bar']);
+        t.equal(f({zoom: 0}, {properties: {foo: 'bar'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 'baz'}}), false);
+        t.end();
+    });
+
+    t.test('==, number', (t) => {
+        const f = filter(['==', 'foo', 0]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.equal(f({zoom: 0}, {properties: {}}), false);
+        t.end();
+    });
+
+    t.test('==, null', (t) => {
+        const f = filter(['==', 'foo', null]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.equal(f({zoom: 0}, {properties: {}}), false);
+        t.end();
+    });
+
+    t.test('==, $type', (t) => {
+        const f = filter(['==', '$type', 'LineString']);
+        t.equal(f({zoom: 0}, {type: 1}), false);
+        t.equal(f({zoom: 0}, {type: 2}), true);
+        t.end();
+    });
+
+    t.test('==, $id', (t) => {
+        const f = filter(['==', '$id', 1234]);
+
+        t.equal(f({zoom: 0}, {id: 1234}), true);
+        t.equal(f({zoom: 0}, {id: '1234'}), false);
+        t.equal(f({zoom: 0}, {properties: {id: 1234}}), false);
+
+        t.end();
+    });
+
+    t.test('!=, string', (t) => {
+        const f = filter(['!=', 'foo', 'bar']);
+        t.equal(f({zoom: 0}, {properties: {foo: 'bar'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 'baz'}}), true);
+        t.end();
+    });
+
+    t.test('!=, number', (t) => {
+        const f = filter(['!=', 'foo', 0]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+        t.equal(f({zoom: 0}, {properties: {}}), true);
+        t.end();
+    });
+
+    t.test('!=, null', (t) => {
+        const f = filter(['!=', 'foo', null]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+        t.equal(f({zoom: 0}, {properties: {}}), true);
+        t.end();
+    });
+
+    t.test('!=, $type', (t) => {
+        const f = filter(['!=', '$type', 'LineString']);
+        t.equal(f({zoom: 0}, {type: 1}), true);
+        t.equal(f({zoom: 0}, {type: 2}), false);
+        t.end();
+    });
+
+    t.test('<, number', (t) => {
+        const f = filter(['<', 'foo', 0]);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: -1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.equal(f({zoom: 0}, {properties: {}}), false);
+        t.end();
+    });
+
+    t.test('<, string', (t) => {
+        const f = filter(['<', 'foo', '0']);
+        t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.end();
+    });
+
+    t.test('<=, number', (t) => {
+        const f = filter(['<=', 'foo', 0]);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: -1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.equal(f({zoom: 0}, {properties: {}}), false);
+        t.end();
+    });
+
+    t.test('<=, string', (t) => {
+        const f = filter(['<=', 'foo', '0']);
+        t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.end();
+    });
+
+    t.test('>, number', (t) => {
+        const f = filter(['>', 'foo', 0]);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.equal(f({zoom: 0}, {properties: {}}), false);
+        t.end();
+    });
+
+    t.test('>, string', (t) => {
+        const f = filter(['>', 'foo', '0']);
+        t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '1'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.end();
+    });
+
+    t.test('>=, number', (t) => {
+        const f = filter(['>=', 'foo', 0]);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.equal(f({zoom: 0}, {properties: {}}), false);
+        t.end();
+    });
+
+    t.test('>=, string', (t) => {
+        const f = filter(['>=', 'foo', '0']);
+        t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '1'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.end();
+    });
+
+    t.test('in, degenerate', (t) => {
+        const f = filter(['in', 'foo']);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.end();
+    });
+
+    t.test('in, string', (t) => {
+        const f = filter(['in', 'foo', '0']);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.equal(f({zoom: 0}, {properties: {}}), false);
+        t.end();
+    });
+
+    t.test('in, number', (t) => {
+        const f = filter(['in', 'foo', 0]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.end();
+    });
+
+    t.test('in, null', (t) => {
+        const f = filter(['in', 'foo', null]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.end();
+    });
+
+    t.test('in, multiple', (t) => {
+        const f = filter(['in', 'foo', 0, 1]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 3}}), false);
+        t.end();
+    });
+
+    t.test('in, large_multiple', (t) => {
+        const values = Array.apply(null, {length: 2000}).map(Number.call, Number);
+        values.reverse();
+        const f = filter(['in', 'foo'].concat(values));
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 2000}}), false);
+        t.end();
+    });
+
+    t.test('in, large_multiple, heterogeneous', (t) => {
+        const values = Array.apply(null, {length: 2000}).map(Number.call, Number);
+        values.push('a');
+        values.unshift('b');
+        const f = filter(['in', 'foo'].concat(values));
+        t.equal(f({zoom: 0}, {properties: {foo: 'b'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 'a'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 2000}}), false);
+        t.end();
+    });
+
+    t.test('in, $type', (t) => {
+        const f = filter(['in', '$type', 'LineString', 'Polygon']);
+        t.equal(f({zoom: 0}, {type: 1}), false);
+        t.equal(f({zoom: 0}, {type: 2}), true);
+        t.equal(f({zoom: 0}, {type: 3}), true);
+
+        const f1 = filter(['in', '$type', 'Polygon', 'LineString', 'Point']);
+        t.equal(f1({zoom: 0}, {type: 1}), true);
+        t.equal(f1({zoom: 0}, {type: 2}), true);
+        t.equal(f1({zoom: 0}, {type: 3}), true);
+
+        t.end();
+    });
+
+    t.test('!in, degenerate', (t) => {
+        const f = filter(['!in', 'foo']);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.end();
+    });
+
+    t.test('!in, string', (t) => {
+        const f = filter(['!in', 'foo', '0']);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+        t.equal(f({zoom: 0}, {properties: {}}), true);
+        t.end();
+    });
+
+    t.test('!in, number', (t) => {
+        const f = filter(['!in', 'foo', 0]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+        t.end();
+    });
+
+    t.test('!in, null', (t) => {
+        const f = filter(['!in', 'foo', null]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+        t.end();
+    });
+
+    t.test('!in, multiple', (t) => {
+        const f = filter(['!in', 'foo', 0, 1]);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 3}}), true);
+        t.end();
+    });
+
+    t.test('!in, large_multiple', (t) => {
+        const f = filter(['!in', 'foo'].concat(Array.apply(null, {length: 2000}).map(Number.call, Number)));
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1999}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 2000}}), true);
+        t.end();
+    });
+
+    t.test('!in, $type', (t) => {
+        const f = filter(['!in', '$type', 'LineString', 'Polygon']);
+        t.equal(f({zoom: 0}, {type: 1}), true);
+        t.equal(f({zoom: 0}, {type: 2}), false);
+        t.equal(f({zoom: 0}, {type: 3}), false);
+        t.end();
+    });
+
+    t.test('any', (t) => {
+        const f1 = filter(['any']);
+        t.equal(f1({zoom: 0}, {properties: {foo: 1}}), false);
+
+        const f2 = filter(['any', ['==', 'foo', 1]]);
+        t.equal(f2({zoom: 0}, {properties: {foo: 1}}), true);
+
+        const f3 = filter(['any', ['==', 'foo', 0]]);
+        t.equal(f3({zoom: 0}, {properties: {foo: 1}}), false);
+
+        const f4 = filter(['any', ['==', 'foo', 0], ['==', 'foo', 1]]);
+        t.equal(f4({zoom: 0}, {properties: {foo: 1}}), true);
+
+        t.end();
+    });
+
+    t.test('all', (t) => {
+        const f1 = filter(['all']);
+        t.equal(f1({zoom: 0}, {properties: {foo: 1}}), true);
+
+        const f2 = filter(['all', ['==', 'foo', 1]]);
+        t.equal(f2({zoom: 0}, {properties: {foo: 1}}), true);
+
+        const f3 = filter(['all', ['==', 'foo', 0]]);
+        t.equal(f3({zoom: 0}, {properties: {foo: 1}}), false);
+
+        const f4 = filter(['all', ['==', 'foo', 0], ['==', 'foo', 1]]);
+        t.equal(f4({zoom: 0}, {properties: {foo: 1}}), false);
+
+        t.end();
+    });
+
+    t.test('none', (t) => {
+        const f1 = filter(['none']);
+        t.equal(f1({zoom: 0}, {properties: {foo: 1}}), true);
+
+        const f2 = filter(['none', ['==', 'foo', 1]]);
+        t.equal(f2({zoom: 0}, {properties: {foo: 1}}), false);
+
+        const f3 = filter(['none', ['==', 'foo', 0]]);
+        t.equal(f3({zoom: 0}, {properties: {foo: 1}}), true);
+
+        const f4 = filter(['none', ['==', 'foo', 0], ['==', 'foo', 1]]);
+        t.equal(f4({zoom: 0}, {properties: {foo: 1}}), false);
+
+        t.end();
+    });
+
+    t.test('has', (t) => {
+        const f = filter(['has', 'foo']);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
+        t.equal(f({zoom: 0}, {properties: {}}), false);
+        t.end();
+    });
+
+    t.test('!has', (t) => {
+        const f = filter(['!has', 'foo']);
+        t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
+        t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
+        t.equal(f({zoom: 0}, {properties: {}}), true);
+        t.end();
     });
 
     t.end();
-});
+};
 
-
-test('degenerate', (t) => {
-    t.equal(filter()(), true);
-    t.equal(filter(undefined)(), true);
-    t.equal(filter(null)(), true);
-    t.end();
-});
-
-test('==, string', (t) => {
-    const f = filter(['==', 'foo', 'bar']);
-    t.equal(f({zoom: 0}, {properties: {foo: 'bar'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 'baz'}}), false);
-    t.end();
-});
-
-test('==, number', (t) => {
-    const f = filter(['==', 'foo', 0]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.equal(f({zoom: 0}, {properties: {}}), false);
-    t.end();
-});
-
-test('==, null', (t) => {
-    const f = filter(['==', 'foo', null]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.equal(f({zoom: 0}, {properties: {}}), false);
-    t.end();
-});
-
-test('==, $type', (t) => {
-    const f = filter(['==', '$type', 'LineString']);
-    t.equal(f({zoom: 0}, {type: 1}), false);
-    t.equal(f({zoom: 0}, {type: 2}), true);
-    t.end();
-});
-
-test('==, $id', (t) => {
-    const f = filter(['==', '$id', 1234]);
-
-    t.equal(f({zoom: 0}, {id: 1234}), true);
-    t.equal(f({zoom: 0}, {id: '1234'}), false);
-    t.equal(f({zoom: 0}, {properties: {id: 1234}}), false);
-
-    t.end();
-});
-
-test('!=, string', (t) => {
-    const f = filter(['!=', 'foo', 'bar']);
-    t.equal(f({zoom: 0}, {properties: {foo: 'bar'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 'baz'}}), true);
-    t.end();
-});
-
-test('!=, number', (t) => {
-    const f = filter(['!=', 'foo', 0]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
-    t.equal(f({zoom: 0}, {properties: {}}), true);
-    t.end();
-});
-
-test('!=, null', (t) => {
-    const f = filter(['!=', 'foo', null]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
-    t.equal(f({zoom: 0}, {properties: {}}), true);
-    t.end();
-});
-
-test('!=, $type', (t) => {
-    const f = filter(['!=', '$type', 'LineString']);
-    t.equal(f({zoom: 0}, {type: 1}), true);
-    t.equal(f({zoom: 0}, {type: 2}), false);
-    t.end();
-});
-
-test('<, number', (t) => {
-    const f = filter(['<', 'foo', 0]);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: -1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.equal(f({zoom: 0}, {properties: {}}), false);
-    t.end();
-});
-
-test('<, string', (t) => {
-    const f = filter(['<', 'foo', '0']);
-    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.end();
-});
-
-test('<=, number', (t) => {
-    const f = filter(['<=', 'foo', 0]);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: -1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.equal(f({zoom: 0}, {properties: {}}), false);
-    t.end();
-});
-
-test('<=, string', (t) => {
-    const f = filter(['<=', 'foo', '0']);
-    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.end();
-});
-
-test('>, number', (t) => {
-    const f = filter(['>', 'foo', 0]);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.equal(f({zoom: 0}, {properties: {}}), false);
-    t.end();
-});
-
-test('>, string', (t) => {
-    const f = filter(['>', 'foo', '0']);
-    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.end();
-});
-
-test('>=, number', (t) => {
-    const f = filter(['>=', 'foo', 0]);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.equal(f({zoom: 0}, {properties: {}}), false);
-    t.end();
-});
-
-test('>=, string', (t) => {
-    const f = filter(['>=', 'foo', '0']);
-    t.equal(f({zoom: 0}, {properties: {foo: -1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '1'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '-1'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.end();
-});
-
-test('in, degenerate', (t) => {
-    const f = filter(['in', 'foo']);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.end();
-});
-
-test('in, string', (t) => {
-    const f = filter(['in', 'foo', '0']);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.equal(f({zoom: 0}, {properties: {}}), false);
-    t.end();
-});
-
-test('in, number', (t) => {
-    const f = filter(['in', 'foo', 0]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.end();
-});
-
-test('in, null', (t) => {
-    const f = filter(['in', 'foo', null]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.end();
-});
-
-test('in, multiple', (t) => {
-    const f = filter(['in', 'foo', 0, 1]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 3}}), false);
-    t.end();
-});
-
-test('in, large_multiple', (t) => {
-    const values = Array.apply(null, {length: 2000}).map(Number.call, Number);
-    values.reverse();
-    const f = filter(['in', 'foo'].concat(values));
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 2000}}), false);
-    t.end();
-});
-
-test('in, large_multiple, heterogeneous', (t) => {
-    const values = Array.apply(null, {length: 2000}).map(Number.call, Number);
-    values.push('a');
-    values.unshift('b');
-    const f = filter(['in', 'foo'].concat(values));
-    t.equal(f({zoom: 0}, {properties: {foo: 'b'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 'a'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 2000}}), false);
-    t.end();
-});
-
-test('in, $type', (t) => {
-    const f = filter(['in', '$type', 'LineString', 'Polygon']);
-    t.equal(f({zoom: 0}, {type: 1}), false);
-    t.equal(f({zoom: 0}, {type: 2}), true);
-    t.equal(f({zoom: 0}, {type: 3}), true);
-
-    const f1 = filter(['in', '$type', 'Polygon', 'LineString', 'Point']);
-    t.equal(f1({zoom: 0}, {type: 1}), true);
-    t.equal(f1({zoom: 0}, {type: 2}), true);
-    t.equal(f1({zoom: 0}, {type: 3}), true);
-
-    t.end();
-});
-
-test('!in, degenerate', (t) => {
-    const f = filter(['!in', 'foo']);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.end();
-});
-
-test('!in, string', (t) => {
-    const f = filter(['!in', 'foo', '0']);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
-    t.equal(f({zoom: 0}, {properties: {}}), true);
-    t.end();
-});
-
-test('!in, number', (t) => {
-    const f = filter(['!in', 'foo', 0]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
-    t.end();
-});
-
-test('!in, null', (t) => {
-    const f = filter(['!in', 'foo', null]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
-    t.end();
-});
-
-test('!in, multiple', (t) => {
-    const f = filter(['!in', 'foo', 0, 1]);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 3}}), true);
-    t.end();
-});
-
-test('!in, large_multiple', (t) => {
-    const f = filter(['!in', 'foo'].concat(Array.apply(null, {length: 2000}).map(Number.call, Number)));
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1999}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 2000}}), true);
-    t.end();
-});
-
-test('!in, $type', (t) => {
-    const f = filter(['!in', '$type', 'LineString', 'Polygon']);
-    t.equal(f({zoom: 0}, {type: 1}), true);
-    t.equal(f({zoom: 0}, {type: 2}), false);
-    t.equal(f({zoom: 0}, {type: 3}), false);
-    t.end();
-});
-
-test('any', (t) => {
-    const f1 = filter(['any']);
-    t.equal(f1({zoom: 0}, {properties: {foo: 1}}), false);
-
-    const f2 = filter(['any', ['==', 'foo', 1]]);
-    t.equal(f2({zoom: 0}, {properties: {foo: 1}}), true);
-
-    const f3 = filter(['any', ['==', 'foo', 0]]);
-    t.equal(f3({zoom: 0}, {properties: {foo: 1}}), false);
-
-    const f4 = filter(['any', ['==', 'foo', 0], ['==', 'foo', 1]]);
-    t.equal(f4({zoom: 0}, {properties: {foo: 1}}), true);
-
-    t.end();
-});
-
-test('all', (t) => {
-    const f1 = filter(['all']);
-    t.equal(f1({zoom: 0}, {properties: {foo: 1}}), true);
-
-    const f2 = filter(['all', ['==', 'foo', 1]]);
-    t.equal(f2({zoom: 0}, {properties: {foo: 1}}), true);
-
-    const f3 = filter(['all', ['==', 'foo', 0]]);
-    t.equal(f3({zoom: 0}, {properties: {foo: 1}}), false);
-
-    const f4 = filter(['all', ['==', 'foo', 0], ['==', 'foo', 1]]);
-    t.equal(f4({zoom: 0}, {properties: {foo: 1}}), false);
-
-    t.end();
-});
-
-test('none', (t) => {
-    const f1 = filter(['none']);
-    t.equal(f1({zoom: 0}, {properties: {foo: 1}}), true);
-
-    const f2 = filter(['none', ['==', 'foo', 1]]);
-    t.equal(f2({zoom: 0}, {properties: {foo: 1}}), false);
-
-    const f3 = filter(['none', ['==', 'foo', 0]]);
-    t.equal(f3({zoom: 0}, {properties: {foo: 1}}), true);
-
-    const f4 = filter(['none', ['==', 'foo', 0], ['==', 'foo', 1]]);
-    t.equal(f4({zoom: 0}, {properties: {foo: 1}}), false);
-
-    t.end();
-});
-
-test('has', (t) => {
-    const f = filter(['has', 'foo']);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: true}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), true);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), true);
-    t.equal(f({zoom: 0}, {properties: {}}), false);
-    t.end();
-});
-
-test('!has', (t) => {
-    const f = filter(['!has', 'foo']);
-    t.equal(f({zoom: 0}, {properties: {foo: 0}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: 1}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: '0'}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: false}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: null}}), false);
-    t.equal(f({zoom: 0}, {properties: {foo: undefined}}), false);
-    t.equal(f({zoom: 0}, {properties: {}}), true);
-    t.end();
-});
+test('filter - eval supported', filterTests(true));
+test('filter - eval not supported', filterTests(false));

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -324,7 +324,23 @@ test('in, multiple', (t) => {
 });
 
 test('in, large_multiple', (t) => {
-    const f = filter(['in', 'foo'].concat(Array.apply(null, {length: 2000}).map(Number.call, Number)));
+    const values = Array.apply(null, {length: 2000}).map(Number.call, Number);
+    values.reverse();
+    const f = filter(['in', 'foo'].concat(values));
+    t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 2000}}), false);
+    t.end();
+});
+
+test('in, large_multiple, heterogeneous', (t) => {
+    const values = Array.apply(null, {length: 2000}).map(Number.call, Number);
+    values.push('a');
+    values.unshift('b');
+    const f = filter(['in', 'foo'].concat(values));
+    t.equal(f({zoom: 0}, {properties: {foo: 'b'}}), true);
+    t.equal(f({zoom: 0}, {properties: {foo: 'a'}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: 0}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: 1}}), true);
     t.equal(f({zoom: 0}, {properties: {foo: 1999}}), true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10548,9 +10548,9 @@ websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
 
-webworkify@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/webworkify/-/webworkify-1.4.0.tgz#71245d1e34cacf54e426bd955f8cc6ee12d024c2"
+webworkify@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/webworkify/-/webworkify-1.5.0.tgz#734ad87a774de6ebdd546e1d3e027da5b8f4a42c"
 
 weinre@^2.0.0-pre-I0Z7U9OV:
   version "2.0.0-pre-I0Z7U9OV"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3463,9 +3463,9 @@ duplexify@^3.2.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-earcut@^2.0.3:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.1.tgz#157634e5f3ebb42224e475016e86a5b6ce556b45"
+earcut@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.3.tgz#ca579545f351941af7c3d0df49c9f7d34af99b0c"
 
 eastasianwidth@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Fixes #559 

Changes:
1. When `new Function()` is unavailable, generate StructArray accessors using closures rather than compiling strings.
2. Reinstate the specialized filter-specific expressions from https://github.com/mapbox/mapbox-gl-js/pull/5193, and convert legacy filters into these expressions when `new Function()` is unavailable


## Benchmarks

There's definitely a performance hit when eval is disabled.  Benchmarks with significant change:

Bench | master | branch
-- | -- | --
Layout | 101 ms | 168 ms ( +67.6 ms / 12.8 std devs )
LayoutDDS | 5.30 ms | 7.01 ms ( +1.71 ms / 2.3 std devs )
Paint | 14.1 ms | 17.1 ms ( +2.95 ms / 2.0 std devs )
LayerLine | 0.0791 ms | 0.101 ms ( +0.0218 ms / 2.9 std devs )
FilterCreate | 0.378 ms | 1.55 ms ( +1.17 ms / 1.9 std devs )
Filter Evaluate | 0.235 ms | 0.606 ms ( +0.371 ms / 12.6 std devs )

All: https://bl.ocks.org/anonymous/raw/d24cf0531c261480dbdd8301c21cbd49/



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
