### PR TITLE
Include bucketIndex in queryRenderedSymbols duplicate feature filter

### DIFF
--- a/src/symbol/collision_index.js
+++ b/src/symbol/collision_index.js
@@ -267,13 +267,18 @@ class CollisionIndex {
             const blocking = collisionBoxArray.get(thisTileFeatures[i]);
             const sourceLayer = blocking.sourceLayerIndex;
             const featureIndex = blocking.featureIndex;
+            const bucketIndex = blocking.bucketIndex;
 
             // Skip already seen features.
             if (sourceLayerFeatures[sourceLayer] === undefined) {
                 sourceLayerFeatures[sourceLayer] = {};
             }
-            if (sourceLayerFeatures[sourceLayer][featureIndex]) continue;
-
+            if (sourceLayerFeatures[sourceLayer][featureIndex] === undefined) {
+                sourceLayerFeatures[sourceLayer][featureIndex] = {};
+            }
+            if (sourceLayerFeatures[sourceLayer][featureIndex][bucketIndex]) {
+                continue;
+            }
 
             // Check if query intersects with the feature box
             // "Collision Circles" for line labels are treated as boxes here
@@ -292,9 +297,11 @@ class CollisionIndex {
                 new Point(x2, y2),
                 new Point(x1, y2)
             ];
-            if (!intersectionTests.polygonIntersectsPolygon(query, bbox)) continue;
+            if (!intersectionTests.polygonIntersectsPolygon(query, bbox)) {
+                continue;
+            }
 
-            sourceLayerFeatures[sourceLayer][featureIndex] = true;
+            sourceLayerFeatures[sourceLayer][featureIndex][bucketIndex] = true;
             result.push(thisTileFeatures[i]);
         }
 

--- a/test/integration/query-tests/regressions/mapbox-gl-js#5172/expected.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#5172/expected.json
@@ -1,0 +1,13 @@
+[
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  }
+]

--- a/test/integration/query-tests/regressions/mapbox-gl-js#5172/style.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#5172/style.json
@@ -1,0 +1,70 @@
+{
+    "version": 8,
+    "metadata": {
+        "test": {
+            "width": 128,
+            "height": 128,
+            "queryGeometry": [
+                64,
+                64
+            ],
+            "queryOptions": {
+              "layers": ["iconlayer"]
+            }
+        }
+    },
+    "zoom": 0,
+    "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
+    "sprite": "local://sprites/sprite",
+    "sources": {
+        "source": {
+            "type": "geojson",
+            "data": {
+              "type": "FeatureCollection",
+              "features": [{
+                "type": "Feature",
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [0, 0]
+                }
+
+              }]
+            }
+        }
+    },
+    "layers": [
+        {
+          "id": "background",
+          "type": "background",
+          "paint": {
+            "background-color": "white"
+          }
+        },
+        {
+          "id": "iconlayer",
+          "type": "symbol",
+          "source": "source",
+          "layout": {
+            "icon-image": "building-12",
+            "icon-allow-overlap": true
+          }
+        },
+        {
+          "id": "textlayer",
+          "type": "symbol",
+          "source": "source",
+          "layout": {
+            "text-field": "ABC",
+            "text-font": [
+                "Open Sans Semibold",
+                "Arial Unicode MS Bold"
+            ],
+            "text-size": 24,
+            "text-offset": [0, 0]
+          },
+          "paint": {
+            "text-color": "green"
+          }
+        }
+    ]
+}


### PR DESCRIPTION
Fixes issue #5172: items from multiple layers but sharing a common source feature would only show up in queryRenderedSymbols results for one of the layers.

Although this doesn't cause any of our existing query tests to fail, I worry a _little_ that we might break assumptions for some users of `queryRenderedSymbols` with this change. Before, we'd never return the same feature twice in a result set -- now it's possible to return the feature multiple times (once for each layer it's part of). Should we change maybe something like `Style#_flattenRenderedFeatures` to remove duplicates?

/cc @mollymerp @anandthakker 