### PR TITLE
Fix style-spec build

### DIFF
--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -38,7 +38,7 @@ export const plugins = () => [
 
 // Using this instead of rollup-plugin-flow due to
 // https://github.com/leebyron/rollup-plugin-flow/issues/5
-function flow() {
+export function flow() {
     return {
         name: 'flow-remove-types',
         transform: (code) => ({

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -12,9 +12,9 @@
   "main": "./dist/index.js",
   "scripts": {
     "copy-flow-typed": "cp -R ../../flow-typed .",
-    "build": "rollup -c",
-    "prepublish": "in-publish && yarn copy-flow-typed && yarn build || not-in-publish",
-    "postpublish": "in-publish && rm -r flow-typed dist/index.js || not-in-publish"
+    "build": "../../node_modules/.bin/rollup -c",
+    "prepublish": "yarn copy-flow-typed && yarn build",
+    "postpublish": "rm -r flow-typed dist/index.js"
   },
   "repository": {
     "type": "git",
@@ -29,9 +29,7 @@
   "dependencies": {
     "@mapbox/jsonlint-lines-primitives": "~2.0.1",
     "@mapbox/unitbezier": "^0.0.0",
-    "brfs": "^1.4.0",
     "csscolorparser": "~1.0.2",
-    "in-publish": "^2.0.0",
     "minimist": "0.0.8",
     "rw": "^1.3.3",
     "sort-object": "^0.3.2"

--- a/src/style-spec/rollup.config.js
+++ b/src/style-spec/rollup.config.js
@@ -1,5 +1,11 @@
 import replace from 'rollup-plugin-replace';
-import {plugins} from '../../build/rollup_plugins';
+import buble from 'rollup-plugin-buble';
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import unassert from 'rollup-plugin-unassert';
+import json from 'rollup-plugin-json';
+import {flow} from '../../build/rollup_plugins';
+
 const config = [{
     input: `${__dirname}/style-spec.js`,
     output: {
@@ -16,7 +22,16 @@ const config = [{
             values: {
                 '_token_stack:': ''
             }
-        })
-    ].concat(plugins())
+        }),
+        flow(),
+        json(),
+        buble({transforms: {dangerousForOf: true}, objectAssign: "Object.assign"}),
+        unassert(),
+        resolve({
+            browser: true,
+            preferBuiltins: false
+        }),
+        commonjs()
+    ]
 }];
 export default config;


### PR DESCRIPTION
 - Fix `yarn build` looking for rollup in `src/style-spec/node_modules`
 - Don't reuse the rollup plugins from the main build (specifically, this included "minifying" the style spec json by stripping out `doc:` fields