### PR TITLE
Bucket version filter should include ignore-placement symbols.

### DIFF
--- a/src/symbol/collision_index.js
+++ b/src/symbol/collision_index.js
@@ -280,13 +280,17 @@ class CollisionIndex {
         const features = this.grid.query(minX, minY, maxX, maxY);
         for (let i = 0; i < features.length; i++) {
             // Only include results from the matching source, tile and version of the bucket that was indexed
-            if (features[i].sourceID === sourceID && features[i].tileID === tileID && bucketInstanceIds[features[i].bucketInstanceId]) {
+            if (features[i].sourceID === sourceID &&
+                features[i].tileID === tileID &&
+                bucketInstanceIds[features[i].bucketInstanceId]) {
                 thisTileFeatures.push(features[i].boxIndex);
             }
         }
         const ignoredFeatures = this.ignoredGrid.query(minX, minY, maxX, maxY);
         for (let i = 0; i < ignoredFeatures.length; i++) {
-            if (ignoredFeatures[i].sourceID === sourceID && ignoredFeatures[i].tileID === tileID) {
+            if (ignoredFeatures[i].sourceID === sourceID &&
+                ignoredFeatures[i].tileID === tileID &&
+                bucketInstanceIds[ignoredFeatures[i].bucketInstanceId]) {
                 thisTileFeatures.push(ignoredFeatures[i].boxIndex);
             }
         }


### PR DESCRIPTION
Fixes issue #6004.

I'd like to get a fuller fix in (tracked as issue #5887), but this fix ensures that we return nothing instead of incorrect results in the period between a tile update and the next completed placement.

/cc @ansis