### PR TITLE
Add update call when showCollisionBoxes disabled #5653

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1579,6 +1579,9 @@ class Map extends Camera {
             // When we turn collision boxes on we have to generate them for existing tiles
             // When we turn them off, there's no cost to leaving existing boxes in place
             this.style._generateCollisionBoxes();
+        } else {
+            // Otherwise, call an update to remove collision boxes
+            this._update();
         }
     }
 


### PR DESCRIPTION
It seems `showCollisionBoxes()` inside `map.js` was missing a call to `this._update()` when collisionboxes are set to false. This PR adds that in.

Should fix and close #5653 