### PR TITLE
docs for hillshade layer and raster-dem source

### DIFF
--- a/docs/pages/example/hillshade.html
+++ b/docs/pages/example/hillshade.html
@@ -1,0 +1,31 @@
+<div id='map'></div>
+<script>
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/outdoors-v9',
+    center: [-118.8291, 37.4266],
+    zoom: 9
+});
+
+map.on('load', function () {
+    map.removeLayer('hillshade_shadow_extreme');
+    map.removeLayer('hillshade_shadow_dark');
+    map.removeLayer('hillshade_shadow_med');
+    map.removeLayer('hillshade_shadow_faint');
+    map.removeLayer('hillshade_highlight_med');
+    map.removeLayer('hillshade_highlight_bright');
+
+    map.addSource('dem', {
+        "type": "raster-dem",
+        "url": "mapbox://mapbox.terrain-rgb"
+    });
+    map.addLayer({
+        "id": "hillshading",
+        "source": "dem",
+        "type": "hillshade"
+    }, 'waterway-river-canal-shadow');
+    // insert below waterway-river-canal-shadow as that is where Hillshading
+    // sits in the Mapbox Outdoors style
+});
+
+</script>

--- a/docs/pages/example/hillshade.html
+++ b/docs/pages/example/hillshade.html
@@ -2,19 +2,12 @@
 <script>
 var map = new mapboxgl.Map({
     container: 'map',
-    style: 'mapbox://styles/mapbox/outdoors-v9',
+    style: 'mapbox://styles/mapbox/cjaudgl840gn32rnrepcb9b9g', // the outdoors-v10 style but without Hillshade layers
     center: [-118.8291, 37.4266],
     zoom: 9
 });
 
 map.on('load', function () {
-    map.removeLayer('hillshade_shadow_extreme');
-    map.removeLayer('hillshade_shadow_dark');
-    map.removeLayer('hillshade_shadow_med');
-    map.removeLayer('hillshade_shadow_faint');
-    map.removeLayer('hillshade_highlight_med');
-    map.removeLayer('hillshade_highlight_bright');
-
     map.addSource('dem', {
         "type": "raster-dem",
         "url": "mapbox://mapbox.terrain-rgb"

--- a/docs/pages/example/hillshade.html
+++ b/docs/pages/example/hillshade.html
@@ -3,7 +3,7 @@
 var map = new mapboxgl.Map({
     container: 'map',
     style: 'mapbox://styles/mapbox/cjaudgl840gn32rnrepcb9b9g', // the outdoors-v10 style but without Hillshade layers
-    center: [-118.8291, 37.4266],
+    center: [-119.5591, 37.715],
     zoom: 9
 });
 
@@ -16,9 +16,8 @@ map.on('load', function () {
         "id": "hillshading",
         "source": "dem",
         "type": "hillshade"
+    // insert below waterway-river-canal-shadow;
+    // where hillshading sits in the Mapbox Outdoors style
     }, 'waterway-river-canal-shadow');
-    // insert below waterway-river-canal-shadow as that is where Hillshading
-    // sits in the Mapbox Outdoors style
 });
-
 </script>

--- a/docs/pages/example/hillshade.js
+++ b/docs/pages/example/hillshade.js
@@ -1,0 +1,11 @@
+/*---
+title: Add hillshading
+description: Adds raster hillshading to a map
+tags:
+  - layers
+  - sources
+pathname: /mapbox-gl-js/example/hillshade/
+---*/
+import Example from '../../components/example';
+import html from './hillshade.html';
+export default Example(html);

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -88,6 +88,9 @@ const navigation = [
                 "title": "raster"
             },
             {
+                "title": "raster-dem"
+            },
+            {
                 "title": "geojson"
             },
             {
@@ -144,6 +147,9 @@ const navigation = [
             },
             {
                 "title": "heatmap"
+            },
+            {
+                "title": "hillshade"
             }
         ]
     },
@@ -218,8 +224,8 @@ const navigation = [
     }
 ];
 
-const sourceTypes = ['vector', 'raster', 'geojson', 'image', 'video', 'canvas'];
-const layerTypes = ['background', 'fill', 'line', 'symbol', 'raster', 'circle', 'fill-extrusion', 'heatmap'];
+const sourceTypes = ['vector', 'raster', 'raster-dem', 'geojson', 'image', 'video', 'canvas'];
+const layerTypes = ['background', 'fill', 'line', 'symbol', 'raster', 'circle', 'fill-extrusion', 'heatmap', 'hillshade'];
 
 const {expressions, expressionGroups} = require('../components/expression-metadata');
 
@@ -655,6 +661,45 @@ export default class extends React.Component {
                                                 <td className='center'>&gt;= 2.0.1</td>
                                                 <td className='center'>&gt;= 2.0.0</td>
                                                 <td className='center'>&gt;= 0.1.0</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+
+                                <div id='sources-raster-dem' className='pad2 keyline-bottom'>
+                                    <h3 className='space-bottom1'><a href='#sources-raster-dem' title='link to raster-dem'>raster-dem</a></h3>
+                                    <p>
+                                        A raster DEM source. Currently only supports <a href="https://blog.mapbox.com/global-elevation-data-6689f1d0ba65">Mapbox Terrain RGB</a> (<code>mapbox://mapbox.terrain-rgb</code>)
+                                    </p>
+                                    <div className='space-bottom1 clearfix'>
+                                        {highlightJSON(`
+                                            "mapbox-terrain-rgb": {
+                                                "type": "raster-dem",
+                                                "url": "mapbox://mapbox.terrain-rgb"
+                                            }`)}
+                                    </div>
+                                    <div className='space-bottom1 clearfix'>
+                                        { entries(ref.source_raster).map(([name, prop], i) =>
+                                            name !== '*' && name !== 'type' &&
+                                            <Item key={i} id={`sources-raster-dem-${name}`} name={name} {...prop}/>)}
+                                    </div>
+                                    <table className="micro">
+                                        <thead>
+                                            <tr className='fill-light'>
+                                                <th>SDK Support</th>
+                                                <td className='center'>Mapbox GL JS</td>
+                                                <td className='center'>Android SDK</td>
+                                                <td className='center'>iOS SDK</td>
+                                                <td className='center'>macOS SDK</td>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td>basic functionality</td>
+                                                <td>&gt;= 0.43.0</td>
+                                                <td>Not supported</td>
+                                                <td>Not supported</td>
+                                                <td>Not supported</td>
                                             </tr>
                                         </tbody>
                                     </table>

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -679,7 +679,7 @@ export default class extends React.Component {
                                             }`)}
                                     </div>
                                     <div className='space-bottom1 clearfix'>
-                                        { entries(ref.source_raster).map(([name, prop], i) =>
+                                        { entries(ref.source_raster_dem).map(([name, prop], i) =>
                                             name !== '*' && name !== 'type' &&
                                             <Item key={i} id={`sources-raster-dem-${name}`} name={name} {...prop}/>)}
                                     </div>

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -108,6 +108,7 @@
   "source": [
     "source_vector",
     "source_raster",
+    "source_raster_dem",
     "source_geojson",
     "source_video",
     "source_image",
@@ -166,9 +167,6 @@
       "values": {
         "raster": {
             "doc": "A raster tile source."
-        },
-        "raster-dem": {
-            "doc": "A raster DEM source using Mapbox Terrain RGB"
         }
       },
       "doc": "The type of the source."
@@ -221,6 +219,26 @@
     "attribution": {
       "type": "string",
       "doc": "Contains an attribution to be displayed when the map is shown to a user."
+    },
+    "*": {
+      "type": "*",
+      "doc": "Other keys to configure the data source."
+    }
+  },
+  "source_raster_dem": {
+    "type": {
+      "required": true,
+      "type": "enum",
+      "values": {
+        "raster-dem": {
+            "doc": "A raster DEM source using Mapbox Terrain RGB"
+        }
+      },
+      "doc": "The type of the source."
+    },
+    "url": {
+      "type": "string",
+      "doc": "A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<mapid>`."
     },
     "*": {
       "type": "*",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -240,6 +240,38 @@
       "type": "string",
       "doc": "A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<mapid>`."
     },
+    "tiles": {
+      "type": "array",
+      "value": "string",
+      "doc": "An array of one or more tile source URLs, as in the TileJSON spec."
+    },
+    "bounds": {
+      "type": "array",
+      "value": "number",
+      "length": 4,
+      "default": [-180, -85.0511, 180, 85.0511],
+      "doc": "An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL."
+    },
+    "minzoom": {
+      "type": "number",
+      "default": 0,
+      "doc": "Minimum zoom level for which tiles are available, as in the TileJSON spec."
+    },
+    "maxzoom": {
+      "type": "number",
+      "default": 22,
+      "doc": "Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles at the maxzoom are used when displaying the map at higher zoom levels."
+    },
+    "tileSize": {
+      "type": "number",
+      "default": 512,
+      "units": "pixels",
+      "doc": "The minimum visual size to display tiles for this layer. Only configurable for raster layers."
+    },
+    "attribution": {
+      "type": "string",
+      "doc": "Contains an attribution to be displayed when the map is shown to a user."
+    },
     "*": {
       "type": "*",
       "doc": "Other keys to configure the data source."

--- a/src/style-spec/validate/validate_source.js
+++ b/src/style-spec/validate/validate_source.js
@@ -20,27 +20,11 @@ module.exports = function validateSource(options) {
     switch (type) {
     case 'vector':
     case 'raster':
-        errors = errors.concat(validateObject({
-            key: key,
-            value: value,
-            valueSpec: styleSpec[`source_${type}`],
-            style: options.style,
-            styleSpec: styleSpec
-        }));
-        if ('url' in value) {
-            for (const prop in value) {
-                if (['type', 'url', 'tileSize'].indexOf(prop) < 0) {
-                    errors.push(new ValidationError(`${key}.${prop}`, value[prop], 'a source with a "url" property may not include a "%s" property', prop));
-                }
-            }
-        }
-        return errors;
-
     case 'raster-dem':
         errors = errors.concat(validateObject({
             key: key,
             value: value,
-            valueSpec: styleSpec[`source_raster`],
+            valueSpec: styleSpec[`source_${type.replace('-', '_')}`],
             style: options.style,
             styleSpec: styleSpec
         }));


### PR DESCRIPTION
@mollymerp This isn't ready for merging, but posting it here for feedback. This PR includes:

1. added hillshade example
I'm not sure if we should have a dedicated example for the hillshade layer, but I put one together.

2. added `raster-dem` source and `hillshade` layer to docs.

3. included `raster-dem` source in the style spec rather than it being a type of the `raster` source.

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
