### PR TITLE
Hide attribution container if empty so as not to show in compact maps

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -214,6 +214,9 @@ a.mapboxgl-ctrl-logo {
     font-weight: bold;
     margin-left: 2px;
 }
+.mapboxgl-attrib-empty {
+    display: none;
+}
 /*stylelint-enable*/
 .mapboxgl-ctrl-scale {
     background-color: rgba(255,255,255,0.75);

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -131,7 +131,12 @@ class AttributionControl {
             }
             return true;
         });
-        this._container.innerHTML = attributions.join(' | ');
+        if (attributions.length) {
+            this._container.innerHTML = attributions.join(' | ');
+            this._container.classList.remove('mapboxgl-attrib-empty');
+        } else {
+            this._container.classList.add('mapboxgl-attrib-empty');
+        }
         // remove old DOM node from _editLink
         this._editLink = null;
     }

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -121,3 +121,39 @@ test('AttributionControl has the correct edit map link', (t) => {
         });
     });
 });
+
+test('AttributionControl is hidden if empty', (t) => {
+    const map = createMap();
+    const attribution = new AttributionControl();
+    map.addControl(attribution);
+    map.on('load', () => {
+        map.addSource('1', { type: 'vector' });
+    });
+
+    const container = map.getContainer();
+
+    const checkEmptyFirst = () => {
+        t.equal(attribution._container.innerHTML, '');
+        t.equal(container.querySelectorAll('.mapboxgl-attrib-empty').length, 1, 'includes empty class when no attribution strings are provided');
+
+        map.addSource('2', { type: 'vector', attribution: 'Hello World' });
+    };
+
+    const checkNotEmptyLater = () => {
+        t.equal(attribution._container.innerHTML, 'Hello World');
+        t.equal(container.querySelectorAll('.mapboxgl-attrib-empty').length, 0, 'removes empty class when source with attribution is added');
+        t.end();
+    };
+
+    let times = 0;
+    map.on('data', (e) => {
+        if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+            times++;
+            if (times === 1) {
+                checkEmptyFirst();
+            } else if (times === 2) {
+                checkNotEmptyLater();
+            }
+        }
+    });
+});


### PR DESCRIPTION
Attribution is "hidden" in maps that don't have attribution (styles and tiles not [hosted by Mapbox](https://www.mapbox.com/help/how-attribution-works/) or otherwise requiring attribution) by virtue of having no text and therefore zero dimensions, but on compact maps the ℹ️  button was showing. This PR adds a class to hide empty attribution containers in either case.

Fixes https://github.com/mapbox/mapbox-gl-js/issues/6037.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
