### PR TITLE
Remove constants validating code from style-spec

### DIFF
--- a/src/style-spec/validate/validate.js
+++ b/src/style-spec/validate/validate.js
@@ -1,6 +1,4 @@
 
-const ValidationError = require('../error/validation_error');
-const getType = require('../util/get_type');
 const extend = require('../util/extend');
 const unbundle = require('../util/unbundle_jsonlint');
 const {isExpression} = require('../expression');
@@ -14,6 +12,7 @@ const {isFunction} = require('../function');
 //   high level object that needs to be descended into deeper or a simple
 //   scalar value.
 // - valueSpec: current spec being evaluated. Tracks value.
+// - styleSpec: current full spec being evaluated.
 
 module.exports = function validate(options) {
 
@@ -41,19 +40,7 @@ module.exports = function validate(options) {
 
     const value = options.value;
     const valueSpec = options.valueSpec;
-    const key = options.key;
     const styleSpec = options.styleSpec;
-    const style = options.style;
-
-    if (getType(value) === 'string' && value[0] === '@') {
-        if (styleSpec.$version > 7) {
-            return [new ValidationError(key, value, 'constants have been deprecated as of v8')];
-        }
-        if (!(value in style.constants)) {
-            return [new ValidationError(key, value, 'constant "%s" not found', value)];
-        }
-        options = extend({}, options, { value: style.constants[value] });
-    }
 
     if (valueSpec.function && isFunction(unbundle(value))) {
         return validateFunction(options);


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js/issues/5875.

Validation is no longer supported for legacy spec versions that support constants.
