### PR TITLE
Guard for undefined light in Style#hasTransitions race condition

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -320,7 +320,7 @@ class Style extends Evented {
     }
 
     hasTransitions() {
-        if (this.light.hasTransition()) {
+        if (this.light && this.light.hasTransition()) {
             return true;
         }
 

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1740,3 +1740,54 @@ test('Style#addSourceType', (t) => {
 
     t.end();
 });
+
+test('Style#hasTransitions', (t) => {
+    t.test('returns false when the style is loading', (t) => {
+        const style = new Style(new StubMap());
+        t.equal(style.hasTransitions(), false);
+        t.end();
+    });
+
+    t.test('returns true when a property is transitioning', (t) => {
+        const style = new Style(new StubMap());
+        style.loadJSON({
+            "version": 8,
+            "sources": {},
+            "layers": [{
+                "id": "background",
+                "type": "background"
+            }]
+        });
+
+        style.on('style.load', () => {
+            style.setPaintProperty("background", "background-color", "blue");
+            style.update();
+            t.equal(style.hasTransitions(), true);
+            t.end();
+        });
+    });
+
+    t.test('returns false when a property is not transitioning', (t) => {
+        const style = new Style(new StubMap());
+        style.loadJSON({
+            "version": 8,
+            "sources": {},
+            "transition": {
+                "duration": 0
+            },
+            "layers": [{
+                "id": "background",
+                "type": "background"
+            }]
+        });
+
+        style.on('style.load', () => {
+            style.setPaintProperty("background", "background-color", "blue");
+            style.update();
+            t.equal(style.hasTransitions(), false);
+            t.end();
+        });
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Fixes #5714. 

It's possible (likely after https://github.com/mapbox/mapbox-gl-js/commit/762aaa9b1a93ffa19de85486329ce60abcc75477) to trigger a race condition in which a move event triggers a `_rerender` before a style is finished loading, in which case `Style.light` will not yet be defined. This just adds a check to verify that `light` exists. (Verified by reproducing this race condition with the fix in place; everything else loaded fine.)