### PR TITLE
Don't mix coalesce calls from multiple GeoJSON sources (issue #5970)

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -181,17 +181,19 @@ class GeoJSONSource extends Evented implements Source {
         // target {this.type}.loadData rather than literally geojson.loadData,
         // so that other geojson-like source types can easily reuse this
         // implementation
-        this.workerID = this.dispatcher.send(`${this.type}.loadData`, options, (err) => {
-            this._loaded = true;
-            // Any `loadData` calls that piled up while we were processing
-            // this one will get coalesced into a single call when this
-            // 'coalesce' message is processed.
-            // We would self-send from the worker if we had access to its
-            // message queue. Waiting instated for the 'coalesce' to round-trip
-            // through the foreground just means we're throttling the worker
-            // to run at a little less than full-throttle.
-            this.dispatcher.send(`${this.type}.coalesce`, null, null, this.workerID);
-            callback(err);
+        this.workerID = this.dispatcher.send(`${this.type}.loadData`, options, (err, abandoned) => {
+            if (!abandoned) {
+                this._loaded = true;
+                // Any `loadData` calls that piled up while we were processing
+                // this one will get coalesced into a single call when this
+                // 'coalesce' message is processed.
+                // We would self-send from the worker if we had access to its
+                // message queue. Waiting instead for the 'coalesce' to round-trip
+                // through the foreground just means we're throttling the worker
+                // to run at a little less than full-throttle.
+                this.dispatcher.send(`${this.type}.coalesce`, this.workerOptions, null, this.workerID);
+                callback(err);
+            }
         }, this.workerID);
     }
 

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -86,7 +86,7 @@ test('reloadTile', (t) => {
 
         function addData(callback) {
             source.loadData({ source: 'sourceId', data: JSON.stringify(geoJson) }, (err) => {
-                source.coalesce();
+                source.coalesce({ source: 'sourceId' });
                 t.equal(err, null);
                 callback();
             });
@@ -127,6 +127,93 @@ test('reloadTile', (t) => {
                 t.equal(loadVectorCallCount, 2);
                 t.end();
             });
+        });
+    });
+
+    t.end();
+});
+
+
+test('loadData', (t) => {
+    const layers = [
+        {
+            id: 'layer1',
+            source: 'source1',
+            type: 'symbol',
+        },
+        {
+            id: 'layer2',
+            source: 'source2',
+            type: 'symbol',
+        }
+    ];
+
+    const geoJson = {
+        "type": "Feature",
+        "geometry": {
+            "type": "Point",
+            "coordinates": [0, 0]
+        }
+    };
+
+    const layerIndex = new StyleLayerIndex(layers);
+    function createWorker() {
+        const worker = new GeoJSONWorkerSource(null, layerIndex);
+
+        // Making the call to loadGeoJSON to asynchronous
+        // allows these tests to mimic a message queue building up
+        // (regardless of timing)
+        const originalLoadGeoJSON = worker.loadGeoJSON;
+        worker.loadGeoJSON = function(params, callback) {
+            setTimeout(() => {
+                originalLoadGeoJSON(params, callback);
+            }, 0);
+        };
+        return worker;
+    }
+
+    t.test('abandons coalesced callbacks', (t) => {
+        // Expect first call to run, second to be abandoned,
+        // and third to run in response to coalesce
+        const worker = createWorker();
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            worker.coalesce({ source: 'source1' });
+        });
+
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.ok(abandoned);
+        });
+
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            t.end();
+        });
+    });
+
+    t.test('does not mix coalesce state between sources', (t) => {
+        // Expect first and second calls to run independently,
+        // and third call should run in response to coalesce
+        // from first call.
+        const worker = createWorker();
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            worker.coalesce({ source: 'source1' });
+        });
+
+        worker.loadData({ source: 'source2', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+        });
+
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            t.end();
         });
     });
 


### PR DESCRIPTION
Fixes issue #5970.

Also: send back an "abandoned" callback for coalesced calls so that foreground doesn't leak callback handles.

Adds 'loadData' unit test for geojson_worker_source that simulates building up a queue of loadData messages.

/cc @ansis @jfirebaugh @anandthakker 