### PR TITLE
Improve hash control precision

### DIFF
--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -54,9 +54,11 @@ class Hash {
     getHashString(mapFeedback?: boolean) {
         const center = this._map.getCenter(),
             zoom = Math.round(this._map.getZoom() * 100) / 100,
-            precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2)),
-            lng = Math.round(center.lng * Math.pow(10, precision)) / Math.pow(10, precision),
-            lat = Math.round(center.lat * Math.pow(10, precision)) / Math.pow(10, precision),
+            // derived from equation: 512px * 2^z / 360 / 10^d < 0.5px
+            precision = Math.ceil((zoom * Math.LN2 + Math.log(512 / 360 / 0.5)) / Math.LN10),
+            m = Math.pow(10, precision),
+            lng = Math.round(center.lng * m) / m,
+            lat = Math.round(center.lat * m) / m,
             bearing = this._map.getBearing(),
             pitch = this._map.getPitch();
         let hash = '';


### PR DESCRIPTION
It always slightly annoyed me that the hash control isn't very precise — e.g. if you navigate to a certain place, then open a new tab and copy the url, it will be slightly off, with a bigger error the more you zoom in. So I derived a new formula for the hash that makes it always precise while keeping the low number of digits on lower zoom levels. 

Here's a table with a comparison of the number of digits after the decimal point:

z | old | new
--- | --- | ---
z0 | 0 | 1
z1 | 0 | 1
z2 | 1 | 2
z3 | 2 | 2
z4 | 2 | 2
z5 | 3 | 2
z6 | 3 | 3
z7 | 3 | 3
z8 | 3 | 3
z9 | 4 | 4
z10 | 4 | 4
z11 | 4 | 4
z12 | 4 | 5
z13 | 4 | 5
z14 | 4 | 5
z15 | 4 | 5
z16 | 4 | 6
z17 | 5 | 6
z18 | 5 | 6
z19 | 5 | 7
z20 | 5 | 7
z21 | 5 | 7
z22 | 5 | 8

The calculation is derived from the following formula:

```
512px * 2^zoom / 360 / 10^numDigits < 0.5px
```

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
