### PR TITLE
Rework spec function/expression taxonomy 

### DIFF
--- a/build/generate-flow-typed-style-spec.js
+++ b/build/generate-flow-typed-style-spec.js
@@ -41,9 +41,9 @@ function flowType(property) {
         }
     })();
 
-    if (properties.isPropertyFunction(property)) {
+    if (properties.isPropertyExpression(property)) {
         return `DataDrivenPropertyValueSpecification<${baseType}>`;
-    } else if (properties.isZoomFunction(property)) {
+    } else if (properties.isZoomExpression(property)) {
         return `PropertyValueSpecification<${baseType}>`;
     } else if (property.expression) {
         return `ExpressionSpecification`;

--- a/build/generate-flow-typed-style-spec.js
+++ b/build/generate-flow-typed-style-spec.js
@@ -1,4 +1,5 @@
 const spec = require('../src/style-spec/reference/v8.json');
+const properties = require('../src/style-spec/util/properties');
 const fs = require('fs');
 
 function flowEnum(values) {
@@ -40,11 +41,11 @@ function flowType(property) {
         }
     })();
 
-    if (property['property-function']) {
+    if (properties.isPropertyFunction(property)) {
         return `DataDrivenPropertyValueSpecification<${baseType}>`;
-    } else if (property['zoom-function']) {
+    } else if (properties.isZoomFunction(property)) {
         return `PropertyValueSpecification<${baseType}>`;
-    } else if (property.function) {
+    } else if (property.expression) {
         return `ExpressionSpecification`;
     } else {
         return baseType;

--- a/build/generate-flow-typed-style-spec.js
+++ b/build/generate-flow-typed-style-spec.js
@@ -41,9 +41,9 @@ function flowType(property) {
         }
     })();
 
-    if (properties.isPropertyExpression(property)) {
+    if (properties.supportsPropertyExpression(property)) {
         return `DataDrivenPropertyValueSpecification<${baseType}>`;
-    } else if (properties.isZoomExpression(property)) {
+    } else if (properties.supportsZoomExpression(property)) {
         return `PropertyValueSpecification<${baseType}>`;
     } else if (property.expression) {
         return `ExpressionSpecification`;

--- a/build/generate-struct-arrays.js
+++ b/build/generate-struct-arrays.js
@@ -226,5 +226,6 @@ ${arraysWithStructAccessors.map(structArrayJs).join('\n')}
 export {
     ${layouts.map(layout => layout.className).join(',\n    ')},
     ${[...arrayTypeEntries].join(',\n    ')}
-};`);
+};
+`);
 

--- a/build/generate-style-code.js
+++ b/build/generate-style-code.js
@@ -43,8 +43,10 @@ global.propertyType = function (property) {
         case 'color-ramp':
             return `ColorRampProperty`;
         case 'data-constant':
-        default:
+        case 'constant':
             return `DataConstantProperty<${flowType(property)}>`;
+        default:
+            throw new Error(`unknown property-type "${property['property-type']}" for ${property.name}`);
     }
 };
 
@@ -97,8 +99,10 @@ global.propertyValue = function (property, type) {
         case 'color-ramp':
             return `new ColorRampProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
         case 'data-constant':
-        default:
+        case 'constant':
             return `new DataConstantProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
+        default:
+            throw new Error(`unknown property-type "${property['property-type']}" for ${property.name}`);
     }
 };
 

--- a/build/generate-style-code.js
+++ b/build/generate-style-code.js
@@ -12,10 +12,6 @@ global.camelize = function (str) {
     });
 };
 
-global.isDataDriven = function (property) {
-    return property['property-function'] === true;
-};
-
 global.flowType = function (property) {
     switch (property.type) {
         case 'boolean':
@@ -39,14 +35,16 @@ global.flowType = function (property) {
 };
 
 global.propertyType = function (property) {
-    if (isDataDriven(property)) {
-        return `DataDrivenProperty<${flowType(property)}>`;
-    } else if (/-pattern$/.test(property.name) || property.name === 'line-dasharray') {
-        return `CrossFadedProperty<${flowType(property)}>`;
-    } else if (property.name === 'heatmap-color' || property.name === 'line-gradient') {
-        return `ColorRampProperty`;
-    } else {
-        return `DataConstantProperty<${flowType(property)}>`;
+    switch (property.expression['property-type']) {
+        case 'data-driven':
+            return `DataDrivenProperty<${flowType(property)}>`;
+        case 'cross-faded':
+            return `CrossFadedProperty<${flowType(property)}>`;
+        case 'color-ramp':
+            return `ColorRampProperty`;
+        case 'data-constant':
+        default:
+            return `DataConstantProperty<${flowType(property)}>`;
     }
 };
 
@@ -91,14 +89,16 @@ global.defaultValue = function (property) {
 };
 
 global.propertyValue = function (property, type) {
-    if (isDataDriven(property)) {
-        return `new DataDrivenProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
-    } else if (/-pattern$/.test(property.name) || property.name === 'line-dasharray') {
-        return `new CrossFadedProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
-    } else if (property.name === 'heatmap-color' || property.name === 'line-gradient') {
-        return `new ColorRampProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
-    } else {
-        return `new DataConstantProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
+    switch (property.expression['property-type']) {
+        case 'data-driven':
+            return `new DataDrivenProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
+        case 'cross-faded':
+            return `new CrossFadedProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
+        case 'color-ramp':
+            return `new ColorRampProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
+        case 'data-constant':
+        default:
+            return `new DataConstantProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
     }
 };
 

--- a/build/generate-style-code.js
+++ b/build/generate-style-code.js
@@ -35,7 +35,7 @@ global.flowType = function (property) {
 };
 
 global.propertyType = function (property) {
-    switch (property.expression['property-type']) {
+    switch (property['property-type']) {
         case 'data-driven':
             return `DataDrivenProperty<${flowType(property)}>`;
         case 'cross-faded':
@@ -89,7 +89,7 @@ global.defaultValue = function (property) {
 };
 
 global.propertyValue = function (property, type) {
-    switch (property.expression['property-type']) {
+    switch (property['property-type']) {
         case 'data-driven':
             return `new DataDrivenProperty(styleSpec["${type}_${property.layerType}"]["${property.name}"])`;
         case 'cross-faded':

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "test-render": "node --max-old-space-size=2048 test/render.test.js",
     "test-query": "node test/query.test.js",
     "test-expressions": "build/run-node test/expression.test.js",
-    "test-flow": "node build/generate-flow-typed-style-spec && flow .",
+    "test-flow": "build/run-node build/generate-flow-typed-style-spec && flow .",
     "test-flow-cov": "flow-coverage-report -i 'src/**/*.js' -t html",
     "test-cov": "nyc --require=@mapbox/flow-remove-types/register --reporter=text-summary --reporter=lcov --cache run-s test-unit test-expressions test-query test-render",
     "prepublish": "in-publish && run-s build-dev build-min || not-in-publish",

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -2,7 +2,7 @@
 
 import { packUint8ToFloat } from '../shaders/encode_attribute';
 import Color from '../style-spec/util/color';
-import { isPropertyExpression } from '../style-spec/util/properties';
+import { supportsPropertyExpression } from '../style-spec/util/properties';
 import { register } from '../util/web_worker_transfer';
 import { PossiblyEvaluatedPropertyValue } from '../style/properties';
 import { StructArrayLayout1f4, StructArrayLayout2f8, StructArrayLayout4f16 } from './array_types';
@@ -292,7 +292,7 @@ export default class ProgramConfiguration {
         for (const property in layer.paint._values) {
             if (!filterProperties(property)) continue;
             const value = layer.paint.get(property);
-            if (!(value instanceof PossiblyEvaluatedPropertyValue) || !isPropertyExpression(value.property.specification)) {
+            if (!(value instanceof PossiblyEvaluatedPropertyValue) || !supportsPropertyExpression(value.property.specification)) {
                 continue;
             }
             const name = paintAttributeName(property, layer.type);

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -2,6 +2,7 @@
 
 import { packUint8ToFloat } from '../shaders/encode_attribute';
 import Color from '../style-spec/util/color';
+import { isPropertyFunction } from '../style-spec/util/properties';
 import { register } from '../util/web_worker_transfer';
 import { PossiblyEvaluatedPropertyValue } from '../style/properties';
 import { StructArrayLayout1f4, StructArrayLayout2f8, StructArrayLayout4f16 } from './array_types';
@@ -291,7 +292,7 @@ export default class ProgramConfiguration {
         for (const property in layer.paint._values) {
             if (!filterProperties(property)) continue;
             const value = layer.paint.get(property);
-            if (!(value instanceof PossiblyEvaluatedPropertyValue) || !value.property.specification['property-function']) {
+            if (!(value instanceof PossiblyEvaluatedPropertyValue) || !isPropertyFunction(value.property.specification)) {
                 continue;
             }
             const name = paintAttributeName(property, layer.type);

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -2,7 +2,7 @@
 
 import { packUint8ToFloat } from '../shaders/encode_attribute';
 import Color from '../style-spec/util/color';
-import { isPropertyFunction } from '../style-spec/util/properties';
+import { isPropertyExpression } from '../style-spec/util/properties';
 import { register } from '../util/web_worker_transfer';
 import { PossiblyEvaluatedPropertyValue } from '../style/properties';
 import { StructArrayLayout1f4, StructArrayLayout2f8, StructArrayLayout4f16 } from './array_types';
@@ -292,7 +292,7 @@ export default class ProgramConfiguration {
         for (const property in layer.paint._values) {
             if (!filterProperties(property)) continue;
             const value = layer.paint.get(property);
-            if (!(value instanceof PossiblyEvaluatedPropertyValue) || !isPropertyFunction(value.property.specification)) {
+            if (!(value instanceof PossiblyEvaluatedPropertyValue) || !isPropertyExpression(value.property.specification)) {
                 continue;
             }
             const name = paintAttributeName(property, layer.type);

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -15,6 +15,7 @@ import definitions from './definitions';
 import * as isConstant from './is_constant';
 import RuntimeError from './runtime_error';
 import { success, error } from '../util/result';
+import { isPropertyFunction, isZoomFunction, isInterpolated } from '../util/properties';
 
 import type {Type} from './types';
 import type {Value} from './values';
@@ -207,12 +208,12 @@ export function createPropertyExpression(expression: mixed, propertySpec: StyleP
     const parsed = expression.value.expression;
 
     const isFeatureConstant = isConstant.isFeatureConstant(parsed);
-    if (!isFeatureConstant && !propertySpec['property-function']) {
+    if (!isFeatureConstant && !isPropertyFunction(propertySpec)) {
         return error([new ParsingError('', 'property expressions not supported')]);
     }
 
     const isZoomConstant = isConstant.isGlobalPropertyConstant(parsed, ['zoom']);
-    if (!isZoomConstant && propertySpec['zoom-function'] === false) {
+    if (!isZoomConstant && !isZoomFunction(propertySpec)) {
         return error([new ParsingError('', 'zoom expressions not supported')]);
     }
 
@@ -221,7 +222,7 @@ export function createPropertyExpression(expression: mixed, propertySpec: StyleP
         return error([new ParsingError('', '"zoom" expression may only be used as input to a top-level "step" or "interpolate" expression.')]);
     } else if (zoomCurve instanceof ParsingError) {
         return error([zoomCurve]);
-    } else if (zoomCurve instanceof Interpolate && propertySpec['function'] === 'piecewise-constant') {
+    } else if (zoomCurve instanceof Interpolate && !isInterpolated(propertySpec)) {
         return error([new ParsingError('', '"interpolate" expressions cannot be used with this property')]);
     }
 

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -15,7 +15,7 @@ import definitions from './definitions';
 import * as isConstant from './is_constant';
 import RuntimeError from './runtime_error';
 import { success, error } from '../util/result';
-import { isPropertyFunction, isZoomFunction, isInterpolated } from '../util/properties';
+import { isPropertyExpression, isZoomExpression, isInterpolated } from '../util/properties';
 
 import type {Type} from './types';
 import type {Value} from './values';
@@ -208,12 +208,12 @@ export function createPropertyExpression(expression: mixed, propertySpec: StyleP
     const parsed = expression.value.expression;
 
     const isFeatureConstant = isConstant.isFeatureConstant(parsed);
-    if (!isFeatureConstant && !isPropertyFunction(propertySpec)) {
+    if (!isFeatureConstant && !isPropertyExpression(propertySpec)) {
         return error([new ParsingError('', 'property expressions not supported')]);
     }
 
     const isZoomConstant = isConstant.isGlobalPropertyConstant(parsed, ['zoom']);
-    if (!isZoomConstant && !isZoomFunction(propertySpec)) {
+    if (!isZoomConstant && !isZoomExpression(propertySpec)) {
         return error([new ParsingError('', 'zoom expressions not supported')]);
     }
 

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -15,7 +15,7 @@ import definitions from './definitions';
 import * as isConstant from './is_constant';
 import RuntimeError from './runtime_error';
 import { success, error } from '../util/result';
-import { isPropertyExpression, isZoomExpression, isInterpolated } from '../util/properties';
+import { supportsPropertyExpression, supportsZoomExpression, supportsInterpolation } from '../util/properties';
 
 import type {Type} from './types';
 import type {Value} from './values';
@@ -208,12 +208,12 @@ export function createPropertyExpression(expression: mixed, propertySpec: StyleP
     const parsed = expression.value.expression;
 
     const isFeatureConstant = isConstant.isFeatureConstant(parsed);
-    if (!isFeatureConstant && !isPropertyExpression(propertySpec)) {
+    if (!isFeatureConstant && !supportsPropertyExpression(propertySpec)) {
         return error([new ParsingError('', 'property expressions not supported')]);
     }
 
     const isZoomConstant = isConstant.isGlobalPropertyConstant(parsed, ['zoom']);
-    if (!isZoomConstant && !isZoomExpression(propertySpec)) {
+    if (!isZoomConstant && !supportsZoomExpression(propertySpec)) {
         return error([new ParsingError('', 'zoom expressions not supported')]);
     }
 
@@ -222,7 +222,7 @@ export function createPropertyExpression(expression: mixed, propertySpec: StyleP
         return error([new ParsingError('', '"zoom" expression may only be used as input to a top-level "step" or "interpolate" expression.')]);
     } else if (zoomCurve instanceof ParsingError) {
         return error([zoomCurve]);
-    } else if (zoomCurve instanceof Interpolate && !isInterpolated(propertySpec)) {
+    } else if (zoomCurve instanceof Interpolate && !supportsInterpolation(propertySpec)) {
         return error([new ParsingError('', '"interpolate" expressions cannot be used with this property')]);
     }
 

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -47,8 +47,8 @@ function isExpressionFilter(filter: any) {
 const filterSpec = {
     'type': 'boolean',
     'default': false,
+    'property-type': 'data-driven',
     'expression': {
-        'type': 'data-driven',
         'interpolated': true,
         'parameters': ['zoom', 'feature']
     }

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -47,9 +47,11 @@ function isExpressionFilter(filter: any) {
 const filterSpec = {
     'type': 'boolean',
     'default': false,
-    'function': true,
-    'property-function': true,
-    'zoom-function': true
+    'expression': {
+        'type': 'data-driven',
+        'interpolated': true,
+        'parameters': ['zoom', 'feature']
+    }
 };
 
 /**

--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -236,8 +236,8 @@ function appendStopPair(curve, input, output, isStep) {
 function getFunctionType(parameters, propertySpec) {
     if (parameters.type) {
         return parameters.type;
-    } else if (propertySpec.function) {
-        return propertySpec.function === 'interpolated' ? 'exponential' : 'interval';
+    } else if (propertySpec.expression) {
+        return propertySpec.expression.interpolated ? 'exponential' : 'interval';
     } else {
         return 'exponential';
     }

--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -236,10 +236,9 @@ function appendStopPair(curve, input, output, isStep) {
 function getFunctionType(parameters, propertySpec) {
     if (parameters.type) {
         return parameters.type;
-    } else if (propertySpec.expression) {
-        return propertySpec.expression.interpolated ? 'exponential' : 'interval';
     } else {
-        return 'exponential';
+        assert(propertySpec.expression);
+        return (propertySpec.expression: any).interpolated ? 'exponential' : 'interval';
     }
 }
 

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -5,7 +5,7 @@ import extend from '../util/extend';
 import getType from '../util/get_type';
 import * as interpolate from '../util/interpolate';
 import Interpolate from '../expression/definitions/interpolate';
-import { isInterpolated } from '../util/properties';
+import { supportsInterpolation } from '../util/properties';
 
 export function isFunction(value) {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -20,7 +20,7 @@ export function createFunction(parameters, propertySpec) {
     const zoomAndFeatureDependent = parameters.stops && typeof parameters.stops[0][0] === 'object';
     const featureDependent = zoomAndFeatureDependent || parameters.property !== undefined;
     const zoomDependent = zoomAndFeatureDependent || !featureDependent;
-    const type = parameters.type || (isInterpolated(propertySpec) ? 'exponential' : 'interval');
+    const type = parameters.type || (supportsInterpolation(propertySpec) ? 'exponential' : 'interval');
 
     if (isColor) {
         parameters = extend({}, parameters);

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -5,6 +5,7 @@ import extend from '../util/extend';
 import getType from '../util/get_type';
 import * as interpolate from '../util/interpolate';
 import Interpolate from '../expression/definitions/interpolate';
+import { isInterpolated } from '../util/properties';
 
 export function isFunction(value) {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -19,7 +20,7 @@ export function createFunction(parameters, propertySpec) {
     const zoomAndFeatureDependent = parameters.stops && typeof parameters.stops[0][0] === 'object';
     const featureDependent = zoomAndFeatureDependent || parameters.property !== undefined;
     const zoomDependent = zoomAndFeatureDependent || !featureDependent;
-    const type = parameters.type || (propertySpec.function === 'interpolated' ? 'exponential' : 'interval');
+    const type = parameters.type || (isInterpolated(propertySpec) ? 'exponential' : 'interval');
 
     if (isColor) {
         parameters = extend({}, parameters);

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -595,7 +595,8 @@
           "ios": "2.0.0",
           "macos": "0.1.0"
         }
-      }
+      },
+      "property-type": "constant"
     }
   },
   "layout_fill": {
@@ -618,7 +619,8 @@
           "ios": "2.0.0",
           "macos": "0.1.0"
         }
-      }
+      },
+      "property-type": "constant"
     }
   },
   "layout_circle": {
@@ -641,7 +643,8 @@
           "ios": "2.0.0",
           "macos": "0.1.0"
         }
-      }
+      },
+      "property-type": "constant"
     }
   },
   "layout_heatmap": {
@@ -661,7 +664,8 @@
         "basic functionality": {
           "js": "0.41.0"
         }
-      }
+      },
+      "property-type": "constant"
     }
   },
   "layout_fill-extrusion": {
@@ -684,7 +688,8 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
-      }
+      },
+      "property-type": "constant"
     }
   },
   "layout_line": {
@@ -713,12 +718,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "line-join": {
       "type": "enum",
@@ -750,13 +755,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": false,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "line-miter-limit": {
       "type": "number",
@@ -777,12 +782,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "line-round-limit": {
       "type": "number",
@@ -803,12 +808,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "visibility": {
       "type": "enum",
@@ -830,7 +835,8 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
-      }
+      },
+      "property-type": "constant"
     }
   },
   "layout_symbol": {
@@ -856,12 +862,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "symbol-spacing": {
       "type": "number",
@@ -884,12 +890,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "symbol-avoid-edges": {
       "type": "boolean",
@@ -905,12 +911,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-allow-overlap": {
       "type": "boolean",
@@ -929,12 +935,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-ignore-placement": {
       "type": "boolean",
@@ -953,12 +959,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-optional": {
       "type": "boolean",
@@ -978,12 +984,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-rotation-alignment": {
       "type": "enum",
@@ -1019,12 +1025,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-size": {
       "type": "number",
@@ -1050,13 +1056,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-text-fit": {
       "type": "enum",
@@ -1090,12 +1096,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-text-fit-padding": {
       "type": "array",
@@ -1130,12 +1136,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-image": {
       "type": "string",
@@ -1156,13 +1162,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": false,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-rotate": {
       "type": "number",
@@ -1188,13 +1194,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-padding": {
       "type": "number",
@@ -1215,12 +1221,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-keep-upright": {
       "type": "boolean",
@@ -1245,12 +1251,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-offset": {
       "type": "array",
@@ -1279,13 +1285,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-anchor": {
       "type": "enum",
@@ -1338,13 +1344,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": false,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-pitch-alignment": {
       "type": "enum",
@@ -1374,12 +1380,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-pitch-alignment": {
       "type": "enum",
@@ -1415,12 +1421,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-rotation-alignment": {
       "type": "enum",
@@ -1456,12 +1462,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-field": {
       "type": "string",
@@ -1483,13 +1489,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": false,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-font": {
       "type": "array",
@@ -1514,13 +1520,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": false,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-size": {
       "type": "number",
@@ -1546,13 +1552,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-max-width": {
       "type": "number",
@@ -1578,13 +1584,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-line-height": {
       "type": "number",
@@ -1604,12 +1610,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-letter-spacing": {
       "type": "number",
@@ -1634,13 +1640,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-justify": {
       "type": "enum",
@@ -1675,13 +1681,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": false,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-anchor": {
       "type": "enum",
@@ -1734,13 +1740,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": false,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-max-angle": {
       "type": "number",
@@ -1763,12 +1769,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-rotate": {
       "type": "number",
@@ -1794,13 +1800,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-padding": {
       "type": "number",
@@ -1821,12 +1827,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-keep-upright": {
       "type": "boolean",
@@ -1851,12 +1857,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-transform": {
       "type": "enum",
@@ -1891,13 +1897,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": false,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-offset": {
       "type": "array",
@@ -1927,13 +1933,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-allow-overlap": {
       "type": "boolean",
@@ -1952,12 +1958,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-ignore-placement": {
       "type": "boolean",
@@ -1976,12 +1982,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-optional": {
       "type": "boolean",
@@ -2001,12 +2007,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "visibility": {
       "type": "enum",
@@ -2028,7 +2034,8 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
-      }
+      },
+      "property-type": "constant"
     }
   },
   "layout_raster": {
@@ -2052,7 +2059,8 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
-      }
+      },
+      "property-type": "constant"
     }
   },
   "layout_hillshade": {
@@ -2073,7 +2081,8 @@
           "js": "0.43.0"
         },
         "data-driven styling": {}
-      }
+      },
+      "property-type": "constant"
     }
   },
   "filter": {
@@ -2863,9 +2872,9 @@
           "doc": "The position of the light source is aligned to the rotation of the viewport."
         }
       },
+      "property-type": "data-constant",
       "transition": false,
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
@@ -2891,9 +2900,9 @@
       ],
       "length": 3,
       "value": "number",
+      "property-type": "data-constant",
       "transition": true,
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
@@ -2916,9 +2925,9 @@
     },
     "color": {
       "type": "color",
+      "property-type": "data-constant",
       "default": "#ffffff",
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
@@ -2937,11 +2946,11 @@
     },
     "intensity": {
       "type": "number",
+      "property-type": "data-constant",
       "default": 0.5,
       "minimum": 0,
       "maximum": 1,
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
@@ -2985,12 +2994,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "fill-opacity": {
       "type": "number",
@@ -3014,13 +3023,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "fill-color": {
       "type": "color",
@@ -3047,13 +3056,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "fill-outline-color": {
       "type": "color",
@@ -3082,13 +3091,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "fill-translate": {
       "type": "array",
@@ -3111,12 +3120,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "fill-translate-anchor": {
       "type": "enum",
@@ -3143,12 +3152,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "fill-pattern": {
       "type": "string",
@@ -3164,12 +3173,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "cross-faded",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "cross-faded"
     }
   },
   "paint_fill-extrusion": {
@@ -3189,12 +3198,12 @@
         }
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "fill-extrusion-color": {
       "type": "color",
@@ -3221,13 +3230,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "fill-extrusion-translate": {
       "type": "array",
@@ -3250,12 +3259,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "fill-extrusion-translate-anchor": {
       "type": "enum",
@@ -3282,12 +3291,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "fill-extrusion-pattern": {
       "type": "string",
@@ -3303,12 +3312,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "cross-faded",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "cross-faded"
     },
     "fill-extrusion-height": {
       "type": "number",
@@ -3332,13 +3341,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "fill-extrusion-base": {
       "type": "number",
@@ -3365,13 +3374,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     }
   },
   "paint_line": {
@@ -3397,13 +3406,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "line-color": {
       "type": "color",
@@ -3430,13 +3439,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "line-translate": {
       "type": "array",
@@ -3459,12 +3468,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "line-translate-anchor": {
       "type": "enum",
@@ -3491,12 +3500,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "line-width": {
       "type": "number",
@@ -3517,13 +3526,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "line-gap-width": {
       "type": "number",
@@ -3547,13 +3556,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "line-offset": {
       "type": "number",
@@ -3576,13 +3585,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "line-blur": {
       "type": "number",
@@ -3606,13 +3615,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "line-dasharray": {
       "type": "array",
@@ -3636,12 +3645,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "cross-faded",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "cross-faded"
     },
     "line-pattern": {
       "type": "string",
@@ -3657,12 +3666,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "cross-faded",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "cross-faded"
     },
     "line-gradient": {
       "type": "color",
@@ -3689,12 +3698,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "color-ramp",
         "interpolated": true,
         "parameters": [
           "line-progress"
         ]
-      }
+      },
+      "property-type": "color-ramp"
     }
   },
   "paint_circle": {
@@ -3720,13 +3729,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "circle-color": {
       "type": "color",
@@ -3748,13 +3757,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "circle-blur": {
       "type": "number",
@@ -3776,13 +3785,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "circle-opacity": {
       "type": "number",
@@ -3806,13 +3815,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "circle-translate": {
       "type": "array",
@@ -3835,12 +3844,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "circle-translate-anchor": {
       "type": "enum",
@@ -3867,12 +3876,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "circle-pitch-scale": {
       "type": "enum",
@@ -3896,12 +3905,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "circle-pitch-alignment": {
       "type": "enum",
@@ -3925,12 +3934,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "circle-stroke-width": {
       "type": "number",
@@ -3954,13 +3963,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "circle-stroke-color": {
       "type": "color",
@@ -3982,13 +3991,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "circle-stroke-opacity": {
       "type": "number",
@@ -4012,13 +4021,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     }
   },
   "paint_heatmap": {
@@ -4038,13 +4047,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "heatmap-weight": {
       "type": "number",
@@ -4061,13 +4070,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "heatmap-intensity": {
       "type": "number",
@@ -4082,12 +4091,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "heatmap-color": {
       "type": "color",
@@ -4121,12 +4130,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "color-ramp",
         "interpolated": true,
         "parameters": [
           "heatmap-density"
         ]
-      }
+      },
+      "property-type": "color-ramp"
     },
     "heatmap-opacity": {
       "type": "number",
@@ -4142,12 +4151,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     }
   },
   "paint_symbol": {
@@ -4176,13 +4185,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-color": {
       "type": "color",
@@ -4207,13 +4216,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-halo-color": {
       "type": "color",
@@ -4238,13 +4247,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-halo-width": {
       "type": "number",
@@ -4271,13 +4280,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-halo-blur": {
       "type": "number",
@@ -4304,13 +4313,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "icon-translate": {
       "type": "array",
@@ -4336,12 +4345,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "icon-translate-anchor": {
       "type": "enum",
@@ -4369,12 +4378,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-opacity": {
       "type": "number",
@@ -4401,13 +4410,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-color": {
       "type": "color",
@@ -4432,13 +4441,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-halo-color": {
       "type": "color",
@@ -4463,13 +4472,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-halo-width": {
       "type": "number",
@@ -4496,13 +4505,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-halo-blur": {
       "type": "number",
@@ -4529,13 +4538,13 @@
         }
       },
       "expression": {
-        "property-type": "data-driven",
         "interpolated": true,
         "parameters": [
           "zoom",
           "feature"
         ]
-      }
+      },
+      "property-type": "data-driven"
     },
     "text-translate": {
       "type": "array",
@@ -4561,12 +4570,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "text-translate-anchor": {
       "type": "enum",
@@ -4594,12 +4603,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     }
   },
   "paint_raster": {
@@ -4620,12 +4629,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "raster-hue-rotate": {
       "type": "number",
@@ -4644,12 +4653,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "raster-brightness-min": {
       "type": "number",
@@ -4668,12 +4677,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "raster-brightness-max": {
       "type": "number",
@@ -4692,12 +4701,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "raster-saturation": {
       "type": "number",
@@ -4716,12 +4725,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "raster-contrast": {
       "type": "number",
@@ -4740,12 +4749,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "raster-fade-duration": {
       "type": "number",
@@ -4764,12 +4773,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     }
   },
   "paint_hillshade": {
@@ -4787,12 +4796,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "hillshade-illumination-anchor": {
       "type": "enum",
@@ -4813,12 +4822,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "hillshade-exaggeration": {
       "type": "number",
@@ -4834,12 +4843,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "hillshade-shadow-color": {
       "type": "color",
@@ -4853,12 +4862,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "hillshade-highlight-color": {
       "type": "color",
@@ -4872,12 +4881,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "hillshade-accent-color": {
       "type": "color",
@@ -4891,12 +4900,12 @@
         "data-driven styling": {}
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     }
   },
   "paint_background": {
@@ -4919,12 +4928,12 @@
         }
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     },
     "background-pattern": {
       "type": "string",
@@ -4939,12 +4948,12 @@
         }
       },
       "expression": {
-        "property-type": "cross-faded",
         "interpolated": false,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "cross-faded"
     },
     "background-opacity": {
       "type": "number",
@@ -4962,12 +4971,12 @@
         }
       },
       "expression": {
-        "property-type": "data-constant",
         "interpolated": true,
         "parameters": [
           "zoom"
         ]
-      }
+      },
+      "property-type": "data-constant"
     }
   },
   "transition": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -4,7 +4,9 @@
     "version": {
       "required": true,
       "type": "enum",
-      "values": [8],
+      "values": [
+        8
+      ],
       "doc": "Style specification version number. Must be 8.",
       "example": 8
     },
@@ -21,7 +23,10 @@
       "type": "array",
       "value": "number",
       "doc": "Default map center in longitude and latitude.  The style center will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
-      "example": [-73.9749, 40.7736]
+      "example": [
+        -73.9749,
+        40.7736
+      ]
     },
     "zoom": {
       "type": "number",
@@ -137,7 +142,12 @@
       "type": "array",
       "value": "number",
       "length": 4,
-      "default": [-180, -85.0511, 180, 85.0511],
+      "default": [
+        -180,
+        -85.0511,
+        180,
+        85.0511
+      ],
       "doc": "An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL."
     },
     "minzoom": {
@@ -165,7 +175,7 @@
       "type": "enum",
       "values": {
         "raster": {
-            "doc": "A raster tile source."
+          "doc": "A raster tile source."
         }
       },
       "doc": "The type of the source."
@@ -183,7 +193,12 @@
       "type": "array",
       "value": "number",
       "length": 4,
-      "default": [-180, -85.0511, 180, 85.0511],
+      "default": [
+        -180,
+        -85.0511,
+        180,
+        85.0511
+      ],
       "doc": "An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL."
     },
     "minzoom": {
@@ -230,7 +245,7 @@
       "type": "enum",
       "values": {
         "raster-dem": {
-            "doc": "A RGB-encoded raster DEM source"
+          "doc": "A RGB-encoded raster DEM source"
         }
       },
       "doc": "The type of the source."
@@ -248,7 +263,12 @@
       "type": "array",
       "value": "number",
       "length": 4,
-      "default": [-180, -85.0511, 180, 85.0511],
+      "default": [
+        -180,
+        -85.0511,
+        180,
+        85.0511
+      ],
       "doc": "An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL."
     },
     "minzoom": {
@@ -560,10 +580,10 @@
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -583,10 +603,10 @@
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -606,10 +626,10 @@
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -629,10 +649,10 @@
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -649,10 +669,10 @@
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -670,17 +690,15 @@
   "layout_line": {
     "line-cap": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "butt": {
-            "doc": "A cap with a squared-off end which is drawn to the exact endpoint of the line."
+          "doc": "A cap with a squared-off end which is drawn to the exact endpoint of the line."
         },
         "round": {
-            "doc": "A cap with a rounded end which is drawn beyond the endpoint of the line at a radius of one-half of the line's width and centered on the endpoint of the line."
+          "doc": "A cap with a rounded end which is drawn beyond the endpoint of the line at a radius of one-half of the line's width and centered on the endpoint of the line."
         },
         "square": {
-            "doc": "A cap with a squared-off end which is drawn beyond the endpoint of the line at a distance of one-half of the line's width."
+          "doc": "A cap with a squared-off end which is drawn beyond the endpoint of the line at a distance of one-half of the line's width."
         }
       },
       "default": "butt",
@@ -693,22 +711,26 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "line-join": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
-      "property-function": true,
       "values": {
         "bevel": {
-            "doc": "A join with a squared-off end which is drawn beyond the endpoint of the line at a distance of one-half of the line's width."
+          "doc": "A join with a squared-off end which is drawn beyond the endpoint of the line at a distance of one-half of the line's width."
         },
         "round": {
-            "doc": "A join with a rounded end which is drawn beyond the endpoint of the line at a radius of one-half of the line's width and centered on the endpoint of the line."
+          "doc": "A join with a rounded end which is drawn beyond the endpoint of the line at a radius of one-half of the line's width and centered on the endpoint of the line."
         },
         "miter": {
-            "doc": "A join with a sharp, angled corner which is drawn with the outer sides beyond the endpoint of the path until they meet."
+          "doc": "A join with a sharp, angled corner which is drawn with the outer sides beyond the endpoint of the path until they meet."
         }
       },
       "default": "miter",
@@ -726,13 +748,19 @@
           "ios": "3.7.0",
           "macos": "0.6.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": false,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "line-miter-limit": {
       "type": "number",
       "default": 2,
-      "function": "interpolated",
-      "zoom-function": true,
       "doc": "Used to automatically convert miter joins to bevel joins for sharp angles.",
       "requires": [
         {
@@ -747,13 +775,18 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "line-round-limit": {
       "type": "number",
       "default": 1.05,
-      "function": "interpolated",
-      "zoom-function": true,
       "doc": "Used to automatically convert round joins to miter joins for shallow angles.",
       "requires": [
         {
@@ -768,16 +801,23 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "visibility": {
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -796,15 +836,13 @@
   "layout_symbol": {
     "symbol-placement": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
-          "point": {
-              "doc": "The label is placed at the point where the geometry is located."
-          },
-          "line": {
-              "doc": "The label is placed along the line of the geometry. Can only be used on `LineString` and `Polygon` geometries."
-          }
+        "point": {
+          "doc": "The label is placed at the point where the geometry is located."
+        },
+        "line": {
+          "doc": "The label is placed along the line of the geometry. Can only be used on `LineString` and `Polygon` geometries."
+        }
       },
       "default": "point",
       "doc": "Label placement relative to its geometry.",
@@ -816,14 +854,19 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "symbol-spacing": {
       "type": "number",
       "default": 250,
       "minimum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
       "units": "pixels",
       "doc": "Distance between two symbol anchors.",
       "requires": [
@@ -839,12 +882,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "symbol-avoid-edges": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": false,
       "doc": "If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer.",
       "sdk-support": {
@@ -855,12 +903,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-allow-overlap": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": false,
       "doc": "If true, the icon will be visible even if it collides with other previously drawn symbols.",
       "requires": [
@@ -874,12 +927,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-ignore-placement": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": false,
       "doc": "If true, other symbols can be visible even if they collide with the icon.",
       "requires": [
@@ -893,12 +951,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-optional": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": false,
       "doc": "If true, text will display without their corresponding icons when the icon collides with other symbols and the text does not.",
       "requires": [
@@ -913,21 +976,26 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-rotation-alignment": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "When `symbol-placement` is set to `point`, aligns icons east-west. When `symbol-placement` is set to `line`, aligns icon x-axes with the line."
+          "doc": "When `symbol-placement` is set to `point`, aligns icons east-west. When `symbol-placement` is set to `line`, aligns icon x-axes with the line."
         },
         "viewport": {
-            "doc": "Produces icons whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbol-placement`."
+          "doc": "Produces icons whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbol-placement`."
         },
         "auto": {
-            "doc": "When `symbol-placement` is set to `point`, this is equivalent to `viewport`. When `symbol-placement` is set to `line`, this is equivalent to `map`."
+          "doc": "When `symbol-placement` is set to `point`, this is equivalent to `viewport`. When `symbol-placement` is set to `line`, this is equivalent to `map`."
         }
       },
       "default": "auto",
@@ -949,15 +1017,19 @@
           "macos": "0.3.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-size": {
       "type": "number",
       "default": 1,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "units": "factor of the original icon size",
       "doc": "Scales the original size of the icon by the provided factor. The new pixel size of the image will be the original pixel size multiplied by `icon-size`. 1 is the original size; 3 triples the size of the image.",
       "requires": [
@@ -976,24 +1048,30 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-text-fit": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "none": {
-            "doc": "The icon is displayed at its intrinsic aspect ratio."
+          "doc": "The icon is displayed at its intrinsic aspect ratio."
         },
         "width": {
-            "doc": "The icon is scaled in the x-dimension to fit the width of the text."
+          "doc": "The icon is scaled in the x-dimension to fit the width of the text."
         },
         "height": {
-            "doc": "The icon is scaled in the y-dimension to fit the height of the text."
+          "doc": "The icon is scaled in the y-dimension to fit the height of the text."
         },
         "both": {
-            "doc": "The icon is scaled in both x- and y-dimensions."
+          "doc": "The icon is scaled in both x- and y-dimensions."
         }
       },
       "default": "none",
@@ -1010,6 +1088,13 @@
           "macos": "0.2.1"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-text-fit-padding": {
@@ -1023,8 +1108,6 @@
         0
       ],
       "units": "pixels",
-      "function": "interpolated",
-      "zoom-function": true,
       "doc": "Size of the additional area added to dimensions determined by `icon-text-fit`, in clockwise order: top, right, bottom, left.",
       "requires": [
         "icon-image",
@@ -1045,13 +1128,17 @@
           "macos": "0.2.1"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-image": {
       "type": "string",
-      "function": "piecewise-constant",
-      "zoom-function": true,
-      "property-function": true,
       "doc": "Name of image in sprite to use for drawing an image background.",
       "tokens": true,
       "sdk-support": {
@@ -1067,15 +1154,20 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": false,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-rotate": {
       "type": "number",
       "default": 0,
       "period": 360,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "units": "degrees",
       "doc": "Rotates the icon clockwise.",
       "requires": [
@@ -1094,14 +1186,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-padding": {
       "type": "number",
       "default": 2,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
       "units": "pixels",
       "doc": "Size of the additional area around the icon bounding box used for detecting symbol collisions.",
       "requires": [
@@ -1115,12 +1213,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-keep-upright": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": false,
       "doc": "If true, the icon may be flipped to prevent it from being rendered upside-down.",
       "requires": [
@@ -1140,6 +1243,13 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-offset": {
@@ -1150,9 +1260,6 @@
         0,
         0
       ],
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "doc": "Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up. Each component is multiplied by the value of `icon-size` to obtain the final offset in pixels. When combined with `icon-rotate` the offset will be as if the rotated direction was up.",
       "requires": [
         "icon-image"
@@ -1170,40 +1277,45 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-anchor": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
-      "property-function": true,
       "values": {
         "center": {
-            "doc": "The center of the icon is placed closest to the anchor."
+          "doc": "The center of the icon is placed closest to the anchor."
         },
         "left": {
-            "doc": "The left side of the icon is placed closest to the anchor."
+          "doc": "The left side of the icon is placed closest to the anchor."
         },
         "right": {
-            "doc": "The right side of the icon is placed closest to the anchor."
+          "doc": "The right side of the icon is placed closest to the anchor."
         },
         "top": {
-            "doc": "The top of the icon is placed closest to the anchor."
+          "doc": "The top of the icon is placed closest to the anchor."
         },
         "bottom": {
-            "doc": "The bottom of the icon is placed closest to the anchor."
+          "doc": "The bottom of the icon is placed closest to the anchor."
         },
         "top-left": {
-            "doc": "The top left corner of the icon is placed closest to the anchor."
+          "doc": "The top left corner of the icon is placed closest to the anchor."
         },
         "top-right": {
-            "doc": "The top right corner of the icon is placed closest to the anchor."
+          "doc": "The top right corner of the icon is placed closest to the anchor."
         },
         "bottom-left": {
-            "doc": "The bottom left corner of the icon is placed closest to the anchor."
+          "doc": "The bottom left corner of the icon is placed closest to the anchor."
         },
         "bottom-right": {
-            "doc": "The bottom right corner of the icon is placed closest to the anchor."
+          "doc": "The bottom right corner of the icon is placed closest to the anchor."
         }
       },
       "default": "center",
@@ -1224,21 +1336,27 @@
           "ios": "3.7.0",
           "macos": "0.6.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": false,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-pitch-alignment": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "The icon is aligned to the plane of the map."
+          "doc": "The icon is aligned to the plane of the map."
         },
         "viewport": {
-            "doc": "The icon is aligned to the plane of the viewport."
+          "doc": "The icon is aligned to the plane of the viewport."
         },
         "auto": {
-            "doc": "Automatically matches the value of `icon-rotation-alignment`."
+          "doc": "Automatically matches the value of `icon-rotation-alignment`."
         }
       },
       "default": "auto",
@@ -1254,21 +1372,26 @@
           "macos": "0.6.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-pitch-alignment": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "The text is aligned to the plane of the map."
+          "doc": "The text is aligned to the plane of the map."
         },
         "viewport": {
-            "doc": "The text is aligned to the plane of the viewport."
+          "doc": "The text is aligned to the plane of the viewport."
         },
         "auto": {
-            "doc": "Automatically matches the value of `text-rotation-alignment`."
+          "doc": "Automatically matches the value of `text-rotation-alignment`."
         }
       },
       "default": "auto",
@@ -1290,21 +1413,26 @@
           "macos": "0.3.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-rotation-alignment": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "When `symbol-placement` is set to `point`, aligns text east-west. When `symbol-placement` is set to `line`, aligns text x-axes with the line."
+          "doc": "When `symbol-placement` is set to `point`, aligns text east-west. When `symbol-placement` is set to `line`, aligns text x-axes with the line."
         },
         "viewport": {
-            "doc": "Produces glyphs whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbol-placement`."
+          "doc": "Produces glyphs whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbol-placement`."
         },
         "auto": {
-            "doc": "When `symbol-placement` is set to `point`, this is equivalent to `viewport`. When `symbol-placement` is set to `line`, this is equivalent to `map`."
+          "doc": "When `symbol-placement` is set to `point`, this is equivalent to `viewport`. When `symbol-placement` is set to `line`, this is equivalent to `map`."
         }
       },
       "default": "auto",
@@ -1326,13 +1454,17 @@
           "macos": "0.3.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-field": {
       "type": "string",
-      "function": "piecewise-constant",
-      "zoom-function": true,
-      "property-function": true,
       "default": "",
       "tokens": true,
       "doc": "Value to use for a text label.",
@@ -1349,15 +1481,23 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": false,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-font": {
       "type": "array",
       "value": "string",
-      "function": "piecewise-constant",
-      "zoom-function": true,
-      "property-function": true,
-      "default": ["Open Sans Regular", "Arial Unicode MS Regular"],
+      "default": [
+        "Open Sans Regular",
+        "Arial Unicode MS Regular"
+      ],
       "doc": "Font stack to use for displaying text.",
       "requires": [
         "text-field"
@@ -1372,6 +1512,14 @@
         "data-driven styling": {
           "js": "0.43.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": false,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-size": {
@@ -1379,9 +1527,6 @@
       "default": 16,
       "minimum": 0,
       "units": "pixels",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "doc": "Font size.",
       "requires": [
         "text-field"
@@ -1399,6 +1544,14 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-max-width": {
@@ -1406,9 +1559,6 @@
       "default": 10,
       "minimum": 0,
       "units": "ems",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "doc": "The maximum line width for text wrapping.",
       "requires": [
         "text-field"
@@ -1426,14 +1576,20 @@
           "ios": "3.7.0",
           "macos": "0.6.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-line-height": {
       "type": "number",
       "default": 1.2,
       "units": "ems",
-      "function": "interpolated",
-      "zoom-function": true,
       "doc": "Text leading value for multi-line text.",
       "requires": [
         "text-field"
@@ -1446,15 +1602,19 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-letter-spacing": {
       "type": "number",
       "default": 0,
       "units": "ems",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "doc": "Text tracking amount.",
       "requires": [
         "text-field"
@@ -1472,22 +1632,27 @@
           "ios": "3.7.0",
           "macos": "0.6.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-justify": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
-      "property-function": true,
       "values": {
         "left": {
-            "doc": "The text is aligned to the left."
+          "doc": "The text is aligned to the left."
         },
         "center": {
-            "doc": "The text is centered."
+          "doc": "The text is centered."
         },
         "right": {
-            "doc": "The text is aligned to the right."
+          "doc": "The text is aligned to the right."
         }
       },
       "default": "center",
@@ -1508,40 +1673,45 @@
           "ios": "3.7.0",
           "macos": "0.6.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": false,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-anchor": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
-      "property-function": true,
       "values": {
         "center": {
-            "doc": "The center of the text is placed closest to the anchor."
+          "doc": "The center of the text is placed closest to the anchor."
         },
         "left": {
-            "doc": "The left side of the text is placed closest to the anchor."
+          "doc": "The left side of the text is placed closest to the anchor."
         },
         "right": {
-            "doc": "The right side of the text is placed closest to the anchor."
+          "doc": "The right side of the text is placed closest to the anchor."
         },
         "top": {
-            "doc": "The top of the text is placed closest to the anchor."
+          "doc": "The top of the text is placed closest to the anchor."
         },
         "bottom": {
-            "doc": "The bottom of the text is placed closest to the anchor."
+          "doc": "The bottom of the text is placed closest to the anchor."
         },
         "top-left": {
-            "doc": "The top left corner of the text is placed closest to the anchor."
+          "doc": "The top left corner of the text is placed closest to the anchor."
         },
         "top-right": {
-            "doc": "The top right corner of the text is placed closest to the anchor."
+          "doc": "The top right corner of the text is placed closest to the anchor."
         },
         "bottom-left": {
-            "doc": "The bottom left corner of the text is placed closest to the anchor."
+          "doc": "The bottom left corner of the text is placed closest to the anchor."
         },
         "bottom-right": {
-            "doc": "The bottom right corner of the text is placed closest to the anchor."
+          "doc": "The bottom right corner of the text is placed closest to the anchor."
         }
       },
       "default": "center",
@@ -1562,14 +1732,20 @@
           "ios": "3.7.0",
           "macos": "0.6.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": false,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-max-angle": {
       "type": "number",
       "default": 45,
       "units": "degrees",
-      "function": "interpolated",
-      "zoom-function": true,
       "doc": "Maximum angle change between adjacent characters.",
       "requires": [
         "text-field",
@@ -1585,6 +1761,13 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-rotate": {
@@ -1592,9 +1775,6 @@
       "default": 0,
       "period": 360,
       "units": "degrees",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "doc": "Rotates the text clockwise.",
       "requires": [
         "text-field"
@@ -1612,6 +1792,14 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-padding": {
@@ -1619,8 +1807,6 @@
       "default": 2,
       "minimum": 0,
       "units": "pixels",
-      "function": "interpolated",
-      "zoom-function": true,
       "doc": "Size of the additional area around the text bounding box used for detecting symbol collisions.",
       "requires": [
         "text-field"
@@ -1633,12 +1819,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-keep-upright": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": true,
       "doc": "If true, the text may be flipped vertically to prevent it from being rendered upside-down.",
       "requires": [
@@ -1658,22 +1849,26 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-transform": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
-      "property-function": true,
       "values": {
         "none": {
-            "doc": "The text is not altered."
+          "doc": "The text is not altered."
         },
         "uppercase": {
-            "doc": "Forces all letters to be displayed in uppercase."
+          "doc": "Forces all letters to be displayed in uppercase."
         },
         "lowercase": {
-            "doc": "Forces all letters to be displayed in lowercase."
+          "doc": "Forces all letters to be displayed in lowercase."
         }
       },
       "default": "none",
@@ -1694,6 +1889,14 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": false,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-offset": {
@@ -1701,9 +1904,6 @@
       "doc": "Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.",
       "value": "number",
       "units": "ems",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "length": 2,
       "default": [
         0,
@@ -1725,12 +1925,18 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-allow-overlap": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": false,
       "doc": "If true, the text will be visible even if it collides with other previously drawn symbols.",
       "requires": [
@@ -1744,12 +1950,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-ignore-placement": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": false,
       "doc": "If true, other symbols can be visible even if they collide with the text.",
       "requires": [
@@ -1763,12 +1974,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-optional": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": false,
       "doc": "If true, icons will display without their corresponding text when the text collides with other symbols and the icon does not.",
       "requires": [
@@ -1783,16 +1999,23 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "visibility": {
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -1813,10 +2036,10 @@
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -1837,10 +2060,10 @@
       "type": "enum",
       "values": {
         "visible": {
-            "doc": "The layer is shown."
+          "doc": "The layer is shown."
         },
         "none": {
-            "doc": "The layer is not shown."
+          "doc": "The layer is not shown."
         }
       },
       "default": "visible",
@@ -1862,43 +2085,43 @@
     "type": "enum",
     "values": {
       "==": {
-          "doc": "`[\"==\", key, value]` equality: `feature[key] = value`"
+        "doc": "`[\"==\", key, value]` equality: `feature[key] = value`"
       },
       "!=": {
-          "doc": "`[\"!=\", key, value]` inequality: `feature[key] ≠ value`"
+        "doc": "`[\"!=\", key, value]` inequality: `feature[key] ≠ value`"
       },
       ">": {
-          "doc": "`[\">\", key, value]` greater than: `feature[key] > value`"
+        "doc": "`[\">\", key, value]` greater than: `feature[key] > value`"
       },
       ">=": {
-          "doc": "`[\">=\", key, value]` greater than or equal: `feature[key] ≥ value`"
+        "doc": "`[\">=\", key, value]` greater than or equal: `feature[key] ≥ value`"
       },
       "<": {
-          "doc": "`[\"<\", key, value]` less than: `feature[key] < value`"
+        "doc": "`[\"<\", key, value]` less than: `feature[key] < value`"
       },
       "<=": {
-          "doc": "`[\"<=\", key, value]` less than or equal: `feature[key] ≤ value`"
+        "doc": "`[\"<=\", key, value]` less than or equal: `feature[key] ≤ value`"
       },
       "in": {
-          "doc": "`[\"in\", key, v0, ..., vn]` set inclusion: `feature[key] ∈ {v0, ..., vn}`"
+        "doc": "`[\"in\", key, v0, ..., vn]` set inclusion: `feature[key] ∈ {v0, ..., vn}`"
       },
       "!in": {
-          "doc": "`[\"!in\", key, v0, ..., vn]` set exclusion: `feature[key] ∉ {v0, ..., vn}`"
+        "doc": "`[\"!in\", key, v0, ..., vn]` set exclusion: `feature[key] ∉ {v0, ..., vn}`"
       },
       "all": {
-          "doc": "`[\"all\", f0, ..., fn]` logical `AND`: `f0 ∧ ... ∧ fn`"
+        "doc": "`[\"all\", f0, ..., fn]` logical `AND`: `f0 ∧ ... ∧ fn`"
       },
       "any": {
-          "doc": "`[\"any\", f0, ..., fn]` logical `OR`: `f0 ∨ ... ∨ fn`"
+        "doc": "`[\"any\", f0, ..., fn]` logical `OR`: `f0 ∨ ... ∨ fn`"
       },
       "none": {
-          "doc": "`[\"none\", f0, ..., fn]` logical `NOR`: `¬f0 ∧ ... ∧ ¬fn`"
+        "doc": "`[\"none\", f0, ..., fn]` logical `NOR`: `¬f0 ∧ ... ∧ ¬fn`"
       },
       "has": {
-          "doc": "`[\"has\", key]` `feature[key]` exists"
+        "doc": "`[\"has\", key]` `feature[key]` exists"
       },
       "!has": {
-          "doc": "`[\"!has\", key]` `feature[key]` does not exist"
+        "doc": "`[\"!has\", key]` `feature[key]` does not exist"
       }
     },
     "doc": "The filter operator."
@@ -1907,13 +2130,13 @@
     "type": "enum",
     "values": {
       "Point": {
-          "doc": "Filter to point geometries."
+        "doc": "Filter to point geometries."
       },
       "LineString": {
-          "doc": "Filter to line geometries."
+        "doc": "Filter to line geometries."
       },
       "Polygon": {
-          "doc": "Filter to polygon geometries."
+        "doc": "Filter to polygon geometries."
       }
     },
     "doc": "The geometry type for the filter to select."
@@ -1942,18 +2165,18 @@
     "type": {
       "type": "enum",
       "values": {
-          "identity": {
-              "doc": "Return the input value as the output value."
-          },
-          "exponential": {
-              "doc": "Generate an output by interpolating between stops just less than and just greater than the function input."
-          },
-          "interval": {
-              "doc": "Return the output value of the stop just less than the function input."
-          },
-          "categorical": {
-              "doc": "Return the output value of the stop equal to the function input."
-          }
+        "identity": {
+          "doc": "Return the input value as the output value."
+        },
+        "exponential": {
+          "doc": "Generate an output by interpolating between stops just less than and just greater than the function input."
+        },
+        "interval": {
+          "doc": "Return the output value of the stop just less than the function input."
+        },
+        "categorical": {
+          "doc": "Return the output value of the stop equal to the function input."
+        }
       },
       "doc": "The interpolation strategy to use in function evaluation.",
       "default": "exponential"
@@ -1961,15 +2184,15 @@
     "colorSpace": {
       "type": "enum",
       "values": {
-          "rgb": {
-              "doc": "Use the RGB color space to interpolate color values"
-          },
-          "lab": {
-              "doc": "Use the LAB color space to interpolate color values."
-          },
-          "hcl": {
-              "doc": "Use the HCL color space to interpolate color values, interpolating the Hue, Chroma, and Luminance channels individually."
-          }
+        "rgb": {
+          "doc": "Use the RGB color space to interpolate color values"
+        },
+        "lab": {
+          "doc": "Use the LAB color space to interpolate color values."
+        },
+        "hcl": {
+          "doc": "Use the HCL color space to interpolate color values, interpolating the Hue, Chroma, and Luminance channels individually."
+        }
       },
       "doc": "The color space in which colors interpolated. Interpolating colors in perceptual color spaces like LAB and HCL tend to produce color ramps that look more consistent and produce colors that can be differentiated more easily than those interpolated in RGB space.",
       "default": "rgb"
@@ -2046,7 +2269,7 @@
           }
         }
       },
-        "case": {
+      "case": {
         "doc": "Selects the first output whose corresponding test condition evaluates to true.",
         "group": "Decision",
         "sdk-support": {
@@ -2641,9 +2864,13 @@
         }
       },
       "transition": false,
-      "zoom-function": true,
-      "property-function": false,
-      "function": "piecewise-constant",
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
+      },
       "doc": "Whether extruded geometries are lit relative to the map or viewport.",
       "example": "map",
       "sdk-support": {
@@ -2657,15 +2884,27 @@
     },
     "position": {
       "type": "array",
-      "default": [1.15, 210, 30],
+      "default": [
+        1.15,
+        210,
+        30
+      ],
       "length": 3,
       "value": "number",
       "transition": true,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": false,
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      },
       "doc": "Position of the light source relative to lit (extruded) geometries, in [r radial coordinate, a azimuthal angle, p polar angle] where r indicates the distance from the center of the base of an object to its light, a indicates the position of the light relative to 0° (0° when `light.anchor` is set to `viewport` corresponds to the top of the viewport, or 0° when `light.anchor` is set to `map` corresponds to due north, and degrees proceed clockwise), and p indicates the height of the light (from 0°, directly above, to 180°, directly below).",
-      "example": [1.5, 90, 80],
+      "example": [
+        1.5,
+        90,
+        80
+      ],
       "sdk-support": {
         "basic functionality": {
           "js": "0.27.0",
@@ -2678,9 +2917,13 @@
     "color": {
       "type": "color",
       "default": "#ffffff",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": false,
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
+      },
       "transition": true,
       "doc": "Color tint for lighting extruded geometries.",
       "sdk-support": {
@@ -2697,9 +2940,13 @@
       "default": 0.5,
       "minimum": 0,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": false,
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      },
       "transition": true,
       "doc": "Intensity of lighting (on a scale from 0 to 1). Higher numbers will present as more extreme contrast.",
       "sdk-support": {
@@ -2726,8 +2973,6 @@
   "paint_fill": {
     "fill-antialias": {
       "type": "boolean",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "default": true,
       "doc": "Whether or not the fill should be antialiased.",
       "sdk-support": {
@@ -2738,13 +2983,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "fill-opacity": {
       "type": "number",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "default": 1,
       "minimum": 0,
       "maximum": 1,
@@ -2763,15 +3012,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "fill-color": {
       "type": "color",
       "default": "#000000",
       "doc": "The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "requires": [
         {
@@ -2791,14 +3045,19 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "fill-outline-color": {
       "type": "color",
       "doc": "The outline color of the fill. Matches the value of `fill-color` if unspecified.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "requires": [
         {
@@ -2821,6 +3080,14 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "fill-translate": {
@@ -2831,8 +3098,6 @@
         0,
         0
       ],
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.",
@@ -2844,18 +3109,23 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "fill-translate-anchor": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "The fill is translated relative to the map."
+          "doc": "The fill is translated relative to the map."
         },
         "viewport": {
-            "doc": "The fill is translated relative to the viewport."
+          "doc": "The fill is translated relative to the viewport."
         }
       },
       "doc": "Controls the frame of reference for `fill-translate`.",
@@ -2871,12 +3141,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "fill-pattern": {
       "type": "string",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "transition": true,
       "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
@@ -2887,15 +3162,19 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "cross-faded",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     }
   },
   "paint_fill-extrusion": {
     "fill-extrusion-opacity": {
       "type": "number",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": false,
       "default": 1,
       "minimum": 0,
       "maximum": 1,
@@ -2908,15 +3187,19 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "fill-extrusion-color": {
       "type": "color",
       "default": "#000000",
       "doc": "The base color of the extruded fill. The extrusion's surfaces will be shaded differently based on this color in combination with the root `light` settings. If this color is specified as `rgba` with an alpha component, the alpha component will be ignored; use `fill-extrusion-opacity` to set layer opacity.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "requires": [
         {
@@ -2936,6 +3219,14 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "fill-extrusion-translate": {
@@ -2946,8 +3237,6 @@
         0,
         0
       ],
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.",
@@ -2959,18 +3248,23 @@
           "macos": "0.5.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "fill-extrusion-translate-anchor": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "The fill extrusion is translated relative to the map."
+          "doc": "The fill extrusion is translated relative to the map."
         },
         "viewport": {
-            "doc": "The fill extrusion is translated relative to the viewport."
+          "doc": "The fill extrusion is translated relative to the viewport."
         }
       },
       "doc": "Controls the frame of reference for `fill-extrusion-translate`.",
@@ -2986,12 +3280,17 @@
           "macos": "0.5.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "fill-extrusion-pattern": {
       "type": "string",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "transition": true,
       "doc": "Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
@@ -3002,13 +3301,17 @@
           "macos": "0.5.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "cross-faded",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "fill-extrusion-height": {
       "type": "number",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "default": 0,
       "minimum": 0,
       "units": "meters",
@@ -3027,13 +3330,18 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "fill-extrusion-base": {
       "type": "number",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "default": 0,
       "minimum": 0,
       "units": "meters",
@@ -3055,6 +3363,14 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     }
   },
@@ -3062,9 +3378,6 @@
     "line-opacity": {
       "type": "number",
       "doc": "The opacity at which the line will be drawn.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "default": 1,
       "minimum": 0,
       "maximum": 1,
@@ -3082,15 +3395,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "line-color": {
       "type": "color",
       "doc": "The color with which the line will be drawn.",
       "default": "#000000",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "requires": [
         {
@@ -3110,6 +3428,14 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "line-translate": {
@@ -3120,8 +3446,6 @@
         0,
         0
       ],
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.",
@@ -3133,18 +3457,23 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "line-translate-anchor": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "The line is translated relative to the map."
+          "doc": "The line is translated relative to the map."
         },
         "viewport": {
-            "doc": "The line is translated relative to the viewport."
+          "doc": "The line is translated relative to the viewport."
         }
       },
       "doc": "Controls the frame of reference for `line-translate`.",
@@ -3160,15 +3489,19 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "line-width": {
       "type": "number",
       "default": 1,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Stroke thickness.",
@@ -3182,6 +3515,14 @@
         "data-driven styling": {
           "js": "0.39.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "line-gap-width": {
@@ -3189,9 +3530,6 @@
       "default": 0,
       "minimum": 0,
       "doc": "Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "sdk-support": {
@@ -3207,15 +3545,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "line-offset": {
       "type": "number",
       "default": 0,
       "doc": "The line's offset. For linear features, a positive value offsets the line to the right, relative to the direction of the line, and a negative value to the left. For polygon features, a positive value results in an inset, and a negative value results in an outset.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "sdk-support": {
@@ -3231,15 +3574,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "line-blur": {
       "type": "number",
       "default": 0,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Blur applied to the line, in pixels.",
@@ -3256,13 +3604,19 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "line-dasharray": {
       "type": "array",
       "value": "number",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "doc": "Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "minimum": 0,
       "transition": true,
@@ -3280,12 +3634,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "cross-faded",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "line-pattern": {
       "type": "string",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "transition": true,
       "doc": "Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
@@ -3296,14 +3655,18 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "cross-faded",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "line-gradient": {
       "type": "color",
       "doc": "Defines a gradient with which to color a line feature. Can only be used with GeoJSON sources that specify `\"lineMetrics\": true`.",
-      "function": "interpolated",
-      "zoom-function": false,
-      "property-function": false,
       "transition": false,
       "requires": [
         {
@@ -3324,6 +3687,13 @@
           "js": "0.45.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "color-ramp",
+        "interpolated": true,
+        "parameters": [
+          "line-progress"
+        ]
       }
     }
   },
@@ -3332,9 +3702,6 @@
       "type": "number",
       "default": 5,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Circle radius.",
@@ -3351,15 +3718,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "circle-color": {
       "type": "color",
       "default": "#000000",
       "doc": "The fill color of the circle.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -3374,15 +3746,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "circle-blur": {
       "type": "number",
       "default": 0,
       "doc": "Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -3397,6 +3774,14 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "circle-opacity": {
@@ -3405,9 +3790,6 @@
       "default": 1,
       "minimum": 0,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -3422,15 +3804,24 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "circle-translate": {
       "type": "array",
       "value": "number",
       "length": 2,
-      "default": [0, 0],
-      "function": "interpolated",
-      "zoom-function": true,
+      "default": [
+        0,
+        0
+      ],
       "transition": true,
       "units": "pixels",
       "doc": "The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.",
@@ -3442,18 +3833,23 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "circle-translate-anchor": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "The circle is translated relative to the map."
+          "doc": "The circle is translated relative to the map."
         },
         "viewport": {
-            "doc": "The circle is translated relative to the viewport."
+          "doc": "The circle is translated relative to the viewport."
         }
       },
       "doc": "Controls the frame of reference for `circle-translate`.",
@@ -3469,18 +3865,23 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "circle-pitch-scale": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "Circles are scaled according to their apparent distance to the camera."
+          "doc": "Circles are scaled according to their apparent distance to the camera."
         },
         "viewport": {
-            "doc": "Circles are not scaled."
+          "doc": "Circles are not scaled."
         }
       },
       "default": "map",
@@ -3493,18 +3894,23 @@
           "macos": "0.2.1"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "circle-pitch-alignment": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "The circle is aligned to the plane of the map."
+          "doc": "The circle is aligned to the plane of the map."
         },
         "viewport": {
-            "doc": "The circle is aligned to the plane of the viewport."
+          "doc": "The circle is aligned to the plane of the viewport."
         }
       },
       "default": "viewport",
@@ -3517,15 +3923,19 @@
           "macos": "0.6.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "circle-stroke-width": {
       "type": "number",
       "default": 0,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "The width of the circle's stroke. Strokes are placed outside of the `circle-radius`.",
@@ -3542,15 +3952,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "circle-stroke-color": {
       "type": "color",
       "default": "#000000",
       "doc": "The stroke color of the circle.",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -3565,6 +3980,14 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "circle-stroke-opacity": {
@@ -3573,9 +3996,6 @@
       "default": 1,
       "minimum": 0,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -3590,6 +4010,14 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     }
   },
@@ -3598,9 +4026,6 @@
       "type": "number",
       "default": 30,
       "minimum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Radius of influence of one heatmap point in pixels. Increasing the value makes the heatmap smoother, but less detailed.",
@@ -3611,15 +4036,20 @@
         "data-driven styling": {
           "js": "0.43.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "heatmap-weight": {
       "type": "number",
       "default": 1,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": false,
       "doc": "A measure of how much an individual point contributes to the heatmap. A value of 10 would be equivalent to having 10 points of weight 1 in the same spot. Especially useful when combined with clustering.",
       "sdk-support": {
@@ -3629,15 +4059,20 @@
         "data-driven styling": {
           "js": "0.41.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "heatmap-intensity": {
       "type": "number",
       "default": 1,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": false,
       "transition": true,
       "doc": "Similar to `heatmap-weight` but controls the intensity of the heatmap globally. Primarily used for adjusting the heatmap based on zoom level.",
       "sdk-support": {
@@ -3645,31 +4080,52 @@
           "js": "0.41.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "heatmap-color": {
       "type": "color",
       "default": [
         "interpolate",
-        ["linear"],
-        ["heatmap-density"],
-        0, "rgba(0, 0, 255, 0)",
-        0.1, "royalblue",
-        0.3, "cyan",
-        0.5, "lime",
-        0.7, "yellow",
-        1, "red"
+        [
+          "linear"
+        ],
+        [
+          "heatmap-density"
+        ],
+        0,
+        "rgba(0, 0, 255, 0)",
+        0.1,
+        "royalblue",
+        0.3,
+        "cyan",
+        0.5,
+        "lime",
+        0.7,
+        "yellow",
+        1,
+        "red"
       ],
       "doc": "Defines the color of each pixel based on its density value in a heatmap.  Should be an expression that uses `[\"heatmap-density\"]` as input.",
-      "function": "interpolated",
-      "zoom-function": false,
-      "property-function": false,
       "transition": false,
       "sdk-support": {
         "basic functionality": {
           "js": "0.41.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "color-ramp",
+        "interpolated": true,
+        "parameters": [
+          "heatmap-density"
+        ]
       }
     },
     "heatmap-opacity": {
@@ -3678,15 +4134,19 @@
       "default": 1,
       "minimum": 0,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": false,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
           "js": "0.41.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     }
   },
@@ -3697,9 +4157,6 @@
       "default": 1,
       "minimum": 0,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "requires": [
         "icon-image"
@@ -3717,14 +4174,19 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-color": {
       "type": "color",
       "default": "#000000",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "doc": "The color of the icon. This can only be used with sdf icons.",
       "requires": [
@@ -3743,14 +4205,19 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-halo-color": {
       "type": "color",
       "default": "rgba(0, 0, 0, 0)",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "doc": "The color of the icon's halo. Icon halos can only be used with SDF icons.",
       "requires": [
@@ -3769,15 +4236,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-halo-width": {
       "type": "number",
       "default": 0,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Distance of halo to the icon outline.",
@@ -3797,15 +4269,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-halo-blur": {
       "type": "number",
       "default": 0,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Fade out the halo towards the outside.",
@@ -3825,6 +4302,14 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "icon-translate": {
@@ -3835,8 +4320,6 @@
         0,
         0
       ],
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.",
@@ -3851,18 +4334,23 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "icon-translate-anchor": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "Icons are translated relative to the map."
+          "doc": "Icons are translated relative to the map."
         },
         "viewport": {
-            "doc": "Icons are translated relative to the viewport."
+          "doc": "Icons are translated relative to the viewport."
         }
       },
       "doc": "Controls the frame of reference for `icon-translate`.",
@@ -3879,6 +4367,13 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-opacity": {
@@ -3887,9 +4382,6 @@
       "default": 1,
       "minimum": 0,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "requires": [
         "text-field"
@@ -3907,15 +4399,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-color": {
       "type": "color",
       "doc": "The color with which the text will be drawn.",
       "default": "#000000",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "requires": [
         "text-field"
@@ -3933,14 +4430,19 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-halo-color": {
       "type": "color",
       "default": "rgba(0, 0, 0, 0)",
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "doc": "The color of the text's halo, which helps it stand out from backgrounds.",
       "requires": [
@@ -3959,15 +4461,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-halo-width": {
       "type": "number",
       "default": 0,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.",
@@ -3987,15 +4494,20 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-halo-blur": {
       "type": "number",
       "default": 0,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
-      "property-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "The halo's fadeout distance towards the outside.",
@@ -4015,6 +4527,14 @@
           "ios": "3.5.0",
           "macos": "0.4.0"
         }
+      },
+      "expression": {
+        "property-type": "data-driven",
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
       }
     },
     "text-translate": {
@@ -4025,8 +4545,6 @@
         0,
         0
       ],
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "units": "pixels",
       "doc": "Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.",
@@ -4041,18 +4559,23 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "text-translate-anchor": {
       "type": "enum",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "values": {
         "map": {
-            "doc": "The text is translated relative to the map."
+          "doc": "The text is translated relative to the map."
         },
         "viewport": {
-            "doc": "The text is translated relative to the viewport."
+          "doc": "The text is translated relative to the viewport."
         }
       },
       "doc": "Controls the frame of reference for `text-translate`.",
@@ -4069,6 +4592,13 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     }
   },
@@ -4079,8 +4609,6 @@
       "default": 1,
       "minimum": 0,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -4090,14 +4618,19 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "raster-hue-rotate": {
       "type": "number",
       "default": 0,
       "period": 360,
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "units": "degrees",
       "doc": "Rotates hues around the color wheel.",
@@ -4109,12 +4642,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "raster-brightness-min": {
       "type": "number",
-      "function": "interpolated",
-      "zoom-function": true,
       "doc": "Increase or reduce the brightness of the image. The value is the minimum brightness.",
       "default": 0,
       "minimum": 0,
@@ -4128,12 +4666,17 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "raster-brightness-max": {
       "type": "number",
-      "function": "interpolated",
-      "zoom-function": true,
       "doc": "Increase or reduce the brightness of the image. The value is the maximum brightness.",
       "default": 1,
       "minimum": 0,
@@ -4147,6 +4690,13 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "raster-saturation": {
@@ -4155,8 +4705,6 @@
       "default": 0,
       "minimum": -1,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -4166,6 +4714,13 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "raster-contrast": {
@@ -4174,8 +4729,6 @@
       "default": 0,
       "minimum": -1,
       "maximum": 1,
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -4185,14 +4738,19 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "raster-fade-duration": {
       "type": "number",
       "default": 300,
       "minimum": 0,
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": false,
       "units": "milliseconds",
       "doc": "Fade duration when a new tile is added.",
@@ -4204,113 +4762,148 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     }
   },
   "paint_hillshade": {
-      "hillshade-illumination-direction": {
-        "type": "number",
-        "default": 335,
-        "minimum": 0,
-        "maximum": 359,
-        "doc": "The direction of the light source used to generate the hillshading with 0 as the top of the viewport if `hillshade-illumination-anchor` is set to `viewport` and due north if `hillshade-illumination-anchor` is set to `map`.",
-        "function": "interpolated",
-        "zoom-function": true,
-        "transition": false,
-        "sdk-support": {
-          "basic functionality": {
-            "js": "0.43.0"
-          },
-          "data-driven styling": {}
-        }
-      },
-      "hillshade-illumination-anchor": {
-        "type": "enum",
-        "function": "piecewise-constant",
-        "zoom-function": true,
-        "values": {
-          "map": {
-              "doc": "The hillshade illumination is relative to the north direction."
-          },
-          "viewport": {
-              "doc": "The hillshade illumination is relative to the top of the viewport."
-          }
+    "hillshade-illumination-direction": {
+      "type": "number",
+      "default": 335,
+      "minimum": 0,
+      "maximum": 359,
+      "doc": "The direction of the light source used to generate the hillshading with 0 as the top of the viewport if `hillshade-illumination-anchor` is set to `viewport` and due north if `hillshade-illumination-anchor` is set to `map`.",
+      "transition": false,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.43.0"
         },
-        "default": "viewport",
-        "doc": "Direction of light source when map is rotated.",
-        "sdk-support": {
-          "basic functionality": {
-            "js": "0.43.0"
-          },
-          "data-driven styling": {}
-        }
+        "data-driven styling": {}
       },
-      "hillshade-exaggeration": {
-        "type": "number",
-        "doc": "Intensity of the hillshade",
-        "default": 0.5,
-        "minimum": 0,
-        "maximum": 1,
-        "function": "interpolated",
-        "zoom-function": true,
-        "transition": true,
-        "sdk-support": {
-          "basic functionality": {
-            "js": "0.43.0"
-          },
-          "data-driven styling": {}
-        }
-      },
-      "hillshade-shadow-color": {
-        "type": "color",
-        "default": "#000000",
-        "doc": "The shading color of areas that face away from the light source.",
-        "function": "interpolated",
-        "zoom-function": true,
-        "transition": true,
-        "sdk-support": {
-          "basic functionality": {
-            "js": "0.43.0"
-          },
-          "data-driven styling": {}
-        }
-      },
-      "hillshade-highlight-color": {
-        "type": "color",
-        "default": "#FFFFFF",
-        "doc": "The shading color of areas that faces towards the light source.",
-        "function": "interpolated",
-        "zoom-function": true,
-        "transition": true,
-        "sdk-support": {
-          "basic functionality": {
-            "js": "0.43.0"
-          },
-          "data-driven styling": {}
-        }
-      },
-      "hillshade-accent-color": {
-        "type": "color",
-        "default": "#000000",
-        "doc": "The shading color used to accentuate rugged terrain like sharp cliffs and gorges.",
-        "function": "interpolated",
-        "zoom-function": true,
-        "transition": true,
-        "sdk-support": {
-          "basic functionality": {
-            "js": "0.43.0"
-          },
-          "data-driven styling": {}
-        }
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
+    },
+    "hillshade-illumination-anchor": {
+      "type": "enum",
+      "values": {
+        "map": {
+          "doc": "The hillshade illumination is relative to the north direction."
+        },
+        "viewport": {
+          "doc": "The hillshade illumination is relative to the top of the viewport."
+        }
+      },
+      "default": "viewport",
+      "doc": "Direction of light source when map is rotated.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.43.0"
+        },
+        "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
+      }
+    },
+    "hillshade-exaggeration": {
+      "type": "number",
+      "doc": "Intensity of the hillshade",
+      "default": 0.5,
+      "minimum": 0,
+      "maximum": 1,
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.43.0"
+        },
+        "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      }
+    },
+    "hillshade-shadow-color": {
+      "type": "color",
+      "default": "#000000",
+      "doc": "The shading color of areas that face away from the light source.",
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.43.0"
+        },
+        "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      }
+    },
+    "hillshade-highlight-color": {
+      "type": "color",
+      "default": "#FFFFFF",
+      "doc": "The shading color of areas that faces towards the light source.",
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.43.0"
+        },
+        "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      }
+    },
+    "hillshade-accent-color": {
+      "type": "color",
+      "default": "#000000",
+      "doc": "The shading color used to accentuate rugged terrain like sharp cliffs and gorges.",
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.43.0"
+        },
+        "data-driven styling": {}
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      }
+    }
   },
   "paint_background": {
     "background-color": {
       "type": "color",
       "default": "#000000",
       "doc": "The color with which the background will be drawn.",
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "requires": [
         {
@@ -4324,12 +4917,17 @@
           "ios": "2.0.0",
           "macos": "0.1.0"
         }
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "background-pattern": {
       "type": "string",
-      "function": "piecewise-constant",
-      "zoom-function": true,
       "transition": true,
       "doc": "Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
@@ -4339,6 +4937,13 @@
           "ios": "2.0.0",
           "macos": "0.1.0"
         }
+      },
+      "expression": {
+        "property-type": "cross-faded",
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
       }
     },
     "background-opacity": {
@@ -4347,8 +4952,6 @@
       "minimum": 0,
       "maximum": 1,
       "doc": "The opacity at which the background will be drawn.",
-      "function": "interpolated",
-      "zoom-function": true,
       "transition": true,
       "sdk-support": {
         "basic functionality": {
@@ -4357,6 +4960,13 @@
           "ios": "2.0.0",
           "macos": "0.1.0"
         }
+      },
+      "expression": {
+        "property-type": "data-constant",
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
       }
     }
   },

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -1,51 +1,46 @@
 // @flow
 
+type ExpressionType = 'data-driven' | 'cross-faded' | 'cross-faded-data-driven' | 'color-ramp' | 'data-constant';
+type ExpressionParameters = Array<'zoom' | 'feature' | 'heatmap-density' | 'line-progress'>;
+
+type ExpressionSpecification = {
+    type: ExpressionType,
+    interpolated: boolean,
+    parameters: ExpressionParameters
+}
+
 export type StylePropertySpecification = {
     type: 'number',
-    'function': boolean,
-    'property-function': boolean,
-    'zoom-function': boolean,
+    expression?: ExpressionSpecification,
     default?: number
 } | {
     type: 'string',
-    'function': boolean,
-    'property-function': boolean,
-    'zoom-function': boolean,
+    expression?: ExpressionSpecification,
     default?: string,
     tokens?: boolean
 } | {
     type: 'boolean',
-    'function': boolean,
-    'property-function': boolean,
-    'zoom-function': boolean,
+    expression?: ExpressionSpecification,
     default?: boolean
 } | {
     type: 'enum',
-    'function': boolean,
-    'property-function': boolean,
-    'zoom-function': boolean,
+    expression?: ExpressionSpecification,
     values: {[string]: {}},
     default?: string
 } | {
     type: 'color',
-    'function': boolean,
-    'property-function': boolean,
-    'zoom-function': boolean,
+    expression?: ExpressionSpecification,
     default?: string
 } | {
     type: 'array',
     value: 'number',
-    'function': boolean,
-    'property-function': boolean,
-    'zoom-function': boolean,
+    expression?: ExpressionSpecification,
     length?: number,
     default?: Array<number>
 } | {
     type: 'array',
     value: 'string',
-    'function': boolean,
-    'property-function': boolean,
-    'zoom-function': boolean,
+    expression?: ExpressionSpecification,
     length?: number,
     default?: Array<string>
 };

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -1,45 +1,51 @@
 // @flow
 
-type ExpressionType = 'data-driven' | 'cross-faded' | 'cross-faded-data-driven' | 'color-ramp' | 'data-constant';
+type ExpressionType = 'data-driven' | 'cross-faded' | 'cross-faded-data-driven' | 'color-ramp' | 'data-constant' | 'constant';
 type ExpressionParameters = Array<'zoom' | 'feature' | 'heatmap-density' | 'line-progress'>;
 
 type ExpressionSpecification = {
-    type: ExpressionType,
     interpolated: boolean,
     parameters: ExpressionParameters
 }
 
 export type StylePropertySpecification = {
     type: 'number',
+    'property-type': ExpressionType,
     expression?: ExpressionSpecification,
     default?: number
 } | {
     type: 'string',
+    'property-type': ExpressionType,
     expression?: ExpressionSpecification,
     default?: string,
     tokens?: boolean
 } | {
     type: 'boolean',
+    'property-type': ExpressionType,
     expression?: ExpressionSpecification,
     default?: boolean
 } | {
     type: 'enum',
+    'property-type': ExpressionType,
     expression?: ExpressionSpecification,
     values: {[string]: {}},
     default?: string
 } | {
     type: 'color',
+    'property-type': ExpressionType,
     expression?: ExpressionSpecification,
     default?: string
 } | {
     type: 'array',
     value: 'number',
+    'property-type': ExpressionType,
     expression?: ExpressionSpecification,
     length?: number,
     default?: Array<number>
 } | {
     type: 'array',
     value: 'string',
+    'property-type': ExpressionType,
     expression?: ExpressionSpecification,
     length?: number,
     default?: Array<string>

--- a/src/style-spec/util/properties.js
+++ b/src/style-spec/util/properties.js
@@ -1,12 +1,10 @@
 // @flow
 
-export function isPropertyFunction(spec: Object): boolean {
-    const dataDrivenTypes = new Set(['data-driven', 'cross-faded-data-driven']);
-
-    return spec.expression && dataDrivenTypes.has(spec.expression['property-type']);
+export function isPropertyExpression(spec: Object): boolean {
+    return spec['property-type'] === 'data-driven' || spec['property-type'] === 'cross-faded-data-driven';
 }
 
-export function isZoomFunction(spec: Object): boolean {
+export function isZoomExpression(spec: Object): boolean {
     return spec.expression && spec.expression.parameters.indexOf('zoom') > -1;
 }
 

--- a/src/style-spec/util/properties.js
+++ b/src/style-spec/util/properties.js
@@ -1,13 +1,15 @@
 // @flow
 
-export function isPropertyExpression(spec: Object): boolean {
+import type {StylePropertySpecification} from '../style-spec';
+
+export function supportsPropertyExpression(spec: StylePropertySpecification): boolean {
     return spec['property-type'] === 'data-driven' || spec['property-type'] === 'cross-faded-data-driven';
 }
 
-export function isZoomExpression(spec: Object): boolean {
-    return spec.expression && spec.expression.parameters.indexOf('zoom') > -1;
+export function supportsZoomExpression(spec: StylePropertySpecification): boolean {
+    return !!spec.expression && spec.expression.parameters.indexOf('zoom') > -1;
 }
 
-export function isInterpolated(spec: Object): boolean {
-    return spec.expression && spec.expression.interpolated;
+export function supportsInterpolation(spec: StylePropertySpecification): boolean {
+    return !!spec.expression && spec.expression.interpolated;
 }

--- a/src/style-spec/util/properties.js
+++ b/src/style-spec/util/properties.js
@@ -1,0 +1,15 @@
+// @flow
+
+export function isPropertyFunction(spec: Object): boolean {
+    const dataDrivenTypes = new Set(['data-driven', 'cross-faded-data-driven']);
+
+    return spec.expression && dataDrivenTypes.has(spec.expression['property-type']);
+}
+
+export function isZoomFunction(spec: Object): boolean {
+    return spec.expression && spec.expression.parameters.indexOf('zoom') > -1;
+}
+
+export function isInterpolated(spec: Object): boolean {
+    return spec.expression && spec.expression.interpolated;
+}

--- a/src/style-spec/validate/validate.js
+++ b/src/style-spec/validate/validate.js
@@ -54,10 +54,10 @@ export default function validate(options) {
     const valueSpec = options.valueSpec;
     const styleSpec = options.styleSpec;
 
-    if (valueSpec.function && isFunction(unbundle(value))) {
+    if (valueSpec.expression && isFunction(unbundle(value))) {
         return validateFunction(options);
 
-    } else if (valueSpec.function && isExpression(deepUnbundle(value))) {
+    } else if (valueSpec.expression && isExpression(deepUnbundle(value))) {
         return validateExpression(options);
 
     } else if (valueSpec.type && VALIDATORS[valueSpec.type]) {

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -7,8 +7,8 @@ import validateArray from './validate_array';
 import validateNumber from './validate_number';
 import { unbundle } from '../util/unbundle_jsonlint';
 import {
-    isPropertyFunction as acceptsPropertyFunction,
-    isZoomFunction as acceptsZoomFunction,
+    isPropertyExpression as acceptsPropertyExpression,
+    isZoomExpression as acceptsZoomExpression,
     isInterpolated as acceptsInterpolated
 } from '../util/properties';
 
@@ -52,9 +52,9 @@ export default function validateFunction(options) {
     }
 
     if (options.styleSpec.$version >= 8) {
-        if (isPropertyFunction && !acceptsPropertyFunction(options.valueSpec)) {
+        if (isPropertyFunction && !acceptsPropertyExpression(options.valueSpec)) {
             errors.push(new ValidationError(options.key, options.value, 'property functions not supported'));
-        } else if (isZoomFunction && !acceptsZoomFunction(options.valueSpec)) {
+        } else if (isZoomFunction && !acceptsZoomExpression(options.valueSpec)) {
             errors.push(new ValidationError(options.key, options.value, 'zoom functions not supported'));
         }
     }
@@ -165,7 +165,7 @@ export default function validateFunction(options) {
 
         if (type !== 'number' && functionType !== 'categorical') {
             let message = `number expected, ${type} found`;
-            if (acceptsPropertyFunction(functionValueSpec) && functionType === undefined) {
+            if (acceptsPropertyExpression(functionValueSpec) && functionType === undefined) {
                 message += '\nIf you intended to use a categorical function, specify `"type": "categorical"`.';
             }
             return [new ValidationError(options.key, reportValue, message)];

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -7,9 +7,9 @@ import validateArray from './validate_array';
 import validateNumber from './validate_number';
 import { unbundle } from '../util/unbundle_jsonlint';
 import {
-    isPropertyExpression as acceptsPropertyExpression,
-    isZoomExpression as acceptsZoomExpression,
-    isInterpolated as acceptsInterpolated
+    supportsPropertyExpression,
+    supportsZoomExpression,
+    supportsInterpolation
 } from '../util/properties';
 
 export default function validateFunction(options) {
@@ -47,14 +47,14 @@ export default function validateFunction(options) {
         errors.push(new ValidationError(options.key, options.value, 'missing required property "stops"'));
     }
 
-    if (functionType === 'exponential' && options.valueSpec.expression && !acceptsInterpolated(options.valueSpec)) {
+    if (functionType === 'exponential' && options.valueSpec.expression && !supportsInterpolation(options.valueSpec)) {
         errors.push(new ValidationError(options.key, options.value, 'exponential functions not supported'));
     }
 
     if (options.styleSpec.$version >= 8) {
-        if (isPropertyFunction && !acceptsPropertyExpression(options.valueSpec)) {
+        if (isPropertyFunction && !supportsPropertyExpression(options.valueSpec)) {
             errors.push(new ValidationError(options.key, options.value, 'property functions not supported'));
-        } else if (isZoomFunction && !acceptsZoomExpression(options.valueSpec)) {
+        } else if (isZoomFunction && !supportsZoomExpression(options.valueSpec)) {
             errors.push(new ValidationError(options.key, options.value, 'zoom functions not supported'));
         }
     }
@@ -165,7 +165,7 @@ export default function validateFunction(options) {
 
         if (type !== 'number' && functionType !== 'categorical') {
             let message = `number expected, ${type} found`;
-            if (acceptsPropertyExpression(functionValueSpec) && functionType === undefined) {
+            if (supportsPropertyExpression(functionValueSpec) && functionType === undefined) {
                 message += '\nIf you intended to use a categorical function, specify `"type": "categorical"`.';
             }
             return [new ValidationError(options.key, reportValue, message)];

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -6,6 +6,11 @@ import validateObject from './validate_object';
 import validateArray from './validate_array';
 import validateNumber from './validate_number';
 import { unbundle } from '../util/unbundle_jsonlint';
+import {
+    isPropertyFunction as acceptsPropertyFunction,
+    isZoomFunction as acceptsZoomFunction,
+    isInterpolated as acceptsInterpolated
+} from '../util/properties';
 
 export default function validateFunction(options) {
     const functionValueSpec = options.valueSpec;
@@ -42,14 +47,14 @@ export default function validateFunction(options) {
         errors.push(new ValidationError(options.key, options.value, 'missing required property "stops"'));
     }
 
-    if (functionType === 'exponential' && options.valueSpec['function'] === 'piecewise-constant') {
+    if (functionType === 'exponential' && options.valueSpec.expression && !acceptsInterpolated(options.valueSpec)) {
         errors.push(new ValidationError(options.key, options.value, 'exponential functions not supported'));
     }
 
     if (options.styleSpec.$version >= 8) {
-        if (isPropertyFunction && !options.valueSpec['property-function']) {
+        if (isPropertyFunction && !acceptsPropertyFunction(options.valueSpec)) {
             errors.push(new ValidationError(options.key, options.value, 'property functions not supported'));
-        } else if (isZoomFunction && !options.valueSpec['zoom-function'] && options.objectKey !== 'heatmap-color' && options.objectKey !== 'line-gradient') {
+        } else if (isZoomFunction && !acceptsZoomFunction(options.valueSpec)) {
             errors.push(new ValidationError(options.key, options.value, 'zoom functions not supported'));
         }
     }
@@ -160,7 +165,7 @@ export default function validateFunction(options) {
 
         if (type !== 'number' && functionType !== 'categorical') {
             let message = `number expected, ${type} found`;
-            if (functionValueSpec['property-function'] && functionType === undefined) {
+            if (acceptsPropertyFunction(functionValueSpec) && functionType === undefined) {
                 message += '\nIf you intended to use a categorical function, specify `"type": "categorical"`.';
             }
             return [new ValidationError(options.key, reportValue, message)];

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -4,7 +4,7 @@ import ValidationError from '../error/validation_error';
 import getType from '../util/get_type';
 import { isFunction } from '../function';
 import { unbundle, deepUnbundle } from '../util/unbundle_jsonlint';
-import { isPropertyExpression } from '../util/properties';
+import { supportsPropertyExpression } from '../util/properties';
 
 export default function validateProperty(options, propertyType) {
     const key = options.key;
@@ -33,7 +33,7 @@ export default function validateProperty(options, propertyType) {
     }
 
     let tokenMatch;
-    if (getType(value) === 'string' && isPropertyExpression(valueSpec) && !valueSpec.tokens && (tokenMatch = /^{([^}]+)}$/.exec(value))) {
+    if (getType(value) === 'string' && supportsPropertyExpression(valueSpec) && !valueSpec.tokens && (tokenMatch = /^{([^}]+)}$/.exec(value))) {
         return [new ValidationError(
             key, value,
             `"${propertyKey}" does not support interpolation syntax\n` +

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -4,7 +4,7 @@ import ValidationError from '../error/validation_error';
 import getType from '../util/get_type';
 import { isFunction } from '../function';
 import { unbundle, deepUnbundle } from '../util/unbundle_jsonlint';
-import { isPropertyFunction } from '../util/properties';
+import { isPropertyExpression } from '../util/properties';
 
 export default function validateProperty(options, propertyType) {
     const key = options.key;
@@ -33,7 +33,7 @@ export default function validateProperty(options, propertyType) {
     }
 
     let tokenMatch;
-    if (getType(value) === 'string' && isPropertyFunction(valueSpec) && !valueSpec.tokens && (tokenMatch = /^{([^}]+)}$/.exec(value))) {
+    if (getType(value) === 'string' && isPropertyExpression(valueSpec) && !valueSpec.tokens && (tokenMatch = /^{([^}]+)}$/.exec(value))) {
         return [new ValidationError(
             key, value,
             `"${propertyKey}" does not support interpolation syntax\n` +

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -4,6 +4,7 @@ import ValidationError from '../error/validation_error';
 import getType from '../util/get_type';
 import { isFunction } from '../function';
 import { unbundle, deepUnbundle } from '../util/unbundle_jsonlint';
+import { isPropertyFunction } from '../util/properties';
 
 export default function validateProperty(options, propertyType) {
     const key = options.key;
@@ -32,7 +33,7 @@ export default function validateProperty(options, propertyType) {
     }
 
     let tokenMatch;
-    if (getType(value) === 'string' && valueSpec['property-function'] && !valueSpec.tokens && (tokenMatch = /^{([^}]+)}$/.exec(value))) {
+    if (getType(value) === 'string' && isPropertyFunction(valueSpec) && !valueSpec.tokens && (tokenMatch = /^{([^}]+)}$/.exec(value))) {
         return [new ValidationError(
             key, value,
             `"${propertyKey}" does not support interpolation syntax\n` +

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -11,8 +11,8 @@ if (process.argv[1] === __filename && process.argv.length > 2) {
 
 expressionSuite.run('js', { ignores, tests }, (fixture) => {
     const spec = Object.assign({}, fixture.propertySpec);
+    spec['property-type'] = 'data-driven';
     spec['expression'] = {
-        'property-type': 'data-driven',
         'interpolated': true,
         'parameters': ['zoom', 'feature']
     };

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -11,8 +11,11 @@ if (process.argv[1] === __filename && process.argv.length > 2) {
 
 expressionSuite.run('js', { ignores, tests }, (fixture) => {
     const spec = Object.assign({}, fixture.propertySpec);
-    spec['function'] = true;
-    spec['property-function'] = true;
+    spec['expression'] = {
+        'property-type': 'data-driven',
+        'interpolated': true,
+        'parameters': ['zoom', 'feature']
+    };
 
     const evaluateExpression = (expression, compilationResult) => {
         if (expression.result === 'error') {

--- a/test/integration/expression-tests/array/implicit-2/test.json
+++ b/test/integration/expression-tests/array/implicit-2/test.json
@@ -2,8 +2,8 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/array/implicit-2/test.json
+++ b/test/integration/expression-tests/array/implicit-2/test.json
@@ -2,8 +2,10 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["get", "array"],
   "inputs": [

--- a/test/integration/expression-tests/array/implicit-3/test.json
+++ b/test/integration/expression-tests/array/implicit-3/test.json
@@ -3,8 +3,8 @@
     "type": "array",
     "value": "number",
     "length": 2,
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/array/implicit-3/test.json
+++ b/test/integration/expression-tests/array/implicit-3/test.json
@@ -3,8 +3,10 @@
     "type": "array",
     "value": "number",
     "length": 2,
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["get", "array"],
   "inputs": [

--- a/test/integration/expression-tests/at/infer-array-type/test.json
+++ b/test/integration/expression-tests/at/infer-array-type/test.json
@@ -1,8 +1,10 @@
 {
   "propertySpec": {
     "type": "string",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["at", 1, ["literal", [1, 2, 3]]],
   "inputs": [],

--- a/test/integration/expression-tests/at/infer-array-type/test.json
+++ b/test/integration/expression-tests/at/infer-array-type/test.json
@@ -1,8 +1,8 @@
 {
   "propertySpec": {
     "type": "string",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/case/basic/test.json
+++ b/test/integration/expression-tests/case/basic/test.json
@@ -1,8 +1,8 @@
 {
   "propertySpec": {
     "type": "string",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/case/basic/test.json
+++ b/test/integration/expression-tests/case/basic/test.json
@@ -1,8 +1,10 @@
 {
   "propertySpec": {
     "type": "string",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["case", ["get", "x"], "x", ["get", "y"], "y", "otherwise"],
   "inputs": [

--- a/test/integration/expression-tests/case/infer-array-type/test.json
+++ b/test/integration/expression-tests/case/infer-array-type/test.json
@@ -2,8 +2,8 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/case/infer-array-type/test.json
+++ b/test/integration/expression-tests/case/infer-array-type/test.json
@@ -2,8 +2,10 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": [
     "case",

--- a/test/integration/expression-tests/coalesce/infer-array-type/test.json
+++ b/test/integration/expression-tests/coalesce/infer-array-type/test.json
@@ -2,8 +2,8 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/coalesce/infer-array-type/test.json
+++ b/test/integration/expression-tests/coalesce/infer-array-type/test.json
@@ -2,8 +2,10 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": [
     "coalesce",

--- a/test/integration/expression-tests/constant-folding/evaluation-error/test.json
+++ b/test/integration/expression-tests/constant-folding/evaluation-error/test.json
@@ -1,8 +1,10 @@
 {
   "propertySpec": {
     "type": "color",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["step", ["get", "x"], "black", 0, "invalid", 10, "blue"],
   "inputs": [

--- a/test/integration/expression-tests/constant-folding/evaluation-error/test.json
+++ b/test/integration/expression-tests/constant-folding/evaluation-error/test.json
@@ -1,8 +1,8 @@
 {
   "propertySpec": {
     "type": "color",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/heatmap-density/basic/test.json
+++ b/test/integration/expression-tests/heatmap-density/basic/test.json
@@ -11,8 +11,8 @@
         [1, "red"]
       ]
     },
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/heatmap-density/basic/test.json
+++ b/test/integration/expression-tests/heatmap-density/basic/test.json
@@ -11,8 +11,10 @@
         [1, "red"]
       ]
     },
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": [
     "interpolate",

--- a/test/integration/expression-tests/interpolate/infer-array-type/test.json
+++ b/test/integration/expression-tests/interpolate/infer-array-type/test.json
@@ -2,8 +2,10 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": [
     "step",

--- a/test/integration/expression-tests/interpolate/infer-array-type/test.json
+++ b/test/integration/expression-tests/interpolate/infer-array-type/test.json
@@ -2,8 +2,8 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/interpolate/linear/test.json
+++ b/test/integration/expression-tests/interpolate/linear/test.json
@@ -1,8 +1,10 @@
 {
   "propertySpec": {
     "type": "number",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["interpolate", ["linear"], ["get", "x"], 0, 100, 10, 200],
   "inputs": [

--- a/test/integration/expression-tests/interpolate/linear/test.json
+++ b/test/integration/expression-tests/interpolate/linear/test.json
@@ -1,8 +1,8 @@
 {
   "propertySpec": {
     "type": "number",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/literal/infer-empty-array-type/test.json
+++ b/test/integration/expression-tests/literal/infer-empty-array-type/test.json
@@ -2,8 +2,10 @@
   "propertySpec": {
     "type": "array",
     "value": "number",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["literal", []],
   "inputs": [],

--- a/test/integration/expression-tests/literal/infer-empty-array-type/test.json
+++ b/test/integration/expression-tests/literal/infer-empty-array-type/test.json
@@ -2,8 +2,8 @@
   "propertySpec": {
     "type": "array",
     "value": "number",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/match/infer-array-type/test.json
+++ b/test/integration/expression-tests/match/infer-array-type/test.json
@@ -2,8 +2,8 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/match/infer-array-type/test.json
+++ b/test/integration/expression-tests/match/infer-array-type/test.json
@@ -2,8 +2,10 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": [
     "match",

--- a/test/integration/expression-tests/typecheck/array-invalid-item/test.json
+++ b/test/integration/expression-tests/typecheck/array-invalid-item/test.json
@@ -3,8 +3,8 @@
     "type": "array",
     "value": "string",
     "length": 2,
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/typecheck/array-invalid-item/test.json
+++ b/test/integration/expression-tests/typecheck/array-invalid-item/test.json
@@ -3,8 +3,10 @@
     "type": "array",
     "value": "string",
     "length": 2,
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["array", "number", 2, ["get", "x"]],
   "inputs": [],

--- a/test/integration/expression-tests/typecheck/array-item-subtyping/test.json
+++ b/test/integration/expression-tests/typecheck/array-item-subtyping/test.json
@@ -1,8 +1,8 @@
 {
   "propertySpec": {
     "type": "array",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/typecheck/array-item-subtyping/test.json
+++ b/test/integration/expression-tests/typecheck/array-item-subtyping/test.json
@@ -1,8 +1,10 @@
 {
   "propertySpec": {
     "type": "array",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["array", "number", 2, ["get", "x"]],
   "inputs": [],

--- a/test/integration/expression-tests/typecheck/array-length-subtyping--no-length/test.json
+++ b/test/integration/expression-tests/typecheck/array-length-subtyping--no-length/test.json
@@ -3,8 +3,8 @@
     "type": "array",
     "value": "number",
     "length": 3,
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/typecheck/array-length-subtyping--no-length/test.json
+++ b/test/integration/expression-tests/typecheck/array-length-subtyping--no-length/test.json
@@ -3,8 +3,10 @@
     "type": "array",
     "value": "number",
     "length": 3,
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["array", "number", ["get", "x"]],
   "inputs": [],

--- a/test/integration/expression-tests/typecheck/array-length-subtyping/test.json
+++ b/test/integration/expression-tests/typecheck/array-length-subtyping/test.json
@@ -2,8 +2,8 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/typecheck/array-length-subtyping/test.json
+++ b/test/integration/expression-tests/typecheck/array-length-subtyping/test.json
@@ -2,8 +2,10 @@
   "propertySpec": {
     "type": "array",
     "value": "string",
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["array", "string", 2, ["get", "x"]],
   "inputs": [],

--- a/test/integration/expression-tests/typecheck/array-wrong-length/test.json
+++ b/test/integration/expression-tests/typecheck/array-wrong-length/test.json
@@ -3,8 +3,8 @@
     "type": "array",
     "value": "number",
     "length": 3,
+    "property-type": "data-driven",
     "expression": {
-      "property-type": "data-driven",
       "parameters": ["zoom", "feature"]
     }
   },

--- a/test/integration/expression-tests/typecheck/array-wrong-length/test.json
+++ b/test/integration/expression-tests/typecheck/array-wrong-length/test.json
@@ -3,8 +3,10 @@
     "type": "array",
     "value": "number",
     "length": 3,
-    "function": true,
-    "property-function": true
+    "expression": {
+      "property-type": "data-driven",
+      "parameters": ["zoom", "feature"]
+    }
   },
   "expression": ["array", "number", 2, ["get", "x"]],
   "inputs": [],

--- a/test/unit/style-spec/convert_function.test.js
+++ b/test/unit/style-spec/convert_function.test.js
@@ -16,8 +16,8 @@ test('convertFunction', (t) => {
 
         const expression = convertFunction(functionValue, {
             type: 'string',
+            'property-type': 'data-constant',
             expression: {
-                'property-type': 'data-constant',
                 'interpolated': false,
                 'parameters': ['zoom']
             },
@@ -66,8 +66,8 @@ test('convertFunction', (t) => {
 
         const expression = convertFunction(functionValue, {
             type: 'string',
+            'property-type': 'data-constant',
             expression: {
-                'property-type': 'data-constant',
                 'interpolated': false,
                 'parameters': ['zoom']
             }
@@ -97,8 +97,8 @@ test('convertFunction', (t) => {
 
         const expression = convertFunction(functionValue, {
             type: 'number',
+            'property-type': 'data-constant',
             expression: {
-                'property-type': 'data-constant',
                 'interpolated': true,
                 'parameters': ['zoom']
             }

--- a/test/unit/style-spec/convert_function.test.js
+++ b/test/unit/style-spec/convert_function.test.js
@@ -16,7 +16,11 @@ test('convertFunction', (t) => {
 
         const expression = convertFunction(functionValue, {
             type: 'string',
-            function: 'piecewise-constant',
+            expression: {
+                'property-type': 'data-constant',
+                'interpolated': false,
+                'parameters': ['zoom']
+            },
             tokens: true
         });
         t.deepEqual(expression, [
@@ -62,7 +66,11 @@ test('convertFunction', (t) => {
 
         const expression = convertFunction(functionValue, {
             type: 'string',
-            function: 'piecewise-constant'
+            expression: {
+                'property-type': 'data-constant',
+                'interpolated': false,
+                'parameters': ['zoom']
+            }
         });
         t.deepEqual(expression, [
             'step',
@@ -89,7 +97,11 @@ test('convertFunction', (t) => {
 
         const expression = convertFunction(functionValue, {
             type: 'number',
-            function: 'interpolated'
+            expression: {
+                'property-type': 'data-constant',
+                'interpolated': true,
+                'parameters': ['zoom']
+            }
         });
         t.deepEqual(expression, [
             'interpolate',

--- a/test/unit/style-spec/expression.test.js
+++ b/test/unit/style-spec/expression.test.js
@@ -2,12 +2,16 @@ import { test } from 'mapbox-gl-js-test';
 import { createPropertyExpression } from '../../../src/style-spec/expression';
 
 test('createPropertyExpression', (t) => {
-    test('prohibits piecewise-constant properties from using an "interpolate" expression', (t) => {
+    test('prohibits non-interpolable properties from using an "interpolate" expression', (t) => {
         const {result, value} = createPropertyExpression([
             'interpolate', ['linear'], ['zoom'], 0, 0, 10, 10
         ], {
             type: 'number',
-            function: 'piecewise-constant'
+            expression: {
+                'property-type': 'data-constant',
+                'interpolated': false,
+                'parameters': ['zoom']
+            }
         });
         t.equal(result, 'error');
         t.equal(value.length, 1);
@@ -24,7 +28,11 @@ test('evaluate expression', (t) => {
             type: 'enum',
             values: {a: {}, b: {}, c: {}},
             default: 'a',
-            'property-function': true
+            expression: {
+                'property-type': 'data-driven',
+                'interpolated': false,
+                'parameters': ['zoom', 'feature']
+            }
         });
 
         t.stub(console, 'warn');

--- a/test/unit/style-spec/expression.test.js
+++ b/test/unit/style-spec/expression.test.js
@@ -7,8 +7,8 @@ test('createPropertyExpression', (t) => {
             'interpolate', ['linear'], ['zoom'], 0, 0, 10, 10
         ], {
             type: 'number',
+            'property-type': 'data-constant',
             expression: {
-                'property-type': 'data-constant',
                 'interpolated': false,
                 'parameters': ['zoom']
             }
@@ -28,8 +28,8 @@ test('evaluate expression', (t) => {
             type: 'enum',
             values: {a: {}, b: {}, c: {}},
             default: 'a',
+            'property-type': 'data-driven',
             expression: {
-                'property-type': 'data-driven',
                 'interpolated': false,
                 'parameters': ['zoom', 'feature']
             }

--- a/test/unit/style-spec/function.test.js
+++ b/test/unit/style-spec/function.test.js
@@ -9,8 +9,8 @@ test('binary search', (t) => {
             base: 2
         }, {
             type: 'number',
+            'property-type': 'data-constant',
             expression: {
-                'property-type': 'data-constant',
                 'interpolated': true,
                 'parameters': ['zoom']
             }
@@ -30,8 +30,8 @@ test('exponential function', (t) => {
             base: 2
         }, {
             type: 'number',
+            'property-type': 'data-constant',
             expression: {
-                'property-type': 'data-constant',
                 'interpolated': true,
                 'parameters': ['zoom']
             }
@@ -471,8 +471,8 @@ test('interval function', (t) => {
             stops: [[-1, 11], [0, 111]]
         }, {
             type: 'number',
+            'property-type': 'data-constant',
             expression: {
-                'property-type': 'data-constant',
                 'interpolated': false,
                 'parameters': ['zoom']
             }

--- a/test/unit/style-spec/function.test.js
+++ b/test/unit/style-spec/function.test.js
@@ -9,7 +9,11 @@ test('binary search', (t) => {
             base: 2
         }, {
             type: 'number',
-            function: 'interpolated'
+            expression: {
+                'property-type': 'data-constant',
+                'interpolated': true,
+                'parameters': ['zoom']
+            }
         }).evaluate;
 
         t.equal(f({zoom: 17}), 11);
@@ -26,7 +30,11 @@ test('exponential function', (t) => {
             base: 2
         }, {
             type: 'number',
-            function: 'interpolated'
+            expression: {
+                'property-type': 'data-constant',
+                'interpolated': true,
+                'parameters': ['zoom']
+            }
         }).evaluate;
 
         t.equalWithPrecision(f({zoom: 2}), 30 / 9, 1e-6);
@@ -458,12 +466,16 @@ test('exponential function', (t) => {
 });
 
 test('interval function', (t) => {
-    t.test('is the default for piecewise-constant properties', (t) => {
+    t.test('is the default for non-interpolated properties', (t) => {
         const f = createFunction({
             stops: [[-1, 11], [0, 111]]
         }, {
             type: 'number',
-            function: 'piecewise-constant'
+            expression: {
+                'property-type': 'data-constant',
+                'interpolated': false,
+                'parameters': ['zoom']
+            }
         }).evaluate;
 
         t.equal(f({zoom: -1.5}), 11);

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -42,6 +42,7 @@ function validSchema(k, t, obj, ref, version, kind) {
         'zoom-function',
         'property-function',
         'function-output',
+        'expression',
         'length',
         'min-length',
         'required',
@@ -114,11 +115,18 @@ function validSchema(k, t, obj, ref, version, kind) {
 
         // schema key function checks
         if (obj.function !== undefined) {
+            t.ok(ref.$version < 8, 'migrated to `expression` schema in v8 spec');
             if (ref.$version >= 7) {
                 t.equal(true, ['interpolated', 'piecewise-constant'].indexOf(obj.function) >= 0, `function: ${obj.function}`);
             } else {
                 t.equal('boolean', typeof obj.function, `${k}.required (boolean)`);
             }
+        } else if (obj.expression !== undefined) {
+            const expression = obj.expression;
+            t.equal(true, ['data-driven', 'cross-faded-data-driven', 'cross-faded', 'color-ramp', 'data-constant'].indexOf(expression['property-type']) >= 0, `${k}.expression: property-type: ${expression['property-type']}`);
+            t.equal('boolean', typeof expression.interpolated, `${k}.expression.interpolated.required (boolean)`);
+            t.equal(true, Array.isArray(expression.parameters), `${k}.expression.parameters array`);
+            if (expression['property-type'] !== 'color-ramp') t.equal(true, expression.parameters.every(k => k === 'zoom' || k === 'feature'));
         }
 
         // schema key required checks

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -43,6 +43,7 @@ function validSchema(k, t, obj, ref, version, kind) {
         'property-function',
         'function-output',
         'expression',
+        'property-type',
         'length',
         'min-length',
         'required',
@@ -123,10 +124,10 @@ function validSchema(k, t, obj, ref, version, kind) {
             }
         } else if (obj.expression !== undefined) {
             const expression = obj.expression;
-            t.equal(true, ['data-driven', 'cross-faded-data-driven', 'cross-faded', 'color-ramp', 'data-constant'].indexOf(expression['property-type']) >= 0, `${k}.expression: property-type: ${expression['property-type']}`);
+            t.equal(true, ['data-driven', 'cross-faded-data-driven', 'cross-faded', 'color-ramp', 'data-constant'].indexOf(obj['property-type']) >= 0, `${k}.expression: property-type: ${obj['property-type']}`);
             t.equal('boolean', typeof expression.interpolated, `${k}.expression.interpolated.required (boolean)`);
             t.equal(true, Array.isArray(expression.parameters), `${k}.expression.parameters array`);
-            if (expression['property-type'] !== 'color-ramp') t.equal(true, expression.parameters.every(k => k === 'zoom' || k === 'feature'));
+            if (obj['property-type'] !== 'color-ramp') t.equal(true, expression.parameters.every(k => k === 'zoom' || k === 'feature'));
         }
 
         // schema key required checks


### PR DESCRIPTION
This PR reworks the taxonomy to describe how a property can use functions/expressions, as described in https://github.com/mapbox/mapbox-gl-js/issues/6389#issuecomment-376187545 and https://github.com/mapbox/mapbox-gl-js/issues/6389#issuecomment-379861063:

``` ts
type ExpressionType = 'data-driven' | 'cross-faded' | 'cross-faded-data-driven' | 'color-ramp' | 'data-constant' | 'constant';

type ExpressionParameters = Array<'zoom' | 'feature' | 'heatmap-density' | 'line-progress'>;

type ExpressionSpecification = {
    interpolated: boolean,
    parameters: ExpressionParameters
}

StylePropertySpecification = {
    ...
    'property-type': ExpressionType,
    'expression': ExpressionSpecification
}
```

so now any property all properties include a `property-type` key, and for all property-types except `constant` also an `expression` property, i.e.
```
    "type": "number",
    "property-type": "data-driven",
    "expression": {
        "interpolated": true,
        "parameters": [
            "zoom",
            "feature"
        ]
    }
```

Benchmarks: http://bl.ocks.org/lbud/raw/2ac3b8869074c112802166978cea8345/ (I couldn't reproduce the Layer discrepancies on subsequent isolated bench runs).

Closes https://github.com/mapbox/mapbox-gl-js/issues/6389
Supersedes / closes https://github.com/mapbox/mapbox-gl-js/issues/4194
Refs https://github.com/mapbox/mapbox-gl-js/pull/6430
Refs https://github.com/mapbox/mapbox-gl-js/pull/6303

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page
