### PR TITLE
Fix another setTimeout memory leak

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -611,6 +611,11 @@ class SourceCache extends Evented {
     }
 
     _setTileReloadTimer(id: string | number, tile: Tile) {
+        if (id in this._timers) {
+            clearTimeout(this._timers[id]);
+            delete this._timers[id];
+        }
+
         const expiryTimeout = tile.getExpiryTimeout();
         if (expiryTimeout) {
             this._timers[id] = setTimeout(() => {
@@ -621,6 +626,11 @@ class SourceCache extends Evented {
     }
 
     _setCacheInvalidationTimer(id: string | number, tile: Tile) {
+        if (id in this._cacheTimers) {
+            clearTimeout(this._cacheTimers[id]);
+            delete this._cacheTimers[id];
+        }
+
         const expiryTimeout = tile.getExpiryTimeout();
         if (expiryTimeout) {
             this._cacheTimers[id] = setTimeout(() => {


### PR DESCRIPTION
Follow on to #5943, fixes #5123.

In the prior PR, I missed the fact that because the keys in `this._cacheTimers` are keys from _unwrapped_ tile IDs, one call to `_setCacheInvalidationTimer` might overwrite the value from a prior call. This guards against that, and does so for the `_timers` map as well for good measure.