### PR TITLE
in Style's addLayer and moveLayer the before param is optional

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -547,7 +547,7 @@ class Style extends Evented {
     /**
      * Add a layer to the map style. The layer will be inserted before the layer with
      * ID `before`, or appended if `before` is omitted.
-     * @param {string} before  ID of an existing layer to insert before
+     * @param {string} [before] ID of an existing layer to insert before
      */
     addLayer(layerObject: LayerSpecification, before?: string, options?: {validate?: boolean}) {
         this._checkLoaded();
@@ -605,7 +605,7 @@ class Style extends Evented {
      * Moves a layer to a different z-position. The layer will be inserted before the layer with
      * ID `before`, or appended if `before` is omitted.
      * @param {string} id  ID of the layer to move
-     * @param {string} before  ID of an existing layer to insert before
+     * @param {string} [before] ID of an existing layer to insert before
      */
     moveLayer(id: string, before?: string) {
         this._checkLoaded();


### PR DESCRIPTION
@jingsam Sorry I missed this when looking over #5679 before it was merged but did you mean to remove that `=`? Or am I missing something? This PR makes before optional again.

Inspecting the code, `before` is an optional param so the JSDoc should reflect this. Flow types already have it as optional.

Low impact since this is for the Style class not map.addLayer so doesn't affect end users.

/cc @mollymerp 