### PR TITLE
default marker offset

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -31,8 +31,6 @@ class Marker {
     _pos: ?Point;
 
     constructor(element: ?HTMLElement, options?: {offset: PointLike}) {
-        this._offset = Point.convert(options && options.offset || [0, 0]);
-
         bindAll(['_update', '_onMapClick'], this);
 
         if (!element) {
@@ -127,7 +125,21 @@ class Marker {
             svg.appendChild(page1);
 
             element.appendChild(svg);
+
+            // if no element and no offset option given apply an offset for the default marker
+            const defaultMarkerOffset = [0, -14];
+            if (!(options && options.offset)) {
+                if (!options) {
+                    options = {
+                        offset: defaultMarkerOffset
+                    };
+                } else {
+                    options.offset = defaultMarkerOffset;
+                }
+            }
         }
+
+        this._offset = Point.convert(options && options.offset || [0, 0]);
 
         element.classList.add('mapboxgl-marker');
         this._element = element;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -127,6 +127,12 @@ class Marker {
             element.appendChild(svg);
 
             // if no element and no offset option given apply an offset for the default marker
+            // the -14 as the y value of the default marker offset was determined as follows
+            //
+            // the marker tip is at the center of the shadow ellipse from the default svg
+            // the y value of the center of the shadow ellipse relative to the svg top left is "shadow transform translate-y (29.0) + ellipse cy (5.80029008)"
+            // offset to the svg center "height (41 / 2)" gives (29.0 + 5.80029008) - (41 / 2) and rounded for an integer pixel offset gives 14
+            // negative is used to move the marker up from the center so the tip is at the Marker lngLat
             const defaultMarkerOffset = [0, -14];
             if (!(options && options.offset)) {
                 if (!options) {

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -6,6 +6,7 @@ const Map = require('../../../src/ui/map');
 const Marker = require('../../../src/ui/marker');
 const Popup = require('../../../src/ui/popup');
 const LngLat = require('../../../src/geo/lng_lat');
+const Point = require('@mapbox/point-geometry');
 
 function createMap() {
     const container = window.document.createElement('div');
@@ -25,6 +26,21 @@ test('Marker', (t) => {
     t.test('default marker', (t) => {
         const marker = new Marker();
         t.ok(marker.getElement(), 'default marker is created');
+        t.ok(marker.getOffset().equals(new Point(0, -14)), 'default marker with no offset uses default marker offset');
+        t.end();
+    });
+
+    t.test('default marker with some options', (t) => {
+        const marker = new Marker(null, { foo: 'bar' });
+        t.ok(marker.getElement(), 'default marker is created');
+        t.ok(marker.getOffset().equals(new Point(0, -14)), 'default marker with no offset uses default marker offset');
+        t.end();
+    });
+
+    t.test('default marker with custom offest', (t) => {
+        const marker = new Marker(null, { offset: [1, 2] });
+        t.ok(marker.getElement(), 'default marker is created');
+        t.ok(marker.getOffset().equals(new Point(1, 2)), 'default marker with supplied offset');
         t.end();
     });
 


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR
#5661 implemented a default Marker element, this PR applies an offset for that default Marker, so the tip of the marker image is located at the marker lng/lat.

 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
I don't think it needs any special documentation as I'd consider it to be expected behaviour so I consider this to be a bug fix rather than a breaking change.

 - [ ] post benchmark scores
 - [x] manually test the debug page
