### PR TITLE
Implement "regex" expression that returns an array of match groups or…

### DIFF
--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -533,7 +533,28 @@ CompoundExpression.register(expressions, {
         StringType,
         varargs(StringType),
         (ctx, args) => args.map(arg => arg.evaluate(ctx)).join('')
-    ]
+    ],
+
+    'regex': {
+        type: array(StringType),
+        overloads: [
+            [
+                [StringType, StringType],
+                (ctx, [r, s]) => {
+                    const m = RegExp(r.evaluate(ctx)).exec(s.evaluate(ctx));
+                    /* Slice will make a new array without the extra attributes of the match object */
+                    return (m !== null)? m.slice(): null;
+                }
+            ], [
+                [StringType, StringType, StringType],
+                (ctx, [r, f, s]) => {
+                    const m = RegExp(r.evaluate(ctx), f.evaluate(ctx)).exec(s.evaluate(ctx));
+                    /* Slice will make a new array without the extra attributes of the match object */
+                    return (m !== null)? m.slice(): null;
+                }
+            ]
+        ]
+    }
 });
 
 module.exports = expressions;

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -543,14 +543,14 @@ CompoundExpression.register(expressions, {
                 (ctx, [r, s]) => {
                     const m = RegExp(r.evaluate(ctx)).exec(s.evaluate(ctx));
                     /* Slice will make a new array without the extra attributes of the match object */
-                    return (m !== null)? m.slice(): null;
+                    return (m !== null) ? m.slice() : null;
                 }
             ], [
                 [StringType, StringType, StringType],
                 (ctx, [r, f, s]) => {
                     const m = RegExp(r.evaluate(ctx), f.evaluate(ctx)).exec(s.evaluate(ctx));
                     /* Slice will make a new array without the extra attributes of the match object */
-                    return (m !== null)? m.slice(): null;
+                    return (m !== null) ? m.slice() : null;
                 }
             ]
         ]

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -534,6 +534,30 @@ CompoundExpression.register(expressions, {
         varargs(StringType),
         (ctx, args) => args.map(arg => arg.evaluate(ctx)).join('')
     ],
+    'regex-test': {
+        type: BooleanType,
+        overloads: [
+            [
+                [StringType, StringType],
+                (ctx, [r, s]) => RegExp(r.evaluate(ctx)).test(s.evaluate(ctx))
+            ], [
+                [StringType, StringType, StringType],
+                (ctx, [r, f, s]) => RegExp(r.evaluate(ctx), f.evaluate(ctx)).test(s.evaluate(ctx))
+            ]
+        ]
+    },
+    'regex-replace': {
+        type: StringType,
+        overloads: [
+            [
+                [StringType, StringType, StringType],
+                (ctx, [r, n, s]) => s.evaluate(ctx).replace(RegExp(r.evaluate(ctx)), n.evaluate(ctx))
+            ], [
+                [StringType, StringType, StringType, StringType],
+                (ctx, [r, f, n, s]) => s.evaluate(ctx).replace(RegExp(r.evaluate(ctx), f.evaluate(ctx)), n.evaluate(ctx))
+            ]
+        ]
+    },
     'regex-match': {
         type: array(StringType),
         overloads: [

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -534,8 +534,7 @@ CompoundExpression.register(expressions, {
         varargs(StringType),
         (ctx, args) => args.map(arg => arg.evaluate(ctx)).join('')
     ],
-
-    'regex': {
+    'regex-match': {
         type: array(StringType),
         overloads: [
             [

--- a/test/integration/expression-tests/regex-match/basic/test.json
+++ b/test/integration/expression-tests/regex-match/basic/test.json
@@ -1,5 +1,5 @@
 {
-  "expression": ["regex", ["get", "r"], ["get", "s"]],
+  "expression": ["regex-match", ["get", "r"], ["get", "s"]],
   "inputs": [
     [{}, {"properties": {"r": ".*", "s": "some string"}}],
     [{}, {"properties": {"r": "me stri", "s": "some string"}}],
@@ -19,6 +19,6 @@
         ["some string", "some"],
         ["some string", "some", "string"]
     ],
-    "serialized": ["regex", ["get", "r"], ["get", "s"]]
+    "serialized": ["regex-match", ["get", "r"], ["get", "s"]]
   }
 }

--- a/test/integration/expression-tests/regex-replace/basic/test.json
+++ b/test/integration/expression-tests/regex-replace/basic/test.json
@@ -1,0 +1,24 @@
+{
+  "expression": ["regex-replace", ["get", "r"], ["get", "n"], ["get", "s"]],
+  "inputs": [
+    [{}, {"properties": {"r": "ome", "n": "uch a", "s": "some string"}}],
+    [{}, {"properties": {"r": "some string", "n": "other text", "s": "some string"}}],
+    [{}, {"properties": {"r": "ME", "n": "ch a", "s": "some string"}}],
+    [{}, {"properties": {"r": "string", "n": "text", "s": "some string"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "string"
+    },
+    "outputs": [
+        "such a string",
+        "other text",
+        "some string",
+        "some text"
+    ],
+    "serialized": ["regex-replace", ["get", "r"], ["get", "n"], ["get", "s"]]
+  }
+}

--- a/test/integration/expression-tests/regex-test/basic/test.json
+++ b/test/integration/expression-tests/regex-test/basic/test.json
@@ -1,0 +1,24 @@
+{
+  "expression": ["regex-test", ["get", "r"], ["get", "s"]],
+  "inputs": [
+    [{}, {"properties": {"r": ".*", "s": "some string"}}],
+    [{}, {"properties": {"r": "(.*) string", "s": "some string"}}],
+    [{}, {"properties": {"r": "NO.*MATCH", "s": "some string"}}],
+    [{}, {"properties": {"r": "SOME string", "s": "some string"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [
+        true,
+        true,
+        false,
+        false
+    ],
+    "serialized": ["regex-test", ["get", "r"], ["get", "s"]]
+  }
+}

--- a/test/integration/expression-tests/regex/basic/test.json
+++ b/test/integration/expression-tests/regex/basic/test.json
@@ -1,0 +1,24 @@
+{
+  "expression": ["regex", ["get", "r"], ["get", "s"]],
+  "inputs": [
+    [{}, {"properties": {"r": ".*", "s": "some string"}}],
+    [{}, {"properties": {"r": "me stri", "s": "some string"}}],
+    [{}, {"properties": {"r": "(.*) string", "s": "some string"}}],
+    [{}, {"properties": {"r": "([eosm]{4}) (string)", "s": "some string"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "array<string>"
+    },
+    "outputs": [
+        ["some string"],
+        ["me stri"],
+        ["some string", "some"],
+        ["some string", "some", "string"]
+    ],
+    "serialized": ["regex", ["get", "r"], ["get", "s"]]
+  }
+}


### PR DESCRIPTION
… null if no match.

Implements a "regex" expression (#4089 ) which takes two or three string parameters: First is the regular expression to use, second (optional) is flags and third is the source string. Also added some basic tests for the regex feature. 

As this returns the match groups, it works for both checking for matches or search and replace type of functionality (#4100 ) by using let, array access and concat operations.

As on failure this returns null, it works nicely with coalesce, in case you need to specify multiple different cases of regexes.