### PR TITLE
Fix marker/popup lag by firing move events 1 frame earlier

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -562,6 +562,8 @@ class Camera extends Evented {
         clearTimeout(this._onEaseEnd);
 
         this._ease(function (k) {
+            this._fireMoveEvents(eventData);
+
             if (this.zooming) {
                 tr.zoom = interpolate(startZoom, zoom, k);
             }
@@ -583,8 +585,6 @@ class Camera extends Evented {
                 const newCenter = tr.unproject(from.add(delta.mult(k * speedup)).mult(scale));
                 tr.setLocationAtPoint(tr.renderWorldCopies ? newCenter.wrap() : newCenter, pointAtOffset);
             }
-
-            this._fireMoveEvents(eventData);
 
         }, () => {
             if (options.delayEndEvents) {
@@ -816,6 +816,8 @@ class Camera extends Evented {
         this._prepareEase(eventData, false);
 
         this._ease(function (k) {
+            this._fireMoveEvents(eventData);
+
             // s: The distance traveled along the flight path, measured in ρ-screenfuls.
             const s = k * S;
             const scale = 1 / w(s);
@@ -830,8 +832,6 @@ class Camera extends Evented {
 
             const newCenter = tr.unproject(from.add(delta.mult(u(s))).mult(scale));
             tr.setLocationAtPoint(tr.renderWorldCopies ? newCenter.wrap() : newCenter, pointAtOffset);
-
-            this._fireMoveEvents(eventData);
 
         }, () => this._easeToEnd(eventData), options);
 


### PR DESCRIPTION
This changes the camera event logic so that `move`/`zoom`/`rotate`/`pitch` events fire before the transform is updated (instead of after). Miraculously, this fixes the longstanding issue with lagging markers/popups on animations (#4670, #4681). 

I'm not entirely sure why, but it seems like the logic that makes the map canvas reflect the transform state happens before the frame handlers for camera animations, which means that when transform is changed in a frame as a part of an animation, it won't be reflected until the next frame while changes in marker positions are reflected instantly, hence the off-by-one-frame sync issues.

@jfirebaugh maybe you have an idea of how to fix that on a fundamentally upper level? Or we could accept this fix for now — it shouldn't be breaking.

cc @bicubic

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
