### PR TITLE
Evaluate query results on queryRenderedFeatures #5677

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -232,7 +232,11 @@ class FeatureIndex {
                 }
 
                 const geojsonFeature = new GeoJSONFeature(feature, this.z, this.x, this.y);
-                (geojsonFeature: any).layer = styleLayer.serialize();
+                let globals;
+                if (this.coord.z !== undefined) {
+                    globals = { zoom: this.coord.z };
+                }
+                (geojsonFeature: any).layer = styleLayer.serialize(globals);
                 let layerResult = result[layerID];
                 if (layerResult === undefined) {
                     layerResult = result[layerID] = [];

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -233,7 +233,7 @@ class StyleLayer extends Evented {
         }
     }
 
-    serialize() {
+    serialize(globals?: GlobalProperties) {
         const output : any = {
             'id': this.id,
             'type': this.type,
@@ -243,8 +243,8 @@ class StyleLayer extends Evented {
             'minzoom': this.minzoom,
             'maxzoom': this.maxzoom,
             'filter': this.filter,
-            'layout': util.mapObject(this._layoutDeclarations, getDeclarationValue),
-            'paint': util.mapObject(this._paintDeclarations, getDeclarationValue)
+            'layout': util.mapObjectWithGlobal(this._layoutDeclarations, getDeclarationValue, globals),
+            'paint': util.mapObjectWithGlobal(this._paintDeclarations, getDeclarationValue, globals)
         };
 
         return util.filterObject(output, (value, key) => {
@@ -341,6 +341,11 @@ StyleLayer.create = function(layer: LayerSpecification) {
     return new subclasses[layer.type](layer);
 };
 
-function getDeclarationValue(declaration) {
+function getDeclarationValue(declaration, globals) {
+    if (globals !== undefined)
+    {
+        return declaration.calculate(globals);
+    }
+        
     return declaration.value;
 }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -273,6 +273,15 @@ exports.mapObject = function(input: Object, iterator: Function, context?: Object
     return output;
 };
 
+exports.mapObjectWithGlobal = function(input: Object, iterator: Function, globals: Any): Object {
+    const output = {};
+    for (const key in input) {
+        output[key] = iterator.call(this, input[key], globals, key, input);
+    }
+    return output;
+};
+
+
 /**
  * Create an object by filtering out values of an existing object.
  *


### PR DESCRIPTION
#### Preface: the code in this PR likely needs to change, but I wanted to show a 'working' example and mention a possible fix if i'm on the right track.

If I understand the issue correctly, this PR will 'fix' #5677, and properly evaluate the current values before showing them. 

The solution I wrote however is a bit hacky, as I realized a couple of things:

- Proper evaluation of the layout and paint declaration rely on the global property `zoom`, which is not available during the `serialize` method.
- Modifying `serialize` to use the global property zoom and pass it along during the mapping of layout and paint would solve one problem and create another, as serialize is also used to grab non-evaluated results.

I think `filterMatching` needs to separate some logic out for `queryRenderedFeatures` somehow, such that you don't need to check when the global context is valid to pass or not.  

My first impression is to maybe create a flag within `filterMatching` which defines whether to serialize **and** evaluate, or _just_ serialize. That way it won't have to rely on checking whether `this.coord.z` is defined or not to determine if the serialization should also perform evaluation.

Something along the lines of:
```javascript
    filterMatching(
        result: {[string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>},
        matching: Array<any>,
        array: any,
        queryGeometry: Array<Array<Point>>,
        filter: FeatureFilter,
        filterLayerIDs: Array<string>,
        styleLayers: {[string]: StyleLayer},
        bearing: number,
        pixelsToTileUnits: number,
        serializeAndEvaluate?: boolean // make optional maybe?
    ) {

            // ....

           // if asked to evaluate, we know the global context is defined and valid
           if (serializeAndEvaluate) {
               (geojsonFeature: any).layer = styleLayer.serializeWithEvaluation(globals);
           } else {
               // otherwise, perform a normal serialization
               (geojsonFeature: any).layer = styleLayer.serialize();
           }
```

Thoughts?

P.S. I used [this](https://www.mapbox.com/mapbox-gl-js/example/queryrenderedfeatures/) example from the ticket to test this.