### PR TITLE
fix #6548, never group symbol layers by layout

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -18,6 +18,7 @@ import Anchor from '../../symbol/anchor';
 import { getSizeData } from '../../symbol/symbol_size';
 import { register } from '../../util/web_worker_transfer';
 import EvaluationParameters from '../../style/evaluation_parameters';
+import assert from 'assert';
 
 import type {Feature as ExpressionFeature} from '../../style-spec/expression';
 import type {
@@ -294,6 +295,8 @@ class SymbolBucket implements Bucket {
         this.zoom = options.zoom;
         this.overscaling = options.overscaling;
         this.layers = options.layers;
+        // symbol layers are never grouped
+        assert(this.layers.length === 1);
         this.layerIds = this.layers.map(layer => layer.id);
         this.index = options.index;
         this.pixelRatio = options.pixelRatio;

--- a/src/style-spec/group_by_layout.js
+++ b/src/style-spec/group_by_layout.js
@@ -23,8 +23,14 @@ function stringify(obj) {
     return `${str}}`;
 }
 
-function getKey(layer) {
+function getKey(layer, i) {
     let key = '';
+
+    // never group symbol layers
+    if (layer.type === 'symbol') {
+        key += i;
+    }
+
     for (const k of refProperties) {
         key += `/${stringify(layer[k])}`;
     }
@@ -51,7 +57,7 @@ function groupByLayout(layers) {
     const groups = {};
 
     for (let i = 0; i < layers.length; i++) {
-        const k = getKey(layers[i]);
+        const k = getKey(layers[i], i);
         let group = groups[k];
         if (!group) {
             group = groups[k] = [];

--- a/test/unit/style-spec/group_by_layout.test.js
+++ b/test/unit/style-spec/group_by_layout.test.js
@@ -64,3 +64,31 @@ t('group works even for differing layout key orders', (t) => {
     ]]);
     t.end();
 });
+
+t('does not group symbol layers', (t) => {
+    t.deepEqual(group([
+        {
+            'id': 'parent',
+            'type': 'symbol',
+            'layout': {'a': 1, 'b': 2}
+        },
+        {
+            'id': 'child',
+            'type': 'symbol',
+            'layout': {'b': 2, 'a': 1}
+        }
+    ]), [[
+        {
+            'id': 'parent',
+            'type': 'symbol',
+            'layout': {'a': 1, 'b': 2}
+        }
+    ], [
+        {
+            'id': 'child',
+            'type': 'symbol',
+            'layout': {'b': 2, 'a': 1}
+        }
+    ]]);
+    t.end();
+});


### PR DESCRIPTION
@ChrisLoer this is a possible fix for #6548 and alternative to https://github.com/mapbox/mapbox-gl-js/pull/6550

Instead of storing `CrossTileIDs` per-layer this just makes it so that symbol buckets never have more than one layer. The layer grouping is an attempted optimization to reduce bucket creation time but this doesn't really matter for symbol layers because there aren't really very many (any?) production uses for having multiple layers with the same layout properties.

EDIT: at first this seemed like a nicer approach than https://github.com/mapbox/mapbox-gl-js/pull/6550 but I'm starting to lean back towards https://github.com/mapbox/mapbox-gl-js/pull/6550. The other pr seems like a cleaner more logical exception, but this approach could possibly avoid some future bugs from layer sharing.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [N/A] document any changes to public APIs
 - [N/A] post benchmark scores
 - [x] manually test the debug page
