### PR TITLE
Ease benchmarking release branch performance

### DIFF
--- a/bench/benchmarks/layers.js
+++ b/bench/benchmarks/layers.js
@@ -26,8 +26,6 @@ class LayerBenchmark extends Benchmark {
     }
 
     bench() {
-        this.map._styleDirty = true;
-        this.map._sourcesDirty = true;
         this.map._render();
     }
 

--- a/bench/benchmarks_view.js
+++ b/bench/benchmarks_view.js
@@ -1,6 +1,6 @@
 /* global d3 */
 
-const versionColor = d3.scaleOrdinal(['#1b9e77', '#7570b3']);
+const versionColor = d3.scaleOrdinal(['#1b9e77', '#7570b3', '#d95f02']);
 
 const formatSample = d3.format(".3r");
 const Axis = require('./lib/axis');

--- a/bench/index.html
+++ b/bench/index.html
@@ -15,6 +15,7 @@
     <script src="https://unpkg.com/react@next/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@next/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/d3@4"></script>
+    <script src="/bench/benchmarks_generated-3d30c4b.js"></script>
     <script>
         // Unless the URL contains a no-master query parameter, include the
         // current master-branch build of benchmarks.js for comparison


### PR DESCRIPTION
Does three things:

* Makes the `Layer*` benchmarks more tightly focused on rendering performance by not forcing style recalculation.
* Applies that above change on the v0.42.2 release tag, and checks in the resulting generated benchmarks.
* Updates the benchmark index page to do a three-way comparison:

![image](https://user-images.githubusercontent.com/98601/34066100-e40b4ed8-e1be-11e7-94e0-eb636cf14971.png)
