### PR TITLE
Fix link to filters in style spec reference

### DIFF
--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -449,7 +449,7 @@ export default class extends React.Component {
                             <a className='block truncate strong quiet' href={`#${slug(title)}`}>{title}</a>
                             {subnav && subnav.map(({title: subtitle}, i) =>
                                 <a key={i} className='block truncate'
-                                    href={`#${slug(title)}-${slug(subtitle)}`}>{subtitle}</a>
+                                    href={`#${slug(title)}-${slug(subtitle.replace(/\s\(.+\)$/, ''))}`}>{subtitle}</a>
                             )}
                         </div>
                     )}

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -218,7 +218,7 @@ const navigation = [
                 "title": "Function"
             },
             {
-                "title": "Filter (deprecated syntax)"
+                "title": "Filter"
             }
         ]
     }
@@ -449,7 +449,7 @@ export default class extends React.Component {
                             <a className='block truncate strong quiet' href={`#${slug(title)}`}>{title}</a>
                             {subnav && subnav.map(({title: subtitle}, i) =>
                                 <a key={i} className='block truncate'
-                                    href={`#${slug(title)}-${slug(subtitle.replace(/\s*\(.+\)$/, ''))}`}>{subtitle}</a>
+                                    href={`#${slug(title)}-${slug(subtitle)}`}>{subtitle}</a>
                             )}
                         </div>
                     )}

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -449,7 +449,7 @@ export default class extends React.Component {
                             <a className='block truncate strong quiet' href={`#${slug(title)}`}>{title}</a>
                             {subnav && subnav.map(({title: subtitle}, i) =>
                                 <a key={i} className='block truncate'
-                                    href={`#${slug(title)}-${slug(subtitle.replace(/\s\(.+\)$/, ''))}`}>{subtitle}</a>
+                                    href={`#${slug(title)}-${slug(subtitle.replace(/\s*\(.+\)$/, ''))}`}>{subtitle}</a>
                             )}
                         </div>
                     )}


### PR DESCRIPTION
The table of contents in the style specification reference linked “Filter (deprecated syntax)” to the `#other-filter-deprecated-syntax` anchor, which doesn’t exist. This change fixes the link.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page

/cc @jfirebaugh