### PR TITLE
Force touchstart, touchmove, and wheel listeners to be non-passive

### DIFF
--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -1,7 +1,7 @@
 // @flow
 
-const DOM = require('../util/dom');
 const Point = require('@mapbox/point-geometry');
+const DOM = require('../util/dom');
 
 import type Map from './map';
 
@@ -29,18 +29,18 @@ module.exports = function bindHandlers(map: Map, options: {}) {
         }
     }
 
-    el.addEventListener('mouseout', onMouseOut, false);
-    el.addEventListener('mousedown', onMouseDown, false);
-    el.addEventListener('mouseup', onMouseUp, false);
-    el.addEventListener('mousemove', onMouseMove, false);
-    el.addEventListener('mouseover', onMouseOver, false);
-    el.addEventListener('touchstart', onTouchStart, false);
-    el.addEventListener('touchend', onTouchEnd, false);
-    el.addEventListener('touchmove', onTouchMove, false);
-    el.addEventListener('touchcancel', onTouchCancel, false);
-    el.addEventListener('click', onClick, false);
-    el.addEventListener('dblclick', onDblClick, false);
-    el.addEventListener('contextmenu', onContextMenu, false);
+    DOM.addEventListener(el, 'mouseout', onMouseOut);
+    DOM.addEventListener(el, 'mousedown', onMouseDown);
+    DOM.addEventListener(el, 'mouseup', onMouseUp);
+    DOM.addEventListener(el, 'mousemove', onMouseMove);
+    DOM.addEventListener(el, 'mouseover', onMouseOver);
+    DOM.addEventListener(el, 'touchstart', onTouchStart, {passive: true}); // passive: true because onTouchStart only fires a map event
+    DOM.addEventListener(el, 'touchmove', onTouchMove, {passive: true}); // passive: true because onTouchMove only fires a map event
+    DOM.addEventListener(el, 'touchend', onTouchEnd);
+    DOM.addEventListener(el, 'touchcancel', onTouchCancel);
+    DOM.addEventListener(el, 'click', onClick);
+    DOM.addEventListener(el, 'dblclick', onDblClick);
+    DOM.addEventListener(el, 'contextmenu', onContextMenu);
 
     function onMouseOut(e: MouseEvent) {
         fireMouseEvent('mouseout', e);

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -72,8 +72,8 @@ class DragPanHandler {
     enable() {
         if (this.isEnabled()) return;
         this._el.classList.add('mapboxgl-touch-drag-pan');
-        this._el.addEventListener('mousedown', this._onDown);
-        this._el.addEventListener('touchstart', this._onDown);
+        DOM.addEventListener(this._el, 'mousedown', this._onDown);
+        DOM.addEventListener(this._el, 'touchstart', this._onDown, {passive: false});
         this._enabled = true;
     }
 
@@ -86,8 +86,8 @@ class DragPanHandler {
     disable() {
         if (!this.isEnabled()) return;
         this._el.classList.remove('mapboxgl-touch-drag-pan');
-        this._el.removeEventListener('mousedown', this._onDown);
-        this._el.removeEventListener('touchstart', this._onDown);
+        DOM.removeEventListener(this._el, 'mousedown', this._onDown);
+        DOM.removeEventListener(this._el, 'touchstart', this._onDown, {passive: false});
         this._enabled = false;
     }
 
@@ -96,14 +96,14 @@ class DragPanHandler {
         if (this.isActive()) return;
 
         if (e.touches) {
-            window.document.addEventListener('touchmove', this._onMove);
-            window.document.addEventListener('touchend', this._onTouchEnd);
+            DOM.addEventListener(window.document, 'touchmove', this._onMove, {passive: false});
+            DOM.addEventListener(window.document, 'touchend', this._onTouchEnd);
         } else {
-            window.document.addEventListener('mousemove', this._onMove);
-            window.document.addEventListener('mouseup', this._onMouseUp);
+            DOM.addEventListener(window.document, 'mousemove', this._onMove);
+            DOM.addEventListener(window.document, 'mouseup', this._onMouseUp);
         }
         /* Deactivate DragPan when the window looses focus. Otherwise if a mouseup occurs when the window isn't in focus, DragPan will still be active even though the mouse is no longer pressed. */
-        window.addEventListener('blur', this._onMouseUp);
+        DOM.addEventListener(window, 'blur', this._onMouseUp);
 
         this._active = false;
         this._previousPos = DOM.mousePos(this._el, e);
@@ -221,16 +221,16 @@ class DragPanHandler {
     _onMouseUp(e: MouseEvent | FocusEvent) {
         if (this._ignoreEvent(e)) return;
         this._onUp(e);
-        window.document.removeEventListener('mousemove', this._onMove);
-        window.document.removeEventListener('mouseup', this._onMouseUp);
-        window.removeEventListener('blur', this._onMouseUp);
+        DOM.removeEventListener(window.document, 'mousemove', this._onMove);
+        DOM.removeEventListener(window.document, 'mouseup', this._onMouseUp);
+        DOM.removeEventListener(window, 'blur', this._onMouseUp);
     }
 
     _onTouchEnd(e: TouchEvent) {
         if (this._ignoreEvent(e)) return;
         this._onUp(e);
-        window.document.removeEventListener('touchmove', this._onMove);
-        window.document.removeEventListener('touchend', this._onTouchEnd);
+        DOM.removeEventListener(window.document, 'touchmove', this._onMove, {passive: false});
+        DOM.removeEventListener(window.document, 'touchend', this._onTouchEnd);
     }
 
     _fireEvent(type: string, e: ?Event) {

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -67,7 +67,7 @@ class TouchZoomRotateHandler {
     enable(options: any) {
         if (this.isEnabled()) return;
         this._el.classList.add('mapboxgl-touch-zoom-rotate');
-        this._el.addEventListener('touchstart', this._onStart, false);
+        DOM.addEventListener(this._el, 'touchstart', this._onStart, {passive: false});
         this._enabled = true;
         this._aroundCenter = options && options.around === 'center';
     }
@@ -81,7 +81,7 @@ class TouchZoomRotateHandler {
     disable() {
         if (!this.isEnabled()) return;
         this._el.classList.remove('mapboxgl-touch-zoom-rotate');
-        this._el.removeEventListener('touchstart', this._onStart);
+        DOM.removeEventListener(this._el, 'touchstart', this._onStart, {passive: false});
         this._enabled = false;
     }
 
@@ -119,8 +119,8 @@ class TouchZoomRotateHandler {
         this._gestureIntent = undefined;
         this._inertia = [];
 
-        window.document.addEventListener('touchmove', this._onMove, false);
-        window.document.addEventListener('touchend', this._onEnd, false);
+        DOM.addEventListener(window.document, 'touchmove', this._onMove, {passive: false});
+        DOM.addEventListener(window.document, 'touchend', this._onEnd);
     }
 
     _onMove(e: TouchEvent) {
@@ -173,8 +173,8 @@ class TouchZoomRotateHandler {
     }
 
     _onEnd(e: TouchEvent) {
-        window.document.removeEventListener('touchmove', this._onMove);
-        window.document.removeEventListener('touchend', this._onEnd);
+        DOM.removeEventListener(window.document, 'touchmove', this._onMove, {passive: false});
+        DOM.removeEventListener(window.document, 'touchend', this._onEnd);
         this._drainInertiaBuffer();
 
         const inertia = this._inertia,

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -45,6 +45,37 @@ exports.setTransform = function(el: HTMLElement, value: string) {
     (el.style: any)[transformProp] = value;
 };
 
+// Feature detection for {passive: false} support in add/removeEventListener.
+let passiveSupported = false;
+
+try {
+    const options = (Object.defineProperty: any)({}, "passive", {
+        get: function() {
+            passiveSupported = true;
+        }
+    });
+    (window.addEventListener: any)("test", options, options);
+    (window.removeEventListener: any)("test", options, options);
+} catch (err) {
+    passiveSupported = false;
+}
+
+exports.addEventListener = function(target: *, type: *, callback: *, options: {passive?: boolean, capture?: boolean} = {}) {
+    if ('passive' in options && passiveSupported) {
+        target.addEventListener(type, callback, (options: any));
+    } else {
+        target.addEventListener(type, callback, options.capture);
+    }
+};
+
+exports.removeEventListener = function(target: *, type: *, callback: *, options: {passive?: boolean, capture?: boolean} = {}) {
+    if ('passive' in options && passiveSupported) {
+        target.removeEventListener(type, callback, (options: any));
+    } else {
+        target.removeEventListener(type, callback, options.capture);
+    }
+};
+
 // Suppress the next click, but only if it's immediate.
 const suppressClick: MouseEventListener = function (e) {
     e.preventDefault();


### PR DESCRIPTION
Cherry pick of 02d652847c01083e9317b6773f91f4fd6edf00e3

Yes, Chrome, yes WebKit: we really do intend to prevent the default scroll behavior for these events.

This is the only way to silence the console warnings from Chrome and support iOS Safari 11.3+.