### PR TITLE
Add "tag studio and design for style spec changes" PR checklist item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,4 @@
  - [ ] document any changes to public APIs
  - [ ] post benchmark scores
  - [ ] manually test the debug page
+ - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes


### PR DESCRIPTION
It's important for downstream consumers of the style-spec to be aware of potential changes that may get generated in the `mapbox-gl-js` repo, and it's hard to watch everything that goes on here. Adding a "think about Studio and Design" checklist item to the PR template is the easiest/most-lightweight process change we could think of (specifically, @mollymerp thought of it) to avoid making stealth changes without fully considering the consequences.

/cc @anandthakker @nickidlugash @samanpwbb 