### PR TITLE
only compact attribution on screens

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -202,34 +202,36 @@ a.mapboxgl-ctrl-logo {
     margin: 0;
 }
 
-.mapboxgl-ctrl-attrib.mapboxgl-compact {
-    padding-top: 2px;
-    padding-bottom: 2px;
-    margin: 0 10px 10px;
-    position: relative;
-    padding-right: 24px;
-    background-color: #fff;
-    border-radius: 3px 12px 12px 3px;
-    visibility: hidden;
-}
+@media screen {
+    .mapboxgl-ctrl-attrib.mapboxgl-compact {
+        padding-top: 2px;
+        padding-bottom: 2px;
+        margin: 0 10px 10px;
+        position: relative;
+        padding-right: 24px;
+        background-color: #fff;
+        border-radius: 3px 12px 12px 3px;
+        visibility: hidden;
+    }
 
-.mapboxgl-ctrl-attrib.mapboxgl-compact:hover {
-    visibility: visible;
-}
+    .mapboxgl-ctrl-attrib.mapboxgl-compact:hover {
+        visibility: visible;
+    }
 
-.mapboxgl-ctrl-attrib.mapboxgl-compact::after {
-    content: '';
-    cursor: pointer;
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    background-image: svg-load('svg/mapboxgl-ctrl-attrib.svg');
-    background-color: rgba(255, 255, 255, 0.5);
-    width: 24px;
-    height: 24px;
-    box-sizing: border-box;
-    visibility: visible;
-    border-radius: 12px;
+    .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+        content: '';
+        cursor: pointer;
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        background-image: svg-load('svg/mapboxgl-ctrl-attrib.svg');
+        background-color: rgba(255, 255, 255, 0.5);
+        width: 24px;
+        height: 24px;
+        box-sizing: border-box;
+        visibility: visible;
+        border-radius: 12px;
+    }
 }
 
 .mapboxgl-ctrl-attrib a {


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

On small maps, the AttributionControl uses an i icon expanded to the full attribution on mouseover.

This PR ensures that only happens for the [screen media](https://developer.mozilla.org/en-US/docs/Web/CSS/@media#Media_types), so that if a user prints a web page displaying a GL JS map the attribution text is still shown.

 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
