### PR TITLE
Fix bug preventing symbol features in overscaled from appearing in queryRenderedFeature results

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -33,7 +33,7 @@ type QueryParameters = {
     collisionBoxArray: CollisionBoxArray,
     sourceID: string,
     bucketInstanceIds: { [number]: boolean },
-    collisionIndex: CollisionIndex
+    collisionIndex: ?CollisionIndex
 }
 
 class FeatureIndex {
@@ -50,8 +50,6 @@ class FeatureIndex {
 
     vtLayers: {[string]: VectorTileLayer};
     sourceLayerCoder: DictionaryCoder;
-
-    collisionIndex: CollisionIndex;
 
     constructor(tileID: OverscaledTileID,
                 overscaling: number,
@@ -207,7 +205,7 @@ class FeatureIndex {
 register(
     'FeatureIndex',
     FeatureIndex,
-    { omit: ['rawTileData', 'sourceLayerCoder', 'collisionIndex'] }
+    { omit: ['rawTileData', 'sourceLayerCoder'] }
 );
 
 module.exports = FeatureIndex;

--- a/src/source/query_features.js
+++ b/src/source/query_features.js
@@ -11,7 +11,7 @@ exports.rendered = function(sourceCache: SourceCache,
                             params: { filter: FilterSpecification, layers: Array<string> },
                             zoom: number,
                             bearing: number,
-                            collisionIndex: CollisionIndex) {
+                            collisionIndex: ?CollisionIndex) {
     const tilesIn = sourceCache.tilesIn(queryGeometry);
 
     tilesIn.sort(sortTilesIn);

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -235,7 +235,7 @@ class Tile {
                           params: { filter: FilterSpecification, layers: Array<string> },
                           bearing: number,
                           sourceID: string,
-                          collisionIndex: CollisionIndex): {[string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>} {
+                          collisionIndex: ?CollisionIndex): {[string]: Array<{ featureIndex: number, feature: GeoJSONFeature }>} {
         if (!this.featureIndex || !this.collisionBoxArray)
             return {};
 

--- a/src/style/pauseable_placement.js
+++ b/src/style/pauseable_placement.js
@@ -89,6 +89,11 @@ class PauseablePlacement {
 
         this._done = true;
     }
+
+    commit(previousPlacement: ?Placement, now: number) {
+        this.placement.commit(previousPlacement, now);
+        return this.placement;
+    }
 }
 
 module.exports = PauseablePlacement;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -33,7 +33,6 @@ import type Transform from '../geo/transform';
 import type {Source} from '../source/source';
 import type {StyleImage} from './style_image';
 import type {StyleGlyph} from './style_glyph';
-import type CollisionIndex from '../symbol/collision_index';
 import type {Callback} from '../types/callback';
 import type EvaluationParameters from './evaluation_parameters';
 import type Placement from '../symbol/placement';
@@ -91,7 +90,6 @@ class Style extends Evented {
     _updatedPaintProps: {[layer: string]: true};
     _layerOrderChanged: boolean;
 
-    collisionIndex: CollisionIndex;
     crossTileSymbolIndex: CrossTileSymbolIndex;
     pauseablePlacement: PauseablePlacement;
     placement: Placement;
@@ -851,7 +849,7 @@ class Style extends Evented {
         const sourceResults = [];
         for (const id in this.sourceCaches) {
             if (params.layers && !includedSources[id]) continue;
-            const results = QueryFeatures.rendered(this.sourceCaches[id], this._layers, queryGeometry, params, zoom, bearing, this.collisionIndex);
+            const results = QueryFeatures.rendered(this.sourceCaches[id], this._layers, queryGeometry, params, zoom, bearing, this.placement ? this.placement.collisionIndex : null);
             sourceResults.push(results);
         }
         return this._flattenRenderedFeatures(sourceResults);
@@ -995,9 +993,7 @@ class Style extends Evented {
             this.pauseablePlacement.continuePlacement(this._order, this._layers, layerTiles);
 
             if (this.pauseablePlacement.isDone()) {
-                this.pauseablePlacement.placement.commit(this.placement, browser.now());
-                this.placement = this.pauseablePlacement.placement;
-                this.collisionIndex = this.placement.collisionIndex;
+                this.placement = this.pauseablePlacement.commit(this.placement, browser.now());
                 placementCommitted = true;
             }
 


### PR DESCRIPTION
This resolves the issue described in https://github.com/mapbox/mapbox-gl-js/issues/6074#issuecomment-363237163 by unconditionally updating `style.placement` and `style.collisionIndex`, rather than only updating them if `placementChanged`.

This necessitated two other changes:
1. Replace `placementChanged` with `placementCommitted`, and use it to make sure that we invoke `updateLayerOpacities` any time `style.placement` is updated.
2. Add a `Placement#lastPlacementChangeTime` property, which is updated only in a `commit()` where placement was actually changed, and otherwise inherited from the previous placement.  Use this new property, rather than `commitTime` for the `hasTransitions()` check.  This wasn't necessary before, because previously we simply threw away the new placement (with its newer commit time) if `commit` resulted in no changes -- whereas now, since we save the new placement even when it's a no-op, we want to treat it as an older commit in that case so that `hasTransitions()` yields false and we stop asking for a new render.

Benchmarks: https://bl.ocks.org/anonymous/raw/ea32279a8eaada909b3111ad2682579a/