### PR TITLE
Restore some Evented backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ⚠️ Breaking changes
 
-* `Evented` is no longer publicly exported, and `Evented#fire` and `Evented#listens` are now private. If you are writing a class that needs event emitting functionality, consider using [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) or similar libraries instead.
+* `Evented#fire` and `Evented#listens` are now marked as private. Though `Evented` is still exported, and `fire` and `listens` are still functional, we encourage you to seek alternatives; a future version may remove their API accessibility or change its behavior. If you are writing a class that needs event emitting functionality, consider using [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) or similar libraries instead.
 * The `"to-string"` expression operator now converts `null` to an empty string rather than to `"null"`. [#6534](https://github.com/mapbox/mapbox-gl-js/pull/6534)
 
 ### ✨ Features and improvements

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import Style from './style/style';
 import LngLat from './geo/lng_lat';
 import LngLatBounds from './geo/lng_lat_bounds';
 import Point from '@mapbox/point-geometry';
+import {Evented} from './util/evented';
 import config from './util/config';
 import {setRTLTextPlugin} from './source/rtl_text_plugin';
 
@@ -37,6 +38,7 @@ const exported = {
     LngLat,
     LngLatBounds,
     Point,
+    Evented,
     config,
 
     /**

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -92,6 +92,13 @@ export class Evented {
     }
 
     fire(event: Event) {
+        // Compatibility with (type: string, properties: Object) signature from previous versions.
+        // See https://github.com/mapbox/mapbox-gl-js/issues/6522,
+        //     https://github.com/mapbox/mapbox-gl-draw/issues/766
+        if (typeof event === 'string') {
+            event = new Event(event, arguments[1] || {});
+        }
+
         const type = event.type;
 
         if (this.listens(type)) {

--- a/test/unit/util/evented.test.js
+++ b/test/unit/util/evented.test.js
@@ -109,6 +109,16 @@ test('Evented', (t) => {
         t.end();
     });
 
+    t.test('has backward compatibility for fire(string, object) API', (t) => {
+        const evented = new Evented();
+        const listener = t.spy();
+        evented.on('a', listener);
+        evented.fire('a', {foo: 'bar'});
+        t.ok(listener.calledOnce);
+        t.ok(listener.firstCall.args[0].foo, 'bar');
+        t.end();
+    });
+
     t.test('evented parents', (t) => {
 
         t.test('adds parents with "setEventedParent"', (t) => {


### PR DESCRIPTION
Cherry picks #6604 to `release-0.45`.