### PR TITLE
Add `mapboxgl.LngLatBounds.isEmpty()` method

### DIFF
--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -201,6 +201,15 @@ class LngLatBounds {
     }
 
     /**
+     * Check if the bounding box is an empty/`null`-type box.
+     *
+     * @returns {boolean} True if bounds have been defined, otherwise false.
+     */
+    isEmpty() {
+        return !(this._sw && this._ne);
+    }
+
+    /**
      * Converts an array to a `LngLatBounds` object.
      *
      * If a `LngLatBounds` object is passed in, the function returns it unchanged.

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -166,5 +166,13 @@ test('LngLatBounds', (t) => {
         t.end();
     });
 
+    t.test('#isEmpty', (t) => {
+        const nullBounds = new LngLatBounds();
+        t.equal(nullBounds.isEmpty(), true);
+        nullBounds.extend([-73.9876, 40.7661], [-73.9397, 40.8002]);
+        t.equal(nullBounds.isEmpty(), false);
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
**Current behavior:** Calling *toArray()* on a null-type bbox throws an exception instead of returning an empty array ("undefined this._sw doesn't have a toArray() method"). To check if bounds are defined the user needs to inspect internal properties.

**Proposed solution:** This PR adds a handy `isEmpty()` method to the public interface, for checking if bounds are defined (similar to the Google Maps *LatLngBounds.isEmpty()* that many are used to having).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
