### PR TITLE
Fix `map#isMoving` return value when scrolling with Apple Magic Mouse (#6562)

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -32,6 +32,7 @@ class ScrollZoomHandler {
     _el: HTMLElement;
     _enabled: boolean;
     _active: boolean;
+    _scrolling: boolean;
     _aroundCenter: boolean;
     _around: Point;
     _aroundPoint: Point;
@@ -79,6 +80,10 @@ class ScrollZoomHandler {
 
     isActive() {
         return !!this._active;
+    }
+
+    isScrolling() {
+        return !!this._scrolling;
     }
 
     /**
@@ -156,7 +161,7 @@ class ScrollZoomHandler {
         if (this._type) {
             this._lastWheelEvent = e;
             this._delta -= value;
-            if (!this.isActive()) {
+            if (!this.isScrolling()) {
                 this._start(e);
             }
         }
@@ -167,7 +172,7 @@ class ScrollZoomHandler {
     _onTimeout(initialEvent: any) {
         this._type = 'wheel';
         this._delta -= this._lastValue;
-        if (!this.isActive()) {
+        if (!this.isScrolling()) {
             this._start(initialEvent);
         }
     }
@@ -181,6 +186,7 @@ class ScrollZoomHandler {
         }
 
         this._active = true;
+        this._scrolling = true;
         this._map.fire(new Event('movestart', {originalEvent: e}));
         this._map.fire(new Event('zoomstart', {originalEvent: e}));
         if (this._finishTimeout) {
@@ -199,7 +205,7 @@ class ScrollZoomHandler {
     _onScrollFrame() {
         this._frameId = null;
 
-        if (!this.isActive()) return;
+        if (!this.isScrolling()) return;
         const tr = this._map.transform;
 
         // if we've had scroll events since the last render frame, consume the
@@ -251,8 +257,9 @@ class ScrollZoomHandler {
         this._map.fire(new Event('zoom', {originalEvent: this._lastWheelEvent}));
 
         if (finished) {
-            this._active = false;
+            this._scrolling = false;
             this._finishTimeout = setTimeout(() => {
+                this._active = false;
                 this._map.fire(new Event('zoomend', {originalEvent: this._lastWheelEvent}));
                 this._map.fire(new Event('moveend', {originalEvent: this._lastWheelEvent}));
                 delete this._targetZoom;


### PR DESCRIPTION
- Fix `map#isMoving` return value when scrolling with Apple Magic Mouse
  - fixed it to match the return value of `map#isMoving` in 44.2 version.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
