### PR TITLE
drop the mapbox-gl-supported script include

### DIFF
--- a/docs/pages/example/check-for-support.html
+++ b/docs/pages/example/check-for-support.html
@@ -1,4 +1,3 @@
-<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-supported/v1.3.0/mapbox-gl-supported.js'></script>
 <div id='map'></div>
 
 <script>


### PR DESCRIPTION
nitpicking here, it's not a big deal but mapboxgl.supported() is included with mapbox-gl-js already so in this example loading the plugin doesn't do anything

the plugin can be loaded on it's own when someone want's to test support without or before loading mapbox-gl-js but this example already loads gl js by default so it's not needed.
