### PR TITLE
Fix tile-boundary flicker in animate-point example.

### DIFF
--- a/docs/pages/example/animate-point-along-route.html
+++ b/docs/pages/example/animate-point-along-route.html
@@ -115,7 +115,8 @@ map.on('load', function () {
         "type": "symbol",
         "layout": {
             "icon-image": "airport-15",
-            "icon-rotate": 90
+            "icon-rotate": 90,
+            "icon-allow-overlap": true
         }
     });
 


### PR DESCRIPTION
Adding "icon-allow-overlap" allows us to avoid doing the fade-in flicker on cross the tile boundary, because we can assume the airplane icon is going to be visible before placement happens. Since "icon-ignore-placement" is still false, the airplane still knocks other labels out of the way

/cc @ansis @kkaefer 
