### PR TITLE
Fix Popup docs + MapTouchEvent/MapWheelEvent targets

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -101,7 +101,7 @@ export class MapTouchEvent extends Event {
     /**
      * The `Map` object that fired the event.
      */
-    map: Map;
+    target: Map;
 
     /**
      * The DOM event which caused the map event.
@@ -182,7 +182,7 @@ export class MapWheelEvent extends Event {
     /**
      * The `Map` object that fired the event.
      */
-    map: Map;
+    target: Map;
 
     /**
      * The DOM event which caused the map event.

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -38,7 +38,7 @@ export type PopupOptions = {
  *   map is clicked.
  * @param {string} [options.anchor] - A string indicating the part of the Popup that should
  *   be positioned closest to the coordinate set via {@link Popup#setLngLat}.
- *   Options are `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
+ *   Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
  *   `'top-right'`, `'bottom-left'`, and `'bottom-right'`. If unset the anchor will be
  *   dynamically set to ensure the popup falls within the map container with a preference
  *   for `'bottom'`.


### PR DESCRIPTION
* Popup `anchor` doc string was omitting the `center` option (while this is admittedly probably not all that useful for a popup, it is a valid anchor position)
* Fixes `MapTouchEvent`/`MapWheelEvent` definitions (~`event.map`~ -> `event.target`); fixes https://github.com/mapbox/mapbox-gl-js/issues/6673