### PR TITLE
Documentation: Remove broken addImage example reference

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1045,7 +1045,6 @@ class Map extends Camera {
      * sprite to add this image.
      *
      * @see [Add an icon to the map](https://www.mapbox.com/mapbox-gl-js/example/add-image/)
-     * @see [Add a generated icon to the map](https://www.mapbox.com/mapbox-gl-js/example/add-image-generated/)
      * @param id The ID of the image.
      * @param data The image as an `HTMLImageElement`, `ImageData`, or object with `width`, `height`, and `data`
      * properties with the same format as `ImageData`.


### PR DESCRIPTION
Launch Checklist

- [x] briefly describe the changes in this PR
On the `addImage` documentation, there is a reference to a page that does not exist anymore:
https://www.mapbox.com/mapbox-gl-js/example/add-image-generated/
This just removes this reference.
- [ ] write tests for all new functionality
No tests needed as this is just documentation change
- [x] document any changes to public APIs
- [ ] post benchmark scores
- [ ] manually test the debug page