### PR TITLE
Don't use _onDragFinished as a "finish" callback for _startAnimation

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "glob": "^7.0.3",
     "in-publish": "^2.0.0",
     "is-builtin-module": "^1.0.0",
-    "jsdom": "^11.5.1",
+    "jsdom": "^11.6.2",
     "json-stringify-pretty-compact": "^1.0.4",
     "lodash": "^4.16.0",
     "minifyify": "^7.0.1",

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -114,18 +114,9 @@ class DragPanHandler {
         this._lastMoveEvent = e;
         e.preventDefault();
 
-        const pos = DOM.mousePos(this._el, e);
+        this._pos = DOM.mousePos(this._el, e);
         this._drainInertiaBuffer();
-        this._inertia.push([browser.now(), pos]);
-
-        // if the dragging animation was interrupted (e.g. by another handler),
-        // we need to reestablish a _previousPos before we can resume dragging
-        if (!this._previousPos) {
-            this._previousPos = pos;
-            return;
-        }
-
-        this._pos = pos;
+        this._inertia.push([browser.now(), this._pos]);
 
         if (!this.isActive()) {
             // we treat the first move event (rather than the mousedown event)
@@ -134,12 +125,9 @@ class DragPanHandler {
             this._map.moving = true;
             this._fireEvent('dragstart', e);
             this._fireEvent('movestart', e);
-
-            this._map._startAnimation(this._onDragFrame, this._onDragFinished);
         }
 
-        // ensure a new render frame is scheduled
-        this._map._update();
+        this._map._startAnimation(this._onDragFrame);
     }
 
     /**

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -37,7 +37,6 @@ class DragPanHandler {
         util.bindAll([
             '_onDown',
             '_onMove',
-            '_onUp',
             '_onTouchEnd',
             '_onMouseUp',
             '_onDragFrame',
@@ -214,13 +213,9 @@ class DragPanHandler {
         }, { originalEvent: e });
     }
 
-    _onUp(e: MouseEvent | TouchEvent | FocusEvent) {
-        this._onDragFinished(e);
-    }
-
     _onMouseUp(e: MouseEvent | FocusEvent) {
         if (this._ignoreEvent(e)) return;
-        this._onUp(e);
+        this._onDragFinished(e);
         window.document.removeEventListener('mousemove', this._onMove);
         window.document.removeEventListener('mouseup', this._onMouseUp);
         window.removeEventListener('blur', this._onMouseUp);
@@ -228,7 +223,7 @@ class DragPanHandler {
 
     _onTouchEnd(e: TouchEvent) {
         if (this._ignoreEvent(e)) return;
-        this._onUp(e);
+        this._onDragFinished(e);
         window.document.removeEventListener('touchmove', this._onMove);
         window.document.removeEventListener('touchend', this._onTouchEnd);
     }

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -55,8 +55,7 @@ class DragRotateHandler {
             '_onDown',
             '_onMove',
             '_onUp',
-            '_onDragFrame',
-            '_onDragFinished'
+            '_onDragFrame'
         ], this);
     }
 
@@ -139,15 +138,7 @@ class DragRotateHandler {
 
     _onMove(e: MouseEvent) {
         this._lastMoveEvent = e;
-        const pos = DOM.mousePos(this._el, e);
-        // if the dragging animation was interrupted (e.g. by another handler),
-        // we need to reestablish a _previousPos before we can resume dragging
-        if (!this._previousPos) {
-            this._previousPos = pos;
-            return;
-        }
-
-        this._pos = pos;
+        this._pos = DOM.mousePos(this._el, e);
 
         if (!this.isActive()) {
             this._active = true;
@@ -157,22 +148,9 @@ class DragRotateHandler {
             if (this._pitchWithRotate) {
                 this._fireEvent('pitchstart', e);
             }
-
-            this._map._startAnimation(this._onDragFrame, this._onDragFinished);
         }
 
-        // ensure a new render frame is scheduled
-        this._map._update();
-    }
-
-    _onUp(e: MouseEvent | FocusEvent) {
-        window.document.removeEventListener('mousemove', this._onMove, {capture: true});
-        window.document.removeEventListener('mouseup', this._onUp);
-        window.removeEventListener('blur', this._onUp);
-
-        DOM.enableDrag();
-
-        this._onDragFinished(e);
+        this._map._startAnimation(this._onDragFrame);
     }
 
     _onDragFrame(tr: Transform) {
@@ -204,7 +182,13 @@ class DragRotateHandler {
         this._previousPos = this._pos;
     }
 
-    _onDragFinished(e: MouseEvent | FocusEvent | void) {
+    _onUp(e: MouseEvent | FocusEvent) {
+        window.document.removeEventListener('mousemove', this._onMove, {capture: true});
+        window.document.removeEventListener('mouseup', this._onUp);
+        window.removeEventListener('blur', this._onUp);
+
+        DOM.enableDrag();
+
         if (!this.isActive()) return;
 
         this._active = false;

--- a/test/node_modules/mapbox-gl-js-test/simulate_interaction.js
+++ b/test/node_modules/mapbox-gl-js-test/simulate_interaction.js
@@ -34,6 +34,15 @@ exports.click = function (target, options) {
     };
 });
 
+[ 'touchstart', 'touchend', 'touchmove', 'touchcancel' ].forEach((event) => {
+    exports[event] = function (target, options) {
+        // Should be using Touch constructor here, but https://github.com/jsdom/jsdom/issues/2152.
+        options = Object.assign({bubbles: true, touches: [{clientX: 0, clientY: 0}]}, options);
+        const TouchEvent = window(target).TouchEvent;
+        target.dispatchEvent(new TouchEvent(event, options));
+    };
+});
+
 ['focus', 'blur'].forEach((event) => {
     exports[event] = function (target, options) {
         options = Object.assign({bubbles: true}, options);

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -1,53 +1,48 @@
 'use strict';
 
 const test = require('mapbox-gl-js-test').test;
-const util = require('../../../../src/util/util');
 const window = require('../../../../src/util/window');
 const Map = require('../../../../src/ui/map');
 const DOM = require('../../../../src/util/dom');
 const simulate = require('mapbox-gl-js-test/simulate_interaction');
 
-function createMap(options) {
-    return new Map(util.extend({
-        container: DOM.create('div', '', window.document.body),
-        style: {
-            "version": 8,
-            "sources": {},
-            "layers": []
-        }
-    }, options));
+function createMap() {
+    return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
 test('DragPanHandler requests a new render frame after each mousemove event', (t) => {
     const map = createMap();
     const update = t.spy(map, '_update');
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas());
+    simulate.mousemove(map.getCanvas());
     t.ok(update.callCount > 0);
 
     // https://github.com/mapbox/mapbox-gl-js/issues/6063
     update.reset();
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousemove(map.getCanvas());
     t.equal(update.callCount, 1);
+
+    map.remove();
     t.end();
 });
 
 test('DragPanHandler recovers after interruption by another handler', (t) => {
-    // https://github.com/mapbox/mapbox-gl-js/issues/6106 
+    // https://github.com/mapbox/mapbox-gl-js/issues/6106
     const map = createMap();
     const initialCenter = map.getCenter();
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, clientX: 10, clientY: 10});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2, clientX: 12, clientY: 10});
+    simulate.mousedown(map.getCanvas(), {clientX: 10, clientY: 10});
+    simulate.mousemove(map.getCanvas(), {clientX: 12, clientY: 10});
     map._updateCamera();
 
     // simluates another handler taking over
     map.stop();
 
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2, clientX: 14, clientY: 10});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2, clientX: 16, clientY: 10});
+    simulate.mousemove(map.getCanvas(), {clientX: 14, clientY: 10});
+    simulate.mousemove(map.getCanvas(), {clientX: 16, clientY: 10});
     map._updateCamera();
     t.equalWithPrecision(map.getCenter().lng, initialCenter.lng - 2.8125, 1e-4);
+
+    map.remove();
     t.end();
 });
-

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -10,6 +10,110 @@ function createMap() {
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
+test('DragPanHandler fires dragstart, drag, and dragend events at appropriate times in response to a mouse-triggered drag', (t) => {
+    const map = createMap();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    map.on('dragstart', dragstart);
+    map.on('drag',      drag);
+    map.on('dragend',   dragend);
+
+    simulate.mousedown(map.getCanvas());
+    map._updateCamera();
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.mousemove(map.getCanvas());
+    map._updateCamera();
+    t.equal(dragstart.callCount, 1);
+    t.equal(drag.callCount, 1);
+    t.equal(dragend.callCount, 0);
+
+    simulate.mouseup(map.getCanvas());
+    map._updateCamera();
+    t.equal(dragstart.callCount, 1);
+    t.equal(drag.callCount, 1);
+    t.equal(dragend.callCount, 1);
+
+    map.remove();
+    t.end();
+});
+
+test('DragPanHandler fires dragstart, drag, and dragend events at appropriate times in response to a touch-triggered drag', (t) => {
+    const map = createMap();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    map.on('dragstart', dragstart);
+    map.on('drag',      drag);
+    map.on('dragend',   dragend);
+
+    simulate.touchstart(map.getCanvas());
+    map._updateCamera();
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.touchmove(map.getCanvas());
+    map._updateCamera();
+    t.equal(dragstart.callCount, 1);
+    t.equal(drag.callCount, 1);
+    t.equal(dragend.callCount, 0);
+
+    simulate.touchend(map.getCanvas());
+    map._updateCamera();
+    t.equal(dragstart.callCount, 1);
+    t.equal(drag.callCount, 1);
+    t.equal(dragend.callCount, 1);
+
+    map.remove();
+    t.end();
+});
+
+test('DragPanHandler ends a mouse-triggered drag if the window blurs', (t) => {
+    const map = createMap();
+
+    const dragend = t.spy();
+    map.on('dragend', dragend);
+
+    simulate.mousedown(map.getCanvas());
+    map._updateCamera();
+
+    simulate.mousemove(map.getCanvas());
+    map._updateCamera();
+
+    simulate.blur(window);
+    t.equal(dragend.callCount, 1);
+
+    map.remove();
+    t.end();
+});
+
+test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
+    const map = createMap();
+
+    const dragend = t.spy();
+    map.on('dragend', dragend);
+
+    simulate.touchstart(map.getCanvas());
+    map._updateCamera();
+
+    simulate.touchmove(map.getCanvas());
+    map._updateCamera();
+
+    simulate.blur(window);
+    t.equal(dragend.callCount, 1);
+
+    map.remove();
+    t.end();
+});
+
 test('DragPanHandler requests a new render frame after each mousemove event', (t) => {
     const map = createMap();
     const update = t.spy(map, '_update');

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -8,32 +8,10 @@ const DOM = require('../../../../src/util/dom');
 const simulate = require('mapbox-gl-js-test/simulate_interaction');
 
 function createMap(options) {
-    return new Map(util.extend({
-        container: DOM.create('div', '', window.document.body),
-        style: {
-            "version": 8,
-            "sources": {},
-            "layers": []
-        }
-    }, options));
+    return new Map(util.extend({ container: DOM.create('div', '', window.document.body) }, options));
 }
 
-test('DragRotateHandler requests a new render frame after each mousemove event', (t) => {
-    const map = createMap();
-    const update = t.spy(map, '_update');
-
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
-    t.ok(update.callCount > 0);
-
-    // https://github.com/mapbox/mapbox-gl-js/issues/6063
-    update.reset();
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
-    t.equal(update.callCount, 1);
-    t.end();
-});
-
-test('DragRotateHandler rotates in response to a right-click drag', (t) => {
+test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a right-click drag', (t) => {
     const map = createMap();
 
     const rotatestart = t.spy();
@@ -44,21 +22,29 @@ test('DragRotateHandler rotates in response to a right-click drag', (t) => {
     map.on('rotate',      rotate);
     map.on('rotateend',   rotateend);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     map._updateCamera();
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
 
-    t.ok(rotatestart.calledOnce);
-    t.ok(rotate.calledOnce);
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    map._updateCamera();
+    t.equal(rotatestart.callCount, 1);
+    t.equal(rotate.callCount, 1);
+    t.equal(rotateend.callCount, 0);
 
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
-    t.ok(rotateend.calledOnce);
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
+    map._updateCamera();
+    t.equal(rotatestart.callCount, 1);
+    t.equal(rotate.callCount, 1);
+    t.equal(rotateend.callCount, 1);
 
     map.remove();
     t.end();
 });
 
-test('DragRotateHandler stops rotating after mouseup', (t) => {
+test('DragRotateHandler stops firing events after mouseup', (t) => {
     const map = createMap();
 
     const spy = t.spy();
@@ -66,21 +52,22 @@ test('DragRotateHandler stops rotating after mouseup', (t) => {
     map.on('rotate',      spy);
     map.on('rotateend',   spy);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
     map._updateCamera();
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
-
-    t.ok(spy.calledThrice);
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
+    t.equal(spy.callCount, 3);
 
     spy.reset();
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 0});
+    simulate.mousemove(map.getCanvas(), {buttons: 0});
+    map._updateCamera();
+    t.equal(spy.callCount, 0);
 
-    t.ok(spy.notCalled);
+    map.remove();
     t.end();
 });
 
-test('DragRotateHandler rotates in response to a control-left-click drag', (t) => {
+test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a control-left-click drag', (t) => {
     const map = createMap();
 
     const rotatestart = t.spy();
@@ -91,15 +78,25 @@ test('DragRotateHandler rotates in response to a control-left-click drag', (t) =
     map.on('rotate',      rotate);
     map.on('rotateend',   rotateend);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 1, button: 0, ctrlKey: true});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 1,            ctrlKey: true});
+    simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
     map._updateCamera();
-    t.ok(rotatestart.calledOnce);
-    t.ok(rotate.calledOnce);
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
 
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 0, ctrlKey: true});
-    t.ok(rotateend.calledOnce);
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
+    map._updateCamera();
+    t.equal(rotatestart.callCount, 1);
+    t.equal(rotate.callCount, 1);
+    t.equal(rotateend.callCount, 0);
 
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 0, ctrlKey: true});
+    map._updateCamera();
+    t.equal(rotatestart.callCount, 1);
+    t.equal(rotate.callCount, 1);
+    t.equal(rotateend.callCount, 1);
+
+    map.remove();
     t.end();
 });
 
@@ -114,15 +111,16 @@ test('DragRotateHandler pitches in response to a right-click drag by default', (
     map.on('pitch',      pitch);
     map.on('pitchend',   pitchend);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
     map._updateCamera();
-    t.ok(pitchstart.calledOnce);
-    t.ok(pitch.calledOnce);
+    t.equal(pitchstart.callCount, 1);
+    t.equal(pitch.callCount, 1);
 
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
-    t.ok(pitchend.calledOnce);
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
+    t.equal(pitchend.callCount, 1);
 
+    map.remove();
     t.end();
 });
 
@@ -137,15 +135,16 @@ test('DragRotateHandler pitches in response to a control-left-click drag', (t) =
     map.on('pitch',      pitch);
     map.on('pitchend',   pitchend);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 1, button: 0, ctrlKey: true});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 1,            ctrlKey: true});
+    simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
     map._updateCamera();
-    t.ok(pitchstart.calledOnce);
-    t.ok(pitch.calledOnce);
+    t.equal(pitchstart.callCount, 1);
+    t.equal(pitch.callCount, 1);
 
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 0, ctrlKey: true});
-    t.ok(pitchend.calledOnce);
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 0, ctrlKey: true});
+    t.equal(pitchend.callCount, 1);
 
+    map.remove();
     t.end();
 });
 
@@ -158,17 +157,19 @@ test('DragRotateHandler does not pitch if given pitchWithRotate: false', (t) => 
     map.on('pitch',       spy);
     map.on('pitchend',    spy);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
     map._updateCamera();
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 1, button: 0, ctrlKey: true});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 1,            ctrlKey: true});
+    simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
     map._updateCamera();
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 0, ctrlKey: true});
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 0, ctrlKey: true});
 
     t.ok(spy.notCalled);
+
+    map.remove();
     t.end();
 });
 
@@ -186,12 +187,14 @@ test('DragRotateHandler does not rotate or pitch when disabled', (t) => {
     map.on('pitch',       spy);
     map.on('pitchend',    spy);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
     map._updateCamera();
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
     t.ok(spy.notCalled);
+
+    map.remove();
     t.end();
 });
 
@@ -199,13 +202,14 @@ test('DragRotateHandler ensures that map.isMoving() returns true during drag', (
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
     const map = createMap({bearingSnap: 0});
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
     t.ok(map.isMoving());
 
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
     t.ok(!map.isMoving());
 
+    map.remove();
     t.end();
 });
 
@@ -221,15 +225,16 @@ test('DragRotateHandler fires move events', (t) => {
     map.on('move',      move);
     map.on('moveend',   moveend);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
     map._updateCamera();
-    t.ok(movestart.calledOnce);
-    t.ok(move.calledOnce);
+    t.equal(movestart.callCount, 1);
+    t.equal(move.callCount, 1);
 
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
-    t.ok(moveend.calledOnce);
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
+    t.equal(moveend.callCount, 1);
 
+    map.remove();
     t.end();
 });
 
@@ -258,10 +263,10 @@ test('DragRotateHandler includes originalEvent property in triggered events', (t
     map.on('move',      move);
     map.on('moveend',   moveend);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
     map._updateCamera();
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 2});
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
     t.ok(rotatestart.firstCall.args[0].originalEvent.type, 'mousemove');
     t.ok(pitchstart.firstCall.args[0].originalEvent.type, 'mousemove');
@@ -275,6 +280,7 @@ test('DragRotateHandler includes originalEvent property in triggered events', (t
     t.ok(pitchend.firstCall.args[0].originalEvent.type, 'mouseup');
     t.ok(moveend.firstCall.args[0].originalEvent.type, 'mouseup');
 
+    map.remove();
     t.end();
 });
 
@@ -289,15 +295,16 @@ test('DragRotateHandler responds to events on the canvas container (#1301)', (t)
     map.on('rotate',      rotate);
     map.on('rotateend',   rotateend);
 
-    simulate.mousedown(map.getCanvasContainer(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvasContainer(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvasContainer(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvasContainer(), {buttons: 2});
     map._updateCamera();
-    t.ok(rotatestart.calledOnce);
-    t.ok(rotate.calledOnce);
+    t.equal(rotatestart.callCount, 1);
+    t.equal(rotate.callCount, 1);
 
-    simulate.mouseup(map.getCanvasContainer(),   {bubbles: true, buttons: 0, button: 2});
-    t.ok(rotateend.calledOnce);
+    simulate.mouseup(map.getCanvasContainer(),   {buttons: 0, button: 2});
+    t.equal(rotateend.callCount, 1);
 
+    map.remove();
     t.end();
 });
 
@@ -307,12 +314,14 @@ test('DragRotateHandler prevents mousemove events from firing during a drag (#15
     const mousemove = t.spy();
     map.on('mousemove', mousemove);
 
-    simulate.mousedown(map.getCanvasContainer(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvasContainer(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvasContainer(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvasContainer(), {buttons: 2});
     map._updateCamera();
-    simulate.mouseup(map.getCanvasContainer(),   {bubbles: true, buttons: 0, button: 2});
+    simulate.mouseup(map.getCanvasContainer(),   {buttons: 0, button: 2});
 
     t.ok(mousemove.notCalled);
+
+    map.remove();
     t.end();
 });
 
@@ -327,15 +336,16 @@ test('DragRotateHandler ends a control-left-click drag on mouseup even when the 
     map.on('rotate',      rotate);
     map.on('rotateend',   rotateend);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 1, button: 0, ctrlKey: true});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 1,            ctrlKey: true});
+    simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
     map._updateCamera();
-    t.ok(rotatestart.calledOnce);
-    t.ok(rotate.calledOnce);
+    t.equal(rotatestart.callCount, 1);
+    t.equal(rotate.callCount, 1);
 
-    simulate.mouseup(map.getCanvas(),   {bubbles: true, buttons: 0, button: 0, ctrlKey: false});
-    t.ok(rotateend.calledOnce);
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 0, ctrlKey: false});
+    t.equal(rotateend.callCount, 1);
 
+    map.remove();
     t.end();
 });
 
@@ -350,31 +360,51 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
     map.on('rotate',      rotate);
     map.on('rotateend',   rotateend);
 
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
     map._updateCamera();
-    t.ok(rotatestart.calledOnce);
-    t.ok(rotate.calledOnce);
+    t.equal(rotatestart.callCount, 1);
+    t.equal(rotate.callCount, 1);
 
     simulate.blur(window);
-    t.ok(rotateend.calledOnce);
+    t.equal(rotateend.callCount, 1);
 
+    map.remove();
     t.end();
 });
 
-test('DragRotateHandler recovers after interruptino by another handler', (t) => {
-    // https://github.com/mapbox/mapbox-gl-js/issues/6106 
+test('DragRotateHandler requests a new render frame after each mousemove event', (t) => {
+    const map = createMap();
+    const update = t.spy(map, '_update');
+
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    t.ok(update.callCount > 0);
+
+    // https://github.com/mapbox/mapbox-gl-js/issues/6063
+    update.reset();
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    t.equal(update.callCount, 1);
+
+    map.remove();
+    t.end();
+});
+
+test('DragRotateHandler recovers after interruption by another handler', (t) => {
+    // https://github.com/mapbox/mapbox-gl-js/issues/6106
     const map = createMap();
     const initialBearing = map.getBearing();
-    simulate.mousedown(map.getCanvas(), {bubbles: true, buttons: 2, button: 2, clientX: 10, clientY: 10});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2, clientX: 12, clientY: 10});
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2, clientX: 10, clientY: 10});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 12, clientY: 10});
     map._updateCamera();
 
     // simluates another handler taking over
     map.stop();
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2, clientX: 12, clientY: 10});
-    simulate.mousemove(map.getCanvas(), {bubbles: true, buttons: 2, clientX: 14, clientY: 10});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 12, clientY: 10});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 14, clientY: 10});
     map._updateCamera();
     t.equalWithPrecision(map.getBearing(), initialBearing + 3.2, 1e-6);
+
+    map.remove();
     t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,6 +144,7 @@
     chalk "^2.3.0"
     d3-queue "^3.0.3"
     diff "^3.0.0"
+    glob "^7.0.3"
     json-stringify-pretty-compact "^1.0.4"
     lodash.template "^4.4.0"
     mapbox-gl-styles "2.0.2"
@@ -239,9 +240,9 @@ JSONStream@^1.0.3, JSONStream@^1.0.4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
 
-abab@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
+abab@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
 abbrev@1:
   version "1.1.0"
@@ -267,7 +268,7 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
-acorn-globals@^4.0.0:
+acorn-globals@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
   dependencies:
@@ -301,9 +302,9 @@ acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
-acorn@^5.1.2:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+acorn@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -598,6 +599,10 @@ async-each-series@0.1.1:
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
 async@1.5.2, async@^1.4.0:
   version "1.5.2"
@@ -2490,9 +2495,9 @@ constants-browserify@^1.0.0, constants-browserify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-content-type-parser@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
+content-type-parser@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
 
 continuable-cache@^0.3.1:
   version "0.3.1"
@@ -5034,9 +5039,9 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-html-encoding-sniffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
+html-encoding-sniffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
 
@@ -5159,7 +5164,7 @@ hyperquest@~1.2.0:
     duplexer2 "~0.0.2"
     through2 "~0.6.3"
 
-iconv-lite@0.4, iconv-lite@^0.4.5:
+iconv-lite@0.4, iconv-lite@0.4.19, iconv-lite@^0.4.5:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -5811,34 +5816,36 @@ jsdom-no-contextify@~3.1.0:
     xml-name-validator "^1.0.0"
     xmlhttprequest ">= 1.6.0 < 2.0.0"
 
-jsdom@^11.5.1:
-  version "11.5.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.5.1.tgz#5df753b8d0bca20142ce21f4f6c039f99a992929"
+jsdom@^11.6.2:
+  version "11.6.2"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.2.tgz#25d1ef332d48adf77fc5221fe2619967923f16bb"
   dependencies:
-    abab "^1.0.3"
-    acorn "^5.1.2"
-    acorn-globals "^4.0.0"
+    abab "^1.0.4"
+    acorn "^5.3.0"
+    acorn-globals "^4.1.0"
     array-equal "^1.0.0"
     browser-process-hrtime "^0.1.2"
-    content-type-parser "^1.0.1"
+    content-type-parser "^1.0.2"
     cssom ">= 0.3.2 < 0.4.0"
     cssstyle ">= 0.2.37 < 0.3.0"
     domexception "^1.0.0"
     escodegen "^1.9.0"
-    html-encoding-sniffer "^1.0.1"
+    html-encoding-sniffer "^1.0.2"
     left-pad "^1.2.0"
     nwmatcher "^1.4.3"
-    parse5 "^3.0.2"
-    pn "^1.0.0"
+    parse5 "4.0.0"
+    pn "^1.1.0"
     request "^2.83.0"
-    request-promise-native "^1.0.3"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
+    request-promise-native "^1.0.5"
+    sax "^1.2.4"
+    symbol-tree "^3.2.2"
     tough-cookie "^2.3.3"
+    w3c-hr-time "^1.0.1"
     webidl-conversions "^4.0.2"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^6.3.0"
-    xml-name-validator "^2.0.1"
+    whatwg-encoding "^1.0.3"
+    whatwg-url "^6.4.0"
+    ws "^4.0.0"
+    xml-name-validator "^3.0.0"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -7499,11 +7506,15 @@ parse-url@^1.3.0:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
 
+parse5@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
 "parse5@>= 1.3.1 < 2.0.0":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
-parse5@^3.0.0, parse5@^3.0.1, parse5@^3.0.2:
+parse5@^3.0.0, parse5@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
   dependencies:
@@ -7706,9 +7717,9 @@ pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
 
-pn@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pn/-/pn-1.0.0.tgz#1cf5a30b0d806cd18f88fc41a6b5d4ad615b3ba9"
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
 pngjs@^3.0.0:
   version "3.2.0"
@@ -8568,7 +8579,7 @@ request-promise-core@1.1.1:
   dependencies:
     lodash "^4.13.1"
 
-request-promise-native@^1.0.3:
+request-promise-native@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
   dependencies:
@@ -8789,7 +8800,7 @@ samsam@1.x, samsam@^1.1.3:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
-sax@^1.2.1:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -9624,7 +9635,7 @@ svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
 
-symbol-tree@^3.2.1:
+symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
@@ -10095,6 +10106,10 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+
 umd@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.1.tgz#8ae556e11011f63c2596708a8837259f01b3d60e"
@@ -10467,6 +10482,12 @@ vt-pbf@^3.0.1:
     "@mapbox/vector-tile" "^1.3.0"
     pbf "^3.0.5"
 
+w3c-hr-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  dependencies:
+    browser-process-hrtime "^0.1.2"
+
 watchify@^3.7.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/watchify/-/watchify-3.9.0.tgz#f075fd2e8a86acde84cedba6e5c2a0bedd523d9e"
@@ -10592,6 +10613,12 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
+whatwg-encoding@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"
+  dependencies:
+    iconv-lite "0.4.19"
+
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
@@ -10600,7 +10627,7 @@ whatwg-fetch@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
 
-whatwg-url@^6.3.0:
+whatwg-url@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
   dependencies:
@@ -10708,6 +10735,14 @@ ws@1.1.1:
     options ">=0.0.5"
     ultron "1.0.x"
 
+ws@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-4.0.0.tgz#bfe1da4c08eeb9780b986e0e4d10eccd7345999f"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
 wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
@@ -10736,9 +10771,9 @@ xml-name-validator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-1.0.0.tgz#dcf82ee092322951ef8cc1ba596c9cbfd14a83f1"
 
-xml-name-validator@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"


### PR DESCRIPTION
I believe that this is a better fix for #6106 than #6113. #6113 doesn't address the related issues that an "interruption" by another handler would trigger inertial panning and a `dragend` event, despite the drag remaining in progress until the mouse or touch is released.

@anandthakker, if you agree, I will port this approach to `DragRotateHandler` as well.