### PR TITLE
don't check if a geojson tile expired (they never do)

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -196,7 +196,7 @@ class GeoJSONSource extends Evented implements Source {
     }
 
     loadTile(tile: Tile, callback: Callback<void>) {
-        const message = tile.workerID === undefined || tile.state === 'expired' ? 'loadTile' : 'reloadTile';
+        const message = tile.workerID === undefined ? 'loadTile' : 'reloadTile';
         const params = {
             type: this.type,
             uid: tile.uid,


### PR DESCRIPTION
This removes a condition which is never true.
@ChrisLoer 