### PR TITLE
fix duplicate layer test, enforce layer id uniqueness

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -521,6 +521,11 @@ class Style extends Evented {
 
         const id = layerObject.id;
 
+        if (this.getLayer(id)) {
+            this.fire('error', {error: new Error(`Layer with id "${id}" already exists on this map`)});
+            return;
+        }
+
         if (typeof layerObject.source === 'object') {
             this.addSource(id, layerObject.source);
             layerObject = util.clone(layerObject);

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -992,20 +992,19 @@ test('Style#addLayer', (t) => {
     });
 
     t.test('emits error on duplicates', (t) => {
+        t.stub(console, 'error');
         const style = new Style(new StubMap());
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'};
 
         style.on('error', (e) => {
-            t.deepEqual(e.layer, {id: 'background'});
-            t.notOk(/duplicate/.match(e.error.message));
+            t.match(e.error, /already exists/);
             t.end();
         });
 
         style.on('style.load', () => {
             style.addLayer(layer);
             style.addLayer(layer);
-            t.end();
         });
     });
 


### PR DESCRIPTION
fix #5989 

the test that was supposed to verify this was erroneously passing due to an extra `t.end()` and validation in validate_layer doesn't work because we're passing in  `arrayIndex = -1` so it never enters the loop to check duplicate ids. 

https://github.com/mapbox/mapbox-gl-js/blob/e077b780a525aa5c39bf9d1489f9bd1f458856ba/src/style-spec/validate/validate_layer.js#L27-L32


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
