### PR TITLE
Add devicePixelRatio option to config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ const exported = {
     /**
      * Gets and sets map's pixel ratio
      * 
-     * @var {number} devicePixelRation
+     * @var {number} devicePixelRatio
      * @example
      * mapboxgl.devicePixelRatio = 2
      */
@@ -69,7 +69,7 @@ const exported = {
     },
 
     set devicePixelRatio(devicePixelRatio: number) {
-        Object.defineProperty(config, 'DEVICE_PIXEL_RATIO', { value: devicePixelRatio });
+        config.DEVICE_PIXEL_RATIO = devicePixelRatio;
     },
 
     workerUrl: ''

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,21 @@ const exported = {
         config.ACCESS_TOKEN = token;
     },
 
+    /**
+     * Gets and sets map's pixel ratio
+     * 
+     * @var {number} devicePixelRation
+     * @example
+     * mapboxgl.devicePixelRatio = 2
+     */
+    get devicePixelRatio() {
+        return config.DEVICE_PIXEL_RATIO;
+    },
+
+    set devicePixelRatio(devicePixelRatio: number) {
+        config.DEVICE_PIXEL_RATIO = devicePixelRatio;
+    },
+
     workerUrl: ''
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ const exported = {
     },
 
     set devicePixelRatio(devicePixelRatio: number) {
-        config.DEVICE_PIXEL_RATIO = devicePixelRatio;
+        Object.defineProperty(config, 'DEVICE_PIXEL_RATIO', { value: devicePixelRatio });
     },
 
     workerUrl: ''

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -1,6 +1,6 @@
 // @flow
 
-import browser from '../util/browser';
+import config from '../util/config';
 
 import pixelsToTileUnits from '../source/pixels_to_tile_units';
 import DepthMode from '../gl/depth_mode';
@@ -72,7 +72,7 @@ function drawLineTile(program, painter, tile, bucket, layer, coord, programConfi
 
             gl.uniform2f(program.uniforms.u_patternscale_a, tileRatio / widthA, -posA.height / 2);
             gl.uniform2f(program.uniforms.u_patternscale_b, tileRatio / widthB, -posB.height / 2);
-            gl.uniform1f(program.uniforms.u_sdfgamma, painter.lineAtlas.width / (Math.min(widthA, widthB) * 256 * browser.devicePixelRatio) / 2);
+            gl.uniform1f(program.uniforms.u_sdfgamma, painter.lineAtlas.width / (Math.min(widthA, widthB) * 256 * config.DEVICE_PIXEL_RATIO) / 2);
 
         } else if (image) {
             imagePosA = painter.imageManager.getPattern(image.from);

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -1,6 +1,6 @@
 // @flow
 
-import browser from '../util/browser';
+import config from '../util/config';
 
 import shaders from '../shaders';
 import assert from 'assert';
@@ -30,7 +30,7 @@ class Program {
         this.program = gl.createProgram();
 
         const defines = configuration.defines().concat(
-            `#define DEVICE_PIXEL_RATIO ${browser.devicePixelRatio.toFixed(1)}`);
+            `#define DEVICE_PIXEL_RATIO ${config.DEVICE_PIXEL_RATIO.toFixed(1)}`);
         if (showOverdrawInspector) {
             defines.push('#define OVERDRAW_INSPECTOR;');
         }

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -5,7 +5,7 @@ import { Event, ErrorEvent, Evented } from '../util/evented';
 import { extend } from '../util/util';
 import EXTENT from '../data/extent';
 import { ResourceType } from '../util/ajax';
-import browser from '../util/browser';
+import config from '../util/config';
 
 import type {Source} from './source';
 import type Map from '../ui/map';

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -5,6 +5,7 @@ import { Event, ErrorEvent, Evented } from '../util/evented';
 import { extend } from '../util/util';
 import EXTENT from '../data/extent';
 import { ResourceType } from '../util/ajax';
+import browser from '../util/browser';
 import config from '../util/config';
 
 import type {Source} from './source';
@@ -283,7 +284,7 @@ class GeoJSONSource extends Evented implements Source {
             maxZoom: this.maxzoom,
             tileSize: this.tileSize,
             source: this.id,
-            pixelRatio: browser.devicePixelRatio,
+            pixelRatio: config.DEVICE_PIXEL_RATIO,
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -111,7 +111,7 @@ class VectorTileSource extends Evented implements Source {
             tileSize: this.tileSize * tile.tileID.overscaleFactor(),
             type: this.type,
             source: this.id,
-            pixelRatio: browser.devicePixelRatio,
+            pixelRatio: config.DEVICE_PIXEL_RATIO,
             showCollisionBoxes: this.map.showCollisionBoxes,
         };
         params.request.collectResourceTiming = this._collectResourceTiming;

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -7,7 +7,7 @@ import loadTileJSON from './load_tilejson';
 import { normalizeTileURL as normalizeURL } from '../util/mapbox';
 import TileBounds from './tile_bounds';
 import { ResourceType } from '../util/ajax';
-import browser from '../util/browser';
+import config from '../util/config';
 
 import type {Source} from './source';
 import type {OverscaledTileID} from './tile_id';

--- a/src/style/load_sprite.js
+++ b/src/style/load_sprite.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { getJSON, getImage, ResourceType } from '../util/ajax';
+import config from '../util/config';
 
 import browser from '../util/browser';
 import { normalizeSpriteURL } from '../util/mapbox';
@@ -15,7 +16,7 @@ export default function(baseURL: string,
                           transformRequestCallback: RequestTransformFunction,
                           callback: Callback<{[string]: StyleImage}>): Cancelable {
     let json: any, image, error;
-    const format = browser.devicePixelRatio > 1 ? '@2x' : '';
+    const format = config.DEVICE_PIXEL_RATIO > 1 ? '@2x' : '';
 
     let jsonRequest = getJSON(transformRequestCallback(normalizeSpriteURL(baseURL, format, '.json'), ResourceType.SpriteJSON), (err, data) => {
         jsonRequest = null;

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -13,9 +13,7 @@ const config: Config = {
     API_URL: 'https://api.mapbox.com',
     REQUIRE_ACCESS_TOKEN: true,
     ACCESS_TOKEN: null,
-    get DEVICE_PIXEL_RATIO() {
-        return browser.devicePixelRatio;
-    }
+    DEVICE_PIXEL_RATIO: browser.devicePixelRatio,
 };
 
 export default config;

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,15 +1,19 @@
 // @flow
 
+import browser from './browser';
+
 type Config = {|
   API_URL: string,
   REQUIRE_ACCESS_TOKEN: boolean,
-  ACCESS_TOKEN: ?string
+  ACCESS_TOKEN: ?string,
+  DEVICE_PIXEL_RATIO: number,
 |};
 
 const config: Config = {
     API_URL: 'https://api.mapbox.com',
     REQUIRE_ACCESS_TOKEN: true,
-    ACCESS_TOKEN: null
+    ACCESS_TOKEN: null,
+    DEVICE_PIXEL_RATIO: browser.devicePixelRatio,
 };
 
 export default config;

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -13,7 +13,9 @@ const config: Config = {
     API_URL: 'https://api.mapbox.com',
     REQUIRE_ACCESS_TOKEN: true,
     ACCESS_TOKEN: null,
-    DEVICE_PIXEL_RATIO: browser.devicePixelRatio,
+    get DEVICE_PIXEL_RATIO() {
+        return browser.devicePixelRatio;
+    }
 };
 
 export default config;

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -84,7 +84,7 @@ export const normalizeTileURL = function(tileURL: string, sourceURL?: ?string, t
     // The v4 mapbox tile API supports 512x512 image tiles only when @2x
     // is appended to the tile URL. If `tileSize: 512` is specified for
     // a Mapbox raster source force the @2x suffix even if a non hidpi device.
-    const suffix = browser.devicePixelRatio >= 2 || tileSize === 512 ? '@2x' : '';
+    const suffix = config.DEVICE_PIXEL_RATIO >= 2 || tileSize === 512 ? '@2x' : '';
     const extension = browser.supportsWebp ? '.webp' : '$1';
     urlObject.path = urlObject.path.replace(imageExtensionRe, `${suffix}${extension}`);
 

--- a/test/unit/util/browser.test.js
+++ b/test/unit/util/browser.test.js
@@ -1,5 +1,6 @@
 import { test } from 'mapbox-gl-js-test';
 import browser from '../../../src/util/browser';
+import config from '../../../src/util/config';
 
 test('browser', (t) => {
     t.test('frame', (t) => {
@@ -24,7 +25,7 @@ test('browser', (t) => {
     });
 
     t.test('devicePixelRatio', (t) => {
-        t.equal(typeof browser.devicePixelRatio, 'number');
+        t.equal(typeof config.DEVICE_PIXEL_RATIO, 'number');
         t.end();
     });
 

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -2,6 +2,7 @@ import { test } from 'mapbox-gl-js-test';
 import * as mapbox from '../../../src/util/mapbox';
 import config from '../../../src/util/config';
 import browser from '../../../src/util/browser';
+import window from '../../../src/util/window';
 
 test("mapbox", (t) => {
     const mapboxSource = 'mapbox://user.map';
@@ -204,12 +205,12 @@ test("mapbox", (t) => {
         });
 
         t.test('inserts @2x on 2x devices', (t) => {
-            config.DEVICE_PIXEL_RATIO = 2;
+            window.devicePixelRatio = 2;
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile@2x.png');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile@2x.png32');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile@2x.jpg70');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource), 'http://path.png/tile@2x.png?access_token=foo');
-            config.DEVICE_PIXEL_RATIO = 1;
+            window.devicePixelRatio = 1;
             t.end();
         });
 

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -2,7 +2,6 @@ import { test } from 'mapbox-gl-js-test';
 import * as mapbox from '../../../src/util/mapbox';
 import config from '../../../src/util/config';
 import browser from '../../../src/util/browser';
-import window from '../../../src/util/window';
 
 test("mapbox", (t) => {
     const mapboxSource = 'mapbox://user.map';
@@ -205,12 +204,12 @@ test("mapbox", (t) => {
         });
 
         t.test('inserts @2x on 2x devices', (t) => {
-            window.devicePixelRatio = 2;
+            config.DEVICE_PIXEL_RATIO = 2;
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/tile@2x.png');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/tile@2x.png32');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/tile@2x.jpg70');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource), 'http://path.png/tile@2x.png?access_token=foo');
-            window.devicePixelRatio = 1;
+            config.DEVICE_PIXEL_RATIO = 1;
             t.end();
         });
 


### PR DESCRIPTION
Makes devicePixelRatio configurable #1953 

By default config gets actual devicePixelRatio from window if no value has been set to devicePixelRatio config property.

Changes

- [x] Add a devicePixelRatio setting to config.js which defaults to browser.devicePixelRatio
- [x] Add a devicePixelRatio getter and setter to index.js
- [x] Change all uses of browser.devicePixelRatio to config.devicePixelRatio

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] manually test the debug page
