### PR TITLE
Animate camera position helpers

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -403,7 +403,7 @@ class Transform {
 
     /**
      * Get the latitude and longitude under the camera, the altitude of the camera in meters, bearing & pitch
-     * @returns {Object} containing longitude, latitude, altitude and pitch
+     * @returns {Object} containing longitude, latitude, altitude and pitch(in degrees)
      */
     getCameraPosition(): { lng: number, lat: number, altitude: number, pitch: number, bearing: number } {
         const pitch = this._pitch;
@@ -413,24 +413,26 @@ class Transform {
         const latLong = this.pointLocation(latPosPointInPixels);
         const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(latLong.lat * (Math.PI / 180))));
         const altitudeInMeters = altitude / verticalScaleConstant;
+        const pitchInDegrees = pitch * (180 / Math.PI);
 
-        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch, bearing: this.bearing };
+        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch: pitchInDegrees, bearing: this.bearing };
     }
 
     /**
-     * Set camera position to desired latitude, longitude, altitude, pitch and bearing
+     * Set camera position to desired latitude, longitude, altitude, pitch (in degrees) and bearing
      * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, bearing & pitch
      */
     setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number, bearing: number }) {
         const { lng, lat, altitude, pitch, bearing } = camPos;
 
+        const pitchInRadians = pitch * (Math.PI / 180);
         const cameraToCenterDistance = 0.5 / Math.tan(this._fov / 2) * this.height;
-        const pixelAltitude = Math.abs(Math.cos(pitch) * cameraToCenterDistance);
+        const pixelAltitude = Math.abs(Math.cos(pitchInRadians) * cameraToCenterDistance);
         const metersInWorldAtLat = (2 * Math.PI * 6378137 * Math.abs(Math.cos(lat * (Math.PI / 180))));
         const worldsize = pixelAltitude / altitude * metersInWorldAtLat;
         const zoom = Math.log(worldsize / this.tileSize) / Math.LN2;
 
-        const latOffset = Math.tan(pitch) * cameraToCenterDistance;
+        const latOffset = Math.tan(pitchInRadians) * cameraToCenterDistance;
         const newPixelPoint = new Point(this.width / 2, this.height / 2 + latOffset);
         const newLongLat = new LngLat(lng, lat);
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -402,10 +402,10 @@ class Transform {
     }
 
     /**
-     * Get the latitude and longitude under the camera, the altitude of the camera in meters, and the pitch
+     * Get the latitude and longitude under the camera, the altitude of the camera in meters, bearing & pitch
      * @returns {Object} containing longitude, latitude, altitude and pitch
      */
-    getCameraPosition(): { lng: number, lat: number, altitude: number, pitch: number } {
+    getCameraPosition(): { lng: number, lat: number, altitude: number, pitch: number, bearing: number } {
         const pitch = this._pitch;
         const altitude = Math.cos(pitch) * this.cameraToCenterDistance;
         const latOffset = Math.tan(pitch) * this.cameraToCenterDistance;
@@ -414,15 +414,15 @@ class Transform {
         const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(latLong.lat * (Math.PI / 180))));
         const altitudeInMeters = altitude / verticalScaleConstant;
 
-        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch };
+        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch, bearing: this.bearing };
     }
 
     /**
-     * Set camera position to desired latitude, longitude, altitude and pitch
-     * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, and pitch
+     * Set camera position to desired latitude, longitude, altitude, pitch and bearing
+     * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, bearing & pitch
      */
-    setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number }) {
-        const { lng, lat, altitude, pitch } = camPos;
+    setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number, bearing: number }) {
+        const { lng, lat, altitude, pitch, bearing } = camPos;
 
         const cameraToCenterDistance = 0.5 / Math.tan(this._fov / 2) * this.height;
         const pixelAltitude = Math.abs(Math.cos(pitch) * cameraToCenterDistance);
@@ -436,6 +436,7 @@ class Transform {
 
         this.zoom = zoom;
         this.pitch = pitch;
+        this.bearing = bearing;
         this.setLocationAtPoint(newLongLat, newPixelPoint);
     }
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -402,6 +402,44 @@ class Transform {
     }
 
     /**
+     * Get the latitude and longitude under the camera, the altitude of the camera in meters, and the pitch
+     * @returns {Object} containing longitude, latitude, altitude and pitch
+     */
+    getCameraPosition(): { lng: number, lat: number, altitude: number, pitch: number } {
+        const pitch = this._pitch;
+        const altitude = Math.cos(pitch) * this.cameraToCenterDistance;
+        const latOffset = Math.tan(pitch) * this.cameraToCenterDistance;
+        const latPosPointInPixels = this.centerPoint.add(new Point(0, latOffset));
+        const latLong = this.pointLocation(latPosPointInPixels);
+        const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(latLong.lat * (Math.PI / 180))));
+        const altitudeInMeters = altitude / verticalScaleConstant;
+
+        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch };
+    }
+
+    /**
+     * Set camera position to desired latitude, longitude, altitude and pitch
+     * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, and pitch
+     */
+    setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number }) {
+        const { lng, lat, altitude, pitch } = camPos;
+
+        const cameraToCenterDistance = 0.5 / Math.tan(this._fov / 2) * this.height;
+        const pixelAltitude = Math.abs(Math.cos(pitch) * cameraToCenterDistance);
+        const metersInWorldAtLat = (2 * Math.PI * 6378137 * Math.abs(Math.cos(lat * (Math.PI / 180))));
+        const worldsize = pixelAltitude / altitude * metersInWorldAtLat;
+        const zoom = Math.log(worldsize / this.tileSize) / Math.LN2;
+
+        const latOffset = Math.tan(pitch) * cameraToCenterDistance;
+        const newPixelPoint = new Point(this.width / 2, this.height / 2 + latOffset);
+        const newLongLat = new LngLat(lng, lat);
+
+        this.zoom = zoom;
+        this.pitch = pitch;
+        this.setLocationAtPoint(newLongLat, newPixelPoint);
+    }
+
+    /**
      * Given a coordinate, return the screen point that corresponds to it
      * @param {Coordinate} coord
      * @returns {Point} screen point

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -71,6 +71,44 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test('gets accurate camera position via getCameraPosition', (t) => {
+        const transform = new Transform();
+        transform.resize(500, 500);
+        transform.zoom = 12;
+        transform.pitch = 50;
+        transform.center = new LngLat(10, 10);
+        const cameraPosition = transform.getCameraPosition();
+        t.deepEqual(cameraPosition, {
+            lng: 10.00000000000881,
+            lat: 9.9028586843625,
+            altitude: 9075.137447222842,
+            pitch: 50,
+            bearing: -0
+        });
+        t.end();
+    });
+
+    t.test('sets camera position via setCameraPosition', (t) => {
+        const transform = new Transform();
+        transform.resize(500, 500);
+        transform.zoom = 12;
+        transform.pitch = 50;
+        transform.center = new LngLat(10, 10);
+        transform.setCameraPosition({
+            lng: 20,
+            lat: 20,
+            altitude: 3000,
+            pitch: 0,
+            bearing: 0
+        });
+
+        t.deepEqual(transform.center, { lng: 20, lat: 20 });
+        t.equal(transform.zoom, 14.166460609951343);
+        t.equal(transform.pitch, 0);
+        t.equal(transform.bearing, 0);
+        t.end();
+    });
+
     t.test('has a default zoom', (t) => {
         const transform = new Transform();
         transform.resize(500, 500);


### PR DESCRIPTION
This PR adds two helper functions that should be useful for camera animation.  The first `getCameraPosition` returns the lat/long underneath the camera (accounting for pitch), the camera's altitude in meters, pitch and bearing.  The second helper function `setCameraPosition` accepts the same data structure outputted by `getCameraPosition` and sets the map transform to match.

Wrote tests, but looks like they're failing on circle due to a difference in floating point precision I think. Is it reasonable to slightly limit precision with `toFixed`?

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
