### PR TITLE
Relax type checking for "length"

### DIFF
--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -156,6 +156,10 @@ const types = {
             'stop_input_n: number, stop_output_n: OutputType, ...'
         ]
     }],
+    length: [{
+        type: 'number',
+        parameters: ['string | array | value']
+    }],
     let: [{
         type: 'OutputType',
         parameters: [{ repeat: ['string (alphanumeric literal)', 'any']}, 'OutputType']

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -28,6 +28,7 @@ const Step = require('./step');
 const Interpolate = require('./interpolate');
 const Coalesce = require('./coalesce');
 const {Equals, NotEquals} = require('./equals');
+const Length = require('./length');
 
 import type { ExpressionRegistry } from '../expression';
 
@@ -41,6 +42,7 @@ const expressions: ExpressionRegistry = {
     'case': Case,
     'coalesce': Coalesce,
     'interpolate': Interpolate,
+    'length': Length,
     'let': Let,
     'literal': Literal,
     'match': Match,
@@ -70,10 +72,6 @@ function has(key, obj) {
 function get(key, obj) {
     const v = obj[key];
     return typeof v === 'undefined' ? null : v;
-}
-
-function length(ctx, [v]) {
-    return v.evaluate(ctx).length;
 }
 
 function lt(ctx, [a, b]) { return a.evaluate(ctx) < b.evaluate(ctx); }
@@ -144,18 +142,6 @@ CompoundExpression.register(expressions, {
         [NumberType, NumberType, NumberType, NumberType],
         rgba
     ],
-    'length': {
-        type: NumberType,
-        overloads: [
-            [
-                [StringType],
-                length
-            ], [
-                [array(ValueType)],
-                length
-            ]
-        ]
-    },
     'has': {
         type: BooleanType,
         overloads: [

--- a/src/style-spec/expression/definitions/length.js
+++ b/src/style-spec/expression/definitions/length.js
@@ -1,0 +1,58 @@
+// @flow
+
+const {
+    NumberType,
+    toString
+} = require('../types');
+const {typeOf} = require('../values');
+
+const RuntimeError = require('../runtime_error');
+
+import type { Expression } from '../expression';
+import type ParsingContext from '../parsing_context';
+import type EvaluationContext from '../evaluation_context';
+import type { Type } from '../types';
+
+class Length implements Expression {
+    type: Type;
+    input: Expression;
+
+    constructor(input: Expression) {
+        this.type = NumberType;
+        this.input = input;
+    }
+
+    static parse(args: Array<mixed>, context: ParsingContext) {
+        if (args.length !== 2)
+            return context.error(`Expected 1 argument, but found ${args.length - 1} instead.`);
+
+        const input = context.parse(args[1], 1);
+        if (!input) return null;
+
+        if (input.type.kind !== 'array' && input.type.kind !== 'string' && input.type.kind !== 'value')
+            return context.error(`Expected argument of type string or array, but found ${toString(input.type)} instead.`);
+
+        return new Length(input);
+    }
+
+    evaluate(ctx: EvaluationContext) {
+        const input = this.input.evaluate(ctx);
+        if (typeof input === 'string') {
+            return input.length;
+        } else if (Array.isArray(input)) {
+            return input.length;
+        } else {
+            throw new RuntimeError(`Expected value to be of type string or array, but found ${toString(typeOf(input))} instead.`);
+        }
+    }
+
+    eachChild(fn: (Expression) => void) {
+        fn(this.input);
+    }
+
+    possibleOutputs() {
+        return [undefined];
+    }
+}
+
+module.exports = Length;

--- a/test/integration/expression-tests/length/implicit/test.json
+++ b/test/integration/expression-tests/length/implicit/test.json
@@ -1,0 +1,24 @@
+{
+  "expression": ["length", ["get", "x"]],
+  "inputs": [
+    [{}, {"properties": {"x": "a string"}}],
+    [{}, {"properties": {"x": []}}],
+    [{}, {"properties": {"x": 0}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "number"
+    },
+    "outputs": [
+      8,
+      0,
+      {
+        "error": "Expected value to be of type string or array, but found number instead."
+      }
+    ],
+    "serialized": ["length", ["get", "x"]]
+  }
+}

--- a/test/integration/expression-tests/length/invalid/test.json
+++ b/test/integration/expression-tests/length/invalid/test.json
@@ -1,0 +1,16 @@
+{
+  "expression": ["length", 0],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [
+        {
+          "key": "",
+          "error": "Expected argument of type string or array, but found number instead."
+        }
+      ]
+    },
+    "serialized": ["length", 0]
+  }
+}


### PR DESCRIPTION
Fixes #6006 by accepting arguments of type `value` and performing runtime type checking.