### PR TITLE
Infer type assertions for object

### DIFF
--- a/src/style-spec/expression/parsing_context.js
+++ b/src/style-spec/expression/parsing_context.js
@@ -91,7 +91,7 @@ class ParsingContext {
                     // When we expect a Color but have a String or Value, we
                     // can wrap it in "to-color" coercion.
                     // Otherwise, we do static type-checking.
-                    if ((expected.kind === 'string' || expected.kind === 'number' || expected.kind === 'boolean') && actual.kind === 'value') {
+                    if ((expected.kind === 'string' || expected.kind === 'number' || expected.kind === 'boolean' || expected.kind === 'object') && actual.kind === 'value') {
                         if (!options.omitTypeAnnotations) {
                             parsed = new Assertion(expected, [parsed]);
                         }

--- a/test/integration/expression-tests/object/implicit/test.json
+++ b/test/integration/expression-tests/object/implicit/test.json
@@ -1,0 +1,20 @@
+{
+  "expression": ["get", "b", ["get", "a"]],
+  "inputs": [
+    [{}, {"properties": {"a": {"b": 0}}}],
+    [{}, {"properties": {"a": "not"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "value"
+    },
+    "outputs": [
+      0,
+      {"error": "Expected value to be of type object, but found string instead."}
+    ],
+    "serialized": ["get", "b", ["get", "a"]]
+  }
+}


### PR DESCRIPTION
Fixes #6235.

(Doc fix to be committed to `mb-pages` separately.)