### PR TITLE
Honor renderWorldCopies in Transform.getVisibleUnwrappedCoordinates()

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -196,9 +196,11 @@ class Transform {
         const w0 = Math.floor(ul.column);
         const w1 = Math.floor(ur.column);
         const result = [new UnwrappedTileID(0, tileID)];
-        for (let w = w0; w <= w1; w++) {
-            if (w === 0) continue;
-            result.push(new UnwrappedTileID(w, tileID));
+        if (this._renderWorldCopies) {
+            for (let w = w0; w <= w1; w++) {
+                if (w === 0) continue;
+                result.push(new UnwrappedTileID(w, tileID));
+            }
         }
         return result;
     }

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -3,8 +3,8 @@
 const test = require('mapbox-gl-js-test').test;
 const Point = require('@mapbox/point-geometry');
 const Transform = require('../../../src/geo/transform');
-const OverscaledTileID = require('../../../src/source/tile_id').OverscaledTileID;
 const LngLat = require('../../../src/geo/lng_lat');
+const {OverscaledTileID, CanonicalTileID} = require('../../../src/source/tile_id');
 
 const fixed = require('mapbox-gl-js-test/fixed');
 const fixedLngLat = fixed.LngLat;
@@ -230,6 +230,23 @@ test('transform', (t) => {
 
         transform.pitch = 90;
         t.equal(transform.pitch, 60);
+
+        t.end();
+    });
+
+    t.test('visibleUnwrappedCoordinates', (t) => {
+        const transform = new Transform();
+        transform.resize(200, 200);
+        transform.zoom = 0;
+        transform.center = { lng: -170.01, lat: 0.01 };
+
+        let unwrappedCoords = transform.getVisibleUnwrappedCoordinates(new CanonicalTileID(0, 0, 0));
+        t.equal(unwrappedCoords.length, 2);
+
+        //getVisibleUnwrappedCoordinates should honor _renderWorldCopies
+        transform._renderWorldCopies = false;
+        unwrappedCoords = transform.getVisibleUnwrappedCoordinates(new CanonicalTileID(0, 0, 0));
+        t.equal(unwrappedCoords.length, 1);
 
         t.end();
     });


### PR DESCRIPTION
Closes #5914 


https://github.com/mapbox/mapbox-gl-js/blob/ca01a1edfc4b0a1b10b85db1a722cc2aa4f6163a/src/source/source_cache.js#L422-L424

For single-tile based sources,` Source.update` calls `Transform.getVisibleUnwrappedCoordinates` which should honor the map's `renderWorldCopies` flag.