### PR TITLE
fix web worker error handling

### DIFF
--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -69,7 +69,7 @@ class Actor {
                 sourceMapId: this.mapId,
                 type: '<response>',
                 id: String(id),
-                error: err ? String(err) : null,
+                error: err ? serialize(err) : null,
                 data: serialize(data, buffers)
             }, buffers);
         };
@@ -78,7 +78,7 @@ class Actor {
             callback = this.callbacks[data.id];
             delete this.callbacks[data.id];
             if (callback && data.error) {
-                callback(new Error(data.error));
+                callback(deserialize(data.error));
             } else if (callback) {
                 callback(null, deserialize(data.data));
             }

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -87,6 +87,7 @@ Grid.deserialize = function deserializeGrid(serialized: ArrayBuffer): Grid {
 register('Grid', Grid);
 
 register('Color', Color);
+register('Error', Error);
 
 register('StylePropertyFunction', StylePropertyFunction);
 register('StyleExpression', StyleExpression, {omit: ['_evaluator']});


### PR DESCRIPTION
changes from #4446 regressed with the new Web Worker transfer, and this was causing hard to diagnose errors like 

```
Error: Error
    at Actor.receive (actor.js:81)
```

because `String(err)` was just outputting "Error" with no status code. 

Related to #6094

