### PR TITLE
Minor corrections in style spec documentation

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1162,7 +1162,7 @@
     "icon-offset": {
       "type": "array",
       "value": "number",
-      "units": "pixels multiplied by the value of \"icon-size\"",
+      "units": "pixels multiplied by the value of `icon-size`",
       "length": 2,
       "default": [
         0,
@@ -1353,7 +1353,7 @@
       "property-function": true,
       "default": "",
       "tokens": true,
-      "doc": "Value to use for a text label. Feature properties are specified using tokens like `{field_name}`. (`{token}` replacement is only supported for literal `text-field` values; not for property functions.)",
+      "doc": "Value to use for a text label. Feature properties are specified using tokens like `{field_name}`. (`{token}` replacement is only supported for literal `text-field` values, not for data expressions or property functions.)",
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",


### PR DESCRIPTION
Made two small changes to the style specification JSON to facilitate better codegen results in mapbox/mapbox-gl-native#10850:

* `icon-offset` uses backticks around the reference to `icon-size` so that `icon-size` can become `iconScale` on iOS/macOS.
* Indicated that `{token}` replacement is also unavailable in data expressions. At least that’s the case in the native implementation; not sure about GL JS.

/cc @jfirebaugh