### PR TITLE
Split new bounds calculation out of fitBounds into new method

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -360,10 +360,10 @@ class Camera extends Evented {
      * @param bounds Calculate the center for these bounds in the viewport and use
      *      the highest zoom level up to and including `Map#getMaxZoom()` that fits
      *      in the viewport.
+     * @param options
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
-     * @param {number} [options.maxZoom] The maximum zoom level to allow when the map view transitions to the specified bounds.
-     * @param eventData Additional properties to be added to event objects of events triggered by this method.
+     * @param {number} [options.maxZoom] The maximum zoom level to allow when the camera would transition to the specified bounds.
      * @returns {CameraOptions | void} If map is able to fit to provided bounds, returns CameraOptions with
      *      at least `center`, `zoom`, `bearing`, `offset`, `padding`, and `maxZoom`, as well as any other
      *      `options` provided in arguments. If map is unable to fit, method will warn and return undefined.

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -364,7 +364,7 @@ class Camera extends Evented {
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the camera would transition to the specified bounds.
-     * @returns {CameraOptions | void} If map is able to fit to provided bounds, returns CameraOptions with
+     * @returns {CameraOptions | void} If map is able to fit to provided bounds, returns `CameraOptions` with
      *      at least `center`, `zoom`, `bearing`, `offset`, `padding`, and `maxZoom`, as well as any other
      *      `options` provided in arguments. If map is unable to fit, method will warn and return undefined.
      * @example

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -465,12 +465,12 @@ class Camera extends Evented {
      * @see [Fit a map to a bounding box](https://www.mapbox.com/mapbox-gl-js/example/fitbounds/)
      */
     fitBounds(bounds: LngLatBoundsLike, options?: AnimationOptions & CameraOptions, eventData?: Object) {
-        const calculatedBounds = this.cameraForBounds(bounds, options);
+        const calculatedOptions = this.cameraForBounds(bounds, options);
 
         // cameraForBounds warns + returns undefined if unable to fit:
-        if (!calculatedBounds) return this;
+        if (!calculatedOptions) return this;
 
-        options = extend(calculatedBounds, options);
+        options = extend(calculatedOptions, options);
 
         return options.linear ?
             this.easeTo(options, eventData) :

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -369,11 +369,11 @@ class Camera extends Evented {
      *      `options` provided in arguments. If map is unable to fit, method will warn and return undefined.
      * @example
      * var bbox = [[-79, 43], [-73, 45]];
-     * var newCameraTransform = map.getFitBoundsTransform(bbox, {
+     * var newCameraTransform = map.cameraForBounds(bbox, {
      *   padding: {top: 10, bottom:25, left: 15, right: 5}
      * });
      */
-    getFitBoundsTransform(bounds: LngLatBoundsLike, options?: CameraOptions): void | CameraOptions & AnimationOptions {
+    cameraForBounds(bounds: LngLatBoundsLike, options?: CameraOptions): void | CameraOptions & AnimationOptions {
         options = extend({
             padding: {
                 top: 0,
@@ -465,9 +465,9 @@ class Camera extends Evented {
      * @see [Fit a map to a bounding box](https://www.mapbox.com/mapbox-gl-js/example/fitbounds/)
      */
     fitBounds(bounds: LngLatBoundsLike, options?: AnimationOptions & CameraOptions, eventData?: Object) {
-        const calculatedBounds = this.getFitBoundsTransform(bounds, options);
+        const calculatedBounds = this.cameraForBounds(bounds, options);
 
-        // getFitBoundsTransform warns + returns undefined if unable to fit:
+        // cameraForBounds warns + returns undefined if unable to fit:
         if (!calculatedBounds) return this;
 
         options = extend(calculatedBounds, options);

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1664,6 +1664,39 @@ test('camera', (t) => {
         t.end();
     });
 
+    t.test('#getFitBoundsTransform', (t) => {
+        t.test('no padding passed', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            const transform = camera.getFitBoundsTransform(bb);
+            t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for new bounds');
+            t.equal(fixedNum(transform.zoom, 3), 2.469);
+            t.end();
+        });
+
+        t.test('padding number', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            const transform = camera.getFitBoundsTransform(bb, { padding: 15 });
+            t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for bounds with padding option as number applied');
+            t.equal(fixedNum(transform.zoom, 3), 2.382);
+            t.end();
+        });
+
+        t.test('padding object', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            const transform = camera.getFitBoundsTransform(bb, { padding: {top: 10, right: 75, bottom: 50, left: 25}, duration: 0 });
+            t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for bounds with padding option as object applied');
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.test('#fitBounds', (t) => {
         t.test('no padding passed', (t) => {
             const camera = createCamera();

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1664,12 +1664,12 @@ test('camera', (t) => {
         t.end();
     });
 
-    t.test('#getFitBoundsTransform', (t) => {
+    t.test('#cameraForBounds', (t) => {
         t.test('no padding passed', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
 
-            const transform = camera.getFitBoundsTransform(bb);
+            const transform = camera.cameraForBounds(bb);
             t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for new bounds');
             t.equal(fixedNum(transform.zoom, 3), 2.469);
             t.end();
@@ -1679,7 +1679,7 @@ test('camera', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
 
-            const transform = camera.getFitBoundsTransform(bb, { padding: 15 });
+            const transform = camera.cameraForBounds(bb, { padding: 15 });
             t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for bounds with padding option as number applied');
             t.equal(fixedNum(transform.zoom, 3), 2.382);
             t.end();
@@ -1689,7 +1689,7 @@ test('camera', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
 
-            const transform = camera.getFitBoundsTransform(bb, { padding: {top: 10, right: 75, bottom: 50, left: 25}, duration: 0 });
+            const transform = camera.cameraForBounds(bb, { padding: {top: 10, right: 75, bottom: 50, left: 25}, duration: 0 });
             t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for bounds with padding option as object applied');
             t.end();
         });


### PR DESCRIPTION
This breaks transform calculations out of `fitBounds` into a separate method, `getFitBoundsTransform`, so that new camera transform calculations can be known without actually moving the map.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
