### PR TITLE
'Collator' expression for controlling case and diacritic sensitivity in string comparisons

### DIFF
--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -11,6 +11,9 @@ const types = {
         parameters: ['string', 'string']
     }, {
         type: 'boolean',
+        parameters: ['string', 'string', 'collator']
+    }, {
+        type: 'boolean',
         parameters: ['number', 'number']
     }, {
         type: 'boolean',
@@ -23,6 +26,9 @@ const types = {
         parameters: ['string', 'value']
     }, {
         type: 'boolean',
+        parameters: ['string', 'value', 'collator']
+    }, {
+        type: 'boolean',
         parameters: ['number', 'value']
     }, {
         type: 'boolean',
@@ -33,6 +39,9 @@ const types = {
     }, {
         type: 'boolean',
         parameters: ['value', 'string']
+    }, {
+        type: 'boolean',
+        parameters: ['value', 'string', 'collator']
     }, {
         type: 'boolean',
         parameters: ['value', 'number']
@@ -48,6 +57,9 @@ const types = {
         parameters: ['string', 'string']
     }, {
         type: 'boolean',
+        parameters: ['string', 'string', 'collator']
+    }, {
+        type: 'boolean',
         parameters: ['number', 'number']
     }, {
         type: 'boolean',
@@ -60,6 +72,9 @@ const types = {
         parameters: ['string', 'value']
     }, {
         type: 'boolean',
+        parameters: ['string', 'value', 'collator']
+    }, {
+        type: 'boolean',
         parameters: ['number', 'value']
     }, {
         type: 'boolean',
@@ -70,6 +85,9 @@ const types = {
     }, {
         type: 'boolean',
         parameters: ['value', 'string']
+    }, {
+        type: 'boolean',
+        parameters: ['value', 'string', 'collator']
     }, {
         type: 'boolean',
         parameters: ['value', 'number']
@@ -190,6 +208,20 @@ const types = {
     var: [{
         type: 'the type of the bound expression',
         parameters: ['previously bound variable name']
+    }],
+    collator: [{
+        type: 'collator',
+        parameters: [
+            'caseSensitive: boolean',
+            'diacriticSensitive: boolean',
+        ]
+    }, {
+        type: 'collator',
+        parameters: [
+            'caseSensitive: boolean',
+            'diacriticSensitive: boolean',
+            'locale: string'
+        ]
     }]
 };
 

--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -211,17 +211,7 @@ const types = {
     }],
     collator: [{
         type: 'collator',
-        parameters: [
-            'caseSensitive: boolean',
-            'diacriticSensitive: boolean',
-        ]
-    }, {
-        type: 'collator',
-        parameters: [
-            'caseSensitive: boolean',
-            'diacriticSensitive: boolean',
-            'locale: string'
-        ]
+        parameters: [ '{ "caseSensitive": boolean, "diacriticSensitive": boolean, "locale": string }' ]
     }]
 };
 

--- a/src/style-spec/expression/definitions/collator.js
+++ b/src/style-spec/expression/definitions/collator.js
@@ -1,0 +1,130 @@
+// @flow
+
+import { StringType, BooleanType, CollatorType } from '../types';
+
+import type { Expression } from '../expression';
+import type EvaluationContext from '../evaluation_context';
+import type ParsingContext from '../parsing_context';
+import type { Type } from '../types';
+
+declare var Intl: {
+  Collator: Class<Collator>
+}
+
+declare class Collator {
+  constructor (
+    locales?: string | string[],
+    options?: CollatorOptions
+  ): Collator;
+
+  static (
+    locales?: string | string[],
+    options?: CollatorOptions
+  ): Collator;
+
+  compare (a: string, b: string): number;
+
+  resolvedOptions(): any;
+}
+
+type CollatorOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  usage?: 'sort' | 'search',
+  sensitivity?: 'base' | 'accent' | 'case' | 'variant',
+  ignorePunctuation?: boolean,
+  numeric?: boolean,
+  caseFirst?: 'upper' | 'lower' | 'false'
+}
+
+export class CollatorInstantiation {
+    locale: string | null;
+    sensitivity: 'base' | 'accent' | 'case' | 'variant';
+
+    constructor(caseSensitive: boolean, diacriticSensitive: boolean, locale: string | null) {
+        if (caseSensitive)
+            this.sensitivity = diacriticSensitive ? 'variant' : 'case';
+        else
+            this.sensitivity = diacriticSensitive ? 'accent' : 'base';
+
+        this.locale = locale;
+    }
+
+    compare(lhs: string, rhs: string): number {
+        return new Intl.Collator(this.locale ? this.locale : [],
+                                 { sensitivity: this.sensitivity, usage: 'search' })
+            .compare(lhs, rhs);
+    }
+
+    resolvedLocale(): string {
+        return new Intl.Collator(this.locale ? this.locale : [])
+            .resolvedOptions().locale;
+    }
+
+    serialize() {
+        const serialized = ["collator"];
+        serialized.push(this.sensitivity === 'variant' || this.sensitivity === 'case');
+        serialized.push(this.sensitivity === 'variant' || this.sensitivity === 'accent');
+        if (this.locale) {
+            serialized.push(this.locale);
+        }
+        return serialized;
+    }
+}
+
+export class CollatorExpression implements Expression {
+    type: Type;
+    caseSensitive: Expression;
+    diacriticSensitive: Expression;
+    locale: Expression | null;
+
+    constructor(caseSensitive: Expression, diacriticSensitive: Expression, locale: Expression | null) {
+        this.type = CollatorType;
+        this.locale = locale;
+        this.caseSensitive = caseSensitive;
+        this.diacriticSensitive = diacriticSensitive;
+    }
+
+    static parse(args: Array<mixed>, context: ParsingContext): ?Expression {
+        if (args.length !== 3 && args.length !== 4)
+            return context.error(`Expected two or three arguments.`);
+
+        const caseSensitive = context.parse(args[1], 1, BooleanType);
+        if (!caseSensitive) return null;
+        const diacriticSensitive = context.parse(args[2], 2, BooleanType);
+        if (!diacriticSensitive) return null;
+
+        let locale = null;
+        if (args.length === 4) {
+            locale = context.parse(args[3], 3, StringType);
+            if (!locale) return null;
+        }
+
+        return new CollatorExpression(caseSensitive, diacriticSensitive, locale);
+    }
+
+    evaluate(ctx: EvaluationContext) {
+        return new CollatorInstantiation(this.caseSensitive.evaluate(ctx), this.diacriticSensitive.evaluate(ctx), this.locale ? this.locale.evaluate(ctx) : null);
+    }
+
+    eachChild(fn: (Expression) => void) {
+        fn(this.caseSensitive);
+        fn(this.diacriticSensitive);
+        if (this.locale) {
+            fn(this.locale);
+        }
+    }
+
+    possibleOutputs() {
+        // Technically the set of possible outputs is the combinatoric set of Collators produced
+        // by all possibleOutputs of locale/caseSensitive/diacriticSensitive
+        // But for the primary use of Collators in comparison operators, we ignore the Collator's
+        // possibleOutputs anyway, so we can get away with leaving this undefined for now.
+        return [undefined];
+    }
+
+    serialize() {
+        const serialized = ["collator"];
+        this.eachChild(child => { serialized.push(child.serialize()); });
+        return serialized;
+    }
+}

--- a/src/style-spec/expression/definitions/equals.js
+++ b/src/style-spec/expression/definitions/equals.js
@@ -1,12 +1,11 @@
 // @flow
 
-import { toString, ValueType, BooleanType } from '../types';
+import { toString, ValueType, BooleanType, CollatorType } from '../types';
 
 import type { Expression } from '../expression';
 import type EvaluationContext from '../evaluation_context';
 import type ParsingContext from '../parsing_context';
 import type { Type } from '../types';
-import type { Value } from '../values';
 
 function isComparableType(type: Type) {
     return type.kind === 'string' ||
@@ -29,21 +28,23 @@ function isComparableType(type: Type) {
  *
  * @private
  */
-function makeComparison(op: string, compare: (Value, Value) => boolean) {
+function makeComparison(op: string, negate: boolean) {
     return class Comparison implements Expression {
         type: Type;
         lhs: Expression;
         rhs: Expression;
+        collator: Expression | null;
 
-        constructor(lhs: Expression, rhs: Expression) {
+        constructor(lhs: Expression, rhs: Expression, collator: Expression | null) {
             this.type = BooleanType;
             this.lhs = lhs;
             this.rhs = rhs;
+            this.collator = collator;
         }
 
         static parse(args: Array<mixed>, context: ParsingContext): ?Expression {
-            if (args.length !== 3)
-                return context.error(`Expected two arguments.`);
+            if (args.length !== 3 && args.length !== 4)
+                return context.error(`Expected two or three arguments.`);
 
             const lhs = context.parse(args[1], 1, ValueType);
             if (!lhs) return null;
@@ -58,16 +59,32 @@ function makeComparison(op: string, compare: (Value, Value) => boolean) {
                 return context.error(`Cannot compare ${toString(lhs.type)} and ${toString(rhs.type)}.`);
             }
 
-            return new Comparison(lhs, rhs);
+            let collator = null;
+            if (args.length === 4) {
+                if (lhs.type.kind !== 'string' && rhs.type.kind !== 'string') {
+                    return context.error(`Cannot use collator to compare non-string types.`);
+                }
+                collator = context.parse(args[3], 3, CollatorType);
+                if (!collator) return null;
+            }
+
+            return new Comparison(lhs, rhs, collator);
         }
 
         evaluate(ctx: EvaluationContext) {
-            return compare(this.lhs.evaluate(ctx), this.rhs.evaluate(ctx));
+            const equal = this.collator ?
+                this.collator.evaluate(ctx).compare(this.lhs.evaluate(ctx), this.rhs.evaluate(ctx)) === 0 :
+                this.lhs.evaluate(ctx) === this.rhs.evaluate(ctx);
+
+            return negate ? !equal : equal;
         }
 
         eachChild(fn: (Expression) => void) {
             fn(this.lhs);
             fn(this.rhs);
+            if (this.collator) {
+                fn(this.collator);
+            }
         }
 
         possibleOutputs() {
@@ -75,10 +92,12 @@ function makeComparison(op: string, compare: (Value, Value) => boolean) {
         }
 
         serialize() {
-            return [op, this.lhs.serialize(), this.rhs.serialize()];
+            const serialized = [op];
+            this.eachChild(child => { serialized.push(child.serialize()); });
+            return serialized;
         }
     };
 }
 
-export const Equals = makeComparison('==', (lhs, rhs) => lhs === rhs);
-export const NotEquals = makeComparison('!=', (lhs, rhs) => lhs !== rhs);
+export const Equals = makeComparison('==', false);
+export const NotEquals = makeComparison('!=', true);

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -557,7 +557,6 @@ CompoundExpression.register(expressions, {
         (ctx, args) => args.map(arg => arg.evaluate(ctx)).join('')
     ],
     'resolved-locale': [
-        // Must be added to non-featureConstant list in parsing_context.js
         StringType,
         [CollatorType],
         (ctx, [collator]) => collator.evaluate(ctx).resolvedLocale()

--- a/src/style-spec/expression/definitions/literal.js
+++ b/src/style-spec/expression/definitions/literal.js
@@ -1,9 +1,7 @@
 // @flow
 
 import assert from 'assert';
-import { isValue, typeOf } from '../values';
-import Color from '../../util/color';
-import { CollatorInstantiation } from '../definitions/collator';
+import { isValue, typeOf, Color, Collator } from '../values';
 
 import type { Type } from '../types';
 import type { Value }  from '../values';
@@ -58,8 +56,13 @@ class Literal implements Expression {
         if (this.type.kind === 'array' || this.type.kind === 'object') {
             return ["literal", this.value];
         } else if (this.value instanceof Color) {
+            // Constant-folding can generate Literal expressions that you
+            // couldn't actually generate with a "literal" expression,
+            // so we have to implement an equivalent serialization here
             return ["rgba"].concat(this.value.toArray());
-        } else if (this.value instanceof CollatorInstantiation) {
+        } else if (this.value instanceof Collator) {
+            // Same as Color above: literal serialization delegated to
+            // Collator (not CollatorExpression)
             return this.value.serialize();
         } else {
             assert(this.value === null ||

--- a/src/style-spec/expression/definitions/literal.js
+++ b/src/style-spec/expression/definitions/literal.js
@@ -3,6 +3,7 @@
 import assert from 'assert';
 import { isValue, typeOf } from '../values';
 import Color from '../../util/color';
+import { CollatorInstantiation } from '../definitions/collator';
 
 import type { Type } from '../types';
 import type { Value }  from '../values';
@@ -58,6 +59,8 @@ class Literal implements Expression {
             return ["literal", this.value];
         } else if (this.value instanceof Color) {
             return ["rgba"].concat(this.value.toArray());
+        } else if (this.value instanceof CollatorInstantiation) {
+            return this.value.serialize();
         } else {
             assert(this.value === null ||
                 typeof this.value === 'string' ||

--- a/src/style-spec/expression/types.js
+++ b/src/style-spec/expression/types.js
@@ -8,6 +8,7 @@ export type ColorTypeT = { kind: 'color' };
 export type ObjectTypeT = { kind: 'object' };
 export type ValueTypeT = { kind: 'value' };
 export type ErrorTypeT = { kind: 'error' };
+export type CollatorTypeT = { kind: 'collator' };
 
 export type Type =
     NullTypeT |
@@ -18,7 +19,8 @@ export type Type =
     ObjectTypeT |
     ValueTypeT |
     ArrayType | // eslint-disable-line no-use-before-define
-    ErrorTypeT
+    ErrorTypeT |
+    CollatorTypeT
 
 export type ArrayType = {
     kind: 'array',
@@ -34,6 +36,7 @@ export const ColorType = { kind: 'color' };
 export const ObjectType = { kind: 'object' };
 export const ValueType = { kind: 'value' };
 export const ErrorType = { kind: 'error' };
+export const CollatorType = { kind: 'collator' };
 
 export function array(itemType: Type, N: ?number): ArrayType {
     return {

--- a/src/style-spec/expression/values.js
+++ b/src/style-spec/expression/values.js
@@ -3,7 +3,8 @@
 import assert from 'assert';
 
 import Color from '../util/color';
-import { NullType, NumberType, StringType, BooleanType, ColorType, ObjectType, ValueType, array } from './types';
+import { Collator } from './definitions/collator';
+import { NullType, NumberType, StringType, BooleanType, ColorType, ObjectType, ValueType, CollatorType, array } from './types';
 
 import type { Type } from './types';
 
@@ -26,7 +27,7 @@ export function validateRGBA(r: mixed, g: mixed, b: mixed, a?: mixed): ?string {
     return null;
 }
 
-export type Value = null | string | boolean | number | Color | $ReadOnlyArray<Value> | { +[string]: Value }
+export type Value = null | string | boolean | number | Color | Collator | $ReadOnlyArray<Value> | { +[string]: Value }
 
 export function isValue(mixed: mixed): boolean {
     if (mixed === null) {
@@ -38,6 +39,8 @@ export function isValue(mixed: mixed): boolean {
     } else if (typeof mixed === 'number') {
         return true;
     } else if (mixed instanceof Color) {
+        return true;
+    } else if (mixed instanceof Collator) {
         return true;
     } else if (Array.isArray(mixed)) {
         for (const item of mixed) {
@@ -69,6 +72,8 @@ export function typeOf(value: Value): Type {
         return NumberType;
     } else if (value instanceof Color) {
         return ColorType;
+    } else if (value instanceof Collator) {
+        return CollatorType;
     } else if (Array.isArray(value)) {
         const length = value.length;
         let itemType: ?Type;
@@ -92,4 +97,4 @@ export function typeOf(value: Value): Type {
     }
 }
 
-export {Color};
+export { Color, Collator };

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2163,6 +2163,15 @@
           }
         }
       },
+      "collator": {
+        "doc": "Returns a `collator` for use in locale dependent comparison operations. The first two arguments control case and diacritic sensitivity, and the optional third argument specifies the IETF language tag of the locale to use. If no locale is provided, the default locale is used.",
+        "group": "Types",
+        "sdk-support": {
+          "basic functionality": {
+            "js": "0.45.0"
+          }
+        }
+      },
       "to-string": {
         "doc": "Converts the input value to a string. If the input is `null`, the result is `\"null\"`. If the input is a boolean, the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a color, it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
         "group": "Types",
@@ -2501,7 +2510,7 @@
         }
       },
       "==": {
-        "doc": "Returns `true` if the input values are equal, `false` otherwise. Equality is strictly typed: values of different types are always considered not equal.",
+        "doc": "Returns `true` if the input values are equal, `false` otherwise. Equality is strictly typed: values of different types are always considered not equal. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2510,7 +2519,7 @@
         }
       },
       "!=": {
-        "doc": "Returns `true` if the input values are not equal, `false` otherwise. Equality is strictly typed: values of different types are always considered not equal.",
+        "doc": "Returns `true` if the input values are not equal, `false` otherwise. Equality is strictly typed: values of different types are always considered not equal. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2519,7 +2528,7 @@
         }
       },
       ">": {
-        "doc": "Returns `true` if the first input is strictly greater than the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type.",
+        "doc": "Returns `true` if the first input is strictly greater than the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2528,7 +2537,7 @@
         }
       },
       "<": {
-        "doc": "Returns `true` if the first input is strictly less than the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type.",
+        "doc": "Returns `true` if the first input is strictly less than the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2537,7 +2546,7 @@
         }
       },
       ">=": {
-        "doc": "Returns `true` if the first input is greater than or equal to the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type.",
+        "doc": "Returns `true` if the first input is greater than or equal to the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2546,7 +2555,7 @@
         }
       },
       "<=": {
-        "doc": "Returns `true` if the first input is less than or equal to the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type.",
+        "doc": "Returns `true` if the first input is less than or equal to the second, `false` otherwise. The inputs must be numbers or strings, and both of the same type. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2605,6 +2614,15 @@
         "sdk-support": {
           "basic functionality": {
             "js": "0.41.0"
+          }
+        }
+      },
+      "resolved-locale": {
+        "doc": "Returns the IETF language tag of the locale being used by the provided `collator`. This can be used to determine the default system locale, or to determine if a requested locale was successfully loaded.",
+        "group": "String",
+        "sdk-support": {
+          "basic functionality": {
+            "js": "0.45.0"
           }
         }
       }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2164,7 +2164,7 @@
         }
       },
       "collator": {
-        "doc": "Returns a `collator` for use in locale dependent comparison operations. The `caseSensitive` and `diacriticSensitive` options default to `false`. The `locale` argument specifies the IETF language tag of the locale to use. If none is provided, the default locale is used. If the requested locale is not available, the `collator` will use a system-defined fallback locale. Use `resolved-locale` to test the results of locale fallback behavior.",
+        "doc": "Returns a `collator` for use in locale-dependent comparison operations. The `caseSensitive` and `diacriticSensitive` options default to `false`. The `locale` argument specifies the IETF language tag of the locale to use. If none is provided, the default locale is used. If the requested locale is not available, the `collator` will use a system-defined fallback locale. Use `resolved-locale` to test the results of locale fallback behavior.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2164,7 +2164,7 @@
         }
       },
       "collator": {
-        "doc": "Returns a `collator` for use in locale dependent comparison operations. The first two arguments control case and diacritic sensitivity, and the optional third argument specifies the IETF language tag of the locale to use. If no locale is provided, the default locale is used.",
+        "doc": "Returns a `collator` for use in locale dependent comparison operations. The `caseSensitive` and `diacriticSensitive` options default to `false`. The `locale` argument specifies the IETF language tag of the locale to use. If none is provided, the default locale is used. If the requested locale is not available, the `collator` will use a system-defined fallback locale. Use `resolved-locale` to test the results of locale fallback behavior.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {

--- a/test/integration/expression-tests/collator/accent-equals-de/test.json
+++ b/test/integration/expression-tests/collator/accent-equals-de/test.json
@@ -1,12 +1,25 @@
 {
   "expression": [
     "case",
-    ["==", ["resolved-locale", ["collator", true, false, "de"]], "de"],
+    [
+      "==",
+      [
+        "resolved-locale",
+        [
+          "collator",
+          {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+        ]
+      ],
+      "de"
+    ],
     [
       "==",
       ["string", ["get", "lhs"]],
       ["get", "rhs"],
-      ["collator", true, false, "de"]
+      [
+        "collator",
+        {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+      ]
     ],
     ["case", ["==", ["get", "rhs"], "ue"], true, false]
   ],
@@ -24,12 +37,15 @@
     "outputs": [true, false],
     "serialized": [
       "case",
-      ["==", ["resolved-locale", ["collator", true, false, "de"]], "de"],
+      false,
       [
         "==",
         ["string", ["get", "lhs"]],
         ["get", "rhs"],
-        ["collator", true, false, "de"]
+        [
+          "collator",
+          {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+        ]
       ],
       ["case", ["==", ["get", "rhs"], "ue"], true, false]
     ]

--- a/test/integration/expression-tests/collator/accent-equals-de/test.json
+++ b/test/integration/expression-tests/collator/accent-equals-de/test.json
@@ -1,0 +1,37 @@
+{
+  "expression": [
+    "case",
+    ["==", ["resolved-locale", ["collator", true, false, "de"]], "de"],
+    [
+      "==",
+      ["string", ["get", "lhs"]],
+      ["get", "rhs"],
+      ["collator", true, false, "de"]
+    ],
+    ["case", ["==", ["get", "rhs"], "ue"], true, false]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "ü", "rhs": "ue"}}],
+    [{}, {"properties": {"lhs": "ü", "rhs": "u"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [true, false],
+    "serialized": [
+      "case",
+      ["==", ["resolved-locale", ["collator", true, false, "de"]], "de"],
+      [
+        "==",
+        ["string", ["get", "lhs"]],
+        ["get", "rhs"],
+        ["collator", true, false, "de"]
+      ],
+      ["case", ["==", ["get", "rhs"], "ue"], true, false]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/accent-lt-en/test.json
+++ b/test/integration/expression-tests/collator/accent-lt-en/test.json
@@ -1,0 +1,28 @@
+{
+  "expression": [
+    "<",
+    ["string", ["get", "lhs"]],
+    ["get", "rhs"],
+    ["collator", true, false, "en"]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "ä", "rhs": "b"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [false, true, true],
+    "serialized": [
+      "<",
+      ["string", ["get", "lhs"]],
+      ["string", ["get", "rhs"]],
+      ["collator", true, false, "en"]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/accent-not-equals-en/test.json
+++ b/test/integration/expression-tests/collator/accent-not-equals-en/test.json
@@ -5,7 +5,10 @@
       "!=",
       ["string", ["get", "lhs"]],
       ["get", "rhs"],
-      ["collator", true, false, "en"]
+      [
+        "collator",
+        {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
+      ]
     ]
   ],
   "inputs": [
@@ -27,7 +30,10 @@
         "!=",
         ["string", ["get", "lhs"]],
         ["get", "rhs"],
-        ["collator", true, false, "en"]
+        [
+          "collator",
+          {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
+        ]
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/accent-not-equals-en/test.json
+++ b/test/integration/expression-tests/collator/accent-not-equals-en/test.json
@@ -1,0 +1,34 @@
+{
+  "expression": [
+    "!",
+    [
+      "!=",
+      ["string", ["get", "lhs"]],
+      ["get", "rhs"],
+      ["collator", true, false, "en"]
+    ]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "b", "rhs": "ä"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [true, false, false],
+    "serialized": [
+      "!",
+      [
+        "!=",
+        ["string", ["get", "lhs"]],
+        ["get", "rhs"],
+        ["collator", true, false, "en"]
+      ]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/base-default-locale/test.json
+++ b/test/integration/expression-tests/collator/base-default-locale/test.json
@@ -3,7 +3,7 @@
     "==",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    ["collator", false, false]
+    ["collator", {"caseSensitive": false, "diacriticSensitive": false}]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "a", "rhs": "a"}}],
@@ -22,7 +22,7 @@
       "==",
       ["string", ["get", "lhs"]],
       ["get", "rhs"],
-      ["collator", false, false]
+      ["collator", {"caseSensitive": false, "diacriticSensitive": false}]
     ]
   }
 }

--- a/test/integration/expression-tests/collator/base-default-locale/test.json
+++ b/test/integration/expression-tests/collator/base-default-locale/test.json
@@ -1,0 +1,28 @@
+{
+  "expression": [
+    "==",
+    ["string", ["get", "lhs"]],
+    ["get", "rhs"],
+    ["collator", false, false]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "a", "rhs": "a"}}],
+    [{}, {"properties": {"lhs": "A", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "b", "rhs": "a"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [true, true, false],
+    "serialized": [
+      "==",
+      ["string", ["get", "lhs"]],
+      ["get", "rhs"],
+      ["collator", false, false]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/base-equals-en/test.json
+++ b/test/integration/expression-tests/collator/base-equals-en/test.json
@@ -1,0 +1,28 @@
+{
+  "expression": [
+    "==",
+    ["string", ["get", "lhs"]],
+    ["get", "rhs"],
+    ["collator", false, false, "en"]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "b", "rhs": "ä"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [true, true, false],
+    "serialized": [
+      "==",
+      ["string", ["get", "lhs"]],
+      ["get", "rhs"],
+      ["collator", false, false, "en"]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/base-equals-en/test.json
+++ b/test/integration/expression-tests/collator/base-equals-en/test.json
@@ -3,7 +3,10 @@
     "==",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    ["collator", false, false, "en"]
+    [
+      "collator",
+      {"caseSensitive": false, "diacriticSensitive": false, "locale": "en"}
+    ]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
@@ -22,7 +25,10 @@
       "==",
       ["string", ["get", "lhs"]],
       ["get", "rhs"],
-      ["collator", false, false, "en"]
+      [
+        "collator",
+        {"caseSensitive": false, "diacriticSensitive": false, "locale": "en"}
+      ]
     ]
   }
 }

--- a/test/integration/expression-tests/collator/base-gt-en/test.json
+++ b/test/integration/expression-tests/collator/base-gt-en/test.json
@@ -3,7 +3,10 @@
     ">",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    ["collator", false, false, "en"]
+    [
+      "collator",
+      {"caseSensitive": false, "diacriticSensitive": false, "locale": "en"}
+    ]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
@@ -22,7 +25,10 @@
       ">",
       ["string", ["get", "lhs"]],
       ["string", ["get", "rhs"]],
-      ["collator", false, false, "en"]
+      [
+        "collator",
+        {"caseSensitive": false, "diacriticSensitive": false, "locale": "en"}
+      ]
     ]
   }
 }

--- a/test/integration/expression-tests/collator/base-gt-en/test.json
+++ b/test/integration/expression-tests/collator/base-gt-en/test.json
@@ -1,0 +1,28 @@
+{
+  "expression": [
+    ">",
+    ["string", ["get", "lhs"]],
+    ["get", "rhs"],
+    ["collator", false, false, "en"]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "b", "rhs": "ä"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [false, false, true],
+    "serialized": [
+      ">",
+      ["string", ["get", "lhs"]],
+      ["string", ["get", "rhs"]],
+      ["collator", false, false, "en"]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/case-lteq-en/test.json
+++ b/test/integration/expression-tests/collator/case-lteq-en/test.json
@@ -1,0 +1,29 @@
+{
+  "expression": [
+    "<=",
+    ["string", ["get", "lhs"]],
+    ["get", "rhs"],
+    ["collator", false, true, "en"]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "ä", "rhs": "a"}}],
+    [{}, {"properties": {"lhs": "A", "rhs": "a"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "a"}}],
+    [{}, {"properties": {"lhs": "ä", "rhs": "b"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [false, true, true, true],
+    "serialized": [
+      "<=",
+      ["string", ["get", "lhs"]],
+      ["string", ["get", "rhs"]],
+      ["collator", false, true, "en"]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/case-lteq-en/test.json
+++ b/test/integration/expression-tests/collator/case-lteq-en/test.json
@@ -3,7 +3,10 @@
     "<=",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    ["collator", false, true, "en"]
+    [
+      "collator",
+      {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+    ]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "ä", "rhs": "a"}}],
@@ -23,7 +26,10 @@
       "<=",
       ["string", ["get", "lhs"]],
       ["string", ["get", "rhs"]],
-      ["collator", false, true, "en"]
+      [
+        "collator",
+        {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+      ]
     ]
   }
 }

--- a/test/integration/expression-tests/collator/case-not-equals-en/test.json
+++ b/test/integration/expression-tests/collator/case-not-equals-en/test.json
@@ -5,7 +5,10 @@
       "!=",
       ["string", ["get", "lhs"]],
       ["get", "rhs"],
-      ["collator", false, true, "en"]
+      [
+        "collator",
+        {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+      ]
     ]
   ],
   "inputs": [
@@ -27,7 +30,10 @@
         "!=",
         ["string", ["get", "lhs"]],
         ["get", "rhs"],
-        ["collator", false, true, "en"]
+        [
+          "collator",
+          {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+        ]
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/case-not-equals-en/test.json
+++ b/test/integration/expression-tests/collator/case-not-equals-en/test.json
@@ -1,0 +1,34 @@
+{
+  "expression": [
+    "!",
+    [
+      "!=",
+      ["string", ["get", "lhs"]],
+      ["get", "rhs"],
+      ["collator", false, true, "en"]
+    ]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "b", "rhs": "ä"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [false, true, false],
+    "serialized": [
+      "!",
+      [
+        "!=",
+        ["string", ["get", "lhs"]],
+        ["get", "rhs"],
+        ["collator", false, true, "en"]
+      ]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/case-omitted-en/test.json
+++ b/test/integration/expression-tests/collator/case-omitted-en/test.json
@@ -1,16 +1,14 @@
 {
   "expression": [
-    "<",
+    "==",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    [
-      "collator",
-      {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
-    ]
+    ["collator", {"diacriticSensitive": true, "locale": "en"}]
   ],
   "inputs": [
-    [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
-    [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "ä", "rhs": "a"}}],
+    [{}, {"properties": {"lhs": "A", "rhs": "a"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "a"}}],
     [{}, {"properties": {"lhs": "ä", "rhs": "b"}}]
   ],
   "expected": {
@@ -20,14 +18,14 @@
       "isZoomConstant": true,
       "type": "boolean"
     },
-    "outputs": [false, true, true],
+    "outputs": [false, true, true, false],
     "serialized": [
-      "<",
+      "==",
       ["string", ["get", "lhs"]],
-      ["string", ["get", "rhs"]],
+      ["get", "rhs"],
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
+        {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/comparison-number-error/test.json
+++ b/test/integration/expression-tests/collator/comparison-number-error/test.json
@@ -1,0 +1,11 @@
+{
+  "expression": ["<", 1, 2, ["collator", false, false]],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [
+        {"key": "[1]", "error": "Expected string but found number instead."}
+      ]
+    }
+  }
+}

--- a/test/integration/expression-tests/collator/comparison-number-error/test.json
+++ b/test/integration/expression-tests/collator/comparison-number-error/test.json
@@ -1,5 +1,10 @@
 {
-  "expression": ["<", 1, 2, ["collator", false, false]],
+  "expression": [
+    "<",
+    1,
+    2,
+    ["collator", {"caseSensitive": false, "diacriticSensitive": false}]
+  ],
   "expected": {
     "compiled": {
       "result": "error",

--- a/test/integration/expression-tests/collator/diacritic-omitted-en/test.json
+++ b/test/integration/expression-tests/collator/diacritic-omitted-en/test.json
@@ -1,18 +1,14 @@
 {
   "expression": [
-    ">=",
+    "<",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    [
-      "collator",
-      {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
-    ]
+    ["collator", {"caseSensitive": ["==", 1, 1], "locale": "en"}]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
     [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
-    [{}, {"properties": {"lhs": "a", "rhs": "a"}}],
-    [{}, {"properties": {"lhs": "b", "rhs": "ä"}}]
+    [{}, {"properties": {"lhs": "ä", "rhs": "b"}}]
   ],
   "expected": {
     "compiled": {
@@ -21,14 +17,14 @@
       "isZoomConstant": true,
       "type": "boolean"
     },
-    "outputs": [false, false, true, true],
+    "outputs": [false, true, true],
     "serialized": [
-      ">=",
+      "<",
       ["string", ["get", "lhs"]],
       ["string", ["get", "rhs"]],
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+        {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/equals-non-string-error/test.json
+++ b/test/integration/expression-tests/collator/equals-non-string-error/test.json
@@ -1,5 +1,10 @@
 {
-  "expression": ["==", 1, 2, ["collator", false, false]],
+  "expression": [
+    "==",
+    1,
+    2,
+    ["collator", {"caseSensitive": false, "diacriticSensitive": false}]
+  ],
   "expected": {
     "compiled": {
       "result": "error",

--- a/test/integration/expression-tests/collator/equals-non-string-error/test.json
+++ b/test/integration/expression-tests/collator/equals-non-string-error/test.json
@@ -1,0 +1,11 @@
+{
+  "expression": ["==", 1, 2, ["collator", false, false]],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [
+        {"key": "", "error": "Cannot use collator to compare non-string types."}
+      ]
+    }
+  }
+}

--- a/test/integration/expression-tests/collator/non-object-error/test.json
+++ b/test/integration/expression-tests/collator/non-object-error/test.json
@@ -1,0 +1,11 @@
+{
+  "expression": ["==", "foo", "bar", ["collator", ["subexpression"]]],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [
+        {"key": "[3]", "error": "Collator options argument must be an object."}
+      ]
+    }
+  }
+}

--- a/test/integration/expression-tests/collator/variant-equals-en/test.json
+++ b/test/integration/expression-tests/collator/variant-equals-en/test.json
@@ -1,0 +1,28 @@
+{
+  "expression": [
+    "==",
+    ["string", ["get", "lhs"]],
+    ["get", "rhs"],
+    ["collator", true, true, "en"]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "b", "rhs": "ä"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [false, false, false],
+    "serialized": [
+      "==",
+      ["string", ["get", "lhs"]],
+      ["get", "rhs"],
+      ["collator", true, true, "en"]
+    ]
+  }
+}

--- a/test/integration/expression-tests/collator/variant-equals-en/test.json
+++ b/test/integration/expression-tests/collator/variant-equals-en/test.json
@@ -3,7 +3,10 @@
     "==",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    ["collator", true, true, "en"]
+    [
+      "collator",
+      {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+    ]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
@@ -22,7 +25,10 @@
       "==",
       ["string", ["get", "lhs"]],
       ["get", "rhs"],
-      ["collator", true, true, "en"]
+      [
+        "collator",
+        {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+      ]
     ]
   }
 }

--- a/test/integration/expression-tests/collator/variant-gteq-en/test.json
+++ b/test/integration/expression-tests/collator/variant-gteq-en/test.json
@@ -1,0 +1,29 @@
+{
+  "expression": [
+    ">=",
+    ["string", ["get", "lhs"]],
+    ["get", "rhs"],
+    ["collator", true, true, "en"]
+  ],
+  "inputs": [
+    [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "A"}}],
+    [{}, {"properties": {"lhs": "a", "rhs": "a"}}],
+    [{}, {"properties": {"lhs": "b", "rhs": "ä"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [false, false, true, true],
+    "serialized": [
+      ">=",
+      ["string", ["get", "lhs"]],
+      ["string", ["get", "rhs"]],
+      ["collator", true, true, "en"]
+    ]
+  }
+}

--- a/test/integration/expression-tests/resolved-locale/basic/test.json
+++ b/test/integration/expression-tests/resolved-locale/basic/test.json
@@ -1,7 +1,13 @@
 {
   "expression": [
     "==",
-    ["resolved-locale", ["collator", true, true, "en"]],
+    [
+      "resolved-locale",
+      [
+        "collator",
+        {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+      ]
+    ],
     "en"
   ],
   "inputs": [[{}, {}]],
@@ -13,10 +19,6 @@
       "type": "boolean"
     },
     "outputs": [true],
-    "serialized": [
-      "==",
-      ["resolved-locale", ["collator", true, true, "en"]],
-      "en"
-    ]
+    "serialized": true
   }
 }

--- a/test/integration/expression-tests/resolved-locale/basic/test.json
+++ b/test/integration/expression-tests/resolved-locale/basic/test.json
@@ -1,0 +1,22 @@
+{
+  "expression": [
+    "==",
+    ["resolved-locale", ["collator", true, true, "en"]],
+    "en"
+  ],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [true],
+    "serialized": [
+      "==",
+      ["resolved-locale", ["collator", true, true, "en"]],
+      "en"
+    ]
+  }
+}


### PR DESCRIPTION
Potential implementation of a fix for https://github.com/mapbox/mapbox-gl-js/issues/4136.

For "locale", we could:

- Get rid of the argument, and always use the runtime's default locale. Advantage: easiest from the point of view of the expression author.
- Allow a single optional string as an argument (currently implemented). Advantage: not _too_ complicated, and allows basic localization (e.g. "let's use German collation rules for this map").
- Allow array of locale strings as an argument. Advantage: allows definition of fallback rules when the set of locally supported locales isn't known ahead of time. Disadvantage: more cumbersome to specify.

It does feel odd to have this operator implemented separately from `==`,`!=`,`<`,`<=`,`>`, and`>=`, (and also `filter-*-in`) *but*:

- The equality operator (along with `!`) gives us what we need for the specific use case of changing map behavior when two values are "near duplicates"
- Greater/less than operators probably (?) make more sense in the context of being able to specify general purpose collation rules.

An alternative approach might be to make `Equals`, `lt`, `gt`, etc. all take an optional "Collation" as an argument and then add expression support for defining a collation. One risk of this approach is that the more customizability we expose the harder it'll be to maintain consistent behavior across platforms (although we expect the underlying implementations to _usually_ be based on some form of ICU).

/cc @1ec5 @anandthakker @kkaefer @nickidlugash 