### PR TITLE
Unify DragPanHandler's mouseup/touchend/blur handling

### DIFF
--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -37,10 +37,8 @@ class DragPanHandler {
         util.bindAll([
             '_onDown',
             '_onMove',
-            '_onTouchEnd',
-            '_onMouseUp',
-            '_onDragFrame',
-            '_onDragFinished'
+            '_onUp',
+            '_onDragFrame'
         ], this);
     }
 
@@ -96,13 +94,15 @@ class DragPanHandler {
 
         if (e.touches) {
             window.document.addEventListener('touchmove', this._onMove);
-            window.document.addEventListener('touchend', this._onTouchEnd);
+            window.document.addEventListener('touchend', this._onUp);
         } else {
             window.document.addEventListener('mousemove', this._onMove);
-            window.document.addEventListener('mouseup', this._onMouseUp);
+            window.document.addEventListener('mouseup', this._onUp);
         }
-        /* Deactivate DragPan when the window looses focus. Otherwise if a mouseup occurs when the window isn't in focus, DragPan will still be active even though the mouse is no longer pressed. */
-        window.addEventListener('blur', this._onMouseUp);
+
+        // Deactivate DragPan when the window loses focus. Otherwise if a mouseup occurs when the window
+        // isn't in focus, DragPan will still be active even though the mouse is no longer pressed.
+        window.addEventListener('blur', this._onUp);
 
         this._active = false;
         this._previousPos = DOM.mousePos(this._el, e);
@@ -150,7 +150,15 @@ class DragPanHandler {
      * Called when dragging stops.
      * @private
      */
-    _onDragFinished(e: MouseEvent | TouchEvent | FocusEvent | void) {
+    _onUp(e: MouseEvent | TouchEvent | FocusEvent) {
+        if (this._ignoreEvent(e)) return;
+
+        window.document.removeEventListener('touchmove', this._onMove);
+        window.document.removeEventListener('touchend', this._onUp);
+        window.document.removeEventListener('mousemove', this._onMove);
+        window.document.removeEventListener('mouseup', this._onUp);
+        window.removeEventListener('blur', this._onUp);
+
         if (!this.isActive()) return;
 
         this._active = false;
@@ -199,21 +207,6 @@ class DragPanHandler {
             easing: inertiaEasing,
             noMoveStart: true
         }, { originalEvent: e });
-    }
-
-    _onMouseUp(e: MouseEvent | FocusEvent) {
-        if (this._ignoreEvent(e)) return;
-        this._onDragFinished(e);
-        window.document.removeEventListener('mousemove', this._onMove);
-        window.document.removeEventListener('mouseup', this._onMouseUp);
-        window.removeEventListener('blur', this._onMouseUp);
-    }
-
-    _onTouchEnd(e: TouchEvent) {
-        if (this._ignoreEvent(e)) return;
-        this._onDragFinished(e);
-        window.document.removeEventListener('touchmove', this._onMove);
-        window.document.removeEventListener('touchend', this._onTouchEnd);
     }
 
     _fireEvent(type: string, e: ?Event) {


### PR DESCRIPTION
This ensures that the window blur event listener isn't leaked after a touch drag. It will call removeEventListener on event bindings that were not registered (either mouse or touch), but that's a harmless no-op.

Fixes #6172.