### PR TITLE
Add Color#toString, expose Color publicly, document it

### DIFF
--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -57,10 +57,10 @@ function rgba(ctx, [r, g, b, a]) {
     r = r.evaluate(ctx);
     g = g.evaluate(ctx);
     b = b.evaluate(ctx);
-    a = a && a.evaluate(ctx);
-    const error = validateRGBA(r, g, b, a);
+    const alpha = a ? a.evaluate(ctx) : 1;
+    const error = validateRGBA(r, g, b, alpha);
     if (error) throw new RuntimeError(error);
-    return new Color(r / 255, g / 255, b / 255, a);
+    return new Color(r / 255 * alpha, g / 255 * alpha, b / 255 * alpha, alpha);
 }
 
 function has(key, obj) {
@@ -101,7 +101,7 @@ CompoundExpression.register(expressions, {
             if (v === null || type === 'string' || type === 'number' || type === 'boolean') {
                 return String(v);
             } else if (v instanceof Color) {
-                return `rgba(${v.r * 255},${v.g * 255},${v.b * 255},${v.a})`;
+                return v.toString();
             } else {
                 return JSON.stringify(v);
             }
@@ -117,7 +117,7 @@ CompoundExpression.register(expressions, {
         [ColorType],
         (ctx, [v]) => {
             const {r, g, b, a} = v.evaluate(ctx);
-            return [255 * r, 255 * g, 255 * b, a];
+            return [255 * r / a, 255 * g / a, 255 * b / a, a];
         }
     ],
     'rgb': [

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -61,6 +61,7 @@ exports.ValidationError = require('./error/validation_error');
 exports.ParsingError = require('./error/parsing_error');
 exports.expression = require('./expression');
 exports.featureFilter = require('./feature_filter');
+exports.Color = require('./util/color');
 
 exports.function = require('./function');
 exports.function.convertFunction = require('./function/convert');

--- a/src/style-spec/util/color.js
+++ b/src/style-spec/util/color.js
@@ -3,8 +3,14 @@
 const {parseCSSColor} = require('csscolorparser');
 
 /**
- * An RGBA color value. All components are in the range [0, 1] and R, B, and G are premultiplied by A.
- * @private
+ * An RGBA color value. Create instances from color strings using the static
+ * method `Color.parse`. The constructor accepts RGB channel values in the range
+ * `[0, 1]`, premultiplied by A.
+ *
+ * @param {number} r The red channel.
+ * @param {number} g The green channel.
+ * @param {number} b The blue channel.
+ * @param {number} a The alpha channel.
  */
 class Color {
     r: number;
@@ -23,6 +29,10 @@ class Color {
     static white: Color;
     static transparent: Color;
 
+    /**
+     * Parses valid CSS color strings and returns a `Color` instance.
+     * @returns A `Color` instance, or `undefined` if the input is not a valid color string.
+     */
     static parse(input: ?string): Color | void {
         if (!input) {
             return undefined;
@@ -47,6 +57,22 @@ class Color {
             rgba[2] / 255 * rgba[3],
             rgba[3]
         );
+    }
+
+    /**
+     * Returns an RGBA string representing the color value.
+     *
+     * @returns An RGBA string.
+     * @example
+     * var purple = new Color.parse('purple');
+     * purple.toString; // = "rgba(128,0,128,1)"
+     * var translucentGreen = new Color.parse('rgba(26, 207, 26, .73)');
+     * translucentGreen.toString(); // = "rgba(26,207,26,0.73)"
+     */
+    toString(): string {
+        const transformRgb = (value: number) => Math.round(value * 255 / this.a);
+        const rgb = [this.r, this.g, this.b].map(transformRgb);
+        return `rgba(${rgb.concat(this.a).join(',')})`;
     }
 }
 

--- a/test/integration/expression-tests/to-rgba/alpha/test.json
+++ b/test/integration/expression-tests/to-rgba/alpha/test.json
@@ -1,0 +1,15 @@
+{
+  "expression": ["to-rgba", ["rgba", 0, 128, 255, 0.5]],
+  "inputs": [
+    [{}, {}]
+  ],
+  "expected": {
+    "outputs": [[0, 128, 255, 0.5]],
+    "compiled": {
+      "result": "success",
+      "isZoomConstant": true,
+      "isFeatureConstant": true,
+      "type": "array<number, 4>"
+    }
+  }
+}

--- a/test/unit/style-spec/color.js
+++ b/test/unit/style-spec/color.js
@@ -13,3 +13,11 @@ test('Color.parse', (t) => {
     t.deepEqual(Color.parse(undefined), undefined);
     t.end();
 });
+
+test('Color#toString', (t) => {
+    const purple = Color.parse('purple');
+    t.equal(purple && purple.toString(), 'rgba(128,0,128,1)');
+    const translucentGreen = Color.parse('rgba(26, 207, 26, .73)');
+    t.equal(translucentGreen && translucentGreen.toString(), 'rgba(26,207,26,0.73)');
+    t.end();
+});


### PR DESCRIPTION
@jfirebaugh We chatted earlier today about converting `Color` instances to `rgba` strings.

- Adds `Color#toString`.
- Exposes the `Color` class publicly.
- Documents the `Color` class.

Here are screenshots of the documentation:

<img width="762" alt="screen shot 2017-12-14 at 1 39 20 pm" src="https://user-images.githubusercontent.com/628431/34013406-a584abb8-e0d4-11e7-9ede-2f704c09e152.png">
<img width="761" alt="screen shot 2017-12-14 at 1 39 25 pm" src="https://user-images.githubusercontent.com/628431/34013407-a5a133b4-e0d4-11e7-8d7c-ac8c01e2bf09.png">

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
