### PR TITLE
Introduce generic serializer for web worker transfers

### DIFF
--- a/src/data/bucket/heatmap_bucket.js
+++ b/src/data/bucket/heatmap_bucket.js
@@ -1,6 +1,9 @@
 // @flow
 
 const CircleBucket = require('./circle_bucket');
+const {register} = require('../../util/web_worker_transfer');
+
+import type StyleLayer from '../../style/style_layer';
 
 const heatmapInterface = {
     layoutAttributes: CircleBucket.programInterface.layoutAttributes,
@@ -11,7 +14,12 @@ const heatmapInterface = {
     ]
 };
 
-class HeatmapBucket extends CircleBucket {}
+class HeatmapBucket extends CircleBucket {
+    // Needed for flow to accept omit: ['layers'] below, due to https://github.com/facebook/flow/issues/4262
+    layers: Array<StyleLayer>;
+}
+
+register(HeatmapBucket, {omit: ['layers']});
 
 HeatmapBucket.programInterface = heatmapInterface;
 

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -791,8 +791,8 @@ class SymbolBucket implements Bucket {
             }
         }
 
-        if (this.text.indexBuffer) this.text.indexBuffer.updateData(this.text.indexArray.serialize());
-        if (this.icon.indexBuffer) this.icon.indexBuffer.updateData(this.icon.indexArray.serialize());
+        if (this.text.indexBuffer) this.text.indexBuffer.updateData(this.text.indexArray);
+        if (this.icon.indexBuffer) this.icon.indexBuffer.updateData(this.icon.indexArray);
     }
 }
 

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -20,7 +20,7 @@ const {getSizeData} = require('../../symbol/symbol_size');
 
 import type {Feature as ExpressionFeature} from '../../style-spec/expression';
 import type {Bucket, IndexedFeature, PopulateParameters} from '../bucket';
-import type {ProgramInterface, SerializedProgramConfiguration} from '../program_configuration';
+import type {ProgramInterface} from '../program_configuration';
 import type CollisionBoxArray, {CollisionBox} from '../../symbol/collision_box';
 import type {
     StructArray,
@@ -31,6 +31,7 @@ import type {SymbolQuad} from '../../symbol/quads';
 import type {SizeData} from '../../symbol/symbol_size';
 import type {PossiblyEvaluatedPropertyValue} from '../../style/properties';
 import type {Transferable} from '../../types/transferable';
+import type {Serialized} from '../../util/web_worker_transfer';
 
 export type SingleCollisionBox = {
     x1: number;
@@ -217,7 +218,7 @@ type SerializedSymbolBuffer = {
     indexArray: SerializedStructArray,
     opacityVertexArray: SerializedStructArray,
     collisionVertexArray: SerializedStructArray,
-    programConfigurations: {[string]: ?SerializedProgramConfiguration},
+    programConfigurations: Serialized,
     segments: Array<Object>,
 };
 

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -286,10 +286,10 @@ class ProgramConfiguration {
             const useIntegerZoom = value.property.useIntegerZoom;
 
             if (value.value.kind === 'constant') {
-                self.binders[name] = new ConstantBinder(value.value, name, type, property);
+                self.binders[property] = new ConstantBinder(value.value, name, type, property);
                 self.cacheKey += `/u_${name}`;
             } else if (value.value.kind === 'source') {
-                self.binders[name] = new SourceExpressionBinder(value.value, name, type, property);
+                self.binders[property] = new SourceExpressionBinder(value.value, name, type, property);
                 self.cacheKey += `/a_${name}`;
                 attributes.push({
                     name: `a_${name}`,
@@ -297,7 +297,7 @@ class ProgramConfiguration {
                     components: type === 'color' ? 2 : 1
                 });
             } else {
-                self.binders[name] = new CompositeExpressionBinder(value.value, name, type, property, useIntegerZoom, zoom);
+                self.binders[property] = new CompositeExpressionBinder(value.value, name, type, property, useIntegerZoom, zoom);
                 self.cacheKey += `/z_${name}`;
                 attributes.push({
                     name: `a_${name}`,
@@ -316,10 +316,10 @@ class ProgramConfiguration {
     static forBackgroundColor(color: Color, opacity: number) {
         const self = new ProgramConfiguration();
 
-        self.binders.color = new ConstantBinder(color, 'color', 'color', 'background-color');
+        self.binders['background-color'] = new ConstantBinder(color, 'color', 'color', 'background-color');
         self.cacheKey += `/u_color`;
 
-        self.binders.opacity = new ConstantBinder(opacity, 'opacity', 'number', 'background-opacity');
+        self.binders['background-opacity'] = new ConstantBinder(opacity, 'opacity', 'number', 'background-opacity');
         self.cacheKey += `/u_opacity`;
 
         return self;
@@ -328,7 +328,7 @@ class ProgramConfiguration {
     static forBackgroundPattern(opacity: number) {
         const self = new ProgramConfiguration();
 
-        self.binders.opacity = new ConstantBinder(opacity, 'opacity', 'number', 'background-opacity');
+        self.binders['background-opacity'] = new ConstantBinder(opacity, 'opacity', 'number', 'background-opacity');
         self.cacheKey += `/u_opacity`;
 
         return self;
@@ -346,8 +346,8 @@ class ProgramConfiguration {
         const start = paintArray.length;
         paintArray.resize(length);
 
-        for (const name in this.binders) {
-            this.binders[name].populatePaintArray(
+        for (const property in this.binders) {
+            this.binders[property].populatePaintArray(
                 paintArray,
                 start, length,
                 feature);
@@ -356,15 +356,15 @@ class ProgramConfiguration {
 
     defines(): Array<string> {
         const result = [];
-        for (const name in this.binders) {
-            result.push.apply(result, this.binders[name].defines());
+        for (const property in this.binders) {
+            result.push.apply(result, this.binders[property].defines());
         }
         return result;
     }
 
     setUniforms<Properties: Object>(gl: WebGLRenderingContext, program: Program, properties: PossiblyEvaluated<Properties>, globals: GlobalProperties) {
-        for (const name in this.binders) {
-            const binder = this.binders[name];
+        for (const property in this.binders) {
+            const binder = this.binders[property];
             binder.setUniforms(gl, program, globals, properties.get(binder.property));
         }
     }

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -16,7 +16,7 @@ import type {Feature, SourceExpression, CompositeExpression} from '../style-spec
 import type {PossiblyEvaluated, PossiblyEvaluatedPropertyValue} from '../style/properties';
 import type {Transferable} from '../types/transferable';
 
-type LayoutAttribute = {
+export type LayoutAttribute = {
     name: string,
     type: ViewType,
     components?: number

--- a/src/data/segment.js
+++ b/src/data/segment.js
@@ -1,6 +1,7 @@
 // @flow
 
 const {warnOnce} = require('../util/util');
+const {register} = require('../util/web_worker_transfer');
 
 import type VertexArrayObject from '../render/vertex_array_object';
 import type {StructArray} from '../util/struct_array';
@@ -49,6 +50,8 @@ class SegmentVector {
         }
     }
 }
+
+register(SegmentVector);
 
 module.exports = {
     SegmentVector,

--- a/src/gl/index_buffer.js
+++ b/src/gl/index_buffer.js
@@ -1,8 +1,8 @@
 // @flow
 const assert = require('assert');
 
+import type {StructArray} from '../util/struct_array';
 import type {TriangleIndexArray, LineIndexArray} from '../data/index_array_type';
-import type {SerializedStructArray} from '../util/struct_array';
 
 
 class IndexBuffer {
@@ -41,7 +41,7 @@ class IndexBuffer {
         this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, this.buffer);
     }
 
-    updateData(array: SerializedStructArray) {
+    updateData(array: StructArray) {
         assert(this.dynamicDraw);
         // The right VAO will get this buffer re-bound later in VertexArrayObject#bind
         // See https://github.com/mapbox/mapbox-gl-js/issues/5620

--- a/src/gl/vertex_buffer.js
+++ b/src/gl/vertex_buffer.js
@@ -2,8 +2,7 @@
 
 import type {
     StructArray,
-    StructArrayMember,
-    SerializedStructArray
+    StructArrayMember
 } from '../util/struct_array';
 
 import type Program from '../render/program';
@@ -59,7 +58,7 @@ class VertexBuffer {
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.buffer);
     }
 
-    updateData(array: SerializedStructArray) {
+    updateData(array: StructArray) {
         this.bind();
         this.gl.bufferSubData(this.gl.ARRAY_BUFFER, 0, array.arrayBuffer);
     }

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -53,7 +53,7 @@ class Program {
         // ProgramInterface so that we don't dynamically link an unused
         // attribute at position 0, which can cause rendering to fail for an
         // entire layer (see #4607, #4728)
-        const layoutAttributes = configuration.interface ? configuration.interface.layoutAttributes : [];
+        const layoutAttributes = configuration.layoutAttributes || [];
         for (let i = 0; i < layoutAttributes.length; i++) {
             gl.bindAttribLocation(this.program, i, layoutAttributes[i].name);
         }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -22,6 +22,7 @@ const {TriangleIndexArray} = require('../data/index_array_type');
 const projection = require('../symbol/projection');
 const {performSymbolPlacement, updateOpacities} = require('../symbol/symbol_placement');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
+const {deserialize} = require('../util/web_worker_transfer');
 
 const CLOCK_SKEW_RETRY_TIMEOUT = 30000;
 
@@ -145,7 +146,8 @@ class Tile {
             this.rawTileData = data.rawTileData;
         }
         this.collisionBoxArray = new CollisionBoxArray(data.collisionBoxArray);
-        this.featureIndex = FeatureIndex.deserialize(data.featureIndex, this.rawTileData);
+        this.featureIndex = (deserialize(data.featureIndex): any);
+        this.featureIndex.rawTileData = this.rawTileData;
         this.buckets = deserializeBucket(data.buckets, painter.style);
 
         if (data.iconAtlasImage) {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -145,7 +145,7 @@ class Tile {
             // Only vector tiles have rawTileData
             this.rawTileData = data.rawTileData;
         }
-        this.collisionBoxArray = new CollisionBoxArray(data.collisionBoxArray);
+        this.collisionBoxArray = (deserialize(data.collisionBoxArray): any);
         this.featureIndex = (deserialize(data.featureIndex): any);
         this.featureIndex.rawTileData = this.rawTileData;
         this.buckets = deserializeBucket(data.buckets, painter.style);

--- a/src/source/tile_coord.js
+++ b/src/source/tile_coord.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const WhooTS = require('@mapbox/whoots-js');
 const Coordinate = require('../geo/coordinate');
+const {register} = require('../util/web_worker_transfer');
 
 /**
  * @module TileCoord
@@ -249,5 +250,7 @@ function getQuadkey(z, x, y) {
     }
     return quadkey;
 }
+
+register(TileCoord, {omit: ['posMatrix']});
 
 module.exports = TileCoord;

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type {Serialized} from '../util/web_worker_transfer';
-import type {SerializedStructArray} from '../util/struct_array';
 import type {RequestParameters} from '../util/ajax';
 import type {RGBAImage, AlphaImage} from '../util/image';
 import type {Transferable} from '../types/transferable';
@@ -27,7 +26,7 @@ export type WorkerTileResult = {
     iconAtlasImage: RGBAImage,
     glyphAtlasImage: AlphaImage,
     featureIndex: Serialized,
-    collisionBoxArray: SerializedStructArray,
+    collisionBoxArray: Serialized,
     rawTileData?: ArrayBuffer,
 };
 

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -1,7 +1,5 @@
 // @flow
 
-import type TileCoord from './tile_coord';
-import type {SerializedFeatureIndex} from '../data/feature_index';
 import type {Serialized} from '../util/web_worker_transfer';
 import type {SerializedStructArray} from '../util/struct_array';
 import type {RequestParameters} from '../util/ajax';
@@ -14,7 +12,7 @@ export type TileParameters = {
 };
 
 export type WorkerTileParameters = TileParameters & {
-    coord: TileCoord,
+    coord: { z: number, x: number, y: number, w: number },
     request: RequestParameters,
     zoom: number,
     maxZoom: number,
@@ -28,7 +26,7 @@ export type WorkerTileResult = {
     buckets: Array<Serialized>,
     iconAtlasImage: RGBAImage,
     glyphAtlasImage: AlphaImage,
-    featureIndex: SerializedFeatureIndex,
+    featureIndex: Serialized,
     collisionBoxArray: SerializedStructArray,
     rawTileData?: ArrayBuffer,
 };

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -1,8 +1,8 @@
 // @flow
 
 import type TileCoord from './tile_coord';
-import type {SerializedBucket} from '../data/bucket';
 import type {SerializedFeatureIndex} from '../data/feature_index';
+import type {Serialized} from '../util/web_worker_transfer';
 import type {SerializedStructArray} from '../util/struct_array';
 import type {RequestParameters} from '../util/ajax';
 import type {RGBAImage, AlphaImage} from '../util/image';
@@ -25,7 +25,7 @@ export type WorkerTileParameters = TileParameters & {
 };
 
 export type WorkerTileResult = {
-    buckets: Array<SerializedBucket>,
+    buckets: Array<Serialized>,
     iconAtlasImage: RGBAImage,
     glyphAtlasImage: AlphaImage,
     featureIndex: SerializedFeatureIndex,

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -9,6 +9,7 @@ const util = require('../util/util');
 const assert = require('assert');
 const {makeImageAtlas} = require('../render/image_atlas');
 const {makeGlyphAtlas} = require('../render/glyph_atlas');
+const {serialize} = require('../util/web_worker_transfer');
 
 import type TileCoord from './tile_coord';
 import type {Bucket} from '../data/bucket';
@@ -198,7 +199,7 @@ function recalculateLayers(layers: $ReadOnlyArray<StyleLayer>, zoom: number) {
 function serializeBuckets(buckets: $ReadOnlyArray<Bucket>, transferables: Array<Transferable>) {
     return buckets
         .filter((b) => !b.isEmpty())
-        .map((b) => b.serialize(transferables));
+        .map((b) => serialize(b, transferables));
 }
 
 module.exports = WorkerTile;

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -10,8 +10,8 @@ const assert = require('assert');
 const {makeImageAtlas} = require('../render/image_atlas');
 const {makeGlyphAtlas} = require('../render/glyph_atlas');
 const {serialize} = require('../util/web_worker_transfer');
+const TileCoord = require('./tile_coord');
 
-import type TileCoord from './tile_coord';
 import type {Bucket} from '../data/bucket';
 import type Actor from '../util/actor';
 import type StyleLayer from '../style/style_layer';
@@ -43,7 +43,7 @@ class WorkerTile {
     vectorTile: VectorTile;
 
     constructor(params: WorkerTileParameters) {
-        this.coord = params.coord;
+        this.coord = new TileCoord(params.coord.z, params.coord.x, params.coord.y, params.coord.w);
         this.uid = params.uid;
         this.zoom = params.zoom;
         this.pixelRatio = params.pixelRatio;
@@ -170,7 +170,7 @@ class WorkerTile {
 
                 callback(null, {
                     buckets: serializeBuckets(util.values(buckets), transferables),
-                    featureIndex: featureIndex.serialize(transferables),
+                    featureIndex: serialize(featureIndex, transferables),
                     collisionBoxArray: this.collisionBoxArray.serialize(),
                     glyphAtlasImage: glyphAtlas.image,
                     iconAtlasImage: imageAtlas.image

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -171,7 +171,7 @@ class WorkerTile {
                 callback(null, {
                     buckets: serializeBuckets(util.values(buckets), transferables),
                     featureIndex: serialize(featureIndex, transferables),
-                    collisionBoxArray: this.collisionBoxArray.serialize(),
+                    collisionBoxArray: serialize(this.collisionBoxArray),
                     glyphAtlasImage: glyphAtlas.image,
                     iconAtlasImage: imageAtlas.image
                 }, transferables);

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 const assert = require('assert');
+const extend = require('../util/extend');
 const ParsingError = require('./parsing_error');
 const ParsingContext = require('./parsing_context');
 const EvaluationContext = require('./evaluation_context');
@@ -19,6 +20,7 @@ import type {Value} from './values';
 import type {Expression} from './expression';
 import type {StylePropertySpecification} from '../style-spec';
 import type {Result} from '../util/result';
+import type {InterpolationType} from './definitions/interpolate';
 
 export type Feature = {
     +type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon',
@@ -31,10 +33,70 @@ export type GlobalProperties = {
     heatmapDensity?: number
 };
 
-export type StyleExpression = {
-    evaluate: (globals: GlobalProperties, feature?: Feature) => any,
-    parsed: Expression
-};
+class StyleExpression {
+    expression: Expression;
+
+    _evaluator: EvaluationContext;
+
+    constructor(expression: Expression) {
+        this.expression = expression;
+    }
+
+    evaluate(globals: GlobalProperties, feature?: Feature): any {
+        if (!this._evaluator) {
+            this._evaluator = new EvaluationContext();
+        }
+
+        this._evaluator.globals = globals;
+        this._evaluator.feature = feature;
+        return this.expression.evaluate(this._evaluator);
+    }
+}
+
+class StyleExpressionWithErrorHandling extends StyleExpression {
+    _defaultValue: Value;
+    _warningHistory: {[key: string]: boolean};
+    _enumValues: {[string]: any};
+
+    _evaluator: EvaluationContext;
+
+    constructor(expression: Expression, propertySpec: StylePropertySpecification) {
+        super(expression);
+        this._warningHistory = {};
+        this._defaultValue = getDefaultValue(propertySpec);
+        if (propertySpec.type === 'enum') {
+            this._enumValues = propertySpec.values;
+        }
+    }
+
+    evaluate(globals: GlobalProperties, feature?: Feature) {
+        if (!this._evaluator) {
+            this._evaluator = new EvaluationContext();
+        }
+
+        this._evaluator.globals = globals;
+        this._evaluator.feature = feature;
+
+        try {
+            const val = this.expression.evaluate(this._evaluator);
+            if (val === null || val === undefined) {
+                return this._defaultValue;
+            }
+            if (this._enumValues && !(val in this._enumValues)) {
+                throw new RuntimeError(`Expected value to be one of ${Object.keys(this._enumValues).map(v => JSON.stringify(v)).join(', ')}, but found ${JSON.stringify(val)} instead.`);
+            }
+            return val;
+        } catch (e) {
+            if (!this._warningHistory[e.message]) {
+                this._warningHistory[e.message] = true;
+                if (typeof console !== 'undefined') {
+                    console.warn(e.message);
+                }
+            }
+            return this._defaultValue;
+        }
+    }
+}
 
 function isExpression(expression: mixed) {
     return Array.isArray(expression) && expression.length > 0 &&
@@ -60,70 +122,75 @@ function createExpression(expression: mixed,
         return error(parser.errors);
     }
 
-    const evaluator = new EvaluationContext();
-
-    let evaluate;
     if (options.handleErrors === false) {
-        evaluate = function (globals, feature) {
-            evaluator.globals = globals;
-            evaluator.feature = feature;
-            return parsed.evaluate(evaluator);
-        };
+        return success(new StyleExpression(parsed));
     } else {
-        const warningHistory: {[key: string]: boolean} = {};
-        const defaultValue = getDefaultValue(propertySpec);
-        let enumValues;
-        if (propertySpec.type === 'enum') {
-            enumValues = propertySpec.values;
+        return success(new StyleExpressionWithErrorHandling(parsed, propertySpec));
+    }
+}
+
+class ZoomConstantExpression<Kind> {
+    kind: Kind;
+    _styleExpression: StyleExpression;
+    constructor(kind: Kind, expression: StyleExpression) {
+        this.kind = kind;
+        this._styleExpression = expression;
+    }
+    evaluate(globals: GlobalProperties, feature?: Feature): any {
+        return this._styleExpression.evaluate(globals, feature);
+    }
+}
+
+class ZoomDependentExpression<Kind> {
+    kind: Kind;
+    zoomStops: Array<number>;
+
+    _styleExpression: StyleExpression;
+    _interpolationType: ?InterpolationType;
+
+    constructor(kind: Kind, expression: StyleExpression, zoomCurve: Step | Interpolate) {
+        this.kind = kind;
+        this.zoomStops = zoomCurve.labels;
+        this._styleExpression = expression;
+        if (zoomCurve instanceof Interpolate) {
+            this._interpolationType = zoomCurve.interpolation;
         }
-        evaluate = function (globals, feature) {
-            evaluator.globals = globals;
-            evaluator.feature = feature;
-            try {
-                const val = parsed.evaluate(evaluator);
-                if (val === null || val === undefined) {
-                    return defaultValue;
-                }
-                if (enumValues && !(val in enumValues)) {
-                    throw new RuntimeError(`Expected value to be one of ${Object.keys(enumValues).map(v => JSON.stringify(v)).join(', ')}, but found ${JSON.stringify(val)} instead.`);
-                }
-                return val;
-            } catch (e) {
-                if (!warningHistory[e.message]) {
-                    warningHistory[e.message] = true;
-                    if (typeof console !== 'undefined') {
-                        console.warn(e.message);
-                    }
-                }
-                return defaultValue;
-            }
-        };
     }
 
-    return success({ evaluate, parsed });
+    evaluate(globals: GlobalProperties, feature?: Feature): any {
+        return this._styleExpression.evaluate(globals, feature);
+    }
+
+    interpolationFactor(input: number, lower: number, upper: number): number {
+        if (this._interpolationType) {
+            return Interpolate.interpolationFactor(this._interpolationType, input, lower, upper);
+        } else {
+            return 0;
+        }
+    }
 }
 
 export type ConstantExpression = {
     kind: 'constant',
-    evaluate: (globals: GlobalProperties, feature?: Feature) => any
-};
+    +evaluate: (globals: GlobalProperties, feature?: Feature) => any,
+}
 
 export type SourceExpression = {
     kind: 'source',
-    evaluate: (globals: GlobalProperties, feature?: Feature) => any,
+    +evaluate: (globals: GlobalProperties, feature?: Feature) => any,
 };
 
 export type CameraExpression = {
     kind: 'camera',
-    evaluate: (globals: GlobalProperties, feature?: Feature) => any,
-    interpolationFactor: (input: number, lower: number, upper: number) => number,
+    +evaluate: (globals: GlobalProperties, feature?: Feature) => any,
+    +interpolationFactor: (input: number, lower: number, upper: number) => number,
     zoomStops: Array<number>
 };
 
 export type CompositeExpression = {
     kind: 'composite',
-    evaluate: (globals: GlobalProperties, feature?: Feature) => any,
-    interpolationFactor: (input: number, lower: number, upper: number) => number,
+    +evaluate: (globals: GlobalProperties, feature?: Feature) => any,
+    +interpolationFactor: (input: number, lower: number, upper: number) => number,
     zoomStops: Array<number>
 };
 
@@ -141,7 +208,7 @@ function createPropertyExpression(expression: mixed,
         return expression;
     }
 
-    const {evaluate, parsed} = expression.value;
+    const parsed = expression.value.expression;
 
     const isFeatureConstant = isConstant.isFeatureConstant(parsed);
     if (!isFeatureConstant && !propertySpec['property-function']) {
@@ -164,26 +231,50 @@ function createPropertyExpression(expression: mixed,
 
     if (!zoomCurve) {
         return success(isFeatureConstant ?
-            { kind: 'constant', parsed, evaluate } :
-            { kind: 'source', parsed, evaluate });
+            (new ZoomConstantExpression('constant', expression.value): ConstantExpression) :
+            (new ZoomConstantExpression('source', expression.value): SourceExpression));
     }
 
-    const interpolationFactor = zoomCurve instanceof Interpolate ?
-        Interpolate.interpolationFactor.bind(undefined, zoomCurve.interpolation) :
-        () => 0;
-    const zoomStops = zoomCurve.labels;
-
     return success(isFeatureConstant ?
-        { kind: 'camera', parsed, evaluate, interpolationFactor, zoomStops } :
-        { kind: 'composite', parsed, evaluate, interpolationFactor, zoomStops });
+        (new ZoomDependentExpression('camera', expression.value, zoomCurve): CameraExpression) :
+        (new ZoomDependentExpression('composite', expression.value, zoomCurve): CompositeExpression));
 }
 
 const {isFunction, createFunction} = require('../function');
 const {Color} = require('./values');
 
+// serialization wrapper for old-style stop functions normalized to the
+// expression interface
+class StylePropertyFunction<T> {
+    _parameters: PropertyValueSpecification<T>;
+    _specification: StylePropertySpecification;
+
+    kind: 'constant' | 'source' | 'camera' | 'composite';
+    evaluate: (globals: GlobalProperties, feature?: Feature) => any;
+    interpolationFactor: ?(input: number, lower: number, upper: number) => number;
+    zoomStops: ?Array<number>;
+
+    constructor(parameters: PropertyValueSpecification<T>, specification: StylePropertySpecification) {
+        this._parameters = parameters;
+        this._specification = specification;
+        extend(this, createFunction(this._parameters, this._specification));
+    }
+
+    static deserialize(serialized: {_parameters: PropertyValueSpecification<T>, _specification: StylePropertySpecification}) {
+        return new StylePropertyFunction(serialized._parameters, serialized._specification);
+    }
+
+    static serialize(input: StylePropertyFunction<T>) {
+        return {
+            _parameters: input._parameters,
+            _specification: input._specification
+        };
+    }
+}
+
 function normalizePropertyExpression<T>(value: PropertyValueSpecification<T>, specification: StylePropertySpecification): StylePropertyExpression {
     if (isFunction(value)) {
-        return createFunction(value, specification);
+        return (new StylePropertyFunction(value, specification): any);
 
     } else if (isExpression(value)) {
         const expression = createPropertyExpression(value, specification);
@@ -206,10 +297,15 @@ function normalizePropertyExpression<T>(value: PropertyValueSpecification<T>, sp
 }
 
 module.exports = {
+    StyleExpression,
+    StyleExpressionWithErrorHandling,
     isExpression,
     createExpression,
     createPropertyExpression,
-    normalizePropertyExpression
+    normalizePropertyExpression,
+    ZoomConstantExpression,
+    ZoomDependentExpression,
+    StylePropertyFunction
 };
 
 // Zoom-dependent expressions may only use ["zoom"] as the input to a top-level "step" or "interpolate"

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -76,7 +76,7 @@ function createFilter(filter: any): FeatureFilter {
     if (compiled.result === 'error') {
         throw new Error(compiled.value.map(err => `${err.key}: ${err.message}`).join(', '));
     } else {
-        return compiled.value.evaluate;
+        return (globalProperties: GlobalProperties, feature: VectorTileFeature) => compiled.value.evaluate(globalProperties, feature);
     }
 }
 

--- a/src/style-spec/validate/validate_expression.js
+++ b/src/style-spec/validate/validate_expression.js
@@ -13,7 +13,7 @@ module.exports = function validateExpression(options: any) {
     }
 
     if (options.expressionContext === 'property' && options.propertyKey === 'text-font' &&
-        (expression.value: any).parsed.possibleOutputs().indexOf(undefined) !== -1) {
+        (expression.value: any)._styleExpression.expression.possibleOutputs().indexOf(undefined) !== -1) {
         return [new ValidationError(options.key, options.value, 'Invalid data expression for "text-font". Output values must be contained as literals within the expression.')];
     }
 

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -5,6 +5,7 @@ const {extend, easeCubicInOut} = require('../util/util');
 const interpolate = require('../style-spec/util/interpolate');
 const {normalizePropertyExpression} = require('../style-spec/expression');
 const Color = require('../style-spec/util/color');
+const {register} = require('../util/web_worker_transfer');
 
 import type {StylePropertySpecification} from '../style-spec/style-spec';
 import type {CrossFaded} from './cross_faded';
@@ -679,6 +680,12 @@ class Properties<Props: Object> {
         }
     }
 }
+
+register(PossiblyEvaluatedPropertyValue);
+register(DataDrivenProperty);
+register(DataConstantProperty);
+register(CrossFadedProperty);
+register(HeatmapColorProperty);
 
 module.exports = {
     PropertyValue,

--- a/src/style/query_utils.js
+++ b/src/style/query_utils.js
@@ -1,5 +1,6 @@
 // @flow
 
+const assert = require('assert');
 const Point = require('@mapbox/point-geometry');
 
 import type {PossiblyEvaluatedPropertyValue} from "./properties";
@@ -11,8 +12,15 @@ function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: Bucke
     if (value.kind === 'constant') {
         return value.value;
     } else {
-        return (bucket: any).programConfigurations.get(layer.id)
-            .paintPropertyStatistics[property].max;
+        const binders = (bucket: any).programConfigurations.get(layer.id).binders;
+        for (const name in binders) {
+            const binder = binders[name];
+            if (binder.property === property) {
+                return binder.statistics.max;
+            }
+        }
+        assert(false, `Missing binder for data-driven property ${property}.`);
+        return -Infinity;
     }
 }
 

--- a/src/style/query_utils.js
+++ b/src/style/query_utils.js
@@ -1,26 +1,19 @@
 // @flow
 
-const assert = require('assert');
 const Point = require('@mapbox/point-geometry');
 
 import type {PossiblyEvaluatedPropertyValue} from "./properties";
 import type StyleLayer from '../style/style_layer';
-import type {Bucket} from '../data/bucket';
+import type CircleBucket from '../data/bucket/circle_bucket';
+import type LineBucket from '../data/bucket/line_bucket';
 
-function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: Bucket): number {
+function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: CircleBucket | LineBucket): number {
     const value = ((layer.paint: any).get(property): PossiblyEvaluatedPropertyValue<any>).value;
     if (value.kind === 'constant') {
         return value.value;
     } else {
-        const binders = (bucket: any).programConfigurations.get(layer.id).binders;
-        for (const name in binders) {
-            const binder = binders[name];
-            if (binder.property === property) {
-                return binder.statistics.max;
-            }
-        }
-        assert(false, `Missing binder for data-driven property ${property}.`);
-        return -Infinity;
+        const binders = bucket.programConfigurations.get(layer.id).binders;
+        return binders[property].statistics.max;
     }
 }
 

--- a/src/symbol/anchor.js
+++ b/src/symbol/anchor.js
@@ -1,6 +1,7 @@
 // @flow
 
 const Point = require('@mapbox/point-geometry');
+const {register} = require('../util/web_worker_transfer');
 
 class Anchor extends Point {
     angle: any;
@@ -18,5 +19,7 @@ class Anchor extends Point {
         return new Anchor(this.x, this.y, this.angle, this.segment);
     }
 }
+
+register(Anchor);
 
 module.exports = Anchor;

--- a/src/symbol/collision_box.js
+++ b/src/symbol/collision_box.js
@@ -1,7 +1,6 @@
 // @flow
 
 const createStructArrayType = require('../util/struct_array');
-const Point = require('@mapbox/point-geometry');
 
 export type CollisionBox = {
     anchorPoint: Point,
@@ -61,11 +60,6 @@ const CollisionBoxArray = createStructArrayType({
         { type: 'Int16', name: 'signedDistanceFromAnchor' }
 
     ]
-});
-
-// https://github.com/facebook/flow/issues/285
-(Object.defineProperty: any)(CollisionBoxArray.prototype.StructType.prototype, 'anchorPoint', {
-    get() { return new Point(this.anchorPointX, this.anchorPointY); }
 });
 
 module.exports = CollisionBoxArray;

--- a/src/symbol/opacity_state.js
+++ b/src/symbol/opacity_state.js
@@ -1,5 +1,7 @@
 // @flow
 
+const {register} = require('../util/web_worker_transfer');
+
 class OpacityState {
     opacity: number;
     targetOpacity: number;
@@ -19,5 +21,7 @@ class OpacityState {
         return clone;
     }
 }
+
+register(OpacityState);
 
 module.exports = OpacityState;

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -211,9 +211,9 @@ function updateLineLabels(bucket: SymbolBucket,
     }
 
     if (isText) {
-        bucket.text.dynamicLayoutVertexBuffer.updateData(dynamicLayoutVertexArray.serialize());
+        bucket.text.dynamicLayoutVertexBuffer.updateData(dynamicLayoutVertexArray);
     } else {
-        bucket.icon.dynamicLayoutVertexBuffer.updateData(dynamicLayoutVertexArray.serialize());
+        bucket.icon.dynamicLayoutVertexBuffer.updateData(dynamicLayoutVertexArray);
     }
 }
 

--- a/src/symbol/symbol_placement.js
+++ b/src/symbol/symbol_placement.js
@@ -109,10 +109,10 @@ function updateOpacities(bucket: SymbolBucket, collisionFadeTimes: any) {
     }
 
     if (glyphOpacityArray && bucket.text.opacityVertexBuffer) {
-        bucket.text.opacityVertexBuffer.updateData(glyphOpacityArray.serialize());
+        bucket.text.opacityVertexBuffer.updateData(glyphOpacityArray);
     }
     if (iconOpacityArray && bucket.icon.opacityVertexBuffer) {
-        bucket.icon.opacityVertexBuffer.updateData(iconOpacityArray.serialize());
+        bucket.icon.opacityVertexBuffer.updateData(iconOpacityArray);
     }
 }
 
@@ -261,7 +261,7 @@ function performSymbolPlacement(bucket: SymbolBucket, collisionIndex: CollisionI
 
     // If the buffer hasn't been uploaded for the first time yet, we don't need to call updateData since it will happen at upload time
     if (collisionDebugBoxArray && bucket.collisionBox.collisionVertexBuffer)
-        bucket.collisionBox.collisionVertexBuffer.updateData(collisionDebugBoxArray.serialize());
+        bucket.collisionBox.collisionVertexBuffer.updateData(collisionDebugBoxArray);
     if (collisionDebugCircleArray && bucket.collisionCircle.collisionVertexBuffer)
-        bucket.collisionCircle.collisionVertexBuffer.updateData(collisionDebugCircleArray.serialize());
+        bucket.collisionCircle.collisionVertexBuffer.updateData(collisionDebugCircleArray);
 }

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -77,7 +77,7 @@ export type StructArrayTypeParameters = {
     alignment?: number
 };
 
-export type SerializedStructArray = {
+type SerializedStructArray = {
     length: number,
     arrayBuffer: ArrayBuffer,
     type: StructArrayTypeParameters,
@@ -115,25 +115,10 @@ class StructArray {
 
     _cacheKey: string;
 
-    constructor(serialized?: SerializedStructArray) {
+    constructor() {
         this.isTransferred = false;
-
-        if (serialized !== undefined) {
-        // Create from an serialized StructArray
-            this.arrayBuffer = serialized.arrayBuffer;
-            this.length = serialized.length;
-            this.capacity = this.arrayBuffer.byteLength / this.bytesPerElement;
-            this._refreshViews();
-
-        // Create a new StructArray
-        } else {
-            this.capacity = -1;
-            this.resize(0);
-        }
-    }
-
-    serialize(transferables?: Array<Transferable>): SerializedStructArray {
-        return StructArray.serialize(this, transferables);
+        this.capacity = -1;
+        this.resize(0);
     }
 
     /**
@@ -166,7 +151,12 @@ class StructArray {
         const Klass = input.cacheKey && input.cacheKey in structArrayTypeCache ?
             structArrayTypeCache[input.cacheKey] :
             createStructArrayType(input.type);
-        return new Klass(input);
+        const structArray = Object.create(Klass.prototype);
+        structArray.arrayBuffer = input.arrayBuffer;
+        structArray.length = input.length;
+        structArray.capacity = structArray.arrayBuffer.byteLength / structArray.bytesPerElement;
+        structArray._refreshViews();
+        return structArray;
     }
 
     /**

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -1,0 +1,203 @@
+// @flow
+
+const assert = require('assert');
+const Color = require('../style-spec/util/color');
+
+import type {Transferable} from '../types/transferable';
+
+export type Serialized =
+    | null
+    | void
+    | boolean
+    | number
+    | string
+    | Boolean
+    | Number
+    | String
+    | Date
+    | RegExp
+    | ArrayBuffer
+    | $ArrayBufferView
+    | Array<Serialized>
+    | {| name: string, properties: {+[string]: Serialized} |};
+
+
+type Registry = {
+    [string]: {
+        klass: Class<any>,
+        omit: $ReadOnlyArray<string>,
+        shallow: $ReadOnlyArray<string>
+    }
+};
+
+type RegisterOptions<T> = {
+    omit?: $ReadOnlyArray<$Keys<T>>,
+    shallow?: $ReadOnlyArray<$Keys<T>>
+}
+
+const registry: Registry = {};
+
+/**
+ * Register the given class as serializable.
+ *
+ * @param options
+ * @param options.omit List of properties to omit from serialization (e.g., cached/computed properties)
+ * @param options.shallow List of properties that should be serialized by a simple shallow copy, rather than by a recursive call to serialize().
+ *
+ * @private
+ */
+function register<T: any>(klass: Class<T>, options: RegisterOptions<T> = {}) {
+    const name: string = klass.name;
+    assert(name);
+    assert(!registry[name], `${name} is already registered.`);
+    registry[name] = {
+        klass,
+        omit: options.omit || [],
+        shallow: options.shallow || []
+    };
+}
+
+register(Object);
+register(Color);
+/**
+ * Serialize the given object for transfer to or from a web worker.
+ *
+ * For non-builtin types, recursively serialize each property (possibly
+ * omitting certain properties - see register()), and package the result along
+ * with the constructor's `name` so that the appropriate constructor can be
+ * looked up in `deserialize()`.
+ *
+ * If a `transferables` array is provided, add any transferable objects (i.e.,
+ * any ArrayBuffers or ArrayBuffer views) to the list. (If a copy is needed,
+ * this should happen in the client code, before using serialize().)
+ */
+function serialize(input: mixed, transferables?: Array<Transferable>): Serialized {
+    if (input === null ||
+        input === undefined ||
+        typeof input === 'boolean' ||
+        typeof input === 'number' ||
+        typeof input === 'string' ||
+        input instanceof Boolean ||
+        input instanceof Number ||
+        input instanceof String ||
+        input instanceof Date ||
+        input instanceof RegExp) {
+        return input;
+    }
+
+    if (input instanceof ArrayBuffer) {
+        if (transferables) {
+            transferables.push(input);
+        }
+        return input;
+    }
+
+    if (ArrayBuffer.isView(input)) {
+        const view: $ArrayBufferView = (input: any);
+        if (transferables) {
+            transferables.push(view.buffer);
+        }
+        return view;
+    }
+
+    if (Array.isArray(input)) {
+        const serialized = [];
+        for (const item of input) {
+            serialized.push(serialize(item, transferables));
+        }
+        return serialized;
+    }
+
+    if (typeof input === 'object') {
+        const klass = (input.constructor: any);
+        const name = klass.name;
+        if (!name) {
+            throw new Error(`can't serialize object of anonymous class`);
+        }
+
+        if (!registry[name]) {
+            throw new Error(`can't serialize unregistered class ${name}`);
+        }
+
+        const properties: {[string]: Serialized} = {};
+
+        if (klass.serialize) {
+            // (Temporary workaround) allow a class to provide static
+            // `serialize()` and `deserialize()` methods to bypass the generic
+            // approach.
+            // This temporary workaround lets us use the generic serialization
+            // approach for objects whose members include instances of dynamic
+            // StructArray types. Once we refactor StructArray to be static,
+            // we can remove this complexity.
+            properties._serialized = (klass.serialize: typeof serialize)(input, transferables);
+        } else {
+            for (const key in input) {
+                // any cast due to https://github.com/facebook/flow/issues/5393
+                if (!(input: any).hasOwnProperty(key)) continue;
+                if (registry[name].omit.indexOf(key) >= 0) continue;
+                const property = (input: any)[key];
+                properties[key] = registry[name].shallow.indexOf(key) >= 0 ?
+                    property :
+                    serialize(property, transferables);
+            }
+        }
+
+        return {name, properties};
+    }
+
+    throw new Error(`can't serialize object of type ${typeof input}`);
+}
+
+function deserialize(input: Serialized): mixed {
+    if (input === null ||
+        input === undefined ||
+        typeof input === 'boolean' ||
+        typeof input === 'number' ||
+        typeof input === 'string' ||
+        input instanceof Boolean ||
+        input instanceof Number ||
+        input instanceof String ||
+        input instanceof Date ||
+        input instanceof RegExp ||
+        input instanceof ArrayBuffer ||
+        ArrayBuffer.isView(input)) {
+        return input;
+    }
+
+    if (Array.isArray(input)) {
+        return input.map((i) => deserialize(i));
+    }
+
+    if (typeof input === 'object') {
+        const {name, properties} = (input: any);
+        if (!name) {
+            throw new Error(`can't deserialize object of anonymous class`);
+        }
+
+        const {klass} = registry[name];
+        if (!klass) {
+            throw new Error(`can't deserialize unregistered class ${name}`);
+        }
+
+        if (klass.deserialize) {
+            return (klass.deserialize: typeof deserialize)(properties._serialized);
+        }
+
+        const result = Object.create(klass.prototype);
+
+        for (const key of Object.keys(properties)) {
+            result[key] = registry[name].shallow.indexOf(key) >= 0 ?
+                properties[key] : deserialize(properties[key]);
+        }
+
+        return result;
+    }
+
+    throw new Error(`can't deserialize object of type ${typeof input}`);
+}
+
+module.exports = {
+    register,
+    serialize,
+    deserialize
+};

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 
+const Grid = require('grid-index');
 const Color = require('../style-spec/util/color');
 const {
     StylePropertyFunction,
@@ -68,6 +69,20 @@ function register<T: any>(klass: Class<T>, options: RegisterOptions<T> = {}) {
 }
 
 register(Object);
+
+Grid.serialize = function serializeGrid(grid: Grid, transferables?: Array<Transferable>): Serialized {
+    const ab = grid.toArrayBuffer();
+    if (transferables) {
+        transferables.push(ab);
+    }
+    return ab;
+};
+
+Grid.deserialize = function deserializeGrid(serialized: ArrayBuffer): Grid {
+    return new Grid(serialized);
+};
+register(Grid);
+
 register(Color);
 
 register(StylePropertyFunction);

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -1,7 +1,17 @@
 // @flow
 
 const assert = require('assert');
+
 const Color = require('../style-spec/util/color');
+const {
+    StylePropertyFunction,
+    StyleExpression,
+    StyleExpressionWithErrorHandling,
+    ZoomDependentExpression,
+    ZoomConstantExpression
+} = require('../style-spec/expression');
+const {CompoundExpression} = require('../style-spec/expression/compound_expression');
+const expressions = require('../style-spec/expression/definitions');
 
 import type {Transferable} from '../types/transferable';
 
@@ -59,6 +69,19 @@ function register<T: any>(klass: Class<T>, options: RegisterOptions<T> = {}) {
 
 register(Object);
 register(Color);
+
+register(StylePropertyFunction);
+register(StyleExpression, {omit: ['_evaluator']});
+register(StyleExpressionWithErrorHandling, {omit: ['_evaluator']});
+register(ZoomDependentExpression);
+register(ZoomConstantExpression);
+register(CompoundExpression, {omit: ['_evaluate']});
+for (const name in expressions) {
+    const Expression = expressions[name];
+    if (registry[Expression.name]) continue;
+    register(expressions[name]);
+}
+
 /**
  * Serialize the given object for transfer to or from a web worker.
  *

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -32,6 +32,8 @@ expressionSuite.run('js', { ignores, tests }, (fixture) => {
 
     expression = expression.value;
 
+    const type = expression._styleExpression.expression.type; // :scream:
+
     const outputs = [];
     const result = {
         outputs,
@@ -39,7 +41,7 @@ expressionSuite.run('js', { ignores, tests }, (fixture) => {
             result: 'success',
             isZoomConstant: expression.kind === 'constant' || expression.kind === 'source',
             isFeatureConstant: expression.kind === 'constant' || expression.kind === 'camera',
-            type: toString(expression.parsed.type)
+            type: toString(type)
         }
     };
 
@@ -53,7 +55,7 @@ expressionSuite.run('js', { ignores, tests }, (fixture) => {
                 feature.type = input[1].geometry.type;
             }
             let value = expression.evaluate(input[0], feature);
-            if (expression.parsed.type.kind === 'color') {
+            if (type.kind === 'color') {
                 value = [value.r, value.g, value.b, value.a];
             }
             outputs.push(value);

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -321,7 +321,7 @@ function createRawTileData() {
 function createVectorData(options) {
     const collisionBoxArray = new CollisionBoxArray();
     return util.extend({
-        collisionBoxArray: collisionBoxArray.serialize(),
+        collisionBoxArray: serialize(collisionBoxArray),
         featureIndex: serialize(new FeatureIndex(new TileCoord(1, 1, 1))),
         buckets: []
     }, options);

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -12,6 +12,7 @@ const CollisionIndex = require('../../../src/symbol/collision_index');
 const Transform = require('../../../src/geo/transform');
 const CollisionBoxArray = require('../../../src/symbol/collision_box');
 const util = require('../../../src/util/util');
+const {serialize} = require('../../../src/util/web_worker_transfer');
 
 test('querySourceFeatures', (t) => {
     const features = [{
@@ -321,7 +322,7 @@ function createVectorData(options) {
     const collisionBoxArray = new CollisionBoxArray();
     return util.extend({
         collisionBoxArray: collisionBoxArray.serialize(),
-        featureIndex: (new FeatureIndex(new TileCoord(1, 1, 1))).serialize(),
+        featureIndex: serialize(new FeatureIndex(new TileCoord(1, 1, 1))),
         buckets: []
     }, options);
 }

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -11,6 +11,7 @@ test('abortTile', (t) => {
         source.loadTile({
             source: 'source',
             uid: 0,
+            coord: {x: 0, y: 0, z: 0, w: 0},
             request: { url: 'http://localhost:2900/abort' }
         }, (err, res) => {
             t.false(err);

--- a/test/unit/source/worker.test.js
+++ b/test/unit/source/worker.test.js
@@ -16,6 +16,7 @@ test('load tile', (t) => {
             type: 'vector',
             source: 'source',
             uid: 0,
+            coord: {x: 0, y: 0, z: 0, w: 0},
             request: { url: '/error' }// Sinon fake server gives 404 responses by default
         }, (err) => {
             t.ok(err);

--- a/test/unit/util/struct_array.test.js
+++ b/test/unit/util/struct_array.test.js
@@ -14,8 +14,7 @@ test('StructArray', (t) => {
     });
 
     t.test('type defined', (t) => {
-
-        t.deepEqual(TestArray.serialize(), {
+        t.deepEqual(TestArray.serialize(new TestArray()).type, {
             members: [{
                 name: 'map',
                 components: 1,

--- a/test/unit/util/web_worker_transfer.test.js
+++ b/test/unit/util/web_worker_transfer.test.js
@@ -1,0 +1,84 @@
+// @flow
+
+'use strict';
+
+const test = require('mapbox-gl-js-test').test;
+const {register, serialize, deserialize} = require('../../../src/util/web_worker_transfer');
+
+/*::
+import type {Serialized} from '../../../src/util/web_worker_transfer';
+*/
+
+test('round trip', (t) => {
+    class Foo {
+        /*:: n: number;*/
+        /*:: buffer: ArrayBuffer;*/
+        /*:: _cached: ?number;*/
+
+        constructor(n) {
+            this.n = n;
+            this.buffer = new ArrayBuffer(100);
+            this.squared();
+        }
+
+        squared() {
+            if (this._cached) {
+                return this._cached;
+            }
+            this._cached = this.n * this.n;
+            return this._cached;
+        }
+    }
+
+    register(Foo, { omit: ['_cached'] });
+
+    const foo = new Foo(10);
+    const transferables = [];
+    const deserialized = deserialize(serialize(foo, transferables));
+    t.assert(deserialized instanceof Foo);
+    const bar/*: Foo*/ = (deserialized/*: any*/);
+
+    t.assert(foo !== bar);
+    t.assert(bar.constructor === Foo);
+    t.assert(bar.n === 10);
+    t.assert(bar.buffer === foo.buffer);
+    t.assert(transferables[0] === foo.buffer);
+    t.assert(bar._cached === undefined);
+    t.assert(bar.squared() === 100);
+    t.end();
+});
+
+test('custom serialization', (t) => {
+    class Bar {
+        /*:: id: string; */
+        /*:: _deserialized: boolean; */
+        constructor(id) {
+            this.id = id;
+            this._deserialized = false;
+        }
+
+        static serialize(b/*: Bar*/)/*: Serialized*/ {
+            return `custom serialization,${b.id}`;
+        }
+
+        static deserialize(input/*: Serialized*/)/*: Bar*/ {
+            const b = new Bar((input/*: any*/).split(',')[1]);
+            b._deserialized = true;
+            return b;
+        }
+    }
+
+    register(Bar);
+
+    const bar = new Bar('a');
+    t.assert(!bar._deserialized);
+
+    const deserialized = deserialize(serialize(bar));
+    t.assert(deserialized instanceof Bar);
+    const bar2/*: Bar*/ = (deserialized/*: any*/);
+    t.equal(bar2.id, bar.id);
+    t.assert(bar2._deserialized);
+    t.end();
+});
+
+


### PR DESCRIPTION
Closes #5143

- [x] Add serialize, deserialize, register
- [x] Replace Bucket#serialize() with generic serialization
- [x] Fixup https://github.com/mapbox/mapbox-gl-js/pull/5702/commits/bbcedde13245729fd41ecc7f9d031f052897d968 to include compiled stop functions
- [x] Make FeatureIndex serializable
- [x] Remove `StructArray#serialize()`
- [x] <del>? Use generic serialization for `setLayers` message</del> (this is pretty involved, punt for now)
- [x] Update unit tests
- [x] Benchmark, profile, recover performance

Benchmarks (no significant change)
https://bl.ocks.org/anonymous/raw/5858aa59155120157d4ba4b938835434/