### PR TITLE
Cherry pick 'collator' fixes

### DIFF
--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -211,7 +211,7 @@ const types = {
     }],
     collator: [{
         type: 'collator',
-        parameters: [ '{ "caseSensitive": boolean, "diacriticSensitive": boolean, "locale": string }' ]
+        parameters: [ '{ "case-sensitive": boolean, "diacritic-sensitive": boolean, "locale": string }' ]
     }]
 };
 

--- a/src/style-spec/expression/definitions/collator.js
+++ b/src/style-spec/expression/definitions/collator.js
@@ -137,10 +137,10 @@ export class CollatorExpression implements Expression {
 
     serialize() {
         const options = {};
-        options['caseSensitive'] = this.caseSensitive;
-        options['diacriticSensitive'] = this.diacriticSensitive;
+        options['caseSensitive'] = this.caseSensitive.serialize();
+        options['diacriticSensitive'] = this.diacriticSensitive.serialize();
         if (this.locale) {
-            options['locale'] = this.locale;
+            options['locale'] = this.locale.serialize();
         }
         return ["collator", options];
     }

--- a/src/style-spec/expression/definitions/collator.js
+++ b/src/style-spec/expression/definitions/collator.js
@@ -65,16 +65,6 @@ export class Collator {
         return new Intl.Collator(this.locale ? this.locale : [])
             .resolvedOptions().locale;
     }
-
-    serialize() {
-        const options = {};
-        options['caseSensitive'] = this.sensitivity === 'variant' || this.sensitivity === 'case';
-        options['diacriticSensitive'] = this.sensitivity === 'variant' || this.sensitivity === 'accent';
-        if (this.locale) {
-            options['locale'] = this.locale;
-        }
-        return ["collator", options];
-    }
 }
 
 export class CollatorExpression implements Expression {

--- a/src/style-spec/expression/definitions/collator.js
+++ b/src/style-spec/expression/definitions/collator.js
@@ -89,11 +89,11 @@ export class CollatorExpression implements Expression {
             return context.error(`Collator options argument must be an object.`);
 
         const caseSensitive = context.parse(
-            options['caseSensitive'] === undefined ? false : options['caseSensitive'], 1, BooleanType);
+            options['case-sensitive'] === undefined ? false : options['case-sensitive'], 1, BooleanType);
         if (!caseSensitive) return null;
 
         const diacriticSensitive = context.parse(
-            options['diacriticSensitive'] === undefined ? false : options['diacriticSensitive'], 1, BooleanType);
+            options['diacritic-sensitive'] === undefined ? false : options['diacritic-sensitive'], 1, BooleanType);
         if (!diacriticSensitive) return null;
 
         let locale = null;
@@ -127,8 +127,8 @@ export class CollatorExpression implements Expression {
 
     serialize() {
         const options = {};
-        options['caseSensitive'] = this.caseSensitive.serialize();
-        options['diacriticSensitive'] = this.diacriticSensitive.serialize();
+        options['case-sensitive'] = this.caseSensitive.serialize();
+        options['diacritic-sensitive'] = this.diacriticSensitive.serialize();
         if (this.locale) {
             options['locale'] = this.locale.serialize();
         }

--- a/src/style-spec/expression/definitions/literal.js
+++ b/src/style-spec/expression/definitions/literal.js
@@ -1,7 +1,7 @@
 // @flow
 
 import assert from 'assert';
-import { isValue, typeOf, Color, Collator } from '../values';
+import { isValue, typeOf, Color } from '../values';
 
 import type { Type } from '../types';
 import type { Value }  from '../values';
@@ -60,10 +60,6 @@ class Literal implements Expression {
             // couldn't actually generate with a "literal" expression,
             // so we have to implement an equivalent serialization here
             return ["rgba"].concat(this.value.toArray());
-        } else if (this.value instanceof Collator) {
-            // Same as Color above: literal serialization delegated to
-            // Collator (not CollatorExpression)
-            return this.value.serialize();
         } else {
             assert(this.value === null ||
                 typeof this.value === 'string' ||

--- a/src/style-spec/expression/parsing_context.js
+++ b/src/style-spec/expression/parsing_context.js
@@ -10,6 +10,7 @@ import ArrayAssertion from './definitions/array';
 import Coercion from './definitions/coercion';
 import EvaluationContext from './evaluation_context';
 import CompoundExpression from './compound_expression';
+import { CollatorExpression } from './definitions/collator';
 import {isGlobalPropertyConstant, isFeatureConstant} from './is_constant';
 import Var from './definitions/var';
 
@@ -192,6 +193,11 @@ function isConstant(expression: Expression) {
     if (expression instanceof Var) {
         return isConstant(expression.boundExpression);
     } else if (expression instanceof CompoundExpression && expression.name === 'error') {
+        return false;
+    } else if (expression instanceof CollatorExpression) {
+        // Although the results of a Collator expression with fixed arguments
+        // generally shouldn't change between executions, we can't serialize them
+        // as constant expressions because results change based on environment.
         return false;
     }
 

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2233,7 +2233,7 @@
         }
       },
       "collator": {
-        "doc": "Returns a `collator` for use in locale-dependent comparison operations. The `caseSensitive` and `diacriticSensitive` options default to `false`. The `locale` argument specifies the IETF language tag of the locale to use. If none is provided, the default locale is used. If the requested locale is not available, the `collator` will use a system-defined fallback locale. Use `resolved-locale` to test the results of locale fallback behavior.",
+        "doc": "Returns a `collator` for use in locale-dependent comparison operations. The `case-sensitive` and `diacritic-sensitive` options default to `false`. The `locale` argument specifies the IETF language tag of the locale to use. If none is provided, the default locale is used. If the requested locale is not available, the `collator` will use a system-defined fallback locale. Use `resolved-locale` to test the results of locale fallback behavior.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {

--- a/test/integration/expression-tests/collator/accent-equals-de/test.json
+++ b/test/integration/expression-tests/collator/accent-equals-de/test.json
@@ -7,7 +7,7 @@
         "resolved-locale",
         [
           "collator",
-          {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+          {"case-sensitive": true, "diacritic-sensitive": false, "locale": "de"}
         ]
       ],
       "de"
@@ -18,7 +18,7 @@
       ["get", "rhs"],
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+        {"case-sensitive": true, "diacritic-sensitive": false, "locale": "de"}
       ]
     ],
     ["case", ["==", ["get", "rhs"], "ue"], true, false]
@@ -43,7 +43,7 @@
           "resolved-locale",
           [
             "collator",
-            {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+            {"case-sensitive": true, "diacritic-sensitive": false, "locale": "de"}
           ]
         ],
         "de"
@@ -54,7 +54,7 @@
         ["get", "rhs"],
         [
           "collator",
-          {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+          {"case-sensitive": true, "diacritic-sensitive": false, "locale": "de"}
         ]
       ],
       ["case", ["==", ["get", "rhs"], "ue"], true, false]

--- a/test/integration/expression-tests/collator/accent-equals-de/test.json
+++ b/test/integration/expression-tests/collator/accent-equals-de/test.json
@@ -37,7 +37,17 @@
     "outputs": [true, false],
     "serialized": [
       "case",
-      false,
+      [
+        "==",
+        [
+          "resolved-locale",
+          [
+            "collator",
+            {"caseSensitive": true, "diacriticSensitive": false, "locale": "de"}
+          ]
+        ],
+        "de"
+      ],
       [
         "==",
         ["string", ["get", "lhs"]],

--- a/test/integration/expression-tests/collator/accent-lt-en/test.json
+++ b/test/integration/expression-tests/collator/accent-lt-en/test.json
@@ -5,7 +5,7 @@
     ["get", "rhs"],
     [
       "collator",
-      {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
+      {"case-sensitive": true, "diacritic-sensitive": false, "locale": "en"}
     ]
   ],
   "inputs": [
@@ -27,7 +27,7 @@
       ["string", ["get", "rhs"]],
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
+        {"case-sensitive": true, "diacritic-sensitive": false, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/accent-not-equals-en/test.json
+++ b/test/integration/expression-tests/collator/accent-not-equals-en/test.json
@@ -7,7 +7,7 @@
       ["get", "rhs"],
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
+        {"case-sensitive": true, "diacritic-sensitive": false, "locale": "en"}
       ]
     ]
   ],
@@ -32,7 +32,7 @@
         ["get", "rhs"],
         [
           "collator",
-          {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
+          {"case-sensitive": true, "diacritic-sensitive": false, "locale": "en"}
         ]
       ]
     ]

--- a/test/integration/expression-tests/collator/base-default-locale/test.json
+++ b/test/integration/expression-tests/collator/base-default-locale/test.json
@@ -3,7 +3,7 @@
     "==",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    ["collator", {"caseSensitive": false, "diacriticSensitive": false}]
+    ["collator", {"case-sensitive": false, "diacritic-sensitive": false}]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "a", "rhs": "a"}}],
@@ -22,7 +22,7 @@
       "==",
       ["string", ["get", "lhs"]],
       ["get", "rhs"],
-      ["collator", {"caseSensitive": false, "diacriticSensitive": false}]
+      ["collator", {"case-sensitive": false, "diacritic-sensitive": false}]
     ]
   }
 }

--- a/test/integration/expression-tests/collator/base-equals-en/test.json
+++ b/test/integration/expression-tests/collator/base-equals-en/test.json
@@ -5,7 +5,7 @@
     ["get", "rhs"],
     [
       "collator",
-      {"caseSensitive": false, "diacriticSensitive": false, "locale": "en"}
+      {"case-sensitive": false, "diacritic-sensitive": false, "locale": "en"}
     ]
   ],
   "inputs": [
@@ -27,7 +27,7 @@
       ["get", "rhs"],
       [
         "collator",
-        {"caseSensitive": false, "diacriticSensitive": false, "locale": "en"}
+        {"case-sensitive": false, "diacritic-sensitive": false, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/base-gt-en/test.json
+++ b/test/integration/expression-tests/collator/base-gt-en/test.json
@@ -5,7 +5,7 @@
     ["get", "rhs"],
     [
       "collator",
-      {"caseSensitive": false, "diacriticSensitive": false, "locale": "en"}
+      {"case-sensitive": false, "diacritic-sensitive": false, "locale": "en"}
     ]
   ],
   "inputs": [
@@ -27,7 +27,7 @@
       ["string", ["get", "rhs"]],
       [
         "collator",
-        {"caseSensitive": false, "diacriticSensitive": false, "locale": "en"}
+        {"case-sensitive": false, "diacritic-sensitive": false, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/case-lteq-en/test.json
+++ b/test/integration/expression-tests/collator/case-lteq-en/test.json
@@ -5,7 +5,7 @@
     ["get", "rhs"],
     [
       "collator",
-      {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+      {"case-sensitive": false, "diacritic-sensitive": true, "locale": "en"}
     ]
   ],
   "inputs": [
@@ -28,7 +28,7 @@
       ["string", ["get", "rhs"]],
       [
         "collator",
-        {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+        {"case-sensitive": false, "diacritic-sensitive": true, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/case-not-equals-en/test.json
+++ b/test/integration/expression-tests/collator/case-not-equals-en/test.json
@@ -7,7 +7,7 @@
       ["get", "rhs"],
       [
         "collator",
-        {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+        {"case-sensitive": false, "diacritic-sensitive": true, "locale": "en"}
       ]
     ]
   ],
@@ -32,7 +32,7 @@
         ["get", "rhs"],
         [
           "collator",
-          {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+          {"case-sensitive": false, "diacritic-sensitive": true, "locale": "en"}
         ]
       ]
     ]

--- a/test/integration/expression-tests/collator/case-omitted-en/test.json
+++ b/test/integration/expression-tests/collator/case-omitted-en/test.json
@@ -3,7 +3,7 @@
     "==",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    ["collator", {"diacriticSensitive": true, "locale": "en"}]
+    ["collator", {"diacritic-sensitive": true, "locale": "en"}]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "ä", "rhs": "a"}}],
@@ -25,7 +25,7 @@
       ["get", "rhs"],
       [
         "collator",
-        {"caseSensitive": false, "diacriticSensitive": true, "locale": "en"}
+        {"case-sensitive": false, "diacritic-sensitive": true, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/comparison-number-error/test.json
+++ b/test/integration/expression-tests/collator/comparison-number-error/test.json
@@ -3,7 +3,7 @@
     "<",
     1,
     2,
-    ["collator", {"caseSensitive": false, "diacriticSensitive": false}]
+    ["collator", {"case-sensitive": false, "diacritic-sensitive": false}]
   ],
   "expected": {
     "compiled": {

--- a/test/integration/expression-tests/collator/diacritic-omitted-en/test.json
+++ b/test/integration/expression-tests/collator/diacritic-omitted-en/test.json
@@ -3,7 +3,7 @@
     "<",
     ["string", ["get", "lhs"]],
     ["get", "rhs"],
-    ["collator", {"caseSensitive": ["==", 1, 1], "locale": "en"}]
+    ["collator", {"case-sensitive": ["==", 1, 1], "locale": "en"}]
   ],
   "inputs": [
     [{}, {"properties": {"lhs": "a", "rhs": "ä"}}],
@@ -24,7 +24,7 @@
       ["string", ["get", "rhs"]],
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": false, "locale": "en"}
+        {"case-sensitive": true, "diacritic-sensitive": false, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/equals-non-string-error/test.json
+++ b/test/integration/expression-tests/collator/equals-non-string-error/test.json
@@ -3,7 +3,7 @@
     "==",
     1,
     2,
-    ["collator", {"caseSensitive": false, "diacriticSensitive": false}]
+    ["collator", {"case-sensitive": false, "diacritic-sensitive": false}]
   ],
   "expected": {
     "compiled": {

--- a/test/integration/expression-tests/collator/variant-equals-en/test.json
+++ b/test/integration/expression-tests/collator/variant-equals-en/test.json
@@ -5,7 +5,7 @@
     ["get", "rhs"],
     [
       "collator",
-      {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+      {"case-sensitive": true, "diacritic-sensitive": true, "locale": "en"}
     ]
   ],
   "inputs": [
@@ -27,7 +27,7 @@
       ["get", "rhs"],
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+        {"case-sensitive": true, "diacritic-sensitive": true, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/collator/variant-gteq-en/test.json
+++ b/test/integration/expression-tests/collator/variant-gteq-en/test.json
@@ -5,7 +5,7 @@
     ["get", "rhs"],
     [
       "collator",
-      {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+      {"case-sensitive": true, "diacritic-sensitive": true, "locale": "en"}
     ]
   ],
   "inputs": [
@@ -28,7 +28,7 @@
       ["string", ["get", "rhs"]],
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+        {"case-sensitive": true, "diacritic-sensitive": true, "locale": "en"}
       ]
     ]
   }

--- a/test/integration/expression-tests/resolved-locale/basic/test.json
+++ b/test/integration/expression-tests/resolved-locale/basic/test.json
@@ -5,7 +5,7 @@
       "resolved-locale",
       [
         "collator",
-        {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+        {"case-sensitive": true, "diacritic-sensitive": true, "locale": "en"}
       ]
     ],
     "en"
@@ -25,7 +25,7 @@
         "resolved-locale",
         [
           "collator",
-          {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+          {"case-sensitive": true, "diacritic-sensitive": true, "locale": "en"}
         ]
       ],
       "en"

--- a/test/integration/expression-tests/resolved-locale/basic/test.json
+++ b/test/integration/expression-tests/resolved-locale/basic/test.json
@@ -19,6 +19,16 @@
       "type": "boolean"
     },
     "outputs": [true],
-    "serialized": true
+    "serialized": [
+      "==",
+      [
+        "resolved-locale",
+        [
+          "collator",
+          {"caseSensitive": true, "diacriticSensitive": true, "locale": "en"}
+        ]
+      ],
+      "en"
+    ]
   }
 }


### PR DESCRIPTION
Fixes issue #6592 -- don't use camel case in expression argument names. This is important to get into release-0.45 because after it's publicly released any further change would be a breaking change to the style-spec.

Also pulls in changes to avoid constant-folding of collator objects. Because the same collator can give different results between environments, constant-folding of expressions that rely on a collator is not appropriate (at least during serialization).

## Launch Checklist

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes

/cc @anandthakker @jfirebaugh @mapbox/studio @mapbox/maps-design 