### PR TITLE
 Support disable() mid drag or rotate gesture

### DIFF
--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -54,8 +54,14 @@ module.exports = function bindHandlers(map: Map, options: {}) {
         }
 
         map.boxZoom.onMouseDown(e);
-        map.dragRotate.onDown(e);
-        map.dragPan.onDown(e);
+
+        if (!map.boxZoom.isActive() && !map.dragPan.isActive()) {
+            map.dragRotate.onDown(e);
+        }
+
+        if (!map.boxZoom.isActive() && !map.dragRotate.isActive()) {
+            map.dragPan.onDown(e);
+        }
     }
 
     function onMouseUp(e: MouseEvent) {
@@ -105,7 +111,10 @@ module.exports = function bindHandlers(map: Map, options: {}) {
 
         map.stop();
 
-        map.dragPan.onDown(e);
+        if (!map.boxZoom.isActive() && !map.dragRotate.isActive()) {
+            map.dragPan.onDown(e);
+        }
+
         map.touchZoomRotate.onStart(e);
         map.doubleClickZoom.onTouchStart(mapEvent);
     }

--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -56,11 +56,11 @@ module.exports = function bindHandlers(map: Map, options: {}) {
         map.boxZoom.onMouseDown(e);
 
         if (!map.boxZoom.isActive() && !map.dragPan.isActive()) {
-            map.dragRotate.onDown(e);
+            map.dragRotate.onMouseDown(e);
         }
 
         if (!map.boxZoom.isActive() && !map.dragRotate.isActive()) {
-            map.dragPan.onDown(e);
+            map.dragPan.onMouseDown(e);
         }
     }
 
@@ -112,7 +112,7 @@ module.exports = function bindHandlers(map: Map, options: {}) {
         map.stop();
 
         if (!map.boxZoom.isActive() && !map.dragRotate.isActive()) {
-            map.dragPan.onDown(e);
+            map.dragPan.onTouchStart(e);
         }
 
         map.touchZoomRotate.onStart(e);

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -87,8 +87,6 @@ class DragPanHandler {
 
     onDown(e: MouseEvent | TouchEvent) {
         if (!this.isEnabled()) return;
-        if (this._map.boxZoom.isActive()) return;
-        if (this._map.dragRotate.isActive()) return;
         if (this.isActive()) return;
 
         // Bind window-level event listeners for move and up/end events. In the absence of

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -104,8 +104,6 @@ class DragRotateHandler {
 
     onDown(e: MouseEvent) {
         if (!this.isEnabled()) return;
-        if (this._map.boxZoom.isActive()) return;
-        if (this._map.dragPan.isActive()) return;
         if (this.isActive()) return;
 
         if (this._button === 'right') {

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -516,3 +516,81 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the to
     map.remove();
     t.end();
 });
+
+['dragstart', 'drag'].forEach(event => {
+    test(`DragPanHandler can be disabled on ${event} (#2419)`, (t) => {
+        const map = createMap();
+
+        map.on(event, () => map.dragPan.disable());
+
+        const dragstart = t.spy();
+        const drag      = t.spy();
+        const dragend   = t.spy();
+
+        map.on('dragstart', dragstart);
+        map.on('drag',      drag);
+        map.on('dragend',   dragend);
+
+        simulate.mousedown(map.getCanvas());
+        map._updateCamera();
+
+        simulate.mousemove(map.getCanvas());
+        map._updateCamera();
+
+        t.equal(dragstart.callCount, 1);
+        t.equal(drag.callCount, event === 'dragstart' ? 0 : 1);
+        t.equal(dragend.callCount, 1);
+        t.equal(map.isMoving(), false);
+        t.equal(map.dragPan.isEnabled(), false);
+
+        simulate.mouseup(map.getCanvas());
+        map._updateCamera();
+
+        t.equal(dragstart.callCount, 1);
+        t.equal(drag.callCount, event === 'dragstart' ? 0 : 1);
+        t.equal(dragend.callCount, 1);
+        t.equal(map.isMoving(), false);
+        t.equal(map.dragPan.isEnabled(), false);
+
+        map.remove();
+        t.end();
+    });
+});
+
+test(`DragPanHandler can be disabled after mousedown (#2419)`, (t) => {
+    const map = createMap();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    map.on('dragstart', dragstart);
+    map.on('drag',      drag);
+    map.on('dragend',   dragend);
+
+    simulate.mousedown(map.getCanvas());
+    map._updateCamera();
+
+    map.dragPan.disable();
+
+    simulate.mousemove(map.getCanvas());
+    map._updateCamera();
+
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+    t.equal(map.isMoving(), false);
+    t.equal(map.dragPan.isEnabled(), false);
+
+    simulate.mouseup(map.getCanvas());
+    map._updateCamera();
+
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+    t.equal(map.isMoving(), false);
+    t.equal(map.dragPan.isEnabled(), false);
+
+    map.remove();
+    t.end();
+});

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -603,3 +603,81 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
     map.remove();
     t.end();
 });
+
+['rotatestart', 'rotate'].forEach(event => {
+    test(`DragRotateHandler can be disabled on ${event} (#2419)`, (t) => {
+        const map = createMap();
+
+        map.on(event, () => map.dragRotate.disable());
+
+        const rotatestart = t.spy();
+        const rotate      = t.spy();
+        const rotateend   = t.spy();
+
+        map.on('rotatestart', rotatestart);
+        map.on('rotate',      rotate);
+        map.on('rotateend',   rotateend);
+
+        simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+        map._updateCamera();
+
+        simulate.mousemove(map.getCanvas(), {buttons: 2});
+        map._updateCamera();
+
+        t.equal(rotatestart.callCount, 1);
+        t.equal(rotate.callCount, event === 'rotatestart' ? 0 : 1);
+        t.equal(rotateend.callCount, 1);
+        t.equal(map.isMoving(), false);
+        t.equal(map.dragRotate.isEnabled(), false);
+
+        simulate.mouseup(map.getCanvas(), {buttons: 0, button: 2});
+        map._updateCamera();
+
+        t.equal(rotatestart.callCount, 1);
+        t.equal(rotate.callCount, event === 'rotatestart' ? 0 : 1);
+        t.equal(rotateend.callCount, 1);
+        t.equal(map.isMoving(), false);
+        t.equal(map.dragRotate.isEnabled(), false);
+
+        map.remove();
+        t.end();
+    });
+});
+
+test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
+    const map = createMap();
+
+    const rotatestart = t.spy();
+    const rotate      = t.spy();
+    const rotateend   = t.spy();
+
+    map.on('rotatestart', rotatestart);
+    map.on('rotate',      rotate);
+    map.on('rotateend',   rotateend);
+
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    map._updateCamera();
+
+    map.dragRotate.disable();
+
+    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    map._updateCamera();
+
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
+    t.equal(map.isMoving(), false);
+    t.equal(map.dragRotate.isEnabled(), false);
+
+    simulate.mouseup(map.getCanvas(), {buttons: 0, button: 2});
+    map._updateCamera();
+
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
+    t.equal(map.isMoving(), false);
+    t.equal(map.dragRotate.isEnabled(), false);
+
+    map.remove();
+    t.end();
+});


### PR DESCRIPTION
Moves `DragPanHandler` and `DragRotateHandler` closer to a state machine based implementation, so that, when disabled, they can perform the appropriate actions in any state.

These two handlers have four states:

* `disabled`: The handler is disabled, and should not respond to any input.
* `enabled`: The handler is enabled but has not started receiving any input.
* `pending`: The handler has received a `mousedown` or `touchstart` event, but not a subsequent `move` event.
* `active`: The handler has received a `mousedown` or `touchstart` event and at least one subsequent `move` event.

Disabling a handler in the `enabled` state doesn't generally require anything special. Disabling a handler in the `pending` state requires unbinding some event listeners. Disabling a handler in the `active` state requires unbinding some event listeners, sending appropriate `*end` events, and _not_ triggering an inertial camera animation.

Fixes #2419.