### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.js.map
 node_modules
 npm-debug.log
+package-lock.json
 *.sublime-*
 coverage
 flow-coverage


### PR DESCRIPTION
Ignores `package-lock.json`, which is generated by npm when it installs packages but evidently isn’t something we’ve decided to check in. I’m not familiar with the rationale behind this, so this PR is merely a suggestion for how to alleviate a downstream issue.

Keeping these files unignored-but-not-checked-in leads to persistently dirty git statuses, especially when this repo is consumed as a submodule, as in `mapbox-gl-native`:

```
$ git diff
diff --git a/mapbox-gl-js b/mapbox-gl-js
--- a/mapbox-gl-js
+++ b/mapbox-gl-js
@@ -1 +1 @@
-Subproject commit bbee7e51695184e9b3c0ecb74d314c4ab73d4c27
+Subproject commit bbee7e51695184e9b3c0ecb74d314c4ab73d4c27-dirty

$ cd mapbox-gl-js
$ git diff
(no changes)

$ git status
HEAD detached at bbee7e516
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	test/integration/package-lock.json

nothing added to commit but untracked files present (use "git add" to track)
```
