### PR TITLE
Round-trip linear interpolators

### DIFF
--- a/test/integration/expression-tests/heatmap-density/basic/test.json
+++ b/test/integration/expression-tests/heatmap-density/basic/test.json
@@ -34,7 +34,7 @@
     "outputs": [[0.5, 0, 0, 1]],
     "serialized": [
       "interpolate",
-      ["exponential", 1],
+      ["linear"],
       ["heatmap-density"],
       0,
       ["rgba", 0, 0, 0, 1],

--- a/test/integration/expression-tests/interpolate/linear-color/test.json
+++ b/test/integration/expression-tests/interpolate/linear-color/test.json
@@ -34,7 +34,7 @@
       "to-rgba",
       [
         "interpolate",
-        ["exponential", 1],
+        ["linear"],
         ["number", ["get", "x"]],
         1,
         ["rgba", 255, 0, 0, 1],

--- a/test/integration/expression-tests/interpolate/linear-many-stops/test.json
+++ b/test/integration/expression-tests/interpolate/linear-many-stops/test.json
@@ -68,7 +68,7 @@
       "number",
       [
         "interpolate",
-        ["exponential", 1],
+        ["linear"],
         ["number", ["get", "x"]],
         2,
         100,

--- a/test/integration/expression-tests/interpolate/linear/test.json
+++ b/test/integration/expression-tests/interpolate/linear/test.json
@@ -32,7 +32,7 @@
     ],
     "serialized": [
       "interpolate",
-      ["exponential", 1],
+      ["linear"],
       ["number", ["get", "x"]],
       0,
       100,

--- a/test/integration/expression-tests/let/zoom/test.json
+++ b/test/integration/expression-tests/let/zoom/test.json
@@ -32,7 +32,7 @@
       30,
       [
         "interpolate",
-        ["exponential", 1],
+        ["linear"],
         ["zoom"],
         0,
         ["var", "z0_value"],

--- a/test/integration/expression-tests/zoom/basic/test.json
+++ b/test/integration/expression-tests/zoom/basic/test.json
@@ -9,6 +9,6 @@
       "type": "number"
     },
     "outputs": [5],
-    "serialized": ["interpolate", ["exponential", 1], ["zoom"], 0, 0, 30, 30]
+    "serialized": ["interpolate", ["linear"], ["zoom"], 0, 0, 30, 30]
   }
 }

--- a/test/integration/expression-tests/zoom/nested-coalesce/test.json
+++ b/test/integration/expression-tests/zoom/nested-coalesce/test.json
@@ -14,7 +14,7 @@
     "outputs": [5],
     "serialized": [
       "coalesce",
-      ["interpolate", ["exponential", 1], ["zoom"], 0, 0, 30, 30]
+      ["interpolate", ["linear"], ["zoom"], 0, 0, 30, 30]
     ]
   }
 }

--- a/test/integration/expression-tests/zoom/nested-let/test.json
+++ b/test/integration/expression-tests/zoom/nested-let/test.json
@@ -18,7 +18,7 @@
       "let",
       "x",
       30,
-      ["interpolate", ["exponential", 1], ["zoom"], 0, 0, 30, ["var", "x"]]
+      ["interpolate", ["linear"], ["zoom"], 0, 0, 30, ["var", "x"]]
     ]
   }
 }


### PR DESCRIPTION
Linear interpolators should be serialized as such rather than as exponential interpolators with a base of 1.0. These test fixture changes are required for mapbox/mapbox-gl-native#11562.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] post benchmark scores
 - [ ] manually test the debug page

/cc @anandthakker @ChrisLoer