### PR TITLE
Update example to use mapbox-gl-directions v3.1.3

### DIFF
--- a/docs/pages/example/mapbox-gl-directions.html
+++ b/docs/pages/example/mapbox-gl-directions.html
@@ -1,5 +1,5 @@
-<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v3.1.2/mapbox-gl-directions.js'></script>
-<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v3.1.2/mapbox-gl-directions.css' type='text/css' />
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v3.1.3/mapbox-gl-directions.js'></script>
+<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v3.1.3/mapbox-gl-directions.css' type='text/css' />
 <div id='map'></div>
 
 <script>


### PR DESCRIPTION
v3.1.3 is available now: https://github.com/mapbox/mapbox-gl-directions/releases

Related: https://github.com/mapbox/mapbox-gl-directions/issues/175



 - [x] manually test documentation server locally
