### PR TITLE
Update filter using "match" instead of "in"

### DIFF
--- a/docs/pages/example/filter-features-within-map-view.html
+++ b/docs/pages/example/filter-features-within-map-view.html
@@ -210,9 +210,9 @@ map.on('load', function() {
         renderListings(filtered);
 
         // Set the filter to populate features into the layer.
-        map.setFilter('airport', ['in', 'abbrev'].concat(filtered.map(function(feature) {
+        map.setFilter('airport', ['match', ['get', 'abbrev'], filtered.map(function(feature) {
             return feature.properties.abbrev;
-        })));
+        }), true, false]);
     });
 
     // Call this function on initialization


### PR DESCRIPTION
Related to #6144

Update filter using `"match" `expression instead of deprecated filter syntax `"in"`.
