### PR TITLE
add getter and setter for renderWorldCopies

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -97,7 +97,13 @@ class Transform {
     }
 
     get renderWorldCopies(): boolean { return this._renderWorldCopies; }
-    set renderWorldCopies(renderWorldCopies: boolean) {
+    set renderWorldCopies(renderWorldCopies?: ?boolean) {
+        if (renderWorldCopies === undefined) {
+            renderWorldCopies = true;
+        } else if (renderWorldCopies === null) {
+            renderWorldCopies = false;
+        }
+
         this._renderWorldCopies = renderWorldCopies;
     }
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -96,8 +96,9 @@ class Transform {
         this.zoom = Math.min(this.zoom, zoom);
     }
 
-    get renderWorldCopies(): boolean {
-        return this._renderWorldCopies;
+    get renderWorldCopies(): boolean { return this._renderWorldCopies; }
+    set renderWorldCopies(renderWorldCopies: boolean) {
+        this._renderWorldCopies = renderWorldCopies;
     }
 
     get worldSize(): number {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -530,6 +530,27 @@ class Map extends Camera {
     }
 
     /**
+     * Returns the state of renderWorldCopies.
+     *
+     * @returns {boolean} renderWorldCopies
+     */
+    getRenderWorldCopies() { return this.transform.renderWorldCopies; }
+
+    /**
+     * Sets the state of renderWorldCopies.
+     *
+     * @param {boolean} renderWorldCopies If `true`, multiple copies of the world will be rendered, when zoomed out.
+     * @returns {Map} `this`
+     */
+    setRenderWorldCopies(renderWorldCopies?: ?boolean) {
+
+        this.transform.renderWorldCopies = renderWorldCopies;
+        this._update();
+
+        return this;
+    }
+
+    /**
      * Returns the map's maximum allowable zoom level.
      *
      * @returns {number} maxZoom

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -539,7 +539,7 @@ class Map extends Camera {
     /**
      * Sets the state of renderWorldCopies.
      *
-     * @param {boolean} renderWorldCopies If `true`, multiple copies of the world will be rendered, when zoomed out.
+     * @param {boolean} renderWorldCopies If `true`, multiple copies of the world will be rendered, when zoomed out. `undefined` is treated as `true`, `null` is treated as `false`.
      * @returns {Map} `this`
      */
     setRenderWorldCopies(renderWorldCopies?: ?boolean) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -544,7 +544,7 @@ class Map extends Camera {
      */
     setRenderWorldCopies(renderWorldCopies?: ?boolean) {
 
-        this.transform.renderWorldCopies = renderWorldCopies;
+        this.transform.renderWorldCopies = renderWorldCopies ? true : false;
         this._update();
 
         return this;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -544,7 +544,7 @@ class Map extends Camera {
      */
     setRenderWorldCopies(renderWorldCopies?: ?boolean) {
 
-        this.transform.renderWorldCopies = renderWorldCopies ? true : false;
+        this.transform.renderWorldCopies = renderWorldCopies;
         this._update();
 
         return this;

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -665,6 +665,40 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('#getRenderWorldCopies', (t) => {
+        t.test('initially false', (t) => {
+            const map = createMap({renderWorldCopies: false});
+            t.equal(map.getRenderWorldCopies(), false);
+            t.end();
+        });
+
+        t.test('initially true', (t) => {
+            const map = createMap({renderWorldCopies: true});
+            t.equal(map.getRenderWorldCopies(), true);
+            t.end();
+        });
+
+        t.end();
+    });
+
+    t.test('#setRenderWorldCopies', (t) => {
+        t.test('initially false', (t) => {
+            const map = createMap({renderWorldCopies: false});
+            map.setRenderWorldCopies(true);
+            t.equal(map.getRenderWorldCopies(), true);
+            t.end();
+        });
+
+        t.test('initially true', (t) => {
+            const map = createMap({renderWorldCopies: true});
+            map.setRenderWorldCopies(false);
+            t.equal(map.getRenderWorldCopies(), false);
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.test('#setMinZoom', (t) => {
         const map = createMap({zoom:5});
         map.setMinZoom(3.5);

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -696,6 +696,20 @@ test('Map', (t) => {
             t.end();
         });
 
+        t.test('undefined', (t) => {
+            const map = createMap({renderWorldCopies: false});
+            map.setRenderWorldCopies(undefined);
+            t.equal(map.getRenderWorldCopies(), true);
+            t.end();
+        });
+
+        t.test('null', (t) => {
+            const map = createMap({renderWorldCopies: true});
+            map.setRenderWorldCopies(null);
+            t.equal(map.getRenderWorldCopies(), false);
+            t.end();
+        });
+
         t.end();
     });
 


### PR DESCRIPTION
Closes #4039

## Launch Checklist

 - [x] briefly describe the changes in this PR

Adds a getter and setter for renderWorldCopies so it can be changed after map initialisation.

 - [x] write tests for all new functionality

Unit tests confirm the getter and setters are in sync.

 - [x] document any changes to public APIs

JS doc included

 - [ ] post benchmark scores
 - [x] manually test the debug page

I've manually tested flipping renderWorldCopies and it updates the visuals correctly.
