### PR TITLE
Upgrade geojson-vt to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "csscolorparser": "~1.0.2",
     "earcut": "^2.0.3",
     "geojson-rewind": "^0.3.0",
-    "geojson-vt": "^2.4.0",
+    "geojson-vt": "^3.0.0",
     "gray-matter": "^3.0.8",
     "grid-index": "^1.0.0",
     "jsonlint-lines-primitives": "~1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2448,14 +2448,6 @@ concat-stream@~1.5.0, concat-stream@~1.5.1:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-concat-stream@~1.5.0, concat-stream@~1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
-  dependencies:
-    inherits "~2.0.1"
-    readable-stream "~2.0.0"
-    typedarray "~0.0.5"
-
 concat-with-sourcemaps@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz#f55b3be2aeb47601b10a2d5259ccfb70fd2f1dd6"
@@ -4273,9 +4265,9 @@ geojson-rewind@^0.3.0:
     concat-stream "~1.6.0"
     minimist "1.2.0"
 
-geojson-vt@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-2.4.0.tgz#3c1cf44493f35eb4d2c70c95da6550de66072c05"
+geojson-vt@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.0.0.tgz#a24cae5488ab4897e86ca0e4bf0d9760d628ae0a"
 
 get-caller-file@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Makes GeoJSON indices take 2x less memory and generate tiles 20%–100% faster.

The external interface in the [new geojson-vt release](https://github.com/mapbox/geojson-vt/releases/tag/v3.0.0) is the same, so this upgrade shouldn't be breaking, but let's watch out for any edge cases.