### PR TITLE
only index features strictly within tile boundaries

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -83,7 +83,12 @@ class FeatureIndex {
                 bbox[3] = Math.max(bbox[3], p.y);
             }
 
-            this.grid.insert(key, bbox[0], bbox[1], bbox[2], bbox[3]);
+            if (bbox[0] < EXTENT &&
+                bbox[1] < EXTENT &&
+                bbox[2] >= 0 &&
+                bbox[3] >= 0) {
+                this.grid.insert(key, bbox[0], bbox[1], bbox[2], bbox[3]);
+            }
         }
     }
 

--- a/test/integration/query-tests/edge-cases/box-cutting-antimeridian-z0/expected.json
+++ b/test/integration/query-tests/edge-cases/box-cutting-antimeridian-z0/expected.json
@@ -1,54 +1,28 @@
 [
-    {
-        "properties": {
-            "id": "B"
-        },
-        "type": "Feature",
-        "geometry": {
-            "type": "Point",
-            "coordinates": [
-                90,
-                0
-            ]
-        }
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        90,
+        0
+      ]
     },
-    {
-        "properties": {
-            "id": "C"
-        },
-        "type": "Feature",
-        "geometry": {
-            "type": "Point",
-            "coordinates": [
-                270,
-                0
-            ]
-        }
-    },
-    {
-        "properties": {
-            "id": "B"
-        },
-        "type": "Feature",
-        "geometry": {
-            "type": "Point",
-            "coordinates": [
-                -270,
-                0
-            ]
-        }
-    },
-    {
-        "properties": {
-            "id": "C"
-        },
-        "type": "Feature",
-        "geometry": {
-            "type": "Point",
-            "coordinates": [
-                -90,
-                0
-            ]
-        }
+    "type": "Feature",
+    "properties": {
+      "id": "B"
     }
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -90,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {
+      "id": "C"
+    }
+  }
 ]

--- a/test/integration/query-tests/edge-cases/null-island/expected.json
+++ b/test/integration/query-tests/edge-cases/null-island/expected.json
@@ -1,46 +1,13 @@
 [
   {
-    "properties": {},
-    "type": "Feature",
     "geometry": {
       "type": "Point",
       "coordinates": [
         0,
         0
       ]
-    }
-  },
-  {
-    "properties": {},
+    },
     "type": "Feature",
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        0,
-        0
-      ]
-    }
-  },
-  {
-    "properties": {},
-    "type": "Feature",
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        0,
-        0
-      ]
-    }
-  },
-  {
-    "properties": {},
-    "type": "Feature",
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        0,
-        0
-      ]
-    }
+    "properties": {}
   }
 ]


### PR DESCRIPTION
Instead of indexing all features for querying, index only those that are actually within the tile boundaries. This prevents duplicate results from being returned for point features. This is only a partial fix for the duplicate results problem (lines and polygons can still return
duplicate results).

Previously we relied on tile buffers for cross-tile indexing. But now that we have https://github.com/mapbox/mapbox-gl-js/pull/6036 we don't need that anymore.

I noticed this while porting https://github.com/mapbox/mapbox-gl-js/pull/6036 to -native. These test changes would be useful to have for that port.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [N/A] document any changes to public APIs
 - [x] post benchmark [scores](https://user-images.githubusercontent.com/1421652/38152270-fa525cae-3434-11e8-819d-a3bd1b21c31c.png)
 - [x] manually test the debug page
