### PR TITLE
Prevent multiple symbols at the same zoom from sharing a crossTileID

### DIFF
--- a/test/unit/symbol/cross_tile_symbol_index.js
+++ b/test/unit/symbol/cross_tile_symbol_index.js
@@ -119,5 +119,37 @@ test('CrossTileSymbolIndex.addLayer', (t) => {
         t.end();
     });
 
+    t.test('does not duplicate ids within one zoom level', (t) => {
+        const index = new CrossTileSymbolIndex();
+
+        const mainID = new OverscaledTileID(6, 0, 6, 8, 8);
+        const mainInstances = [
+            makeSymbolInstance(1000, 1000, ""), // A
+            makeSymbolInstance(1000, 1000, "")  // B
+        ];
+        const mainTile = makeTile(mainID, mainInstances);
+
+        const childID = new OverscaledTileID(7, 0, 7, 16, 16);
+        const childInstances = [
+            makeSymbolInstance(2000, 2000, ""), // A'
+            makeSymbolInstance(2000, 2000, ""), // B'
+            makeSymbolInstance(2000, 2000, "")  // C'
+        ];
+        const childTile = makeTile(childID, childInstances);
+
+        // assigns new ids
+        index.addLayer(styleLayer, [mainTile]);
+        t.equal(mainInstances[0].crossTileID, 1);
+        t.equal(mainInstances[1].crossTileID, 2);
+
+        // copies parent ids without duplicate ids in this tile
+        index.addLayer(styleLayer, [childTile]);
+        t.equal(childInstances[0].crossTileID, 1); // A' copies from A
+        t.equal(childInstances[1].crossTileID, 2); // B' copies from B
+        t.equal(childInstances[2].crossTileID, 3); // C' gets new ID
+
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
Fixes issue #5993, which would allow multiple symbols in a tile to share the same crossTileID as one of their duplicate parent-tile symbols. Once the symbols shared a crossTileID, they would permanently remain "duplicates" of each other, even after increasing zoom level allowed the CrossTileSymbolIndex to distinguish between them.

This change introduces some extra work on removing a bucket (since we have to iterate through all symbol instances removing their crossTileIDs from the index), but it doesn't really show up in benchmarks. However, running the Chrome javascript profiler while doing pan and zoom operations, I'm seeing `removeStaleBuckets` taking .5-1.5% of CPU time, which seems tolerable but still pretty concerning. Since there's no time urgency on the pruning, maybe we can set up a separate pruning function that we just run once every N minutes/iterations/frames?

On top of the unit test, I tested by manually exercising the "chinese.html" debug page with the keys all set to the same value. I watched to see how crossTileIDs got assigned and watched that `usedCrossTileIDs` wasn't growing without bound.

@friedbunny once we get this in we'll port it over to native to fix the original annotation view bug.

/cc @ansis