### PR TITLE
Updated Examples to use Map#setFeatureState

### DIFF
--- a/docs/pages/example/data-join.html
+++ b/docs/pages/example/data-join.html
@@ -12,58 +12,58 @@ var map = new mapboxgl.Map({
 // Join local JSON data with vector tile geometry
 // USA unemployment rate in 2009
 // Source https://data.bls.gov/timeseries/LNS14000000
-var maxValue = 13;
+var maxValue = 14;
 var data = [
-    {"STATE_ID": "01", "unemployment": 13.17},
-    {"STATE_ID": "02", "unemployment": 9.5},
-    {"STATE_ID": "04", "unemployment": 12.15},
-    {"STATE_ID": "05", "unemployment": 8.99},
-    {"STATE_ID": "06", "unemployment": 11.83},
-    {"STATE_ID": "08", "unemployment": 7.52},
-    {"STATE_ID": "09", "unemployment": 6.44},
-    {"STATE_ID": "10", "unemployment": 5.17},
-    {"STATE_ID": "12", "unemployment": 9.67},
-    {"STATE_ID": "13", "unemployment": 10.64},
-    {"STATE_ID": "15", "unemployment": 12.38},
-    {"STATE_ID": "16", "unemployment": 10.13},
-    {"STATE_ID": "17", "unemployment": 9.58},
-    {"STATE_ID": "18", "unemployment": 10.63},
-    {"STATE_ID": "19", "unemployment": 8.09},
-    {"STATE_ID": "20", "unemployment": 5.93},
-    {"STATE_ID": "21", "unemployment": 9.86},
-    {"STATE_ID": "22", "unemployment": 9.81},
-    {"STATE_ID": "23", "unemployment": 7.82},
-    {"STATE_ID": "24", "unemployment": 8.35},
-    {"STATE_ID": "25", "unemployment": 9.1},
-    {"STATE_ID": "26", "unemployment": 10.69},
-    {"STATE_ID": "27", "unemployment": 11.53},
-    {"STATE_ID": "28", "unemployment": 9.29},
-    {"STATE_ID": "29", "unemployment": 9.94},
-    {"STATE_ID": "30", "unemployment": 9.29},
-    {"STATE_ID": "31", "unemployment": 5.45},
-    {"STATE_ID": "32", "unemployment": 4.21},
-    {"STATE_ID": "33", "unemployment": 4.27},
-    {"STATE_ID": "34", "unemployment": 4.09},
-    {"STATE_ID": "35", "unemployment": 7.83},
-    {"STATE_ID": "36", "unemployment": 8.01},
-    {"STATE_ID": "37", "unemployment": 9.34},
-    {"STATE_ID": "38", "unemployment": 11.23},
-    {"STATE_ID": "39", "unemployment": 7.08},
-    {"STATE_ID": "40", "unemployment": 11.22},
-    {"STATE_ID": "41", "unemployment": 6.2},
-    {"STATE_ID": "42", "unemployment": 9.11},
-    {"STATE_ID": "44", "unemployment": 10.42},
-    {"STATE_ID": "45", "unemployment": 8.89},
-    {"STATE_ID": "46", "unemployment": 11.03},
-    {"STATE_ID": "47", "unemployment": 7.35},
-    {"STATE_ID": "48", "unemployment": 8.92},
-    {"STATE_ID": "49", "unemployment": 7.65},
-    {"STATE_ID": "50", "unemployment": 8.01},
-    {"STATE_ID": "51", "unemployment": 7.62},
-    {"STATE_ID": "53", "unemployment": 7.77},
-    {"STATE_ID": "54", "unemployment": 8.49},
-    {"STATE_ID": "55", "unemployment": 9.42},
-    {"STATE_ID": "56", "unemployment": 7.59}
+    {"STATE_ID": 1, "unemployment": 13.17},
+    {"STATE_ID": 2, "unemployment": 9.5},
+    {"STATE_ID": 4, "unemployment": 12.15},
+    {"STATE_ID": 5, "unemployment": 8.99},
+    {"STATE_ID": 6, "unemployment": 11.83},
+    {"STATE_ID": 8, "unemployment": 7.52},
+    {"STATE_ID": 9, "unemployment": 6.44},
+    {"STATE_ID": 10, "unemployment": 5.17},
+    {"STATE_ID": 12, "unemployment": 9.67},
+    {"STATE_ID": 13, "unemployment": 10.64},
+    {"STATE_ID": 15, "unemployment": 12.38},
+    {"STATE_ID": 16, "unemployment": 10.13},
+    {"STATE_ID": 17, "unemployment": 9.58},
+    {"STATE_ID": 18, "unemployment": 10.63},
+    {"STATE_ID": 19, "unemployment": 8.09},
+    {"STATE_ID": 20, "unemployment": 5.93},
+    {"STATE_ID": 21, "unemployment": 9.86},
+    {"STATE_ID": 22, "unemployment": 9.81},
+    {"STATE_ID": 23, "unemployment": 7.82},
+    {"STATE_ID": 24, "unemployment": 8.35},
+    {"STATE_ID": 25, "unemployment": 9.1},
+    {"STATE_ID": 26, "unemployment": 10.69},
+    {"STATE_ID": 27, "unemployment": 11.53},
+    {"STATE_ID": 28, "unemployment": 9.29},
+    {"STATE_ID": 29, "unemployment": 9.94},
+    {"STATE_ID": 30, "unemployment": 9.29},
+    {"STATE_ID": 31, "unemployment": 5.45},
+    {"STATE_ID": 32, "unemployment": 4.21},
+    {"STATE_ID": 33, "unemployment": 4.27},
+    {"STATE_ID": 34, "unemployment": 4.09},
+    {"STATE_ID": 35, "unemployment": 7.83},
+    {"STATE_ID": 36, "unemployment": 8.01},
+    {"STATE_ID": 37, "unemployment": 9.34},
+    {"STATE_ID": 38, "unemployment": 11.23},
+    {"STATE_ID": 39, "unemployment": 7.08},
+    {"STATE_ID": 40, "unemployment": 11.22},
+    {"STATE_ID": 41, "unemployment": 6.2},
+    {"STATE_ID": 42, "unemployment": 9.11},
+    {"STATE_ID": 44, "unemployment": 10.42},
+    {"STATE_ID": 45, "unemployment": 8.89},
+    {"STATE_ID": 46, "unemployment": 11.03},
+    {"STATE_ID": 47, "unemployment": 7.35},
+    {"STATE_ID": 48, "unemployment": 8.92},
+    {"STATE_ID": 49, "unemployment": 7.65},
+    {"STATE_ID": 50, "unemployment": 8.01},
+    {"STATE_ID": 51, "unemployment": 7.62},
+    {"STATE_ID": 53, "unemployment": 7.77},
+    {"STATE_ID": 54, "unemployment": 8.49},
+    {"STATE_ID": 55, "unemployment": 9.42},
+    {"STATE_ID": 56, "unemployment": 7.59}
 ];
 
 map.on('load', function() {
@@ -72,30 +72,35 @@ map.on('load', function() {
     // https://www.census.gov/geo/maps-data/data/cbf/cbf_state.html
     map.addSource("states", {
         type: "vector",
-        url: "mapbox://mapbox.us_census_states_2015"
+        url: "mapbox://mapbox.10asuvo4",
     });
 
-    var expression = ["match", ["get", "STATEFP"]];
-
-    // Calculate color for each state based on the unemployment rate
-    data.forEach(function(row) {
-        var green = (row["unemployment"] / maxValue) * 255;
-        var color = "rgba(" + 0 + ", " + green + ", " + 0 + ", 1)";
-        expression.push(row["STATE_ID"], color);
-    });
-
-    // Last value is the default, used where there is no data
-    expression.push("rgba(0,0,0,0)");
-
-    // Add layer from the vector tile source with data-driven style
     map.addLayer({
         "id": "states-join",
         "type": "fill",
         "source": "states",
         "source-layer": "states",
         "paint": {
-            "fill-color": expression
+            "fill-color": ["rgba",
+                0,
+                [ "*", [ "/", ["to-number", ["feature-state", "unemployment"]], maxValue], 255],
+                0,
+                0.9]
         }
     }, 'waterway-label');
+
+    function setStates() {
+        data.forEach(function(row) {
+            map.setFeatureState({source: 'states', sourceLayer: 'states', id: row["STATE_ID"]}, row);
+        });
+    }
+
+    if (map.isSourceLoaded('states')) {
+        setStates();
+    } else map.on('sourcedata', function(e) {
+        if (e.sourceId === 'states' && e.isSourceLoaded) {
+            setStates();
+        }
+    });
 });
 </script>

--- a/docs/pages/example/data-join.html
+++ b/docs/pages/example/data-join.html
@@ -72,7 +72,7 @@ map.on('load', function() {
     // https://www.census.gov/geo/maps-data/data/cbf/cbf_state.html
     map.addSource("states", {
         type: "vector",
-        url: "mapbox://mapbox.10asuvo4",
+        url: "mapbox://mapbox.us_census_states_2015"
     });
 
     // Add layer from the vector tile source with data-driven style
@@ -94,19 +94,19 @@ map.on('load', function() {
 
     // Join the JSON unemployment data with the corresponding vector features where
     // feautre.id == STATE_ID
-    function setStates() {
-        data.forEach(function(row) {
-            map.setFeatureState({source: 'states', sourceLayer: 'states', id: row["STATE_ID"]}, row);
-        });
+    function setStates(e) {
+        if (e.sourceId === 'states' && e.isSourceLoaded) {
+            map.off('sourcedata', setStates);
+            data.forEach(function(row) {
+                map.setFeatureState({source: 'states', sourceLayer: 'states', id: row["STATE_ID"]}, row);
+            });
+        }
     }
 
     if (map.isSourceLoaded('states')) {
-        setStates();
-    } else map.on('sourcedata', function(e) {
-        if (e.sourceId === 'states' && e.isSourceLoaded) {
-            setStates();
-            map.off('sourcedata');
-        }
-    });
+        setStates({ sourceId: 'states', isSourceLoaded: true});
+    } else {
+        map.on('sourcedata', setStates);
+    }
 });
 </script>

--- a/docs/pages/example/data-join.html
+++ b/docs/pages/example/data-join.html
@@ -75,6 +75,9 @@ map.on('load', function() {
         url: "mapbox://mapbox.10asuvo4",
     });
 
+    // Add layer from the vector tile source with data-driven style
+    // Use a feature-state dependent expression to compute the the green color band based on
+    //  the unemployment percentage
     map.addLayer({
         "id": "states-join",
         "type": "fill",
@@ -89,6 +92,8 @@ map.on('load', function() {
         }
     }, 'waterway-label');
 
+    // Join the JSON unemployment data with the corresponding vector features where
+    // feautre.id == STATE_ID
     function setStates() {
         data.forEach(function(row) {
             map.setFeatureState({source: 'states', sourceLayer: 'states', id: row["STATE_ID"]}, row);
@@ -100,6 +105,7 @@ map.on('load', function() {
     } else map.on('sourcedata', function(e) {
         if (e.sourceId === 'states' && e.isSourceLoaded) {
             setStates();
+            map.off('sourcedata');
         }
     });
 });

--- a/docs/pages/example/hover-styles.html
+++ b/docs/pages/example/hover-styles.html
@@ -6,11 +6,12 @@ var map = new mapboxgl.Map({
     center: [-100.486052, 37.830348],
     zoom: 2
 });
+var hoveredStateId =  null;
 
 map.on('load', function () {
     map.addSource("states", {
         "type": "geojson",
-        "data": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_1_states_provinces.geojson"
+        "data": "/mapbox-gl-js/assets/us_states.geojson"
     });
 
     map.addLayer({
@@ -20,7 +21,11 @@ map.on('load', function () {
         "layout": {},
         "paint": {
             "fill-color": "#627BC1",
-            "fill-opacity": 0.5
+            "fill-opacity": ["case",
+                ["boolean", ["feature-state", "hover"], false],
+                1,
+                0.5
+            ]
         }
     });
 
@@ -35,27 +40,22 @@ map.on('load', function () {
         }
     });
 
-    map.addLayer({
-        "id": "state-fills-hover",
-        "type": "fill",
-        "source": "states",
-        "layout": {},
-        "paint": {
-            "fill-color": "#627BC1",
-            "fill-opacity": 1
-        },
-        "filter": ["==", "name", ""]
-    });
-
     // When the user moves their mouse over the states-fill layer, we'll update the filter in
     // the state-fills-hover layer to only show the matching state, thus making a hover effect.
     map.on("mousemove", "state-fills", function(e) {
-        map.setFilter("state-fills-hover", ["==", "name", e.features[0].properties.name]);
+        if (e.features.length > 0) {
+            if (hoveredStateId) {
+                map.setFeatureState({source: 'states', id: hoveredStateId}, { hover: false});
+            }
+            hoveredStateId = e.features[0].id;
+            map.setFeatureState({source: 'states', id: hoveredStateId}, { hover: true});
+        }
     });
 
     // Reset the state-fills-hover layer's filter when the mouse leaves the layer.
     map.on("mouseleave", "state-fills", function() {
-        map.setFilter("state-fills-hover", ["==", "name", ""]);
+        map.setFeatureState({source: 'states', id: hoveredStateId}, { hover: false});
+        hoveredStateId =  null;
     });
 });
 </script>

--- a/docs/pages/example/hover-styles.html
+++ b/docs/pages/example/hover-styles.html
@@ -14,6 +14,8 @@ map.on('load', function () {
         "data": "/mapbox-gl-js/assets/us_states.geojson"
     });
 
+    // The feature-state dependent fill-opacity expression will render the hover effect
+    //  when a feature's hover state is set to true.
     map.addLayer({
         "id": "state-fills",
         "type": "fill",
@@ -40,8 +42,8 @@ map.on('load', function () {
         }
     });
 
-    // When the user moves their mouse over the states-fill layer, we'll update the filter in
-    // the state-fills-hover layer to only show the matching state, thus making a hover effect.
+    // When the user moves their mouse over the states-fill layer, we'll update the 
+    // feature state for the feature under the mouse.
     map.on("mousemove", "state-fills", function(e) {
         if (e.features.length > 0) {
             if (hoveredStateId) {
@@ -54,7 +56,9 @@ map.on('load', function () {
 
     // Reset the state-fills-hover layer's filter when the mouse leaves the layer.
     map.on("mouseleave", "state-fills", function() {
-        map.setFeatureState({source: 'states', id: hoveredStateId}, { hover: false});
+        if (hoveredStateId) {
+            map.setFeatureState({source: 'states', id: hoveredStateId}, { hover: false});
+        }
         hoveredStateId =  null;
     });
 });


### PR DESCRIPTION
Updated the tilesets/geojson sources to include top level feature Ids. These are required for using `Map#setFeatureState` at this time.

Updated the Data Join example to use a single `feature-state` dependent expression and using `Map#setFeatureState` to join the JSON data with the vector tile source. The result is a fixed size expression, as opposed to an expression with individual match entries for each entry in the JSON data.

Update the Hover Styles example to use a single data-driven styling fill layer with `feature-state` dependent `fill-opacity`. Use `Map#setFeatureState` to set/unset the `hover` state on the feature under the mouse.

cc: @ryanbaumann