### PR TITLE
Fix draw fns' program equality checking to fix redundant setUniforms calls

### DIFF
--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -39,9 +39,12 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
         const bucket: ?CircleBucket<*> = (tile.getBucket(layer): any);
         if (!bucket) continue;
 
+        const prevProgram = painter.context.program.get();
         const programConfiguration = bucket.programConfigurations.get(layer.id);
         const program = painter.useProgram('circle', programConfiguration);
-        programConfiguration.setUniforms(context, program, layer.paint, {zoom: painter.transform.zoom});
+        if (i === 0 || program.program !== prevProgram) {
+            programConfiguration.setUniforms(context, program, layer.paint, {zoom: painter.transform.zoom});
+        }
 
         gl.uniform1f(program.uniforms.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);
         gl.uniform1i(program.uniforms.u_scale_with_map, layer.paint.get('circle-pitch-scale') === 'map' ? 1 : 0);

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -32,6 +32,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
     context.setStencilMode(StencilMode.disabled());
     context.setColorMode(painter.colorModeForRenderPass());
 
+    let first = true;
     for (let i = 0; i < coords.length; i++) {
         const coord = coords[i];
 
@@ -42,8 +43,9 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
         const prevProgram = painter.context.program.get();
         const programConfiguration = bucket.programConfigurations.get(layer.id);
         const program = painter.useProgram('circle', programConfiguration);
-        if (i === 0 || program.program !== prevProgram) {
+        if (first || program.program !== prevProgram) {
             programConfiguration.setUniforms(context, program, layer.paint, {zoom: painter.transform.zoom});
+            first = false;
         }
 
         gl.uniform1f(program.uniforms.u_camera_to_center_distance, painter.transform.cameraToCenterDistance);

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -105,15 +105,15 @@ function drawStrokeTile(painter, sourceCache, layer, tile, coord, bucket, firstT
 
 function setFillProgram(programId, pat: ?CrossFaded<string>, painter, programConfiguration, layer, tile, coord, firstTile) {
     let program;
-    const prevProgram = painter.currentProgram;
+    const prevProgram = painter.context.program.get();
     if (!pat) {
         program = painter.useProgram(programId, programConfiguration);
-        if (firstTile || program !== prevProgram) {
+        if (firstTile || program.program !== prevProgram) {
             programConfiguration.setUniforms(painter.context, program, layer.paint, {zoom: painter.transform.zoom});
         }
     } else {
         program = painter.useProgram(`${programId}Pattern`, programConfiguration);
-        if (firstTile || program !== prevProgram) {
+        if (firstTile || program.program !== prevProgram) {
             programConfiguration.setUniforms(painter.context, program, layer.paint, {zoom: painter.transform.zoom});
             pattern.prepare(pat, painter, program);
         }

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -27,7 +27,7 @@ function draw(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLa
         drawToExtrusionFramebuffer(painter, layer);
 
         for (let i = 0; i < coords.length; i++) {
-            drawExtrusion(painter, source, layer, coords[i]);
+            drawExtrusion(painter, source, layer, coords[i], i);
         }
     } else if (painter.renderPass === 'translucent') {
         drawExtrusionTexture(painter, layer);
@@ -95,7 +95,7 @@ function drawExtrusionTexture(painter, layer) {
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
 }
 
-function drawExtrusion(painter, source, layer, coord) {
+function drawExtrusion(painter, source, layer, coord, i) {
     const tile = source.getTile(coord);
     const bucket: ?FillExtrusionBucket = (tile.getBucket(layer): any);
     if (!bucket) return;
@@ -105,9 +105,12 @@ function drawExtrusion(painter, source, layer, coord) {
 
     const image = layer.paint.get('fill-extrusion-pattern');
 
+    const prevProgram = painter.context.program.get();
     const programConfiguration = bucket.programConfigurations.get(layer.id);
     const program = painter.useProgram(image ? 'fillExtrusionPattern' : 'fillExtrusion', programConfiguration);
-    programConfiguration.setUniforms(context, program, layer.paint, {zoom: painter.transform.zoom});
+    if (i === 0 || program.program !== prevProgram) {
+        programConfiguration.setUniforms(context, program, layer.paint, {zoom: painter.transform.zoom});
+    }
 
     if (image) {
         if (pattern.isPatternMissing(image, painter)) return;

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -52,10 +52,13 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
             const bucket: ?HeatmapBucket = (tile.getBucket(layer): any);
             if (!bucket) continue;
 
+            const prevProgram = painter.context.program.get();
             const programConfiguration = bucket.programConfigurations.get(layer.id);
             const program = painter.useProgram('heatmap', programConfiguration);
             const {zoom} = painter.transform;
-            programConfiguration.setUniforms(painter.context, program, layer.paint, {zoom});
+            if (i === 0 || program.program !== prevProgram) {
+                programConfiguration.setUniforms(painter.context, program, layer.paint, {zoom});
+            }
             gl.uniform1f(program.uniforms.u_radius, layer.paint.get('heatmap-radius'));
 
             gl.uniform1f(program.uniforms.u_extrude_scale, pixelsToTileUnits(tile, 1, zoom));

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -40,6 +40,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
             blendFunction: [gl.ONE, gl.ONE]
         }));
 
+        let first;
         for (let i = 0; i < coords.length; i++) {
             const coord = coords[i];
 
@@ -56,8 +57,9 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
             const programConfiguration = bucket.programConfigurations.get(layer.id);
             const program = painter.useProgram('heatmap', programConfiguration);
             const {zoom} = painter.transform;
-            if (i === 0 || program.program !== prevProgram) {
+            if (first || program.program !== prevProgram) {
                 programConfiguration.setUniforms(painter.context, program, layer.paint, {zoom});
+                first = false;
             }
             gl.uniform1f(program.uniforms.u_radius, layer.paint.get('heatmap-radius'));
 

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -40,7 +40,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
             blendFunction: [gl.ONE, gl.ONE]
         }));
 
-        let first;
+        let first = true;
         for (let i = 0; i < coords.length; i++) {
             const coord = coords[i];
 

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -34,9 +34,9 @@ module.exports = function drawLine(painter: Painter, sourceCache: SourceCache, l
         if (!bucket) continue;
 
         const programConfiguration = bucket.programConfigurations.get(layer.id);
-        const prevProgram = painter.currentProgram;
+        const prevProgram = painter.context.program.get();
         const program = painter.useProgram(programId, programConfiguration);
-        const programChanged = firstTile || program !== prevProgram;
+        const programChanged = firstTile || program.program !== prevProgram;
         const tileRatioChanged = prevTileZoom !== tile.tileID.overscaledZ;
 
         if (programChanged) {

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -94,7 +94,6 @@ class Painter {
     id: string;
     _showOverdrawInspector: boolean;
     cache: { [string]: Program };
-    currentProgram: Program;
     crossTileSymbolIndex: CrossTileSymbolIndex;
 
     constructor(gl: WebGLRenderingContext, transform: Transform) {


### PR DESCRIPTION
`drawFill` and `drawLine` were both checking program equality against a reference that was removed in https://github.com/mapbox/mapbox-gl-js/commit/98b521343207bc9a9c0182059e59185639a30f6b. This PR updates those references and adds a similar program equality check to other draw functions that call `setUniforms`.
This regains a bit of performance as compared to current master ([paint benchmark](https://bl.ocks.org/anonymous/raw/22ac5c15e127fecac6eba34019df9921/)), but not the [full 0.42.2 &rarr; 0.43.0-beta.1 difference](https://github.com/mapbox/mapbox-gl-js/issues/5865) ([paint benchmark :(](https://bl.ocks.org/anonymous/raw/d90a146752318c53cdd3dd668e52ee8e/)).