### PR TITLE
per-SourceType WorkerSource -> per-source-instance WorkerSource

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -79,6 +79,7 @@ class GeoJSONSource extends Evented implements Source {
     _loaded: boolean;
     _collectResourceTiming: boolean;
     _resourceTiming: Array<PerformanceResourceTiming>;
+    _removed: boolean;
 
     constructor(id: string, options: GeojsonSourceSpecification & {workerOptions?: any, collectResourceTiming: boolean}, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
@@ -94,6 +95,7 @@ class GeoJSONSource extends Evented implements Source {
         this.tileSize = 512;
         this.isTileClipped = true;
         this.reparseOverscaled = true;
+        this._removed = false;
 
         this.dispatcher = dispatcher;
         this.setEventedParent(eventedParent);
@@ -198,11 +200,11 @@ class GeoJSONSource extends Evented implements Source {
             options.data = JSON.stringify(data);
         }
 
-        // target {this.type}.loadData rather than literally geojson.loadData,
+        // target {this.type}.{options.source}.loadData rather than literally geojson.loadData,
         // so that other geojson-like source types can easily reuse this
         // implementation
-        this.workerID = this.dispatcher.send(`${this.type}.loadData`, options, (err, abandoned) => {
-            if (!abandoned) {
+        this.workerID = this.dispatcher.send(`${this.type}.${options.source}.loadData`, options, (err, abandoned) => {
+            if (!abandoned && !this._removed) {
                 this._loaded = true;
 
            		if (result && result.resourceTiming && result.resourceTiming[this.id])
@@ -214,7 +216,7 @@ class GeoJSONSource extends Evented implements Source {
                 // message queue. Waiting instead for the 'coalesce' to round-trip
                 // through the foreground just means we're throttling the worker
                 // to run at a little less than full-throttle.
-                this.dispatcher.send(`${this.type}.coalesce`, this.workerOptions, null, this.workerID);
+                this.dispatcher.send(`${this.type}.${options.source}.coalesce`, null, null, this.workerID);
                 callback(err);
             }
         }, this.workerID);
@@ -262,7 +264,8 @@ class GeoJSONSource extends Evented implements Source {
     }
 
     onRemove() {
-        this.dispatcher.broadcast('removeSource', { type: this.type, source: this.id });
+        this._removed = true;
+        this.dispatcher.send('removeSource', { type: this.type, source: this.id }, null, this.workerID);
     }
 
     serialize() {

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -85,7 +85,9 @@ export type SourceState =
 class GeoJSONWorkerSource extends VectorTileWorkerSource {
     loadGeoJSON: LoadGeoJSON;
     _state: SourceState;
-    _pendingCallback: Callback<boolean>;
+    _pendingCallback: Callback<{
+        resourceTiming?: {[string]: Array<PerformanceResourceTiming>},
+        abandoned?: boolean }>;
     _pendingLoadDataParams: LoadGeoJSONParameters;
     _geoJSONIndex: GeoJSONIndex
 
@@ -117,10 +119,12 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * @param params
      * @param callback
      */
-    loadData(params: LoadGeoJSONParameters, callback: Callback<boolean>) {
+    loadData(params: LoadGeoJSONParameters, callback: Callback<{
+        resourceTiming?: {[string]: Array<PerformanceResourceTiming>},
+        abandoned?: boolean }>) {
         if (this._pendingCallback) {
             // Tell the foreground the previous call has been abandoned
-            this._pendingCallback(null, true);
+            this._pendingCallback(null, { abandoned: true });
         }
         this._pendingCallback = callback;
         this._pendingLoadDataParams = params;
@@ -261,7 +265,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     removeSource(params: {source: string}, callback: Callback<mixed>) {
         if (this._pendingCallback) {
             // Don't leak callbacks
-            this._pendingCallback(null, true);
+            this._pendingCallback(null, { abandoned: true });
         }
         callback();
     }

--- a/src/source/raster_dem_tile_worker_source.js
+++ b/src/source/raster_dem_tile_worker_source.js
@@ -12,8 +12,8 @@ import type {
 
 class RasterDEMTileWorkerSource {
     actor: Actor;
-    loading: {[string]: {[string]: DEMData}};
-    loaded: {[string]: {[string]: DEMData}};
+    loading: {[string]: DEMData};
+    loaded: {[string]: DEMData};
 
     constructor() {
         this.loading = {};
@@ -21,24 +21,20 @@ class RasterDEMTileWorkerSource {
     }
 
     loadTile(params: WorkerDEMTileParameters, callback: WorkerDEMTileCallback) {
-        const source = params.source,
-            uid = params.uid;
-
-        if (!this.loading[source])
-            this.loading[source] = {};
+        const uid = params.uid;
 
         const dem = new DEMData(uid);
-        this.loading[source][uid] = dem;
+        this.loading[uid] = dem;
         dem.loadFromImage(params.rawImageData);
-        delete this.loading[source][uid];
+        delete this.loading[uid];
 
-        this.loaded[source] = this.loaded[source] || {};
-        this.loaded[source][uid] = dem;
+        this.loaded = this.loaded || {};
+        this.loaded[uid] = dem;
         callback(null, dem);
     }
 
     removeTile(params: TileParameters) {
-        const loaded = this.loaded[params.source],
+        const loaded = this.loaded,
             uid = params.uid;
         if (loaded && loaded[uid]) {
             delete loaded[uid];

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -85,5 +85,10 @@ export interface WorkerSource {
      */
     removeTile(params: TileParameters, callback: WorkerTileCallback): void;
 
+    /**
+     * Tells the WorkerSource to abort in-progress tasks and release resources.
+     * The foreground Source is responsible for ensuring that 'removeSource' is
+     * the last message sent to the WorkerSource.
+     */
     removeSource?: (params: {source: string}, callback: WorkerTileCallback) => void;
 }

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -38,7 +38,7 @@ class Actor {
      * Sends a message from a main-thread map to a Worker or from a Worker back to
      * a main-thread map instance.
      *
-     * @param type The name of the target method to invoke or '[source-type].name' for a method on a WorkerSource.
+     * @param type The name of the target method to invoke or '[source-type].[source-name].name' for a method on a WorkerSource.
      * @param targetMapId A particular mapId to which to send this message.
      * @private
      */
@@ -86,10 +86,10 @@ class Actor {
             // data.type == 'loadTile', 'removeTile', etc.
             this.parent[data.type](data.sourceMapId, deserialize(data.data), done);
         } else if (typeof data.id !== 'undefined' && this.parent.getWorkerSource) {
-            // data.type == sourcetype.method
+            // data.type == sourcetype.sourcename.method
             const keys = data.type.split('.');
-            const workerSource = (this.parent: any).getWorkerSource(data.sourceMapId, keys[0]);
-            workerSource[keys[1]](deserialize(data.data), done);
+            const workerSource = (this.parent: any).getWorkerSource(data.sourceMapId, keys[0], keys[1]);
+            workerSource[keys[2]](deserialize(data.data), done);
         } else {
             this.parent[data.type](deserialize(data.data));
         }

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -52,7 +52,9 @@ test('GeoJSONSource#setData', (t) => {
         opts = util.extend(opts, { data: {} });
         return new GeoJSONSource('id', opts, {
             send: function (type, data, callback) {
-                return setTimeout(callback, 0);
+                if (callback) {
+                    return setTimeout(callback, 0);
+                }
             }
         });
     }
@@ -172,7 +174,9 @@ test('GeoJSONSource#update', (t) => {
     t.test('fires event when metadata loads', (t) => {
         const mockDispatcher = {
             send: function(message, args, callback) {
-                setTimeout(callback, 0);
+                if (callback) {
+                    setTimeout(callback, 0);
+                }
             }
         };
 
@@ -188,7 +192,9 @@ test('GeoJSONSource#update', (t) => {
     t.test('fires "error"', (t) => {
         const mockDispatcher = {
             send: function(message, args, callback) {
-                setTimeout(callback.bind(null, 'error'), 0);
+                if (callback) {
+                    setTimeout(callback.bind(null, 'error'), 0);
+                }
             }
         };
 
@@ -209,7 +215,9 @@ test('GeoJSONSource#update', (t) => {
                 if (message === 'geojson.loadData' && --expectedLoadDataCalls <= 0) {
                     t.end();
                 }
-                setTimeout(callback, 0);
+                if (callback) {
+                    setTimeout(callback, 0);
+                }
             }
         };
 

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -102,13 +102,13 @@ test('GeoJSONSource#setData', (t) => {
 test('GeoJSONSource#onRemove', (t) => {
     t.test('broadcasts "removeSource" event', (t) => {
         const source = new GeoJSONSource('id', {data: {}}, {
-            broadcast: function (type, data, callback) {
+            send: function (type, data, callback) {
                 t.false(callback);
                 t.equal(type, 'removeSource');
                 t.deepEqual(data, { type: 'geojson', source: 'id' });
                 t.end();
             },
-            send: function() {
+            broadcast: function() {
                 // Ignore
             }
         });
@@ -129,7 +129,7 @@ test('GeoJSONSource#update', (t) => {
     t.test('sends initial loadData request to dispatcher', (t) => {
         const mockDispatcher = {
             send: function(message) {
-                t.equal(message, 'geojson.loadData');
+                t.equal(message, 'geojson.id.loadData');
                 t.end();
             }
         };
@@ -141,7 +141,7 @@ test('GeoJSONSource#update', (t) => {
     t.test('forwards geojson-vt options with worker request', (t) => {
         const mockDispatcher = {
             send: function(message, params) {
-                t.equal(message, 'geojson.loadData');
+                t.equal(message, 'geojson.id.loadData');
                 t.deepEqual(params.geojsonVtOptions, {
                     extent: 8192,
                     maxZoom: 10,
@@ -212,7 +212,7 @@ test('GeoJSONSource#update', (t) => {
         let expectedLoadDataCalls = 2;
         const mockDispatcher = {
             send: function(message, args, callback) {
-                if (message === 'geojson.loadData' && --expectedLoadDataCalls <= 0) {
+                if (message === 'geojson.id.loadData' && --expectedLoadDataCalls <= 0) {
                     t.end();
                 }
                 if (callback) {

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -86,7 +86,7 @@ test('GeoJSONSource#setData', (t) => {
             _transformRequest: (data) => { return { url: data }; }
         };
         source.dispatcher.send = function(type, params, cb) {
-            if (type === 'geojson.loadData') {
+            if (type === 'geojson.id.loadData') {
                 t.true(params.request.collectResourceTiming, 'collectResourceTiming is true on dispatcher message');
                 setTimeout(cb, 0);
                 t.end();

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -193,20 +193,20 @@ test('loadData', (t) => {
         // Expect first call to run, second to be abandoned,
         // and third to run in response to coalesce
         const worker = createWorker();
-        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, result) => {
             t.equal(err, null);
-            t.notOk(abandoned);
+            t.notOk(result && result.abandoned);
             worker.coalesce({ source: 'source1' });
         });
 
-        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, result) => {
             t.equal(err, null);
-            t.ok(abandoned);
+            t.ok(result && result.abandoned);
         });
 
-        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, result) => {
             t.equal(err, null);
-            t.notOk(abandoned);
+            t.notOk(result && result.abandoned);
             t.end();
         });
     });
@@ -218,15 +218,15 @@ test('loadData', (t) => {
         // removeSource is executed immediately
         // First loadData finishes running, sends results back to foreground
         const worker = createWorker();
-        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, result) => {
             t.equal(err, null);
-            t.notOk(abandoned);
+            t.notOk(result && result.abandoned);
             t.end();
         });
 
-        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, result) => {
             t.equal(err, null);
-            t.ok(abandoned);
+            t.ok(result && result.abandoned);
         });
 
         worker.removeSource({ source: 'source1' }, (err) => {

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -6,54 +6,6 @@ const StyleLayerIndex = require('../../../src/style/style_layer_index');
 const OverscaledTileID = require('../../../src/source/tile_id').OverscaledTileID;
 const perf = require('../../../src/util/performance');
 
-test('removeSource', (t) => {
-    t.test('removes the source from _geoJSONIndexes', (t) => {
-        const source = new GeoJSONWorkerSource(null, new StyleLayerIndex());
-        const geoJson = {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [0, 0]
-            }
-        };
-
-        function addData(callback) {
-            source.loadData({ source: 'source', data: JSON.stringify(geoJson) }, (err) => {
-                t.equal(err, null);
-                callback();
-            });
-        }
-
-        function loadTile(callback) {
-            const loadVectorDataOpts = {
-                source: 'source',
-                tileID: new OverscaledTileID(0, 0, 0, 0, 0),
-                maxZoom: 10
-            };
-            source.loadVectorData(loadVectorDataOpts, (err, vectorTile) => {
-                t.equal(err, null);
-                callback(vectorTile);
-            });
-        }
-
-        addData(() => {
-            loadTile((vectorTile) => {
-                t.notEqual(vectorTile, null);
-                source.removeSource({ source: 'source' }, (err, res) => {
-                    t.false(err);
-                    t.false(res);
-                });
-                loadTile((vectorTile) => {
-                    t.equal(vectorTile, null);
-                    t.end();
-                });
-            });
-        });
-    });
-
-    t.end();
-});
-
 test('reloadTile', (t) => {
     t.test('does not rebuild vector data unless data has changed', (t) => {
         const layers = [
@@ -259,56 +211,28 @@ test('loadData', (t) => {
         });
     });
 
-    t.test('does not mix coalesce state between sources', (t) => {
-        // Expect first and second calls to run independently,
-        // and third call should run in response to coalesce
-        // from first call.
+    t.test('removeSource aborts callbacks', (t) => {
+        // Expect:
+        // First loadData starts running before removeSource arrives
+        // Second loadData is pending when removeSource arrives, gets cancelled
+        // removeSource is executed immediately
+        // First loadData finishes running, sends results back to foreground
         const worker = createWorker();
-        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
-            t.equal(err, null);
-            t.notOk(abandoned);
-            worker.coalesce({ source: 'source1' });
-        });
-
-        worker.loadData({ source: 'source2', data: JSON.stringify(geoJson) }, (err, abandoned) => {
-            t.equal(err, null);
-            t.notOk(abandoned);
-        });
-
         worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
             t.equal(err, null);
             t.notOk(abandoned);
             t.end();
         });
-    });
-
-    t.test('does not mix stored callbacks between sources', (t) => {
-        // Two loadData calls per source means no calls should
-        // be abandoned.
-        const worker = createWorker();
-        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
-            t.equal(err, null);
-            t.notOk(abandoned);
-            worker.coalesce({ source: 'source1' });
-        });
-
-        worker.loadData({ source: 'source2', data: JSON.stringify(geoJson) }, (err, abandoned) => {
-            t.equal(err, null);
-            t.notOk(abandoned);
-            worker.coalesce({ source: 'source2' });
-        });
-
-        worker.loadData({ source: 'source2', data: JSON.stringify(geoJson) }, (err, abandoned) => {
-            t.equal(err, null);
-            t.notOk(abandoned);
-            // test ends here because source2 has the last coalesce call
-            t.end();
-        });
 
         worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
             t.equal(err, null);
-            t.notOk(abandoned);
+            t.ok(abandoned);
         });
+
+        worker.removeSource({ source: 'source1' }, (err) => {
+            t.notOk(err);
+        });
+
     });
 
     t.end();

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -87,6 +87,7 @@ test('reloadTile', (t) => {
 
         function addData(callback) {
             source.loadData({ source: 'sourceId', data: JSON.stringify(geoJson) }, (err) => {
+                source.coalesce({ source: 'sourceId' });
                 t.equal(err, null);
                 callback();
             });
@@ -192,6 +193,121 @@ test('resourceTiming', (t) => {
             t.equal(err, null);
             t.equal(result.resourceTiming, undefined, 'no resourceTiming property when loadData is not sent a URL');
             t.end();
+        });
+    });
+
+    t.end();
+});
+
+test('loadData', (t) => {
+    const layers = [
+        {
+            id: 'layer1',
+            source: 'source1',
+            type: 'symbol',
+        },
+        {
+            id: 'layer2',
+            source: 'source2',
+            type: 'symbol',
+        }
+    ];
+
+    const geoJson = {
+        "type": "Feature",
+        "geometry": {
+            "type": "Point",
+            "coordinates": [0, 0]
+        }
+    };
+
+    const layerIndex = new StyleLayerIndex(layers);
+    function createWorker() {
+        const worker = new GeoJSONWorkerSource(null, layerIndex);
+
+        // Making the call to loadGeoJSON asynchronous
+        // allows these tests to mimic a message queue building up
+        // (regardless of timing)
+        const originalLoadGeoJSON = worker.loadGeoJSON;
+        worker.loadGeoJSON = function(params, callback) {
+            setTimeout(() => {
+                originalLoadGeoJSON(params, callback);
+            }, 0);
+        };
+        return worker;
+    }
+
+    t.test('abandons coalesced callbacks', (t) => {
+        // Expect first call to run, second to be abandoned,
+        // and third to run in response to coalesce
+        const worker = createWorker();
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            worker.coalesce({ source: 'source1' });
+        });
+
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.ok(abandoned);
+        });
+
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            t.end();
+        });
+    });
+
+    t.test('does not mix coalesce state between sources', (t) => {
+        // Expect first and second calls to run independently,
+        // and third call should run in response to coalesce
+        // from first call.
+        const worker = createWorker();
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            worker.coalesce({ source: 'source1' });
+        });
+
+        worker.loadData({ source: 'source2', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+        });
+
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            t.end();
+        });
+    });
+
+    t.test('does not mix stored callbacks between sources', (t) => {
+        // Two loadData calls per source means no calls should
+        // be abandoned.
+        const worker = createWorker();
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            worker.coalesce({ source: 'source1' });
+        });
+
+        worker.loadData({ source: 'source2', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            worker.coalesce({ source: 'source2' });
+        });
+
+        worker.loadData({ source: 'source2', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
+            // test ends here because source2 has the last coalesce call
+            t.end();
+        });
+
+        worker.loadData({ source: 'source1', data: JSON.stringify(geoJson) }, (err, abandoned) => {
+            t.equal(err, null);
+            t.notOk(abandoned);
         });
     });
 

--- a/test/unit/source/raster_dem_tile_worker_source.test.js
+++ b/test/unit/source/raster_dem_tile_worker_source.test.js
@@ -16,7 +16,7 @@ test('loadTile', (t) => {
             dim: 256
         }, (err, data)=>{
             if (err) t.fail();
-            t.deepEqual(source.loading, { source: {} });
+            t.deepEqual(source.loading, {});
             t.ok(data instanceof DEMData, 'returns DEM data');
 
             t.end();
@@ -31,9 +31,7 @@ test('removeTile', (t) => {
         const source = new RasterDEMTileWorkerSource(null, new StyleLayerIndex());
 
         source.loaded = {
-            source: {
-                '0': {}
-            }
+            '0': {}
         };
 
         source.removeTile({
@@ -41,10 +39,9 @@ test('removeTile', (t) => {
             uid: 0
         });
 
-        t.deepEqual(source.loaded, { source: {} });
+        t.deepEqual(source.loaded, {});
         t.end();
     });
 
     t.end();
 });
-

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -31,7 +31,7 @@ test('abortTile', (t) => {
             t.false(res);
         });
 
-        t.deepEqual(source.loading, { source: {} });
+        t.deepEqual(source.loading, {});
         t.end();
     });
 
@@ -43,9 +43,7 @@ test('removeTile', (t) => {
         const source = new VectorTileWorkerSource(null, new StyleLayerIndex());
 
         source.loaded = {
-            source: {
-                '0': {}
-            }
+            '0': {}
         };
 
         source.removeTile({
@@ -56,7 +54,7 @@ test('removeTile', (t) => {
             t.false(res);
         });
 
-        t.deepEqual(source.loaded, { source: {} });
+        t.deepEqual(source.loaded, {});
         t.end();
     });
 


### PR DESCRIPTION
Based on @jfirebaugh 's feedback on #5983, I started exploring instantiating `WorkerSource`s on a per-source basis instead of a per-source-type basis.

The initial set of changes were not too bad, and it allows for a nice simplification of geojson_worker_source that still supports the `setData` coalescing behavior.

My biggest concern is how this will affect custom sources -- requiring a source name to be included (either in parameters or in the "data.type" argument) is probably breaking the implied API?

`removeSource` also needs some re-thinking to handle messages that arrive after a source has been removed (or, moving even more into edge-case territory, to handle messages that were sent to a _previous_ instantiation of a source, which has been removed and then re-added).

The unit tests that handle multiple sources are currently broken, but render/query tests pass.

/cc @jfirebaugh @anandthakker 