### PR TITLE
Fix touch panning in Edge

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -28,16 +28,19 @@
     cursor: grabbing;
 }
 
-.mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate {
+.mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate,
+.mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate .mapboxgl-canvas {
     -ms-touch-action: pan-x pan-y;
     touch-action: pan-x pan-y;
 }
 
-.mapboxgl-canvas-container.mapboxgl-touch-drag-pan {
+.mapboxgl-canvas-container.mapboxgl-touch-drag-pan,
+.mapboxgl-canvas-container.mapboxgl-touch-drag-pan .mapboxgl-canvas {
     -ms-touch-action: pinch-zoom;
 }
 
-.mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate.mapboxgl-touch-drag-pan {
+.mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate.mapboxgl-touch-drag-pan,
+.mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate.mapboxgl-touch-drag-pan .mapboxgl-canvas {
     -ms-touch-action: none;
     touch-action: none;
 }

--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -30,18 +30,16 @@
 
 .mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate,
 .mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate .mapboxgl-canvas {
-    -ms-touch-action: pan-x pan-y;
     touch-action: pan-x pan-y;
 }
 
 .mapboxgl-canvas-container.mapboxgl-touch-drag-pan,
 .mapboxgl-canvas-container.mapboxgl-touch-drag-pan .mapboxgl-canvas {
-    -ms-touch-action: pinch-zoom;
+    touch-action: pinch-zoom;
 }
 
 .mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate.mapboxgl-touch-drag-pan,
 .mapboxgl-canvas-container.mapboxgl-touch-zoom-rotate.mapboxgl-touch-drag-pan .mapboxgl-canvas {
-    -ms-touch-action: none;
     touch-action: none;
 }
 


### PR DESCRIPTION
Touch events are behind a flag in Edge, even on touchscreen devices. 🤷‍♂️ However, Edge _will_ dispatch mouse events in response to touch input -- in certain circumstances which are not well documented. It seems that it depends on the `touch-action` CSS property being present on particular elements. We previously set `touch-action: none` on the `.mapboxgl-canvas-container` element, but this is apparently not enough for Edge. In my tests setting `touch-action: none` on the body element works, as does setting `touch-action: none` on both the canvas container _and_ the canvas. Since we don't want to affect touch-action on the entire page, here's the latter solution.

Note that this doesn't fix pinch zooming or touch rotating. Until touch events are unflagged by default, the only way to support those is via pointer events.

Refs #1928.