### PR TITLE
Coalesce high-frequency 'setData' calls

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -183,6 +183,14 @@ class GeoJSONSource extends Evented implements Source {
         // implementation
         this.workerID = this.dispatcher.send(`${this.type}.loadData`, options, (err) => {
             this._loaded = true;
+            // Any `loadData` calls that piled up while we were processing
+            // this one will get coalesced into a single call when this
+            // 'coalesce' message is processed.
+            // We would self-send from the worker if we had access to its
+            // message queue. Waiting instated for the 'coalesce' to round-trip
+            // through the foreground just means we're throttling the worker
+            // to run at a little less than full-throttle.
+            this.dispatcher.send(`${this.type}.coalesce`, null, null, this.workerID);
             callback(err);
         }, this.workerID);
     }

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -66,6 +66,11 @@ function loadGeoJSONTile(params: WorkerTileParameters, callback: LoadVectorDataC
     });
 }
 
+export type SourceState =
+    | 'Idle'            // Source empty or data loaded
+    | 'Coalescing'      // Data finished loading, but discard 'loadData' messages until receiving 'coalesced'
+    | 'NeedsLoadData';  // 'loadData' received while coalescing, trigger one more 'loadData' on receiving 'coalesced'
+
 /**
  * The {@link WorkerSource} implementation that supports {@link GeoJSONSource}.
  * This class is designed to be easily reused to support custom source types
@@ -79,6 +84,9 @@ function loadGeoJSONTile(params: WorkerTileParameters, callback: LoadVectorDataC
 class GeoJSONWorkerSource extends VectorTileWorkerSource {
     _geoJSONIndexes: { [string]: GeoJSONIndex };
     loadGeoJSON: LoadGeoJSON;
+    state: SourceState;
+    pendingCallback: Callback<void>;
+    pendingLoadDataParams: LoadGeoJSONParameters;
 
     /**
      * @param [loadGeoJSON] Optional method for custom loading/parsing of
@@ -92,6 +100,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
         }
         // object mapping source ids to geojson-vt-like tile indexes
         this._geoJSONIndexes = {};
+        this.state = 'Idle';
     }
 
     /**
@@ -102,11 +111,35 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * Defers to {@link GeoJSONWorkerSource#loadGeoJSON} for the fetching/parsing,
      * expecting `callback(error, data)` to be called with either an error or a
      * parsed GeoJSON object.
+     *
+     * When `loadData` requests come in faster than they can be processed,
+     * they are coalesced into a single request using the latest data.
+     * See {@link GeoJSONWorkerSource#coalesce}
+     *
      * @param params
      * @param params.source The id of the source.
      * @param callback
      */
     loadData(params: LoadGeoJSONParameters, callback: Callback<void>) {
+        this.pendingCallback = callback;
+        this.pendingLoadDataParams = params;
+        if (this.state !== 'Idle') {
+            this.state = 'NeedsLoadData';
+        } else {
+            this.state = 'Coalescing';
+            this._loadData();
+        }
+    }
+
+    /**
+     * Internal implementation: called directly by `loadData`
+     * or by `coalesce` using stored parameters.
+     */
+    _loadData() {
+        const callback = this.pendingCallback;
+        const params = this.pendingLoadDataParams;
+        delete this.pendingCallback;
+        delete this.pendingLoadDataParams;
         this.loadGeoJSON(params, (err, data) => {
             if (err || !data) {
                 return callback(err);
@@ -127,6 +160,35 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
                 callback(null);
             }
         });
+    }
+
+    /**
+     * While processing `loadData`, we coalesce all further
+     * `loadData` messages into a single call to _loadData
+     * that will happen once we've finished processing the
+     * first message. {@link GeoJSONSource#_updateWorkerData}
+     * is responsible for sending us the `coalesce` message
+     * at the time it receives a response from `loadData`
+     *
+     *          State: Idle
+     *          ↑          |
+     *     'coalesce'   'loadData'
+     *          |     (triggers load)
+     *          |          ↓
+     *        State: Coalescing
+     *          ↑          |
+     *   (triggers load)   |
+     *     'coalesce'   'loadData'
+     *          |          ↓
+     *        State: NeedsLoadData
+     */
+    coalesce() {
+        if (this.state === 'Coalescing') {
+            this.state = 'Idle';
+        } else if (this.state === 'NeedsLoadData') {
+            this.state = 'Coalescing';
+            this._loadData();
+        }
     }
 
     /**

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -49,7 +49,9 @@ test('GeoJSONSource#setData', (t) => {
     function createSource() {
         return new GeoJSONSource('id', {data: {}}, {
             send: function (type, data, callback) {
-                return setTimeout(callback, 0);
+                if (callback) {
+                    return setTimeout(callback, 0);
+                }
             }
         });
     }
@@ -153,7 +155,9 @@ test('GeoJSONSource#update', (t) => {
     t.test('fires event when metadata loads', (t) => {
         const mockDispatcher = {
             send: function(message, args, callback) {
-                setTimeout(callback, 0);
+                if (callback) {
+                    setTimeout(callback, 0);
+                }
             }
         };
 
@@ -169,7 +173,9 @@ test('GeoJSONSource#update', (t) => {
     t.test('fires "error"', (t) => {
         const mockDispatcher = {
             send: function(message, args, callback) {
-                setTimeout(callback.bind(null, 'error'), 0);
+                if (callback) {
+                    setTimeout(callback.bind(null, 'error'), 0);
+                }
             }
         };
 
@@ -190,7 +196,9 @@ test('GeoJSONSource#update', (t) => {
                 if (message === 'geojson.loadData' && --expectedLoadDataCalls <= 0) {
                     t.end();
                 }
-                setTimeout(callback, 0);
+                if (callback) {
+                    setTimeout(callback, 0);
+                }
             }
         };
 

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -86,6 +86,7 @@ test('reloadTile', (t) => {
 
         function addData(callback) {
             source.loadData({ source: 'sourceId', data: JSON.stringify(geoJson) }, (err) => {
+                source.coalesce();
                 t.equal(err, null);
                 callback();
             });


### PR DESCRIPTION
This is an exploratory PR motivated by various example animations provided in https://github.com/mapbox/mapbox-gl-js/issues/5716. The common theme was using high-frequency `setData` calls to animate items in a GeoJSON source.

When you send `setData` calls to the source faster than they can be processed, you end up with an unbounded backlog of requests on the GeoJSON worker, and every request gets processed in order (also several `reloadTile` requests get added to the backlog for every `setData`) no matter how far behind you are. Non-GeoJSON requests to the same worker may also starve.

This PR introduces a coalescing mechanism on `setData` so that the worker will always finish any `loadData` call it starts, and it will always process the last `loadData` it receives, but it is allowed to discard calls that arrive while it is already in the middle of processing an earlier request.

I couldn't figure out a good way to self-send a "coalesced" message so I ended up round-tripping a "coalesce" message back to the parent, which adds a little latency but I think should still be correct.

The `set_data.html` debug page contains a relatively slow `setData` animation that exercises this functionality, and there are currently log statements that record how many calls are getting coalesced.

On my machine, this demo page works _ok_ without the coalescing, and coalescing only seems to skip roughly half of the `setData` calls, so maybe this isn't that important an optimization. But just upping the size of the GeoJSON feature set is enough to make the animation start developing a large backlog if it doesn't have coalescing enabled.

/cc @ansis @jfirebaugh @andrewharvey 