### PR TITLE
check if before layer exists

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -622,6 +622,10 @@ class Style extends Evented {
         this._order.splice(index, 1);
 
         const newIndex = before ? this._order.indexOf(before) : this._order.length;
+        if (before && newIndex === -1) {
+            this.fire('error', { message: new Error(`Layer with id "${before}" does not exist on this map.`)});
+            return;
+        }
         this._order.splice(newIndex, 0, id);
 
         this._layerOrderChanged = true;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -568,7 +568,7 @@ class Style extends Evented {
 
         const index = before ? this._order.indexOf(before) : this._order.length;
         if (before && index === -1) {
-            this.fire('error', { message: new Error(`Layer with id "${before}" does not exist on this map.`)});
+            this.fire('error', { error: new Error(`Layer with id "${before}" does not exist on this map.`)});
             return;
         }
 
@@ -624,7 +624,7 @@ class Style extends Evented {
 
         const newIndex = before ? this._order.indexOf(before) : this._order.length;
         if (before && newIndex === -1) {
-            this.fire('error', { message: new Error(`Layer with id "${before}" does not exist on this map.`)});
+            this.fire('error', { error: new Error(`Layer with id "${before}" does not exist on this map.`)});
             return;
         }
         this._order.splice(newIndex, 0, id);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -543,7 +543,7 @@ class Style extends Evented {
     /**
      * Add a layer to the map style. The layer will be inserted before the layer with
      * ID `before`, or appended if `before` is omitted.
-     * @param {string=} before  ID of an existing layer to insert before
+     * @param {string} before  ID of an existing layer to insert before
      */
     addLayer(layerObject: LayerSpecification, before?: string, options?: {validate?: boolean}) {
         this._checkLoaded();
@@ -599,9 +599,10 @@ class Style extends Evented {
     }
 
     /**
-     * Add a layer to the map style. The layer will be inserted before the layer with
+     * Moves a layer to a different z-position. The layer will be inserted before the layer with
      * ID `before`, or appended if `before` is omitted.
-     * @param {string=} before  ID of an existing layer to insert before
+     * @param {string} id  ID of the layer to move
+     * @param {string} before  ID of an existing layer to insert before
      */
     moveLayer(id: string, before?: string) {
         this._checkLoaded();

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1022,7 +1022,7 @@ test('Style#addLayer', (t) => {
 
         style.on('style.load', () => {
             style.on('error', (error)=>{
-                t.match(error.message, /does not exist on this map/);
+                t.match(error.error, /does not exist on this map/);
                 t.end();
             });
             style.addLayer(layer, 'z');


### PR DESCRIPTION
I think we should check if `before` layer exists when move a layer

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
