### PR TITLE
Don't show private constructors in docs

### DIFF
--- a/docs/pages/api.js
+++ b/docs/pages/api.js
@@ -188,7 +188,9 @@ class Item extends React.Component {
                     <p>Extends {section.augments.map((tag, i) =>
                         <span key={i} dangerouslySetInnerHTML={{__html: formatters.autolink(tag.name)}}/>)}.</p>}
 
-                {section.kind === 'class' && !section.interface &&
+                {section.kind === 'class' &&
+                    !section.interface &&
+                    (!section.constructorComment || section.constructorComment.access !== 'private') &&
                     <div className='code pad1 small round fill-light'
                         dangerouslySetInnerHTML={{__html: `new ${section.name}${formatters.parameters(section)}`}}/>}
 
@@ -198,7 +200,7 @@ class Item extends React.Component {
                 {section.copyright && <div>Copyright: {section.copyright}</div>}
                 {section.since && <div>Since: {section.since}</div>}
 
-                {!empty(section.params) && !(section.kind === 'class' && section.interface) &&
+                {!empty(section.params) && (section.kind !== 'class' || !section.constructorComment || section.constructorComment.access !== 'private') &&
                     <div>
                         <div className='pad1y quiet space-top2 prose-big'>Parameters</div>
                         <div>

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -13,7 +13,7 @@ import type Evented from '../util/evented';
 /**
  * A data source containing the contents of an HTML canvas.
  * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-canvas) for detailed documentation of options.)
- * @interface CanvasSource
+ *
  * @example
  * // add to map
  * map.addSource('some id', {
@@ -49,6 +49,9 @@ class CanvasSource extends ImageSource {
     pause: () => void;
     _playing: boolean;
 
+    /**
+     * @private
+     */
     constructor(id: string, options: CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
         super(id, options, dispatcher, eventedParent);
         this.options = options;

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -18,9 +18,7 @@ import type {PerformanceResourceTiming} from '../types/performance_resource_timi
  * A source containing GeoJSON.
  * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson) for detailed documentation of options.)
  *
- * @interface GeoJSONSource
  * @example
- *
  * map.addSource('some id', {
  *     type: 'geojson',
  *     data: 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_ports.geojson'
@@ -81,6 +79,9 @@ class GeoJSONSource extends Evented implements Source {
     _resourceTiming: Array<PerformanceResourceTiming>;
     _removed: boolean;
 
+    /**
+     * @private
+     */
     constructor(id: string, options: GeojsonSourceSpecification & {workerOptions?: any, collectResourceTiming: boolean}, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
 

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -25,7 +25,6 @@ import type VertexBuffer from '../gl/vertex_buffer';
  * A data source containing an image.
  * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-image) for detailed documentation of options.)
  *
- * @interface ImageSource
  * @example
  * // add to map
  * map.addSource('some id', {
@@ -72,6 +71,9 @@ class ImageSource extends Evented implements Source {
     boundsBuffer: VertexBuffer;
     boundsVAO: VertexArrayObject;
 
+    /**
+     * @private
+     */
     constructor(id: string, options: ImageSourceSpecification | VideoSourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
         this.id = id;

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -13,7 +13,6 @@ import type {Callback} from '../types/callback';
  * The `Source` interface must be implemented by each source type, including "core" types (`vector`, `raster`,
  * `video`, etc.) and all custom, third-party types.
  *
- * @class Source
  * @private
  *
  * @param {string} id The id for the source. Must not be used by any existing source.

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -13,7 +13,7 @@ import type Evented from '../util/evented';
 /**
  * A data source containing video.
  * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-video) for detailed documentation of options.)
- * @interface VideoSource
+ *
  * @example
  * // add to map
  * map.addSource('some id', {
@@ -48,6 +48,9 @@ class VideoSource extends ImageSource {
     video: HTMLVideoElement;
     roundZoom: boolean;
 
+    /**
+     * @private
+     */
     constructor(id: string, options: VideoSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
         super(id, options, dispatcher, eventedParent);
         this.roundZoom = true;

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -10,8 +10,6 @@ import type Map from '../map';
 /**
  * The `BoxZoomHandler` allows the user to zoom the map to fit within a bounding box.
  * The bounding box is defined by clicking and holding `shift` while dragging the cursor.
- *
- * @param {Map} map The Mapbox GL JS map to add the handler to.
  */
 class BoxZoomHandler {
     _map: Map;
@@ -22,6 +20,9 @@ class BoxZoomHandler {
     _startPos: any;
     _box: HTMLElement;
 
+    /**
+     * @private
+     */
     constructor(map: Map) {
         this._map = map;
         this._el = map.getCanvasContainer();

--- a/src/ui/handler/dblclick_zoom.js
+++ b/src/ui/handler/dblclick_zoom.js
@@ -7,14 +7,15 @@ import type Map from '../map';
 /**
  * The `DoubleClickZoomHandler` allows the user to zoom the map at a point by
  * double clicking.
- *
- * @param {Map} map The Mapbox GL JS map to add the handler to.
  */
 class DoubleClickZoomHandler {
     _map: Map;
     _enabled: boolean;
     _active: boolean;
 
+    /**
+     * @private
+     */
     constructor(map: Map) {
         this._map = map;
 

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -17,8 +17,6 @@ const inertiaLinearity = 0.3,
 /**
  * The `DragPanHandler` allows the user to pan the map by clicking and dragging
  * the cursor.
- *
- * @param {Map} map The Mapbox GL JS map to add the handler to.
  */
 class DragPanHandler {
     _map: Map;
@@ -30,6 +28,9 @@ class DragPanHandler {
     _inertia: Array<[number, Point]>;
     _lastMoveEvent: MouseEvent | TouchEvent | void;
 
+    /**
+     * @private
+     */
     constructor(map: Map) {
         this._map = map;
         this._el = map.getCanvasContainer();

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -17,12 +17,6 @@ const inertiaLinearity = 0.25,
 /**
  * The `DragRotateHandler` allows the user to rotate the map by clicking and
  * dragging the cursor while holding the right mouse button or `ctrl` key.
- *
- * @param {Map} map The Mapbox GL JS map to add the handler to.
- * @param {Object} [options]
- * @param {number} [options.bearingSnap] The threshold, measured in degrees, that determines when the map's
- *   bearing will snap to north.
- * @param {bool} [options.pitchWithRotate=true] Control the map pitch in addition to the bearing
  */
 class DragRotateHandler {
     _map: Map;
@@ -40,6 +34,14 @@ class DragRotateHandler {
     _inertia: Array<[number, number]>;
     _center: Point;
 
+    /**
+     * @param {Map} map The Mapbox GL JS map to add the handler to.
+     * @param {Object} [options]
+     * @param {number} [options.bearingSnap] The threshold, measured in degrees, that determines when the map's
+     *   bearing will snap to north.
+     * @param {bool} [options.pitchWithRotate=true] Control the map pitch in addition to the bearing
+     * @private
+     */
     constructor(map: Map, options: {
         button?: 'right' | 'left',
         element?: HTMLElement,

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -21,14 +21,15 @@ const panStep = 100,
  * - `Shift+⇠`: Decrease the rotation by 15 degrees.
  * - `Shift+⇡`: Increase the pitch by 10 degrees.
  * - `Shift+⇣`: Decrease the pitch by 10 degrees.
- *
- * @param {Map} map The Mapbox GL JS map to add the handler to.
  */
 class KeyboardHandler {
     _map: Map;
     _el: HTMLElement;
     _enabled: boolean;
 
+    /**
+     * @private
+     */
     constructor(map: Map) {
         this._map = map;
         this._el = map.getCanvasContainer();

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -28,8 +28,6 @@ const ua = window.navigator.userAgent.toLowerCase(),
 
 /**
  * The `ScrollZoomHandler` allows the user to zoom the map by scrolling.
- *
- * @param {Map} map The Mapbox GL JS map to add the handler to.
  */
 class ScrollZoomHandler {
     _map: Map;
@@ -53,6 +51,9 @@ class ScrollZoomHandler {
     _easing: (number) => number;
     _prevEase: {start: number, duration: number, easing: (number) => number};
 
+    /**
+     * @private
+     */
     constructor(map: Map) {
         this._map = map;
         this._el = map.getCanvasContainer();

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -18,8 +18,6 @@ const inertiaLinearity = 0.15,
 /**
  * The `TouchZoomRotateHandler` allows the user to zoom and rotate the map by
  * pinching on a touchscreen.
- *
- * @param {Map} map The Mapbox GL JS map to add the handler to.
  */
 class TouchZoomRotateHandler {
     _map: Map;
@@ -33,6 +31,9 @@ class TouchZoomRotateHandler {
     _gestureIntent: 'rotate' | 'zoom' | void;
     _inertia: Array<[number, number, Point]>;
 
+    /**
+     * @private
+     */
     constructor(map: Map) {
         this._map = map;
         this._el = map.getCanvasContainer();

--- a/src/util/dispatcher.js
+++ b/src/util/dispatcher.js
@@ -9,7 +9,6 @@ import type WorkerPool from './worker_pool';
  * Responsible for sending messages from a {@link Source} to an associated
  * {@link WorkerSource}.
  *
- * @interface Dispatcher
  * @private
  */
 class Dispatcher {


### PR DESCRIPTION
E.g. before:

![image](https://user-images.githubusercontent.com/98601/36449266-2e5c3056-163f-11e8-968a-eaddbf754bc7.png)

Vs after:

![image](https://user-images.githubusercontent.com/98601/36449251-225018d6-163f-11e8-9eef-bd246419ca0c.png)
