### PR TITLE
Handle thrown errors gracefully in integratin tests

### DIFF
--- a/src/util/web_worker.js
+++ b/src/util/web_worker.js
@@ -49,8 +49,12 @@ class MessageBus implements WorkerInterface, WorkerGlobalScopeInterface {
 
     postMessage(data: Object) {
         setImmediate(() => {
-            for (const listener of this.postListeners) {
-                listener({data: data, target: this.target});
+            try {
+                for (const listener of this.postListeners) {
+                    listener({data: data, target: this.target});
+                }
+            } catch (e) {
+                console.error(e);
             }
         });
     }

--- a/test/integration/expression-tests/result_item.html.tmpl
+++ b/test/integration/expression-tests/result_item.html.tmpl
@@ -4,7 +4,8 @@
         <pre><%- r.expression %></pre>
     </td>
     <td>
-        <h2 style="text-align:center; background:<%- r.color %>"><a href="<%- r.group %>/case.json"><%- r.group %>/<%- r.test %></a></h2>
+        <h2 style="text-align:center; background:<%- r.color %>"><a href="<%- r.group %>/case.json"><%- r.group %>/<%- r.test %> <% if (!r.ok) { %>(<%=r.status%>)<% } %></a></h2>
+        <% if (r.error) { %><div>error: <%- r.error.message %></div><% } %>
         <pre><%- r.difference %></pre>
     </td>
     <td>

--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -133,8 +133,16 @@ module.exports = function (directory, implementation, options, run) {
 
     sequence.forEach((test) => {
         q.defer((callback) => {
-            run(test.style, test.params, (err) => {
-                if (err) return callback(err);
+            try {
+                run(test.style, test.params, handleResult);
+            } catch (error) {
+                handleResult(error);
+            }
+
+            function handleResult (error) {
+                if (error) {
+                    test.params.error = error;
+                }
 
                 if (test.params.ignored && !test.params.ok) {
                     test.params.color = '#9E9E9E';
@@ -144,6 +152,10 @@ module.exports = function (directory, implementation, options, run) {
                     test.params.color = '#E8A408';
                     test.params.status = 'ignored passed';
                     console.log(colors.yellow(`* ignore ${test.params.group} ${test.params.test} (${test.params.ignored})`));
+                } else if (test.params.error) {
+                    test.params.color = 'red';
+                    test.params.status = 'errored';
+                    console.log(colors.red(`* errored ${test.params.group} ${test.params.test}`));
                 } else if (!test.params.ok) {
                     test.params.color = 'red';
                     test.params.status = 'failed';
@@ -155,7 +167,7 @@ module.exports = function (directory, implementation, options, run) {
                 }
 
                 callback(null, test.params);
-            });
+            }
         });
     });
 
@@ -178,13 +190,16 @@ module.exports = function (directory, implementation, options, run) {
         let passedCount = 0,
             ignoreCount = 0,
             ignorePassCount = 0,
-            failedCount = 0;
+            failedCount = 0,
+            erroredCount = 0;
 
         results.forEach((params) => {
             if (params.ignored && !params.ok) {
                 ignoreCount++;
             } else if (params.ignored) {
                 ignorePassCount++;
+            } else if (params.error) {
+                erroredCount++;
             } else if (!params.ok) {
                 failedCount++;
             } else {
@@ -192,7 +207,7 @@ module.exports = function (directory, implementation, options, run) {
             }
         });
 
-        const totalCount = passedCount + ignorePassCount + ignoreCount + failedCount;
+        const totalCount = passedCount + ignorePassCount + ignoreCount + failedCount + erroredCount;
 
         if (passedCount > 0) {
             console.log(colors.green('%d passed (%s%)'),
@@ -214,12 +229,17 @@ module.exports = function (directory, implementation, options, run) {
                 failedCount, (100 * failedCount / totalCount).toFixed(1));
         }
 
+        if (erroredCount > 0) {
+            console.log(colors.red('%d errored (%s%)'),
+                erroredCount, (100 * erroredCount / totalCount).toFixed(1));
+        }
+
         const resultsTemplate = template(fs.readFileSync(path.join(__dirname, '..', 'results.html.tmpl'), 'utf8'));
         const itemTemplate = template(fs.readFileSync(path.join(directory, 'result_item.html.tmpl'), 'utf8'));
 
-        const failed = results.filter(r => r.status === 'failed');
+        const unsuccessful = results.filter(r => r.status === 'failed' || r.status === 'errored');
 
-        const resultsShell = resultsTemplate({ failed, sequence, shuffle: options.shuffle, seed: options.seed })
+        const resultsShell = resultsTemplate({ unsuccessful, sequence, shuffle: options.shuffle, seed: options.seed })
             .split('<!-- results go here -->');
 
         const p = path.join(directory, options.recycleMap ? 'index-recycle-map.html' : 'index.html');
@@ -228,14 +248,14 @@ module.exports = function (directory, implementation, options, run) {
         const q = queue(1);
         q.defer(write, out, resultsShell[0]);
         for (const r of results) {
-            q.defer(write, out, itemTemplate({ r, hasFailedTests: failed.length > 0 }));
+            q.defer(write, out, itemTemplate({ r, hasFailedTests: unsuccessful.length > 0 }));
         }
         q.defer(write, out, resultsShell[1]);
         q.await(() => {
             out.end();
             out.on('close', () => {
                 console.log(`Results at: ${p}`);
-                process.exit(failedCount === 0 ? 0 : 1);
+                process.exit((failedCount + erroredCount) === 0 ? 0 : 1);
             });
         });
     });

--- a/test/integration/query-tests/result_item.html.tmpl
+++ b/test/integration/query-tests/result_item.html.tmpl
@@ -1,8 +1,11 @@
 <tr class="<%- r.status %> <%- (hasFailedTests && /passed/.test(r.status) || /ignored/.test(r.status)) ? 'hide' : '' %>">
-    <td><img src="data:image/png;base64,<%- r.actual %>"></td>
     <td>
-        <h2 style="text-align:center; background:<%- r.color %>"><a href="<%- r.group %>/style.json"><%- r.group %>/<%- r.test %> <% if (!r.ok) { %>(failed)<% } %></a></h2>
+    <% if (r.status !== 'errored') { %><img src="data:image/png;base64,<%- r.actual %>"><% } %>
+    </td>
+    <td>
+        <h2 style="text-align:center; background:<%- r.color %>"><a href="<%- r.group %>/style.json"><%- r.group %>/<%- r.test %> <% if (!r.ok) { %>(<%=r.status%>)<% } %></a></h2>
         <ul>
+            <% if (r.error) { %><li>error: <%- r.error.message %></li><% } %>
             <li>diff: <strong><%- r.difference %></strong></li>
             <li>zoom: <strong><%- r.zoom %></strong></li>
             <li>center: <strong><%- r.center %></strong></li>

--- a/test/integration/render-tests/result_item.html.tmpl
+++ b/test/integration/render-tests/result_item.html.tmpl
@@ -1,10 +1,16 @@
 
 <tr class="<%- r.status %> <%- (hasFailedTests && /passed/.test(r.status) || /ignored/.test(r.status)) ? 'hide' : '' %>">
+
+<% if (r.status !== 'errored') { %>
     <td><img style="width: <%- r.width %>; height: <%- r.height %>" src="data:image/png;base64,<%- r.actual %>" data-alt-src="data:image/png;base64,<%- r.expected %>"></td>
     <td><img style="width: <%- r.width %>; height: <%- r.height %>" src="data:image/png;base64,<%- r.diff %>"></td>
+<% } else { %>
+    <td></td><td></td>
+<% } %>
     <td>
-        <h2 style="background: <%- r.color %>"><a href="<%- r.group %>/<%- r.test %>/style.json"><%- r.group %>/<%- r.test %> <% if (!r.ok) { %>(failed)<% } %></a></h2>
+        <h2 style="background: <%- r.color %>"><a href="<%- r.group %>/<%- r.test %>/style.json"><%- r.group %>/<%- r.test %> <% if (!r.ok) { %>(<%=r.status%>)<% } %></a></h2>
         <ul>
+            <% if (r.error) { %><li>error: <%- r.error.message %></li><% } %>
             <li>diff: <strong><%- r.difference %></strong></li>
             <% if (r.zoom) { %><li>zoom: <strong><%- r.zoom %></strong></li><% } %>
             <% if (r.center) { %><li>center: <strong><%- r.center %></strong></li><% } %>

--- a/test/integration/results.html.tmpl
+++ b/test/integration/results.html.tmpl
@@ -23,10 +23,10 @@
 <% if (shuffle) { %>
 <div>Shuffle seed: <%- seed %></div>
 <% } %>
-<% if (failed.length) { %>
+<% if (unsuccessful.length) { %>
 <div>
   <strong style="color: darkred;">Failed Tests:</strong>
-  <% for (const r of failed) { %><%- r.group %>/<%- r.test %> <% } %>
+  <% for (const r of unsuccessful) { %><%- r.group %>/<%- r.test %> <% } %>
 </div>
 <% } else { %>
 <div><strong style="color: darkgreen;">All tests passed!</div>

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -19,7 +19,7 @@ module.exports = function(style, options, _callback) {
 
     const timeout = setTimeout(() => {
         callback(new Error('Test timed out'));
-    }, options.timeout || 1000);
+    }, options.timeout || 20000);
 
     function callback() {
         if (!wasCallbackCalled) {

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -16,8 +16,14 @@ rtlTextPlugin['processBidirectionalText'] = rtlText.processBidirectionalText;
 
 module.exports = function(style, options, _callback) {
     let wasCallbackCalled = false;
+
+    const timeout = setTimeout(() => {
+        callback(new Error('Test timed out'));
+    }, options.timeout || 1000);
+
     function callback() {
         if (!wasCallbackCalled) {
+            clearTimeout(timeout);
             wasCallbackCalled = true;
             _callback.apply(this, arguments);
         }


### PR DESCRIPTION
Currently, if a bug causes an uncaught error, it crashes the integration tests. (And since a test's results are only printed to the console after it completes, determining which test caused the error means searching through the alphabetical directory listing).