### PR TITLE
Prevent CollatorExpression from evaluating as "constant"

### DIFF
--- a/src/style-spec/expression/definitions/collator.js
+++ b/src/style-spec/expression/definitions/collator.js
@@ -137,10 +137,10 @@ export class CollatorExpression implements Expression {
 
     serialize() {
         const options = {};
-        options['caseSensitive'] = this.caseSensitive;
-        options['diacriticSensitive'] = this.diacriticSensitive;
+        options['caseSensitive'] = this.caseSensitive.serialize();
+        options['diacriticSensitive'] = this.diacriticSensitive.serialize();
         if (this.locale) {
-            options['locale'] = this.locale;
+            options['locale'] = this.locale.serialize();
         }
         return ["collator", options];
     }

--- a/src/style-spec/expression/parsing_context.js
+++ b/src/style-spec/expression/parsing_context.js
@@ -10,6 +10,7 @@ import ArrayAssertion from './definitions/array';
 import Coercion from './definitions/coercion';
 import EvaluationContext from './evaluation_context';
 import CompoundExpression from './compound_expression';
+import { CollatorExpression } from './definitions/collator';
 import {isGlobalPropertyConstant, isFeatureConstant} from './is_constant';
 import Var from './definitions/var';
 
@@ -192,6 +193,11 @@ function isConstant(expression: Expression) {
     if (expression instanceof Var) {
         return isConstant(expression.boundExpression);
     } else if (expression instanceof CompoundExpression && expression.name === 'error') {
+        return false;
+    } else if (expression instanceof CollatorExpression) {
+        // Although the results of a Collator expression with fixed arguments
+        // generally shouldn't change between executions, we can't serialize them
+        // as constant expressions because results change based on environment.
         return false;
     }
 

--- a/test/integration/expression-tests/collator/accent-equals-de/test.json
+++ b/test/integration/expression-tests/collator/accent-equals-de/test.json
@@ -37,7 +37,17 @@
     "outputs": [true, false],
     "serialized": [
       "case",
-      false,
+      [
+        "==",
+        [
+          "resolved-locale",
+          [
+            "collator",
+            {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+          ]
+        ],
+        "de"
+      ],
       [
         "==",
         ["string", ["get", "lhs"]],

--- a/test/integration/expression-tests/resolved-locale/basic/test.json
+++ b/test/integration/expression-tests/resolved-locale/basic/test.json
@@ -19,6 +19,16 @@
       "type": "boolean"
     },
     "outputs": [true],
-    "serialized": true
+    "serialized": [
+      "==",
+      [
+        "resolved-locale",
+        [
+          "collator",
+          {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+        ]
+      ],
+      "en"
+    ]
   }
 }


### PR DESCRIPTION
Although the results shouldn't change between evaluations, they may change between environments, so we don't want constant folding to make serializations that are inconsistent on different machines.
`CollatorExpression#serialize` was not previously used by the test suite because of constant folding, and was broken -- it needed to explicitly serialize its children.

/cc @anandthakker @jfirebaugh