### PR TITLE
to-rgba of rgba serializes as a literal

### DIFF
--- a/test/integration/expression-tests/to-rgba/zero/test.json
+++ b/test/integration/expression-tests/to-rgba/zero/test.json
@@ -11,6 +11,6 @@
       "type": "array<number, 4>"
     },
     "outputs": [[0, 0, 0, 0]],
-    "serialized": ["to-rgba", ["rgba", 0, 0, 0, 0]]
+    "serialized": ["literal", [0, 0, 0, 0]]
   }
 }


### PR DESCRIPTION
#6388 causes mapbox/mapbox-gl-native#11565 to fail because the `to-rgba` operator cancels out the `rgba` operator, at least in mbgl. This change updates the test fixture so that mapbox/mapbox-gl-native#11565 can pass.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page

/cc @jfirebaugh @ChrisLoer