### PR TITLE
v0.43.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## 0.43.0-beta.1 (December 14, 2017)
+
+### ⚠️ Breaking changes
+
+* It is now an error to attempt to remove a source that is in use [#5562](https://github.com/mapbox/mapbox-gl-js/pull/5562)
+* It is now an error if the layer specified by the `before` parameter to `moveLayer` does not exist [#5679](https://github.com/mapbox/mapbox-gl-js/pull/5679)
+* `"colorSpace": "hcl"` now uses shortest-path interpolation for hue [#5811](https://github.com/mapbox/mapbox-gl-js/issues/5811)
+
+### ✨ Features and improvements
+
+* Introduce client-side hillshading with `raster-dem` source type and `hillshade` layer type [#5286](https://github.com/mapbox/mapbox-gl-js/pull/5286)
+* GeoJSON sources take 2x less memory and generate tiles 20%–100% faster [#5799](https://github.com/mapbox/mapbox-gl-js/pull/5799)
+* Enable data-driven values for text-font [#5698](https://github.com/mapbox/mapbox-gl-js/pull/5698)
+* Add getter and setter for offset on marker [#5759](https://github.com/mapbox/mapbox-gl-js/pull/5759)
+* Add `Map#hasImage` [#5775](https://github.com/mapbox/mapbox-gl-js/pull/5775)
+* Improve typing for `==` and `!=` expressions [#5840](https://github.com/mapbox/mapbox-gl-js/pull/5840)
+* Made `coalesce` expressions more useful [#5755](https://github.com/mapbox/mapbox-gl-js/issues/5755)
+* Enable implicit type assertions for array types [#5738](https://github.com/mapbox/mapbox-gl-js/pull/5738)
+* Improve hash control precision [#5767](https://github.com/mapbox/mapbox-gl-js/pull/5767)
+* `supported()` now returns false on old IE 11 versions that don't support Web Worker blob URLs [#5801](https://github.com/mapbox/mapbox-gl-js/pull/5801)
+* Remove flow globals TileJSON and Transferable [#5668](https://github.com/mapbox/mapbox-gl-js/pull/5668)
+* Improve performance of image, video, and canvas sources [#5845](https://github.com/mapbox/mapbox-gl-js/pull/5845)
+
+### 🐛 Bug fixes
+
+* Fix popups and markers lag during pan animation [#4670](https://github.com/mapbox/mapbox-gl-js/issues/4670)
+* Fix fading of symbol layers caused by setData [#5716](https://github.com/mapbox/mapbox-gl-js/issues/5716)
+* Fix behavior of `to-rgba` and `rgba` expressions [#5778](https://github.com/mapbox/mapbox-gl-js/pull/5778), [#5866](https://github.com/mapbox/mapbox-gl-js/pull/5866)
+* Fix cross-fading of `*-pattern` and `line-dasharray` [#5791](https://github.com/mapbox/mapbox-gl-js/pull/5791)
+* Fix `colorSpace` function property [#5843](https://github.com/mapbox/mapbox-gl-js/pull/5843)
+* Fix style diffing when changing GeoJSON source properties [#5731](https://github.com/mapbox/mapbox-gl-js/issues/5731)
+* Fix missing labels when zooming out from overzoomed tile [#5827](https://github.com/mapbox/mapbox-gl-js/issues/5827)
+* Fix missing labels when zooming out and quickly using setData [#5837](https://github.com/mapbox/mapbox-gl-js/issues/5837)
+* Handle NaN as input to step and interpolate expressions [#5757](https://github.com/mapbox/mapbox-gl-js/pull/5757)
+* Clone property values on input and output [#5806](https://github.com/mapbox/mapbox-gl-js/pull/5806)
+* Bump geojson-rewind dependency [#5769](https://github.com/mapbox/mapbox-gl-js/pull/5769)
+
 ## 0.42.2 (November 21, 2017)
 
 ### 🐛 Bug fixes

--- a/docs/pages/roadmap.js
+++ b/docs/pages/roadmap.js
@@ -10,7 +10,7 @@ const meta = {
 };
 
 const roadmap = {
-    "updated_at": "August 1, 2017",
+    "updated_at": "November 25, 2017",
     "roadmap_items": [
         {
             "term": "Active",
@@ -21,25 +21,6 @@ const roadmap = {
                     "issues": [
                         "3730",
                         "4701"
-                    ]
-                },
-                {
-                    "name": "Arbitrary expressions for property functions",
-                    "issues": [
-                        "4715"
-                    ]
-                },
-                {
-                    "name": "Viewport label placement",
-                    "issues": [
-                        "4704",
-                        "#4972"
-                    ]
-                },
-                {
-                    "name": "Heatmaps",
-                    "issues": [
-                        "4756"
                     ]
                 }
             ]

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -5,7 +5,7 @@ import md from '../components/md';
 import PageShell from '../components/page_shell';
 import LeftNav from '../components/left_nav';
 import TopNav from '../components/top_nav';
-import {highlightJavascript, highlightJSON} from '../components/prism_highlight';
+import {highlightJavascript, highlightJSON, highlightMarkup} from '../components/prism_highlight';
 import entries from 'object.entries';
 
 const ref = require('../../src/style-spec/reference/latest');
@@ -469,12 +469,12 @@ export default class extends React.Component {
                                     than use <a href='https://www.mapbox.com/studio'>Mapbox Studio</a></li>
                                 <li>Developers using style-related features of <a
                                     href='https://www.mapbox.com/mapbox-gl-js/'>Mapbox GL JS</a> or the <a
-                                    href='https://www.mapbox.com/android-sdk/'>Mapbox Android SDK</a></li>
+                                    href='https://www.mapbox.com/android-sdk/'>Mapbox Maps SDK for Android</a></li>
                                 <li>Authors of software that generates or processes Mapbox styles.</li>
                             </ul>
-                            <p>Developers using the <a href='https://www.mapbox.com/ios-sdk/'>Mapbox iOS SDK</a> or <a
-                                href='https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/'>Mapbox
-                                macOS SDK</a> should consult the iOS SDK API reference for platform-appropriate
+                            <p>Developers using the <a href='https://www.mapbox.com/ios-sdk/'>Mapbox Maps SDK for iOS</a> or <a
+                                href='https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/'>
+                                Mapbox Maps SDK for macOS</a> should consult the iOS SDK API reference for platform-appropriate
                                 documentation of style-related features.</p>
                         </div>
 
@@ -889,12 +889,12 @@ export default class extends React.Component {
                                         If an HTML document contains a canvas such as this:
                                     </p>
                                     <div className='space-bottom1 clearfix'>
-                                        &lt;canvas id="mycanvas" width="400" height="300" style="display: none;"&gt;&lt;/canvas&gt;
+                                        {highlightMarkup(`<canvas id="mycanvas" width="400" height="300" style="display: none;"/>`)}
                                     </div>
                                     <p>
                                         the corresponding canvas source would be specified as follows:
                                     </p>
-                                    <div>
+                                    <div className='space-bottom1 clearfix'>
                                         {highlightJSON(`
                                             "canvas": {
                                                 "type": "canvas",
@@ -907,6 +907,10 @@ export default class extends React.Component {
                                                 ]
                                             }`)}
                                     </div>
+                                    <p>
+                                        This source type is available only in Mapbox GL JS. Avoid using it in styles that need to maintain
+                                        compatibility with other Mapbox Maps SDKs.
+                                    </p>
                                     <div className='space-bottom1 clearfix'>
                                         { entries(ref.source_canvas).map(([name, prop], i) =>
                                             name !== '*' && name !== 'type' &&
@@ -1731,7 +1735,7 @@ export default class extends React.Component {
                                 </div>
 
                                 <div className='pad2'>
-                                    <a id='#other-filter' className='anchor'></a>
+                                    <a id='other-filter' className='anchor'></a>
                                     <h3 className='space-bottom1'><a href='#other-filter' title='link to filter'>Filter</a></h3>
                                     <p>A filter selects specific features from a layer. A filter is defined using any boolean <a href="#types-expression">expression</a>. In previous versions of the style specification, filters were defined using the deprecated syntax documented below:</p>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "0.42.2",
+  "version": "0.43.0-beta.1",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -33,7 +33,7 @@
       "default": 0,
       "period": 360,
       "units": "degrees",
-      "doc": "Default bearing, in degrees clockwise from true north.  The style bearing will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
+      "doc": "Default bearing, in degrees. The bearing is the compass direction that is \"up\"; for example, a bearing of 90° orients the map so that east is up. This value will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
       "example": 29
     },
     "pitch": {
@@ -3277,7 +3277,7 @@
       "function": "interpolated",
       "zoom-function": false,
       "property-function": false,
-      "transition": true,
+      "transition": false,
       "sdk-support": {
         "basic functionality": {
           "js": "0.41.0"

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -20,8 +20,8 @@ import type {LngLatBoundsLike} from '../geo/lng_lat_bounds';
  * @typedef {Object} CameraOptions
  * @property {LngLatLike} center The desired center.
  * @property {number} zoom The desired zoom level.
- * @property {number} bearing The desired bearing, in degrees counter-clockwise from north. A `bearing` of 90° orients the map
- * so that east is up.
+ * @property {number} bearing The desired bearing, in degrees. The bearing is the compass direction that
+ * is "up"; for example, a bearing of 90° orients the map so that east is up.
  * @property {number} pitch The desired pitch, in degrees.
  * @property {LngLatLike} around If `zoom` is specified, `around` determines the point around which the zoom is centered.
  */
@@ -235,19 +235,23 @@ class Camera extends Evented {
     }
 
     /**
-     * Returns the map's current bearing (rotation).
+     * Returns the map's current bearing. The bearing is the compass direction that is \"up\"; for example, a bearing
+     * of 90° orients the map so that east is up.
      *
      * @memberof Map#
-     * @returns The map's current bearing, measured in degrees counter-clockwise from north.
+     * @returns The map's current bearing.
      * @see [Navigate the map with game-like controls](https://www.mapbox.com/mapbox-gl-js/example/game-controls/)
      */
     getBearing(): number { return this.transform.bearing; }
 
     /**
-     * Sets the maps' bearing (rotation). Equivalent to `jumpTo({bearing: bearing})`.
+     * Sets the map's bearing (rotation). The bearing is the compass direction that is \"up\"; for example, a bearing
+     * of 90° orients the map so that east is up.
+     *
+     * Equivalent to `jumpTo({bearing: bearing})`.
      *
      * @memberof Map#
-     * @param bearing The bearing to set, measured in degrees counter-clockwise from north.
+     * @param bearing The desired bearing.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
@@ -262,10 +266,11 @@ class Camera extends Evented {
     }
 
     /**
-     * Rotates the map to the specified bearing, with an animated transition.
+     * Rotates the map to the specified bearing, with an animated transition. The bearing is the compass direction
+     * that is \"up\"; for example, a bearing of 90° orients the map so that east is up.
      *
      * @memberof Map#
-     * @param bearing The bearing to rotate the map to, measured in degrees counter-clockwise from north.
+     * @param bearing The desired bearing.
      * @param options
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
@@ -279,7 +284,7 @@ class Camera extends Evented {
     }
 
     /**
-     * Rotates the map to a bearing of 0 (due north), with an animated transition.
+     * Rotates the map so that north is up (0° bearing), with an animated transition.
      *
      * @memberof Map#
      * @param options
@@ -294,7 +299,8 @@ class Camera extends Evented {
     }
 
     /**
-     * Snaps the map's bearing to 0 (due north), if the current bearing is close enough to it (i.e. within the `bearingSnap` threshold).
+     * Snaps the map so that north is up (0° bearing), if the current bearing is close enough to it (i.e. within the
+     * `bearingSnap` threshold).
      *
      * @memberof Map#
      * @param options

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -20,7 +20,7 @@ const inertiaLinearity = 0.25,
  * @param {Map} map The Mapbox GL JS map to add the handler to.
  * @param {Object} [options]
  * @param {number} [options.bearingSnap] The threshold, measured in degrees, that determines when the map's
- *   bearing (rotation) will snap to north.
+ *   bearing will snap to north.
  * @param {bool} [options.pitchWithRotate=true] Control the map pitch in addition to the bearing
  */
 class DragRotateHandler {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -164,7 +164,7 @@ const defaultOptions = {
  *   For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
  * @param {boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners will be attached to the map, so it will not respond to interaction.
  * @param {number} [options.bearingSnap=7] The threshold, measured in degrees, that determines when the map's
- *   bearing (rotation) will snap to north. For example, with a `bearingSnap` of 7, if the user rotates
+ *   bearing will snap to north. For example, with a `bearingSnap` of 7, if the user rotates
  *   the map within 7 degrees of north, the map will automatically snap to exact north.
  * @param {boolean} [options.pitchWithRotate=true] If `false`, the map's pitch (tilt) control with "drag to rotate" interaction will be disabled.
  * @param {boolean} [options.attributionControl=true] If `true`, an {@link AttributionControl} will be added to the map.

--- a/vendor/dotcom-page-shell/react-page-shell.js
+++ b/vendor/dotcom-page-shell/react-page-shell.js
@@ -723,28 +723,28 @@ var navigationMenuData = {
     documentation: {
       name: 'Documentation',
       links: [{
-        name: 'iOS SDK',
-        to: '/ios-sdk/',
-        hideInHeader: true
-      }, {
-        name: 'Android SDK',
-        to: '/android-docs/map-sdk/overview/',
-        hideInHeader: true
-      }, {
-        name: 'Navigation SDK',
-        to: '/navigation-sdk/',
-        hideInHeader: true
-      }, {
         name: 'GL JS',
         to: '/mapbox-gl-js/api/',
         hideInHeader: true
       }, {
-        name: 'Unity SDK',
+        name: 'Maps SDK - iOS',
+        to: '/ios-sdk/',
+        hideInHeader: true
+      }, {
+        name: 'Maps SDK - Android',
+        to: '/android-docs/map-sdk/overview/',
+        hideInHeader: true
+      }, {
+        name: 'Maps SDK - Unity',
         to: '/unity-sdk/',
         hideInHeader: true
       }, {
-        name: 'Qt SDK',
+        name: 'Maps SDK - Qt',
         to: '/qt/',
+        hideInHeader: true
+      }, {
+        name: 'Navigation SDK',
+        to: '/navigation-sdk/',
         hideInHeader: true
       }],
       highlightedLinks: [{
@@ -763,25 +763,25 @@ var navigationMenuData = {
     }
   },
   sdkDocumentationMenu: {
-    name: 'SDK Documentation',
+    name: 'SDK & Plugin Documentation',
     links: [{
-      name: 'iOS SDK',
-      to: '/ios-sdk/'
-    }, {
-      name: 'Android SDK',
-      to: '/android-docs/map-sdk/overview/'
-    }, {
-      name: 'Navigation SDK',
-      to: '/navigation-sdk/'
-    }, {
-      name: 'Unity SDK',
-      to: '/unity-sdk/'
-    }, {
       name: 'GL JS',
       to: '/mapbox-gl-js/api/'
     }, {
-      name: 'Qt SDK',
+      name: 'Maps SDK - iOS',
+      to: '/ios-sdk/'
+    }, {
+      name: 'Maps SDK - Android',
+      to: '/android-docs/map-sdk/overview/'
+    }, {
+      name: 'Maps SDK - Unity',
+      to: '/unity-sdk/'
+    }, {
+      name: 'Maps SDK - Qt',
       to: '/qt/'
+    }, {
+      name: 'Navigation SDK',
+      to: '/navigation-sdk/'
     }],
     highlightedLinks: []
   },
@@ -2079,15 +2079,31 @@ var FooterSocialMediaStrip = function (_React$Component) {
         React.createElement(
           'a',
           {
+            'aria-label': 'Github',
+            className: 'shell-color-blue shell-color-gray-dark-on-hover',
+            href: 'https://github.com/mapbox'
+          },
+          React.createElement(
+            'svg',
+            {
+              viewBox: '0 0 1790 1790',
+              className: 'shell-mr18 shell-icon shell-icon--s shell-inline'
+            },
+            React.createElement('path', { d: 'M704 1216q0 40-12.5 82t-43 76-72.5 34-72.5-34-43-76-12.5-82 12.5-82 43-76 72.5-34 72.5 34 43 76 12.5 82zm640 0q0 40-12.5 82t-43 76-72.5 34-72.5-34-43-76-12.5-82 12.5-82 43-76 72.5-34 72.5 34 43 76 12.5 82zm160 0q0-120-69-204t-187-84q-41 0-195 21-71 11-157 11t-157-11q-152-21-195-21-118 0-187 84t-69 204q0 88 32 153.5t81 103 122 60 140 29.5 149 7h168q82 0 149-7t140-29.5 122-60 81-103 32-153.5zm224-176q0 207-61 331-38 77-105.5 133t-141 86-170 47.5-171.5 22-167 4.5q-78 0-142-3t-147.5-12.5-152.5-30-137-51.5-121-81-86-115q-62-123-62-331 0-237 136-396-27-82-27-170 0-116 51-218 108 0 190 39.5t189 123.5q147-35 309-35 148 0 280 32 105-82 187-121t189-39q51 102 51 218 0 87-27 168 136 160 136 398z' })
+          )
+        ),
+        React.createElement(
+          'a',
+          {
             'aria-label': 'Twitter',
-            className: 'shell-mr18 shell-color-blue shell-color-gray-dark-on-hover',
+            className: 'shell-color-blue shell-color-gray-dark-on-hover ',
             href: 'https://twitter.com/mapbox/'
           },
           React.createElement(
             'svg',
             {
               viewBox: '0 0 50 50',
-              className: 'shell-icon shell-icon--s shell-inline'
+              className: 'shell-mr18 shell-icon shell-icon--s shell-inline'
             },
             React.createElement(
               'g',
@@ -2100,14 +2116,14 @@ var FooterSocialMediaStrip = function (_React$Component) {
           'a',
           {
             'aria-label': 'LinkedIn',
-            className: 'shell-mr18 shell-color-blue shell-color-gray-dark-on-hover',
+            className: 'shell-color-blue shell-color-gray-dark-on-hover',
             href: 'https://www.linkedin.com/company/mapbox'
           },
           React.createElement(
             'svg',
             {
               viewBox: '0 0 50 50',
-              className: 'shell-icon shell-icon--s shell-inline'
+              className: 'shell-mr18 shell-icon shell-icon--s shell-inline'
             },
             React.createElement(
               'g',
@@ -2122,14 +2138,14 @@ var FooterSocialMediaStrip = function (_React$Component) {
           'a',
           {
             'aria-label': 'Facebook',
-            className: 'shell-mr18 shell-color-blue shell-color-gray-dark-on-hover',
+            className: 'shell-color-blue shell-color-gray-dark-on-hover',
             href: 'https://www.facebook.com/Mapbox'
           },
           React.createElement(
             'svg',
             {
               viewBox: '0 0 50 50',
-              className: 'shell-icon shell-icon--s shell-inline'
+              className: 'shell-mr18 shell-icon shell-icon--s shell-inline'
             },
             React.createElement(
               'g',
@@ -2139,6 +2155,30 @@ var FooterSocialMediaStrip = function (_React$Component) {
                 'data-name': 'f',
                 d: 'M28.87,50V27.19h7.65l1.15-8.89h-8.8V12.63c0-2.57.71-4.33,4.41-4.33H38v-8A63.78,63.78,0,0,0,31.13,0C24.34,0,19.69,4.14,19.69,11.75V18.3H12v8.89h7.68V50Z'
               })
+            )
+          )
+        ),
+        React.createElement(
+          'a',
+          {
+            'aria-label': 'Dribbble',
+            className: 'shell-color-blue shell-color-gray-dark-on-hover',
+            href: 'https://dribbble.com/mapbox'
+          },
+          React.createElement(
+            'svg',
+            {
+              viewBox: '0 0 216 216',
+              className: 'shell-mr18 shell-icon shell-icon--s shell-inline'
+            },
+            React.createElement(
+              'g',
+              { id: 'bce6e84c-15aa-4744-93d1-a9e4a673398a', 'data-name': 'ball' },
+              React.createElement(
+                'g',
+                { id: '99079e24-a239-40f3-bf61-84ebc8f0b2ce', 'data-name': 'ball' },
+                React.createElement('path', { d: 'M108,15.78a92.16,92.16,0,1,0,92.16,92.16A92.27,92.27,0,0,0,108,15.78ZM169,58.28a78.31,78.31,0,0,1,17.78,49c-2.6-.55-28.62-5.83-54.81-2.54-.55-1.35-1.12-2.7-1.7-4.06-1.63-3.84-3.39-7.65-5.22-11.4C154.1,77.44,167.29,60.53,169,58.28ZM108,29.34A78.41,78.41,0,0,1,160.2,49.18c-1.41,2-13.26,17.94-41.25,28.43A421.91,421.91,0,0,0,89.58,31.53,79,79,0,0,1,108,29.34ZM74.56,36.82a503.63,503.63,0,0,1,29.18,45.53A293.82,293.82,0,0,1,31,91.94,79,79,0,0,1,74.56,36.82ZM29.31,108.06c0-.8,0-1.61,0-2.41,3.44.08,41.59.57,80.9-11.2,2.25,4.41,4.4,8.89,6.38,13.36-1,.29-2.08.61-3.1.94-40.6,13.12-62.2,48.89-64,51.94A78.39,78.39,0,0,1,29.31,108.06ZM108,186.78a78.29,78.29,0,0,1-48.31-16.62c1.41-2.9,17.35-33.69,61.75-49.16l.52-.17a326.92,326.92,0,0,1,16.79,59.69A78.19,78.19,0,0,1,108,186.78Zm44-13.47a338.31,338.31,0,0,0-15.29-56.12c24.67-4,46.34,2.51,49,3.36A78.84,78.84,0,0,1,152,173.31Z' })
+              )
             )
           )
         ),
@@ -2336,7 +2376,7 @@ var MetaTagger = function (_React$PureComponent) {
 
       var metaItems = [{ name: 'description', content: preppedDescription }];
 
-      metaItems.push({ name: 'twitter:title', content: props.title }, { name: 'og:title', content: props.title }, { name: 'twitter:description', content: preppedDescription }, { name: 'og:description', content: preppedDescription }, { name: 'og:url', content: prodUrl }, { name: 'og:type', content: 'website' }, {
+      metaItems.push({ name: 'twitter:title', content: props.title }, { property: 'og:title', content: props.title }, { name: 'twitter:description', content: preppedDescription }, { property: 'og:description', content: preppedDescription }, { property: 'og:url', content: prodUrl }, { property: 'og:type', content: 'website' }, {
         class: 'swiftype',
         name: 'title',
         'data-type': 'string',
@@ -2346,7 +2386,7 @@ var MetaTagger = function (_React$PureComponent) {
         name: 'excerpt',
         'data-type': 'string',
         content: props.description
-      }, { name: 'twitter:image:alt', content: props.imageAlt }, { name: 'og:image', content: props.imageUrl }, {
+      }, { name: 'twitter:image:alt', content: props.imageAlt }, { property: 'og:image', content: props.imageUrl }, {
         class: 'swiftype',
         name: 'image',
         'data-type': 'enum',


### PR DESCRIPTION
🌞 ⛰  🎉  Hi all! The next release is going to be a big one, with the marquee feature being **client-side hillshading**. 

| Before | After |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/98601/34019860-b5b08c44-e0e5-11e7-9817-8e3f467fae49.png) | ![image](https://user-images.githubusercontent.com/98601/34019869-bfa29eea-e0e5-11e7-941d-7837ebbb3b9a.png) |

To ensure the final release is as solid as possible, we're doing a brief beta period. Today we're releasing `v0.43.0-beta.1`, and we aim to release `v0.43.0` in about a week. We hope you'll give the beta a spin, try out the new features, and let us know if you spot any issues. In particular, I'd like to give a shout out to recently active contributors @andrewharvey, @vicapow, @jingsam, @stevage, @bartvde, @musicformellons, and @pathmapper. Your PRs and bug reports have been great, and we'd love it if you tried out the beta.

The complete changelog follows. The release will be available on npm and the CDN shortly after this PR is merged.

## 0.43.0-beta.1 (December 14, 2017)

### ⚠️ Breaking changes

* It is now an error to attempt to remove a source that is in use [#5562](https://github.com/mapbox/mapbox-gl-js/pull/5562)
* It is now an error if the layer specified by the `before` parameter to `moveLayer` does not exist [#5679](https://github.com/mapbox/mapbox-gl-js/pull/5679)
* `"colorSpace": "hcl"` now uses shortest-path interpolation for hue [#5811](https://github.com/mapbox/mapbox-gl-js/issues/5811)

### ✨ Features and improvements

* Introduce client-side hillshading with `raster-dem` source type and `hillshade` layer type [#5286](https://github.com/mapbox/mapbox-gl-js/pull/5286)
* GeoJSON sources take 2x less memory and generate tiles 20%–100% faster [#5799](https://github.com/mapbox/mapbox-gl-js/pull/5799)
* Enable data-driven values for text-font [#5698](https://github.com/mapbox/mapbox-gl-js/pull/5698)
* Add getter and setter for offset on marker [#5759](https://github.com/mapbox/mapbox-gl-js/pull/5759)
* Add `Map#hasImage` [#5775](https://github.com/mapbox/mapbox-gl-js/pull/5775)
* Improve typing for `==` and `!=` expressions [#5840](https://github.com/mapbox/mapbox-gl-js/pull/5840)
* Made `coalesce` expressions more useful [#5755](https://github.com/mapbox/mapbox-gl-js/issues/5755)
* Enable implicit type assertions for array types [#5738](https://github.com/mapbox/mapbox-gl-js/pull/5738)
* Improve hash control precision [#5767](https://github.com/mapbox/mapbox-gl-js/pull/5767)
* `supported()` now returns false on old IE 11 versions that don't support Web Worker blob URLs [#5801](https://github.com/mapbox/mapbox-gl-js/pull/5801)
* Remove flow globals TileJSON and Transferable [#5668](https://github.com/mapbox/mapbox-gl-js/pull/5668)
* Improve performance of image, video, and canvas sources [#5845](https://github.com/mapbox/mapbox-gl-js/pull/5845)

### 🐛 Bug fixes

* Fix popups and markers lag during pan animation [#4670](https://github.com/mapbox/mapbox-gl-js/issues/4670)
* Fix fading of symbol layers caused by setData [#5716](https://github.com/mapbox/mapbox-gl-js/issues/5716)
* Fix behavior of `to-rgba` and `rgba` expressions [#5778](https://github.com/mapbox/mapbox-gl-js/pull/5778), [#5866](https://github.com/mapbox/mapbox-gl-js/pull/5866)
* Fix cross-fading of `*-pattern` and `line-dasharray` [#5791](https://github.com/mapbox/mapbox-gl-js/pull/5791)
* Fix `colorSpace` function property [#5843](https://github.com/mapbox/mapbox-gl-js/pull/5843)
* Fix style diffing when changing GeoJSON source properties [#5731](https://github.com/mapbox/mapbox-gl-js/issues/5731)
* Fix missing labels when zooming out from overzoomed tile [#5827](https://github.com/mapbox/mapbox-gl-js/issues/5827)
* Fix missing labels when zooming out and quickly using setData [#5837](https://github.com/mapbox/mapbox-gl-js/issues/5837)
* Handle NaN as input to step and interpolate expressions [#5757](https://github.com/mapbox/mapbox-gl-js/pull/5757)
* Clone property values on input and output [#5806](https://github.com/mapbox/mapbox-gl-js/pull/5806)
* Bump geojson-rewind dependency [#5769](https://github.com/mapbox/mapbox-gl-js/pull/5769)
