### PR TITLE
fix #6501, fix moving layer to it's current location

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -605,6 +605,10 @@ class Style extends Evented {
             return;
         }
 
+        if (id === before) {
+            return;
+        }
+
         const index = this._order.indexOf(id);
         this._order.splice(index, 1);
 

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1273,6 +1273,23 @@ test('Style#moveLayer', (t) => {
         });
     });
 
+    t.test('moves to existing location', (t) => {
+        const style = new Style(new StubMap());
+        style.loadJSON(createStyleJSON({
+            layers: [
+                {id: 'a', type: 'background'},
+                {id: 'b', type: 'background'},
+                {id: 'c', type: 'background'}
+            ]
+        }));
+
+        style.on('style.load', () => {
+            style.moveLayer('b', 'b');
+            t.deepEqual(style._order, ['a', 'b', 'c']);
+            t.end();
+        });
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Fixes #6501 by doing nothing when the moved layer's id is the same as the layer to insert it before.

While moving a layer to before itself is a bit weird, it doesn't seem wrong enough to fail with an error.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [N/A] document any changes to public APIs
 - [N/A] post benchmark scores
 - [N/A] manually test the debug page
