### PR TITLE
Fix incorrect textPixelRatio argument

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -122,7 +122,7 @@ class FeatureIndex {
         this.filterMatching(result, matching, this.featureIndexArray, queryGeometry, filter, params.layers, styleLayers, args.bearing, pixelsToTileUnits);
 
         const matchingSymbols = args.collisionIndex ?
-            args.collisionIndex.queryRenderedSymbols(queryGeometry, this.tileID, EXTENT / args.tileSize, args.collisionBoxArray, args.sourceID, args.bucketInstanceIds) :
+            args.collisionIndex.queryRenderedSymbols(queryGeometry, this.tileID, args.tileSize / EXTENT, args.collisionBoxArray, args.sourceID, args.bucketInstanceIds) :
             [];
         matchingSymbols.sort();
         this.filterMatching(result, matchingSymbols, args.collisionBoxArray, queryGeometry, filter, params.layers, styleLayers, args.bearing, pixelsToTileUnits);

--- a/test/integration/query-tests/regressions/mapbox-gl-js#6075/expected.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#6075/expected.json
@@ -1,0 +1,13 @@
+[
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {}
+  }
+]

--- a/test/integration/query-tests/regressions/mapbox-gl-js#6075/style.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#6075/style.json
@@ -1,0 +1,51 @@
+{
+    "version": 8,
+    "metadata": {
+        "test": {
+            "width": 128,
+            "height": 128,
+            "queryGeometry": [
+                79,
+                64
+            ],
+            "queryOptions": {
+            }
+        }
+    },
+    "zoom": 0,
+    "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
+    "sprite": "local://sprites/sprite",
+    "sources": {
+        "source": {
+            "type": "geojson",
+            "data": {
+              "type": "FeatureCollection",
+              "features": [{
+                "type": "Feature",
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [0, 0]
+                }
+              }]
+            }
+        }
+    },
+    "layers": [
+        {
+          "id": "background",
+          "type": "background",
+          "paint": {
+            "background-color": "white"
+          }
+        },
+        {
+          "id": "iconlayer",
+          "type": "symbol",
+          "source": "source",
+          "layout": {
+            "icon-image": "building-12",
+            "icon-offset": [15, 0]
+          }
+        }
+    ]
+}


### PR DESCRIPTION
Closes #6075

`textPixelRatio` is used to scale tile coordinates to viewport coordinates; the value that was being passed here, EXTENT / tileSize, was the reciprocal of the ratio needed -- we were passing 16 instead of 0.0625.

As a result, the corners of the viewport-projected collision box that we reconstructed here, https://github.com/mapbox/mapbox-gl-js/blob/f13c86ea356c384fdab31855b9152f5bf5ef97b8/src/symbol/collision_index.js#L322-L325, were 16^2 times farther from the anchor than they should have been. With `icon-offset: [0, 0]`, this didn't matter, because the incorrectly large box would contain the (much smaller) correct box.  But when there's an offset, it too gets scaled too much, and so we run out of luck.