### PR TITLE
Fix race conditions in symbol querying

### DIFF
--- a/debug/debug.html
+++ b/debug/debug.html
@@ -82,6 +82,39 @@ map.on('load', function() {
             "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"]
         }
     });
+
+    map.addLayer({
+        id: "marker",
+        type: "symbol",
+        source: "points",
+        layout: {
+            "icon-image": "bus-11",
+            "icon-size": 2,
+            "icon-ignore-placement": true,
+            "icon-allow-overlap": true
+        }
+    });
+
+    map.addLayer({
+        id: "marker-hover",
+        type: "symbol",
+        filter: ["==", "name", ""],
+        source: "points",
+        layout: {
+            "icon-image": "bus-15",
+            "icon-size": 2,
+            "icon-ignore-placement": true,
+            "icon-allow-overlap": true
+        }
+    });
+
+    map.on('mouseenter', 'marker', function(e) {
+        map.setFilter('marker-hover', ['==', 'name', e.features[0].properties.name]);
+    });
+    map.on('mouseleave', 'marker', function(e) {
+        map.setFilter('marker-hover', ['==', 'name', '']);
+    });
+
 });
 
 map.on('click', function(e) {

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -238,7 +238,6 @@ class GeoJSONSource extends Evented implements Source {
             tileSize: this.tileSize,
             source: this.id,
             pixelRatio: browser.devicePixelRatio,
-            overscaling: tile.tileID.overscaleFactor(),
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -757,6 +757,14 @@ class SourceCache extends Evented {
 
         return false;
     }
+
+    commitPlacement(usedBucketInstanceIds: {[number]: boolean}) {
+        const ids = this.getIds();
+        for (let i = 0; i < ids.length; i++) {
+            const tile = this.getTileByID(ids[i]);
+            tile.pruneFeatureIndexes(usedBucketInstanceIds);
+        }
+    }
 }
 
 SourceCache.maxOverzooming = 10;
@@ -779,4 +787,3 @@ function isRasterType(type) {
 }
 
 export default SourceCache;
-

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -460,10 +460,21 @@ class Tile {
         }
     }
 
-    pruneFeatureIndexes(usedBucketInstanceIds: {[number]: boolean}) {
+    pruneFeatureIndexes(placedBucketInstanceIds: {[number]: boolean}) {
+        const latestBucketInstanceIds = {};
+        for (const id in this.buckets) {
+            const bucket = this.buckets[id];
+            if (bucket instanceof SymbolBucket) {
+                // We're counting on `pruneFeatureIndexes` only being called immediately after
+                // placement so that all buckets have a bucketInstanceId assigned to them
+                latestBucketInstanceIds[bucket.bucketInstanceId] = true;
+            }
+        }
         for (const bucketInstanceId of Object.keys(this.retainedFeatureIndexes).map(Number)) {
-            if (!usedBucketInstanceIds[bucketInstanceId]) {
+            if (!placedBucketInstanceIds[bucketInstanceId] &&
+                !latestBucketInstanceIds[bucketInstanceId]) {
                 // This bucket was no longer used in the latest placement,
+                // and it's not in the latest data waiting for placement,
                 // so discard the associated querying data if this was the
                 // last bucket to use it.
                 delete this.retainedFeatureIndexes[bucketInstanceId];

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -93,18 +93,16 @@ class VectorTileSource extends Evented implements Source {
     }
 
     loadTile(tile: Tile, callback: Callback<void>) {
-        const overscaling = tile.tileID.overscaleFactor();
         const url = normalizeURL(tile.tileID.canonical.url(this.tiles, this.scheme), this.url);
         const params = {
             request: this.map._transformRequest(url, ResourceType.Tile),
             uid: tile.uid,
             tileID: tile.tileID,
             zoom: tile.tileID.overscaledZ,
-            tileSize: this.tileSize * overscaling,
+            tileSize: this.tileSize * tile.tileID.overscaleFactor(),
             type: this.type,
             source: this.id,
             pixelRatio: browser.devicePixelRatio,
-            overscaling: overscaling,
             showCollisionBoxes: this.map.showCollisionBoxes,
         };
         params.request.collectResourceTiming = this._collectResourceTiming;

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -5,7 +5,6 @@ import type {RGBAImage, AlphaImage} from '../util/image';
 import type {OverscaledTileID} from './tile_id';
 import type {Bucket} from '../data/bucket';
 import type FeatureIndex from '../data/feature_index';
-import type {CollisionBoxArray} from '../data/array_types';
 import type DEMData from '../data/dem_data';
 import type {PerformanceResourceTiming} from '../types/performance_resource_timing';
 
@@ -21,7 +20,6 @@ export type WorkerTileParameters = TileParameters & {
     maxZoom: number,
     tileSize: number,
     pixelRatio: number,
-    overscaling: number,
     showCollisionBoxes: boolean,
     collectResourceTiming?: boolean
 };
@@ -37,7 +35,6 @@ export type WorkerTileResult = {
     iconAtlasImage: RGBAImage,
     glyphAtlasImage: AlphaImage,
     featureIndex: FeatureIndex,
-    collisionBoxArray: CollisionBoxArray,
     rawTileData?: ArrayBuffer,
     resourceTiming?: Array<PerformanceResourceTiming>
 };

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -977,6 +977,10 @@ class Style extends Evented {
 
             if (this.pauseablePlacement.isDone()) {
                 this.placement = this.pauseablePlacement.commit(this.placement, browser.now());
+                for (const id in this.sourceCaches) {
+                    // Allows tiles to prune data no longer necessary for querying
+                    this.sourceCaches[id].commitPlacement(this.placement.bucketInstanceIds);
+                }
                 placementCommitted = true;
             }
 

--- a/src/symbol/cross_tile_symbol_index.js
+++ b/src/symbol/cross_tile_symbol_index.js
@@ -234,6 +234,10 @@ class CrossTileSymbolIndex {
 
             if (!symbolBucket.bucketInstanceId) {
                 symbolBucket.bucketInstanceId = ++this.maxBucketInstanceId;
+                // As long as this bucket is used in any committed placement, we have to hold onto
+                // the matching FeatureIndex/CollisionBoxArray/data for querying purposes
+                if (tile.latestFeatureIndex)
+                    tile.retainedFeatureIndexes[symbolBucket.bucketInstanceId] = tile.latestFeatureIndex;
             }
 
             if (layerIndex.addBucket(tile.tileID, symbolBucket, this.crossTileIDs)) {

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -69,6 +69,7 @@ class Placement {
     lastPlacementChangeTime: number;
     stale: boolean;
     fadeDuration: number;
+    bucketInstanceIds: {[number]: boolean};
 
     constructor(transform: Transform, fadeDuration: number) {
         this.transform = transform.clone();
@@ -77,11 +78,16 @@ class Placement {
         this.opacities = {};
         this.stale = false;
         this.fadeDuration = fadeDuration;
+
+        this.bucketInstanceIds = {};
     }
 
     placeLayerTile(styleLayer: StyleLayer, tile: Tile, showCollisionBoxes: boolean, seenCrossTileIDs: { [string | number]: boolean }) {
         const symbolBucket = ((tile.getBucket(styleLayer): any): SymbolBucket);
-        if (!symbolBucket) return;
+        if (!symbolBucket || !tile.latestFeatureIndex)
+            return;
+
+        const collisionBoxArray = tile.latestFeatureIndex.collisionBoxArray;
 
         const layout = symbolBucket.layers[0].layout;
 
@@ -103,7 +109,7 @@ class Placement {
                 pixelsToTileUnits(tile, 1, this.transform.zoom));
 
         this.placeLayerBucket(symbolBucket, posMatrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, textPixelRatio,
-                showCollisionBoxes, seenCrossTileIDs, tile.collisionBoxArray, tile.tileID.key, styleLayer.source);
+                showCollisionBoxes, seenCrossTileIDs, collisionBoxArray, tile.tileID.key, styleLayer.source);
     }
 
     placeLayerBucket(bucket: SymbolBucket, posMatrix: mat4, textLabelPlaneMatrix: mat4, iconLabelPlaneMatrix: mat4,
@@ -116,6 +122,10 @@ class Placement {
 
         const iconWithoutText = !bucket.hasTextData() || layout.get('text-optional');
         const textWithoutIcon = !bucket.hasIconData() || layout.get('icon-optional');
+
+        // Mark this bucket version as "used" by this placement.
+        // This is necessary to hold onto tile data for symbol querying
+        this.bucketInstanceIds[bucket.bucketInstanceId] = true;
 
         for (const symbolInstance of bucket.symbolInstances) {
             if (!seenCrossTileIDs[symbolInstance.crossTileID]) {
@@ -259,8 +269,8 @@ class Placement {
 
         for (const tile of tiles) {
             const symbolBucket = ((tile.getBucket(styleLayer): any): SymbolBucket);
-            if (symbolBucket) {
-                this.updateBucketOpacities(symbolBucket, seenCrossTileIDs, tile.collisionBoxArray);
+            if (symbolBucket && tile.latestFeatureIndex) {
+                this.updateBucketOpacities(symbolBucket, seenCrossTileIDs, tile.latestFeatureIndex.collisionBoxArray);
             }
         }
     }

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -13,6 +13,7 @@ import Transform from '../../../src/geo/transform';
 import { OverscaledTileID } from '../../../src/source/tile_id';
 import Tile from '../../../src/source/tile';
 import CrossTileSymbolIndex from '../../../src/symbol/cross_tile_symbol_index';
+import FeatureIndex from '../../../src/data/feature_index';
 
 // Load a point feature from fixture tile.
 const vt = new VectorTile(new Protobuf(fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'))));
@@ -57,6 +58,7 @@ test('SymbolBucket', (t) => {
     bucketA.populate([{feature}], options);
     performSymbolLayout(bucketA, stacks, {});
     const tileA = new Tile(tileID, 512);
+    tileA.latestFeatureIndex = new FeatureIndex(tileID);
     tileA.buckets = { test: bucketA };
     tileA.collisionBoxArray = collisionBoxArray;
 

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -21,6 +21,7 @@ test('querySourceFeatures', (t) => {
 
     t.test('geojson tile', (t) => {
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 1, 1));
+        tile.latestFeatureIndex = new FeatureIndex(tile.tileID);
         let result;
 
         result = [];
@@ -29,7 +30,7 @@ test('querySourceFeatures', (t) => {
 
         const geojsonWrapper = new GeoJSONWrapper(features);
         geojsonWrapper.name = '_geojsonTileLayer';
-        tile.rawTileData = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
+        tile.latestFeatureIndex.rawTileData = vtpbf({ layers: { '_geojsonTileLayer': geojsonWrapper }});
 
         result = [];
         tile.querySourceFeatures(result);

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -128,6 +128,42 @@ test('querySourceFeatures', (t) => {
         t.end();
     });
 
+    t.test('loadVectorData preserves old symbol data until it has been pruned', (t) => {
+        const tile = new Tile(new OverscaledTileID(1, 0, 1, 1, 1));
+        tile.state = 'loaded';
+
+        tile.loadVectorData(
+            createVectorData({rawTileData: createRawTileData()}),
+            createPainter()
+        );
+
+        tile.retainedFeatureIndexes[0] = tile.latestFeatureIndex;
+
+        tile.loadVectorData(
+            createVectorData(),
+            createPainter()
+        );
+
+        tile.pruneFeatureIndexes({0: true});
+        t.equal(Object.keys(tile.retainedFeatureIndexes).length, 1);
+
+        t.notEqual(tile.retainedFeatureIndexes[0], tile.latestFeatureIndex);
+
+        let features = [];
+        tile.querySourceFeatures(features, { 'sourceLayer': 'road' });
+        t.equal(features.length, 3);
+
+        tile.pruneFeatureIndexes({});
+
+        t.equal(Object.keys(tile.retainedFeatureIndexes).length, 0);
+
+        features = [];
+        tile.querySourceFeatures(features, { 'sourceLayer': 'road' });
+        t.equal(features.length, 3);
+
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Addresses hover flicker from issues #5887 and #5506.
Moves all data necessary for symbol querying into FeatureIndex.
Retains old FeatureIndexes if they're associated with a bucket that was used in the current placement.

The approach to fixing these bugs is unfortunately a bit complicated: because GL JS supports "incremental placement", it's possible that one `CollisionIndex` (which we use for querying rendered symbols) is built with data from multiple different versions of the same tile. Placement can't be interrupted for a single bucket of a single tile, so what we do here is hold on to all the data we need to query each bucket that gets included in a given placement. We piggy-back on the existing `bucketInstanceId` mechanism in `CrossTileSymbolIndex` that guarantees a unique ID number for each new version of a bucket.

In the case where one tile has multiple `FeatureIndex`es (because tile updates have arrived in the middle of an incremental placement), we run our symbol query against each of those indices separately, filtering `CollisionIndex` results against the set of bucket ids associated with each `FeatureIndex`. 

Although this is a pretty inefficient way to store/query what is for the most part a bunch of duplicate data, I'm not too worried about it because it's just a temporary added cost during the period of time between a tile update and the next placement. This PR does introduce a lot of shared pointers to data, though -- one way it could go wrong would be to start leaking that data.

I've manually tested this branch against the repro case in #5506, but I haven't come up with any automated tests yet. Although they'll be a bit contrived, I think I can at least add some cases to the `Tile` unit test that try to exercise the functionality.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] Ran benchmarks, nothing jumped out. How do we post now that anonymous gists are broken?
 - [x] manually test the debug page

/cc @ansis @malwoodsantoro @ryanbaumann @lilykaiser 