### PR TITLE
Use tokens property

### DIFF
--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -261,6 +261,8 @@ function convertTokenString(s) {
 
     if (pos < s.length) {
         result.push(s.slice(pos));
+    } else if (result.length === 2) {
+        return result[1];
     }
 
     return result;

--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -1,9 +1,13 @@
+// @flow
+
 const assert = require('assert');
 const extend = require('../util/extend');
 
+import type {StylePropertySpecification} from '../style-spec';
+
 module.exports = convertFunction;
 
-function convertFunction(parameters, propertySpec, name) {
+function convertFunction(parameters: PropertyValueSpecification<any>, propertySpec: StylePropertySpecification) {
     let expression;
 
     parameters = extend({}, parameters);
@@ -23,7 +27,7 @@ function convertFunction(parameters, propertySpec, name) {
         const zoomDependent = zoomAndFeatureDependent || !featureDependent;
 
         const stops = parameters.stops.map((stop) => {
-            if (!featureDependent && (name === 'icon-image' || name === 'text-field') && typeof stop[1] === 'string') {
+            if (!featureDependent && propertySpec.tokens && typeof stop[1] === 'string') {
                 return [stop[0], convertTokenString(stop[1])];
 
             }
@@ -51,15 +55,14 @@ function convertFunction(parameters, propertySpec, name) {
 
 function convertIdentityFunction(parameters, propertySpec, defaultExpression) {
     const get = ['get', parameters.property];
-    const type = propertySpec.type;
 
-    if (type === 'color') {
+    if (propertySpec.type === 'color') {
         return parameters.default === undefined ? get : ['to-color', get, parameters.default];
-    } else if (type === 'array' && typeof propertySpec.length === 'number') {
+    } else if (propertySpec.type === 'array' && typeof propertySpec.length === 'number') {
         return ['array', propertySpec.value, propertySpec.length, get];
-    } else if (type === 'array') {
+    } else if (propertySpec.type === 'array') {
         return ['array', propertySpec.value, get];
-    } else if (type === 'enum') {
+    } else if (propertySpec.type === 'enum') {
         return [
             'let',
             'property_value', ['string', get],

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -11,7 +11,8 @@ export type StylePropertySpecification = {
     'function': boolean,
     'property-function': boolean,
     'zoom-function': boolean,
-    default?: string
+    default?: string,
+    tokens?: boolean
 } | {
     type: 'boolean',
     'function': boolean,

--- a/test/unit/style-spec/convert_function.test.js
+++ b/test/unit/style-spec/convert_function.test.js
@@ -9,7 +9,10 @@ test('convertFunction', (t) => {
             stops: [
                 [0, 'my name is {name}.'],
                 [1, '{a} {b} {c}'],
-                [2, 'no tokens']
+                [2, 'no tokens'],
+                [3, '{one_token}'],
+                [4, '{leading} token'],
+                [5, 'trailing {token}']
             ]
         };
 
@@ -37,7 +40,13 @@ test('convertFunction', (t) => {
                 ['to-string', ['get', 'c']]
             ],
             2,
-            'no tokens'
+            'no tokens',
+            3,
+            ['to-string', ['get', 'one_token']],
+            4,
+            ['concat', ['to-string', ['get', 'leading']], ' token'],
+            5,
+            ['concat', 'trailing ', ['to-string', ['get', 'token']]]
         ]);
 
         t.end();

--- a/test/unit/style-spec/convert_function.test.js
+++ b/test/unit/style-spec/convert_function.test.js
@@ -15,8 +15,9 @@ test('convertFunction', (t) => {
 
         const expression = convertFunction(functionValue, {
             type: 'string',
-            function: 'piecewise-constant'
-        }, 'text-field');
+            function: 'piecewise-constant',
+            tokens: true
+        });
         t.deepEqual(expression, [
             'step',
             ['zoom'],
@@ -55,7 +56,7 @@ test('convertFunction', (t) => {
         const expression = convertFunction(functionValue, {
             type: 'string',
             function: 'piecewise-constant'
-        }, 'text-field');
+        });
         t.deepEqual(expression, [
             'step',
             ['zoom'],
@@ -82,7 +83,7 @@ test('convertFunction', (t) => {
         const expression = convertFunction(functionValue, {
             type: 'number',
             function: 'interpolated'
-        }, 'text-size');
+        });
         t.deepEqual(expression, [
             'interpolate',
             ['exponential', 1],


### PR DESCRIPTION
The style spec includes a `tokens` property that we can use instead of checking the property name. Splitting this out of #5812 to isolate its effect on benchmarks: the change causes the `EvaluateExpression` benchmark to take longer. This is because the benchmark setup called `convertFunction` without the third argument, so tokens were never getting converted/evaluated. Now the third argument is gone, so tokens are correctly evaluated. I noticed that we can optimize the evaluation slightly in a common case, so I did that as well.

https://bl.ocks.org/anonymous/raw/a6d5d7e052713aa66bcc996e16334681/