### PR TITLE
improve ajax error messages

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -42,9 +42,19 @@ export type RequestParameters = {
 
 class AJAXError extends Error {
     status: number;
-    constructor(message: string, status: number) {
+    url: string;
+    constructor(message: string, status: number, url: string) {
         super(message);
         this.status = status;
+        this.url = url;
+
+        // work around for https://github.com/Rich-Harris/buble/issues/40
+        this.name = this.constructor.name;
+        this.message = message;
+    }
+
+    toString() {
+        return `${this.name}: ${this.message} (${this.status}): ${this.url}`;
     }
 }
 
@@ -75,7 +85,7 @@ exports.getJSON = function(requestParameters: RequestParameters, callback: Callb
             }
             callback(null, data);
         } else {
-            callback(new AJAXError(xhr.statusText, xhr.status));
+            callback(new AJAXError(xhr.statusText, xhr.status, requestParameters.url));
         }
     };
     xhr.send();
@@ -100,7 +110,7 @@ exports.getArrayBuffer = function(requestParameters: RequestParameters, callback
                 expires: xhr.getResponseHeader('Expires')
             });
         } else {
-            callback(new AJAXError(xhr.statusText, xhr.status));
+            callback(new AJAXError(xhr.statusText, xhr.status, requestParameters.url));
         }
     };
     xhr.send();


### PR DESCRIPTION
A failed GeoJSON load now logs `AJAXError: Not Found (404): http://example.com/asdf.geojson` instead of `Error`.

No error message was printed because of a lack of support for extending errors in Buble: https://github.com/Rich-Harris/buble/issues/40


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [N/A] write tests for all new functionality
 - [N/A] document any changes to public APIs
 - [N/A] post benchmark scores
 - [x] manually test the debug page
