### PR TITLE
fix #5827 unblock labels with overscaled tiles correctly

### DIFF
--- a/src/symbol/cross_tile_symbol_index.js
+++ b/src/symbol/cross_tile_symbol_index.js
@@ -187,7 +187,7 @@ class CrossTileSymbolLayerIndex {
 
         const minZoom = Math.min(25, ...(Object.keys(this.indexes): any));
 
-        for (let z = tileID.canonical.z - 1; z >= minZoom; z--) {
+        for (let z = tileID.overscaledZ - 1; z >= minZoom; z--) {
             const parentCoord = tileID.scaledTo(z);
             if (!parentCoord) break; // Flow doesn't know that z >= minZoom would prevent this
             const parentIndex = this.indexes[z] && this.indexes[z][parentCoord.key];


### PR DESCRIPTION
This fixes #5827 by using `overscaledZ` instead of `canonical.z`, letting overscaled tiles unblock labels correctly.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [N/A] write tests for all new functionality
 - [N/A] document any changes to public APIs
 - [N/A] post benchmark scores
 - [x] manually test the debug page

@jfirebaugh 