### PR TITLE
add box-sizing to user-location-dot css

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -439,6 +439,7 @@ a.mapboxgl-ctrl-logo {
     position: absolute;
     top: -2px;
     width: 15px;
+    box-sizing: content-box;
 }
 
 @-webkit-keyframes mapboxgl-user-location-dot-pulse {

--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -434,12 +434,12 @@ a.mapboxgl-ctrl-logo {
     border-radius: 50%;
     border: 2px solid #fff;
     content: '';
-    height: 15px;
+    height: 19px;
     left: -2px;
     position: absolute;
     top: -2px;
-    width: 15px;
-    box-sizing: content-box;
+    width: 19px;
+    box-sizing: border-box;
 }
 
 @-webkit-keyframes mapboxgl-user-location-dot-pulse {


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

if the map div has inherited a `box-sizing: border-box` for example applied to a whole application outside of mapbox gl js then the geolocation dot will look wrong. This PR explicitly sets the geolocation dot to use `box-sizing: content-box;`.

 - n/a write tests for all new functionality
 - n/a document any changes to public APIs
 - n/a post benchmark scores
 - [x] manually test the debug page
