### PR TITLE
Enable eslint html plugin for debug folder

### DIFF
--- a/debug/.eslintrc
+++ b/debug/.eslintrc
@@ -1,5 +1,8 @@
 {
-  "parserOptions": {
+    "plugins": [
+        "html"
+    ],
+    "parserOptions": {
     "ecmaFeatures": {
       "jsx": true
     }


### PR DESCRIPTION
Fixes linter errors in `/debug/*.html` files seen on some machines. 

The `eslint-plugin-html` plugin needs to be enabled in the `debug` folder to correctly process `.html`  files.

cc @chrisloer @lbud 