### PR TITLE
Improve CI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,20 +24,29 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-mapbox-gl-js-cache
+          keys:
+            - v1-yarn-{{ checksum "yarn.lock" }}
+            - v1-yarn
+      - restore_cache:
+          keys:
+            - v1-lint-{{ .Branch }}
+            - v1-lint
       - run:
           name: install dependencies
           command: yarn
       - save_cache:
-          key: v1-mapbox-gl-js-cache
+          key: v1-yarn-{{ checksum "yarn.lock" }}
           paths:
             - '~/.yarn'
-            - '.eslintcache'
             - 'node_modules'
       - run:
           name: run tests
           command: |
             bash ./.circleci/test.sh
+      - save_cache:
+          key: v1-lint-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - '.eslintcache'
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
       - store_artifacts:


### PR DESCRIPTION
- Cache .eslintcache separately; don't write it until after linting
- Better key names and fallbacks (see https://circleci.com/docs/2.0/caching/)

Result: the "install dependencies" step takes 2 seconds instead of 1m+. Linting still takes 30s though; somehow the cache is not being used.