### PR TITLE
Exclude render-tests directory in flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,7 @@
 .*/node_modules/htmltojsx/.*
 .*/node_modules/documentation/.*
 .*/test/unit/style-spec/fixture/invalidjson.input.json
+.*/test/integration/render-tests/.*
 
 [options]
 unsafe.enable_getters_and_setters=true


### PR DESCRIPTION
This speeds up `yarn test-render` significantly when you have a flow server running:

Before:
```
real	2m53.985s
user	1m37.477s
sys	0m6.235s
```
After:
```
real	1m30.587s
user	1m31.434s
sys	0m6.321s
```