### PR TITLE
Style spec support updates for 'agua' releases

### DIFF
--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -769,9 +769,9 @@ export default class extends React.Component {
                                             <tr>
                                                 <td>basic functionality</td>
                                                 <td className='center'>&gt;= 0.10.0</td>
-                                                <td className='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
-                                                <td className='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
-                                                <td className='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
+                                                <td className='center'>&gt;= 5.2.0</td>
+                                                <td className='center'>&gt;= 3.7.0</td>
+                                                <td className='center'>&gt;= 0.6.0</td>
                                             </tr>
                                         </tbody>
                                     </table>

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -675,7 +675,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1165,10 +1168,16 @@
       ],
       "sdk-support": {
         "basic functionality": {
-          "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         },
         "data-driven styling": {
-          "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1194,7 +1203,10 @@
       ],
       "sdk-support": {
         "basic functionality": {
-          "js": "0.39.0"
+          "js": "0.39.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         },
         "data-driven styling": {}
       }
@@ -1361,7 +1373,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-            "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1404,7 +1419,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-            "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1437,7 +1455,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-            "js": "0.39.0"
+          "js": "0.39.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1488,7 +1509,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-            "js": "0.39.0"
+          "js": "0.39.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -3016,7 +3040,10 @@
       "doc": "Orientation of circle when map is pitched.",
       "sdk-support": {
         "basic functionality": {
-          "js": "0.39.0"
+          "js": "0.39.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         },
         "data-driven styling": {}
       }


### PR DESCRIPTION
Updates the style spec’s SDK support matrices for the so-called “agua” releases — Android 5.2.0 and iOS 3.7.0. (@1ec5, this also presupposes the existence of macOS 0.6.0.)

This adds native support for:

- `line-join` (DDS-only, basic support already existed)
- `icon-anchor`
- `icon-pitch-alignment`
- `circle-pitch-alignment`
- `text-max-width`
- `text-letter-spacing`
- `text-justify`
- `text-anchor`

I gleaned this list from [the iOS SDK changelog](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v3.7.0), so please let me know if it’s over-ambitious or missing anything.

/cc @asheemmamoowala @lbud @ChrisLoer @jfirebaugh @fabian-guerra @Guardiola31337 