### PR TITLE
fix Marker crash by map.fire click event

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -279,6 +279,7 @@ export default class Marker {
     }
 
     _onMapClick(event: MapMouseEvent) {
+        if (!event.originalEvent) return;
         const targetElement = event.originalEvent.target;
         const element = this._element;
 


### PR DESCRIPTION
_onMapClick() add check for event.originalEvent to avoid crash by map.fire click event

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
