### PR TITLE
Register {Alpha,RGBA}Image for transfer

### DIFF
--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -96,7 +96,7 @@ class DEMData {
     }
 
     getPixels() {
-        return RGBAImage.create({width: this.level.dim + 2 * this.level.border, height: this.level.dim + 2 * this.level.border}, new Uint8Array(this.level.data.buffer));
+        return new RGBAImage({width: this.level.dim + 2 * this.level.border, height: this.level.dim + 2 * this.level.border}, new Uint8Array(this.level.data.buffer));
     }
 
     backfillBorder(borderTile: DEMData, dx: number, dy: number) {

--- a/src/render/glyph_atlas.js
+++ b/src/render/glyph_atlas.js
@@ -25,7 +25,7 @@ export type GlyphAtlas = {
 };
 
 function makeGlyphAtlas(stacks: {[string]: {[number]: ?StyleGlyph}}): GlyphAtlas {
-    const image = AlphaImage.create({width: 0, height: 0});
+    const image = new AlphaImage({width: 0, height: 0});
     const positions = {};
 
     const pack = new ShelfPack(0, 0, {autoResize: true});
@@ -41,7 +41,7 @@ function makeGlyphAtlas(stacks: {[string]: {[number]: ?StyleGlyph}}): GlyphAtlas
                     src.bitmap.width + 2 * padding,
                     src.bitmap.height + 2 * padding);
 
-                AlphaImage.resize(image, {
+                image.resize({
                     width: pack.w,
                     height: pack.h
                 });
@@ -62,7 +62,7 @@ function makeGlyphAtlas(stacks: {[string]: {[number]: ?StyleGlyph}}): GlyphAtlas
     }
 
     pack.shrink();
-    AlphaImage.resize(image, {
+    image.resize({
         width: pack.w,
         height: pack.h
     });

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -5,7 +5,6 @@ const TinySDF = require('@mapbox/tiny-sdf');
 const isChar = require('../util/is_char_in_unicode_block');
 const {asyncAll} = require('../util/util');
 const {AlphaImage} = require('../util/image');
-const {clone} = require('../util/util');
 
 import type {StyleGlyph} from '../style/style_glyph';
 import type {RequestTransformFunction} from '../ui/map';
@@ -102,7 +101,11 @@ class GlyphManager {
 
                 for (const {stack, id, glyph} of glyphs) {
                     // Clone the glyph so that our own copy of its ArrayBuffer doesn't get transferred.
-                    (result[stack] || (result[stack] = {}))[id] = clone(glyph);
+                    (result[stack] || (result[stack] = {}))[id] = glyph && {
+                        id: glyph.id,
+                        bitmap: glyph.bitmap.clone(),
+                        metrics: glyph.metrics
+                    };
                 }
 
                 callback(null, result);
@@ -135,7 +138,7 @@ class GlyphManager {
 
         return {
             id,
-            bitmap: AlphaImage.create({width: 30, height: 30}, tinySDF.draw(String.fromCharCode(id))),
+            bitmap: new AlphaImage({width: 30, height: 30}, tinySDF.draw(String.fromCharCode(id))),
             metrics: {
                 width: 24,
                 height: 24,

--- a/src/render/image_atlas.js
+++ b/src/render/image_atlas.js
@@ -56,7 +56,7 @@ export type ImageAtlas = {
 };
 
 function makeImageAtlas(images: {[string]: StyleImage}): ImageAtlas {
-    const image = RGBAImage.create({width: 0, height: 0});
+    const image = new RGBAImage({width: 0, height: 0});
     const positions = {};
 
     const pack = new ShelfPack(0, 0, {autoResize: true});
@@ -68,7 +68,7 @@ function makeImageAtlas(images: {[string]: StyleImage}): ImageAtlas {
             src.data.width + 2 * padding,
             src.data.height + 2 * padding);
 
-        RGBAImage.resize(image, {
+        image.resize({
             width: pack.w,
             height: pack.h
         });
@@ -87,7 +87,7 @@ function makeImageAtlas(images: {[string]: StyleImage}): ImageAtlas {
     }
 
     pack.shrink();
-    RGBAImage.resize(image, {
+    image.resize({
         width: pack.w,
         height: pack.h
     });

--- a/src/render/image_manager.js
+++ b/src/render/image_manager.js
@@ -5,7 +5,6 @@ const {RGBAImage} = require('../util/image');
 const {imagePosition} = require('./image_atlas');
 const Texture = require('./texture');
 const assert = require('assert');
-const {clone} = require('../util/util');
 
 import type {StyleImage} from '../style/style_image';
 import type Context from '../gl/context';
@@ -52,7 +51,7 @@ class ImageManager {
 
         this.shelfPack = new ShelfPack(64, 64, {autoResize: true});
         this.patterns = {};
-        this.atlasImage = RGBAImage.create({width: 64, height: 64});
+        this.atlasImage = new RGBAImage({width: 64, height: 64});
         this.dirty = true;
     }
 
@@ -122,7 +121,11 @@ class ImageManager {
             const image = this.images[id];
             if (image) {
                 // Clone the image so that our own copy of its ArrayBuffer doesn't get transferred.
-                response[id] = clone(image);
+                response[id] = {
+                    data: image.data.clone(),
+                    pixelRatio: image.pixelRatio,
+                    sdf: image.sdf
+                };
             }
         }
 
@@ -157,7 +160,7 @@ class ImageManager {
             return null;
         }
 
-        RGBAImage.resize(this.atlasImage, this.getPixelSize());
+        this.atlasImage.resize(this.getPixelSize());
 
         const src = image.data;
         const dst = this.atlasImage;

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -163,13 +163,6 @@ class Tile {
         if (data.glyphAtlasImage) {
             this.glyphAtlasImage = data.glyphAtlasImage;
         }
-
-        if (data.iconAtlasImage) {
-            this.iconAtlasImage = data.iconAtlasImage;
-        }
-        if (data.glyphAtlasImage) {
-            this.glyphAtlasImage = data.glyphAtlasImage;
-        }
     }
 
     /**

--- a/src/style/load_sprite.js
+++ b/src/style/load_sprite.js
@@ -40,7 +40,7 @@ module.exports = function(baseURL: string,
 
             for (const id in json) {
                 const {width, height, x, y, sdf, pixelRatio} = json[id];
-                const data = RGBAImage.create({width, height});
+                const data = new RGBAImage({width, height});
                 RGBAImage.copy(imageData, data, {x, y}, {x: 0, y: 0}, {width, height});
                 result[id] = {data, pixelRatio, sdf};
             }

--- a/src/style/parse_glyph_pbf.js
+++ b/src/style/parse_glyph_pbf.js
@@ -17,7 +17,7 @@ function readFontstack(tag: number, glyphs: Array<StyleGlyph>, pbf: Protobuf) {
         const {id, bitmap, width, height, left, top, advance} = pbf.readMessage(readGlyph, {});
         glyphs.push({
             id,
-            bitmap: AlphaImage.create({
+            bitmap: new AlphaImage({
                 width: width + 2 * border,
                 height: height + 2 * border
             }, bitmap),

--- a/src/style/style_layer/heatmap_style_layer.js
+++ b/src/style/style_layer/heatmap_style_layer.js
@@ -56,7 +56,7 @@ class HeatmapStyleLayer extends StyleLayer {
             colorRampData[i + 2] = Math.floor(pxColor.b * 255 / pxColor.a);
             colorRampData[i + 3] = Math.floor(pxColor.a * 255);
         }
-        this.colorRamp = RGBAImage.create({width: 256, height: 1}, colorRampData);
+        this.colorRamp = new RGBAImage({width: 256, height: 1}, colorRampData);
         this.colorRampTexture = null;
     }
 

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -1,6 +1,7 @@
 // @flow
 
 const assert = require('assert');
+const {register} = require('./web_worker_transfer');
 
 export type Size = {
     width: number,
@@ -12,21 +13,24 @@ type Point = {
     y: number
 };
 
-function createImage({width, height}: Size, channels: number, data?: Uint8Array) {
+function createImage(image: *, {width, height}: Size, channels: number, data?: Uint8Array | Uint8ClampedArray) {
     if (!data) {
         data = new Uint8Array(width * height * channels);
     } else if (data.length !== width * height * channels) {
         throw new RangeError('mismatched image size');
     }
-    return { width, height, data };
+    image.width = width;
+    image.height = height;
+    image.data = data;
+    return image;
 }
 
 function resizeImage(image: *, {width, height}: Size, channels: number) {
     if (width === image.width && height === image.height) {
-        return image;
+        return;
     }
 
-    const newImage = createImage({width, height}, channels);
+    const newImage = createImage({}, {width, height}, channels);
 
     copyImage(image, newImage, {x: 0, y: 0}, {x: 0, y: 0}, {
         width: Math.min(image.width, width),
@@ -73,21 +77,21 @@ function copyImage(srcImg: *, dstImg: *, srcPt: Point, dstPt: Point, size: Size,
     return dstImg;
 }
 
-// These "classes" are really just a combination of type (for the properties)
-// and namespace (for the static methods). In reality, the type at runtime is
-// a plain old object; we can't use instance methods because these values are
-// transferred to and from workers.
 class AlphaImage {
     width: number;
     height: number;
-    data: Uint8Array;
+    data: Uint8Array | Uint8ClampedArray;
 
-    static create(size: Size, data?: Uint8Array) {
-        return ((createImage(size, 1, data): any): AlphaImage);
+    constructor(size: Size, data?: Uint8Array | Uint8ClampedArray) {
+        createImage(this, size, 1, data);
     }
 
-    static resize(image: AlphaImage, size: Size) {
-        resizeImage(image, size, 1);
+    resize(size: Size) {
+        resizeImage(this, size, 1);
+    }
+
+    clone() {
+        return new AlphaImage({width: this.width, height: this.height}, this.data.slice());
     }
 
     static copy(srcImg: AlphaImage, dstImg: AlphaImage, srcPt: Point, dstPt: Point, size: Size) {
@@ -100,20 +104,27 @@ class AlphaImage {
 class RGBAImage {
     width: number;
     height: number;
-    data: Uint8Array;
+    data: Uint8Array | Uint8ClampedArray;
 
-    static create(size: Size, data?: Uint8Array) {
-        return ((createImage(size, 4, data): any): RGBAImage);
+    constructor(size: Size, data?: Uint8Array | Uint8ClampedArray) {
+        createImage(this, size, 4, data);
     }
 
-    static resize(image: RGBAImage, size: Size) {
-        resizeImage(image, size, 4);
+    resize(size: Size) {
+        resizeImage(this, size, 4);
+    }
+
+    clone() {
+        return new RGBAImage({width: this.width, height: this.height}, this.data.slice());
     }
 
     static copy(srcImg: RGBAImage | ImageData, dstImg: RGBAImage, srcPt: Point, dstPt: Point, size: Size) {
         copyImage(srcImg, dstImg, srcPt, dstPt, size, 4);
     }
 }
+
+register('AlphaImage', AlphaImage);
+register('RGBAImage', RGBAImage);
 
 module.exports = {
     AlphaImage,

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -321,12 +321,6 @@ exports.deepEqual = function(a: ?mixed, b: ?mixed): boolean {
 exports.clone = function<T>(input: T): T {
     if (Array.isArray(input)) {
         return input.map(exports.clone);
-    } else if (input instanceof DataView) {
-        return (new DataView(input.buffer.slice(0), input.byteOffset, input.byteLength): any);
-    } else if (input instanceof ArrayBuffer) {
-        return input.slice(0);
-    } else if (ArrayBuffer.isView(input)) {
-        return (input: any).slice(0);
     } else if (typeof input === 'object' && input) {
         return ((exports.mapObject(input, exports.clone): any): T);
     } else {

--- a/test/unit/data/dem_data.test.js
+++ b/test/unit/data/dem_data.test.js
@@ -10,7 +10,7 @@ function createMockImage(height, width) {
     for (let i = 0; i < pixels.length; i++) {
         pixels[i] = (i + 1) % 4 === 0 ? 1 : Math.floor(Math.random() * 256);
     }
-    return RGBAImage.create({height: height, width: width}, pixels);
+    return new RGBAImage({height: height, width: width}, pixels);
 }
 
 test('Level', (t)=>{

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -196,34 +196,6 @@ test('util', (t) => {
             t.end();
         });
 
-        t.test('ArrayBuffer', (t) => {
-            const input = new ArrayBuffer(1);
-            const output = util.clone(input);
-            t.notEqual(input, output);
-            t.deepEqual(input, output);
-            t.ok(output instanceof ArrayBuffer);
-            t.end();
-        });
-
-        t.test('TypedArray', (t) => {
-            const input = new Int8Array(1);
-            const output = util.clone(input);
-            t.notEqual(input, output);
-            t.deepEqual(input, output);
-            t.ok(output instanceof Int8Array);
-            t.end();
-        });
-
-        t.test('DataView', (t) => {
-            const buffer = new ArrayBuffer(1);
-            const input = new DataView(buffer);
-            const output = util.clone(input);
-            t.notEqual(input, output);
-            t.deepEqual(input, output);
-            t.ok(output instanceof DataView);
-            t.end();
-        });
-
         t.test('deep object', (t) => {
             const input = {object: {a: false, b: 1, c: 'two'}};
             const output = util.clone(input);


### PR DESCRIPTION
Now that #5702 landed, we can remove the workarounds we had in place where we were avoiding using classes, `instanceof`, etc. for things that needed to be transferred to and from workers. One such case was `AlphaImage`/`RGBAImage`, which is nice because not having these be actual classes was confusing and led to issues like #5414.