### PR TITLE
Introduce Map#_requestRenderFrame

### DIFF
--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -8,7 +8,7 @@ import { Event } from '../../util/evented';
 
 import type Map from '../map';
 import type Point from '@mapbox/point-geometry';
-import type Transform from '../../geo/transform';
+import type {TaskID} from '../../util/task_queue';
 
 const inertiaLinearity = 0.15,
     inertiaEasing = bezier(0, 0, inertiaLinearity, 1),
@@ -33,6 +33,7 @@ class TouchZoomRotateHandler {
     _gestureIntent: 'rotate' | 'zoom' | void;
     _inertia: Array<[number, number, Point]>;
     _lastTouchEvent: TouchEvent;
+    _frameId: ?TaskID;
 
     /**
      * @private
@@ -162,14 +163,20 @@ class TouchZoomRotateHandler {
         }
 
         this._lastTouchEvent = e;
-        this._map._startAnimation(this._onTouchFrame);
+        if (!this._frameId) {
+            this._frameId = this._map._requestRenderFrame(this._onTouchFrame);
+        }
 
         e.preventDefault();
     }
 
-    _onTouchFrame(tr: Transform) {
+    _onTouchFrame() {
+        this._frameId = null;
+
         const gestureIntent = this._gestureIntent;
         if (!gestureIntent) return;
+
+        const tr = this._map.transform;
 
         if (!this._startScale) {
             this._startScale = tr.scale;
@@ -202,6 +209,10 @@ class TouchZoomRotateHandler {
         const gestureIntent = this._gestureIntent;
         const startScale = this._startScale;
 
+        if (this._frameId) {
+            this._map._cancelRenderFrame(this._frameId);
+            this._frameId = null;
+        }
         delete this._gestureIntent;
         delete this._startScale;
         delete this._startBearing;

--- a/src/util/task_queue.js
+++ b/src/util/task_queue.js
@@ -1,0 +1,68 @@
+// @flow
+import assert from 'assert';
+
+export type TaskID = number; // can't mark opaque due to https://github.com/flowtype/flow-remove-types/pull/61
+type Task = {
+    callback: () => void;
+    id: TaskID;
+    cancelled: boolean;
+};
+
+class TaskQueue {
+    _queue: Array<Task>;
+    _id: TaskID;
+    _cleared: boolean;
+    _currentlyRunning: Array<Task> | false;
+
+    constructor()  {
+        this._queue = [];
+        this._id = 0;
+        this._cleared = false;
+        this._currentlyRunning = false;
+    }
+
+    add(callback: () => void): TaskID {
+        const id = ++this._id;
+        const queue = this._queue;
+        queue.push({callback, id, cancelled: false});
+        return id;
+    }
+
+    remove(id: TaskID) {
+        const running = this._currentlyRunning;
+        const queue = running ? this._queue.concat(running) : this._queue;
+        for (const task of queue) {
+            if (task.id === id) {
+                task.cancelled = true;
+                return;
+            }
+        }
+    }
+
+    run() {
+        assert(!this._currentlyRunning);
+        const queue = this._currentlyRunning = this._queue;
+
+        // Tasks queued by callbacks in the current queue should be executed
+        // on the next run, not the current run.
+        this._queue = [];
+
+        for (const task of queue) {
+            if (task.cancelled) continue;
+            task.callback();
+            if (this._cleared) break;
+        }
+
+        this._cleared = false;
+        this._currentlyRunning = false;
+    }
+
+    clear() {
+        if (this._currentlyRunning) {
+            this._cleared = true;
+        }
+        this._queue = [];
+    }
+}
+
+export default TaskQueue;

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1,19 +1,28 @@
 import { test } from 'mapbox-gl-js-test';
 import Camera from '../../../src/ui/camera';
 import Transform from '../../../src/geo/transform';
+import TaskQueue from '../../../src/util/task_queue';
 import browser from '../../../src/util/browser';
 import fixed from 'mapbox-gl-js-test/fixed';
 const fixedLngLat = fixed.LngLat;
 const fixedNum = fixed.Num;
 
 test('camera', (t) => {
+    function attachSimulateFrame(camera) {
+        const queue = new TaskQueue();
+        camera._requestRenderFrame = (cb) => queue.add(cb);
+        camera._cancelRenderFrame = (id) => queue.remove(id);
+        camera.simulateFrame = () => queue.run();
+        return camera;
+    }
+
     function createCamera(options) {
         options = options || {};
 
         const transform = new Transform(0, 20, options.renderWorldCopies);
         transform.resize(512, 512);
 
-        const camera = new Camera(transform, {})
+        const camera = attachSimulateFrame(new Camera(transform, {}))
             .jumpTo(options);
 
         camera._update = () => {};
@@ -779,21 +788,21 @@ test('camera', (t) => {
 
                     setTimeout(() => {
                         stub.callsFake(() => 30);
-                        camera._updateCamera();
+                        camera.simulateFrame();
                     }, 0);
                 });
 
                 // setTimeout to avoid a synchronous callback
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             });
 
             // setTimeout to avoid a synchronous callback
             setTimeout(() => {
                 stub.callsFake(() => 10);
-                camera._updateCamera();
+                camera.simulateFrame();
             }, 0);
         });
 
@@ -820,11 +829,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -852,11 +861,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -889,7 +898,8 @@ test('camera', (t) => {
         t.test('does not throw when cameras current zoom is above maxzoom and an offset creates infinite zoom out factor', (t)=>{
             const transform = new Transform(0, 20.9999, true);
             transform.resize(512, 512);
-            const camera = new Camera(transform, {}).jumpTo({zoom: 21, center:[0, 0]});
+            const camera = attachSimulateFrame(new Camera(transform, {}))
+                .jumpTo({zoom: 21, center:[0, 0]});
             camera._update = () => {};
             t.doesNotThrow(()=>camera.flyTo({zoom:7.5, center:[0, 0], offset:[0, 70]}));
             t.end();
@@ -1087,11 +1097,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1122,15 +1132,15 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 10);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateCamera();
+                    camera.simulateFrame();
 
                     setTimeout(() => {
                         stub.callsFake(() => 30);
-                        camera._updateCamera();
+                        camera.simulateFrame();
                     }, 0);
                 }, 0);
             }, 0);
@@ -1159,11 +1169,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1191,11 +1201,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1223,11 +1233,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1255,11 +1265,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 20);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1287,11 +1297,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1319,11 +1329,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1351,11 +1361,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1382,11 +1392,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1419,11 +1429,11 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 3);
-                camera._updateCamera();
+                camera.simulateFrame();
 
                 setTimeout(() => {
                     stub.callsFake(() => 10);
-                    camera._updateCamera();
+                    camera.simulateFrame();
                 }, 0);
             }, 0);
         });
@@ -1432,7 +1442,7 @@ test('camera', (t) => {
             const transform = new Transform(2, 10, false);
             transform.resize(512, 512);
 
-            const camera = new Camera(transform, {});
+            const camera = attachSimulateFrame(new Camera(transform, {}));
             camera._update = () => {};
 
             camera.on('moveend', () => {
@@ -1450,7 +1460,7 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 10);
-                camera._updateCamera();
+                camera.simulateFrame();
             }, 0);
         });
 
@@ -1458,7 +1468,7 @@ test('camera', (t) => {
             const transform = new Transform(2, 10, false);
             transform.resize(512, 512);
 
-            const camera = new Camera(transform, {});
+            const camera = attachSimulateFrame(new Camera(transform, {}));
             camera._update = () => {};
 
             camera.on('moveend', () => {
@@ -1476,7 +1486,7 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 10);
-                camera._updateCamera();
+                camera.simulateFrame();
             }, 0);
         });
 
@@ -1524,7 +1534,7 @@ test('camera', (t) => {
             camera.panTo([100, 0], {duration: 1});
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
             }, 0);
         });
 
@@ -1546,7 +1556,7 @@ test('camera', (t) => {
             camera.zoomTo(3.2, {duration: 1});
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
             }, 0);
         });
 
@@ -1568,7 +1578,7 @@ test('camera', (t) => {
             camera.rotateTo(90, {duration: 1});
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
             }, 0);
         });
 
@@ -1647,7 +1657,7 @@ test('camera', (t) => {
 
             setTimeout(() => {
                 stub.callsFake(() => 1);
-                camera._updateCamera();
+                camera.simulateFrame();
             }, 0);
         });
 

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -18,17 +18,17 @@ test('BoxZoomHandler fires boxzoomstart and boxzoomend events at appropriate tim
     map.on('boxzoomend',   boxzoomend);
 
     simulate.mousedown(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 0);
     t.equal(boxzoomend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {shiftKey: true, clientX: 5, clientY: 5});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 1);
     t.equal(boxzoomend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(), {shiftKey: true, clientX: 5, clientY: 5});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 1);
     t.equal(boxzoomend.callCount, 1);
 
@@ -57,17 +57,17 @@ test('BoxZoomHandler avoids conflicts with DragPanHandler when disabled and reen
     map.on('dragend',   dragend);
 
     simulate.mousedown(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 0);
     t.equal(boxzoomend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {shiftKey: true, clientX: 5, clientY: 5});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 1);
     t.equal(boxzoomend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(), {shiftKey: true, clientX: 5, clientY: 5});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(boxzoomstart.callCount, 1);
     t.equal(boxzoomend.callCount, 1);
 
@@ -91,13 +91,13 @@ test('BoxZoomHandler does not begin a box zoom if preventDefault is called on th
     map.on('boxzoomend',   boxzoomend);
 
     simulate.mousedown(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mousemove(map.getCanvas(), {shiftKey: true, clientX: 5, clientY: 5});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas(), {shiftKey: true, clientX: 5, clientY: 5});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     t.equal(boxzoomstart.callCount, 0);
     t.equal(boxzoomend.callCount, 0);

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -21,19 +21,19 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 1);
@@ -52,13 +52,13 @@ test('DragRotateHandler stops firing events after mouseup', (t) => {
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
     t.equal(spy.callCount, 3);
 
     spy.reset();
     simulate.mousemove(map.getCanvas(), {buttons: 0});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(spy.callCount, 0);
 
     map.remove();
@@ -77,19 +77,19 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 0, ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 1);
@@ -111,7 +111,7 @@ test('DragRotateHandler pitches in response to a right-click drag by default', (
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(pitchstart.callCount, 1);
     t.equal(pitch.callCount, 1);
 
@@ -135,7 +135,7 @@ test('DragRotateHandler pitches in response to a control-left-click drag', (t) =
 
     simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
     simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(pitchstart.callCount, 1);
     t.equal(pitch.callCount, 1);
 
@@ -157,12 +157,12 @@ test('DragRotateHandler does not pitch if given pitchWithRotate: false', (t) => 
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
     simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
     simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 0, ctrlKey: true});
 
     t.ok(spy.notCalled);
@@ -187,7 +187,7 @@ test('DragRotateHandler does not rotate or pitch when disabled', (t) => {
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
     t.ok(spy.notCalled);
@@ -225,7 +225,7 @@ test('DragRotateHandler fires move events', (t) => {
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(movestart.callCount, 1);
     t.equal(move.callCount, 1);
 
@@ -263,7 +263,7 @@ test('DragRotateHandler includes originalEvent property in triggered events', (t
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
     t.ok(rotatestart.firstCall.args[0].originalEvent.type, 'mousemove');
@@ -295,7 +295,7 @@ test('DragRotateHandler responds to events on the canvas container (#1301)', (t)
 
     simulate.mousedown(map.getCanvasContainer(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvasContainer(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
 
@@ -314,7 +314,7 @@ test('DragRotateHandler prevents mousemove events from firing during a drag (#15
 
     simulate.mousedown(map.getCanvasContainer(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvasContainer(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvasContainer(),   {buttons: 0, button: 2});
 
     t.ok(mousemove.notCalled);
@@ -336,7 +336,7 @@ test('DragRotateHandler ends a control-left-click drag on mouseup even when the 
 
     simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
     simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
 
@@ -360,7 +360,7 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
 
@@ -373,16 +373,18 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
 
 test('DragRotateHandler requests a new render frame after each mousemove event', (t) => {
     const map = createMap();
-    const update = t.spy(map, '_update');
+    const requestRenderFrame = t.spy(map, '_requestRenderFrame');
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    t.ok(update.callCount > 0);
+    t.ok(requestRenderFrame.callCount > 0);
+
+    map._renderTaskQueue.run();
 
     // https://github.com/mapbox/mapbox-gl-js/issues/6063
-    update.reset();
+    requestRenderFrame.reset();
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    t.equal(update.callCount, 1);
+    t.equal(requestRenderFrame.callCount, 1);
 
     map.remove();
     t.end();
@@ -401,31 +403,33 @@ test('DragRotateHandler can interleave with another handler', (t) => {
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     // simulates another handler taking over
-    map.stop();
+    // simulate a scroll zoom
+    simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
     t.equal(rotateend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
     t.equal(rotateend.callCount, 1);
@@ -447,19 +451,19 @@ test('DragRotateHandler does not begin a drag on left-button mousedown without t
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
     simulate.mouseup(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
@@ -481,37 +485,37 @@ test('DragRotateHandler does not end a right-button drag on left-button mouseup'
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousedown(map.getCanvas(), {buttons: 3, button: 0});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(),   {buttons: 2, button: 0});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
     t.equal(rotateend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
     t.equal(rotateend.callCount, 1);
@@ -533,37 +537,37 @@ test('DragRotateHandler does not end a control-left-button drag on right-button 
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousedown(map.getCanvas(), {buttons: 3, button: 2, ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(),   {buttons: 1, button: 2, ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
     t.equal(rotateend.callCount, 0);
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 0, ctrlKey: true});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
     t.equal(rotateend.callCount, 1);
@@ -586,13 +590,13 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
@@ -617,10 +621,10 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
         map.on('rotateend',   rotateend);
 
         simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         simulate.mousemove(map.getCanvas(), {buttons: 2});
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         t.equal(rotatestart.callCount, 1);
         t.equal(rotate.callCount, event === 'rotatestart' ? 0 : 1);
@@ -629,7 +633,7 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
         t.equal(map.dragRotate.isEnabled(), false);
 
         simulate.mouseup(map.getCanvas(), {buttons: 0, button: 2});
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         t.equal(rotatestart.callCount, 1);
         t.equal(rotate.callCount, event === 'rotatestart' ? 0 : 1);
@@ -654,12 +658,12 @@ test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     map.dragRotate.disable();
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
@@ -668,7 +672,7 @@ test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
     t.equal(map.dragRotate.isEnabled(), false);
 
     simulate.mouseup(map.getCanvas(), {buttons: 0, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -24,16 +24,16 @@ test('ScrollZoomHandler', (t) => {
 
     t.test('Zooms for single mouse wheel tick', (t) => {
         const map = createMap();
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         // simulate a single 'wheel' event
         const startZoom = map.getZoom();
 
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         now += 400;
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         t.equalWithPrecision(map.getZoom() - startZoom,  0.0285, 0.001);
 
@@ -43,7 +43,7 @@ test('ScrollZoomHandler', (t) => {
 
     t.test('Zooms for single mouse wheel tick with non-magical deltaY', (t) => {
         const map = createMap();
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         // Simulate a single 'wheel' event without the magical deltaY value.
         // This requires the handler to briefly wait to see if a subsequent
@@ -58,7 +58,7 @@ test('ScrollZoomHandler', (t) => {
     t.test('Zooms for multiple mouse wheel ticks', (t) => {
         const map = createMap();
 
-        map._updateCamera();
+        map._renderTaskQueue.run();
         const startZoom = map.getZoom();
 
         const events = [
@@ -83,7 +83,7 @@ test('ScrollZoomHandler', (t) => {
                 lastWheelEvent = now;
             }
             if (now % 20 === 0) {
-                map._updateCamera();
+                map._renderTaskQueue.run();
             }
         }
 
@@ -95,7 +95,7 @@ test('ScrollZoomHandler', (t) => {
 
     t.test('Gracefully ignores wheel events with deltaY: 0', (t) => {
         const map = createMap();
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         const startZoom = map.getZoom();
         // simulate  shift+'wheel' events
@@ -103,10 +103,10 @@ test('ScrollZoomHandler', (t) => {
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -0, shiftKey: true});
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -0, shiftKey: true});
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -0, shiftKey: true});
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         now += 400;
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         t.equal(map.getZoom() - startZoom, 0.0);
 
@@ -119,10 +119,10 @@ test('ScrollZoomHandler', (t) => {
         map.on('wheel', e => e.preventDefault());
 
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         now += 400;
-        map._updateCamera();
+        map._renderTaskQueue.run();
 
         t.equal(map.getZoom(), 0);
 

--- a/test/unit/ui/handler/touch_zoom_rotate.test.js
+++ b/test/unit/ui/handler/touch_zoom_rotate.test.js
@@ -20,25 +20,25 @@ test('TouchZoomRotateHandler fires zoomstart, zoom, and zoomend events at approp
     map.on('zoomend',   zoomend);
 
     simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: -5}, {clientX: 0, clientY: 5}]});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(zoomstart.callCount, 0);
     t.equal(zoom.callCount, 0);
     t.equal(zoomend.callCount, 0);
 
     simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: -10}, {clientX: 0, clientY: 10}]});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(zoomstart.callCount, 1);
     t.equal(zoom.callCount, 1);
     t.equal(zoomend.callCount, 0);
 
     simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: -5}, {clientX: 0, clientY: 5}]});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(zoomstart.callCount, 1);
     t.equal(zoom.callCount, 2);
     t.equal(zoomend.callCount, 0);
 
     simulate.touchend(map.getCanvas(), {touches: []});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(zoomstart.callCount, 1);
     t.equal(zoom.callCount, 2);
     t.equal(zoomend.callCount, 1);
@@ -59,25 +59,25 @@ test('TouchZoomRotateHandler fires rotatestart, rotate, and rotateend events at 
     map.on('rotateend',   rotateend);
 
     simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: -5}, {clientX: 0, clientY: 5}]});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
     simulate.touchmove(map.getCanvas(), {touches: [{clientX: -5, clientY: 0}, {clientX: 5, clientY: 0}]});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
     simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: -5}, {clientX: 0, clientY: 5}]});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
     t.equal(rotateend.callCount, 0);
 
     simulate.touchend(map.getCanvas(), {touches: []});
-    map._updateCamera();
+    map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
     t.equal(rotateend.callCount, 1);
@@ -95,13 +95,13 @@ test('TouchZoomRotateHandler does not begin a gesture if preventDefault is calle
     map.on('move', move);
 
     simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 5, clientY: 0}]});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 0, clientY: 5}]});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.touchend(map.getCanvas(), {touches: []});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     t.equal(move.callCount, 0);
 

--- a/test/unit/ui/map/isMoving.test.js
+++ b/test/unit/ui/map/isMoving.test.js
@@ -46,13 +46,13 @@ test('Map#isMoving returns true when drag panning', (t) => {
     });
 
     simulate.mousedown(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mousemove(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
 });
 
 test('Map#isMoving returns true when drag rotating', (t) => {
@@ -69,13 +69,13 @@ test('Map#isMoving returns true when drag rotating', (t) => {
     });
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 });
 
 test('Map#isMoving returns true when scroll zooming', (t) => {
@@ -96,10 +96,10 @@ test('Map#isMoving returns true when scroll zooming', (t) => {
     browserNow.callsFake(() => now);
 
     simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     now += 400;
-    map._updateCamera();
+    map._renderTaskQueue.run();
 });
 
 test('Map#isMoving returns true when drag panning and scroll zooming interleave', (t) => {
@@ -116,7 +116,7 @@ test('Map#isMoving returns true when drag panning and scroll zooming interleave'
     map.on('zoomend', () => {
         t.equal(map.isMoving(), true);
         simulate.mouseup(map.getCanvas());
-        map._updateCamera();
+        map._renderTaskQueue.run();
     });
 
     map.on('dragend', () => {
@@ -129,18 +129,18 @@ test('Map#isMoving returns true when drag panning and scroll zooming interleave'
     // pair is nested within a dragstart/dragend pair.
 
     simulate.mousedown(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mousemove(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     const browserNow = t.stub(browser, 'now');
     let now = 0;
     browserNow.callsFake(() => now);
 
     simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     now += 400;
-    map._updateCamera();
+    map._renderTaskQueue.run();
 });

--- a/test/unit/ui/map/isRotating.test.js
+++ b/test/unit/ui/map/isRotating.test.js
@@ -45,11 +45,11 @@ test('Map#isRotating returns true when drag rotating', (t) => {
     });
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mousemove(map.getCanvas(), {buttons: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 });

--- a/test/unit/ui/map/isZooming.test.js
+++ b/test/unit/ui/map/isZooming.test.js
@@ -49,10 +49,10 @@ test('Map#isZooming returns true when scroll zooming', (t) => {
     t.stub(browser, 'now').callsFake(() => now);
 
     simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     now += 400;
-    map._updateCamera();
+    map._renderTaskQueue.run();
 });
 
 test('Map#isZooming returns true when double-click zooming', (t) => {
@@ -72,8 +72,8 @@ test('Map#isZooming returns true when double-click zooming', (t) => {
     t.stub(browser, 'now').callsFake(() => now);
 
     simulate.dblclick(map.getCanvas());
-    map._updateCamera();
+    map._renderTaskQueue.run();
 
     now += 500;
-    map._updateCamera();
+    map._renderTaskQueue.run();
 });

--- a/test/unit/ui/map/requestRenderFrame.test.js
+++ b/test/unit/ui/map/requestRenderFrame.test.js
@@ -1,0 +1,47 @@
+import { test } from 'mapbox-gl-js-test';
+import window from '../../../../src/util/window';
+import Map from '../../../../src/ui/map';
+import DOM from '../../../../src/util/dom';
+
+function createMap() {
+    return new Map({
+        container: DOM.create('div', '', window.document.body),
+        style: {
+            "version": 8,
+            "sources": {},
+            "layers": []
+        }
+    });
+}
+
+test('Map#_requestRenderFrame schedules a new render frame if necessary', (t) => {
+    const map = createMap();
+    t.stub(map, '_rerender');
+    map._requestRenderFrame(() => {});
+    t.equal(map._rerender.callCount, 1);
+    map.remove();
+    t.end();
+});
+
+test('Map#_requestRenderFrame queues a task for the next render frame', (t) => {
+    const map = createMap();
+    const cb = t.spy();
+    map._requestRenderFrame(cb);
+    map.once('render', () => {
+        t.equal(cb.callCount, 1);
+        map.remove();
+        t.end();
+    });
+});
+
+test('Map#_cancelRenderFrame cancels a queued task', (t) => {
+    const map = createMap();
+    const cb = t.spy();
+    const id = map._requestRenderFrame(cb);
+    map._cancelRenderFrame(id);
+    map.once('render', () => {
+        t.equal(cb.callCount, 0);
+        map.remove();
+        t.end();
+    });
+});

--- a/test/unit/util/task_queue.test.js
+++ b/test/unit/util/task_queue.test.js
@@ -1,0 +1,122 @@
+import { test } from 'mapbox-gl-js-test';
+import TaskQueue from '../../../src/util/task_queue';
+
+test('TaskQueue', (t) => {
+    t.test('Calls callbacks, in order', (t) => {
+        const q = new TaskQueue();
+        let first = 0;
+        let second = 0;
+        q.add(() => t.equal(++first, 1) && t.equal(second, 0));
+        q.add(() => t.equal(first, 1) && t.equal(++second, 1));
+        q.run();
+        t.equal(first, 1);
+        t.equal(second, 1);
+        t.end();
+    });
+
+    t.test('Allows a given callback to be queued multiple times', (t) => {
+        const q = new TaskQueue();
+        const fn = t.spy();
+        q.add(fn);
+        q.add(fn);
+        q.run();
+        t.equal(fn.callCount, 2);
+        t.end();
+    });
+
+    t.test('Does not call a callback that was cancelled before the queue was run', (t) => {
+        const q = new TaskQueue();
+        const yes = t.spy();
+        const no = t.spy();
+        q.add(yes);
+        const id = q.add(no);
+        q.remove(id);
+        q.run();
+        t.equal(yes.callCount, 1);
+        t.equal(no.callCount, 0);
+        t.end();
+    });
+
+    t.test('Does not call a callback that was cancelled while the queue was running', (t) => {
+        const q = new TaskQueue();
+        const yes = t.spy();
+        const no = t.spy();
+        q.add(yes);
+        let id; // eslint-disable-line prefer-const
+        q.add(() => q.remove(id));
+        id = q.add(no);
+        q.run();
+        t.equal(yes.callCount, 1);
+        t.equal(no.callCount, 0);
+        t.end();
+    });
+
+
+    t.test('Allows each instance of a multiply-queued callback to be cancelled independently', (t) => {
+        const q = new TaskQueue();
+        const cb = t.spy();
+        q.add(cb);
+        const id = q.add(cb);
+        q.remove(id);
+        q.run();
+        t.equal(cb.callCount, 1);
+        t.end();
+    });
+
+    t.test('Does not throw if a remove() is called after running the queue', (t) => {
+        const q = new TaskQueue();
+        const cb = t.spy();
+        const id = q.add(cb);
+        q.run();
+        q.remove(id);
+        t.equal(cb.callCount, 1);
+        t.end();
+    });
+
+    t.test('Does not add tasks to the currently-running queue', (t) => {
+        const q = new TaskQueue();
+        const cb = t.spy();
+        q.add(() => q.add(cb));
+        q.run();
+        t.equal(cb.callCount, 0);
+        q.run();
+        t.equal(cb.callCount, 1);
+        t.end();
+    });
+
+    t.test('TaskQueue#run() throws on attempted re-entrance', (t) => {
+        const q = new TaskQueue();
+        q.add(() => q.run());
+        t.throws(() => q.run());
+        t.end();
+    });
+
+    t.test('TaskQueue#clear() prevents queued task from being executed', (t) => {
+        const q = new TaskQueue();
+        const before = t.spy();
+        const after = t.spy();
+        q.add(before);
+        q.clear();
+        q.add(after);
+        q.run();
+        t.equal(before.callCount, 0);
+        t.equal(after.callCount, 1);
+        t.end();
+    });
+
+    t.test('TaskQueue#clear() interrupts currently-running queue', (t) => {
+        const q = new TaskQueue();
+        const before = t.spy();
+        const after = t.spy();
+        q.add(() => q.add(after));
+        q.add(() => q.clear());
+        q.add(before);
+        q.run();
+        t.equal(before.callCount, 0);
+        q.run();
+        t.equal(after.callCount, 0);
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Fixes #6233

- [x] Update "can interleave with another handler" unit tests (`map.stop()` no longer correctly simulates another handler taking over)
- [ ] Add tests confirming that handlers are indifferent to relative timing of mouse events & render frames (or mouse events for different handlers)