### PR TITLE
add support for GeoJSON attribution

### DIFF
--- a/debug/debug.html
+++ b/debug/debug.html
@@ -56,7 +56,8 @@ map.addControl(new mapboxgl.ScaleControl());
 map.on('load', function() {
     map.addSource('geojson', {
         "type": "geojson",
-        "data": "/test/integration/data/linestring.geojson"
+        "data": "/test/integration/data/linestring.geojson",
+        "attribution": "GeoJSON Attribution"
     });
     map.addLayer({
         "id": "route",

--- a/flow-typed/style-spec.js
+++ b/flow-typed/style-spec.js
@@ -110,6 +110,7 @@ declare type GeojsonSourceSpecification = {|
     "type": "geojson",
     "data"?: mixed,
     "maxzoom"?: number,
+    "attribution"?: string,
     "buffer"?: number,
     "tolerance"?: number,
     "cluster"?: boolean,

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -66,6 +66,7 @@ class GeoJSONSource extends Evented implements Source {
     minzoom: number;
     maxzoom: number;
     tileSize: number;
+    attribution: string;
 
     isTileClipped: boolean;
     reparseOverscaled: boolean;
@@ -110,6 +111,7 @@ class GeoJSONSource extends Evented implements Source {
 
         if (options.maxzoom !== undefined) this.maxzoom = options.maxzoom;
         if (options.type) this.type = options.type;
+        if (options.attribution) this.attribution = options.attribution;
 
         const scale = EXTENT / this.tileSize;
 

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -310,6 +310,10 @@
       "default": 18,
       "doc": "Maximum zoom level at which to create vector tiles (higher means greater detail at high zoom levels)."
     },
+    "attribution": {
+      "type": "string",
+      "doc": "Contains an attribution to be displayed when the map is shown to a user."
+    },
     "buffer": {
       "type": "number",
       "default": 128,

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -89,14 +89,16 @@ test('AttributionControl dedupes attributions that are substrings of others', (t
         map.addSource('3', { type: 'vector', attribution: 'Another Source' });
         map.addSource('4', { type: 'vector', attribution: 'Hello' });
         map.addSource('5', { type: 'vector', attribution: 'Hello World' });
+        map.addSource('6', { type: 'geojson', data: { type: 'FeatureCollection', features: [] }, attribution: 'Hello World' });
+        map.addSource('7', { type: 'geojson', data: { type: 'FeatureCollection', features: [] }, attribution: 'GeoJSON Source' });
 
     });
 
     let times = 0;
     map.on('data', (e) => {
         if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-            if (++times === 5) {
-                t.equal(attribution._container.innerHTML, 'Hello World | Another Source');
+            if (++times === 7) {
+                t.equal(attribution._container.innerHTML, 'Hello World | Another Source | GeoJSON Source');
                 t.end();
             }
         }


### PR DESCRIPTION
## Launch Checklist
 - [x] briefly describe the changes in this PR

adds support for custom attribution strings in GeoJSON sources. This implements the latter part of the discussion of #1485, but could be used as a workaround for the original issue by using a dummy GeoJSON source.

I think to close #1485 we would still need to allow custom attribution strings passed directly to the AttributionControl not attached to any source.

The Vector and Raster sources set their attribution properties via the shared TileJSON code, but since GeoJSON is loaded directly without a TileJSON, they need to be handled separately in the GeoJSON Source code.

 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - N/A post benchmark scores
 - [x] manually test the debug page
