### PR TITLE
Allocate static modes just once

### DIFF
--- a/src/gl/color_mode.js
+++ b/src/gl/color_mode.js
@@ -20,19 +20,15 @@ class ColorMode {
 
     static Replace: BlendFuncType;
 
-    static disabled(): ColorMode {
-        return new ColorMode(ColorMode.Replace, Color.transparent, [false, false, false, false]);
-    }
-
-    static unblended(): ColorMode {
-        return new ColorMode(ColorMode.Replace, Color.transparent, [true, true, true, true]);
-    }
-
-    static alphaBlended(): ColorMode {
-        return new ColorMode([ONE, ONE_MINUS_SRC_ALPHA], Color.transparent, [true, true, true, true]);
-    }
+    static disabled: ColorMode;
+    static unblended: ColorMode;
+    static alphaBlended: ColorMode;
 }
 
 ColorMode.Replace = [ONE, ZERO];
+
+ColorMode.disabled = new ColorMode(ColorMode.Replace, Color.transparent, [false, false, false, false]);
+ColorMode.unblended = new ColorMode(ColorMode.Replace, Color.transparent, [true, true, true, true]);
+ColorMode.alphaBlended = new ColorMode([ONE, ONE_MINUS_SRC_ALPHA], Color.transparent, [true, true, true, true]);
 
 module.exports = ColorMode;

--- a/src/gl/color_mode.js
+++ b/src/gl/color_mode.js
@@ -20,9 +20,9 @@ class ColorMode {
 
     static Replace: BlendFuncType;
 
-    static disabled: ColorMode;
-    static unblended: ColorMode;
-    static alphaBlended: ColorMode;
+    static disabled: $ReadOnly<ColorMode>;
+    static unblended: $ReadOnly<ColorMode>;
+    static alphaBlended: $ReadOnly<ColorMode>;
 }
 
 ColorMode.Replace = [ONE, ZERO];

--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -187,7 +187,7 @@ class Context {
         gl.clear(mask);
     }
 
-    setDepthMode(depthMode: DepthMode) {
+    setDepthMode(depthMode: $ReadOnly<DepthMode>) {
         if (depthMode.func === this.gl.ALWAYS && !depthMode.mask) {
             this.depthTest.set(false);
         } else {
@@ -198,7 +198,7 @@ class Context {
         }
     }
 
-    setStencilMode(stencilMode: StencilMode) {
+    setStencilMode(stencilMode: $ReadOnly<StencilMode>) {
         if (stencilMode.func === this.gl.ALWAYS && !stencilMode.mask) {
             this.stencilTest.set(false);
         } else {
@@ -213,7 +213,7 @@ class Context {
         }
     }
 
-    setColorMode(colorMode: ColorMode) {
+    setColorMode(colorMode: $ReadOnly<ColorMode>) {
         if (util.deepEqual(colorMode.blendFunction, ColorMode.Replace)) {
             this.blend.set(false);
         } else {

--- a/src/gl/depth_mode.js
+++ b/src/gl/depth_mode.js
@@ -18,12 +18,12 @@ class DepthMode {
         this.range = depthRange;
     }
 
-    static disabled() {
-        return new DepthMode(ALWAYS, DepthMode.ReadOnly, [0, 1]);
-    }
+    static disabled: DepthMode;
 }
 
 DepthMode.ReadOnly = false;
 DepthMode.ReadWrite = true;
+
+DepthMode.disabled = new DepthMode(ALWAYS, DepthMode.ReadOnly, [0, 1]);
 
 module.exports = DepthMode;

--- a/src/gl/depth_mode.js
+++ b/src/gl/depth_mode.js
@@ -18,7 +18,7 @@ class DepthMode {
         this.range = depthRange;
     }
 
-    static disabled: DepthMode;
+    static disabled: $ReadOnly<DepthMode>;
 }
 
 DepthMode.ReadOnly = false;

--- a/src/gl/stencil_mode.js
+++ b/src/gl/stencil_mode.js
@@ -22,9 +22,9 @@ class StencilMode {
         this.pass = pass;
     }
 
-    static disabled() {
-        return new StencilMode({ func: ALWAYS, mask: 0 }, 0, 0, KEEP, KEEP, KEEP);
-    }
+    static disabled: StencilMode;
 }
+
+StencilMode.disabled = new StencilMode({ func: ALWAYS, mask: 0 }, 0, 0, KEEP, KEEP, KEEP);
 
 module.exports = StencilMode;

--- a/src/gl/stencil_mode.js
+++ b/src/gl/stencil_mode.js
@@ -22,7 +22,7 @@ class StencilMode {
         this.pass = pass;
     }
 
-    static disabled: StencilMode;
+    static disabled: $ReadOnly<StencilMode>;
 }
 
 StencilMode.disabled = new StencilMode({ func: ALWAYS, mask: 0 }, 0, 0, KEEP, KEEP, KEEP);

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -29,7 +29,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
     const pass = (!image && color.a === 1 && opacity === 1) ? 'opaque' : 'translucent';
     if (painter.renderPass !== pass) return;
 
-    context.setStencilMode(StencilMode.disabled());
+    context.setStencilMode(StencilMode.disabled);
     context.setDepthMode(painter.depthModeForSublayer(0, pass === 'opaque' ? DepthMode.ReadWrite : DepthMode.ReadOnly));
     context.setColorMode(painter.colorModeForRenderPass());
 

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -29,7 +29,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
     context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
     // Allow circles to be drawn across boundaries, so that
     // large circles are not clipped to tiles
-    context.setStencilMode(StencilMode.disabled());
+    context.setStencilMode(StencilMode.disabled);
     context.setColorMode(painter.colorModeForRenderPass());
 
     let first = true;

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -16,8 +16,8 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
     const gl = context.gl;
     const program = drawCircles ? painter.useProgram('collisionCircle') : painter.useProgram('collisionBox');
 
-    context.setDepthMode(DepthMode.disabled());
-    context.setStencilMode(StencilMode.disabled());
+    context.setDepthMode(DepthMode.disabled);
+    context.setStencilMode(StencilMode.disabled);
     context.setColorMode(painter.colorModeForRenderPass());
 
     for (let i = 0; i < coords.length; i++) {

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -30,8 +30,8 @@ function drawDebugTile(painter, sourceCache, coord) {
     const posMatrix = coord.posMatrix;
     const program = painter.useProgram('debug');
 
-    context.setDepthMode(DepthMode.disabled());
-    context.setStencilMode(StencilMode.disabled());
+    context.setDepthMode(DepthMode.disabled);
+    context.setStencilMode(StencilMode.disabled);
     context.setColorMode(painter.colorModeForRenderPass());
 
     gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -68,7 +68,7 @@ function drawToExtrusionFramebuffer(painter, layer) {
 
     context.clear({ color: Color.transparent });
 
-    context.setStencilMode(StencilMode.disabled());
+    context.setStencilMode(StencilMode.disabled);
     context.setDepthMode(new DepthMode(gl.LEQUAL, DepthMode.ReadWrite, [0, 1]));
     context.setColorMode(painter.colorModeForRenderPass());
 }
@@ -81,8 +81,8 @@ function drawExtrusionTexture(painter, layer) {
     const gl = context.gl;
     const program = painter.useProgram('extrusionTexture');
 
-    context.setStencilMode(StencilMode.disabled());
-    context.setDepthMode(DepthMode.disabled());
+    context.setStencilMode(StencilMode.disabled);
+    context.setDepthMode(DepthMode.disabled);
     context.setColorMode(painter.colorModeForRenderPass());
 
     context.activeTexture.set(gl.TEXTURE0);

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -6,6 +6,7 @@ const pixelsToTileUnits = require('../source/pixels_to_tile_units');
 const Color = require('../style-spec/util/color');
 const DepthMode = require('../gl/depth_mode');
 const StencilMode = require('../gl/stencil_mode');
+const ColorMode = require('../gl/color_mode');
 const util = require('../util/util');
 
 import type Painter from './painter';
@@ -36,9 +37,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
         context.clear({ color: Color.transparent });
 
         // Turn on additive blending for kernels, which is a key aspect of kernel density estimation formula
-        context.setColorMode(util.extend({}, painter.colorModeForRenderPass(), {
-            blendFunction: [gl.ONE, gl.ONE]
-        }));
+        context.setColorMode(new ColorMode([gl.ONE, gl.ONE], Color.transparent, [true, true, true, true]));
 
         let first = true;
         for (let i = 0; i < coords.length; i++) {

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -36,7 +36,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
         context.clear({ color: Color.transparent });
 
         // Turn on additive blending for kernels, which is a key aspect of kernel density estimation formula
-        context.setColorMode(util.extend(painter.colorModeForRenderPass(), {
+        context.setColorMode(util.extend({}, painter.colorModeForRenderPass(), {
             blendFunction: [gl.ONE, gl.ONE]
         }));
 

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -29,7 +29,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
 
         // Allow kernels to be drawn across boundaries, so that
         // large kernels are not clipped to tiles
-        context.setStencilMode(StencilMode.disabled());
+        context.setStencilMode(StencilMode.disabled);
 
         bindFramebuffer(context, painter, layer);
 
@@ -149,7 +149,7 @@ function renderTextureToMap(painter, layer) {
     }
     colorRampTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
 
-    context.setDepthMode(DepthMode.disabled());
+    context.setDepthMode(DepthMode.disabled);
 
     const program = painter.useProgram('heatmapTexture');
 

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -7,7 +7,6 @@ const Color = require('../style-spec/util/color');
 const DepthMode = require('../gl/depth_mode');
 const StencilMode = require('../gl/stencil_mode');
 const ColorMode = require('../gl/color_mode');
-const util = require('../util/util');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -19,7 +19,7 @@ function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: Hillsh
     const context = painter.context;
 
     context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
-    context.setStencilMode(StencilMode.disabled());
+    context.setStencilMode(StencilMode.disabled);
     context.setColorMode(painter.colorModeForRenderPass());
 
     for (const tileID of tileIDs) {

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -22,7 +22,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
     const source = sourceCache.getSource();
     const program = painter.useProgram('raster');
 
-    context.setStencilMode(StencilMode.disabled());
+    context.setStencilMode(StencilMode.disabled);
     context.setColorMode(painter.colorModeForRenderPass());
 
     // Constant parameters.

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -25,7 +25,7 @@ function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolSt
     const context = painter.context;
 
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
-    context.setStencilMode(StencilMode.disabled());
+    context.setStencilMode(StencilMode.disabled);
     context.setColorMode(painter.colorModeForRenderPass());
 
     if (layer.paint.get('icon-opacity').constantOr(1) !== 0) {
@@ -70,7 +70,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
     const depthOn = pitchWithMap;
 
-    context.setDepthMode(depthOn ? painter.depthModeForSublayer(0, DepthMode.ReadOnly) : DepthMode.disabled());
+    context.setDepthMode(depthOn ? painter.depthModeForSublayer(0, DepthMode.ReadOnly) : DepthMode.disabled);
 
     let program;
 

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -235,7 +235,7 @@ class Painter {
         return new StencilMode({ func: gl.EQUAL, mask: 0xFF }, this._tileClippingMaskIDs[tileID.key], 0x00, gl.KEEP, gl.KEEP, gl.REPLACE);
     }
 
-    colorModeForRenderPass(): ColorMode {
+    colorModeForRenderPass(): $ReadOnly<ColorMode> {
         const gl = this.context.gl;
         if (this._showOverdrawInspector) {
             const numOverdrawSteps = 8;

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -189,8 +189,8 @@ class Painter {
         // effectively clearing the stencil buffer: once an upstream patch lands, remove
         // this function in favor of context.clear({ stencil: 0x0 })
 
-        context.setColorMode(ColorMode.disabled());
-        context.setDepthMode(DepthMode.disabled());
+        context.setColorMode(ColorMode.disabled);
+        context.setDepthMode(DepthMode.disabled);
         context.setStencilMode(new StencilMode({ func: gl.ALWAYS, mask: 0 }, 0x0, 0xFF, gl.ZERO, gl.ZERO, gl.ZERO));
 
         const matrix = mat4.create();
@@ -208,8 +208,8 @@ class Painter {
         const context = this.context;
         const gl = context.gl;
 
-        context.setColorMode(ColorMode.disabled());
-        context.setDepthMode(DepthMode.disabled());
+        context.setColorMode(ColorMode.disabled);
+        context.setDepthMode(DepthMode.disabled);
 
         let idNext = 1;
         this._tileClippingMaskIDs = {};
@@ -243,9 +243,9 @@ class Painter {
 
             return new ColorMode([gl.CONSTANT_COLOR, gl.ONE], new Color(a, a, a, 0), [true, true, true, true]);
         } else if (this.renderPass === 'opaque') {
-            return ColorMode.unblended();
+            return ColorMode.unblended;
         } else {
-            return ColorMode.alphaBlended();
+            return ColorMode.alphaBlended;
         }
     }
 


### PR DESCRIPTION
Changes static modes (`[ColorMode/StencilMode/DepthMode].disabled` / `ColorMode.alphaBlended` / `ColorMode.unblended`) to be allocated on the relevant mode class export rather than reallocated with methods on every use.

Sadly this doesn't move the paint benchmark at all 😢  