### PR TITLE
fix data-join example

### DIFF
--- a/docs/pages/example/data-join.html
+++ b/docs/pages/example/data-join.html
@@ -75,7 +75,7 @@ map.on('load', function() {
         url: "mapbox://mapbox.us_census_states_2015"
     });
 
-    var expression = ["match", ["get", "STATEFP"]];
+    var expression = ["match", ["get", "STATE_ID"]];
 
     // Calculate color for each state based on the unemployment rate
     data.forEach(function(row) {


### PR DESCRIPTION
## Launch Checklist
 - [x] briefly describe the changes in this PR

the [data-join example](https://www.mapbox.com/mapbox-gl-js/example/data-join/) is currently broken. I'm not sure if this is due to a change in the tileset, but either way this PR fixes it.

PS. This isn't an issue in master due to #6580, but this PR ensures the example is working until 0.46 is released.

 - n/a write tests for all new functionality
 - n/a document any changes to public APIs
 - n/a post benchmark scores
 - [x] manually test the debug page
 - n/a tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
