### PR TITLE
retain all loaded children

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -447,7 +447,7 @@ class SourceCache extends Evented {
         const retain = {};
         const checked: {[number]: boolean } = {};
         const minCoveringZoom = Math.max(zoom - SourceCache.maxOverzooming, this._source.minzoom);
-
+        const maxCoveringZoom = Math.max(zoom + SourceCache.maxUnderzooming,  this._source.minzoom);
 
         for (i = 0; i < idealTileCoords.length; i++) {
             coord = idealTileCoords[i];
@@ -478,15 +478,13 @@ class SourceCache extends Evented {
                         covered = false;
                     }
                 } else {
-                    // Check all four actual child tiles.
+                    this._findLoadedChildren(coord, maxCoveringZoom, retain);
+                    // check if all 4 immediate children are loaded (i.e. the missing ideal tile is covered)
                     const children = coord.children(this._source.maxzoom);
                     for (let j = 0; j < children.length; j++) {
-                        const childCoord = children[j];
-                        const childTile = childCoord ? this.getTile(childCoord) : null;
-                        if (!!childTile && childTile.hasData()) {
-                            retain[childCoord.id] = true;
-                        } else {
+                        if (!retain[children[j].id]) {
                             covered = false;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
... even those at ZL more than one greater than the ideal tile.

popping this out of #5286. right now we're only checking for loaded children that are exactly one ZL higher from the ideal tile. this change makes it so we retain all loaded children of not-yet-loaded ideal tiles so that in the event of a fast zoom out we don't drop deep descendent child tiles before the parents are loaded. 


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
