### PR TITLE
Restore target property for mouse{enter,over,leave,out}

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -33,7 +33,7 @@ export class MapMouseEvent extends Event {
     /**
      * The `Map` object that fired the event.
      */
-    map: Map;
+    target: Map;
 
     /**
      * The DOM event which caused the map event.
@@ -82,6 +82,7 @@ export class MapMouseEvent extends Event {
         const lngLat = map.unproject(point);
         super(type, extend({ point, lngLat, originalEvent }, data));
         this._defaultPrevented = false;
+        this.target = map;
     }
 }
 

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -237,7 +237,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
 });
 
 ['mouseenter', 'mouseover'].forEach((event) => {
-    test(`Map#on ${event} does not fire if the specified layer does not exiist`, (t) => {
+    test(`Map#on ${event} does not fire if the specified layer does not exist`, (t) => {
         const map = createMap();
 
         t.stub(map, 'getLayer').returns(null);
@@ -265,6 +265,7 @@ test('Map#off distinguishes distinct listeners', (t) => {
         const spy = t.spy(function (e) {
             t.equal(this, map);
             t.equal(e.type, event);
+            t.equal(e.target, map);
             t.equal(e.features, features);
         });
 


### PR DESCRIPTION
Fixes #6623.