### PR TITLE
Fix hash bug

### DIFF
--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -47,6 +47,8 @@ class Hash {
     remove() {
         window.removeEventListener('hashchange', this._onHashChange, false);
         this._map.off('moveend', this._updateHash);
+        clearTimeout(this._updateHash());
+
         delete this._map;
         return this;
     }

--- a/test/unit/ui/hash.test.js
+++ b/test/unit/ui/hash.test.js
@@ -149,5 +149,23 @@ test('hash', (t) => {
         t.end();
     });
 
+    t.test('map#remove', (t) => {
+        const container = window.document.createElement('div');
+        Object.defineProperty(container, 'offsetWidth', {value: 512});
+        Object.defineProperty(container, 'offsetHeight', {value: 512});
+
+        const map = new Map({
+            container,
+            center: [-74.50, 40],
+            zoom: 9,
+            hash: true,
+        });
+
+        map.remove();
+
+        t.ok(map);
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
Adds a clearTimeout to the remove method, clearing the throttled event before it attempts to trigger again. The unit test demonstrates that a type error is thrown (“Cannot read property 'getCenter' of undefined”) when initializing a map with hash option set to true, then calling map#remove. The `createMap()` helper is avoided because this issue appears to be specific to when initializing the map with the options object.

Closes #6452. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
Adds a clearTimeout to the remove method of the hash task, clearing the throttled event before it attempts to trigger again.
 - [x] write tests for all new functionality
~I'm not sure how to add a test for this - guidance appreciated.~
 - [x] document any changes to public APIs
No changes
 - [ ] ~post benchmark scores~
~How do I do this? `yarn run build-benchmarks`?~
 - [x] manually test the debug page
I added a manual test to the debug page. 
