### PR TITLE
offset the popup around the default marker

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -44,6 +44,7 @@ export default class Marker {
     _lngLat: LngLat;
     _pos: ?Point;
     _color: ?string;
+    _defaultMarker: boolean;
 
     constructor(options?: Options) {
         // For backward compatibility -- the constructor used to accept the element as a
@@ -58,6 +59,7 @@ export default class Marker {
         this._color = options && options.color || '#3FB1CE';
 
         if (!options || !options.element) {
+            this._defaultMarker = true;
             this._element = DOM.create('div');
 
             // create default map marker SVG
@@ -255,7 +257,19 @@ export default class Marker {
 
         if (popup) {
             if (!('offset' in popup.options)) {
-                popup.options.offset = this._offset;
+                const markerHeight = 41 - (5.8 / 2);
+                const markerRadius = 13.5;
+                const linearOffset = Math.sqrt(Math.pow(markerRadius, 2) / 2);
+                popup.options.offset = this._defaultMarker ? {
+                    'top': [0, 0],
+                    'top-left': [0, 0],
+                    'top-right': [0, 0],
+                    'bottom': [0, -markerHeight],
+                    'bottom-left': [linearOffset, (markerHeight - markerRadius + linearOffset) * -1],
+                    'bottom-right': [-linearOffset, (markerHeight - markerRadius + linearOffset) * -1],
+                    'left': [markerRadius, (markerHeight - markerRadius) * -1],
+                    'right': [-markerRadius, (markerHeight - markerRadius) * -1]
+                } : this._offset;
             }
             this._popup = popup;
             if (this._lngLat) this._popup.setLngLat(this._lngLat);

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -156,3 +156,80 @@ test('Marker accepts backward-compatible constructor parameters', (t) => {
     t.ok(m2.getOffset().equals(new Point(1, 2)));
     t.end();
 });
+
+test('Popup offsets around default Marker', (t) => {
+    const map = createMap();
+
+    const marker = new Marker()
+        .setLngLat([0, 0])
+        .setPopup(new Popup().setText('Test'))
+        .addTo(map);
+
+    t.ok(marker.getPopup().options.offset.bottom[1] < 0, 'popup is vertically offset somewhere above the tip');
+    t.ok(marker.getPopup().options.offset.top[1] === 0, 'popup is vertically offset at the tip');
+    t.ok(marker.getPopup().options.offset.left[0] > 0, 'popup is horizontally offset somewhere to the right of the tip');
+    t.ok(marker.getPopup().options.offset.right[0] < 0, 'popup is horizontally offset somewhere to the left of the tip');
+
+    t.ok(marker.getPopup().options.offset['bottom-left'][0] > 0, 'popup is horizontally offset somewhere to the top right of the tip');
+    t.ok(marker.getPopup().options.offset['bottom-left'][1] < 0, 'popup is vertically offset somewhere to the top right of the tip');
+    t.ok(marker.getPopup().options.offset['bottom-right'][0] < 0, 'popup is horizontally offset somewhere to the top left of the tip');
+    t.ok(marker.getPopup().options.offset['bottom-right'][1] < 0, 'popup is vertically offset somewhere to the top left of the tip');
+
+    t.deepEqual(marker.getPopup().options.offset['top-left'], [0, 0], 'popup offset at the tip when below to the right');
+    t.deepEqual(marker.getPopup().options.offset['top-right'], [0, 0], 'popup offset at the tip when below to the left');
+
+    t.end();
+});
+
+test('Popup anchors around default Marker', (t) => {
+    const map = createMap();
+
+    const marker = new Marker()
+        .setLngLat([0, 0])
+        .setPopup(new Popup().setText('Test'))
+        .addTo(map);
+
+    // open the popup
+    marker.togglePopup();
+
+    const mapHeight = map.getContainer().offsetHeight;
+    const markerTop = -marker.getPopup().options.offset.bottom[1]; // vertical distance from tip of marker to the top in pixels
+    const markerRight = -marker.getPopup().options.offset.right[0]; // horizontal distance from the tip of the marker to the right in pixels
+
+    // give the popup some height
+    Object.defineProperty(marker.getPopup()._container, 'offsetWidth', {value: 100});
+    Object.defineProperty(marker.getPopup()._container, 'offsetHeight', {value: 100});
+
+    // marker should default to above since it has enough space
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-bottom'), 'popup anchors above marker');
+
+    // move marker to the top forcing the popup to below
+    marker.setLngLat(map.unproject([mapHeight / 2, markerTop]));
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-top'), 'popup anchors bolow marker');
+
+    // move marker to the right forcing the popup to the left
+    marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight / 2]));
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-right'), 'popup anchors left of marker');
+
+    // move marker to the left forcing the popup to the right
+    marker.setLngLat(map.unproject([markerRight, mapHeight / 2]));
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-left'), 'popup anchors right of marker');
+
+    // move marker to the top left forcing the popup to the bottom right
+    marker.setLngLat(map.unproject([markerRight, markerTop]));
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-top-left'), 'popup anchors bottom right of marker');
+
+    // move marker to the top right forcing the popup to the bottom left
+    marker.setLngLat(map.unproject([mapHeight - markerRight, markerTop]));
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-top-right'), 'popup anchors bottom left of marker');
+
+    // move marker to the bottom left forcing the popup to the top right
+    marker.setLngLat(map.unproject([markerRight, mapHeight]));
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-bottom-left'), 'popup anchors top right of marker');
+
+    // move marker to the bottom right forcing the popup to the top left
+    marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight]));
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-bottom-right'), 'popup anchors top left of marker');
+
+    t.end();
+});


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

if you create a default marker with a popup it looks like this:
```js
var marker = new mapboxgl.Marker()
    .setLngLat([0, 0])
    .setPopup(new mapboxgl.Popup().setText('hello hi');)
    .addTo(map);
```

![selection_864](https://user-images.githubusercontent.com/117278/38064620-b17244a8-334a-11e8-82c3-abebee51ebc4.png)

with this PR it sets the offset of the popup so the tip touches the outside of the marker icon:

![selection_863](https://user-images.githubusercontent.com/117278/38064537-2d78656a-334a-11e8-8d27-d83e5c2818ac.png)
![selection_862](https://user-images.githubusercontent.com/117278/38064544-3051ab16-334a-11e8-8552-70c55ccd7854.png)
![selection_861](https://user-images.githubusercontent.com/117278/38064547-323199be-334a-11e8-97bb-a629de1c44c5.png)
![selection_860](https://user-images.githubusercontent.com/117278/38064549-343dcba6-334a-11e8-8a41-e3791d10bd86.png)
![selection_859](https://user-images.githubusercontent.com/117278/38064550-363697bc-334a-11e8-9a93-a1453175ba18.png)

This is only the default when not providing your own Marker element and no Popup offset. It can still be overridden:

```js
var marker = new mapboxgl.Marker()
    .setLngLat([0, 0])
    .setPopup(new mapboxgl.Popup({offset: [0, 0]}).setText('hello hi');)
    .addTo(map);
```

 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
