### PR TITLE
update documentation for map.setMaxZoom default

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -511,7 +511,7 @@ class Map extends Camera {
      * the map will zoom to the new maximum.
      *
      * @param {number | null | undefined} maxZoom The maximum zoom level to set.
-     *   If `null` or `undefined` is provided, the function removes the current maximum zoom (sets it to 24).
+     *   If `null` or `undefined` is provided, the function removes the current maximum zoom (sets it to 22).
      * @returns {Map} `this`
      */
     setMaxZoom(maxZoom?: ?number) {


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR
#5678 was pushed through but it incorrectly changed the documentation for what happens when you do `map.setMaxZoom(null)`. As demonstrated by https://jsbin.com/cedudadeyi/1/edit?html,console,output when passed null or undefined it will reset the map's maxZoom to the default, which is 22, not 24 which is the maximum value you can set maxZoom.

 - [ ] write tests for all new functionality
it's a documentation change so no tests

 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
