### PR TITLE
made license field SPDX compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.44.1",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
-  "license": "SEE LICENSE IN LICENSE.txt",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.com/mapbox/mapbox-gl-js.git"


### PR DESCRIPTION
Since ca54b3aeb3d718f9f5f80f15f8390c2bfc5f317f the package.json states a license `SEE LICENSE IN LICENSE.txt` whitch is not ideal.

The [npm documentation](https://docs.npmjs.com/files/package.json#license) recommends using SPDX compatible licenses.