### PR TITLE
Add popup open event

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -95,6 +95,18 @@ class Popup extends Evented {
             this._map.on('click', this._onClickClose);
         }
         this._update();
+
+        /**
+         * Fired when the popup is opened manually or programatically.
+         *
+         * @event open
+         * @memberof Popup
+         * @instance
+         * @type {Object}
+         * @property {Popup} popup object that was opened
+         */
+        this.fire(new Event('open'));
+
         return this;
     }
 

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -97,6 +97,21 @@ test('Popup fires close event when removed', (t) => {
     t.end();
 });
 
+
+test('Popup fires open event when added', (t) => {
+    const map = createMap();
+    const onOpen = t.spy();
+
+    new Popup()
+        .setText("Test")
+        .setLngLat([0, 0])
+        .on('open', onOpen)
+        .addTo(map);
+
+    t.ok(onOpen.called);
+    t.end();
+});
+
 test('Popup content can be set via setText', (t) => {
     const map = createMap();
 


### PR DESCRIPTION
This PR adds the 'open' event to popups when they're added to a map.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
