### PR TITLE
Preserve history state when updating hash

### DIFF
--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -91,7 +91,7 @@ class Hash {
 
     _updateHashUnthrottled() {
         const hash = this.getHashString();
-        window.history.replaceState('', '', hash);
+        window.history.replaceState(window.history.state, '', hash);
     }
 
 }


### PR DESCRIPTION
Current implementation replaces history state on every moveend with empty string.

The purposed solution replaces state with current state instead of empty string. The reason for this is to let other code to use history state as it is usual for single page applications.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
