### PR TITLE
"Clear" stencil buffer manually; workaround for #5490

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -219,9 +219,40 @@ class Painter {
      */
     clearStencil() {
         const gl = this.gl;
-        gl.clearStencil(0x0);
+
+        // As a temporary workaround for https://github.com/mapbox/mapbox-gl-js/issues/5490,
+        // pending an upstream fix, we draw a fullscreen stencil=0 clipping mask here,
+        // effectively clearing the stencil buffer: restore this code for native
+        // performance and readability once an upstream patch lands.
+
+        // gl.clearStencil(0x0);
+        // gl.stencilMask(0xFF);
+        // gl.clear(gl.STENCIL_BUFFER_BIT);
+
+        gl.colorMask(false, false, false, false);
+        this.depthMask(false);
+        gl.disable(gl.DEPTH_TEST);
+        gl.enable(gl.STENCIL_TEST);
+
         gl.stencilMask(0xFF);
-        gl.clear(gl.STENCIL_BUFFER_BIT);
+        gl.stencilOp(gl.ZERO, gl.ZERO, gl.ZERO);
+
+        gl.stencilFunc(gl.ALWAYS, 0x0, 0xFF);
+
+        const matrix = mat4.create();
+        mat4.ortho(matrix, 0, this.width, this.height, 0, 0, 1);
+        mat4.scale(matrix, matrix, [gl.drawingBufferWidth, gl.drawingBufferHeight, 0]);
+
+        const program = this.useProgram('fill', this.basicFillProgramConfiguration);
+        gl.uniformMatrix4fv(program.uniforms.u_matrix, false, matrix);
+
+        this.viewportVAO.bind(gl, program, this.viewportBuffer);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+        gl.stencilMask(0x00);
+        gl.colorMask(true, true, true, true);
+        this.depthMask(true);
+        gl.enable(gl.DEPTH_TEST);
     }
 
     clearDepth() {


### PR DESCRIPTION
As of Chrome v62, depth reads in certain Intel Iris graphics cards (at least Intel Iris Graphics 6100) all fail on intermittent frames, creating a flashing effect as in https://github.com/mapbox/mapbox-gl-js/issues/5490. I believe this bug is some kind of race condition or incorrect vector access related to stencil buffer clearing. This PR mitigates this issue pending an upstream fix by never using `gl.clear(gl.STENCIL_BUFFER_BIT)` and instead "clearing" it manually by drawing a stencil mask of all 0s to the full viewport. I've confirmed on maps where this effect is most dramatic (maps with many sources) that this fix eliminates flashing entirely.

Fixes #5490.
Upstream issue: https://bugs.chromium.org/p/chromium/issues/detail?id=784030