### PR TITLE
add originalEvent on user-initiated scroll zoomend and moveend #1975

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -251,8 +251,8 @@ class ScrollZoomHandler {
         if (!this.isActive()) return;
         this._active = false;
         this._finishTimeout = setTimeout(() => {
-            this._map.fire(new Event('zoomend'));
-            this._map.fire(new Event('moveend'));
+            this._map.fire(new Event('zoomend', {originalEvent: this._lastWheelEvent}));
+            this._map.fire(new Event('moveend', {originalEvent: this._lastWheelEvent}));
             delete this._targetZoom;
         }, 200);
     }


### PR DESCRIPTION
`originalEvent` is missing on `zoomend` and `moveend` user-initiated scroll events. This PR adds `_lastWheelEvent` as `originalEvent` to `zoomend` and `moveend` events.

See #1975 for more info.

## Launch Checklist

 - [ ] write tests for all new functionality
 - [x] manually test the debug page
