### PR TITLE
Low-hanging rollup perf tweaks

### DIFF
--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -8,7 +8,6 @@ import json from 'rollup-plugin-json';
 import browserifyPlugin from 'rollup-plugin-browserify-transform';
 import brfs from 'brfs';
 import uglify from 'rollup-plugin-uglify';
-import sourcemaps from 'rollup-plugin-sourcemaps';
 import minifyStyleSpec from './rollup_plugin_minify_style_spec';
 
 const production = process.env.BUILD === 'production';
@@ -17,7 +16,6 @@ const production = process.env.BUILD === 'production';
 // builds (main mapboxgl bundle, style-spec package, benchmarks bundle)
 
 export const plugins = () => [
-    sourcemaps(),
     flow(),
     minifyStyleSpec(),
     json(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,7 +50,13 @@ if (!shared) {
 }
 }`
     },
-    plugins: [sourcemaps()],
+    treeshake: false,
+    indent: false,
+    plugins: [
+        // Ingest the sourcemaps produced in the first step of the build.
+        // This is the only reason we use Rollup for this second pass
+        sourcemaps()
+    ],
 }];
 
 export default config


### PR DESCRIPTION
* Don't use rollup-plugin-sourcemaps for main build, since we don't need to ingest incoming sourcemaps there
* Don't use treeshaking for the final build step, since it's not relevant: we're basically just concatenating files here.