### PR TITLE
Fix merge collision between PR#6559 and PR#6263.

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -413,17 +413,19 @@ class Tile {
     }
 
     setFeatureState(states: LayerFeatureStates) {
-        if (!this.latestRawTileData || Object.keys(states).length === 0) return;
-
-        if (!this.vtLayers) {
-            this.vtLayers = new vt.VectorTile(new Protobuf(this.latestRawTileData)).layers;
+        if (!this.latestFeatureIndex ||
+            !this.latestFeatureIndex.rawTileData ||
+            Object.keys(states).length === 0) {
+            return;
         }
+
+        const vtLayers = this.latestFeatureIndex.loadVTLayers();
 
         for (const i in this.buckets) {
             const bucket = this.buckets[i];
             // Buckets are grouped by common source-layer
             const sourceLayerId = bucket.layers[0]['sourceLayer'] || '_geojsonTileLayer';
-            const sourceLayer = this.vtLayers[sourceLayerId];
+            const sourceLayer = vtLayers[sourceLayerId];
             const sourceLayerStates = states[sourceLayerId];
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 

--- a/test/integration/query-tests/regressions/mapbox-gl-js#6555/expected.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#6555/expected.json
@@ -8,6 +8,8 @@
       ]
     },
     "type": "Feature",
-    "properties": {}
+    "properties": {},
+    "source": "source",
+    "state": {}
   }
 ]


### PR DESCRIPTION
- Query tests now have extra data in them
- Tile#setFeatureState needs to switch to getting vtLayers from FeatureIndex.

For what it's worth, this is the first breaking merge collision I've seen in the last year and a half...

/cc @asheemmamoowala @jfirebaugh 