### PR TITLE
V0.42.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
-# 0.42.1 (November 17, 2017)
+## 0.42.2 (November 21, 2017)
 
-# 🐛 Bug fixes
+### 🐛 Bug fixes
+
+- Add box-sizing to the "mapboxgl-ctrl-scale"-class [#5715](https://github.com/mapbox/mapbox-gl-js/pull/5715)
+- Fix rendering in Safari [#5712](https://github.com/mapbox/mapbox-gl-js/issues/5712)
+- Fix "Cannot read property 'hasTransition' of undefined" error [#5714](https://github.com/mapbox/mapbox-gl-js/issues/5714)
+- Fix misplaced raster tiles [#5713](https://github.com/mapbox/mapbox-gl-js/issues/5713)
+- Fix raster tile fading [#5722](https://github.com/mapbox/mapbox-gl-js/issues/5722)
+- Ensure that an unset filter is undefined rather than null [#5727](https://github.com/mapbox/mapbox-gl-js/pull/5727)
+- Restore pitch-with-rotate to nav control [#5725](https://github.com/mapbox/mapbox-gl-js/pull/5725)
+- Validate container option in map constructor [#5695](https://github.com/mapbox/mapbox-gl-js/pull/5695)
+- Fix queryRenderedFeatures behavior for features displayed in multiple layers [#5172](https://github.com/mapbox/mapbox-gl-js/issues/5172)
+
+## 0.42.1 (November 17, 2017)
+
+### 🐛 Bug fixes
 
 - Workaround for map flashing bug on Chrome 62+ with Intel Iris Graphics 6100 cards [#5704](https://github.com/mapbox/mapbox-gl-js/pull/5704)
 - Rerender map when `map.showCollisionBoxes` is set to `false` [#5673](https://github.com/mapbox/mapbox-gl-js/pull/5673)
@@ -8,13 +22,13 @@
 - Fix runtime updating of `heatmap-color` [#5682](https://github.com/mapbox/mapbox-gl-js/pull/5682)
 - Fix mobile Safari `history.replaceState` error [#5613](https://github.com/mapbox/mapbox-gl-js/pull/5613)
 
-# ✨ Features and improvements
+### ✨ Features and improvements
 
 - Provide default element for Marker class [#5661](https://github.com/mapbox/mapbox-gl-js/pull/5661)
 
 # 0.42.0 (November 10, 2017)
 
-# ⚠️ Breaking changes
+### ⚠️ Breaking changes
 
 - Require that `heatmap-color` use expressions instead of stop functions [#5624](https://github.com/mapbox/mapbox-gl-js/issues/5624)
 - Remove support for validating and migrating v6 styles
@@ -23,7 +37,7 @@
 - Split `curve` expression into `step` and `interpolate` expressions [#5542](https://github.com/mapbox/mapbox-gl-js/pull/5542)
 - Disallow interpolation in expressions for `line-dasharray` [#5519](https://github.com/mapbox/mapbox-gl-js/pull/5519)
 
-# ✨ Features and improvements
+### ✨ Features and improvements
 
 - Improve label collision detection [#5150](https://github.com/mapbox/mapbox-gl-js/pull/5150)
   - Labels from different sources will now collide with each other
@@ -31,7 +45,7 @@
   - Improved algorithm for fewer erroneous collisions, denser label placement, and greater label stability during rotation
 - Add `sqrt` expression [#5493](https://github.com/mapbox/mapbox-gl-js/pull/5493)
 
-# 🐛 Bug fixes and error reporting improvements
+### 🐛 Bug fixes and error reporting improvements
 
 - Fix viewport calculations for `fitBounds` when both zooming and padding change [#4846](https://github.com/mapbox/mapbox-gl-js/issues/4846)
 - Fix WebGL "range out of bounds for buffer" error caused by sorted symbol layers [#5620](https://github.com/mapbox/mapbox-gl-js/issues/5620)
@@ -51,7 +65,7 @@
 - Improve validation to catch uses of deprecated function syntax [#5667](https://github.com/mapbox/mapbox-gl-js/pull/5667)
 - Permit altitude coordinates in `position` field in GeoJSON [#5608](https://github.com/mapbox/mapbox-gl-js/pull/5608)
 
-# 0.41.0 (October 11, 2017)
+## 0.41.0 (October 11, 2017)
 
 ### :warning: Breaking changes
 - Removed support for paint classes [#3643](https://github.com/mapbox/mapbox-gl-js/pull/3643). Instead, use runtime styling APIs or `Map#setStyle`.

--- a/docs/pages/example/3d-buildings.html
+++ b/docs/pages/example/3d-buildings.html
@@ -3,7 +3,7 @@
 var map = new mapboxgl.Map({
     style: 'mapbox://styles/mapbox/light-v9',
     center: [-74.0066, 40.7135],
-    zoom: 15,
+    zoom: 15.5,
     pitch: 45,
     bearing: -17.6,
     hash: true,
@@ -14,11 +14,16 @@ var map = new mapboxgl.Map({
 // data from OpenStreetMap.
 map.on('load', function() {
     // Insert the layer beneath any symbol layer.
-    var layers = map.getStyle().layers.reverse();
-    var labelLayerIdx = layers.findIndex(function (layer) {
-        return layer.type !== 'symbol';
-    });
-    var labelLayerId = labelLayerIdx !== -1 ? layers[labelLayerIdx].id : undefined;
+    var layers = map.getStyle().layers;
+
+    var labelLayerId;
+    for (var i = 0; i < layers.length; i++) {
+        if (layers[i].type === 'symbol' && layers[i].layout['text-field']) {
+            labelLayerId = layers[i].id;
+            break;
+        }
+    }
+
     map.addLayer({
         'id': '3d-buildings',
         'source': 'composite',
@@ -28,14 +33,19 @@ map.on('load', function() {
         'minzoom': 15,
         'paint': {
             'fill-extrusion-color': '#aaa',
-            'fill-extrusion-height': {
-                'type': 'identity',
-                'property': 'height'
-            },
-            'fill-extrusion-base': {
-                'type': 'identity',
-                'property': 'min_height'
-            },
+
+            // use an 'interpolate' expression to add a smooth transition effect to the
+            // buildings as the user zooms in
+            'fill-extrusion-height': [
+                "interpolate", ["linear"], ["zoom"],
+                15, 0,
+                15.05, ["get", "height"]
+            ],
+            'fill-extrusion-base': [
+                "interpolate", ["linear"], ["zoom"],
+                15, 0,
+                15.05, ["get", "min_height"]
+            ],
             'fill-extrusion-opacity': .6
         }
     }, labelLayerId);

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -769,9 +769,9 @@ export default class extends React.Component {
                                             <tr>
                                                 <td>basic functionality</td>
                                                 <td className='center'>&gt;= 0.10.0</td>
-                                                <td className='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
-                                                <td className='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
-                                                <td className='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
+                                                <td className='center'>&gt;= 5.2.0</td>
+                                                <td className='center'>&gt;= 3.7.0</td>
+                                                <td className='center'>&gt;= 0.6.0</td>
                                             </tr>
                                         </tbody>
                                     </table>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -675,7 +675,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1165,10 +1168,16 @@
       ],
       "sdk-support": {
         "basic functionality": {
-          "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         },
         "data-driven styling": {
-          "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1194,7 +1203,10 @@
       ],
       "sdk-support": {
         "basic functionality": {
-          "js": "0.39.0"
+          "js": "0.39.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         },
         "data-driven styling": {}
       }
@@ -1361,7 +1373,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-            "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1404,7 +1419,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-            "js": "0.40.0"
+          "js": "0.40.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1437,7 +1455,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-            "js": "0.39.0"
+          "js": "0.39.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1488,7 +1509,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-            "js": "0.39.0"
+          "js": "0.39.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         }
       }
     },
@@ -1965,55 +1989,55 @@
         "group": "Types"
       },
       "string": {
-        "doc": "Asserts that the input value is a string. If multiple values are provided, each one is evaluated in order until a string value is obtained. If, when the last provided input is evaluated, it is not of the asserted type, then this assertion will cause the whole expression to be aborted.",
+        "doc": "Asserts that the input value is a string. If multiple values are provided, each one is evaluated in order until a string value is obtained. If none of the inputs are strings, the expression is an error.",
         "group": "Types"
       },
       "number": {
-        "doc": "Asserts that the input value is a number. If multiple values are provided, each one is evaluated in order until a number value is obtained. If, when the last provided input is evaluated, it is not a number, then this assertion will cause the whole expression to be aborted.",
+        "doc": "Asserts that the input value is a number. If multiple values are provided, each one is evaluated in order until a number value is obtained. If none of the inputs are numbers, the expression is an error.",
         "group": "Types"
       },
       "boolean": {
-        "doc": "Asserts that the input value is a boolean. If multiple values are provided, each one is evaluated in order until a boolean value is obtained. If, when the last provided input is evaluated, it is not of the asserted type, then this assertion will cause the whole expression to be aborted.",
+        "doc": "Asserts that the input value is a boolean. If multiple values are provided, each one is evaluated in order until a boolean value is obtained. If none of the inputs are booleans, the expression is an error.",
         "group": "Types"
       },
       "object": {
-        "doc": "Asserts that the input value is an Objects.",
+        "doc": "Asserts that the input value is an object. If it is not, the expression is an error.",
         "group": "Types"
       },
       "to-string": {
-        "doc": "Converts the input value to a string.",
+        "doc": "Converts the input value to a string. If the input is `null`, the result is `\"null\"`. If the input is a boolean, the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a color, it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
         "group": "Types"
       },
       "to-number": {
-        "doc": "Converts the input value to a number, if possible. If multiple values are provided, each one is evaluated in order until the first successful conversion is obtained.",
+        "doc": "Converts the input value to a number, if possible. If the input is `null` or `false`, the result is 0. If the input is `true`, the result is 1. If the input is a string, it is converted to a number as specified by the [\"ToNumber Applied to the String Type\" algorithm](https://tc39.github.io/ecma262/#sec-tonumber-applied-to-the-string-type) of the ECMAScript Language Specification. If multiple values are provided, each one is evaluated in order until the first successful conversion is obtained. If none of the inputs can be converted, the expression is an error.",
         "group": "Types"
       },
       "to-boolean": {
-        "doc": "Converts the input value to a boolean.",
+        "doc": "Converts the input value to a boolean. The result is `false` when then input is an empty string, 0, `false`, `null`, or `NaN`; otherwise it is `true`.",
         "group": "Types"
       },
       "to-rgba": {
-        "doc": "Returns the an array of the given color's r, g, b, a components.",
+        "doc": "Returns a four-element array containing the input color's red, green, blue, and alpha components, in that order.",
         "group": "Color"
       },
       "to-color": {
-        "doc": "Converts the input value to a color. If multiple values are provided, each one is evaluated in order until the first successful conversion is obtained.",
+        "doc": "Converts the input value to a color. If multiple values are provided, each one is evaluated in order until the first successful conversion is obtained. If none of the inputs can be converted, the expression is an error.",
         "group": "Types"
       },
       "rgb": {
-        "doc": "Creates a color value from r, g, b components.",
+        "doc": "Creates a color value from red, green, and blue components, which must range between 0 and 255, and an alpha component of 1. If any component is out of range, the expression is an error.",
         "group": "Color"
       },
       "rgba": {
-        "doc": "Creates a color value from r, g, b, a components.",
+        "doc": "Creates a color value from red, green, blue components, which must range between 0 and 255, and an alpha component which must range between 0 and 1. If any component is out of range, the expression is an error.",
         "group": "Color"
       },
       "get": {
-        "doc": "Retrieves a property value from the current feature's properties (or from another object if one is provided).  Returns null if the requested property is missing.",
+        "doc": "Retrieves a property value from the current feature's properties, or from another object if a second argument is provided. Returns null if the requested property is missing.",
         "group": "Lookup"
       },
       "has": {
-        "doc": "Tests for the presence of an property value in the current featur's properties (or from another object if one is provided).",
+        "doc": "Tests for the presence of an property value in the current feature's properties, or from another object if a second argument is provided.",
         "group": "Lookup"
       },
       "length": {
@@ -2041,123 +2065,123 @@
         "group": "Heatmap"
       },
       "+": {
-        "doc": "",
+        "doc": "Returns the sum of the inputs.",
         "group": "Math"
       },
       "*": {
-        "doc": "",
+        "doc": "Returns the product of the inputs.",
         "group": "Math"
       },
       "-": {
-        "doc": "",
+        "doc": "For two inputs, returns the result of subtracting the second input from the first. For a single input, returns the result of subtracting it from 0.",
         "group": "Math"
       },
       "/": {
-        "doc": "",
+        "doc": "Returns the result of floating point division of the first input by the second.",
         "group": "Math"
       },
       "%": {
-        "doc": "",
+        "doc": "Returns the remainder after integer division of the first input by the second.",
         "group": "Math"
       },
       "^": {
-        "doc": "",
+        "doc": "Returns the result of raising the first input to the power specified by the second.",
         "group": "Math"
       },
       "sqrt": {
-        "doc": "",
+        "doc": "Returns the square root of the input.",
         "group": "Math"
       },
       "log10": {
-        "doc": "",
+        "doc": "Returns the base-ten logarithm of the input.",
         "group": "Math"
       },
       "ln": {
-        "doc": "",
+        "doc": "Returns the natural logarithm of the input.",
         "group": "Math"
       },
       "log2": {
-        "doc": "",
+        "doc": "Returns the base-two logarithm of the input.",
         "group": "Math"
       },
       "sin": {
-        "doc": "",
+        "doc": "Returns the sine of the input.",
         "group": "Math"
       },
       "cos": {
-        "doc": "",
+        "doc": "Returns the cosine of the input.",
         "group": "Math"
       },
       "tan": {
-        "doc": "",
+        "doc": "Returns the tangent of the input.",
         "group": "Math"
       },
       "asin": {
-        "doc": "",
+        "doc": "Returns the arcsine of the input.",
         "group": "Math"
       },
       "acos": {
-        "doc": "",
+        "doc": "Returns the arccosine of the input.",
         "group": "Math"
       },
       "atan": {
-        "doc": "",
+        "doc": "Returns the arctangent of the input.",
         "group": "Math"
       },
       "min": {
-        "doc": "",
+        "doc": "Returns the minimum value of the inputs.",
         "group": "Math"
       },
       "max": {
-        "doc": "",
+        "doc": "Returns the maximum value of the inputs.",
         "group": "Math"
       },
       "==": {
-        "doc": "",
+        "doc": "Returns `true` if the input values are equal, `false` otherwise. The inputs must be numbers, strings, or booleans, and both of the same type.",
         "group": "Decision"
       },
       "!=": {
-        "doc": "",
+        "doc": "Returns `true` if the input values are not equal, `false` otherwise. The inputs must be numbers, strings, or booleans, and both of the same type.",
         "group": "Decision"
       },
       ">": {
-        "doc": "",
+        "doc": "Returns `true` if the first input is strictly greater than the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type.",
         "group": "Decision"
       },
       "<": {
-        "doc": "",
+        "doc": "Returns `true` if the first input is strictly less than the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type.",
         "group": "Decision"
       },
       ">=": {
-        "doc": "",
+        "doc": "Returns `true` if the first input is greater than or equal to the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type.",
         "group": "Decision"
       },
       "<=": {
-        "doc": "",
+        "doc": "Returns `true` if the first input is less than or equal to the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type.",
         "group": "Decision"
       },
       "all": {
-        "doc": "",
+        "doc": "Returns `true` if all the inputs are `true`, `false` otherwise. The inputs are evaluated in order, and evaluation is short-circuiting: once an input expression evaluates to `false`, the result is `false` and no further input expressions are evaluated.",
         "group": "Decision"
       },
       "any": {
-        "doc": "",
+        "doc": "Returns `true` if any of the inputs are `true`, `false` otherwise. The inputs are evaluated in order, and evaluation is short-circuiting: once an input expression evaluates to `true`, the result is `true` and no further input expressions are evaluated.",
         "group": "Decision"
       },
       "!": {
-        "doc": "",
+        "doc": "Logical negation. Returns `true` if the input is `false`, and `false` if the input is `true`.",
         "group": "Decision"
       },
       "upcase": {
-        "doc": "",
+        "doc": "Returns the input string converted to uppercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.",
         "group": "String"
       },
       "downcase": {
-        "doc": "",
+        "doc": "Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.",
         "group": "String"
       },
       "concat": {
-        "doc": "Concetenate the given strings.",
+        "doc": "Returns a string consisting of the concatenation of the inputs.",
         "group": "String"
       }
     }
@@ -3016,7 +3040,10 @@
       "doc": "Orientation of circle when map is pitched.",
       "sdk-support": {
         "basic functionality": {
-          "js": "0.39.0"
+          "js": "0.39.0",
+          "android": "5.2.0",
+          "ios": "3.7.0",
+          "macos": "0.6.0"
         },
         "data-driven styling": {}
       }


### PR DESCRIPTION
## 0.42.2 (November 21, 2017)

### 🐛 Bug fixes

- Add box-sizing to the "mapboxgl-ctrl-scale"-class [#5715](https://github.com/mapbox/mapbox-gl-js/pull/5715)
- Fix rendering in Safari [#5712](https://github.com/mapbox/mapbox-gl-js/issues/5712)
- Fix "Cannot read property 'hasTransition' of undefined" error [#5714](https://github.com/mapbox/mapbox-gl-js/issues/5714)
- Fix misplaced raster tiles [#5713](https://github.com/mapbox/mapbox-gl-js/issues/5713)
- Fix raster tile fading [#5722](https://github.com/mapbox/mapbox-gl-js/issues/5722)
- Ensure that an unset filter is undefined rather than null [#5727](https://github.com/mapbox/mapbox-gl-js/pull/5727)
- Restore pitch-with-rotate to nav control [#5725](https://github.com/mapbox/mapbox-gl-js/pull/5725)
- Validate container option in map constructor [#5695](https://github.com/mapbox/mapbox-gl-js/pull/5695)
- Fix queryRenderedFeatures behavior for features displayed in multiple layers [#5172](https://github.com/mapbox/mapbox-gl-js/issues/5172)
