### PR TITLE
Guard against undefined stylesheet.

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1481,7 +1481,7 @@ class Map extends Camera {
                 now,
                 fadeDuration: this._fadeDuration,
                 zoomHistory: this.style.zoomHistory,
-                transition: util.extend({ duration: 300, delay: 0 }, this.style.stylesheet.transition)
+                transition: this.style.getTransition()
             });
 
             const factor = parameters.crossFadingFactor();


### PR DESCRIPTION
We're seeing issues in production with stylesheet being undefined. There also seem to be other places were it's access is guarded. see: https://github.com/mapbox/mapbox-gl-js/blob/ca01a1edfc4b0a1b10b85db1a722cc2aa4f6163a/src/style/style.js#L776