### PR TITLE
always hide duplicate labels instantly

### DIFF
--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -284,9 +284,6 @@ class Placement {
                 opacityState = duplicateOpacityState;
             } else if (!opacityState) {
                 opacityState = defaultOpacityState;
-            }
-
-            if (!this.opacities[symbolInstance.crossTileID]) {
                 // store the state so that future placements use it as a starting point
                 this.opacities[symbolInstance.crossTileID] = opacityState;
             }

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -270,6 +270,7 @@ class Placement {
         if (bucket.hasCollisionCircleData()) bucket.collisionCircle.collisionVertexArray.clear();
 
         const layout = bucket.layers[0].layout;
+        const duplicateOpacityState = new JointOpacityState(null, 0, false, false, true);
         const defaultOpacityState = new JointOpacityState(null, 0,
                 layout.get('text-allow-overlap'),
                 layout.get('icon-allow-overlap'), true);
@@ -279,12 +280,15 @@ class Placement {
             const isDuplicate = seenCrossTileIDs[symbolInstance.crossTileID];
 
             let opacityState = this.opacities[symbolInstance.crossTileID];
-            if (!opacityState) {
+            if (isDuplicate) {
+                opacityState = duplicateOpacityState;
+            } else if (!opacityState) {
                 opacityState = defaultOpacityState;
+            }
+
+            if (!this.opacities[symbolInstance.crossTileID]) {
                 // store the state so that future placements use it as a starting point
                 this.opacities[symbolInstance.crossTileID] = opacityState;
-            } else if (isDuplicate) {
-                opacityState = defaultOpacityState;
             }
 
             seenCrossTileIDs[symbolInstance.crossTileID] = true;


### PR DESCRIPTION
Duplicate labels were not always hidden instantly, resulting in the same label being rendered twice by different tiles. This fixes that.

port of https://github.com/mapbox/mapbox-gl-native/pull/11207

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [N/A] document any changes to public APIs
 - [N/A] post benchmark scores
 - [x] manually test the debug page
