### PR TITLE
Use console warning rather than DOM element to indicate missing stylesheet

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -10,8 +10,8 @@
     height: 100%;
 }
 
-.mapboxgl-missing-css {
-    display: none;
+.mapboxgl-canary {
+    background-color: salmon;
 }
 
 .mapboxgl-canvas-container.mapboxgl-interactive,

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1474,7 +1474,7 @@ class Map extends Camera {
     _detectMissingCSS(): void {
         const computedColor = window.getComputedStyle(this._missingCSSCanary).getPropertyValue('background-color');
         if (computedColor !== 'rgb(250, 128, 114)') {
-            util.warnOnce('Missing Mapbox GL JS CSS: map may not display correctly.');
+            warnOnce('Missing Mapbox GL JS CSS: map may not display correctly.');
         }
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1474,7 +1474,10 @@ class Map extends Camera {
     _detectMissingCSS(): void {
         const computedColor = window.getComputedStyle(this._missingCSSCanary).getPropertyValue('background-color');
         if (computedColor !== 'rgb(250, 128, 114)') {
-            warnOnce('Missing Mapbox GL JS CSS: map may not display correctly.');
+            warnOnce('This page appears to be missing CSS declarations for ' +
+                'Mapbox GL JS, which may cause the map to display incorrectly. ' +
+                'Please ensure your page includes mapbox-gl.css, as described ' +
+                'in https://www.mapbox.com/mapbox-gl-js/api/.');
         }
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -222,7 +222,7 @@ class Map extends Camera {
     painter: Painter;
 
     _container: HTMLElement;
-    _missingCSSContainer: HTMLElement;
+    _missingCSSCanary: HTMLElement;
     _canvasContainer: HTMLElement;
     _controlContainer: HTMLElement;
     _controlPositions: {[string]: HTMLElement};
@@ -1471,12 +1471,20 @@ class Map extends Camera {
         return [width, height];
     }
 
+    _detectMissingCSS(): void {
+        const computedColor = window.getComputedStyle(this._missingCSSCanary).getPropertyValue('background-color');
+        if (computedColor !== 'rgb(250, 128, 114)') {
+            util.warnOnce('Missing Mapbox GL JS CSS: map may not display correctly.');
+        }
+    }
+
     _setupContainer() {
         const container = this._container;
         container.classList.add('mapboxgl-map');
 
-        const missingCSSContainer = this._missingCSSContainer = DOM.create('div', 'mapboxgl-missing-css', container);
-        missingCSSContainer.innerHTML = 'Missing Mapbox GL JS CSS';
+        const missingCSSCanary = this._missingCSSCanary = DOM.create('div', 'mapboxgl-canary', container);
+        missingCSSCanary.style.visibility = 'hidden';
+        this._detectMissingCSS();
 
         const canvasContainer = this._canvasContainer = DOM.create('div', 'mapboxgl-canvas-container', container);
         if (this._interactive) {
@@ -1700,7 +1708,7 @@ class Map extends Camera {
         if (extension) extension.loseContext();
         removeNode(this._canvasContainer);
         removeNode(this._controlContainer);
-        removeNode(this._missingCSSContainer);
+        removeNode(this._missingCSSCanary);
         this._container.classList.remove('mapboxgl-map');
         this.fire(new Event('remove'));
     }

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -1,14 +1,12 @@
 import { test } from 'mapbox-gl-js-test';
-import window from '../../../../src/util/window';
-import Map from '../../../../src/ui/map';
 import config from '../../../../src/util/config';
 import AttributionControl from '../../../../src/ui/control/attribution_control';
+import { createMap as globalCreateMap } from '../../../util';
 
-function createMap() {
-    const container = window.document.createElement('div');
+function createMap(t) {
     config.ACCESS_TOKEN = 'pk.123';
-    return new Map({
-        container: container,
+
+    return globalCreateMap(t, {
         attributionControl: false,
         style: {
             version: 8,
@@ -19,11 +17,10 @@ function createMap() {
         },
         hash: true
     });
-
 }
 
 test('AttributionControl appears in bottom-right by default', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.addControl(new AttributionControl());
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-bottom-right .mapboxgl-ctrl-attrib').length, 1);
@@ -31,7 +28,7 @@ test('AttributionControl appears in bottom-right by default', (t) => {
 });
 
 test('AttributionControl appears in the position specified by the position option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.addControl(new AttributionControl(), 'top-left');
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib').length, 1);
@@ -39,7 +36,7 @@ test('AttributionControl appears in the position specified by the position optio
 });
 
 test('AttributionControl appears in compact mode if compact option is used', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 700, configurable: true});
 
     let attributionControl = new AttributionControl({
@@ -63,7 +60,7 @@ test('AttributionControl appears in compact mode if compact option is used', (t)
 });
 
 test('AttributionControl appears in compact mode if container is less then 640 pixel wide', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 700, configurable: true});
     map.addControl(new AttributionControl());
 
@@ -79,7 +76,7 @@ test('AttributionControl appears in compact mode if container is less then 640 p
 });
 
 test('AttributionControl dedupes attributions that are substrings of others', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const attribution = new AttributionControl();
     map.addControl(attribution);
 
@@ -106,7 +103,7 @@ test('AttributionControl dedupes attributions that are substrings of others', (t
 });
 
 test('AttributionControl has the correct edit map link', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const attribution = new AttributionControl();
     map.addControl(attribution);
     map.on('load', () => {
@@ -123,7 +120,7 @@ test('AttributionControl has the correct edit map link', (t) => {
 });
 
 test('AttributionControl is hidden if empty', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const attribution = new AttributionControl();
     map.addControl(attribution);
     map.on('load', () => {

--- a/test/unit/ui/control/fullscreen.test.js
+++ b/test/unit/ui/control/fullscreen.test.js
@@ -1,24 +1,12 @@
 import { test } from 'mapbox-gl-js-test';
 import window from '../../../../src/util/window';
-import Map from '../../../../src/ui/map';
+import { createMap } from '../../../util';
 import FullscreenControl from '../../../../src/ui/control/fullscreen_control';
-
-function createMap() {
-    const container = window.document.createElement('div');
-    return new Map({
-        container: container,
-        style: {
-            version: 8,
-            sources: {},
-            layers: []
-        }
-    });
-}
 
 test('FullscreenControl appears when fullscreen is enabled', (t) => {
     window.document.fullscreenEnabled = true;
 
-    const map = createMap();
+    const map = createMap(t);
     const fullscreen = new FullscreenControl();
     map.addControl(fullscreen);
 
@@ -31,7 +19,7 @@ test('FullscreenControl does not appears when fullscreen is not enabled', (t) =>
 
     const consoleWarn = t.stub(console, 'warn');
 
-    const map = createMap();
+    const map = createMap(t);
     const fullscreen = new FullscreenControl();
     map.addControl(fullscreen);
 

--- a/test/unit/ui/control/fullscreen.test.js
+++ b/test/unit/ui/control/fullscreen.test.js
@@ -1,6 +1,6 @@
 import { test } from 'mapbox-gl-js-test';
 import window from '../../../../src/util/window';
-import { createMap } from '../../../util';
+import { createMap } from '../../../util';
 import FullscreenControl from '../../../../src/ui/control/fullscreen_control';
 
 test('FullscreenControl appears when fullscreen is enabled', (t) => {

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -1,6 +1,6 @@
 import { test } from 'mapbox-gl-js-test';
 import window from '../../../../src/util/window';
-import { createMap } from '../../../util';
+import { createMap } from '../../../util';
 import GeolocateControl from '../../../../src/ui/control/geolocate_control';
 
 // window and navigator globals need to be set for mock-geolocation
@@ -71,7 +71,7 @@ test('GeolocateControl geolocate event', (t) => {
 test('GeolocateControl trigger', (t) => {
     t.plan(1);
 
-    const map = createMap();
+    const map = createMap(t);
     const geolocate = new GeolocateControl();
     map.addControl(geolocate);
 

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -1,6 +1,6 @@
 import { test } from 'mapbox-gl-js-test';
 import window from '../../../../src/util/window';
-import Map from '../../../../src/ui/map';
+import { createMap } from '../../../util';
 import GeolocateControl from '../../../../src/ui/control/geolocate_control';
 
 // window and navigator globals need to be set for mock-geolocation
@@ -13,18 +13,6 @@ geolocation.use();
 global.window.navigator = global.navigator;
 window.navigator.geolocation = global.window.navigator.geolocation;
 
-function createMap() {
-    const container = window.document.createElement('div');
-    return new Map({
-        container: container,
-        style: {
-            version: 8,
-            sources: {},
-            layers: []
-        }
-    });
-}
-
 // convert the coordinates of a LngLat object to a fixed number of digits
 function lngLatAsFixed(lngLat, digits) {
     return Object.keys(lngLat).reduce((previous, current) => {
@@ -34,9 +22,9 @@ function lngLatAsFixed(lngLat, digits) {
 }
 
 test('GeolocateControl with no options', (t) => {
+    const map = createMap(t);
     t.plan(0);
 
-    const map = createMap();
     const geolocate = new GeolocateControl();
     map.addControl(geolocate);
     t.end();
@@ -45,7 +33,7 @@ test('GeolocateControl with no options', (t) => {
 test('GeolocateControl error event', (t) => {
     t.plan(2);
 
-    const map = createMap();
+    const map = createMap(t);
     const geolocate = new GeolocateControl();
     map.addControl(geolocate);
 
@@ -63,7 +51,7 @@ test('GeolocateControl error event', (t) => {
 test('GeolocateControl geolocate event', (t) => {
     t.plan(4);
 
-    const map = createMap();
+    const map = createMap(t);
     const geolocate = new GeolocateControl();
     map.addControl(geolocate);
 
@@ -108,7 +96,7 @@ test('GeolocateControl trigger before added to map', (t) => {
 test('GeolocateControl geolocate fitBoundsOptions', (t) => {
     t.plan(1);
 
-    const map = createMap();
+    const map = createMap(t);
     const geolocate = new GeolocateControl({
         fitBoundsOptions: {
             linear: true,
@@ -131,7 +119,7 @@ test('GeolocateControl geolocate fitBoundsOptions', (t) => {
 test('GeolocateControl no watching map camera on geolocation', (t) => {
     t.plan(6);
 
-    const map = createMap();
+    const map = createMap(t);
     const geolocate = new GeolocateControl({
         fitBoundsOptions: {
             maxZoom: 20,
@@ -174,7 +162,7 @@ test('GeolocateControl no watching map camera on geolocation', (t) => {
 test('GeolocateControl watching map updates recenter on location with dot', (t) => {
     t.plan(6);
 
-    const map = createMap();
+    const map = createMap(t);
     const geolocate = new GeolocateControl({
         trackUserLocation: true,
         showUserLocation: true,
@@ -212,9 +200,9 @@ test('GeolocateControl watching map updates recenter on location with dot', (t) 
 });
 
 test('GeolocateControl watching map background event', (t) => {
+    const map = createMap(t);
     t.plan(0);
 
-    const map = createMap();
     const geolocate = new GeolocateControl({
         trackUserLocation: true,
         fitBoundsOptions: {
@@ -250,7 +238,7 @@ test('GeolocateControl watching map background event', (t) => {
 test('GeolocateControl watching map background state', (t) => {
     t.plan(1);
 
-    const map = createMap();
+    const map = createMap(t);
     const geolocate = new GeolocateControl({
         trackUserLocation: true,
         fitBoundsOptions: {
@@ -289,9 +277,9 @@ test('GeolocateControl watching map background state', (t) => {
 });
 
 test('GeolocateControl trackuserlocationstart event', (t) => {
+    const map = createMap(t);
     t.plan(0);
 
-    const map = createMap();
     const geolocate = new GeolocateControl({
         trackUserLocation: true,
         fitBoundsOptions: {

--- a/test/unit/ui/control/logo.test.js
+++ b/test/unit/ui/control/logo.test.js
@@ -1,12 +1,9 @@
 import { test } from 'mapbox-gl-js-test';
+import { createMap as globalCreateMap } from '../../../util';
 import VectorTileSource from '../../../../src/source/vector_tile_source';
-import window from '../../../../src/util/window';
-import Map from '../../../../src/ui/map';
 
-function createMap(logoPosition, logoRequired) {
-    const container = window.document.createElement('div');
-    return new Map({
-        container: container,
+function createMap(t, logoPosition, logoRequired) {
+    return globalCreateMap(t, {
         style: {
             version: 8,
             sources: {
@@ -38,7 +35,7 @@ function createSource(options, logoRequired) {
     return source;
 }
 test('LogoControl appears in bottom-left by default', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.on('load', () => {
         t.equal(map.getContainer().querySelectorAll(
             '.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-logo'
@@ -48,7 +45,7 @@ test('LogoControl appears in bottom-left by default', (t) => {
 });
 
 test('LogoControl appears in the position specified by the position option', (t) => {
-    const map = createMap('top-left');
+    const map = createMap(t, 'top-left');
     map.on('load', () => {
         t.equal(map.getContainer().querySelectorAll(
             '.mapboxgl-ctrl-top-left .mapboxgl-ctrl-logo'
@@ -58,14 +55,14 @@ test('LogoControl appears in the position specified by the position option', (t)
 });
 
 test('LogoControl is not displayed when the mapbox_logo property is false', (t) => {
-    const map = createMap('top-left', false);
+    const map = createMap(t, 'top-left', false);
     map.on('load', () => {
         t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-top-left > .mapboxgl-ctrl')[0].style.display, 'none');
         t.end();
     });
 });
 test('LogoControl is not added more than once', (t)=>{
-    const map = createMap();
+    const map = createMap(t);
     const source = createSource({
         minzoom: 1,
         maxzoom: 10,

--- a/test/unit/ui/control/logo.test.js
+++ b/test/unit/ui/control/logo.test.js
@@ -1,5 +1,5 @@
 import { test } from 'mapbox-gl-js-test';
-import { createMap as globalCreateMap } from '../../../util';
+import { createMap as globalCreateMap } from '../../../util';
 import VectorTileSource from '../../../../src/source/vector_tile_source';
 
 function createMap(t, logoPosition, logoRequired) {
@@ -84,7 +84,7 @@ test('LogoControl is not added more than once', (t)=>{
 });
 
 test('LogoControl appears in compact mode if container is less then 250 pixel wide', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const container = map.getContainer();
 
     Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 255, configurable: true});

--- a/test/unit/ui/control/scale.test.js
+++ b/test/unit/ui/control/scale.test.js
@@ -1,6 +1,6 @@
 
 import { test } from 'mapbox-gl-js-test';
-import { createMap } from '../../../util';
+import { createMap } from '../../../util';
 import ScaleControl from '../../../../src/ui/control/scale_control';
 
 test('ScaleControl appears in bottom-left by default', (t) => {

--- a/test/unit/ui/control/scale.test.js
+++ b/test/unit/ui/control/scale.test.js
@@ -1,25 +1,10 @@
 
-import {test} from 'mapbox-gl-js-test';
-import window from '../../../../src/util/window';
-import Map from '../../../../src/ui/map';
+import { test } from 'mapbox-gl-js-test';
+import { createMap } from '../../../util';
 import ScaleControl from '../../../../src/ui/control/scale_control';
 
-function createMap() {
-    const container = window.document.createElement('div');
-    return new Map({
-        container,
-        style: {
-            version: 8,
-            sources: {},
-            layers: []
-        },
-        hash: true
-    });
-
-}
-
 test('ScaleControl appears in bottom-left by default', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.addControl(new ScaleControl());
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale').length, 1);
@@ -27,7 +12,7 @@ test('ScaleControl appears in bottom-left by default', (t) => {
 });
 
 test('ScaleControl appears in the position specified by the position option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.addControl(new ScaleControl(), 'top-left');
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-top-left .mapboxgl-ctrl-scale').length, 1);
@@ -35,7 +20,7 @@ test('ScaleControl appears in the position specified by the position option', (t
 });
 
 test('ScaleControl should change unit of distance after calling setUnit', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const scale = new ScaleControl();
     const selector = '.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale';
     map.addControl(scale);

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -108,7 +108,7 @@ test('BoxZoomHandler does not begin a box zoom if preventDefault is called on th
 });
 
 test('BoxZoomHandler does not begin a box zoom on spurious mousemove events', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const boxzoomstart = t.spy();
     const boxzoomend   = t.spy();

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -4,12 +4,13 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap() {
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
 test('BoxZoomHandler fires boxzoomstart and boxzoomend events at appropriate times', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const boxzoomstart = t.spy();
     const boxzoomend   = t.spy();
@@ -37,7 +38,7 @@ test('BoxZoomHandler fires boxzoomstart and boxzoomend events at appropriate tim
 });
 
 test('BoxZoomHandler avoids conflicts with DragPanHandler when disabled and reenabled (#2237)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.boxZoom.disable();
     map.boxZoom.enable();
@@ -80,7 +81,7 @@ test('BoxZoomHandler avoids conflicts with DragPanHandler when disabled and reen
 });
 
 test('BoxZoomHandler does not begin a box zoom if preventDefault is called on the mousedown event', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('mousedown', e => e.preventDefault());
 

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -4,12 +4,13 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap() {
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
 test('DoubleClickZoomHandler does not zoom if preventDefault is called on the dblclick event', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('dblclick', e => e.preventDefault());
 

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -598,7 +598,7 @@ test(`DragPanHandler can be disabled after mousedown (#2419)`, (t) => {
 });
 
 test('DragPanHandler does not begin a drag on spurious mousemove events', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.dragRotate.disable();
 
     const dragstart = t.spy();
@@ -632,7 +632,7 @@ test('DragPanHandler does not begin a drag on spurious mousemove events', (t) =>
 });
 
 test('DragPanHandler does not begin a drag on spurious touchmove events', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const dragstart = t.spy();
     const drag      = t.spy();

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -4,12 +4,13 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap() {
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
 test('DragPanHandler fires dragstart, drag, and dragend events at appropriate times in response to a mouse-triggered drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const dragstart = t.spy();
     const drag      = t.spy();
@@ -42,7 +43,7 @@ test('DragPanHandler fires dragstart, drag, and dragend events at appropriate ti
 });
 
 test('DragPanHandler captures mousemove events during a mouse-triggered drag (receives them even if they occur outside the map)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const dragstart = t.spy();
     const drag      = t.spy();
@@ -75,7 +76,7 @@ test('DragPanHandler captures mousemove events during a mouse-triggered drag (re
 });
 
 test('DragPanHandler fires dragstart, drag, and dragend events at appropriate times in response to a touch-triggered drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const dragstart = t.spy();
     const drag      = t.spy();
@@ -108,7 +109,7 @@ test('DragPanHandler fires dragstart, drag, and dragend events at appropriate ti
 });
 
 test('DragPanHandler captures touchmove events during a mouse-triggered drag (receives them even if they occur outside the map)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const dragstart = t.spy();
     const drag      = t.spy();
@@ -141,7 +142,7 @@ test('DragPanHandler captures touchmove events during a mouse-triggered drag (re
 });
 
 test('DragPanHandler prevents mousemove events from firing during a drag (#1555)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const mousemove = t.spy();
     map.on('mousemove', mousemove);
@@ -162,7 +163,7 @@ test('DragPanHandler prevents mousemove events from firing during a drag (#1555)
 });
 
 test('DragPanHandler ends a mouse-triggered drag if the window blurs', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const dragend = t.spy();
     map.on('dragend', dragend);
@@ -181,7 +182,7 @@ test('DragPanHandler ends a mouse-triggered drag if the window blurs', (t) => {
 });
 
 test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const dragend = t.spy();
     map.on('dragend', dragend);
@@ -200,7 +201,7 @@ test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
 });
 
 test('DragPanHandler requests a new render frame after each mousemove event', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const requestFrame = t.spy(map, '_requestRenderFrame');
 
     simulate.mousedown(map.getCanvas());
@@ -220,7 +221,7 @@ test('DragPanHandler requests a new render frame after each mousemove event', (t
 
 test('DragPanHandler can interleave with another handler', (t) => {
     // https://github.com/mapbox/mapbox-gl-js/issues/6106
-    const map = createMap();
+    const map = createMap(t);
 
     const dragstart = t.spy();
     const drag      = t.spy();
@@ -267,7 +268,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
 
 ['ctrl', 'shift'].forEach((modifier) => {
     test(`DragPanHandler does not begin a drag if the ${modifier} key is down on mousedown`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
         map.dragRotate.disable();
 
         const dragstart = t.spy();
@@ -301,7 +302,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
     });
 
     test(`DragPanHandler still ends a drag if the ${modifier} key is down on mouseup`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
         map.dragRotate.disable();
 
         const dragstart = t.spy();
@@ -336,7 +337,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
 });
 
 test('DragPanHandler does not begin a drag on right button mousedown', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.dragRotate.disable();
 
     const dragstart = t.spy();
@@ -370,7 +371,7 @@ test('DragPanHandler does not begin a drag on right button mousedown', (t) => {
 });
 
 test('DragPanHandler does not end a drag on right button mouseup', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.dragRotate.disable();
 
     const dragstart = t.spy();
@@ -422,7 +423,7 @@ test('DragPanHandler does not end a drag on right button mouseup', (t) => {
 });
 
 test('DragPanHandler does not begin a drag if preventDefault is called on the mousedown event', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('mousedown', e => e.preventDefault());
 
@@ -452,7 +453,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the mo
 });
 
 test('DragPanHandler does not begin a drag if preventDefault is called on the touchstart event', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('touchstart', e => e.preventDefault());
 
@@ -482,7 +483,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the to
 });
 
 test('DragPanHandler does not begin a drag if preventDefault is called on the touchstart event (delegated)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     t.stub(map, 'getLayer')
         .callsFake(() => true);
@@ -520,7 +521,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the to
 
 ['dragstart', 'drag'].forEach(event => {
     test(`DragPanHandler can be disabled on ${event} (#2419)`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         map.on(event, () => map.dragPan.disable());
 
@@ -559,7 +560,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the to
 });
 
 test(`DragPanHandler can be disabled after mousedown (#2419)`, (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const dragstart = t.spy();
     const drag      = t.spy();

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -6,12 +6,13 @@ import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
-function createMap(options) {
+function createMap(t, options) {
+    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map(extend({ container: DOM.create('div', '', window.document.body) }, options));
 }
 
 test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a right-click drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -47,7 +48,7 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
 });
 
 test('DragRotateHandler stops firing events after mouseup', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -73,7 +74,7 @@ test('DragRotateHandler stops firing events after mouseup', (t) => {
 });
 
 test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a control-left-click drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -109,7 +110,7 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
 });
 
 test('DragRotateHandler pitches in response to a right-click drag by default', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -136,7 +137,7 @@ test('DragRotateHandler pitches in response to a right-click drag by default', (
 });
 
 test('DragRotateHandler pitches in response to a control-left-click drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -163,7 +164,7 @@ test('DragRotateHandler pitches in response to a control-left-click drag', (t) =
 });
 
 test('DragRotateHandler does not pitch if given pitchWithRotate: false', (t) => {
-    const map = createMap({pitchWithRotate: false});
+    const map = createMap(t, {pitchWithRotate: false});
 
     const spy = t.spy();
 
@@ -188,7 +189,7 @@ test('DragRotateHandler does not pitch if given pitchWithRotate: false', (t) => 
 });
 
 test('DragRotateHandler does not rotate or pitch when disabled', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.dragRotate.disable();
 
@@ -214,7 +215,7 @@ test('DragRotateHandler does not rotate or pitch when disabled', (t) => {
 
 test('DragRotateHandler ensures that map.isMoving() returns true during drag', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
-    const map = createMap({bearingSnap: 0});
+    const map = createMap(t, {bearingSnap: 0});
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
@@ -229,7 +230,7 @@ test('DragRotateHandler ensures that map.isMoving() returns true during drag', (
 
 test('DragRotateHandler fires move events', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
-    const map = createMap({bearingSnap: 0});
+    const map = createMap(t, {bearingSnap: 0});
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -257,7 +258,7 @@ test('DragRotateHandler fires move events', (t) => {
 
 test('DragRotateHandler includes originalEvent property in triggered events', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
-    const map = createMap({bearingSnap: 0});
+    const map = createMap(t, {bearingSnap: 0});
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -305,7 +306,7 @@ test('DragRotateHandler includes originalEvent property in triggered events', (t
 });
 
 test('DragRotateHandler responds to events on the canvas container (#1301)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -332,7 +333,7 @@ test('DragRotateHandler responds to events on the canvas container (#1301)', (t)
 });
 
 test('DragRotateHandler prevents mousemove events from firing during a drag (#1555)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -352,7 +353,7 @@ test('DragRotateHandler prevents mousemove events from firing during a drag (#15
 });
 
 test('DragRotateHandler ends a control-left-click drag on mouseup even when the control key was previously released (#1888)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -379,7 +380,7 @@ test('DragRotateHandler ends a control-left-click drag on mouseup even when the 
 });
 
 test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -406,7 +407,7 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
 });
 
 test('DragRotateHandler requests a new render frame after each mousemove event', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const requestRenderFrame = t.spy(map, '_requestRenderFrame');
 
     // Prevent inertial rotation.
@@ -429,7 +430,7 @@ test('DragRotateHandler requests a new render frame after each mousemove event',
 
 test('DragRotateHandler can interleave with another handler', (t) => {
     // https://github.com/mapbox/mapbox-gl-js/issues/6106
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -479,7 +480,7 @@ test('DragRotateHandler can interleave with another handler', (t) => {
 });
 
 test('DragRotateHandler does not begin a drag on left-button mousedown without the control key', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.dragPan.disable();
 
     const rotatestart = t.spy();
@@ -513,7 +514,7 @@ test('DragRotateHandler does not begin a drag on left-button mousedown without t
 });
 
 test('DragRotateHandler does not end a right-button drag on left-button mouseup', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.dragPan.disable();
 
     // Prevent inertial rotation.
@@ -568,7 +569,7 @@ test('DragRotateHandler does not end a right-button drag on left-button mouseup'
 });
 
 test('DragRotateHandler does not end a control-left-button drag on right-button mouseup', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     map.dragPan.disable();
 
     // Prevent inertial rotation.
@@ -623,7 +624,7 @@ test('DragRotateHandler does not end a control-left-button drag on right-button 
 });
 
 test('DragRotateHandler does not begin a drag if preventDefault is called on the mousedown event', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('mousedown', e => e.preventDefault());
 
@@ -654,7 +655,7 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
 
 ['rotatestart', 'rotate'].forEach(event => {
     test(`DragRotateHandler can be disabled on ${event} (#2419)`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         // Prevent inertial rotation.
         t.stub(browser, 'now').returns(0);
@@ -696,7 +697,7 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
 });
 
 test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -738,7 +738,7 @@ test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
 });
 
 test('DragRotateHandler does not begin rotation on spurious mousemove events', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const rotatestart = t.spy();
     const rotate      = t.spy();

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -1,20 +1,20 @@
 import { test } from 'mapbox-gl-js-test';
 import browser from '../../../../src/util/browser';
-import { extend } from '../../../../src/util/util';
 import window from '../../../../src/util/window';
 import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap(options) {
-    return new Map(extend({
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
+    return new Map({
         container: DOM.create('div', '', window.document.body),
         style: {
             "version": 8,
             "sources": {},
             "layers": []
         }
-    }, options));
+    });
 }
 
 test('ScrollZoomHandler', (t) => {
@@ -23,7 +23,7 @@ test('ScrollZoomHandler', (t) => {
     browserNow.callsFake(() => now);
 
     t.test('Zooms for single mouse wheel tick', (t) => {
-        const map = createMap();
+        const map = createMap(t);
         map._renderTaskQueue.run();
 
         // simulate a single 'wheel' event
@@ -42,7 +42,7 @@ test('ScrollZoomHandler', (t) => {
     });
 
     t.test('Zooms for single mouse wheel tick with non-magical deltaY', (t) => {
-        const map = createMap();
+        const map = createMap(t);
         map._renderTaskQueue.run();
 
         // Simulate a single 'wheel' event without the magical deltaY value.
@@ -56,7 +56,7 @@ test('ScrollZoomHandler', (t) => {
     });
 
     t.test('Zooms for multiple mouse wheel ticks', (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         map._renderTaskQueue.run();
         const startZoom = map.getZoom();
@@ -94,7 +94,7 @@ test('ScrollZoomHandler', (t) => {
     });
 
     t.test('Gracefully ignores wheel events with deltaY: 0', (t) => {
-        const map = createMap();
+        const map = createMap(t);
         map._renderTaskQueue.run();
 
         const startZoom = map.getZoom();
@@ -114,7 +114,7 @@ test('ScrollZoomHandler', (t) => {
     });
 
     test('does not zoom if preventDefault is called on the wheel event', (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         map.on('wheel', e => e.preventDefault());
 

--- a/test/unit/ui/handler/touch_zoom_rotate.test.js
+++ b/test/unit/ui/handler/touch_zoom_rotate.test.js
@@ -4,12 +4,13 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap() {
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
 test('TouchZoomRotateHandler fires zoomstart, zoom, and zoomend events at appropriate times in response to a pinch-zoom gesture', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const zoomstart = t.spy();
     const zoom      = t.spy();
@@ -48,7 +49,7 @@ test('TouchZoomRotateHandler fires zoomstart, zoom, and zoomend events at approp
 });
 
 test('TouchZoomRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a pinch-rotate gesture', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const rotatestart = t.spy();
     const rotate      = t.spy();
@@ -87,7 +88,7 @@ test('TouchZoomRotateHandler fires rotatestart, rotate, and rotateend events at 
 });
 
 test('TouchZoomRotateHandler does not begin a gesture if preventDefault is called on the touchstart event', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('touchstart', e => e.preventDefault());
 

--- a/test/unit/ui/hash.test.js
+++ b/test/unit/ui/hash.test.js
@@ -1,7 +1,6 @@
 import { test } from 'mapbox-gl-js-test';
 import Hash from '../../../src/ui/hash';
 import window from '../../../src/util/window';
-import Map from '../../../src/ui/map';
 import { createMap as globalCreateMap } from '../../util';
 
 test('hash', (t) => {
@@ -155,12 +154,7 @@ test('hash', (t) => {
         Object.defineProperty(container, 'offsetWidth', {value: 512});
         Object.defineProperty(container, 'offsetHeight', {value: 512});
 
-        const map = new Map({
-            container,
-            center: [-74.50, 40],
-            zoom: 9,
-            hash: true,
-        });
+        const map = createMap(t, { hash: true });
 
         map.remove();
 

--- a/test/unit/ui/hash.test.js
+++ b/test/unit/ui/hash.test.js
@@ -2,6 +2,7 @@ import { test } from 'mapbox-gl-js-test';
 import Hash from '../../../src/ui/hash';
 import window from '../../../src/util/window';
 import Map from '../../../src/ui/map';
+import { createMap as globalCreateMap } from '../../util';
 
 test('hash', (t) => {
     function createHash() {
@@ -10,16 +11,16 @@ test('hash', (t) => {
         return hash;
     }
 
-    function createMap() {
+    function createMap(t) {
         const container = window.document.createElement('div');
         Object.defineProperty(container, 'offsetWidth', {value: 512});
         Object.defineProperty(container, 'offsetHeight', {value: 512});
-        return new Map({container: container});
+        return globalCreateMap(t, {container: container});
     }
 
 
     t.test('#addTo', (t) => {
-        const map = createMap();
+        const map = createMap(t);
         const hash = createHash();
 
         t.notok(hash._map);
@@ -31,7 +32,7 @@ test('hash', (t) => {
     });
 
     t.test('#remove', (t) => {
-        const map = createMap();
+        const map = createMap(t);
         const hash = createHash()
             .addTo(map);
 
@@ -44,7 +45,7 @@ test('hash', (t) => {
     });
 
     t.test('#_onHashChange', (t) => {
-        const map = createMap();
+        const map = createMap(t);
         const hash = createHash()
             .addTo(map);
 
@@ -74,7 +75,7 @@ test('hash', (t) => {
     });
 
     t.test('#_onHashChange empty', (t) => {
-        const map = createMap();
+        const map = createMap(t);
         const hash = createHash()
             .addTo(map);
 
@@ -106,7 +107,7 @@ test('hash', (t) => {
             return window.location.hash.split('/');
         }
 
-        const map = createMap();
+        const map = createMap(t);
         createHash()
             .addTo(map);
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -825,7 +825,7 @@ test('Map', (t) => {
     });
 
     t.test('#listImages', (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         map.on('load', () => {
             t.equals(map.listImages().length, 0);
@@ -840,7 +840,7 @@ test('Map', (t) => {
     });
 
     t.test('#listImages throws an error if called before "load"', (t) => {
-        const map = createMap();
+        const map = createMap(t);
         t.throws(() => {
             map.listImages();
         }, Error);
@@ -1222,7 +1222,7 @@ test('Map', (t) => {
 
     t.test('#setFeatureState', (t) => {
         t.test('sets state', (t) => {
-            const map = createMap({
+            const map = createMap(t, {
                 style: {
                     "version": 8,
                     "sources": {
@@ -1239,7 +1239,7 @@ test('Map', (t) => {
             });
         });
         t.test('throw before loaded', (t) => {
-            const map = createMap({
+            const map = createMap(t, {
                 style: {
                     "version": 8,
                     "sources": {
@@ -1255,7 +1255,7 @@ test('Map', (t) => {
             t.end();
         });
         t.test('fires an error if source not found', (t) => {
-            const map = createMap({
+            const map = createMap(t, {
                 style: {
                     "version": 8,
                     "sources": {
@@ -1273,7 +1273,7 @@ test('Map', (t) => {
             });
         });
         t.test('fires an error if sourceLayer not provided for a vector source', (t) => {
-            const map = createMap({
+            const map = createMap(t, {
                 style: {
                     "version": 8,
                     "sources": {
@@ -1421,9 +1421,11 @@ test('Map', (t) => {
         t.equal(map.isEasing(), true);
 
         map.remove();
+        t.end();
+    });
 
     t.test('should not warn when CSS is present', (t) => {
-        const stub = t.stub(util, 'warnOnce');
+        const stub = t.stub(console, 'warn');
 
         const styleSheet = new window.CSSStyleSheet();
         styleSheet.insertRule('.mapboxgl-canary { background-color: rgb(250, 128, 114); }', 0);
@@ -1437,7 +1439,7 @@ test('Map', (t) => {
     });
 
     t.test('should warn when CSS is missing', (t) => {
-        const stub = t.stub(util, 'warnOnce');
+        const stub = t.stub(console, 'warn');
         new Map({ container: window.document.createElement('div') });
 
         t.ok(stub.calledOnce);

--- a/test/unit/ui/map/isMoving.test.js
+++ b/test/unit/ui/map/isMoving.test.js
@@ -5,19 +5,20 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap() {
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
 test('Map#isMoving returns false by default', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     t.equal(map.isMoving(), false);
     map.remove();
     t.end();
 });
 
 test('Map#isMoving returns true during a camera zoom animation', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('zoomstart', () => {
         t.equal(map.isMoving(), true);
@@ -33,7 +34,7 @@ test('Map#isMoving returns true during a camera zoom animation', (t) => {
 });
 
 test('Map#isMoving returns true when drag panning', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('dragstart', () => {
         t.equal(map.isMoving(), true);
@@ -56,7 +57,7 @@ test('Map#isMoving returns true when drag panning', (t) => {
 });
 
 test('Map#isMoving returns true when drag rotating', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -82,7 +83,7 @@ test('Map#isMoving returns true when drag rotating', (t) => {
 });
 
 test('Map#isMoving returns true when scroll zooming', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('zoomstart', () => {
         t.equal(map.isMoving(), true);
@@ -106,7 +107,7 @@ test('Map#isMoving returns true when scroll zooming', (t) => {
 });
 
 test('Map#isMoving returns true when drag panning and scroll zooming interleave', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('dragstart', () => {
         t.equal(map.isMoving(), true);

--- a/test/unit/ui/map/isRotating.test.js
+++ b/test/unit/ui/map/isRotating.test.js
@@ -5,19 +5,20 @@ import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
-function createMap() {
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
 test('Map#isRotating returns false by default', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     t.equal(map.isRotating(), false);
     map.remove();
     t.end();
 });
 
 test('Map#isRotating returns true during a camera rotate animation', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('rotatestart', () => {
         t.equal(map.isRotating(), true);
@@ -33,7 +34,7 @@ test('Map#isRotating returns true during a camera rotate animation', (t) => {
 });
 
 test('Map#isRotating returns true when drag rotating', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);

--- a/test/unit/ui/map/isZooming.test.js
+++ b/test/unit/ui/map/isZooming.test.js
@@ -5,19 +5,20 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap() {
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
 test('Map#isZooming returns false by default', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     t.equal(map.isZooming(), false);
     map.remove();
     t.end();
 });
 
 test('Map#isZooming returns true during a camera zoom animation', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('zoomstart', () => {
         t.equal(map.isZooming(), true);
@@ -33,7 +34,7 @@ test('Map#isZooming returns true during a camera zoom animation', (t) => {
 });
 
 test('Map#isZooming returns true when scroll zooming', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('zoomstart', () => {
         t.equal(map.isZooming(), true);
@@ -56,7 +57,7 @@ test('Map#isZooming returns true when scroll zooming', (t) => {
 });
 
 test('Map#isZooming returns true when double-click zooming', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('zoomstart', () => {
         t.equal(map.isZooming(), true);

--- a/test/unit/ui/map/requestRenderFrame.test.js
+++ b/test/unit/ui/map/requestRenderFrame.test.js
@@ -1,21 +1,8 @@
 import { test } from 'mapbox-gl-js-test';
-import window from '../../../../src/util/window';
-import Map from '../../../../src/ui/map';
-import DOM from '../../../../src/util/dom';
-
-function createMap() {
-    return new Map({
-        container: DOM.create('div', '', window.document.body),
-        style: {
-            "version": 8,
-            "sources": {},
-            "layers": []
-        }
-    });
-}
+import { createMap } from '../../../util';
 
 test('Map#_requestRenderFrame schedules a new render frame if necessary', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     t.stub(map, '_rerender');
     map._requestRenderFrame(() => {});
     t.equal(map._rerender.callCount, 1);
@@ -24,7 +11,7 @@ test('Map#_requestRenderFrame schedules a new render frame if necessary', (t) =>
 });
 
 test('Map#_requestRenderFrame queues a task for the next render frame', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const cb = t.spy();
     map._requestRenderFrame(cb);
     map.once('render', () => {
@@ -35,7 +22,7 @@ test('Map#_requestRenderFrame queues a task for the next render frame', (t) => {
 });
 
 test('Map#_cancelRenderFrame cancels a queued task', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const cb = t.spy();
     const id = map._requestRenderFrame(cb);
     map._cancelRenderFrame(id);

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -1,16 +1,10 @@
 import { test } from 'mapbox-gl-js-test';
-import Map from '../../../src/ui/map';
 import window from '../../../src/util/window';
+import { createMap } from '../../util';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap() {
-    return new Map({
-        container: window.document.createElement('div')
-    });
-}
-
 test('Map#on adds a non-delegated event listener', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const spy = t.spy(function (e) {
         t.equal(this, map);
         t.equal(e.type, 'click');
@@ -24,7 +18,7 @@ test('Map#on adds a non-delegated event listener', (t) => {
 });
 
 test('Map#off removes a non-delegated event listener', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const spy = t.spy();
 
     map.on('click', spy);
@@ -36,7 +30,7 @@ test('Map#off removes a non-delegated event listener', (t) => {
 });
 
 test('Map#on adds a listener for an event on a given layer', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const features = [{}];
 
     t.stub(map, 'getLayer').returns({});
@@ -59,7 +53,7 @@ test('Map#on adds a listener for an event on a given layer', (t) => {
 });
 
 test('Map#on adds a listener not triggered for events not matching any features', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const features = [];
 
     t.stub(map, 'getLayer').returns({});
@@ -78,7 +72,7 @@ test('Map#on adds a listener not triggered for events not matching any features'
 });
 
 test(`Map#on adds a listener not triggered when the specified layer does not exiist`, (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     t.stub(map, 'getLayer').returns(null);
 
@@ -92,7 +86,7 @@ test(`Map#on adds a listener not triggered when the specified layer does not exi
 });
 
 test('Map#on distinguishes distinct event types', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     t.stub(map, 'getLayer').returns({});
     t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -115,7 +109,7 @@ test('Map#on distinguishes distinct event types', (t) => {
 });
 
 test('Map#on distinguishes distinct layers', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const featuresA = [{}];
     const featuresB = [{}];
 
@@ -142,7 +136,7 @@ test('Map#on distinguishes distinct layers', (t) => {
 });
 
 test('Map#on distinguishes distinct listeners', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     t.stub(map, 'getLayer').returns({});
     t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -160,7 +154,7 @@ test('Map#on distinguishes distinct listeners', (t) => {
 });
 
 test('Map#off removes a delegated event listener', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     t.stub(map, 'getLayer').returns({});
     t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -176,7 +170,7 @@ test('Map#off removes a delegated event listener', (t) => {
 });
 
 test('Map#off distinguishes distinct event types', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     t.stub(map, 'getLayer').returns({});
     t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -195,7 +189,7 @@ test('Map#off distinguishes distinct event types', (t) => {
 });
 
 test('Map#off distinguishes distinct layers', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const featuresA = [{}];
 
     t.stub(map, 'getLayer').returns({});
@@ -218,7 +212,7 @@ test('Map#off distinguishes distinct layers', (t) => {
 });
 
 test('Map#off distinguishes distinct listeners', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     t.stub(map, 'getLayer').returns({});
     t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -238,7 +232,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
 
 ['mouseenter', 'mouseover'].forEach((event) => {
     test(`Map#on ${event} does not fire if the specified layer does not exist`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns(null);
 
@@ -253,7 +247,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} fires when entering the specified layer`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
         const features = [{}];
 
         t.stub(map, 'getLayer').returns({});
@@ -277,7 +271,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} does not fire on mousemove within the specified layer`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -293,7 +287,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} fires when reentering the specified layer`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures')
@@ -313,7 +307,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} fires when reentering the specified layer after leaving the canvas`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -330,7 +324,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} distinguishes distinct layers`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
         const featuresA = [{}];
         const featuresB = [{}];
 
@@ -359,7 +353,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} distinguishes distinct listeners`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -377,7 +371,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#off ${event} removes a delegated event listener`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -393,7 +387,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#off ${event} distinguishes distinct layers`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
         const featuresA = [{}];
 
         t.stub(map, 'getLayer').returns({});
@@ -416,7 +410,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#off ${event} distinguishes distinct listeners`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -437,7 +431,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
 
 ['mouseleave', 'mouseout'].forEach((event) => {
     test(`Map#on ${event} does not fire if the specified layer does not exiist`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns(null);
 
@@ -452,7 +446,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} does not fire on mousemove when entering or within the specified layer`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -468,7 +462,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} fires when exiting the specified layer`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures')
@@ -490,7 +484,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#on ${event} fires when exiting the canvas`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures').returns([{}]);
@@ -510,7 +504,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
     });
 
     test(`Map#off ${event} removes a delegated event listener`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
 
         t.stub(map, 'getLayer').returns({});
         t.stub(map, 'queryRenderedFeatures')
@@ -531,7 +525,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
 });
 
 test(`Map#on mousedown can have default behavior prevented and still fire subsequent click event`, (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('mousedown', e => e.preventDefault());
 

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -1,5 +1,4 @@
 import { test } from 'mapbox-gl-js-test';
-import window from '../../../src/util/window';
 import { createMap } from '../../util';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
@@ -540,7 +539,7 @@ test(`Map#on mousedown can have default behavior prevented and still fire subseq
 });
 
 test(`Map#on mousedown doesn't fire subsequent click event if mousepos changes`, (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     map.on('mousedown', e => e.preventDefault());
 

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -1,17 +1,17 @@
 import { test } from 'mapbox-gl-js-test';
 import window from '../../../src/util/window';
-import Map from '../../../src/ui/map';
+import { createMap as globalCreateMap } from '../../util';
 import Marker from '../../../src/ui/marker';
 import Popup from '../../../src/ui/popup';
 import LngLat from '../../../src/geo/lng_lat';
 import Point from '@mapbox/point-geometry';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap() {
+function createMap(t) {
     const container = window.document.createElement('div');
     Object.defineProperty(container, 'offsetWidth', {value: 512});
     Object.defineProperty(container, 'offsetHeight', {value: 512});
-    return new Map({container: container});
+    return globalCreateMap(t, {container: container});
 }
 
 test('Marker uses a default marker element with an appropriate offset', (t) => {
@@ -42,7 +42,7 @@ test('Marker uses the provided element', (t) => {
 });
 
 test('Marker#addTo adds the marker element to the canvas container', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     new Marker()
         .setLngLat([-77.01866, 38.888])
         .addTo(map);
@@ -92,7 +92,7 @@ test('Marker#setPopup unbinds a popup', (t) => {
 });
 
 test('Marker#togglePopup opens a popup that was closed', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker()
         .setLngLat([0, 0])
         .addTo(map)
@@ -106,7 +106,7 @@ test('Marker#togglePopup opens a popup that was closed', (t) => {
 });
 
 test('Marker#togglePopup closes a popup that was open', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker()
         .setLngLat([0, 0])
         .addTo(map)
@@ -121,7 +121,7 @@ test('Marker#togglePopup closes a popup that was open', (t) => {
 });
 
 test('Marker anchor defaults to center', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker()
         .setLngLat([0, 0])
         .addTo(map);
@@ -134,7 +134,7 @@ test('Marker anchor defaults to center', (t) => {
 });
 
 test('Marker anchors as specified by the anchor option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({anchor: 'top'})
         .setLngLat([0, 0])
         .addTo(map);
@@ -159,7 +159,7 @@ test('Marker accepts backward-compatible constructor parameters', (t) => {
 });
 
 test('Popup offsets around default Marker', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const marker = new Marker()
         .setLngLat([0, 0])
@@ -183,7 +183,7 @@ test('Popup offsets around default Marker', (t) => {
 });
 
 test('Popup anchors around default Marker', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const marker = new Marker()
         .setLngLat([0, 0])
@@ -236,7 +236,7 @@ test('Popup anchors around default Marker', (t) => {
 });
 
 test('Marker drag functionality can be added with drag option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({draggable: true})
         .setLngLat([0, 0])
         .addTo(map);
@@ -248,7 +248,7 @@ test('Marker drag functionality can be added with drag option', (t) => {
 });
 
 test('Marker#setDraggable adds drag functionality', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker()
         .setLngLat([0, 0])
         .setDraggable(true)
@@ -261,7 +261,7 @@ test('Marker#setDraggable adds drag functionality', (t) => {
 });
 
 test('Marker#setDraggable turns off drag functionality', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({draggable: true})
         .setLngLat([0, 0])
         .addTo(map);
@@ -277,7 +277,7 @@ test('Marker#setDraggable turns off drag functionality', (t) => {
 });
 
 test('Marker with draggable:true fires dragstart, drag, and dragend events at appropriate times in response to a mouse-triggered drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({draggable: true})
         .setLngLat([0, 0])
         .addTo(map);
@@ -311,7 +311,7 @@ test('Marker with draggable:true fires dragstart, drag, and dragend events at ap
 });
 
 test('Marker with draggable:false does not fire dragstart, drag, and dragend events in response to a mouse-triggered drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({})
         .setLngLat([0, 0])
         .addTo(map);
@@ -345,7 +345,7 @@ test('Marker with draggable:false does not fire dragstart, drag, and dragend eve
 });
 
 test('Marker with draggable:true fires dragstart, drag, and dragend events at appropriate times in response to a touch-triggered drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({draggable: true})
         .setLngLat([0, 0])
         .addTo(map);
@@ -379,7 +379,7 @@ test('Marker with draggable:true fires dragstart, drag, and dragend events at ap
 });
 
 test('Marker with draggable:false does not fire dragstart, drag, and dragend events in response to a touch-triggered drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({})
         .setLngLat([0, 0])
         .addTo(map);
@@ -413,7 +413,7 @@ test('Marker with draggable:false does not fire dragstart, drag, and dragend eve
 });
 
 test('Marker with draggable:true moves to new position in response to a mouse-triggered drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({draggable: true})
         .setLngLat([0, 0])
         .addTo(map);
@@ -432,7 +432,7 @@ test('Marker with draggable:true moves to new position in response to a mouse-tr
 });
 
 test('Marker with draggable:false does not move to new position in response to a mouse-triggered drag', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const marker = new Marker({})
         .setLngLat([0, 0])
         .addTo(map);

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -97,7 +97,7 @@ test('Popup fires close event when removed', (t) => {
 
 
 test('Popup fires open event when added', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const onOpen = t.spy();
 
     new Popup()
@@ -448,7 +448,7 @@ test('Popup#remove is idempotent (#2395)', (t) => {
 });
 
 test('Popup adds classes from className option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     new Popup({className: 'some classes'})
         .setText("Test")
         .setLngLat([0, 0])

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -1,6 +1,6 @@
 import { test } from 'mapbox-gl-js-test';
 import window from '../../../src/util/window';
-import Map from '../../../src/ui/map';
+import { createMap as globalCreateMap } from '../../util';
 import Popup from '../../../src/ui/popup';
 import LngLat from '../../../src/geo/lng_lat';
 import Point from '@mapbox/point-geometry';
@@ -9,16 +9,16 @@ import { click as simulateClick } from 'mapbox-gl-js-test/simulate_interaction';
 const containerWidth = 512;
 const containerHeight = 512;
 
-function createMap(options) {
+function createMap(t, options) {
     options = options || {};
     const container = window.document.createElement('div');
     Object.defineProperty(container, 'offsetWidth', {value: options.width || containerWidth});
     Object.defineProperty(container, 'offsetHeight', {value: options.height || containerHeight});
-    return new Map({container: container});
+    return globalCreateMap(t, { container: container });
 }
 
 test('Popup#addTo adds a .mapboxgl-popup element', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const popup = new Popup()
         .setText("Test")
         .setLngLat([0, 0])
@@ -30,7 +30,7 @@ test('Popup#addTo adds a .mapboxgl-popup element', (t) => {
 });
 
 test('Popup closes on map click events by default', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const popup = new Popup()
         .setText("Test")
         .setLngLat([0, 0])
@@ -43,7 +43,7 @@ test('Popup closes on map click events by default', (t) => {
 });
 
 test('Popup does not close on map click events when the closeOnClick option is false', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const popup = new Popup({closeOnClick: false})
         .setText("Test")
         .setLngLat([0, 0])
@@ -56,7 +56,7 @@ test('Popup does not close on map click events when the closeOnClick option is f
 });
 
 test('Popup closes on close button click events', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const popup = new Popup()
         .setText("Test")
         .setLngLat([0, 0])
@@ -69,7 +69,7 @@ test('Popup closes on close button click events', (t) => {
 });
 
 test('Popup has no close button if closeButton option is false', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     new Popup({closeButton: false})
         .setText("Test")
@@ -81,7 +81,7 @@ test('Popup has no close button if closeButton option is false', (t) => {
 });
 
 test('Popup fires close event when removed', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const onClose = t.spy();
 
     new Popup()
@@ -111,7 +111,7 @@ test('Popup fires open event when added', (t) => {
 });
 
 test('Popup content can be set via setText', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     new Popup({closeButton: false})
         .setLngLat([0, 0])
@@ -123,7 +123,7 @@ test('Popup content can be set via setText', (t) => {
 });
 
 test('Popup content can be set via setHTML', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     new Popup({closeButton: false})
         .setLngLat([0, 0])
@@ -135,7 +135,7 @@ test('Popup content can be set via setHTML', (t) => {
 });
 
 test('Popup content can be set via setDOMContent', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const content = window.document.createElement('span');
 
     new Popup({closeButton: false})
@@ -148,7 +148,7 @@ test('Popup content can be set via setDOMContent', (t) => {
 });
 
 test('Popup#setText protects against XSS', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     new Popup({closeButton: false})
         .setLngLat([0, 0])
@@ -160,7 +160,7 @@ test('Popup#setText protects against XSS', (t) => {
 });
 
 test('Popup content setters overwrite previous content', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     const popup = new Popup({closeButton: false})
         .setLngLat([0, 0])
@@ -191,7 +191,7 @@ test('Popup provides LngLat accessors', (t) => {
 });
 
 test('Popup is positioned at the specified LngLat in a world copy', (t) => {
-    const map = createMap({width: 1024}); // longitude bounds: [-360, 360]
+    const map = createMap(t, {width: 1024}); // longitude bounds: [-360, 360]
 
     const popup = new Popup()
         .setLngLat([270, 0])
@@ -203,7 +203,7 @@ test('Popup is positioned at the specified LngLat in a world copy', (t) => {
 });
 
 test('Popup preserves object constancy of position after map move', (t) => {
-    const map = createMap({width: 1024}); // longitude bounds: [-360, 360]
+    const map = createMap(t, {width: 1024}); // longitude bounds: [-360, 360]
 
     const popup = new Popup()
         .setLngLat([270, 0])
@@ -220,7 +220,7 @@ test('Popup preserves object constancy of position after map move', (t) => {
 });
 
 test('Popup preserves object constancy of position after auto-wrapping center (left)', (t) => {
-    const map = createMap({width: 1024});
+    const map = createMap(t, {width: 1024});
     map.setCenter([-175, 0]); // longitude bounds: [-535, 185]
 
     const popup = new Popup()
@@ -235,7 +235,7 @@ test('Popup preserves object constancy of position after auto-wrapping center (l
 });
 
 test('Popup preserves object constancy of position after auto-wrapping center (right)', (t) => {
-    const map = createMap({width: 1024});
+    const map = createMap(t, {width: 1024});
     map.setCenter([175, 0]); // longitude bounds: [-185, 535]
 
     const popup = new Popup()
@@ -250,7 +250,7 @@ test('Popup preserves object constancy of position after auto-wrapping center (r
 });
 
 test('Popup wraps position after map move if it would otherwise go offscreen (right)', (t) => {
-    const map = createMap({width: 1024}); // longitude bounds: [-360, 360]
+    const map = createMap(t, {width: 1024}); // longitude bounds: [-360, 360]
 
     const popup = new Popup()
         .setLngLat([-355, 0])
@@ -263,7 +263,7 @@ test('Popup wraps position after map move if it would otherwise go offscreen (ri
 });
 
 test('Popup wraps position after map move if it would otherwise go offscreen (right)', (t) => {
-    const map = createMap({width: 1024}); // longitude bounds: [-360, 360]
+    const map = createMap(t, {width: 1024}); // longitude bounds: [-360, 360]
 
     const popup = new Popup()
         .setLngLat([355, 0])
@@ -276,7 +276,7 @@ test('Popup wraps position after map move if it would otherwise go offscreen (ri
 });
 
 test('Popup is repositioned at the specified LngLat', (t) => {
-    const map = createMap({width: 1024}); // longitude bounds: [-360, 360]
+    const map = createMap(t, {width: 1024}); // longitude bounds: [-360, 360]
 
     const popup = new Popup()
         .setLngLat([270, 0])
@@ -289,7 +289,7 @@ test('Popup is repositioned at the specified LngLat', (t) => {
 });
 
 test('Popup anchors as specified by the anchor option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const popup = new Popup({anchor: 'top-left'})
         .setLngLat([0, 0])
         .setText('Test')
@@ -315,7 +315,7 @@ test('Popup anchors as specified by the anchor option', (t) => {
     const transform = args[2];
 
     test(`Popup automatically anchors to ${anchor}`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
         const popup = new Popup()
             .setLngLat([0, 0])
             .setText('Test')
@@ -332,7 +332,7 @@ test('Popup anchors as specified by the anchor option', (t) => {
     });
 
     test(`Popup translation reflects offset and ${anchor} anchor`, (t) => {
-        const map = createMap();
+        const map = createMap(t);
         t.stub(map, 'project').returns(new Point(0, 0));
 
         const popup = new Popup({anchor: anchor, offset: 10})
@@ -346,7 +346,7 @@ test('Popup anchors as specified by the anchor option', (t) => {
 });
 
 test('Popup automatically anchors to top if its bottom offset would push it off-screen', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     const point = new Point(containerWidth / 2, containerHeight / 2);
     const options = { offset: {
         'bottom': [0, -25],
@@ -368,7 +368,7 @@ test('Popup automatically anchors to top if its bottom offset would push it off-
 });
 
 test('Popup is offset via a PointLike offset option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     t.stub(map, 'project').returns(new Point(0, 0));
 
     const popup = new Popup({anchor: 'top-left', offset: [5, 10]})
@@ -381,7 +381,7 @@ test('Popup is offset via a PointLike offset option', (t) => {
 });
 
 test('Popup is offset via an object offset option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     t.stub(map, 'project').returns(new Point(0, 0));
 
     const popup = new Popup({anchor: 'top-left', offset: {'top-left': [5, 10]}})
@@ -394,7 +394,7 @@ test('Popup is offset via an object offset option', (t) => {
 });
 
 test('Popup is offset via an incomplete object offset option', (t) => {
-    const map = createMap();
+    const map = createMap(t);
     t.stub(map, 'project').returns(new Point(0, 0));
 
     const popup = new Popup({anchor: 'top-right', offset: {'top-left': [5, 10]}})
@@ -407,7 +407,7 @@ test('Popup is offset via an incomplete object offset option', (t) => {
 });
 
 test('Popup can be removed and added again (#1477)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     new Popup()
         .setText("Test")
@@ -421,7 +421,7 @@ test('Popup can be removed and added again (#1477)', (t) => {
 });
 
 test('Popup#addTo is idempotent (#1811)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     new Popup({closeButton: false})
         .setText("Test")
@@ -434,7 +434,7 @@ test('Popup#addTo is idempotent (#1811)', (t) => {
 });
 
 test('Popup#remove is idempotent (#2395)', (t) => {
-    const map = createMap();
+    const map = createMap(t);
 
     new Popup({closeButton: false})
         .setText("Test")

--- a/test/util.js
+++ b/test/util.js
@@ -1,10 +1,8 @@
-'use strict';
+import window from '../src/util/window';
+import Map from '../src/ui/map';
+import { extend} from '../src/util/util';
 
-const window = require('../src/util/window');
-const Map = require('../src/ui/map');
-const util = require('../src/util/util');
-
-module.exports.createMap = function(t, options, callback) {
+export function createMap(t, options, callback) {
     const container = window.document.createElement('div');
 
     Object.defineProperty(container, 'offsetWidth', {value: 200, configurable: true});
@@ -12,7 +10,7 @@ module.exports.createMap = function(t, options, callback) {
 
     if (!options || !options.skipCSSStub) t.stub(Map.prototype, '_detectMissingCSS');
 
-    const map = new Map(util.extend({
+    const map = new Map(extend({
         container: container,
         interactive: false,
         attributionControl: false,
@@ -29,4 +27,4 @@ module.exports.createMap = function(t, options, callback) {
     });
 
     return map;
-};
+}

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const window = require('../src/util/window');
+const Map = require('../src/ui/map');
+const util = require('../src/util/util');
+
+module.exports.createMap = function(t, options, callback) {
+    const container = window.document.createElement('div');
+
+    Object.defineProperty(container, 'offsetWidth', {value: 200, configurable: true});
+    Object.defineProperty(container, 'offsetHeight', {value: 200, configurable: true});
+
+    if (!options || !options.skipCSSStub) t.stub(Map.prototype, '_detectMissingCSS');
+
+    const map = new Map(util.extend({
+        container: container,
+        interactive: false,
+        attributionControl: false,
+        trackResize: true,
+        style: {
+            "version": 8,
+            "sources": {},
+            "layers": []
+        }
+    }, options));
+
+    if (callback) map.on('load', () => {
+        callback(null, map);
+    });
+
+    return map;
+};


### PR DESCRIPTION
This uses CSSOM interfaces to check for the presence of a `.mapboxgl-map` CSS rule upon map creation and display a warning in the console if it's missing, rather than adding and hiding a DOM element (ref https://github.com/mapbox/mapbox-gl-js/issues/5785, https://github.com/mapbox/mapbox-gl-js/issues/5359#issuecomment-342325200).

Fixes https://github.com/mapbox/mapbox-gl-js/issues/5786.

Having to stub `console.warn` so many places in the unit tests feels weird, and treacherous for future writers of tests that include `Map` — if there's a better way to do this I'm all ears!

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page