### PR TITLE
link to tutorials from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ native SDKs. For code and issues specific to the native SDKs, see the
 [mapbox/mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native/) repository.
 
 - [Getting started with Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/api/)
+- [Tutorials](https://www.mapbox.com/help/tutorials/#web-apps)
 - [API documentation](https://www.mapbox.com/mapbox-gl-js/api/)
 - [Examples](https://www.mapbox.com/mapbox-gl-js/examples/)
 - [Style documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/)


### PR DESCRIPTION
There are some great GL JS tutorials at https://www.mapbox.com/help/tutorials/#web-apps but for someone who lands at this repository rather than mapbox.com they might not find or know about them. Hopefully adding this link will make them more discoverable.

Right now you would have to go to the Getting Started link which takes you to https://www.mapbox.com/mapbox-gl-js/api, then GL JS Fundamentals which takes you to https://www.mapbox.com/help/mapbox-gl-js-fundamentals/ then at the end of that you get some more tutorials.