### PR TITLE
Use custom class property for serialization registry

### DIFF
--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -56,7 +56,6 @@ const LayoutVertexArrayType = createVertexArrayType(circleInterface.layoutAttrib
  * @private
  */
 class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucket {
-    static classRegistryName;
     static programInterface: ProgramInterface;
     index: number;
     zoom: number;

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -56,6 +56,7 @@ const LayoutVertexArrayType = createVertexArrayType(circleInterface.layoutAttrib
  * @private
  */
 class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucket {
+    static classRegistryName;
     static programInterface: ProgramInterface;
     index: number;
     zoom: number;
@@ -153,7 +154,7 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
     }
 }
 
-register(CircleBucket, {omit: ['layers']});
+register('CircleBucket', CircleBucket, {omit: ['layers']});
 
 CircleBucket.programInterface = circleInterface;
 

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -169,7 +169,7 @@ class FillBucket implements Bucket {
     }
 }
 
-register(FillBucket, {omit: ['layers']});
+register('FillBucket', FillBucket, {omit: ['layers']});
 
 FillBucket.programInterface = fillInterface;
 

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -214,7 +214,7 @@ class FillExtrusionBucket implements Bucket {
     }
 }
 
-register(FillExtrusionBucket, {omit: ['layers']});
+register('FillExtrusionBucket', FillExtrusionBucket, {omit: ['layers']});
 
 FillExtrusionBucket.programInterface = fillExtrusionInterface;
 

--- a/src/data/bucket/heatmap_bucket.js
+++ b/src/data/bucket/heatmap_bucket.js
@@ -20,7 +20,7 @@ class HeatmapBucket extends CircleBucket<HeatmapStyleLayer> {
     layers: Array<HeatmapStyleLayer>;
 }
 
-register(HeatmapBucket, {omit: ['layers']});
+register('HeatmapBucket', HeatmapBucket, {omit: ['layers']});
 
 HeatmapBucket.programInterface = heatmapInterface;
 

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -529,7 +529,7 @@ class LineBucket implements Bucket {
     }
 }
 
-register(LineBucket, {omit: ['layers']});
+register('LineBucket', LineBucket, {omit: ['layers']});
 
 LineBucket.programInterface = lineInterface;
 

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -304,7 +304,7 @@ class SymbolBuffers {
     }
 }
 
-register(SymbolBuffers);
+register('SymbolBuffers', SymbolBuffers);
 
 /**
  * Unlike other buckets, which simply implement #addFeature with type-specific
@@ -758,7 +758,7 @@ class SymbolBucket implements Bucket {
     }
 }
 
-register(SymbolBucket, {
+register('SymbolBucket', SymbolBucket, {
     omit: ['layers', 'collisionBoxArray', 'features', 'compareText'],
     shallow: ['symbolInstances']
 });

--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -38,7 +38,7 @@ class Level {
     }
 }
 
-register(Level);
+register('Level', Level);
 
 // DEMData is a data structure for decoding, backfilling, and storing elevation data for processing in the hillshade shaders
 // data can be populated either from a pngraw image tile or from serliazed data sent back from a worker. When data is initially
@@ -150,6 +150,6 @@ class DEMData {
     }
 }
 
-register(DEMData);
+register('DEMData', DEMData);
 module.exports = {DEMData, Level};
 

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -215,7 +215,11 @@ class FeatureIndex {
     }
 }
 
-register(FeatureIndex, { omit: ['rawTileData', 'sourceLayerCoder', 'collisionIndex'] });
+register(
+    'FeatureIndex',
+    FeatureIndex,
+    { omit: ['rawTileData', 'sourceLayerCoder', 'collisionIndex'] }
+);
 
 module.exports = FeatureIndex;
 

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -413,11 +413,11 @@ class ProgramConfigurationSet<Layer: TypedStyleLayer> {
     }
 }
 
-register(ConstantBinder);
-register(SourceExpressionBinder);
-register(CompositeExpressionBinder);
-register(ProgramConfiguration, {omit: ['PaintVertexArray']});
-register(ProgramConfigurationSet);
+register('ConstantBinder', ConstantBinder);
+register('SourceExpressionBinder', SourceExpressionBinder);
+register('CompositeExpressionBinder', CompositeExpressionBinder);
+register('ProgramConfiguration', ProgramConfiguration, {omit: ['PaintVertexArray']});
+register('ProgramConfigurationSet', ProgramConfigurationSet);
 
 module.exports = {
     ProgramConfiguration,

--- a/src/data/segment.js
+++ b/src/data/segment.js
@@ -51,7 +51,7 @@ class SegmentVector {
     }
 }
 
-register(SegmentVector);
+register('SegmentVector', SegmentVector);
 
 module.exports = {
     SegmentVector,

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -301,10 +301,7 @@ class SourceCache extends Evented {
         }
     }
     /**
-     * Get a specific tile by TileCoordinate
-=======
-     * Get a specific tile by TileID 
->>>>>>> switch TileCoord to -native's TileID types
+     * Get a specific tile by TileID
      */
     getTile(tileID: OverscaledTileID): Tile {
         return this.getTileByID(tileID.key);

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -155,8 +155,8 @@ function getQuadkey(z, x, y) {
     return quadkey;
 }
 
-register(CanonicalTileID);
-register(OverscaledTileID, {omit: ['posMatrix']});
+register('CanonicalTileID', CanonicalTileID);
+register('OverscaledTileID', OverscaledTileID, {omit: ['posMatrix']});
 
 module.exports = {
     CanonicalTileID: CanonicalTileID,

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -674,10 +674,10 @@ class Properties<Props: Object> {
     }
 }
 
-register(DataDrivenProperty);
-register(DataConstantProperty);
-register(CrossFadedProperty);
-register(HeatmapColorProperty);
+register('DataDrivenProperty', DataDrivenProperty);
+register('DataConstantProperty', DataConstantProperty);
+register('CrossFadedProperty', CrossFadedProperty);
+register('HeatmapColorProperty', HeatmapColorProperty);
 
 module.exports = {
     PropertyValue,

--- a/src/symbol/anchor.js
+++ b/src/symbol/anchor.js
@@ -20,6 +20,6 @@ class Anchor extends Point {
     }
 }
 
-register(Anchor);
+register('Anchor', Anchor);
 
 module.exports = Anchor;

--- a/src/symbol/opacity_state.js
+++ b/src/symbol/opacity_state.js
@@ -22,6 +22,6 @@ class OpacityState {
     }
 }
 
-register(OpacityState);
+register('OpacityState', OpacityState);
 
 module.exports = OpacityState;

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -235,10 +235,10 @@ class StructArray {
     }
 }
 
-register(StructArray);
+register('StructArray', StructArray);
 
 class StructArrayType extends StructArray {}
-register(StructArrayType);
+register('StructArrayType', StructArrayType);
 
 export type { StructArray as StructArray };
 

--- a/test/unit/util/web_worker_transfer.test.js
+++ b/test/unit/util/web_worker_transfer.test.js
@@ -30,7 +30,7 @@ test('round trip', (t) => {
         }
     }
 
-    register(Foo, { omit: ['_cached'] });
+    register('Foo', Foo, { omit: ['_cached'] });
 
     const foo = new Foo(10);
     const transferables = [];
@@ -45,6 +45,16 @@ test('round trip', (t) => {
     t.assert(transferables[0] === foo.buffer);
     t.assert(bar._cached === undefined);
     t.assert(bar.squared() === 100);
+    t.end();
+});
+
+test('anonymous class', (t) => {
+    const Klass = (() => class {})();
+    t.assert(!Klass.name);
+    register('Anon', Klass);
+    const x = new Klass();
+    const deserialized = deserialize(serialize(x));
+    t.assert(deserialized instanceof Klass);
     t.end();
 });
 
@@ -68,7 +78,7 @@ test('custom serialization', (t) => {
         }
     }
 
-    register(Bar);
+    register('Bar', Bar);
 
     const bar = new Bar('a');
     t.assert(!bar._deserialized);


### PR DESCRIPTION
Fixes #5800

It's possible for named classes to become anonymous after minification,
so relying on `constructor.name` isn't safe.  Instead, we attach a
custom class property when the class is registered and use that rather
than `constructor.name` to recover the correct class for
deserialization.