### PR TITLE
Prune unused layers from the CrossTileSymbolIndex

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -971,6 +971,7 @@ class Style extends Evented {
             const layerBucketsChanged = this.crossTileSymbolIndex.addLayer(styleLayer, layerTiles[styleLayer.source]);
             symbolBucketsChanged = symbolBucketsChanged || layerBucketsChanged;
         }
+        this.crossTileSymbolIndex.pruneUnusedLayers(this._order);
 
         // Anything that changes our "in progress" layer and tile indices requires us
         // to start over. When we start over, we do a full placement instead of incremental

--- a/src/symbol/cross_tile_symbol_index.js
+++ b/src/symbol/cross_tile_symbol_index.js
@@ -249,6 +249,18 @@ class CrossTileSymbolIndex {
 
         return symbolBucketsChanged;
     }
+
+    pruneUnusedLayers(usedLayers: Array<string>) {
+        const usedLayerMap = {};
+        usedLayers.forEach((usedLayer) => {
+            usedLayerMap[usedLayer] = true;
+        });
+        for (const layerId in this.layerIndexes) {
+            if (!usedLayerMap[layerId]) {
+                delete this.layerIndexes[layerId];
+            }
+        }
+    }
 }
 
 module.exports = CrossTileSymbolIndex;

--- a/test/unit/symbol/cross_tile_symbol_index.js
+++ b/test/unit/symbol/cross_tile_symbol_index.js
@@ -196,3 +196,26 @@ test('CrossTileSymbolIndex.addLayer', (t) => {
 
     t.end();
 });
+
+test('CrossTileSymbolIndex.pruneUnusedLayers', (t) => {
+    const index = new CrossTileSymbolIndex();
+
+    const tileID = new OverscaledTileID(6, 0, 6, 8, 8);
+    const instances = [
+        makeSymbolInstance(1000, 1000, ""), // A
+        makeSymbolInstance(1000, 1000, "")  // B
+    ];
+    const tile = makeTile(tileID, instances);
+
+    // assigns new ids
+    index.addLayer(styleLayer, [tile]);
+    t.equal(instances[0].crossTileID, 1);
+    t.equal(instances[1].crossTileID, 2);
+    t.ok(index.layerIndexes[styleLayer.id]);
+
+    // remove styleLayer
+    index.pruneUnusedLayers([]);
+    t.notOk(index.layerIndexes[styleLayer.id]);
+
+    t.end();
+});


### PR DESCRIPTION
Fixes issue #5995 (index leaked removed layers).

I don't think #5995 was a very big deal, but I just wanted to get this loose end out of the way. There are two changes here:

1) If you add and remove many layers with unique IDs, you won't end up with left-behind cruft in the `CrossTileSymbolIndex`
2) If you and and remove a layer with the same ID, you won't pick up the `crossTileIDs` from previously indexed versions of the layer. I don't _think_ this change matters, because (a) crossTileIDs are always contained to one layer, and the entire layer was removed, so (b) there's no existing fade/collision state that's going to get copied over because you're using old IDs vs new IDs.

I added a basic unit test for the remove process and manually tested removing a layer from an active map and then adding it back.

/cc @ansis @mollymerp 