### PR TITLE
Use template strings for validation errors

### DIFF
--- a/src/style-spec/error/validation_error.js
+++ b/src/style-spec/error/validation_error.js
@@ -1,8 +1,6 @@
 
-const format = require('util').format;
-
-function ValidationError(key, value, ...args) {
-    this.message = (key ? `${key}: ` : '') + format.apply(format, args);
+function ValidationError(key, value, message) {
+    this.message = (key ? `${key}: ` : '') + message;
 
     if (value !== null && value !== undefined && value.__line__) {
         this.line = value.__line__;

--- a/src/style-spec/validate/validate_array.js
+++ b/src/style-spec/validate/validate_array.js
@@ -12,15 +12,15 @@ module.exports = function validateArray(options) {
     const validateArrayElement = options.arrayElementValidator || validate;
 
     if (getType(array) !== 'array') {
-        return [new ValidationError(key, array, 'array expected, %s found', getType(array))];
+        return [new ValidationError(key, array, `array expected, ${getType(array)} found`)];
     }
 
     if (arraySpec.length && array.length !== arraySpec.length) {
-        return [new ValidationError(key, array, 'array length %d expected, length %d found', arraySpec.length, array.length)];
+        return [new ValidationError(key, array, `array length ${arraySpec.length} expected, length ${array.length} found`)];
     }
 
     if (arraySpec['min-length'] && array.length < arraySpec['min-length']) {
-        return [new ValidationError(key, array, 'array length at least %d expected, length %d found', arraySpec['min-length'], array.length)];
+        return [new ValidationError(key, array, `array length at least ${arraySpec['min-length']} expected, length ${array.length} found`)];
     }
 
     let arrayElementSpec = {

--- a/src/style-spec/validate/validate_boolean.js
+++ b/src/style-spec/validate/validate_boolean.js
@@ -8,7 +8,7 @@ module.exports = function validateBoolean(options) {
     const type = getType(value);
 
     if (type !== 'boolean') {
-        return [new ValidationError(key, value, 'boolean expected, %s found', type)];
+        return [new ValidationError(key, value, `boolean expected, ${type} found`)];
     }
 
     return [];

--- a/src/style-spec/validate/validate_color.js
+++ b/src/style-spec/validate/validate_color.js
@@ -9,11 +9,11 @@ module.exports = function validateColor(options) {
     const type = getType(value);
 
     if (type !== 'string') {
-        return [new ValidationError(key, value, 'color expected, %s found', type)];
+        return [new ValidationError(key, value, `color expected, ${type} found`)];
     }
 
     if (parseCSSColor(value) === null) {
-        return [new ValidationError(key, value, 'color expected, "%s" found', value)];
+        return [new ValidationError(key, value, `color expected, "${value}" found`)];
     }
 
     return [];

--- a/src/style-spec/validate/validate_enum.js
+++ b/src/style-spec/validate/validate_enum.js
@@ -10,11 +10,11 @@ module.exports = function validateEnum(options) {
 
     if (Array.isArray(valueSpec.values)) { // <=v7
         if (valueSpec.values.indexOf(unbundle(value)) === -1) {
-            errors.push(new ValidationError(key, value, 'expected one of [%s], %s found', valueSpec.values.join(', '), JSON.stringify(value)));
+            errors.push(new ValidationError(key, value, `expected one of [${valueSpec.values.join(', ')}], ${JSON.stringify(value)} found`));
         }
     } else { // >=v8
         if (Object.keys(valueSpec.values).indexOf(unbundle(value)) === -1) {
-            errors.push(new ValidationError(key, value, 'expected one of [%s], %s found', Object.keys(valueSpec.values).join(', '), JSON.stringify(value)));
+            errors.push(new ValidationError(key, value, `expected one of [${Object.keys(valueSpec.values).join(', ')}], ${JSON.stringify(value)} found`));
         }
     }
     return errors;

--- a/src/style-spec/validate/validate_filter.js
+++ b/src/style-spec/validate/validate_filter.js
@@ -23,7 +23,7 @@ function validateNonExpressionFilter(options) {
     const key = options.key;
 
     if (getType(value) !== 'array') {
-        return [new ValidationError(key, value, 'array expected, %s found', getType(value))];
+        return [new ValidationError(key, value, `array expected, ${getType(value)} found`)];
     }
 
     const styleSpec = options.styleSpec;
@@ -49,13 +49,13 @@ function validateNonExpressionFilter(options) {
     case '>':
     case '>=':
         if (value.length >= 2 && unbundle(value[1]) === '$type') {
-            errors.push(new ValidationError(key, value, '"$type" cannot be use with operator "%s"', value[0]));
+            errors.push(new ValidationError(key, value, `"$type" cannot be use with operator "${value[0]}"`));
         }
         /* falls through */
     case '==':
     case '!=':
         if (value.length !== 3) {
-            errors.push(new ValidationError(key, value, 'filter array for operator "%s" must have 3 elements', value[0]));
+            errors.push(new ValidationError(key, value, `filter array for operator "${value[0]}" must have 3 elements`));
         }
         /* falls through */
     case 'in':
@@ -63,7 +63,7 @@ function validateNonExpressionFilter(options) {
         if (value.length >= 2) {
             type = getType(value[1]);
             if (type !== 'string') {
-                errors.push(new ValidationError(`${key}[1]`, value[1], 'string expected, %s found', type));
+                errors.push(new ValidationError(`${key}[1]`, value[1], `string expected, ${type} found`));
             }
         }
         for (let i = 2; i < value.length; i++) {
@@ -77,7 +77,7 @@ function validateNonExpressionFilter(options) {
                     styleSpec: options.styleSpec
                 }));
             } else if (type !== 'string' && type !== 'number' && type !== 'boolean') {
-                errors.push(new ValidationError(`${key}[${i}]`, value[i], 'string, number, or boolean expected, %s found', type));
+                errors.push(new ValidationError(`${key}[${i}]`, value[i], `string, number, or boolean expected, ${type} found`));
             }
         }
         break;
@@ -99,9 +99,9 @@ function validateNonExpressionFilter(options) {
     case '!has':
         type = getType(value[1]);
         if (value.length !== 2) {
-            errors.push(new ValidationError(key, value, 'filter array for "%s" operator must have 2 elements', value[0]));
+            errors.push(new ValidationError(key, value, `filter array for "${value[0]}" operator must have 2 elements`));
         } else if (type !== 'string') {
-            errors.push(new ValidationError(`${key}[1]`, value[1], 'string expected, %s found', type));
+            errors.push(new ValidationError(`${key}[1]`, value[1], `string expected, ${type} found`));
         }
         break;
 

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -90,16 +90,16 @@ module.exports = function validateFunction(options) {
         const key = options.key;
 
         if (getType(value) !== 'array') {
-            return [new ValidationError(key, value, 'array expected, %s found', getType(value))];
+            return [new ValidationError(key, value, `array expected, ${getType(value)} found`)];
         }
 
         if (value.length !== 2) {
-            return [new ValidationError(key, value, 'array length %d expected, length %d found', 2, value.length)];
+            return [new ValidationError(key, value, `array length 2 expected, length ${value.length} found`)];
         }
 
         if (isZoomAndPropertyFunction) {
             if (getType(value[0]) !== 'object') {
-                return [new ValidationError(key, value, 'object expected, %s found', getType(value[0]))];
+                return [new ValidationError(key, value, `object expected, ${getType(value[0])} found`)];
             }
             if (value[0].zoom === undefined) {
                 return [new ValidationError(key, value, 'object stop key must have zoom')];
@@ -151,7 +151,7 @@ module.exports = function validateFunction(options) {
         if (!stopKeyType) {
             stopKeyType = type;
         } else if (type !== stopKeyType) {
-            return [new ValidationError(options.key, reportValue, '%s stop domain type must match previous stop domain type %s', type, stopKeyType)];
+            return [new ValidationError(options.key, reportValue, `${type} stop domain type must match previous stop domain type ${stopKeyType}`)];
         }
 
         if (type !== 'number' && type !== 'string' && type !== 'boolean') {
@@ -159,15 +159,15 @@ module.exports = function validateFunction(options) {
         }
 
         if (type !== 'number' && functionType !== 'categorical') {
-            let message = 'number expected, %s found';
+            let message = `number expected, ${type} found`;
             if (functionValueSpec['property-function'] && functionType === undefined) {
                 message += '\nIf you intended to use a categorical function, specify `"type": "categorical"`.';
             }
-            return [new ValidationError(options.key, reportValue, message, type)];
+            return [new ValidationError(options.key, reportValue, message)];
         }
 
         if (functionType === 'categorical' && type === 'number' && (!isFinite(value) || Math.floor(value) !== value)) {
-            return [new ValidationError(options.key, reportValue, 'integer expected, found %s', value)];
+            return [new ValidationError(options.key, reportValue, `integer expected, found ${value}`)];
         }
 
         if (functionType !== 'categorical' && type === 'number' && previousStopDomainValue !== undefined && value < previousStopDomainValue) {

--- a/src/style-spec/validate/validate_layer.js
+++ b/src/style-spec/validate/validate_layer.js
@@ -27,7 +27,7 @@ module.exports = function validateLayer(options) {
         for (let i = 0; i < options.arrayIndex; i++) {
             const otherLayer = style.layers[i];
             if (unbundle(otherLayer.id) === layerId) {
-                errors.push(new ValidationError(key, layer.id, 'duplicate layer id "%s", previously used at line %d', layer.id, otherLayer.id.__line__));
+                errors.push(new ValidationError(key, layer.id, `duplicate layer id "${layer.id}", previously used at line ${otherLayer.id.__line__}`));
             }
         }
     }
@@ -35,7 +35,7 @@ module.exports = function validateLayer(options) {
     if ('ref' in layer) {
         ['type', 'source', 'source-layer', 'filter', 'layout'].forEach((p) => {
             if (p in layer) {
-                errors.push(new ValidationError(key, layer[p], '"%s" is prohibited for ref layers', p));
+                errors.push(new ValidationError(key, layer[p], `"${p}" is prohibited for ref layers`));
             }
         });
 
@@ -46,7 +46,7 @@ module.exports = function validateLayer(options) {
         });
 
         if (!parent) {
-            errors.push(new ValidationError(key, layer.ref, 'ref layer "%s" not found', ref));
+            errors.push(new ValidationError(key, layer.ref, `ref layer "${ref}" not found`));
         } else if (parent.ref) {
             errors.push(new ValidationError(key, layer.ref, 'ref cannot reference another ref layer'));
         } else {
@@ -59,15 +59,15 @@ module.exports = function validateLayer(options) {
             const source = style.sources && style.sources[layer.source];
             const sourceType = source && unbundle(source.type);
             if (!source) {
-                errors.push(new ValidationError(key, layer.source, 'source "%s" not found', layer.source));
+                errors.push(new ValidationError(key, layer.source, `source "${layer.source}" not found`));
             } else if (sourceType === 'vector' && type === 'raster') {
-                errors.push(new ValidationError(key, layer.source, 'layer "%s" requires a raster source', layer.id));
+                errors.push(new ValidationError(key, layer.source, `layer "${layer.id}" requires a raster source`));
             } else if (sourceType === 'raster' && type !== 'raster') {
-                errors.push(new ValidationError(key, layer.source, 'layer "%s" requires a vector source', layer.id));
+                errors.push(new ValidationError(key, layer.source, `layer "${layer.id}" requires a vector source`));
             } else if (sourceType === 'vector' && !layer['source-layer']) {
-                errors.push(new ValidationError(key, layer, 'layer "%s" must specify a "source-layer"', layer.id));
+                errors.push(new ValidationError(key, layer, `layer "${layer.id}" must specify a "source-layer"`));
             } else if (sourceType === 'raster-dem' && type !== 'hillshade') {
-                errors.push(new ValidationError(key, layer.source, 'raster-dem source can only be used with layer type \'hillshade\'.', layer.id));
+                errors.push(new ValidationError(key, layer.source, 'raster-dem source can only be used with layer type \'hillshade\'.'));
             }
         }
     }

--- a/src/style-spec/validate/validate_light.js
+++ b/src/style-spec/validate/validate_light.js
@@ -15,7 +15,7 @@ module.exports = function validateLight(options) {
     if (light === undefined) {
         return errors;
     } else if (rootType !== 'object') {
-        errors = errors.concat([new ValidationError('light', light, 'object expected, %s found', rootType)]);
+        errors = errors.concat([new ValidationError('light', light, `object expected, ${rootType} found`)]);
         return errors;
     }
 
@@ -39,7 +39,7 @@ module.exports = function validateLight(options) {
                 styleSpec: styleSpec
             }));
         } else {
-            errors = errors.concat([new ValidationError(key, light[key], 'unknown property "%s"', key)]);
+            errors = errors.concat([new ValidationError(key, light[key], `unknown property "${key}"`)]);
         }
     }
 

--- a/src/style-spec/validate/validate_number.js
+++ b/src/style-spec/validate/validate_number.js
@@ -9,15 +9,15 @@ module.exports = function validateNumber(options) {
     const type = getType(value);
 
     if (type !== 'number') {
-        return [new ValidationError(key, value, 'number expected, %s found', type)];
+        return [new ValidationError(key, value, `number expected, ${type} found`)];
     }
 
     if ('minimum' in valueSpec && value < valueSpec.minimum) {
-        return [new ValidationError(key, value, '%s is less than the minimum value %s', value, valueSpec.minimum)];
+        return [new ValidationError(key, value, `${value} is less than the minimum value ${valueSpec.minimum}`)];
     }
 
     if ('maximum' in valueSpec && value > valueSpec.maximum) {
-        return [new ValidationError(key, value, '%s is greater than the maximum value %s', value, valueSpec.maximum)];
+        return [new ValidationError(key, value, `${value} is greater than the maximum value ${valueSpec.maximum}`)];
     }
 
     return [];

--- a/src/style-spec/validate/validate_object.js
+++ b/src/style-spec/validate/validate_object.js
@@ -14,7 +14,7 @@ module.exports = function validateObject(options) {
 
     const type = getType(object);
     if (type !== 'object') {
-        return [new ValidationError(key, object, 'object expected, %s found', type)];
+        return [new ValidationError(key, object, `object expected, ${type} found`)];
     }
 
     for (const objectKey in object) {
@@ -31,7 +31,7 @@ module.exports = function validateObject(options) {
         } else if (elementSpecs['*']) {
             validateElement = validateSpec;
         } else {
-            errors.push(new ValidationError(key, object[objectKey], 'unknown property "%s"', objectKey));
+            errors.push(new ValidationError(key, object[objectKey], `unknown property "${objectKey}"`));
             continue;
         }
 
@@ -53,7 +53,7 @@ module.exports = function validateObject(options) {
         }
 
         if (elementSpecs[elementSpecKey].required && elementSpecs[elementSpecKey]['default'] === undefined && object[elementSpecKey] === undefined) {
-            errors.push(new ValidationError(key, object, 'missing required property "%s"', elementSpecKey));
+            errors.push(new ValidationError(key, object, `missing required property "${elementSpecKey}"`));
         }
     }
 

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -28,17 +28,15 @@ module.exports = function validateProperty(options, propertyType) {
 
     const valueSpec = options.valueSpec || layerSpec[propertyKey];
     if (!valueSpec) {
-        return [new ValidationError(key, value, 'unknown property "%s"', propertyKey)];
+        return [new ValidationError(key, value, `unknown property "${propertyKey}"`)];
     }
 
     let tokenMatch;
     if (getType(value) === 'string' && valueSpec['property-function'] && !valueSpec.tokens && (tokenMatch = /^{([^}]+)}$/.exec(value))) {
         return [new ValidationError(
             key, value,
-            '"%s" does not support interpolation syntax\n' +
-                'Use an identity property function instead: `{ "type": "identity", "property": %s` }`.',
-            propertyKey, JSON.stringify(tokenMatch[1])
-        )];
+            `"${propertyKey}" does not support interpolation syntax\n` +
+                `Use an identity property function instead: \`{ "type": "identity", "property": ${JSON.stringify(tokenMatch[1])} }\`.`)];
     }
 
     const errors = [];

--- a/src/style-spec/validate/validate_source.js
+++ b/src/style-spec/validate/validate_source.js
@@ -31,7 +31,7 @@ module.exports = function validateSource(options) {
         if ('url' in value) {
             for (const prop in value) {
                 if (['type', 'url', 'tileSize'].indexOf(prop) < 0) {
-                    errors.push(new ValidationError(`${key}.${prop}`, value[prop], 'a source with a "url" property may not include a "%s" property', prop));
+                    errors.push(new ValidationError(`${key}.${prop}`, value[prop], `a source with a "url" property may not include a "${prop}" property`));
                 }
             }
         }

--- a/src/style-spec/validate/validate_string.js
+++ b/src/style-spec/validate/validate_string.js
@@ -8,7 +8,7 @@ module.exports = function validateString(options) {
     const type = getType(value);
 
     if (type !== 'string') {
-        return [new ValidationError(key, value, 'string expected, %s found', type)];
+        return [new ValidationError(key, value, `string expected, ${type} found`)];
     }
 
     return [];

--- a/test/unit/style-spec/fixture/properties.output.json
+++ b/test/unit/style-spec/fixture/properties.output.json
@@ -39,7 +39,7 @@
     "line": 65
   },
   {
-    "message": "layers[4].paint.fill-opacity: \"fill-opacity\" does not support interpolation syntax\nUse an identity property function instead: `{ \"type\": \"identity\", \"property\": \"opacity\"` }`.",
+    "message": "layers[4].paint.fill-opacity: \"fill-opacity\" does not support interpolation syntax\nUse an identity property function instead: `{ \"type\": \"identity\", \"property\": \"opacity\" }`.",
     "line": 74
   }
 ]


### PR DESCRIPTION
Eliminates the need for the browserified `util` module — we don't need `format` since we have ES6 template strings. Reduces the build a bit:

```bash
# before
orig: 706.92KB
gzip: 171.55KB (24.27%)

#after
orig: 696.23KB
gzip: 168.29KB (24.17%)
```