### PR TITLE
ScaleControl docs had wrong value for default maxWidth

### DIFF
--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -10,7 +10,7 @@ import type Map from '../map';
  *
  * @implements {IControl}
  * @param {Object} [options]
- * @param {number} [options.maxWidth='150'] The maximum length of the scale control in pixels.
+ * @param {number} [options.maxWidth='100'] The maximum length of the scale control in pixels.
  * @param {string} [options.unit='metric'] Unit of the distance (`'imperial'`, `'metric'` or `'nautical'`).
  * @example
  * map.addControl(new mapboxgl.ScaleControl({


### PR DESCRIPTION
 - [x] briefly describe the changes in this PR
The `ScaleControl` docs listed the default `maxWidth` as 150 pixels, but [the actual default is 100 pixels](https://github.com/mapbox/mapbox-gl-js/blob/master/src/ui/control/scale_control.js#L66).
 - [x] write tests for all new functionality
N/A
 - [x] document any changes to public APIs
 - [x] post benchmark scores
N/A
 - [x] manually test the debug page
