### PR TITLE
Omit inferred type annotations for 'coalesce' arguments

### DIFF
--- a/src/style-spec/expression/definitions/coalesce.js
+++ b/src/style-spec/expression/definitions/coalesce.js
@@ -1,6 +1,7 @@
 // @flow
 
 const assert = require('assert');
+const {checkSubtype, ValueType} = require('../types');
 
 import type { Expression } from '../expression';
 import type ParsingContext from '../parsing_context';
@@ -21,18 +22,31 @@ class Coalesce implements Expression {
             return context.error("Expectected at least one argument.");
         }
         let outputType: Type = (null: any);
-        if (context.expectedType && context.expectedType.kind !== 'value') {
-            outputType = context.expectedType;
+        const expectedType = context.expectedType;
+        if (expectedType && expectedType.kind !== 'value') {
+            outputType = expectedType;
         }
         const parsedArgs = [];
+
         for (const arg of args.slice(1)) {
-            const parsed = context.parse(arg, 1 + parsedArgs.length, outputType);
+            const parsed = context.parse(arg, 1 + parsedArgs.length, outputType, undefined, {omitTypeAnnotations: true});
             if (!parsed) return null;
             outputType = outputType || parsed.type;
             parsedArgs.push(parsed);
         }
         assert(outputType);
-        return new Coalesce((outputType: any), parsedArgs);
+
+        // Above, we parse arguments without inferred type annotation so that
+        // they don't produce a runtime error for `null` input, which would
+        // preempt the desired null-coalescing behavior.
+        // Thus, if any of our arguments would have needed an annotation, we
+        // need to wrap the enclosing coalesce expression with it instead.
+        const needsAnnotation = expectedType &&
+            parsedArgs.some(arg => checkSubtype(expectedType, arg.type));
+
+        return needsAnnotation ?
+            new Coalesce(ValueType, parsedArgs) :
+            new Coalesce((outputType: any), parsedArgs);
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/test/integration/expression-tests/coalesce/argument-type-mismatch/test.json
+++ b/test/integration/expression-tests/coalesce/argument-type-mismatch/test.json
@@ -1,0 +1,17 @@
+{
+  "propertySpec": {"type": "string"},
+  "expression": [
+    "coalesce",
+    ["get", "a"],
+    5
+  ],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [{
+        "key": "[2]",
+        "error": "Expected string but found number instead."
+      }]
+    }
+  }
+}

--- a/test/integration/expression-tests/coalesce/inference/test.json
+++ b/test/integration/expression-tests/coalesce/inference/test.json
@@ -1,0 +1,28 @@
+{
+  "propertySpec": {"type": "string"},
+  "expression": [
+    "coalesce",
+    ["get", "a"],
+    ["get", "b"]
+  ],
+  "inputs": [
+    [{}, {"properties": {"a": "one"}}],
+    [{}, {"properties": {"b": "two"}}],
+    [{}, {"properties": {"b": 5}}],
+    [{}, {"properties": {}}]
+  ],
+  "expected": {
+    "compiled": {
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "result": "success",
+      "type": "string"
+    },
+    "outputs": [
+      "one",
+      "two",
+      {"error": "Expected value to be of type string, but found number instead."},
+      {"error": "Expected value to be of type string, but found null instead."}
+    ]
+  }
+}


### PR DESCRIPTION
As described in #5755, such inferred annotations cause a runtime type error for `null` inputs, thus preempting the desired null-coalescing behavior of something like `["coalesce", ["get", "a"], ["get", "b"]]`.