### PR TITLE
Introduce ColorMode, StencilMode, DepthMode abstractions

### DIFF
--- a/src/gl/color_mode.js
+++ b/src/gl/color_mode.js
@@ -9,10 +9,10 @@ const ONE_MINUS_SRC_ALPHA = 0x0303;
 
 class ColorMode {
     blendFunction: BlendFuncType;
-    blendColor: ?Color;
+    blendColor: Color;
     mask: ColorMaskType;
 
-    constructor(blendFunction: BlendFuncType, blendColor: ?Color, mask: ColorMaskType) {
+    constructor(blendFunction: BlendFuncType, blendColor: Color, mask: ColorMaskType) {
         this.blendFunction = blendFunction;
         this.blendColor = blendColor;
         this.mask = mask;
@@ -21,15 +21,15 @@ class ColorMode {
     static Replace: BlendFuncType;
 
     static disabled(): ColorMode {
-        return new ColorMode(ColorMode.Replace, null, [false, false, false, false]);
+        return new ColorMode(ColorMode.Replace, Color.transparent, [false, false, false, false]);
     }
 
     static unblended(): ColorMode {
-        return new ColorMode(ColorMode.Replace, null, [true, true, true, true]);
+        return new ColorMode(ColorMode.Replace, Color.transparent, [true, true, true, true]);
     }
 
     static alphaBlended(): ColorMode {
-        return new ColorMode([ONE, ONE_MINUS_SRC_ALPHA], null, [true, true, true, true]);
+        return new ColorMode([ONE, ONE_MINUS_SRC_ALPHA], Color.transparent, [true, true, true, true]);
     }
 }
 

--- a/src/gl/color_mode.js
+++ b/src/gl/color_mode.js
@@ -1,0 +1,39 @@
+// @flow
+const Color = require('../style-spec/util/color');
+
+import type {BlendFuncType, ColorMaskType} from './types';
+
+const ONE = 1;
+const ONE_MINUS_SRC_ALPHA = 0x0303;
+
+class ColorMode {
+    blend: boolean;
+    blendFunction: BlendFuncType;
+    blendColor: ?Color;
+    mask: ColorMaskType;
+
+    constructor(blend: boolean, blendFunction: BlendFuncType, blendColor: ?Color, mask: ColorMaskType) {
+        this.blend = blend;
+        this.blendFunction = blendFunction;
+        this.blendColor = blendColor;
+        this.mask = mask;
+    }
+
+    static Replace: BlendFuncType;
+
+    static disabled(): ColorMode {
+        return new ColorMode(false, ColorMode.Replace, null, [false, false, false, false]);
+    }
+
+    static unblended(): ColorMode {
+        return new ColorMode(false, ColorMode.Replace, null, [true, true, true, true]);
+    }
+
+    static alphaBlended(): ColorMode {
+        return new ColorMode(true, [ONE, ONE_MINUS_SRC_ALPHA], null, [true, true, true, true]);
+    }
+}
+
+ColorMode.Replace = [ONE, ONE];
+
+module.exports = ColorMode;

--- a/src/gl/color_mode.js
+++ b/src/gl/color_mode.js
@@ -3,17 +3,16 @@ const Color = require('../style-spec/util/color');
 
 import type {BlendFuncType, ColorMaskType} from './types';
 
-const ONE = 1;
+const ZERO = 0x0000;
+const ONE = 0x0001;
 const ONE_MINUS_SRC_ALPHA = 0x0303;
 
 class ColorMode {
-    blend: boolean;
     blendFunction: BlendFuncType;
     blendColor: ?Color;
     mask: ColorMaskType;
 
-    constructor(blend: boolean, blendFunction: BlendFuncType, blendColor: ?Color, mask: ColorMaskType) {
-        this.blend = blend;
+    constructor(blendFunction: BlendFuncType, blendColor: ?Color, mask: ColorMaskType) {
         this.blendFunction = blendFunction;
         this.blendColor = blendColor;
         this.mask = mask;
@@ -22,18 +21,18 @@ class ColorMode {
     static Replace: BlendFuncType;
 
     static disabled(): ColorMode {
-        return new ColorMode(false, ColorMode.Replace, null, [false, false, false, false]);
+        return new ColorMode(ColorMode.Replace, null, [false, false, false, false]);
     }
 
     static unblended(): ColorMode {
-        return new ColorMode(false, ColorMode.Replace, null, [true, true, true, true]);
+        return new ColorMode(ColorMode.Replace, null, [true, true, true, true]);
     }
 
     static alphaBlended(): ColorMode {
-        return new ColorMode(true, [ONE, ONE_MINUS_SRC_ALPHA], null, [true, true, true, true]);
+        return new ColorMode([ONE, ONE_MINUS_SRC_ALPHA], null, [true, true, true, true]);
     }
 }
 
-ColorMode.Replace = [ONE, ONE];
+ColorMode.Replace = [ONE, ZERO];
 
 module.exports = ColorMode;

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -3,6 +3,7 @@ const IndexBuffer = require('./index_buffer');
 const VertexBuffer = require('./vertex_buffer');
 const Framebuffer = require('./framebuffer');
 const State = require('./state');
+const DepthMode = require('./depth_mode');
 const {
     ClearColor,
     ClearDepth,
@@ -189,6 +190,13 @@ class Context {
         // }
 
         gl.clear(mask);
+    }
+
+    setDepthMode(depthMode: DepthMode) {
+        this.depthFunc.set(depthMode.func);
+        this.depthMask.set(depthMode.mask);
+        this.depthRange.set(depthMode.range);
+        this.depthTest.set(depthMode.test);
     }
 }
 

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -59,6 +59,7 @@ class Context {
     gl: WebGLRenderingContext;
     extVertexArrayObject: any;
     currentNumAttributes: ?number;
+    lineWidthRange: [number, number];
 
     clearColor: State<Color>;
     clearDepth: State<number>;
@@ -95,6 +96,7 @@ class Context {
     constructor(gl: WebGLRenderingContext) {
         this.gl = gl;
         this.extVertexArrayObject = this.gl.getExtension('OES_vertex_array_object');
+        this.lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
 
         this.clearColor = new State(new ClearColor(this));
         this.clearDepth = new State(new ClearDepth(this));

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -196,28 +196,39 @@ class Context {
     }
 
     setDepthMode(depthMode: DepthMode) {
-        this.depthFunc.set(depthMode.func);
-        this.depthMask.set(depthMode.mask);
-        this.depthRange.set(depthMode.range);
-        this.depthTest.set(depthMode.test);
+        if (depthMode.func === this.gl.ALWAYS && !depthMode.mask) {
+            this.depthTest.set(false);
+        } else {
+            this.depthTest.set(true);
+            this.depthFunc.set(depthMode.func);
+            this.depthMask.set(depthMode.mask);
+            this.depthRange.set(depthMode.range);
+        }
     }
 
     setStencilMode(stencilMode: StencilMode) {
-        this.stencilFunc.set(util.pick(stencilMode, ['func', 'ref', 'mask']));
-        this.stencilOp.set([stencilMode.fail, stencilMode.depthFail, stencilMode.pass]);
-        this.stencilTest.set(stencilMode.test);
-        this.stencilMask.set(stencilMode.mask);
+        if (stencilMode.func === this.gl.ALWAYS && !stencilMode.mask) {
+            this.stencilTest.set(false);
+        } else {
+            this.stencilTest.set(true);
+            this.stencilMask.set(stencilMode.mask);
+            this.stencilOp.set([stencilMode.fail, stencilMode.depthFail, stencilMode.pass]);
+            this.stencilFunc.set(util.pick(stencilMode, ['func', 'ref', 'mask']));
+        }
     }
 
     setColorMode(colorMode: ColorMode) {
-        this.blend.set(colorMode.blend);
-        this.colorMask.set(colorMode.mask);
-        if (colorMode.blend) {
+        if (util.deepEqual(colorMode.blendFunction, ColorMode.Replace)) {
+            this.blend.set(false);
+        } else {
+            this.blend.set(true);
             this.blendFunc.set(colorMode.blendFunction);
             if (colorMode.blendColor) {
                 this.blendColor.set(colorMode.blendColor);
             }
         }
+
+        this.colorMask.set(colorMode.mask);
     }
 }
 

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -5,6 +5,7 @@ const Framebuffer = require('./framebuffer');
 const State = require('./state');
 const DepthMode = require('./depth_mode');
 const StencilMode = require('./stencil_mode');
+const ColorMode = require('./color_mode');
 const util = require('../util/util');
 const {
     ClearColor,
@@ -206,6 +207,18 @@ class Context {
         this.stencilOp.set([stencilMode.fail, stencilMode.depthFail, stencilMode.pass]);
         this.stencilTest.set(stencilMode.test);
         this.stencilMask.set(stencilMode.mask);
+    }
+
+    setColorMode(colorMode: ColorMode) {
+        this.blend.set(colorMode.blend);
+        if (colorMode.blend) {
+            this.blend.set(true);
+            this.blendFunc.set(colorMode.blendFunction);
+            this.colorMask.set(colorMode.mask);
+            if (colorMode.blendColor) {
+                this.blendColor.set(colorMode.blendColor);
+            }
+        }
     }
 }
 

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -211,10 +211,9 @@ class Context {
 
     setColorMode(colorMode: ColorMode) {
         this.blend.set(colorMode.blend);
+        this.colorMask.set(colorMode.mask);
         if (colorMode.blend) {
-            this.blend.set(true);
             this.blendFunc.set(colorMode.blendFunction);
-            this.colorMask.set(colorMode.mask);
             if (colorMode.blendColor) {
                 this.blendColor.set(colorMode.blendColor);
             }

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -223,9 +223,7 @@ class Context {
         } else {
             this.blend.set(true);
             this.blendFunc.set(colorMode.blendFunction);
-            if (colorMode.blendColor) {
-                this.blendColor.set(colorMode.blendColor);
-            }
+            this.blendColor.set(colorMode.blendColor);
         }
 
         this.colorMask.set(colorMode.mask);

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -4,6 +4,8 @@ const VertexBuffer = require('./vertex_buffer');
 const Framebuffer = require('./framebuffer');
 const State = require('./state');
 const DepthMode = require('./depth_mode');
+const StencilMode = require('./stencil_mode');
+const util = require('../util/util');
 const {
     ClearColor,
     ClearDepth,
@@ -197,6 +199,13 @@ class Context {
         this.depthMask.set(depthMode.mask);
         this.depthRange.set(depthMode.range);
         this.depthTest.set(depthMode.test);
+    }
+
+    setStencilMode(stencilMode: StencilMode) {
+        this.stencilFunc.set(util.pick(stencilMode, ['func', 'ref', 'mask']));
+        this.stencilOp.set([stencilMode.fail, stencilMode.depthFail, stencilMode.pass]);
+        this.stencilTest.set(stencilMode.test);
+        this.stencilMask.set(stencilMode.mask);
     }
 }
 

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -213,7 +213,11 @@ class Context {
             this.stencilTest.set(true);
             this.stencilMask.set(stencilMode.mask);
             this.stencilOp.set([stencilMode.fail, stencilMode.depthFail, stencilMode.pass]);
-            this.stencilFunc.set(util.pick(stencilMode, ['func', 'ref', 'mask']));
+            this.stencilFunc.set({
+                func: stencilMode.test.func,
+                ref: stencilMode.ref,
+                mask: stencilMode.test.mask
+            });
         }
     }
 

--- a/src/gl/depth_mode.js
+++ b/src/gl/depth_mode.js
@@ -1,0 +1,25 @@
+// @flow
+import type { DepthFuncType, DepthMaskType, DepthRangeType } from './types';
+
+const glALWAYS = 0x0207;
+
+class DepthMode {
+    func: DepthFuncType;
+    mask: DepthMaskType;
+    range: DepthRangeType;
+    test: boolean;
+
+    constructor(depthFunc: DepthFuncType, depthMask: DepthMaskType, depthRange: DepthRangeType, test: ?boolean) {
+        this.func = depthFunc;
+        this.mask = depthMask;
+        this.range = depthRange;
+        this.test = (typeof test !== 'undefined' && test !== null) ? test :
+            !(this.func === glALWAYS && !this.mask);
+    }
+
+    static disabled() {
+        return new DepthMode(glALWAYS, false, [0, 1]);
+    }
+}
+
+module.exports = DepthMode;

--- a/src/gl/depth_mode.js
+++ b/src/gl/depth_mode.js
@@ -1,7 +1,7 @@
 // @flow
 import type { DepthFuncType, DepthMaskType, DepthRangeType } from './types';
 
-const glALWAYS = 0x0207;
+const ALWAYS = 0x0207;
 
 class DepthMode {
     func: DepthFuncType;
@@ -14,11 +14,11 @@ class DepthMode {
         this.mask = depthMask;
         this.range = depthRange;
         this.test = (typeof test !== 'undefined' && test !== null) ? test :
-            !(this.func === glALWAYS && !this.mask);
+            !(this.func === ALWAYS && !this.mask);
     }
 
     static disabled() {
-        return new DepthMode(glALWAYS, false, [0, 1]);
+        return new DepthMode(ALWAYS, false, [0, 1]);
     }
 }
 

--- a/src/gl/depth_mode.js
+++ b/src/gl/depth_mode.js
@@ -7,14 +7,11 @@ class DepthMode {
     func: DepthFuncType;
     mask: DepthMaskType;
     range: DepthRangeType;
-    test: boolean;
 
-    constructor(depthFunc: DepthFuncType, depthMask: DepthMaskType, depthRange: DepthRangeType, test: ?boolean) {
+    constructor(depthFunc: DepthFuncType, depthMask: DepthMaskType, depthRange: DepthRangeType) {
         this.func = depthFunc;
         this.mask = depthMask;
         this.range = depthRange;
-        this.test = (typeof test !== 'undefined' && test !== null) ? test :
-            !(this.func === ALWAYS && !this.mask);
     }
 
     static disabled() {

--- a/src/gl/depth_mode.js
+++ b/src/gl/depth_mode.js
@@ -8,6 +8,10 @@ class DepthMode {
     mask: DepthMaskType;
     range: DepthRangeType;
 
+    // DepthMask enums
+    static ReadOnly: boolean;
+    static ReadWrite: boolean;
+
     constructor(depthFunc: DepthFuncType, depthMask: DepthMaskType, depthRange: DepthRangeType) {
         this.func = depthFunc;
         this.mask = depthMask;
@@ -15,8 +19,11 @@ class DepthMode {
     }
 
     static disabled() {
-        return new DepthMode(ALWAYS, false, [0, 1]);
+        return new DepthMode(ALWAYS, DepthMode.ReadOnly, [0, 1]);
     }
 }
+
+DepthMode.ReadOnly = false;
+DepthMode.ReadWrite = true;
 
 module.exports = DepthMode;

--- a/src/gl/stencil_mode.js
+++ b/src/gl/stencil_mode.js
@@ -1,20 +1,20 @@
 // @flow
-import type { CompareFuncType, StencilOpConstant } from './types';
+import type { StencilOpConstant, StencilTest } from './types';
 
 const ALWAYS = 0x0207;
 const KEEP = 0x1E00;
 
 class StencilMode {
-    func: CompareFuncType;
+    test: StencilTest;
     ref: number;
     mask: number;
     fail: StencilOpConstant;
     depthFail: StencilOpConstant;
     pass: StencilOpConstant;
 
-    constructor(func: CompareFuncType, ref: number, mask: number, fail: StencilOpConstant,
+    constructor(test: StencilTest, ref: number, mask: number, fail: StencilOpConstant,
         depthFail: StencilOpConstant, pass: StencilOpConstant) {
-        this.func = func;
+        this.test = test;
         this.ref = ref;
         this.mask = mask;
         this.fail = fail;
@@ -23,7 +23,7 @@ class StencilMode {
     }
 
     static disabled() {
-        return new StencilMode(ALWAYS, 0, 0, KEEP, KEEP, KEEP);
+        return new StencilMode({ func: ALWAYS, mask: 0 }, 0, 0, KEEP, KEEP, KEEP);
     }
 }
 

--- a/src/gl/stencil_mode.js
+++ b/src/gl/stencil_mode.js
@@ -1,0 +1,33 @@
+// @flow
+import type { CompareFuncType, StencilOpConstant } from './types';
+
+const ALWAYS = 0x0207;
+const KEEP = 0x1E00;
+
+class StencilMode {
+    func: CompareFuncType;
+    ref: number;
+    mask: number;
+    fail: StencilOpConstant;
+    depthFail: StencilOpConstant;
+    pass: StencilOpConstant;
+    test: boolean;
+
+    constructor(func: CompareFuncType, ref: number, mask: number, fail: StencilOpConstant,
+        depthFail: StencilOpConstant, pass: StencilOpConstant, test: ?boolean) {
+        this.func = func;
+        this.ref = ref;
+        this.mask = mask;
+        this.fail = fail;
+        this.depthFail = depthFail;
+        this.pass = pass;
+        this.test = (test !== null && typeof test !== 'undefined') ? test :
+            !(func === ALWAYS && !mask);
+    }
+
+    static disabled() {
+        return new StencilMode(ALWAYS, 0, 0, KEEP, KEEP, KEEP);
+    }
+}
+
+module.exports = StencilMode;

--- a/src/gl/stencil_mode.js
+++ b/src/gl/stencil_mode.js
@@ -11,18 +11,15 @@ class StencilMode {
     fail: StencilOpConstant;
     depthFail: StencilOpConstant;
     pass: StencilOpConstant;
-    test: boolean;
 
     constructor(func: CompareFuncType, ref: number, mask: number, fail: StencilOpConstant,
-        depthFail: StencilOpConstant, pass: StencilOpConstant, test: ?boolean) {
+        depthFail: StencilOpConstant, pass: StencilOpConstant) {
         this.func = func;
         this.ref = ref;
         this.mask = mask;
         this.fail = fail;
         this.depthFail = depthFail;
         this.pass = pass;
-        this.test = (test !== null && typeof test !== 'undefined') ? test :
-            !(func === ALWAYS && !mask);
     }
 
     static disabled() {

--- a/src/gl/types.js
+++ b/src/gl/types.js
@@ -43,7 +43,7 @@ export type StencilFuncType = {
     mask: number
 };
 
-type StencilOpConstant =
+export type StencilOpConstant =
     | $PropertyType<WebGLRenderingContext, 'KEEP'>
     | $PropertyType<WebGLRenderingContext, 'ZERO'>
     | $PropertyType<WebGLRenderingContext, 'REPLACE'>

--- a/src/gl/types.js
+++ b/src/gl/types.js
@@ -21,8 +21,6 @@ export type BlendFuncType = [BlendFuncConstant, BlendFuncConstant];
 
 export type ColorMaskType = [boolean, boolean, boolean, boolean];
 
-export type DepthRangeType = [number, number];
-
 export type CompareFuncType =
     | $PropertyType<WebGLRenderingContext, 'NEVER'>
     | $PropertyType<WebGLRenderingContext, 'LESS'>
@@ -33,13 +31,17 @@ export type CompareFuncType =
     | $PropertyType<WebGLRenderingContext, 'GEQUAL'>
     | $PropertyType<WebGLRenderingContext, 'ALWAYS'>;
 
+export type DepthMaskType = boolean;
+
+export type DepthRangeType = [number, number];
+
+export type DepthFuncType = CompareFuncType;
+
 export type StencilFuncType = {
     func: CompareFuncType,
     ref: number,
     mask: number
 };
-
-export type DepthFuncType = CompareFuncType;
 
 type StencilOpConstant =
     | $PropertyType<WebGLRenderingContext, 'KEEP'>

--- a/src/gl/types.js
+++ b/src/gl/types.js
@@ -58,3 +58,13 @@ export type StencilOpType = [StencilOpConstant, StencilOpConstant, StencilOpCons
 export type TextureUnitType = number;
 
 export type ViewportType = [number, number, number, number];
+
+export type StencilTest =
+    | { func: $PropertyType<WebGLRenderingContext, 'NEVER'>, mask: 0 }
+    | { func: $PropertyType<WebGLRenderingContext, 'LESS'>, mask: number }
+    | { func: $PropertyType<WebGLRenderingContext, 'EQUAL'>, mask: number }
+    | { func: $PropertyType<WebGLRenderingContext, 'LEQUAL'>, mask: number }
+    | { func: $PropertyType<WebGLRenderingContext, 'GREATER'>, mask: number }
+    | { func: $PropertyType<WebGLRenderingContext, 'NOTEQUAL'>, mask: number }
+    | { func: $PropertyType<WebGLRenderingContext, 'GEQUAL'>, mask: number }
+    | { func: $PropertyType<WebGLRenderingContext, 'ALWAYS'>, mask: 0 };

--- a/src/gl/value.js
+++ b/src/gl/value.js
@@ -199,7 +199,8 @@ class LineWidth extends ContextValue implements Value<number> {
     static default() { return 1; }
 
     set(v: number): void {
-        this.context.gl.lineWidth(v);
+        const range = this.context.lineWidthRange;
+        this.context.gl.lineWidth(util.clamp(v, range[0], range[1]));
     }
 }
 

--- a/src/gl/value.js
+++ b/src/gl/value.js
@@ -8,6 +8,7 @@ import type {
     BlendFuncType,
     ColorMaskType,
     DepthRangeType,
+    DepthMaskType,
     StencilFuncType,
     StencilOpType,
     DepthFuncType,
@@ -66,10 +67,10 @@ class ColorMask extends ContextValue implements Value<ColorMaskType> {
     }
 }
 
-class DepthMask extends ContextValue implements Value<boolean> {
+class DepthMask extends ContextValue implements Value<DepthMaskType> {
     static default() { return true; }
 
-    set(v: boolean): void {
+    set(v: DepthMaskType): void {
         this.context.gl.depthMask(v);
     }
 }

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -4,6 +4,7 @@ const pattern = require('./pattern');
 const {ProgramConfiguration} = require('../data/program_configuration');
 const {PossiblyEvaluated, PossiblyEvaluatedPropertyValue} = require('../style/properties');
 const fillLayerPaintProperties = require('../style/style_layer/fill_style_layer_properties').paint;
+const StencilMode = require('../gl/stencil_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -27,7 +28,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
     const pass = (!image && color.a === 1 && opacity === 1) ? 'opaque' : 'translucent';
     if (painter.renderPass !== pass) return;
 
-    context.stencilTest.set(false);
+    context.setStencilMode(StencilMode.disabled());
     context.setDepthMode(painter.depthModeForSublayer(0, false));
 
     const properties = new PossiblyEvaluated(fillLayerPaintProperties);

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -30,6 +30,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
 
     context.setStencilMode(StencilMode.disabled());
     context.setDepthMode(painter.depthModeForSublayer(0, false));
+    context.setColorMode(painter.colorModeForRenderPass());
 
     const properties = new PossiblyEvaluated(fillLayerPaintProperties);
 

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -28,8 +28,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
     if (painter.renderPass !== pass) return;
 
     context.stencilTest.set(false);
-    context.depthMask.set(pass === 'opaque');
-    painter.setDepthSublayer(0);
+    context.setDepthMode(painter.depthModeForSublayer(0, false));
 
     const properties = new PossiblyEvaluated(fillLayerPaintProperties);
 

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -5,6 +5,7 @@ const {ProgramConfiguration} = require('../data/program_configuration');
 const {PossiblyEvaluated, PossiblyEvaluatedPropertyValue} = require('../style/properties');
 const fillLayerPaintProperties = require('../style/style_layer/fill_style_layer_properties').paint;
 const StencilMode = require('../gl/stencil_mode');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -29,7 +30,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
     if (painter.renderPass !== pass) return;
 
     context.setStencilMode(StencilMode.disabled());
-    context.setDepthMode(painter.depthModeForSublayer(0, true));
+    context.setDepthMode(painter.depthModeForSublayer(0, pass === 'opaque' ? DepthMode.ReadWrite : DepthMode.ReadOnly));
     context.setColorMode(painter.colorModeForRenderPass());
 
     const properties = new PossiblyEvaluated(fillLayerPaintProperties);

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -29,7 +29,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
     if (painter.renderPass !== pass) return;
 
     context.setStencilMode(StencilMode.disabled());
-    context.setDepthMode(painter.depthModeForSublayer(0, false));
+    context.setDepthMode(painter.depthModeForSublayer(0, true));
     context.setColorMode(painter.colorModeForRenderPass());
 
     const properties = new PossiblyEvaluated(fillLayerPaintProperties);

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -24,8 +24,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
     const context = painter.context;
     const gl = context.gl;
 
-    painter.setDepthSublayer(0);
-    context.depthMask.set(false);
+    context.setDepthMode(painter.depthModeForSublayer(0, false));
 
     // Allow circles to be drawn across boundaries, so that
     // large circles are not clipped to tiles

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -1,6 +1,7 @@
 // @flow
 
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
+const StencilMode = require('../gl/stencil_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -28,7 +29,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
 
     // Allow circles to be drawn across boundaries, so that
     // large circles are not clipped to tiles
-    context.stencilTest.set(false);
+    context.setStencilMode(StencilMode.disabled());
 
     for (let i = 0; i < coords.length; i++) {
         const coord = coords[i];

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -26,10 +26,10 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
     const gl = context.gl;
 
     context.setDepthMode(painter.depthModeForSublayer(0, false));
-
     // Allow circles to be drawn across boundaries, so that
     // large circles are not clipped to tiles
     context.setStencilMode(StencilMode.disabled());
+    context.setColorMode(painter.colorModeForRenderPass());
 
     for (let i = 0; i < coords.length; i++) {
         const coord = coords[i];

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -2,6 +2,7 @@
 
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 const StencilMode = require('../gl/stencil_mode');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -25,7 +26,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
     const context = painter.context;
     const gl = context.gl;
 
-    context.setDepthMode(painter.depthModeForSublayer(0, false));
+    context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
     // Allow circles to be drawn across boundaries, so that
     // large circles are not clipped to tiles
     context.setStencilMode(StencilMode.disabled());

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -7,6 +7,7 @@ import type {OverscaledTileID} from '../source/tile_id';
 import type SymbolBucket from '../data/bucket/symbol_bucket';
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 const DepthMode = require('../gl/depth_mode');
+const StencilMode = require('../gl/stencil_mode');
 
 module.exports = drawCollisionDebug;
 
@@ -16,6 +17,7 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
     const program = drawCircles ? painter.useProgram('collisionCircle') : painter.useProgram('collisionBox');
 
     context.setDepthMode(DepthMode.disabled());
+    context.setStencilMode(StencilMode.disabled());
 
     for (let i = 0; i < coords.length; i++) {
         const coord = coords[i];

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -24,7 +24,7 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
         gl.uniformMatrix4fv(program.uniforms.u_matrix, false, coord.posMatrix);
 
         if (!drawCircles) {
-            painter.lineWidth(1);
+            context.lineWidth.set(1);
         }
 
         gl.uniform1f(program.uniforms.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -6,6 +6,7 @@ import type StyleLayer from '../style/style_layer';
 import type {OverscaledTileID} from '../source/tile_id';
 import type SymbolBucket from '../data/bucket/symbol_bucket';
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
+const DepthMode = require('../gl/depth_mode');
 
 module.exports = drawCollisionDebug;
 
@@ -13,6 +14,9 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
     const context = painter.context;
     const gl = context.gl;
     const program = drawCircles ? painter.useProgram('collisionCircle') : painter.useProgram('collisionBox');
+
+    context.setDepthMode(DepthMode.disabled());
+
     for (let i = 0; i < coords.length; i++) {
         const coord = coords[i];
         const tile = sourceCache.getTile(coord);
@@ -20,6 +24,7 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
         if (!bucket) continue;
         const buffers = drawCircles ? bucket.collisionCircle : bucket.collisionBox;
         if (!buffers) continue;
+
 
         gl.uniformMatrix4fv(program.uniforms.u_matrix, false, coord.posMatrix);
 

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -18,6 +18,7 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
 
     context.setDepthMode(DepthMode.disabled());
     context.setStencilMode(StencilMode.disabled());
+    context.setColorMode(painter.colorModeForRenderPass());
 
     for (let i = 0; i < coords.length; i++) {
         const coord = coords[i];

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -5,6 +5,7 @@ const mat4 = require('@mapbox/gl-matrix').mat4;
 const EXTENT = require('../data/extent');
 const VertexArrayObject = require('./vertex_array_object');
 const PosArray = require('../data/pos_array');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -27,6 +28,8 @@ function drawDebugTile(painter, sourceCache, coord) {
 
     const posMatrix = coord.posMatrix;
     const program = painter.useProgram('debug');
+
+    context.setDepthMode(DepthMode.disabled());
 
     gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
     gl.uniform4f(program.uniforms.u_color, 1, 0, 0, 1);

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -23,7 +23,7 @@ function drawDebugTile(painter, sourceCache, coord) {
     const gl = context.gl;
 
     context.stencilTest.set(false);
-    painter.lineWidth(1 * browser.devicePixelRatio);
+    context.lineWidth.set(1 * browser.devicePixelRatio);
 
     const posMatrix = coord.posMatrix;
     const program = painter.useProgram('debug');

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -6,6 +6,7 @@ const EXTENT = require('../data/extent');
 const VertexArrayObject = require('./vertex_array_object');
 const PosArray = require('../data/pos_array');
 const DepthMode = require('../gl/depth_mode');
+const StencilMode = require('../gl/stencil_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -23,13 +24,13 @@ function drawDebugTile(painter, sourceCache, coord) {
     const context = painter.context;
     const gl = context.gl;
 
-    context.stencilTest.set(false);
     context.lineWidth.set(1 * browser.devicePixelRatio);
 
     const posMatrix = coord.posMatrix;
     const program = painter.useProgram('debug');
 
     context.setDepthMode(DepthMode.disabled());
+    context.setStencilMode(StencilMode.disabled());
 
     gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
     gl.uniform4f(program.uniforms.u_color, 1, 0, 0, 1);

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -31,6 +31,7 @@ function drawDebugTile(painter, sourceCache, coord) {
 
     context.setDepthMode(DepthMode.disabled());
     context.setStencilMode(StencilMode.disabled());
+    context.setColorMode(painter.colorModeForRenderPass());
 
     gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
     gl.uniform4f(program.uniforms.u_color, 1, 0, 0, 1);

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -31,15 +31,13 @@ function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLa
     if (painter.renderPass === pass) {
         // Once we switch to earcut drawing we can pull most of the WebGL setup
         // outside of this coords loop.
-        painter.setDepthSublayer(1);
-        context.depthMask.set(painter.renderPass === 'opaque');
+        context.setDepthMode(painter.depthModeForSublayer(1, painter.renderPass === 'opaque'));
         drawFillTiles(painter, sourceCache, layer, coords, drawFillTile);
     }
 
     // Draw stroke
     if (painter.renderPass === 'translucent' && layer.paint.get('fill-antialias')) {
         context.lineWidth.set(2);
-        context.depthMask.set(false);
 
         // If we defined a different color for the fill outline, we are
         // going to ignore the bits in 0x07 and just care about the global
@@ -49,7 +47,8 @@ function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLa
         // or stroke color is translucent. If we wouldn't clip to outside
         // the current shape, some pixels from the outline stroke overlapped
         // the (non-antialiased) fill.
-        painter.setDepthSublayer(layer.getPaintProperty('fill-outline-color') ? 2 : 0);
+        context.setDepthMode(painter.depthModeForSublayer(
+            layer.getPaintProperty('fill-outline-color') ? 2 : 0, false));
         drawFillTiles(painter, sourceCache, layer, coords, drawStrokeTile);
     }
 }

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -21,7 +21,6 @@ function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLa
     }
 
     const context = painter.context;
-    context.stencilTest.set(true);
 
     const pass = (!layer.paint.get('fill-pattern') &&
         color.constantOr(Color.transparent).a === 1 &&
@@ -62,7 +61,7 @@ function drawFillTiles(painter, sourceCache, layer, coords, drawFn) {
         const bucket: ?FillBucket = (tile.getBucket(layer): any);
         if (!bucket) continue;
 
-        painter.enableTileClippingMask(coord);
+        painter.context.setStencilMode(painter.stencilModeForClipping(coord));
         drawFn(painter, sourceCache, layer, tile, coord, bucket, firstTile);
         firstTile = false;
     }

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -38,7 +38,7 @@ function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLa
 
     // Draw stroke
     if (painter.renderPass === 'translucent' && layer.paint.get('fill-antialias')) {
-        painter.lineWidth(2);
+        context.lineWidth.set(2);
         context.depthMask.set(false);
 
         // If we defined a different color for the fill outline, we are

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -2,6 +2,7 @@
 
 const pattern = require('./pattern');
 const Color = require('../style-spec/util/color');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -31,7 +32,7 @@ function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLa
     if (painter.renderPass === pass) {
         // Once we switch to earcut drawing we can pull most of the WebGL setup
         // outside of this coords loop.
-        context.setDepthMode(painter.depthModeForSublayer(1, painter.renderPass === 'opaque'));
+        context.setDepthMode(painter.depthModeForSublayer(1, painter.renderPass === 'opaque' ? DepthMode.ReadWrite : DepthMode.ReadOnly));
         drawFillTiles(painter, sourceCache, layer, coords, drawFillTile);
     }
 
@@ -48,7 +49,7 @@ function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLa
         // the current shape, some pixels from the outline stroke overlapped
         // the (non-antialiased) fill.
         context.setDepthMode(painter.depthModeForSublayer(
-            layer.getPaintProperty('fill-outline-color') ? 2 : 0, false));
+            layer.getPaintProperty('fill-outline-color') ? 2 : 0, DepthMode.ReadOnly));
         drawFillTiles(painter, sourceCache, layer, coords, drawStrokeTile);
     }
 }

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -21,6 +21,7 @@ function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLa
     }
 
     const context = painter.context;
+    context.setColorMode(painter.colorModeForRenderPass());
 
     const pass = (!layer.paint.get('fill-pattern') &&
         color.constantOr(Color.transparent).a === 1 &&

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -30,7 +30,6 @@ function draw(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLa
             drawExtrusion(painter, source, layer, coords[i]);
         }
     } else if (painter.renderPass === 'translucent') {
-        painter.context.setColorMode(painter.colorModeForRenderPass());
         drawExtrusionTexture(painter, layer);
     }
 }
@@ -64,7 +63,7 @@ function drawToExtrusionFramebuffer(painter, layer) {
     context.clear({ color: Color.transparent });
 
     context.setStencilMode(StencilMode.disabled());
-    context.setDepthMode(new DepthMode(gl.LEQUAL, true, [0, 1]));
+    context.setDepthMode(new DepthMode(gl.LEQUAL, DepthMode.ReadWrite, [0, 1]));
     context.setColorMode(painter.colorModeForRenderPass());
 }
 
@@ -78,6 +77,7 @@ function drawExtrusionTexture(painter, layer) {
 
     context.setStencilMode(StencilMode.disabled());
     context.setDepthMode(DepthMode.disabled());
+    context.setColorMode(painter.colorModeForRenderPass());
 
     context.activeTexture.set(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, renderedTexture.colorAttachment.get());

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -4,6 +4,7 @@ const glMatrix = require('@mapbox/gl-matrix');
 const pattern = require('./pattern');
 const Texture = require('./texture');
 const Color = require('../style-spec/util/color');
+const DepthMode = require('../gl/depth_mode');
 const mat3 = glMatrix.mat3;
 const mat4 = glMatrix.mat4;
 const vec3 = glMatrix.vec3;
@@ -59,10 +60,9 @@ function drawToExtrusionFramebuffer(painter, layer) {
     }
 
     context.stencilTest.set(false);
-    context.depthTest.set(true);
-
     context.clear({ color: Color.transparent });
-    context.depthMask.set(true);
+
+    context.setDepthMode(new DepthMode(gl.LEQUAL, true, [0, 1]));
 }
 
 function drawExtrusionTexture(painter, layer) {
@@ -74,7 +74,7 @@ function drawExtrusionTexture(painter, layer) {
     const program = painter.useProgram('extrusionTexture');
 
     context.stencilTest.set(false);
-    context.depthTest.set(false);
+    context.setDepthMode(DepthMode.disabled());
 
     context.activeTexture.set(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, renderedTexture.colorAttachment.get());

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -8,6 +8,7 @@ const DepthMode = require('../gl/depth_mode');
 const mat3 = glMatrix.mat3;
 const mat4 = glMatrix.mat4;
 const vec3 = glMatrix.vec3;
+const StencilMode = require('../gl/stencil_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -59,9 +60,9 @@ function drawToExtrusionFramebuffer(painter, layer) {
         painter.depthRboNeedsClear = false;
     }
 
-    context.stencilTest.set(false);
     context.clear({ color: Color.transparent });
 
+    context.setStencilMode(StencilMode.disabled());
     context.setDepthMode(new DepthMode(gl.LEQUAL, true, [0, 1]));
 }
 
@@ -73,7 +74,7 @@ function drawExtrusionTexture(painter, layer) {
     const gl = context.gl;
     const program = painter.useProgram('extrusionTexture');
 
-    context.stencilTest.set(false);
+    context.setStencilMode(StencilMode.disabled());
     context.setDepthMode(DepthMode.disabled());
 
     context.activeTexture.set(gl.TEXTURE0);

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -30,6 +30,7 @@ function draw(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLa
             drawExtrusion(painter, source, layer, coords[i]);
         }
     } else if (painter.renderPass === 'translucent') {
+        painter.context.setColorMode(painter.colorModeForRenderPass());
         drawExtrusionTexture(painter, layer);
     }
 }
@@ -64,6 +65,7 @@ function drawToExtrusionFramebuffer(painter, layer) {
 
     context.setStencilMode(StencilMode.disabled());
     context.setDepthMode(new DepthMode(gl.LEQUAL, true, [0, 1]));
+    context.setColorMode(painter.colorModeForRenderPass());
 }
 
 function drawExtrusionTexture(painter, layer) {

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -4,6 +4,7 @@ const mat4 = require('@mapbox/gl-matrix').mat4;
 const Texture = require('./texture');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 const Color = require('../style-spec/util/color');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -22,8 +23,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
         const context = painter.context;
         const gl = context.gl;
 
-        painter.setDepthSublayer(0);
-        context.depthMask.set(false);
+        context.setDepthMode(painter.depthModeForSublayer(0, false));
 
         // Allow kernels to be drawn across boundaries, so that
         // large kernels are not clipped to tiles
@@ -140,7 +140,7 @@ function renderTextureToMap(painter, layer) {
     }
     colorRampTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
 
-    context.depthTest.set(false);
+    context.setDepthMode(DepthMode.disabled());
 
     const program = painter.useProgram('heatmapTexture');
 
@@ -158,6 +158,4 @@ function renderTextureToMap(painter, layer) {
 
     painter.viewportVAO.bind(painter.context, program, painter.viewportBuffer);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
-
-    context.depthTest.set(true);
 }

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -5,6 +5,7 @@ const Texture = require('./texture');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 const Color = require('../style-spec/util/color');
 const DepthMode = require('../gl/depth_mode');
+const StencilMode = require('../gl/stencil_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -27,7 +28,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
 
         // Allow kernels to be drawn across boundaries, so that
         // large kernels are not clipped to tiles
-        context.stencilTest.set(false);
+        context.setStencilMode(StencilMode.disabled());
 
         bindFramebuffer(context, painter, layer);
 

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -6,6 +6,7 @@ const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 const Color = require('../style-spec/util/color');
 const DepthMode = require('../gl/depth_mode');
 const StencilMode = require('../gl/stencil_mode');
+const util = require('../util/util');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -35,7 +36,9 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
         context.clear({ color: Color.transparent });
 
         // Turn on additive blending for kernels, which is a key aspect of kernel density estimation formula
-        context.blendFunc.set([gl.ONE, gl.ONE]);
+        context.setColorMode(util.extend(painter.colorModeForRenderPass(), {
+            blendFunction: [gl.ONE, gl.ONE]
+        }));
 
         for (let i = 0; i < coords.length; i++) {
             const coord = coords[i];
@@ -71,9 +74,9 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
         }
 
         context.viewport.set([0, 0, painter.width, painter.height]);
-        context.blendFunc.set(painter._showOverdrawInspector ? [gl.CONSTANT_COLOR, gl.ONE] : [gl.ONE, gl.ONE_MINUS_SRC_ALPHA]);
 
     } else if (painter.renderPass === 'translucent') {
+        painter.context.setColorMode(painter.colorModeForRenderPass());
         renderTextureToMap(painter, layer);
     }
 }

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -25,7 +25,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
         const context = painter.context;
         const gl = context.gl;
 
-        context.setDepthMode(painter.depthModeForSublayer(0, false));
+        context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
 
         // Allow kernels to be drawn across boundaries, so that
         // large kernels are not clipped to tiles

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -3,6 +3,7 @@ const Coordinate = require('../geo/coordinate');
 const Texture = require('./texture');
 const EXTENT = require('../data/extent');
 const mat4 = require('@mapbox/gl-matrix').mat4;
+const StencilMode = require('../gl/stencil_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -17,7 +18,7 @@ function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: Hillsh
     const context = painter.context;
 
     context.setDepthMode(painter.depthModeForSublayer(0, false));
-    context.stencilTest.set(false);
+    context.setStencilMode(StencilMode.disabled());
 
     for (const tileID of tileIDs) {
         const tile = sourceCache.getTile(tileID);

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -16,7 +16,7 @@ function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: Hillsh
 
     const context = painter.context;
 
-    painter.setDepthSublayer(0);
+    context.setDepthMode(painter.depthModeForSublayer(0, false));
     context.stencilTest.set(false);
 
     for (const tileID of tileIDs) {

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -4,6 +4,7 @@ const Texture = require('./texture');
 const EXTENT = require('../data/extent');
 const mat4 = require('@mapbox/gl-matrix').mat4;
 const StencilMode = require('../gl/stencil_mode');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -17,7 +18,7 @@ function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: Hillsh
 
     const context = painter.context;
 
-    context.setDepthMode(painter.depthModeForSublayer(0, false));
+    context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
     context.setStencilMode(StencilMode.disabled());
     context.setColorMode(painter.colorModeForRenderPass());
 

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -19,6 +19,7 @@ function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: Hillsh
 
     context.setDepthMode(painter.depthModeForSublayer(0, false));
     context.setStencilMode(StencilMode.disabled());
+    context.setColorMode(painter.colorModeForRenderPass());
 
     for (const tileID of tileIDs) {
         const tile = sourceCache.getTile(tileID);

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -17,8 +17,7 @@ module.exports = function drawLine(painter: Painter, sourceCache: SourceCache, l
 
     const context = painter.context;
 
-    painter.setDepthSublayer(0);
-    context.depthMask.set(false);
+    context.setDepthMode(painter.depthModeForSublayer(0, false));
 
     context.stencilTest.set(true);
 

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -19,8 +19,6 @@ module.exports = function drawLine(painter: Painter, sourceCache: SourceCache, l
 
     context.setDepthMode(painter.depthModeForSublayer(0, false));
 
-    context.stencilTest.set(true);
-
     const programId =
         layer.paint.get('line-dasharray') ? 'lineSDF' :
         layer.paint.get('line-pattern') ? 'linePattern' : 'line';
@@ -109,7 +107,7 @@ function drawLineTile(program, painter, tile, bucket, layer, coord, programConfi
         }
     }
 
-    painter.enableTileClippingMask(coord);
+    context.setStencilMode(painter.stencilModeForClipping(coord));
 
     const posMatrix = painter.translatePosMatrix(coord.posMatrix, tile, layer.paint.get('line-translate'), layer.paint.get('line-translate-anchor'));
     gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -2,6 +2,7 @@
 
 const browser = require('../util/browser');
 const pixelsToTileUnits = require('../source/pixels_to_tile_units');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -17,7 +18,7 @@ module.exports = function drawLine(painter: Painter, sourceCache: SourceCache, l
 
     const context = painter.context;
 
-    context.setDepthMode(painter.depthModeForSublayer(0, false));
+    context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
     context.setColorMode(painter.colorModeForRenderPass());
 
     const programId =

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -18,6 +18,7 @@ module.exports = function drawLine(painter: Painter, sourceCache: SourceCache, l
     const context = painter.context;
 
     context.setDepthMode(painter.depthModeForSublayer(0, false));
+    context.setColorMode(painter.colorModeForRenderPass());
 
     const programId =
         layer.paint.get('line-dasharray') ? 'lineSDF' :

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -3,6 +3,7 @@
 const util = require('../util/util');
 const ImageSource = require('../source/image_source');
 const browser = require('../util/browser');
+const StencilMode = require('../gl/stencil_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -20,7 +21,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
     const source = sourceCache.getSource();
     const program = painter.useProgram('raster');
 
-    context.stencilTest.set(false);
+    context.setStencilMode(StencilMode.disabled());
 
     // Constant parameters.
     gl.uniform1f(program.uniforms.u_brightness_low, layer.paint.get('raster-brightness-min'));

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -22,6 +22,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
     const program = painter.useProgram('raster');
 
     context.setStencilMode(StencilMode.disabled());
+    context.setColorMode(painter.colorModeForRenderPass());
 
     // Constant parameters.
     gl.uniform1f(program.uniforms.u_brightness_low, layer.paint.get('raster-brightness-min'));

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -4,6 +4,7 @@ const util = require('../util/util');
 const ImageSource = require('../source/image_source');
 const browser = require('../util/browser');
 const StencilMode = require('../gl/stencil_mode');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -40,7 +41,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
         // Set the lower zoom level to sublayer 0, and higher zoom levels to higher sublayers
         // Use gl.LESS to prevent double drawing in areas where tiles overlap.
         context.setDepthMode(painter.depthModeForSublayer(coord.overscaledZ - minTileZ,
-            layer.paint.get('raster-opacity') === 1, gl.LESS));
+            layer.paint.get('raster-opacity') === 1 ? DepthMode.ReadWrite : DepthMode.ReadOnly, gl.LESS));
 
         const tile = sourceCache.getTile(coord);
         const posMatrix = painter.transform.calculatePosMatrix(coord.toUnwrapped());

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -40,7 +40,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
         // Set the lower zoom level to sublayer 0, and higher zoom levels to higher sublayers
         // Use gl.LESS to prevent double drawing in areas where tiles overlap.
         context.setDepthMode(painter.depthModeForSublayer(coord.overscaledZ - minTileZ,
-            layer.paint.get('raster-opacity') === 1, gl.LESS, true));
+            layer.paint.get('raster-opacity') === 1, gl.LESS));
 
         const tile = sourceCache.getTile(coord);
         const posMatrix = painter.transform.calculatePosMatrix(coord.toUnwrapped());

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -8,6 +8,7 @@ const mat4 = require('@mapbox/gl-matrix').mat4;
 const identityMat4 = mat4.identity(new Float32Array(16));
 const symbolLayoutProperties = require('../style/style_layer/symbol_style_layer_properties').layout;
 const browser = require('../util/browser');
+const StencilMode = require('../gl/stencil_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -23,7 +24,7 @@ function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolSt
     const context = painter.context;
 
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
-    context.stencilTest.set(false);
+    context.setStencilMode(StencilMode.disabled());
 
     context.setDepthMode(painter.depthModeForSublayer(0, false));
 
@@ -106,8 +107,6 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
                 gl.LINEAR : gl.NEAREST, gl.CLAMP_TO_EDGE);
             gl.uniform2fv(program.uniforms.u_texsize, tile.iconAtlasTexture.size);
         }
-
-        painter.enableTileClippingMask(coord);
 
         gl.uniformMatrix4fv(program.uniforms.u_matrix, false, painter.translatePosMatrix(coord.posMatrix, tile, translate, translateAnchor));
 

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -25,8 +25,7 @@ function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolSt
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
     context.stencilTest.set(false);
 
-    painter.setDepthSublayer(0);
-    context.depthMask.set(false);
+    context.setDepthMode(painter.depthModeForSublayer(0, false));
 
     if (layer.paint.get('icon-opacity').constantOr(1) !== 0) {
         drawLayerSymbols(painter, sourceCache, layer, coords, false,
@@ -128,8 +127,6 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         drawTileSymbols(program, programConfiguration, painter, layer, tile, buffers, isText, isSDF, pitchWithMap);
     }
-
-    if (!depthOn) context.depthTest.set(true);
 }
 
 function setSymbolDrawState(program, painter, layer, isText, rotateInShader, pitchWithMap, sizeData) {

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -25,7 +25,6 @@ function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolSt
 
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
     context.setStencilMode(StencilMode.disabled());
-    context.setDepthMode(painter.depthModeForSublayer(0, false));
     context.setColorMode(painter.colorModeForRenderPass());
 
     if (layer.paint.get('icon-opacity').constantOr(1) !== 0) {
@@ -70,7 +69,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
     const depthOn = pitchWithMap;
 
-    context.depthTest.set(depthOn);
+    context.setDepthMode(painter.depthModeForSublayer(0, false, undefined, depthOn));
 
     let program;
 

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -9,6 +9,7 @@ const identityMat4 = mat4.identity(new Float32Array(16));
 const symbolLayoutProperties = require('../style/style_layer/symbol_style_layer_properties').layout;
 const browser = require('../util/browser');
 const StencilMode = require('../gl/stencil_mode');
+const DepthMode = require('../gl/depth_mode');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -69,7 +70,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
     const depthOn = pitchWithMap;
 
-    context.setDepthMode(painter.depthModeForSublayer(0, false, undefined, depthOn));
+    context.setDepthMode(depthOn ? painter.depthModeForSublayer(0, false) : DepthMode.disabled());
 
     let program;
 

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -25,8 +25,8 @@ function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolSt
 
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
     context.setStencilMode(StencilMode.disabled());
-
     context.setDepthMode(painter.depthModeForSublayer(0, false));
+    context.setColorMode(painter.colorModeForRenderPass());
 
     if (layer.paint.get('icon-opacity').constantOr(1) !== 0) {
         drawLayerSymbols(painter, sourceCache, layer, coords, false,

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -70,7 +70,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
     const depthOn = pitchWithMap;
 
-    context.setDepthMode(depthOn ? painter.depthModeForSublayer(0, false) : DepthMode.disabled());
+    context.setDepthMode(depthOn ? painter.depthModeForSublayer(0, DepthMode.ReadOnly) : DepthMode.disabled());
 
     let program;
 

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -14,6 +14,7 @@ const CrossTileSymbolIndex = require('../symbol/cross_tile_symbol_index');
 const shaders = require('../shaders');
 const Program = require('./program');
 const Context = require('../gl/context');
+const DepthMode = require('../gl/depth_mode');
 const Texture = require('./texture');
 const updateTileMasks = require('./tile_mask');
 const Color = require('../style-spec/util/color');
@@ -40,6 +41,7 @@ import type LineAtlas from './line_atlas';
 import type ImageManager from './image_manager';
 import type GlyphManager from './glyph_manager';
 import type VertexBuffer from '../gl/vertex_buffer';
+import type {DepthMaskType, DepthFuncType} from '../gl/types';
 
 export type RenderPass = 'offscreen' | 'opaque' | 'translucent';
 
@@ -422,10 +424,10 @@ class Painter {
         draw[layer.type](painter, sourceCache, layer, coords);
     }
 
-    setDepthSublayer(n: number) {
+    depthModeForSublayer(n: number, mask: DepthMaskType, func: ?DepthFuncType, test: ?boolean): DepthMode {
         const farDepth = 1 - ((1 + this.currentLayer) * this.numSublayers + n) * this.depthEpsilon;
         const nearDepth = farDepth - 1 + this.depthRange;
-        this.context.depthRange.set([nearDepth, farDepth]);
+        return new DepthMode(func || this.context.gl.LEQUAL, mask, [nearDepth, farDepth], test);
     }
 
     /**

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -191,7 +191,7 @@ class Painter {
 
         context.setColorMode(ColorMode.disabled());
         context.setDepthMode(DepthMode.disabled());
-        context.setStencilMode(new StencilMode(gl.ALWAYS, 0x0, 0xFF, gl.ZERO, gl.ZERO, gl.ZERO));
+        context.setStencilMode(new StencilMode({ func: gl.ALWAYS, mask: 0 }, 0x0, 0xFF, gl.ZERO, gl.ZERO, gl.ZERO));
 
         const matrix = mat4.create();
         mat4.ortho(matrix, 0, this.width, this.height, 0, 0, 1);
@@ -219,7 +219,7 @@ class Painter {
             const id = this._tileClippingMaskIDs[tileID.key] = idNext++;
 
             // Tests will always pass, and ref value will be written to stencil buffer.
-            context.setStencilMode(new StencilMode(gl.ALWAYS, id, 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE));
+            context.setStencilMode(new StencilMode({ func: gl.ALWAYS, mask: 0 }, id, 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE));
 
             const program = this.useProgram('fill', programConfiguration);
             gl.uniformMatrix4fv(program.uniforms.u_matrix, false, tileID.posMatrix);
@@ -232,7 +232,7 @@ class Painter {
 
     stencilModeForClipping(tileID: OverscaledTileID): StencilMode {
         const gl = this.context.gl;
-        return new StencilMode(gl.EQUAL, this._tileClippingMaskIDs[tileID.key], 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE);
+        return new StencilMode({ func: gl.EQUAL, mask: 0xFF }, this._tileClippingMaskIDs[tileID.key], 0x00, gl.KEEP, gl.KEEP, gl.REPLACE);
     }
 
     colorModeForRenderPass(): ColorMode {

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -191,7 +191,7 @@ class Painter {
 
         context.setColorMode(ColorMode.disabled());
         context.setDepthMode(DepthMode.disabled());
-        context.setStencilMode(new StencilMode(gl.ALWAYS, 0x0, 0xFF, gl.ZERO, gl.ZERO, gl.ZERO, false));
+        context.setStencilMode(new StencilMode(gl.ALWAYS, 0x0, 0xFF, gl.ZERO, gl.ZERO, gl.ZERO));
 
         const matrix = mat4.create();
         mat4.ortho(matrix, 0, this.width, this.height, 0, 0, 1);
@@ -219,7 +219,7 @@ class Painter {
             const id = this._tileClippingMaskIDs[tileID.key] = idNext++;
 
             // Tests will always pass, and ref value will be written to stencil buffer.
-            context.setStencilMode(new StencilMode(gl.ALWAYS, id, 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE, true));
+            context.setStencilMode(new StencilMode(gl.ALWAYS, id, 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE));
 
             const program = this.useProgram('fill', programConfiguration);
             gl.uniformMatrix4fv(program.uniforms.u_matrix, false, tileID.posMatrix);
@@ -232,7 +232,7 @@ class Painter {
 
     stencilModeForClipping(tileID: OverscaledTileID): StencilMode {
         const gl = this.context.gl;
-        return new StencilMode(gl.EQUAL, this._tileClippingMaskIDs[tileID.key], 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE, true);
+        return new StencilMode(gl.EQUAL, this._tileClippingMaskIDs[tileID.key], 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE);
     }
 
     colorModeForRenderPass(): ColorMode {
@@ -241,7 +241,7 @@ class Painter {
             const numOverdrawSteps = 8;
             const a = 1 / numOverdrawSteps;
 
-            return new ColorMode(true, [gl.CONSTANT_COLOR, gl.ONE], new Color(a, a, a, 0), [true, true, true, true]);
+            return new ColorMode([gl.CONSTANT_COLOR, gl.ONE], new Color(a, a, a, 0), [true, true, true, true]);
         } else if (this.renderPass === 'opaque') {
             return ColorMode.unblended();
         } else {
@@ -249,10 +249,10 @@ class Painter {
         }
     }
 
-    depthModeForSublayer(n: number, mask: DepthMaskType, func: ?DepthFuncType, test: ?boolean): DepthMode {
+    depthModeForSublayer(n: number, mask: DepthMaskType, func: ?DepthFuncType): DepthMode {
         const farDepth = 1 - ((1 + this.currentLayer) * this.numSublayers + n) * this.depthEpsilon;
         const nearDepth = farDepth - 1 + this.depthRange;
-        return new DepthMode(func || this.context.gl.LEQUAL, mask, [nearDepth, farDepth], test);
+        return new DepthMode(func || this.context.gl.LEQUAL, mask, [nearDepth, farDepth]);
     }
 
     render(style: Style, options: PainterOptions) {

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -63,7 +63,6 @@ class Painter {
     _tileTextures: { [number]: Array<Texture> };
     numSublayers: number;
     depthEpsilon: number;
-    lineWidthRange: [number, number];
     emptyProgramConfiguration: ProgramConfiguration;
     width: number;
     height: number;
@@ -106,8 +105,6 @@ class Painter {
         this.depthEpsilon = 1 / Math.pow(2, 16);
 
         this.depthRboNeedsClear = true;
-
-        this.lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
 
         this.emptyProgramConfiguration = new ProgramConfiguration();
 
@@ -475,10 +472,6 @@ class Painter {
     getTileTexture(size: number) {
         const textures = this._tileTextures[size];
         return textures && textures.length > 0 ? textures.pop() : null;
-    }
-
-    lineWidth(width: number) {
-        this.context.lineWidth.set(util.clamp(width, this.lineWidthRange[0], this.lineWidthRange[1]));
     }
 
     showOverdrawInspector(enabled: boolean) {


### PR DESCRIPTION
Abstracts all depth-, color- and stencil-related state manipulation into "modes," so that each render function is responsible for setting its own modes (with `context.set*Mode` as an intermediate step, but eventually as part of `program.draw`). This eliminates all instances of render functions needing to reset assumed state after they're finished 🎉 

I figured out all of the quirks I mentioned offline, so `context.setStencilMode`, `context.setColorMode`, and `context.setDepthMode` behave almost exactly the same as in native (the one slight difference being how we handle `blendColor`, which is set mostly as default-initialized in native, but is optional and often therefore not set here).

Benchmarks: https://bl.ocks.org/anonymous/raw/5a607b699c5f57ed705e4a7e2aa342a1/

The `LayerBackground` test does consistently look significantly slower (~1.89 ms, as opposed to previously ~0.59 ms) but I don't feel that's concerning given that most maps use one or very few background layer.

I don't feel comfortable merging this yet until I add a bunch of render tests that test various combinations of layers (which would have caught e.g. https://github.com/mapbox/mapbox-gl-js/commit/5565087ddabcc792b5b7ed5a2d500849112bd6be — I'm going to add the render test for that to a new branch off of current master).

Refs https://github.com/mapbox/mapbox-gl-js/issues/145.
Refs https://github.com/mapbox/mapbox-gl-native/pull/10655.