### PR TITLE
Mark layer "type" property as required

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -521,7 +521,8 @@
           }
         }
       },
-      "doc": "Rendering type of this layer."
+      "doc": "Rendering type of this layer.",
+      "required": true
     },
     "metadata": {
       "type": "*",

--- a/src/style-spec/validate/validate_layer.js
+++ b/src/style-spec/validate/validate_layer.js
@@ -71,10 +71,14 @@ module.exports = function validateLayer(options) {
         }
     }
 
+    // https://github.com/mapbox/mapbox-gl-js/issues/5772
+    const valueSpec = extend({}, styleSpec.layer,
+        {type: extend({}, styleSpec.layer.type, {required: false})});
+
     errors = errors.concat(validateObject({
         key: key,
         value: layer,
-        valueSpec: styleSpec.layer,
+        valueSpec,
         style: options.style,
         styleSpec: options.styleSpec,
         objectElementValidators: {

--- a/src/style-spec/validate/validate_object.js
+++ b/src/style-spec/validate/validate_object.js
@@ -47,6 +47,11 @@ module.exports = function validateObject(options) {
     }
 
     for (const elementSpecKey in elementSpecs) {
+        // Don't check `required` when there's a custom validator for that property.
+        if (elementValidators[elementSpecKey]) {
+            continue;
+        }
+
         if (elementSpecs[elementSpecKey].required && elementSpecs[elementSpecKey]['default'] === undefined && object[elementSpecKey] === undefined) {
             errors.push(new ValidationError(key, object, 'missing required property "%s"', elementSpecKey));
         }


### PR DESCRIPTION
But special-case it for validation, for backward compatibility with "ref" mechanism.

Fixes #5772.