### PR TITLE
Add documentation clarifying stop output value type

### DIFF
--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -1481,9 +1481,10 @@ export default class extends React.Component {
                                             <div><em className='quiet'>Required (except
                                                 for <var>identity</var> functions) <a href='#types-array'>array</a>.</em></div>
                                             <div>Functions are defined in terms of input and output values. A set of one
-                                                input value and one output value is known as a "stop." Output values can
-                                                be strings, numbers, and booleans. They cannot be functions or
-                                                expressions.
+                                                input value and one output value is known as a "stop." Stop output values
+                                                must be literal values (i.e. not functions or expressions), and appropriate
+                                                for the property. For example, stop output values for a function used in
+                                                the `fill-color` property must be <a href="#types-color">colors</a>.
                                             </div>
                                         </div>
                                         <div className="col12 clearfix pad0y pad2x space-bottom2">

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -1478,10 +1478,12 @@ export default class extends React.Component {
                                         <div className="col12 clearfix pad0y pad2x space-bottom2">
                                             <div><span className='code'><a id="function-stops" href="#function-stops">stops</a></span>
                                             </div>
-                                            <div><em className='quiet'>Required (except for <var>identity</var>
-                                                functions) <a href='#types-array'>array</a>.</em></div>
+                                            <div><em className='quiet'>Required (except
+                                                for <var>identity</var> functions) <a href='#types-array'>array</a>.</em></div>
                                             <div>Functions are defined in terms of input and output values. A set of one
-                                                input value and one output value is known as a "stop."
+                                                input value and one output value is known as a "stop." Output values can
+                                                be strings, numbers, and booleans. They cannot be functions or
+                                                expressions.
                                             </div>
                                         </div>
                                         <div className="col12 clearfix pad0y pad2x space-bottom2">

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -1484,7 +1484,7 @@ export default class extends React.Component {
                                                 input value and one output value is known as a "stop." Stop output values
                                                 must be literal values (i.e. not functions or expressions), and appropriate
                                                 for the property. For example, stop output values for a function used in
-                                                the `fill-color` property must be <a href="#types-color">colors</a>.
+                                                the <code>fill-color</code> property must be <a href="#types-color">colors</a>.
                                             </div>
                                         </div>
                                         <div className="col12 clearfix pad0y pad2x space-bottom2">


### PR DESCRIPTION
Earlier today I was trying an expression as the output of a stop value. There were cryptic errors, but I didn't find in the spec whether this was *supposed* to work or not. @jfirebaugh clarified in chat that this shouldn't work, so I thought I'd try amending the docs.

I also corrected a spacing problem.

Before:

<img width="647" alt="screen shot 2018-01-05 at 3 29 10 pm" src="https://user-images.githubusercontent.com/628431/34631358-38889122-f22d-11e7-8e56-bf0fcad4e1ee.png">

After:

<img width="663" alt="screen shot 2018-01-05 at 3 27 24 pm" src="https://user-images.githubusercontent.com/628431/34631332-1b429a4a-f22d-11e7-9bff-e39feba46ddd.png">
