### PR TITLE
Replace exported objects with named exports

### DIFF
--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -69,38 +69,30 @@ export interface Bucket {
     destroy(): void;
 }
 
-const exported = {
-    deserialize(input: Array<Bucket>, style: Style): {[string]: Bucket} {
-        const output = {};
+export function deserialize(input: Array<Bucket>, style: Style): {[string]: Bucket} {
+    const output = {};
 
-        // Guard against the case where the map's style has been set to null while
-        // this bucket has been parsing.
-        if (!style) return output;
+    // Guard against the case where the map's style has been set to null while
+    // this bucket has been parsing.
+    if (!style) return output;
 
-        for (const bucket of input) {
-            const layers = bucket.layerIds
-                .map((id) => style.getLayer(id))
-                .filter(Boolean);
+    for (const bucket of input) {
+        const layers = bucket.layerIds
+            .map((id) => style.getLayer(id))
+            .filter(Boolean);
 
-            if (layers.length === 0) {
-                continue;
-            }
-
-            // look up StyleLayer objects from layer ids (since we don't
-            // want to waste time serializing/copying them from the worker)
-            (bucket: any).layers = layers;
-
-            for (const layer of layers) {
-                output[layer.id] = bucket;
-            }
+        if (layers.length === 0) {
+            continue;
         }
 
-        return output;
+        // look up StyleLayer objects from layer ids (since we don't
+        // want to waste time serializing/copying them from the worker)
+        (bucket: any).layers = layers;
+
+        for (const layer of layers) {
+            output[layer.id] = bucket;
+        }
     }
-};
 
-export default exported;
-
-export const {
-    deserialize
-} = exported;
+    return output;
+}

--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -4,7 +4,7 @@ import { RGBAImage } from '../util/image';
 import { warnOnce, clamp } from '../util/util';
 import { register } from '../util/web_worker_transfer';
 
-class Level {
+export class Level {
     dim: number;
     border: number;
     stride: number;
@@ -44,7 +44,7 @@ register('Level', Level);
 // surrounding pixel values to compute the slope at that pixel, and we cannot accurately calculate the slope at pixels on a
 // tile's edge without backfilling from neighboring tiles.
 
-class DEMData {
+export default class DEMData {
     uid: string;
     scale: number;
     level: Level;
@@ -163,12 +163,3 @@ class DEMData {
 }
 
 register('DEMData', DEMData);
-
-const exported = {
-    DEMData,
-    Level
-};
-
-export default exported;
-export { DEMData, Level };
-

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -270,7 +270,7 @@ class CompositeExpressionBinder<T> implements Binder<T> {
  *
  * @private
  */
-class ProgramConfiguration {
+export default class ProgramConfiguration {
     binders: { [string]: Binder<any> };
     cacheKey: string;
     layoutAttributes: Array<StructArrayMember>;
@@ -365,7 +365,7 @@ class ProgramConfiguration {
     }
 }
 
-class ProgramConfigurationSet<Layer: TypedStyleLayer> {
+export class ProgramConfigurationSet<Layer: TypedStyleLayer> {
     programConfigurations: {[string]: ProgramConfiguration};
 
     constructor(layoutAttributes: Array<StructArrayMember>, layers: $ReadOnlyArray<Layer>, zoom: number, filterProperties: (string) => boolean = () => true) {
@@ -423,11 +423,3 @@ register('SourceExpressionBinder', SourceExpressionBinder);
 register('CompositeExpressionBinder', CompositeExpressionBinder);
 register('ProgramConfiguration', ProgramConfiguration, {omit: ['_buffers']});
 register('ProgramConfigurationSet', ProgramConfigurationSet);
-
-const exported = {
-    ProgramConfiguration,
-    ProgramConfigurationSet
-};
-
-export default exported;
-export { ProgramConfiguration, ProgramConfigurationSet };

--- a/src/gl/value.js
+++ b/src/gl/value.js
@@ -24,7 +24,7 @@ export interface Value<T> {
     set(value: T): void;
 }
 
-class ClearColor implements Value<Color> {
+export class ClearColor implements Value<Color> {
     context: Context;
     current: Color;
 
@@ -44,7 +44,7 @@ class ClearColor implements Value<Color> {
     }
 }
 
-class ClearDepth implements Value<number> {
+export class ClearDepth implements Value<number> {
     context: Context;
     current: number;
 
@@ -63,7 +63,7 @@ class ClearDepth implements Value<number> {
     }
 }
 
-class ClearStencil implements Value<number> {
+export class ClearStencil implements Value<number> {
     context: Context;
     current: number;
 
@@ -82,7 +82,7 @@ class ClearStencil implements Value<number> {
     }
 }
 
-class ColorMask implements Value<ColorMaskType> {
+export class ColorMask implements Value<ColorMaskType> {
     context: Context;
     current: ColorMaskType;
 
@@ -102,7 +102,7 @@ class ColorMask implements Value<ColorMaskType> {
     }
 }
 
-class DepthMask implements Value<DepthMaskType> {
+export class DepthMask implements Value<DepthMaskType> {
     context: Context;
     current: DepthMaskType;
 
@@ -121,7 +121,7 @@ class DepthMask implements Value<DepthMaskType> {
     }
 }
 
-class StencilMask implements Value<number> {
+export class StencilMask implements Value<number> {
     context: Context;
     current: number;
 
@@ -140,7 +140,7 @@ class StencilMask implements Value<number> {
     }
 }
 
-class StencilFunc implements Value<StencilFuncType> {
+export class StencilFunc implements Value<StencilFuncType> {
     context: Context;
     current: StencilFuncType;
 
@@ -164,7 +164,7 @@ class StencilFunc implements Value<StencilFuncType> {
     }
 }
 
-class StencilOp implements Value<StencilOpType> {
+export class StencilOp implements Value<StencilOpType> {
     context: Context;
     current: StencilOpType;
 
@@ -185,7 +185,7 @@ class StencilOp implements Value<StencilOpType> {
     }
 }
 
-class StencilTest implements Value<boolean> {
+export class StencilTest implements Value<boolean> {
     context: Context;
     current: boolean;
 
@@ -209,7 +209,7 @@ class StencilTest implements Value<boolean> {
     }
 }
 
-class DepthRange implements Value<DepthRangeType> {
+export class DepthRange implements Value<DepthRangeType> {
     context: Context;
     current: DepthRangeType;
 
@@ -229,7 +229,7 @@ class DepthRange implements Value<DepthRangeType> {
     }
 }
 
-class DepthTest implements Value<boolean> {
+export class DepthTest implements Value<boolean> {
     context: Context;
     current: boolean;
 
@@ -253,7 +253,7 @@ class DepthTest implements Value<boolean> {
     }
 }
 
-class DepthFunc implements Value<DepthFuncType> {
+export class DepthFunc implements Value<DepthFuncType> {
     context: Context;
     current: DepthFuncType;
 
@@ -272,7 +272,7 @@ class DepthFunc implements Value<DepthFuncType> {
     }
 }
 
-class Blend implements Value<boolean> {
+export class Blend implements Value<boolean> {
     context: Context;
     current: boolean;
 
@@ -296,7 +296,7 @@ class Blend implements Value<boolean> {
     }
 }
 
-class BlendFunc implements Value<BlendFuncType> {
+export class BlendFunc implements Value<BlendFuncType> {
     context: Context;
     current: BlendFuncType;
 
@@ -317,7 +317,7 @@ class BlendFunc implements Value<BlendFuncType> {
     }
 }
 
-class BlendColor implements Value<Color> {
+export class BlendColor implements Value<Color> {
     context: Context;
     current: Color;
 
@@ -337,7 +337,7 @@ class BlendColor implements Value<Color> {
     }
 }
 
-class Program implements Value<?WebGLProgram> {
+export class Program implements Value<?WebGLProgram> {
     context: Context;
     current: ?WebGLProgram;
 
@@ -356,7 +356,7 @@ class Program implements Value<?WebGLProgram> {
     }
 }
 
-class LineWidth implements Value<number> {
+export class LineWidth implements Value<number> {
     context: Context;
     current: number;
 
@@ -377,7 +377,7 @@ class LineWidth implements Value<number> {
     }
 }
 
-class ActiveTextureUnit implements Value<TextureUnitType> {
+export class ActiveTextureUnit implements Value<TextureUnitType> {
     context: Context;
     current: TextureUnitType;
 
@@ -396,7 +396,7 @@ class ActiveTextureUnit implements Value<TextureUnitType> {
     }
 }
 
-class Viewport implements Value<ViewportType> {
+export class Viewport implements Value<ViewportType> {
     context: Context;
     current: ViewportType;
 
@@ -417,7 +417,7 @@ class Viewport implements Value<ViewportType> {
     }
 }
 
-class BindFramebuffer implements Value<?WebGLFramebuffer> {
+export class BindFramebuffer implements Value<?WebGLFramebuffer> {
     context: Context;
     current: ?WebGLFramebuffer;
 
@@ -437,7 +437,7 @@ class BindFramebuffer implements Value<?WebGLFramebuffer> {
     }
 }
 
-class BindRenderbuffer implements Value<?WebGLRenderbuffer> {
+export class BindRenderbuffer implements Value<?WebGLRenderbuffer> {
     context: Context;
     current: ?WebGLRenderbuffer;
 
@@ -457,7 +457,7 @@ class BindRenderbuffer implements Value<?WebGLRenderbuffer> {
     }
 }
 
-class BindTexture implements Value<?WebGLTexture> {
+export class BindTexture implements Value<?WebGLTexture> {
     context: Context;
     current: ?WebGLTexture;
 
@@ -477,7 +477,7 @@ class BindTexture implements Value<?WebGLTexture> {
     }
 }
 
-class BindVertexBuffer implements Value<?WebGLBuffer> {
+export class BindVertexBuffer implements Value<?WebGLBuffer> {
     context: Context;
     current: ?WebGLBuffer;
 
@@ -497,7 +497,7 @@ class BindVertexBuffer implements Value<?WebGLBuffer> {
     }
 }
 
-class BindElementBuffer implements Value<?WebGLBuffer> {
+export class BindElementBuffer implements Value<?WebGLBuffer> {
     context: Context;
     current: ?WebGLBuffer;
 
@@ -516,7 +516,7 @@ class BindElementBuffer implements Value<?WebGLBuffer> {
     }
 }
 
-class BindVertexArrayOES implements Value<any> {
+export class BindVertexArrayOES implements Value<any> {
     context: Context;
     current: any;
 
@@ -535,7 +535,7 @@ class BindVertexArrayOES implements Value<any> {
     }
 }
 
-class PixelStoreUnpack implements Value<number> {
+export class PixelStoreUnpack implements Value<number> {
     context: Context;
     current: number;
 
@@ -555,7 +555,7 @@ class PixelStoreUnpack implements Value<number> {
     }
 }
 
-class PixelStoreUnpackPremultiplyAlpha implements Value<boolean> {
+export class PixelStoreUnpackPremultiplyAlpha implements Value<boolean> {
     context: Context;
     current: boolean;
 
@@ -579,7 +579,7 @@ class PixelStoreUnpackPremultiplyAlpha implements Value<boolean> {
  * Framebuffer values
  * @private
  */
-class FramebufferValue<T> {
+export class FramebufferValue<T> {
     context: Context;
     parent: WebGLFramebuffer;
     current: ?T;
@@ -593,7 +593,7 @@ class FramebufferValue<T> {
     get(): ?T { return this.current; }
 }
 
-class ColorAttachment extends FramebufferValue<?WebGLTexture> implements Value<?WebGLTexture> {
+export class ColorAttachment extends FramebufferValue<?WebGLTexture> implements Value<?WebGLTexture> {
     dirty: boolean;
 
     constructor(context: Context, parent: WebGLFramebuffer) {
@@ -618,7 +618,7 @@ class ColorAttachment extends FramebufferValue<?WebGLTexture> implements Value<?
     }
 }
 
-class DepthAttachment extends FramebufferValue<?WebGLRenderbuffer> implements Value<?WebGLRenderbuffer> {
+export class DepthAttachment extends FramebufferValue<?WebGLRenderbuffer> implements Value<?WebGLRenderbuffer> {
     set(v: ?WebGLRenderbuffer): void {
         if (this.current !== v) {
             const gl = this.context.gl;
@@ -630,38 +630,3 @@ class DepthAttachment extends FramebufferValue<?WebGLRenderbuffer> implements Va
         }
     }
 }
-
-const exported = {
-    ClearColor,
-    ClearDepth,
-    ClearStencil,
-    ColorMask,
-    DepthMask,
-    StencilMask,
-    StencilFunc,
-    StencilOp,
-    StencilTest,
-    DepthRange,
-    DepthTest,
-    DepthFunc,
-    Blend,
-    BlendFunc,
-    BlendColor,
-    Program,
-    LineWidth,
-    ActiveTextureUnit,
-    Viewport,
-    BindFramebuffer,
-    BindRenderbuffer,
-    BindTexture,
-    BindVertexBuffer,
-    BindElementBuffer,
-    BindVertexArrayOES,
-    PixelStoreUnpack,
-    PixelStoreUnpackPremultiplyAlpha,
-    ColorAttachment,
-    DepthAttachment
-};
-
-export default exported;
-export { ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, Program, LineWidth, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha, ColorAttachment, DepthAttachment };

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -11,7 +11,7 @@ import VertexArrayObject from './vertex_array_object';
 import { RasterBoundsArray, PosArray } from '../data/array_types';
 import rasterBoundsAttributes from '../data/raster_bounds_attributes';
 import posAttributes from '../data/pos_attributes';
-import { ProgramConfiguration } from '../data/program_configuration';
+import ProgramConfiguration from '../data/program_configuration';
 import CrossTileSymbolIndex from '../symbol/cross_tile_symbol_index';
 import shaders from '../shaders';
 import Program from './program';

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -4,7 +4,7 @@ import browser from '../util/browser';
 
 import shaders from '../shaders';
 import assert from 'assert';
-import { ProgramConfiguration } from '../data/program_configuration';
+import ProgramConfiguration from '../data/program_configuration';
 import VertexArrayObject from './vertex_array_object';
 import Context from '../gl/context';
 

--- a/src/source/raster_dem_tile_worker_source.js
+++ b/src/source/raster_dem_tile_worker_source.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { DEMData } from '../data/dem_data';
+import DEMData from '../data/dem_data';
 
 import type Actor from '../util/actor';
 import type {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -23,7 +23,7 @@ const CLOCK_SKEW_RETRY_TIMEOUT = 30000;
 import type {Bucket} from '../data/bucket';
 import type StyleLayer from '../style/style_layer';
 import type {WorkerTileResult} from './worker_source';
-import type {DEMData} from '../data/dem_data';
+import type DEMData from '../data/dem_data';
 import type {RGBAImage, AlphaImage} from '../util/image';
 import type Mask from '../render/tile_mask';
 import type Context from '../gl/context';

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -6,7 +6,7 @@ import assert from 'assert';
 import { register } from '../util/web_worker_transfer';
 import Coordinate from '../geo/coordinate';
 
-class CanonicalTileID {
+export class CanonicalTileID {
     z: number;
     x: number;
     y: number;
@@ -41,7 +41,7 @@ class CanonicalTileID {
     }
 }
 
-class UnwrappedTileID {
+export class UnwrappedTileID {
     wrap: number;
     canonical: CanonicalTileID;
     key: number;
@@ -53,7 +53,7 @@ class UnwrappedTileID {
     }
 }
 
-class OverscaledTileID {
+export class OverscaledTileID {
     overscaledZ: number;
     wrap: number;
     canonical: CanonicalTileID;
@@ -158,12 +158,3 @@ function getQuadkey(z, x, y) {
 
 register('CanonicalTileID', CanonicalTileID);
 register('OverscaledTileID', OverscaledTileID, {omit: ['posMatrix']});
-
-const exported = {
-    CanonicalTileID: CanonicalTileID,
-    OverscaledTileID: OverscaledTileID,
-    UnwrappedTileID: UnwrappedTileID
-};
-
-export default exported;
-export { CanonicalTileID, OverscaledTileID, UnwrappedTileID };

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -6,7 +6,7 @@ import type {OverscaledTileID} from './tile_id';
 import type {Bucket} from '../data/bucket';
 import type FeatureIndex from '../data/feature_index';
 import type {CollisionBoxArray} from '../data/array_types';
-import type {DEMData} from '../data/dem_data';
+import type DEMData from '../data/dem_data';
 import type {PerformanceResourceTiming} from '../types/performance_resource_timing';
 
 export type TileParameters = {

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -34,7 +34,7 @@ export type GlobalProperties = {
     heatmapDensity?: number
 };
 
-class StyleExpression {
+export class StyleExpression {
     expression: Expression;
 
     _evaluator: EvaluationContext;
@@ -54,7 +54,7 @@ class StyleExpression {
     }
 }
 
-class StyleExpressionWithErrorHandling extends StyleExpression {
+export class StyleExpressionWithErrorHandling extends StyleExpression {
     _defaultValue: Value;
     _warningHistory: {[key: string]: boolean};
     _enumValues: {[string]: any};
@@ -99,7 +99,7 @@ class StyleExpressionWithErrorHandling extends StyleExpression {
     }
 }
 
-function isExpression(expression: mixed) {
+export function isExpression(expression: mixed) {
     return Array.isArray(expression) && expression.length > 0 &&
         typeof expression[0] === 'string' && expression[0] in definitions;
 }
@@ -113,7 +113,7 @@ function isExpression(expression: mixed) {
  *
  * @private
  */
-function createExpression(expression: mixed,
+export function createExpression(expression: mixed,
                           propertySpec: StylePropertySpecification,
                           options: {handleErrors?: boolean} = {}): Result<StyleExpression, Array<ParsingError>> {
     const parser = new ParsingContext(definitions, [], getExpectedType(propertySpec));
@@ -130,7 +130,7 @@ function createExpression(expression: mixed,
     }
 }
 
-class ZoomConstantExpression<Kind> {
+export class ZoomConstantExpression<Kind> {
     kind: Kind;
     _styleExpression: StyleExpression;
     constructor(kind: Kind, expression: StyleExpression) {
@@ -142,7 +142,7 @@ class ZoomConstantExpression<Kind> {
     }
 }
 
-class ZoomDependentExpression<Kind> {
+export class ZoomDependentExpression<Kind> {
     kind: Kind;
     zoomStops: Array<number>;
 
@@ -201,7 +201,7 @@ export type StylePropertyExpression =
     | CameraExpression
     | CompositeExpression;
 
-function createPropertyExpression(expression: mixed,
+export function createPropertyExpression(expression: mixed,
                                   propertySpec: StylePropertySpecification,
                                   options: {handleErrors?: boolean} = {}): Result<StylePropertyExpression, Array<ParsingError>> {
     expression = createExpression(expression, propertySpec, options);
@@ -246,7 +246,7 @@ import { Color } from './values';
 
 // serialization wrapper for old-style stop functions normalized to the
 // expression interface
-class StylePropertyFunction<T> {
+export class StylePropertyFunction<T> {
     _parameters: PropertyValueSpecification<T>;
     _specification: StylePropertySpecification;
 
@@ -273,7 +273,7 @@ class StylePropertyFunction<T> {
     }
 }
 
-function normalizePropertyExpression<T>(value: PropertyValueSpecification<T>, specification: StylePropertySpecification): StylePropertyExpression {
+export function normalizePropertyExpression<T>(value: PropertyValueSpecification<T>, specification: StylePropertySpecification): StylePropertyExpression {
     if (isFunction(value)) {
         return (new StylePropertyFunction(value, specification): any);
 
@@ -296,21 +296,6 @@ function normalizePropertyExpression<T>(value: PropertyValueSpecification<T>, sp
         };
     }
 }
-
-const exported = {
-    StyleExpression,
-    StyleExpressionWithErrorHandling,
-    isExpression,
-    createExpression,
-    createPropertyExpression,
-    normalizePropertyExpression,
-    ZoomConstantExpression,
-    ZoomDependentExpression,
-    StylePropertyFunction
-};
-
-export default exported;
-export { StyleExpression, StyleExpressionWithErrorHandling, isExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction };
 
 // Zoom-dependent expressions may only use ["zoom"] as the input to a top-level "step" or "interpolate"
 // expression (collectively referred to as a "curve"). The curve may be wrapped in one or more "let" or

--- a/src/style-spec/expression/stops.js
+++ b/src/style-spec/expression/stops.js
@@ -10,7 +10,7 @@ export type Stops = Array<[number, Expression]>;
  * Returns the index of the last stop <= input, or 0 if it doesn't exist.
  * @private
  */
-function findStopLessThanOrEqualTo(stops: Array<number>, input: number) {
+export function findStopLessThanOrEqualTo(stops: Array<number>, input: number) {
     const n = stops.length;
     let lowerIndex = 0;
     let upperIndex = n - 1;
@@ -34,10 +34,3 @@ function findStopLessThanOrEqualTo(stops: Array<number>, input: number) {
 
     return Math.max(currentIndex - 1, 0);
 }
-
-const exported = {
-    findStopLessThanOrEqualTo
-};
-
-export default exported;
-export { findStopLessThanOrEqualTo };

--- a/src/style-spec/expression/types.js
+++ b/src/style-spec/expression/types.js
@@ -26,16 +26,16 @@ export type ArrayType = {
     N: ?number
 }
 
-const NullType = { kind: 'null' };
-const NumberType = { kind: 'number' };
-const StringType = { kind: 'string' };
-const BooleanType = { kind: 'boolean' };
-const ColorType = { kind: 'color' };
-const ObjectType = { kind: 'object' };
-const ValueType = { kind: 'value' };
-const ErrorType = { kind: 'error' };
+export const NullType = { kind: 'null' };
+export const NumberType = { kind: 'number' };
+export const StringType = { kind: 'string' };
+export const BooleanType = { kind: 'boolean' };
+export const ColorType = { kind: 'color' };
+export const ObjectType = { kind: 'object' };
+export const ValueType = { kind: 'value' };
+export const ErrorType = { kind: 'error' };
 
-function array(itemType: Type, N: ?number): ArrayType {
+export function array(itemType: Type, N: ?number): ArrayType {
     return {
         kind: 'array',
         itemType,
@@ -43,7 +43,7 @@ function array(itemType: Type, N: ?number): ArrayType {
     };
 }
 
-function toString(type: Type): string {
+export function toString(type: Type): string {
     if (type.kind === 'array') {
         const itemType = toString(type.itemType);
         return typeof type.N === 'number' ?
@@ -69,7 +69,7 @@ const valueMemberTypes = [
  * error message.
  * @private
  */
-function checkSubtype(expected: Type, t: Type): ?string {
+export function checkSubtype(expected: Type, t: Type): ?string {
     if (t.kind === 'error') {
         // Error is a subtype of every type
         return null;
@@ -91,20 +91,3 @@ function checkSubtype(expected: Type, t: Type): ?string {
 
     return `Expected ${toString(expected)} but found ${toString(t)} instead.`;
 }
-
-const exported = {
-    NullType,
-    NumberType,
-    StringType,
-    BooleanType,
-    ColorType,
-    ObjectType,
-    ValueType,
-    array,
-    ErrorType,
-    toString,
-    checkSubtype
-};
-
-export default exported;
-export { NullType, NumberType, StringType, BooleanType, ColorType, ObjectType, ValueType, array, ErrorType, toString, checkSubtype };

--- a/src/style-spec/expression/values.js
+++ b/src/style-spec/expression/values.js
@@ -7,7 +7,7 @@ import { NullType, NumberType, StringType, BooleanType, ColorType, ObjectType, V
 
 import type { Type } from './types';
 
-function validateRGBA(r: mixed, g: mixed, b: mixed, a?: mixed): ?string {
+export function validateRGBA(r: mixed, g: mixed, b: mixed, a?: mixed): ?string {
     if (!(
         typeof r === 'number' && r >= 0 && r <= 255 &&
         typeof g === 'number' && g >= 0 && g <= 255 &&
@@ -28,7 +28,7 @@ function validateRGBA(r: mixed, g: mixed, b: mixed, a?: mixed): ?string {
 
 export type Value = null | string | boolean | number | Color | $ReadOnlyArray<Value> | { +[string]: Value }
 
-function isValue(mixed: mixed): boolean {
+export function isValue(mixed: mixed): boolean {
     if (mixed === null) {
         return true;
     } else if (typeof mixed === 'string') {
@@ -58,7 +58,7 @@ function isValue(mixed: mixed): boolean {
     }
 }
 
-function typeOf(value: Value): Type {
+export function typeOf(value: Value): Type {
     if (value === null) {
         return NullType;
     } else if (typeof value === 'string') {
@@ -92,12 +92,4 @@ function typeOf(value: Value): Type {
     }
 }
 
-const exported = {
-    Color,
-    validateRGBA,
-    isValue,
-    typeOf
-};
-
-export default exported;
-export { Color, validateRGBA, isValue, typeOf };
+export {Color};

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -6,7 +6,7 @@ import getType from '../util/get_type';
 import * as interpolate from '../util/interpolate';
 import Interpolate from '../expression/definitions/interpolate';
 
-function isFunction(value) {
+export function isFunction(value) {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
@@ -14,7 +14,7 @@ function identityFunction(x) {
     return x;
 }
 
-function createFunction(parameters, propertySpec) {
+export function createFunction(parameters, propertySpec) {
     const isColor = propertySpec.type === 'color';
     const zoomAndFeatureDependent = parameters.stops && typeof parameters.stops[0][0] === 'object';
     const featureDependent = zoomAndFeatureDependent || parameters.property !== undefined;
@@ -277,11 +277,3 @@ function interpolationFactor(input, base, lowerValue, upperValue) {
         return (Math.pow(base, progress) - 1) / (Math.pow(base, difference) - 1);
     }
 }
-
-const exported = {
-    createFunction,
-    isFunction
-};
-
-export default exported;
-export { createFunction, isFunction };

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -60,10 +60,10 @@ import composite from './composite';
 import diff from './diff';
 import ValidationError from './error/validation_error';
 import ParsingError from './error/parsing_error';
-import expression from './expression';
+import { StyleExpression, StyleExpressionWithErrorHandling, isExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction } from './expression';
 import featureFilter from './feature_filter';
 import Color from './util/color';
-import styleFunction from './function';
+import { createFunction, isFunction } from './function';
 import convertFunction from './function/convert';
 
 import validate from './validate_style';
@@ -76,16 +76,28 @@ const exported = {
     diff,
     ValidationError,
     ParsingError,
-    expression,
+    expression: {
+        StyleExpression,
+        StyleExpressionWithErrorHandling,
+        isExpression,
+        createExpression,
+        createPropertyExpression,
+        normalizePropertyExpression,
+        ZoomConstantExpression,
+        ZoomDependentExpression,
+        StylePropertyFunction
+    },
     featureFilter,
     Color,
-    function: styleFunction,
+    function: {
+        convertFunction,
+        createFunction,
+        isFunction
+    },
     validate
 };
 
 export default exported;
-
-exported.function.convertFunction = convertFunction;
 
 validate.parsed = validate;
 validate.latest = validate;

--- a/src/style-spec/util/result.js
+++ b/src/style-spec/util/result.js
@@ -10,18 +10,10 @@ export type Result<T, E> =
     | {| result: 'success', value: T |}
     | {| result: 'error', value: E |};
 
-function success<T, E>(value: T): Result<T, E> {
+export function success<T, E>(value: T): Result<T, E> {
     return { result: 'success', value };
 }
 
-function error<T, E>(value: E): Result<T, E> {
+export function error<T, E>(value: E): Result<T, E> {
     return { result: 'error', value };
 }
-
-const exported = {
-    success,
-    error
-};
-
-export default exported;
-export { success, error };

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -82,7 +82,7 @@ export interface Property<T, R> {
  *
  *  @private
  */
-class PropertyValue<T, R> {
+export class PropertyValue<T, R> {
     property: Property<T, R>;
     value: PropertyValueSpecification<T> | void;
     expression: StylePropertyExpression;
@@ -158,7 +158,7 @@ type TransitionablePropertyValues<Props: Object>
  *
  * @private
  */
-class Transitionable<Props: Object> {
+export class Transitionable<Props: Object> {
     _properties: Properties<Props>;
     _values: TransitionablePropertyValues<Props>;
 
@@ -300,7 +300,7 @@ type TransitioningPropertyValues<Props: Object>
  *
  * @private
  */
-class Transitioning<Props: Object> {
+export class Transitioning<Props: Object> {
     _properties: Properties<Props>;
     _values: TransitioningPropertyValues<Props>;
 
@@ -349,7 +349,7 @@ type PropertyValues<Props: Object>
  *
  * @private
  */
-class Layout<Props: Object> {
+export class Layout<Props: Object> {
     _properties: Properties<Props>;
     _values: PropertyValues<Props>;
 
@@ -422,7 +422,7 @@ type PossiblyEvaluatedValue<T> =
  *
  * @private
  */
-class PossiblyEvaluatedPropertyValue<T> {
+export class PossiblyEvaluatedPropertyValue<T> {
     property: DataDrivenProperty<T>;
     value: PossiblyEvaluatedValue<T>;
     globals: GlobalProperties;
@@ -475,7 +475,7 @@ type PossiblyEvaluatedPropertyValues<Props: Object>
  * given layer type.
  * @private
  */
-class PossiblyEvaluated<Props: Object> {
+export class PossiblyEvaluated<Props: Object> {
     _properties: Properties<Props>;
     _values: PossiblyEvaluatedPropertyValues<Props>;
 
@@ -496,7 +496,7 @@ class PossiblyEvaluated<Props: Object> {
  *
  * @private
  */
-class DataConstantProperty<T> implements Property<T, T> {
+export class DataConstantProperty<T> implements Property<T, T> {
     specification: StylePropertySpecification;
 
     constructor(specification: StylePropertySpecification) {
@@ -525,7 +525,7 @@ class DataConstantProperty<T> implements Property<T, T> {
  *
  * @private
  */
-class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPropertyValue<T>> {
+export class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPropertyValue<T>> {
     specification: StylePropertySpecification;
 
     constructor(specification: StylePropertySpecification) {
@@ -582,7 +582,7 @@ class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPropertyValu
  *
  * @private
  */
-class CrossFadedProperty<T> implements Property<T, ?CrossFaded<T>> {
+export class CrossFadedProperty<T> implements Property<T, ?CrossFaded<T>> {
     specification: StylePropertySpecification;
 
     constructor(specification: StylePropertySpecification) {
@@ -625,7 +625,7 @@ class CrossFadedProperty<T> implements Property<T, ?CrossFaded<T>> {
  *
  * @private
  */
-class HeatmapColorProperty implements Property<Color, void> {
+export class HeatmapColorProperty implements Property<Color, void> {
     specification: StylePropertySpecification;
 
     constructor(specification: StylePropertySpecification) {
@@ -647,7 +647,7 @@ class HeatmapColorProperty implements Property<Color, void> {
  *
  * @private
  */
-class Properties<Props: Object> {
+export class Properties<Props: Object> {
     properties: Props;
     defaultPropertyValues: PropertyValues<Props>;
     defaultTransitionablePropertyValues: TransitionablePropertyValues<Props>;
@@ -679,20 +679,3 @@ register('DataDrivenProperty', DataDrivenProperty);
 register('DataConstantProperty', DataConstantProperty);
 register('CrossFadedProperty', CrossFadedProperty);
 register('HeatmapColorProperty', HeatmapColorProperty);
-
-const exported = {
-    PropertyValue,
-    Transitionable,
-    Transitioning,
-    Layout,
-    PossiblyEvaluatedPropertyValue,
-    PossiblyEvaluated,
-    DataConstantProperty,
-    DataDrivenProperty,
-    CrossFadedProperty,
-    HeatmapColorProperty,
-    Properties
-};
-
-export default exported;
-export { PropertyValue, Transitionable, Transitioning, Layout, PossiblyEvaluatedPropertyValue, PossiblyEvaluated, DataConstantProperty, DataDrivenProperty, CrossFadedProperty, HeatmapColorProperty, Properties };

--- a/src/style/query_utils.js
+++ b/src/style/query_utils.js
@@ -7,7 +7,7 @@ import type StyleLayer from '../style/style_layer';
 import type CircleBucket from '../data/bucket/circle_bucket';
 import type LineBucket from '../data/bucket/line_bucket';
 
-function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: CircleBucket<*> | LineBucket): number {
+export function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: CircleBucket<*> | LineBucket): number {
     const value = ((layer.paint: any).get(property): PossiblyEvaluatedPropertyValue<any>).value;
     if (value.kind === 'constant') {
         return value.value;
@@ -17,11 +17,11 @@ function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: Circl
     }
 }
 
-function translateDistance(translate: [number, number]) {
+export function translateDistance(translate: [number, number]) {
     return Math.sqrt(translate[0] * translate[0] + translate[1] * translate[1]);
 }
 
-function translate(queryGeometry: Array<Array<Point>>,
+export function translate(queryGeometry: Array<Array<Point>>,
                    translate: [number, number],
                    translateAnchor: 'viewport' | 'map',
                    bearing: number,
@@ -47,12 +47,3 @@ function translate(queryGeometry: Array<Array<Point>>,
     }
     return translated;
 }
-
-const exported = {
-    getMaximumPaintValue,
-    translateDistance,
-    translate
-};
-
-export default exported;
-export { getMaximumPaintValue, translateDistance, translate };

--- a/src/symbol/quads.js
+++ b/src/symbol/quads.js
@@ -10,14 +10,6 @@ import type SymbolStyleLayer from '../style/style_layer/symbol_style_layer';
 import type {Feature} from '../style-spec/expression';
 import type {GlyphPosition} from '../render/glyph_atlas';
 
-const exported = {
-    getIconQuads,
-    getGlyphQuads
-};
-
-export default exported;
-export { getIconQuads, getGlyphQuads };
-
 /**
  * A textured quad for rendering a single icon or glyph.
  *
@@ -50,7 +42,7 @@ export type SymbolQuad = {
  * Create the quads used for rendering an icon.
  * @private
  */
-function getIconQuads(anchor: Anchor,
+export function getIconQuads(anchor: Anchor,
                       shapedIcon: PositionedIcon,
                       layer: SymbolStyleLayer,
                       alongLine: boolean,
@@ -130,7 +122,7 @@ function getIconQuads(anchor: Anchor,
  * Create the quads used for rendering a text label.
  * @private
  */
-function getGlyphQuads(anchor: Anchor,
+export function getGlyphQuads(anchor: Anchor,
                        shaping: Shaping,
                        layer: SymbolStyleLayer,
                        alongLine: boolean,

--- a/src/symbol/symbol_layout.js
+++ b/src/symbol/symbol_layout.js
@@ -31,13 +31,6 @@ import type {PossiblyEvaluatedPropertyValue} from '../style/properties';
 
 import Point from '@mapbox/point-geometry';
 
-const exported = {
-    performSymbolLayout
-};
-
-export default exported;
-export { performSymbolLayout };
-
 // The symbol layout process needs `text-size` evaluated at up to five different zoom levels, and
 // `icon-size` at up to three:
 //
@@ -60,7 +53,7 @@ type Sizes = {
     compositeIconSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>], // (5)
 };
 
-function performSymbolLayout(bucket: SymbolBucket,
+export function performSymbolLayout(bucket: SymbolBucket,
                              glyphMap: {[string]: {[number]: ?StyleGlyph}},
                              glyphPositions: {[string]: {[number]: GlyphPosition}},
                              imageMap: {[string]: StyleImage},

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -14,7 +14,7 @@ import type LngLatBounds from '../geo/lng_lat_bounds';
  * `MapMouseEvent` is the event type for mouse-related map events.
  * @extends {Object}
  */
-class MapMouseEvent extends Event {
+export class MapMouseEvent extends Event {
     /**
      * The event type.
      */
@@ -89,7 +89,7 @@ class MapMouseEvent extends Event {
  * `MapTouchEvent` is the event type for touch-related map events.
  * @extends {Object}
  */
-class MapTouchEvent extends Event {
+export class MapTouchEvent extends Event {
     /**
      * The event type.
      */
@@ -172,7 +172,7 @@ class MapTouchEvent extends Event {
  * `MapWheelEvent` is the event type for the `wheel` map event.
  * @extends {Object}
  */
-class MapWheelEvent extends Event {
+export class MapWheelEvent extends Event {
     /**
      * The event type.
      */
@@ -785,12 +785,3 @@ export type MapEvent =
      * @private
      */
     | 'style.load';
-
-const exported = {
-    MapMouseEvent,
-    MapTouchEvent,
-    MapWheelEvent
-};
-
-export default exported;
-export { MapMouseEvent, MapTouchEvent, MapWheelEvent };

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -19,7 +19,7 @@ function _removeEventListener(type: string, listener: Listener, listenerList: Li
     }
 }
 
-class Event {
+export class Event {
     +type: string;
 
     constructor(type: string, data: Object = {}) {
@@ -28,7 +28,7 @@ class Event {
     }
 }
 
-class ErrorEvent extends Event {
+export class ErrorEvent extends Event {
     constructor(error: Error, data: Object = {}) {
         super('error', extend({error}, data));
     }
@@ -39,7 +39,7 @@ class ErrorEvent extends Event {
  *
  * @mixin Evented
  */
-class Evented {
+export class Evented {
     _listeners: Listeners;
     _oneTimeListeners: Listeners;
     _eventedParent: ?Evented;
@@ -156,12 +156,3 @@ class Evented {
         return this;
     }
 }
-
-const exported = {
-    Event,
-    ErrorEvent,
-    Evented
-};
-
-export default exported;
-export { Event, ErrorEvent, Evented };

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -78,7 +78,7 @@ function copyImage(srcImg: *, dstImg: *, srcPt: Point, dstPt: Point, size: Size,
     return dstImg;
 }
 
-class AlphaImage {
+export class AlphaImage {
     width: number;
     height: number;
     data: Uint8Array | Uint8ClampedArray;
@@ -102,7 +102,7 @@ class AlphaImage {
 
 // Not premultiplied, because ImageData is not premultiplied.
 // UNPACK_PREMULTIPLY_ALPHA_WEBGL must be used when uploading to a texture.
-class RGBAImage {
+export class RGBAImage {
     width: number;
     height: number;
     data: Uint8Array | Uint8ClampedArray;
@@ -126,11 +126,3 @@ class RGBAImage {
 
 register('AlphaImage', AlphaImage);
 register('RGBAImage', RGBAImage);
-
-const exported = {
-    AlphaImage,
-    RGBAImage
-};
-
-export default exported;
-export { AlphaImage, RGBAImage };

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -53,7 +53,7 @@ const registry: Registry = {};
  *
  * @private
  */
-function register<T: any>(name: string, klass: Class<T>, options: RegisterOptions<T> = {}) {
+export function register<T: any>(name: string, klass: Class<T>, options: RegisterOptions<T> = {}) {
     assert(!registry[name], `${name} is already registered.`);
     (Object.defineProperty: any)(klass, '_classRegistryKey', {
         value: name,
@@ -113,7 +113,7 @@ for (const name in expressions) {
  *
  * @private
  */
-function serialize(input: mixed, transferables?: Array<Transferable>): Serialized {
+export function serialize(input: mixed, transferables?: Array<Transferable>): Serialized {
     if (input === null ||
         input === undefined ||
         typeof input === 'boolean' ||
@@ -198,7 +198,7 @@ function serialize(input: mixed, transferables?: Array<Transferable>): Serialize
     throw new Error(`can't serialize object of type ${typeof input}`);
 }
 
-function deserialize(input: Serialized): mixed {
+export function deserialize(input: Serialized): mixed {
     if (input === null ||
         input === undefined ||
         typeof input === 'boolean' ||
@@ -246,12 +246,3 @@ function deserialize(input: Serialized): mixed {
 
     throw new Error(`can't deserialize object of type ${typeof input}`);
 }
-
-const exported = {
-    register,
-    serialize,
-    deserialize
-};
-
-export default exported;
-export { register, serialize, deserialize };

--- a/test/unit/data/dem_data.test.js
+++ b/test/unit/data/dem_data.test.js
@@ -1,5 +1,5 @@
 import { test } from 'mapbox-gl-js-test';
-import { DEMData, Level } from '../../../src/data/dem_data';
+import DEMData, { Level } from '../../../src/data/dem_data';
 import { RGBAImage } from '../../../src/util/image';
 import { serialize, deserialize } from '../../../src/util/web_worker_transfer';
 

--- a/test/unit/source/raster_dem_tile_worker_source.test.js
+++ b/test/unit/source/raster_dem_tile_worker_source.test.js
@@ -1,7 +1,7 @@
 import { test } from 'mapbox-gl-js-test';
 import RasterDEMTileWorkerSource from '../../../src/source/raster_dem_tile_worker_source';
 import StyleLayerIndex from '../../../src/style/style_layer_index';
-import { DEMData } from '../../../src/data/dem_data';
+import DEMData from '../../../src/data/dem_data';
 
 test('loadTile', (t) => {
     t.test('loads DEM tile', (t) => {


### PR DESCRIPTION
Fixes #6293.

Remaining cases of `export default exported` are the main `index.js` and `style-spec.js` which I am afraid to touch, and `browser.js` and `performance.js` which rely on stubbing.