### PR TITLE
fix values setting for the Light object

### DIFF
--- a/src/style/light.js
+++ b/src/style/light.js
@@ -78,6 +78,12 @@ class Light extends Evented {
     constructor(lightOptions?: LightSpecification) {
         super();
         this._transitionable = new Transitionable(properties);
+        // make sure initial state is set even if all light values are defaults.
+        lightOptions = lightOptions || {};
+        for (const key in properties.properties) {
+            if (lightOptions[key] === undefined) lightOptions[key] = styleSpec.light[key].default;
+        }
+
         this.setLight(lightOptions);
         this._transitioning = this._transitionable.untransitioned();
     }

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -287,6 +287,25 @@ test('Style#loadJSON', (t) => {
         });
     });
 
+    t.test('populates light values even if style does not specify properties', (t)=>{
+        const style = new Style(new StubMap());
+        style.on('style.load', ()=>{
+            console.log(Object.keys(style.getLight()));
+            t.deepEqual(Object.keys(style.getLight()), ['anchor', 'position', 'color', 'intensity']);
+            t.end();
+        });
+
+        style.loadJSON({
+            "version": 8,
+            "sources": {
+                "foo": {
+                    "type": "vector"
+                }
+            },
+            "layers": []
+        });
+    });
+
     t.test('transforms sprite json and image URLs before request', (t) => {
         window.useFakeXMLHttpRequest();
 


### PR DESCRIPTION
noticed this when `map.getLight` was returning an empty object – it turns out when a style used all defaults for the `Light` properties, we were never initializing their values with `setLight` because `lightOptions` was undefined. 

open to alternative approaches if this is not the best way to go about this

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
