### PR TITLE
Replace trailing use of Date with browser.now()

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -944,7 +944,7 @@ class Camera extends Evented {
         }
 
         this._prevEase = {
-            start: (new Date()).getTime(),
+            start: browser.now(),
             duration: duration,
             easing: easing
         };


### PR DESCRIPTION
Refs #5985, but reportedly doesn't fix it. 🤷‍♂️ 