### PR TITLE
Upgrade Rollup to 0.57.1

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,8 @@ const config = [{
     output: {
         dir: 'rollup/build/mapboxgl',
         format: 'amd',
-        sourcemap: 'inline'
+        sourcemap: 'inline',
+        indent: false
     },
     experimentalCodeSplitting: true,
     treeshake: production,
@@ -32,6 +33,7 @@ const config = [{
         file: outputFile,
         format: 'umd',
         sourcemap: production ? true : 'inline',
+        indent: false,
         intro: `
 let shared, worker, mapboxgl;
 // define gets called three times: one for each chunk. we rely on the order
@@ -52,7 +54,6 @@ if (!shared) {
 }`
     },
     treeshake: false,
-    indent: false,
     plugins: [
         // Ingest the sourcemaps produced in the first step of the build.
         // This is the only reason we use Rollup for this second pass

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,17 +343,17 @@ acorn@^4.0.0, acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.1.2, acorn@^5.2.1, acorn@^5.3.0, acorn@^5.4.0:
+acorn@^5.0.0, acorn@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
+acorn@^5.1.2, acorn@^5.2.1, acorn@^5.3.0, acorn@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
 acorn@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.0.tgz#1abb587fbf051f94e3de20e6b26ef910b1828298"
-
-acorn@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -8724,8 +8724,8 @@ rollup-pluginutils@^2.0.1:
     micromatch "^2.3.11"
 
 rollup@^0.57.0:
-  version "0.57.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.57.0.tgz#0a57884477175592efe0c8bfc408ea12aa4c0f21"
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.57.1.tgz#0bb28be6151d253f67cf4a00fea48fb823c74027"
   dependencies:
     "@types/acorn" "^4.0.3"
     acorn "^5.5.3"


### PR DESCRIPTION
Includes https://github.com/rollup/rollup/pull/2062 which makes source map generation ~2x faster.