### PR TITLE
Use ~ to install node-mapnik

### DIFF
--- a/test/integration/tiles/package.json
+++ b/test/integration/tiles/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "mapnik": "^3.5.13"
+    "mapnik": "~3.6.2"
   }
 }


### PR DESCRIPTION
This will protect your module from automatically upgrading to node-mapnik v3.7.0 (when it is published). This in turn will protect your users from breakages if they are running windows.

Refs mapnik/node-mapnik#848
