### PR TITLE
Sync continuously-updating interaction handlers with render loop

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -73,8 +73,9 @@ class Camera extends Evented {
     _bearingSnap: number;
     _onEaseEnd: number;
     _easeStart: number;
+    _isEasing: boolean;
     _easeOptions: {duration: number, easing: (number) => number};
-    _easeFn: (number) => void;
+    _onFrame: (Transform) => void;
     _finishFn: () => void;
     _prevEase: any;
     +_update: () => void;
@@ -848,7 +849,7 @@ class Camera extends Evented {
     }
 
     isEasing() {
-        return !!this._easeFn;
+        return !!this._isEasing;
     }
 
     /**
@@ -868,8 +869,8 @@ class Camera extends Evented {
      * @returns {Map} `this`
      */
     stop(): this {
-        if (this._easeFn) {
-            this._finishEase();
+        if (this._onFrame) {
+            this._finishAnimation();
         }
         return this;
     }
@@ -882,25 +883,49 @@ class Camera extends Evented {
             finish();
         } else {
             this._easeStart = browser.now();
-            this._easeFn = frame;
-            this._finishFn = finish;
+            this._isEasing = true;
             this._easeOptions = options;
-            this._update();
+            this._startAnimation((_) => {
+                const t = Math.min((browser.now() - this._easeStart) / this._easeOptions.duration, 1);
+                frame(this._easeOptions.easing(t));
+                if (t === 1) this.stop();
+            }, () => {
+                this._isEasing = false;
+                finish();
+            });
         }
     }
 
-    _updateEase() {
-        const t = Math.min((browser.now() - this._easeStart) / this._easeOptions.duration, 1);
-        this._easeFn(this._easeOptions.easing(t));
-        if (t === 1) {
-            this._finishEase();
+    /*
+     * Should be called at the top of the render loop to update camera position
+     * and orientation before they're read by any rendering logic.
+     */
+    _updateCamera() {
+        if (this._onFrame) {
+            this._onFrame(this.transform);
         }
     }
 
-    _finishEase() {
-        delete this._easeFn;
-        // The finish function might emit events which trigger new eases, which
-        // set a new _finishFn. Ensure we don't delete it unintentionally.
+    /*
+     * Start the camera animation using the given onFrame callback.
+     *
+     * @param onFrame A callback responsible for updating the transform to reflect the desired camera position and orientation, and also for firing any relevant camera movement events.
+     * @param finish A callback that is called when this animation is stopped (i.e., when `Camera#stop()` is called).
+     */
+    _startAnimation(onFrame: (Transform) => void,
+           finish: () => void): this {
+        this.stop();
+        this._onFrame = onFrame;
+        this._finishFn = finish;
+        this._update();
+        return this;
+    }
+
+    _finishAnimation() {
+        delete this._onFrame;
+        // The finish function might emit events which trigger new animation,
+        // which sets a new _finishFn. Ensure we don't delete it
+        // unintentionally.
         const finish = this._finishFn;
         delete this._finishFn;
         finish.call(this);

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -913,7 +913,7 @@ class Camera extends Evented {
      * @param finish A callback that is called when this animation is stopped (i.e., when `Camera#stop()` is called).
      */
     _startAnimation(onFrame: (Transform) => void,
-           finish: () => void): this {
+                    finish: () => void = () => {}): this {
         this.stop();
         this._onFrame = onFrame;
         this._finishFn = finish;

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -7,6 +7,7 @@ const browser = require('../../util/browser');
 
 import type Map from '../map';
 import type Point from '@mapbox/point-geometry';
+import type Transform from '../../geo/transform';
 
 const inertiaLinearity = 0.3,
     inertiaEasing = util.bezier(0, 0, inertiaLinearity, 1),
@@ -25,8 +26,10 @@ class DragPanHandler {
     _enabled: boolean;
     _active: boolean;
     _pos: Point;
+    _previousPos: Point;
     _startPos: Point;
     _inertia: Array<[number, Point]>;
+    _lastMoveEvent: MouseEvent | TouchEvent | void;
 
     constructor(map: Map) {
         this._map = map;
@@ -37,7 +40,9 @@ class DragPanHandler {
             '_onMove',
             '_onUp',
             '_onTouchEnd',
-            '_onMouseUp'
+            '_onMouseUp',
+            '_onDragFrame',
+            '_onDragFinished'
         ], this);
     }
 
@@ -102,41 +107,58 @@ class DragPanHandler {
         window.addEventListener('blur', this._onMouseUp);
 
         this._active = false;
-        this._startPos = this._pos = DOM.mousePos(this._el, e);
+        this._startPos = this._previousPos = DOM.mousePos(this._el, e);
         this._inertia = [[browser.now(), this._pos]];
     }
 
     _onMove(e: MouseEvent | TouchEvent) {
         if (this._ignoreEvent(e)) return;
+        this._lastMoveEvent = e;
+        e.preventDefault();
+
+        this._pos = DOM.mousePos(this._el, e);
+        this._drainInertiaBuffer();
+        this._inertia.push([browser.now(), this._pos]);
 
         if (!this.isActive()) {
+            // we treat the first move event (rather than the mousedown event)
+            // as the start of the drag
             this._active = true;
             this._map.moving = true;
             this._fireEvent('dragstart', e);
             this._fireEvent('movestart', e);
+
+            this._map._startAnimation(this._onDragFrame, this._onDragFinished);
         }
+    }
 
-        const pos = DOM.mousePos(this._el, e),
-            map = this._map;
+    /**
+     * Called in each render frame while dragging is happening.
+     * @private
+     */
+    _onDragFrame(tr: Transform) {
+        const e = this._lastMoveEvent;
+        if (!e) return;
 
-        map.stop();
-        this._drainInertiaBuffer();
-        this._inertia.push([browser.now(), pos]);
-
-        map.transform.setLocationAtPoint(map.transform.pointLocation(this._pos), pos);
-
+        tr.setLocationAtPoint(tr.pointLocation(this._previousPos), this._pos);
         this._fireEvent('drag', e);
         this._fireEvent('move', e);
 
-        this._pos = pos;
-
-        e.preventDefault();
+        this._previousPos = this._pos;
+        delete this._lastMoveEvent;
     }
 
-    _onUp(e: MouseEvent | TouchEvent | FocusEvent) {
+    /**
+     * Called when dragging stops.
+     * @private
+     */
+    _onDragFinished(e: MouseEvent | TouchEvent | FocusEvent | void) {
         if (!this.isActive()) return;
 
         this._active = false;
+        delete this._lastMoveEvent;
+        delete this._previousPos;
+
         this._fireEvent('dragend', e);
         this._drainInertiaBuffer();
 
@@ -180,6 +202,10 @@ class DragPanHandler {
         }, { originalEvent: e });
     }
 
+    _onUp(e: MouseEvent | TouchEvent | FocusEvent) {
+        this._onDragFinished(e);
+    }
+
     _onMouseUp(e: MouseEvent | FocusEvent) {
         if (this._ignoreEvent(e)) return;
         this._onUp(e);
@@ -195,8 +221,8 @@ class DragPanHandler {
         window.document.removeEventListener('touchend', this._onTouchEnd);
     }
 
-    _fireEvent(type: string, e: Event) {
-        return this._map.fire(type, { originalEvent: e });
+    _fireEvent(type: string, e: ?Event) {
+        return this._map.fire(type, e ? { originalEvent: e } : {});
     }
 
     _ignoreEvent(e: any) {

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -7,6 +7,7 @@ const browser = require('../../util/browser');
 
 import type Map from '../map';
 import type Point from '@mapbox/point-geometry';
+import type Transform from '../../geo/transform';
 
 const inertiaLinearity = 0.25,
     inertiaEasing = util.bezier(0, 0, inertiaLinearity, 1),
@@ -31,7 +32,10 @@ class DragRotateHandler {
     _button: 'right' | 'left';
     _bearingSnap: number;
     _pitchWithRotate: boolean;
+
+    _lastMoveEvent: MouseEvent;
     _pos: Point;
+    _previousPos: Point;
     _startPos: Point;
     _inertia: Array<[number, number]>;
     _center: Point;
@@ -51,7 +55,9 @@ class DragRotateHandler {
         util.bindAll([
             '_onDown',
             '_onMove',
-            '_onUp'
+            '_onUp',
+            '_onDragFrame',
+            '_onDragFinished'
         ], this);
     }
 
@@ -126,13 +132,16 @@ class DragRotateHandler {
 
         this._active = false;
         this._inertia = [[browser.now(), this._map.getBearing()]];
-        this._startPos = this._pos = DOM.mousePos(this._el, e);
+        this._startPos = this._previousPos = DOM.mousePos(this._el, e);
         this._center = this._map.transform.centerPoint;  // Center of rotation
 
         e.preventDefault();
     }
 
     _onMove(e: MouseEvent) {
+        this._lastMoveEvent = e;
+        this._pos = DOM.mousePos(this._el, e);
+
         if (!this.isActive()) {
             this._active = true;
             this._map.moving = true;
@@ -141,33 +150,9 @@ class DragRotateHandler {
             if (this._pitchWithRotate) {
                 this._fireEvent('pitchstart', e);
             }
+
+            this._map._startAnimation(this._onDragFrame, this._onDragFinished);
         }
-
-        const map = this._map;
-        map.stop();
-
-        const p1 = this._pos,
-            p2 = DOM.mousePos(this._el, e),
-            bearingDiff = (p1.x - p2.x) * 0.8,
-            pitchDiff = (p1.y - p2.y) * -0.5,
-            bearing = map.getBearing() - bearingDiff,
-            pitch = map.getPitch() - pitchDiff,
-            inertia = this._inertia,
-            last = inertia[inertia.length - 1];
-
-        this._drainInertiaBuffer();
-        inertia.push([browser.now(), map._normalizeBearing(bearing, last[1])]);
-
-        map.transform.bearing = bearing;
-        if (this._pitchWithRotate) {
-            this._fireEvent('pitch', e);
-            map.transform.pitch = pitch;
-        }
-
-        this._fireEvent('rotate', e);
-        this._fireEvent('move', e);
-
-        this._pos = p2;
     }
 
     _onUp(e: MouseEvent | FocusEvent) {
@@ -177,9 +162,45 @@ class DragRotateHandler {
 
         DOM.enableDrag();
 
+        this._onDragFinished(e);
+    }
+
+    _onDragFrame(tr: Transform) {
+        const e = this._lastMoveEvent;
+        if (!e) return;
+
+        const p1 = this._previousPos,
+            p2 = this._pos,
+            bearingDiff = (p1.x - p2.x) * 0.8,
+            pitchDiff = (p1.y - p2.y) * -0.5,
+            bearing = tr.bearing - bearingDiff,
+            pitch = tr.pitch - pitchDiff,
+            inertia = this._inertia,
+            last = inertia[inertia.length - 1];
+
+        this._drainInertiaBuffer();
+        inertia.push([browser.now(), this._map._normalizeBearing(bearing, last[1])]);
+
+        tr.bearing = bearing;
+        if (this._pitchWithRotate) {
+            this._fireEvent('pitch', e);
+            tr.pitch = pitch;
+        }
+
+        this._fireEvent('rotate', e);
+        this._fireEvent('move', e);
+
+        delete this._lastMoveEvent;
+        this._previousPos = this._pos;
+    }
+
+    _onDragFinished(e: MouseEvent | FocusEvent | void) {
         if (!this.isActive()) return;
 
         this._active = false;
+        delete this._lastMoveEvent;
+        delete this._previousPos;
+
         this._fireEvent('rotateend', e);
         this._drainInertiaBuffer();
 
@@ -236,8 +257,8 @@ class DragRotateHandler {
         }, { originalEvent: e });
     }
 
-    _fireEvent(type: string, e: Event) {
-        return this._map.fire(type, { originalEvent: e });
+    _fireEvent(type: string, e: ?Event) {
+        return this._map.fire(type, e ? { originalEvent: e } : {});
     }
 
     _drainInertiaBuffer() {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -309,9 +309,6 @@ class Map extends Camera {
 
         this.on('move', this._update.bind(this, false));
         this.on('zoom', this._update.bind(this, true));
-        this.on('move', () => {
-            this._rerender();
-        });
 
         if (typeof window !== 'undefined') {
             window.addEventListener('online', this._onWindowOnline, false);
@@ -1528,7 +1525,7 @@ class Map extends Camera {
         // Even though `_styleDirty` and `_sourcesDirty` are reset in this
         // method, synchronous events fired during Style#update or
         // Style#_updateSources could have caused them to be set again.
-        if (this._sourcesDirty || this._repaint || this._styleDirty || this._placementDirty || this.isEasing()) {
+        if (this._sourcesDirty || this._repaint || this._styleDirty || this._placementDirty) {
             this._rerender();
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1458,9 +1458,7 @@ class Map extends Camera {
      * @private
      */
     _render() {
-        if (this.isEasing()) {
-            this._updateEase();
-        }
+        this._updateCamera();
 
         let crossFading = false;
 

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -735,21 +735,21 @@ test('camera', (t) => {
 
                     setTimeout(() => {
                         stub.callsFake(() => 30);
-                        camera._updateEase();
+                        camera._updateCamera();
                     }, 0);
                 });
 
                 // setTimeout to avoid a synchronous callback
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             });
 
             // setTimeout to avoid a synchronous callback
             setTimeout(() => {
                 stub.callsFake(() => 10);
-                camera._updateEase();
+                camera._updateCamera();
             }, 0);
         });
 
@@ -776,11 +776,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -808,11 +808,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1019,11 +1019,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1054,15 +1054,15 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 10);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateEase();
+                    camera._updateCamera();
 
                     setTimeout(() => {
                         stub.callsFake(() => 30);
-                        camera._updateEase();
+                        camera._updateCamera();
                     }, 0);
                 }, 0);
             }, 0);
@@ -1091,11 +1091,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1123,11 +1123,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1155,11 +1155,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1187,11 +1187,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1219,11 +1219,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1251,11 +1251,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1283,11 +1283,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1314,11 +1314,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1351,11 +1351,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 3);
-                camera._updateEase();
+                camera._updateCamera();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateEase();
+                    camera._updateCamera();
                 }, 0);
             }, 0);
         });
@@ -1382,7 +1382,7 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 10);
-                camera._updateEase();
+                camera._updateCamera();
             }, 0);
         });
 
@@ -1408,7 +1408,7 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 10);
-                camera._updateEase();
+                camera._updateCamera();
             }, 0);
         });
 
@@ -1456,7 +1456,7 @@ test('camera', (t) => {
             camera.panTo([100, 0], {duration: 1});
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
             }, 0);
         });
 
@@ -1478,7 +1478,7 @@ test('camera', (t) => {
             camera.zoomTo(3.2, {duration: 1});
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
             }, 0);
         });
 
@@ -1500,7 +1500,7 @@ test('camera', (t) => {
             camera.rotateTo(90, {duration: 1});
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
             }, 0);
         });
 
@@ -1579,7 +1579,7 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateEase();
+                camera._updateCamera();
             }, 0);
         });
 

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -31,6 +31,8 @@ test('DragRotateHandler rotates in response to a right-click drag', (t) => {
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    map._updateCamera();
+
     t.ok(rotatestart.calledOnce);
     t.ok(rotate.calledOnce);
 
@@ -44,16 +46,19 @@ test('DragRotateHandler rotates in response to a right-click drag', (t) => {
 test('DragRotateHandler stops rotating after mouseup', (t) => {
     const map = createMap();
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
-
     const spy = t.spy();
-
     map.on('rotatestart', spy);
     map.on('rotate',      spy);
     map.on('rotateend',   spy);
 
+    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    map._updateCamera();
+    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
+
+    t.ok(spy.calledThrice);
+
+    spy.reset();
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 0});
 
     t.ok(spy.notCalled);
@@ -73,6 +78,7 @@ test('DragRotateHandler rotates in response to a control-left-click drag', (t) =
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 1, button: 0, ctrlKey: true});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 1,            ctrlKey: true});
+    map._updateCamera();
     t.ok(rotatestart.calledOnce);
     t.ok(rotate.calledOnce);
 
@@ -95,6 +101,7 @@ test('DragRotateHandler pitches in response to a right-click drag by default', (
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    map._updateCamera();
     t.ok(pitchstart.calledOnce);
     t.ok(pitch.calledOnce);
 
@@ -117,6 +124,7 @@ test('DragRotateHandler pitches in response to a control-left-click drag', (t) =
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 1, button: 0, ctrlKey: true});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 1,            ctrlKey: true});
+    map._updateCamera();
     t.ok(pitchstart.calledOnce);
     t.ok(pitch.calledOnce);
 
@@ -137,10 +145,12 @@ test('DragRotateHandler does not pitch if given pitchWithRotate: false', (t) => 
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    map._updateCamera();
     simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 1, button: 0, ctrlKey: true});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 1,            ctrlKey: true});
+    map._updateCamera();
     simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 0, ctrlKey: true});
 
     t.ok(spy.notCalled);
@@ -163,6 +173,7 @@ test('DragRotateHandler does not rotate or pitch when disabled', (t) => {
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    map._updateCamera();
     simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
 
     t.ok(spy.notCalled);
@@ -197,6 +208,7 @@ test('DragRotateHandler fires move events', (t) => {
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    map._updateCamera();
     t.ok(movestart.calledOnce);
     t.ok(move.calledOnce);
 
@@ -233,6 +245,7 @@ test('DragRotateHandler includes originalEvent property in triggered events', (t
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    map._updateCamera();
     simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
 
     t.ok(rotatestart.firstCall.args[0].originalEvent.type, 'mousemove');
@@ -263,6 +276,7 @@ test('DragRotateHandler responds to events on the canvas container (#1301)', (t)
 
     simulate.mousedown(map.getCanvasContainer(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvasContainer(), {bubbles: true, buttons: 2});
+    map._updateCamera();
     t.ok(rotatestart.calledOnce);
     t.ok(rotate.calledOnce);
 
@@ -280,6 +294,7 @@ test('DragRotateHandler prevents mousemove events from firing during a drag (#15
 
     simulate.mousedown(map.getCanvasContainer(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvasContainer(), {bubbles: true, buttons: 2});
+    map._updateCamera();
     simulate.mouseup(map.getCanvasContainer(),   {bubbles: true, buttons: 0, button: 2});
 
     t.ok(mousemove.notCalled);
@@ -299,6 +314,7 @@ test('DragRotateHandler ends a control-left-click drag on mouseup even when the 
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 1, button: 0, ctrlKey: true});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 1,            ctrlKey: true});
+    map._updateCamera();
     t.ok(rotatestart.calledOnce);
     t.ok(rotate.calledOnce);
 
@@ -321,6 +337,7 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
 
     simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    map._updateCamera();
     t.ok(rotatestart.calledOnce);
     t.ok(rotate.calledOnce);
 


### PR DESCRIPTION
Closes #5390 

Quoting from that issue:

> the DragPan handler updates the camera directly and fires a move event. Updates to the DOM that happen in move listeners happen synchronously, but the map renderer doesn't update until the next animation frame.

This PR aims to solve this issue by having the `DragPan` handler (and the other continuously-updating handlers) cede control to the camera, which in turn is driven by the render loop.

I think it's also a step towards further refactoring of camera of `Camera` that eliminates some of the complicated internal state, simplifies/clarifies `move`-related event firing, etc.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] <del>write tests for all new functionality</del> (blocked by https://github.com/mapbox/mapbox-gl-js/issues/1550)
 - [ ] post benchmark scores
 - [x] manually test the debug page
