### PR TITLE
only use mipmaps for power-of-two textures

### DIFF
--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -123,10 +123,10 @@ function prepareHillshade(painter, tile, sourceMaxZoom) {
         tile.demTexture = tile.demTexture || painter.getTileTexture(tile.tileSize);
         if (tile.demTexture) {
             const demTexture = tile.demTexture;
-            demTexture.update(pixelData, false);
+            demTexture.update(pixelData, { premultiply: false });
             demTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
         } else {
-            tile.demTexture = new Texture(context, pixelData, gl.RGBA, false);
+            tile.demTexture = new Texture(context, pixelData, gl.RGBA, { premultiply: false });
             tile.demTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
         }
 

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -43,20 +43,20 @@ class Texture {
     useMipmap: boolean;
     powerOfTwoSize: boolean;
 
-    constructor(context: Context, image: TextureImage, format: TextureFormat, premultiply: ?boolean, useMipmap: ?boolean) {
+    constructor(context: Context, image: TextureImage, format: TextureFormat, options: ?{ premultiply?: boolean, useMipmap?: boolean }) {
         this.context = context;
         this.format = format;
         this.texture = context.gl.createTexture();
-        this.update(image, premultiply, useMipmap);
+        this.update(image, options);
     }
 
-    update(image: TextureImage, premultiply: ?boolean, useMipmap: ?boolean) {
+    update(image: TextureImage, options: ?{premultiply?: boolean, useMipmap?: boolean}) {
         const {width, height} = image;
         const resize = !this.size || this.size[0] !== width || this.size[1] !== height;
         const {context} = this;
         const {gl} = context;
 
-        this.useMipmap = Boolean(useMipmap);
+        this.useMipmap = Boolean(options && options.useMipmap);
         gl.bindTexture(gl.TEXTURE_2D, this.texture);
 
         if (resize) {
@@ -65,7 +65,7 @@ class Texture {
 
             context.pixelStoreUnpack.set(1);
 
-            if (this.format === gl.RGBA && premultiply !== false) {
+            if (this.format === gl.RGBA && (!options || options.premultiply !== false)) {
                 context.pixelStoreUnpackPremultiplyAlpha.set(true);
             }
 

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -40,12 +40,14 @@ class Texture {
     format: TextureFormat;
     filter: ?TextureFilter;
     wrap: ?TextureWrap;
+    powerOfTwoSize: boolean;
 
     constructor(context: Context, image: TextureImage, format: TextureFormat, premultiply: ?boolean) {
         this.context = context;
 
         const {width, height} = image;
         this.size = [width, height];
+        this.powerOfTwoSize = width === height && (Math.log(width) / Math.LN2) % 1 === 0;
         this.format = format;
 
         this.texture = context.gl.createTexture();
@@ -76,6 +78,10 @@ class Texture {
         const {context} = this;
         const {gl} = context;
         gl.bindTexture(gl.TEXTURE_2D, this.texture);
+
+        if (minFilter === gl.LINEAR_MIPMAP_NEAREST && !this.powerOfTwoSize) {
+            minFilter = gl.LINEAR;
+        }
 
         if (filter !== this.filter) {
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -47,7 +47,6 @@ class Texture {
 
         const {width, height} = image;
         this.size = [width, height];
-        this.powerOfTwoSize = width === height && (Math.log(width) / Math.LN2) % 1 === 0;
         this.format = format;
 
         this.texture = context.gl.createTexture();
@@ -72,6 +71,8 @@ class Texture {
         } else {
             gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, gl.UNSIGNED_BYTE, image.data);
         }
+
+        this.powerOfTwoSize = width === height && (Math.log(width) / Math.LN2) % 1 === 0;
     }
 
     bind(filter: TextureFilter, wrap: TextureWrap, minFilter: ?TextureFilter) {

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -41,7 +41,6 @@ class Texture {
     filter: ?TextureFilter;
     wrap: ?TextureWrap;
     useMipmap: boolean;
-    powerOfTwoSize: boolean;
 
     constructor(context: Context, image: TextureImage, format: TextureFormat, options: ?{ premultiply?: boolean, useMipmap?: boolean }) {
         this.context = context;
@@ -61,7 +60,6 @@ class Texture {
 
         if (resize) {
             this.size = [width, height];
-            this.powerOfTwoSize = width === height && (Math.log(width) / Math.LN2) % 1 === 0;
 
             context.pixelStoreUnpack.set(1);
 
@@ -83,7 +81,7 @@ class Texture {
             }
         }
 
-        if (this.useMipmap && this.powerOfTwoSize) {
+        if (this.useMipmap && this.isSizePowerOfTwo()) {
             gl.generateMipmap(gl.TEXTURE_2D);
         }
     }
@@ -93,7 +91,7 @@ class Texture {
         const {gl} = context;
         gl.bindTexture(gl.TEXTURE_2D, this.texture);
 
-        if (minFilter === gl.LINEAR_MIPMAP_NEAREST && !this.powerOfTwoSize) {
+        if (minFilter === gl.LINEAR_MIPMAP_NEAREST && !this.isSizePowerOfTwo()) {
             minFilter = gl.LINEAR;
         }
 
@@ -108,6 +106,10 @@ class Texture {
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrap);
             this.wrap = wrap;
         }
+    }
+
+    isSizePowerOfTwo() {
+        return this.size[0] === this.size[1] && (Math.log(this.size[0]) / Math.LN2) % 1 === 0;
     }
 
     destroy() {

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -104,9 +104,9 @@ class RasterTileSource extends Evented implements Source {
                 const gl = context.gl;
                 tile.texture = this.map.painter.getTileTexture(img.width);
                 if (tile.texture) {
-                    tile.texture.update(img, undefined, true);
+                    tile.texture.update(img, { useMipmap: true });
                 } else {
-                    tile.texture = new Texture(context, img, gl.RGBA, undefined, true);
+                    tile.texture = new Texture(context, img, gl.RGBA, { useMipmap: true });
                     tile.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_NEAREST);
 
                     if (context.extTextureFilterAnisotropic) {

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -114,7 +114,7 @@ class RasterTileSource extends Evented implements Source {
                         gl.texParameterf(gl.TEXTURE_2D, context.extTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, context.extTextureFilterAnisotropicMax);
                     }
                 }
-                gl.generateMipmap(gl.TEXTURE_2D);
+                if (tile.texture.powerOfTwoSize) gl.generateMipmap(gl.TEXTURE_2D);
 
                 tile.state = 'loaded';
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -104,17 +104,15 @@ class RasterTileSource extends Evented implements Source {
                 const gl = context.gl;
                 tile.texture = this.map.painter.getTileTexture(img.width);
                 if (tile.texture) {
-                    tile.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_NEAREST);
-                    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, img);
+                    tile.texture.update(img, undefined, true);
                 } else {
-                    tile.texture = new Texture(context, img, gl.RGBA);
+                    tile.texture = new Texture(context, img, gl.RGBA, undefined, true);
                     tile.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_NEAREST);
 
                     if (context.extTextureFilterAnisotropic) {
                         gl.texParameterf(gl.TEXTURE_2D, context.extTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, context.extTextureFilterAnisotropicMax);
                     }
                 }
-                if (tile.texture.powerOfTwoSize) gl.generateMipmap(gl.TEXTURE_2D);
 
                 tile.state = 'loaded';
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/6440

The WMS source in that example returns 400x400 tiles. WebGL only supports mipmaps for power-of-two size textures. This fix just disables mipmap generation and filtering for textures that are not power-of-two.

Alternative: we could either upscale the image to a power-of-two texture or add padding and draw only part of the texture but both of these solutions are significantly more complex and might not look better. Mipmapping only helps rasters look a bit better when they are significantly underzoomed (zooming out and the tiles get smaller).

I wrote a render test for this but it doesn't fail without the fix (I guess the node module implementation doesn't error the same way) so I didn't include it here. I don't have any other ideas on how to test this.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [tried] write tests for all new functionality
 - [n/a] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
