### PR TITLE
Introduce 'gpuTiming' map options

### DIFF
--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -61,10 +61,12 @@ class Context {
     extTextureFilterAnisotropic: any;
     extTextureFilterAnisotropicMax: any;
     extTextureHalfFloat: any;
+    timerQueryExt: any;
 
     constructor(gl: WebGLRenderingContext) {
         this.gl = gl;
         this.extVertexArrayObject = this.gl.getExtension('OES_vertex_array_object');
+        this.timerQueryExt = this.gl.getExtension('EXT_disjoint_timer_query');
         this.lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
 
         this.clearColor = new ClearColor(this);

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -58,13 +58,15 @@ import type VertexBuffer from '../gl/vertex_buffer';
 import type {DepthMaskType, DepthFuncType} from '../gl/types';
 
 export type RenderPass = 'offscreen' | 'opaque' | 'translucent';
+export type GPUTiming = 'none' | 'frame' | 'layer';
 
 type PainterOptions = {
     showOverdrawInspector: boolean,
     showTileBoundaries: boolean,
     rotating: boolean,
     zooming: boolean,
-    fadeDuration: number
+    fadeDuration: number,
+    gpuTiming: GPUTiming
 }
 
 /**
@@ -107,6 +109,7 @@ class Painter {
     cache: { [string]: Program };
     crossTileSymbolIndex: CrossTileSymbolIndex;
     symbolFadeChange: number;
+    layerTimers: { [string]: any };
 
     constructor(gl: WebGLRenderingContext, transform: Transform) {
         this.context = new Context(gl);
@@ -125,6 +128,8 @@ class Painter {
         this.emptyProgramConfiguration = new ProgramConfiguration();
 
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
+
+        this.layerTimers = {};
     }
 
     /*
@@ -323,7 +328,7 @@ class Painter {
 
                 if (!coords.length) continue;
 
-                this.renderLayer(this, (sourceCache: any), layer, coords);
+                this.renderLayer(this, (sourceCache: any), layer, coords, options.gpuTiming);
             }
 
             // Rebind the main framebuffer now that all offscreen layers
@@ -363,7 +368,7 @@ class Painter {
                     }
                 }
 
-                this.renderLayer(this, (sourceCache: any), layer, coords);
+                this.renderLayer(this, (sourceCache: any), layer, coords, options.gpuTiming);
             }
         }
 
@@ -394,7 +399,7 @@ class Painter {
                     coords.reverse();
                 }
 
-                this.renderLayer(this, (sourceCache: any), layer, coords);
+                this.renderLayer(this, (sourceCache: any), layer, coords, options.gpuTiming);
             }
         }
 
@@ -414,12 +419,59 @@ class Painter {
         }
     }
 
-    renderLayer(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, coords: Array<OverscaledTileID>) {
+    renderLayer(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, coords: Array<OverscaledTileID>, gpuTiming: GPUTiming) {
         if (layer.isHidden(this.transform.zoom)) return;
         if (layer.type !== 'background' && !coords.length) return;
         this.id = layer.id;
 
+        const ext = this.context.timerQueryExt;
+        let renderLayerStart = 0;
+        let layerTimer = {};
+        if (gpuTiming === 'layer') {
+            // This tries to time the draw call itself, but note that the cost for drawing a layer
+            // may be dominated by the cost of uploading vertices to the GPU.
+            // To instrument that, we'd need to pass the layerTimers object down into the bucket
+            // uploading logic.
+            layerTimer = this.layerTimers[layer.id];
+            if (!layerTimer) {
+                layerTimer = this.layerTimers[layer.id] = {
+                    calls: 0,
+                    cpuTime: 0,
+                    query: ext.createQueryEXT()
+                };
+            }
+            layerTimer.calls++;
+            ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, layerTimer.query);
+            renderLayerStart = browser.now();
+        }
+
         draw[layer.type](painter, sourceCache, layer, coords);
+
+        if (gpuTiming === 'layer') {
+            layerTimer.cpuTime = browser.now() - renderLayerStart;
+            ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
+        }
+    }
+
+    resetLayerTimers() {
+        const currentLayerTimers = this.layerTimers;
+        this.layerTimers = {};
+        return currentLayerTimers;
+    }
+
+    queryAndClearLayerTimers(layerTimers: {[string]: any}) {
+        const layers = {};
+        for (const layerId in layerTimers) {
+            const layerTimer = layerTimers[layerId];
+            const ext = this.context.timerQueryExt;
+            const gpuTime = ext.getQueryObjectEXT(layerTimer.query, ext.QUERY_RESULT_EXT) / (1000 * 1000);
+            ext.deleteQueryEXT(layerTimer.query);
+            layers[layerId] = {
+                gpuTime: gpuTime,
+                cpuTime: layerTimer.cpuTime
+            };
+        }
+        return layers;
     }
 
     /**


### PR DESCRIPTION
I've been working on an "animation benchmarker" that replays animated scenes to collect performance statistics. @jfirebaugh pointed me at the [disjoint_query_timer extension](https://developer.mozilla.org/en-US/docs/Web/API/EXT_disjoint_timer_query) as a way to try to capture meaningful GPU timing stats to combine with CPU timing stats collected using `window.performance`. This PR tries to generalize the frame-timing part of that work. It introduces a new "gpuTiming" Map option which can be 'none' (default), 'frame', or 'layer'.

 - 'frame' records total CPU and GPU time spent rendering every frame

![screenshot 2018-01-08 16 27 18](https://user-images.githubusercontent.com/375121/34699198-d6f4d04a-f490-11e7-8faf-2fe6c6ba834c.png)

 - 'layer' breaks down CPU and GPU draw call time by layer. Draw calls alone miss a lot of the costs of rendering, so interpret these numbers with caution.

![screenshot 2018-01-08 16 25 57](https://user-images.githubusercontent.com/375121/34699202-dc4d6aca-f490-11e7-8c01-d34dd3e8f41f.png)

When timing is on, the map fires a `frame-timing` event after each frame.

The 'frame' method gives results that seem to line up decently well with what I see in the Chrome performance timeline. I'm much less confident in what the 'layer' method is measuring -- although the results seem to correlate with other measures of layer cost, the measured costs seem to be an order of magnitude too low. Adding bucket upload times to the per-layer measurements might help, but I suspect it's either a limitation of the query API or my misuse of it.

I haven't handled "disjoint" errors at all, I don't know if that's likely to make a big difference in the "performance testing on a desktop" case:

> Disjoint operations occur whenever a change in the GPU occurs that will
    make the values returned by this extension unusable for performance 
    metrics. An example can be seen with how mobile GPUs need to proactively
    try to conserve power, which might cause the GPU to go to sleep at the 
    lower levers. This means disjoint states will occur at different times on
    different platforms and are implementation dependent.

You can play around with this on the debug page by adding a 'gpuTiming' option and something like:

    map.on('frame-timing', function(data) {
        console.log(data);
    });

/cc @jfirebaugh @lbud @nickidlugash @kkaefer 