### PR TITLE
Fix spacing issue: "afunction" -> "a function"

### DIFF
--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -1473,8 +1473,8 @@ export default class extends React.Component {
                                     <a id='other-function' className='anchor'/>
                                     <h3 className='space-bottom1'><a href='#other-function' title='link to function'>Function</a></h3>
 
-                                    <p>The value for any layout or paint property may be specified as a
-                                        <em>function</em>. Functions allow you to make the appearance of a map feature
+                                    <p>The value for any layout or paint property may be specified as
+                                        a <em>function</em>. Functions allow you to make the appearance of a map feature
                                         change with the current zoom level and/or the feature's properties.</p>
                                     <div className='col12 pad1x'>
                                         <div className="col12 clearfix pad0y pad2x space-bottom2">


### PR DESCRIPTION
![screen shot 2018-03-19 at 4 15 13 pm](https://user-images.githubusercontent.com/8186438/37627231-c0d34562-2b90-11e8-8905-f71cffc05d3d.png)

Formatting funkiness is causing "a function" to look like "afunction" under the [Other](https://www.mapbox.com/mapbox-gl-js/style-spec/#other-function) section. LMK if there's a better way of fixing this!
