### PR TITLE
use examples' descriptions in search filter

### DIFF
--- a/docs/components/example.js
+++ b/docs/components/example.js
@@ -93,8 +93,8 @@ ${html}
                             <div key={i} className='space-bottom1'>
                                 {!filter && <h3 className='heading'>{title}</h3>}
                                 {examples
-                                    .filter(({tags, title}) =>
-                                        tags.indexOf(tag) !== -1 && title.toLowerCase().indexOf(filter) !== -1)
+                                    .filter(({tags, title, description}) =>
+                                        tags.indexOf(tag) !== -1 && (title.toLowerCase().indexOf(filter) !== -1 || description.toLowerCase().indexOf(filter) !== -1))
                                     .map(({pathname, title}, i) =>
                                         <a key={i} href={prefixUrl(pathname)}
                                             className={`block small truncate ${title === frontMatter.title && 'active'}`}>{title}</a>


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

something that's bugged me for a while is searching for an example by a term not in the title. This PR includes the example description text in that search/filter. This catches a few extra terms like these which would otherwise go exampleless.

raster base -> Display a satellite map
geolocate -> Locate the user
expressions
switcher -> show and hide layers
compare -> swipe between maps

 - n/a write tests for all new functionality
 - n/a document any changes to public APIs
 - n/a post benchmark scores
 - [x] manually test the debug page