### PR TITLE
Fix lint in shaders/index.js

### DIFF
--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -1,11 +1,11 @@
 // @flow
 
-const fs = require('fs');
-
 // We use brfs, a browserify transform, to inline shader sources during bundling. As a result:
 // - readFileSync calls must be written out long-form
 // - this module must use CommonJS rather than ES2015 syntax
 /* eslint-disable prefer-template, no-path-concat, import/unambiguous */
+
+const fs = require('fs');
 
 const shaders: {[string]: {fragmentSource: string, vertexSource: string}} = {
     prelude: {


### PR DESCRIPTION
eslint-disable directive needed to be above the `require('fs')`

