### PR TITLE
adjust empty string fix to match -native

### DIFF
--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -112,14 +112,11 @@ class Placement {
 
         const partiallyEvaluatedTextSize = symbolSize.evaluateSizeForZoom(bucket.textSizeData, this.transform.zoom, symbolLayoutProperties.properties['text-size']);
 
-        const iconWithoutText = !bucket.hasTextData() || layout.get('text-optional');
-        const textWithoutIcon = !bucket.hasIconData() || layout.get('icon-optional');
-
         for (const symbolInstance of bucket.symbolInstances) {
             if (!seenCrossTileIDs[symbolInstance.crossTileID]) {
 
-                let placeText = symbolInstance.feature.text !== undefined;
-                let placeIcon = symbolInstance.feature.icon !== undefined;
+                let placeText = false;
+                let placeIcon = false;
                 let offscreen = true;
 
                 let placedGlyphBoxes = null;
@@ -169,6 +166,11 @@ class Placement {
                     placeIcon = placedIconBoxes.box.length > 0;
                     offscreen = offscreen && placedIconBoxes.offscreen;
                 }
+
+                const hasTextData = Boolean(symbolInstance.collisionArrays.textBox || symbolInstance.collisionArrays.textCircles);
+                const hasIconData = Boolean(symbolInstance.collisionArrays && symbolInstance.collisionArrays.iconBox);
+                const iconWithoutText = !hasTextData || layout.get('text-optional');
+                const textWithoutIcon = !hasIconData || layout.get('icon-optional');
 
                 // Combine the scales for icons and text.
                 if (!iconWithoutText && !textWithoutIcon) {


### PR DESCRIPTION
This should not change behaviour. This just brings -js slightly closer to the -native fix: https://github.com/mapbox/mapbox-gl-native/pull/11206

benchmarks:
The benchmarks looked good except for Layout. But I wasn't able to reproduce the that difference on [later runs](https://bl.ocks.org/anonymous/raw/e9a09f3cfaa256552ee0c67572b381f9/).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [N/A] write tests for all new functionality
 - [N/A] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
