### PR TITLE
Don't call tile.added() for tiles that have been removed from the render tree

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -256,8 +256,11 @@ class SourceCache extends Evented {
         if (this.map) this.map.painter.tileExtentVAO.vao = null;
 
         this._updatePlacement();
-        if (this.map)
+        if (this.map && this.getTileByID(id)) {
+            // Only add this tile to the CrossTileSymbolIndex if it is still in the retain set
+            // See issue #5837
             tile.added(this.map.painter.crossTileSymbolIndex);
+        }
     }
 
     /**

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -249,6 +249,23 @@ test('SourceCache#removeTile', (t) => {
         t.end();
     });
 
+    t.test('_tileLoaded after _removeTile skips tile.added', (t) => {
+        const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
+
+        const sourceCache = createSourceCache({
+            loadTile: function(tile, callback) {
+                tile.added = t.notOk();
+                sourceCache._removeTile(tileID.key);
+                callback();
+            }
+        });
+        sourceCache.map = { painter: { crossTileSymbolIndex: "", tileExtentVAO: {} } };
+
+        sourceCache._addTile(tileID);
+
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Fixes issue #5837, which could cause symbols to be incorrectly hidden.

This is a temporary patch while we wait for the back-port from gl-native of the new `CrossTileSymbolIndex` approach.

/cc @ttsirkia @ansis @jfirebaugh 