### PR TITLE
Upgrade deps in the test suite

### DIFF
--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -5,8 +5,8 @@
 const fs = require('fs');
 const path = require('path');
 const queue = require('d3-queue').queue;
-const colors = require('colors/safe');
-const template = require('lodash').template;
+const colors = require('chalk');
+const template = require('lodash.template');
 const shuffler = require('shuffle-seed');
 
 module.exports = function (directory, implementation, options, run) {

--- a/test/integration/lib/server.js
+++ b/test/integration/lib/server.js
@@ -3,7 +3,7 @@
 const st = require('st');
 const http = require('http');
 const path = require('path');
-const colors = require('colors/safe');
+const colors = require('chalk');
 const fs = require('fs');
 
 module.exports = function () {

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -5,11 +5,11 @@
   "license": "BSD",
   "main": "index.js",
   "dependencies": {
-    "colors": "^1.1.2",
+    "chalk": "^2.3.0",
     "d3-queue": "^3.0.3",
     "diff": "^3.0.0",
     "json-stringify-pretty-compact": "^1.0.4",
-    "lodash": "^4.17.4",
+    "lodash.template": "^4.4.0",
     "mapbox-gl-styles": "2.0.2",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,11 +141,11 @@
 "@mapbox/mapbox-gl-test-suite@file:test/integration":
   version "0.0.0"
   dependencies:
-    colors "^1.1.2"
+    chalk "^2.3.0"
     d3-queue "^3.0.3"
     diff "^3.0.0"
     json-stringify-pretty-compact "^1.0.4"
-    lodash "^4.17.4"
+    lodash.template "^4.4.0"
     mapbox-gl-styles "2.0.2"
     pixelmatch "^4.0.2"
     pngjs "^3.0.0"
@@ -2344,7 +2344,7 @@ color-support@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
 
-colors@^1.0.3, colors@^1.1.2:
+colors@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -6184,7 +6184,7 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
-lodash._reinterpolate@^3.0.0:
+lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
 
@@ -6319,12 +6319,25 @@ lodash.template@^3.6.1:
     lodash.restparam "^3.0.0"
     lodash.templatesettings "^3.0.0"
 
+lodash.template@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
+    lodash.templatesettings "^4.0.0"
+
 lodash.templatesettings@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz#fb307844753b66b9f1afa54e262c745307dba8e5"
   dependencies:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
+
+lodash.templatesettings@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
 
 lodash.toplainobject@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- Replaces `colors.js` (old and unmaintained) with `chalk` (a modern, extremely popular equivalent). Color support should now be autodetected, so no more weird symbols when running render tests for GL Native in Xcode (in theory).
- Narrows down the `lodash` dep for the template.