### PR TITLE
temporarily disable transitions for hillshade-illumination-direction

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2302,7 +2302,7 @@
       "default": [1.15, 210, 30],
       "length": 3,
       "value": "number",
-      "transition": true,
+      "transition": false,
       "function": "interpolated",
       "zoom-function": true,
       "property-function": false,
@@ -3828,7 +3828,7 @@
         "doc": "The direction of the light source used to generate the hillshading with 0 as the top of the viewport if `hillshade-illumination-anchor` is set to `viewport` and due north if `hillshade-illumination-anchor` is set to `map`.",
         "function": "interpolated",
         "zoom-function": true,
-        "transition": true
+        "transition": false
       },
       "hillshade-illumination-anchor": {
         "type": "enum",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2302,7 +2302,7 @@
       "default": [1.15, 210, 30],
       "length": 3,
       "value": "number",
-      "transition": false,
+      "transition": true,
       "function": "interpolated",
       "zoom-function": true,
       "property-function": false,


### PR DESCRIPTION
temporary workaround for https://github.com/mapbox/mapbox-gl-js/issues/5934
cc @stevage 

light-position wasn't actually transitioning, despite having `transition: true` in the style spec, so this won't change behavior from the current version. 

when I have some spare time I will implement an interpolation function that accounts for light-position and hillshade-illumination-direction for a better solution

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
