### PR TITLE
queryRenderedFeatures crash the map

### DIFF
--- a/debug/1178.html
+++ b/debug/1178.html
@@ -33,7 +33,7 @@
     });
 
     map.on('load', async () => {
-      const geojson = await fetch('https://storage.googleapis.com/storage.ubidev.net/meteogroup/dWU5OHd6Zmg4NzI5cmZjMDh6/geojson/geojsonsample-1178.json').then(res => res.json());
+      const geojson = await fetch('https://storage.googleapis.com/storage.ubidev.net/mapbox-gl-js/329034912902/geojsonsample-1178.json').then(res => res.json());
       map.addSource('src', {
         type: 'geojson',
         data: geojson

--- a/debug/1178.html
+++ b/debug/1178.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Mapbox GL JS debug page</title>
+  <meta charset='utf-8'>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+
+    html,
+    body,
+    #map {
+      height: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <div id='map'></div>
+
+  <script src='/dist/mapbox-gl-dev.js'></script>
+  <script src='/debug/access_token_generated.js'></script>
+  <script>
+
+    const map = window.map = new mapboxgl.Map({
+      container: 'map',
+      style: 'mapbox://styles/mapbox/streets-v10'
+    });
+
+    map.on('load', async () => {
+      const geojson = await fetch('https://storage.googleapis.com/storage.ubidev.net/meteogroup/dWU5OHd6Zmg4NzI5cmZjMDh6/geojson/geojsonsample-1178.json').then(res => res.json());
+      map.addSource('src', {
+        type: 'geojson',
+        data: geojson
+      });
+
+      map.addLayer({
+        type: 'fill',
+        id: 'layer',
+        source: 'src',
+        paint: {
+          'fill-opacity': 0.3
+        }
+      });
+
+      map.on('mousemove', event => {
+        map.queryRenderedFeatures(event.point, { layers: ['layer'] })
+      });
+    });
+
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Not a feature, but an example which completely crashes the map. I wasn't able to reproduce this in a jsfiddle, that's why I'm providing the sample as a debug page in a PR.

**mapbox-gl-js version**: v0.43.0/current master

### Steps to Trigger Behavior

0. (start the debug server, `npm run start-debug`)
1. Navigate to http://localhost:9966/debug/1178.html
2. Zoom close to the netherlands
3. Move your mouse over the rendered geojson polygons
4. The map & chrome tab get stuck/crash

### Expected Behavior

The map does not crash.

### Actual Behavior

The map crashes.

Hopefully this is reproducible for someone else. I don't think that this is an issue of calling `queryRenderedFeatures` in quick succession, this also happens with a similar setup listening for `click` events.