### PR TITLE
Fix `layer_properties` template in order to generate valid-flow empty PaintProps

### DIFF
--- a/src/style/style_layer/layer_properties.js.ejs
+++ b/src/style/style_layer/layer_properties.js.ejs
@@ -32,13 +32,15 @@ const layout: Properties<LayoutProps> = new Properties({
 <% } -%>
 });
 <% } -%>
-
+<% if(paintProperties.length){ %>
 export type PaintProps = {|
 <% for (const property of paintProperties) { -%>
     "<%= property.name %>": <%- propertyType(property) %>,
 <% } -%>
 |};
-
+<% } else{ %>
+export type PaintProps = {};
+<% } %>
 const paint: Properties<PaintProps> = new Properties({
 <% for (const property of paintProperties) { -%>
     "<%= property.name %>": <%- propertyValue(property, 'paint') %>,


### PR DESCRIPTION
This PR adds a fix in the `layer_properties.js.ejs` file to prevent the generation of non-flow-compatible code when the `paintProperties` array is empty. Instead of the following code:

```js
export type PaintProps = {|
|};
```

now the following code is generated:

```js
export type PaintProps = {};
```

Thanks!

