### PR TITLE
Update rtl-text plugin to 0.1.2 in example/doc/test.

### DIFF
--- a/docs/pages/example/mapbox-gl-rtl-text.html
+++ b/docs/pages/example/mapbox-gl-rtl-text.html
@@ -1,7 +1,7 @@
 <div id='map'></div>
 
 <script>
-mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.1/mapbox-gl-rtl-text.js');
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.2/mapbox-gl-rtl-text.js');
 
 var map = new mapboxgl.Map({
     container: 'map',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@mapbox/batfish": "^0.13.3",
-    "@mapbox/mapbox-gl-rtl-text": "^0.1.1",
+    "@mapbox/mapbox-gl-rtl-text": "^0.1.2",
     "@mapbox/mapbox-gl-test-suite": "file:test/integration",
     "babel-eslint": "^7.0.0",
     "benchmark": "~2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,6 @@ module.exports = {
  * @param {string} pluginURL URL pointing to the Mapbox RTL text plugin source.
  * @param {Function} callback Called with an error argument if there is an error.
  * @example
- * mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.1/mapbox-gl-rtl-text.js');
+ * mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.2/mapbox-gl-rtl-text.js');
  * @see [Add support for right-to-left scripts](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-rtl-text/)
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,9 +130,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@mapbox/link-to-location/-/link-to-location-1.0.0.tgz#484a4d922e3e6f7b54fd7964d8035bcb00bbf59a"
 
-"@mapbox/mapbox-gl-rtl-text@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.1.1.tgz#1ceb3103cd668b16563b5492c0690c3f091c7491"
+"@mapbox/mapbox-gl-rtl-text@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.1.2.tgz#c6bdcc05ac71c1caa4dfa09022466d1e278083bc"
 
 "@mapbox/mapbox-gl-supported@^1.3.0":
   version "1.3.0"


### PR DESCRIPTION
Version 0.1.2 is rebuilt to be smaller and to be eval-free for CSP compliance.

Until `mb-pages` merges back to `master`, the Arabic tests will use version 0.1.1 instead of 0.1.2, but since the interface hasn't changed and we require both to work, I think that's fine.

I did a brief manual test of the example page with `yarn run start-docs` 