### PR TITLE
Remove unnecessary files from package files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "build/",
     "dist/",
     "flow-typed/",
-    "src/",
     ".flowconfig"
   ]
 }


### PR DESCRIPTION
The `src` files should not publish to the npm registry, we should only publish the `dist` files.