### PR TITLE
Don't create RTL text plugin blob on foreground.

### DIFF
--- a/debug/csp.html
+++ b/debug/csp.html
@@ -27,6 +27,8 @@ var map = window.map = new mapboxgl.Map({
     hash: true
 });
 
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.2/mapbox-gl-rtl-text.js');
+
 </script>
 </body>
 </html>

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -1,51 +1,38 @@
 // @flow
-
-const ajax = require('../util/ajax');
 const Evented = require('../util/evented');
-const window = require('../util/window');
 
 let pluginRequested = false;
-let pluginBlobURL = null;
+let pluginURL = null;
 
 module.exports.evented = new Evented();
 
 type ErrorCallback = (error: Error) => void;
 
 module.exports.registerForPluginAvailability = function(
-    callback: (args: {pluginBlobURL: string, errorCallback: ErrorCallback}) => void
+    callback: (args: {pluginURL: string, errorCallback: ErrorCallback}) => void
 ) {
-    if (pluginBlobURL) {
-        callback({ pluginBlobURL: pluginBlobURL, errorCallback: module.exports.errorCallback});
+    if (pluginURL) {
+        callback({ pluginURL: pluginURL, errorCallback: module.exports.errorCallback});
     } else {
         module.exports.evented.once('pluginAvailable', callback);
     }
     return callback;
 };
 
-// Exposed so it can be stubbed out by tests
-module.exports.createBlobURL = function(response: Object) {
-    return window.URL.createObjectURL(new window.Blob([response.data], {type: "text/javascript"}));
-};
 // Only exposed for tests
 module.exports.clearRTLTextPlugin = function() {
     pluginRequested = false;
-    pluginBlobURL = null;
+    pluginURL = null;
 };
 
-module.exports.setRTLTextPlugin = function(pluginURL: string, callback: ErrorCallback) {
+module.exports.setRTLTextPlugin = function(url: string, callback: ErrorCallback) {
     if (pluginRequested) {
         throw new Error('setRTLTextPlugin cannot be called multiple times.');
     }
     pluginRequested = true;
+    pluginURL = url;
     module.exports.errorCallback = callback;
-    ajax.getArrayBuffer({ url: pluginURL }, (err, response) => {
-        if (err) {
-            callback(err);
-        } else if (response) {
-            pluginBlobURL = module.exports.createBlobURL(response);
-            module.exports.evented.fire('pluginAvailable', { pluginBlobURL: pluginBlobURL, errorCallback: callback });
-        }
-    });
+    module.exports.evented.fire('pluginAvailable', { pluginURL: pluginURL, errorCallback: callback });
 };
 
 module.exports.applyArabicShaping = (null: ?Function);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -115,7 +115,7 @@ class Style extends Evented {
 
         const self = this;
         this._rtlTextPluginCallback = rtlTextPlugin.registerForPluginAvailability((args) => {
-            self.dispatcher.broadcast('loadRTLTextPlugin', args.pluginBlobURL, args.errorCallback);
+            self.dispatcher.broadcast('loadRTLTextPlugin', args.pluginURL, args.errorCallback);
             for (const id in self.sourceCaches) {
                 self.sourceCaches[id].reload(); // Should be a no-op if the plugin loads before any tiles load
             }

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -60,18 +60,15 @@ test('Style', (t) => {
 
     t.test('registers plugin listener', (t) => {
         rtlTextPlugin.clearRTLTextPlugin();
-        t.stub(rtlTextPlugin, 'createBlobURL').returns("data:text/javascript;base64,abc");
-        window.useFakeXMLHttpRequest();
-        window.server.respondWith('/plugin.js', "doesn't matter");
-        rtlTextPlugin.setRTLTextPlugin("/plugin.js");
+
         t.spy(rtlTextPlugin, 'registerForPluginAvailability');
 
         const style = new Style(new StubMap());
         t.spy(style.dispatcher, 'broadcast');
         t.ok(rtlTextPlugin.registerForPluginAvailability.calledOnce);
 
-        window.server.respond();
-        t.ok(style.dispatcher.broadcast.calledWith('loadRTLTextPlugin', "data:text/javascript;base64,abc"));
+        rtlTextPlugin.setRTLTextPlugin("some bogus url");
+        t.ok(style.dispatcher.broadcast.calledWith('loadRTLTextPlugin', "some bogus url"));
         t.end();
     });
 


### PR DESCRIPTION
Avoids CSP script-src constraints.
Fixes issue #6169.

Now that I built and tested this, I remember the motivation for creating a blob on the foreground -- we had hoped that the browser could coalesce the duplicate requests for the same plugin from the workers, but it looks like on the first map load (with the cache clear), all four workers download the blob in parallel. So that's 800KB to load instead of 200KB.

Does it make sense to turn this into a configurable "CSP friendly" option? What did we do in the worker source case?

I added a `setRTLTextPlugin` call to `csp.html` to test this out, but it currently points to the eval-free "0.1.2" version which I haven't published yet.

/cc @jfirebaugh @anandthakker 