### PR TITLE
Order cacheKey components consistently

### DIFF
--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -287,6 +287,8 @@ class ProgramConfiguration {
 
     static createDynamic<Layer: TypedStyleLayer>(layer: Layer, zoom: number, filterProperties: (string) => boolean) {
         const self = new ProgramConfiguration();
+        const keys = [];
+
         for (const property in layer.paint._values) {
             if (!filterProperties(property)) continue;
             const value = layer.paint.get(property);
@@ -299,15 +301,17 @@ class ProgramConfiguration {
 
             if (value.value.kind === 'constant') {
                 self.binders[property] = new ConstantBinder(value.value, name, type);
-                self.cacheKey += `/u_${name}`;
+                keys.push(`/u_${name}`);
             } else if (value.value.kind === 'source') {
                 self.binders[property] = new SourceExpressionBinder(value.value, name, type);
-                self.cacheKey += `/a_${name}`;
+                keys.push(`/a_${name}`);
             } else {
                 self.binders[property] = new CompositeExpressionBinder(value.value, name, type, useIntegerZoom, zoom);
-                self.cacheKey += `/z_${name}`;
+                keys.push(`/z_${name}`);
             }
         }
+
+        self.cacheKey = keys.sort().join('');
 
         return self;
     }


### PR DESCRIPTION
Previously, two `ProgramConfiguration`s that should use the same `Program` might have had different cache keys due to inconsistent iteration order of `layer.paint._values`. This would cause inefficient use of the `Program` cache.

https://bl.ocks.org/anonymous/raw/a61cd4ff4a1bf0ac80b551b23e0410ed/

I spent a lot of time trying to ensure that `layer.paint._values` had consistent order, which in theory would be good for performance due to V8's [hidden class optimizations](https://draft.li/blog/2016/12/22/javascript-engines-hidden-classes/), but they all turned out to be at best a wash and in some cases pessimizations.