### PR TITLE
Align match behavior with case/==

### DIFF
--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -141,37 +141,24 @@ function convertZoomAndPropertyFunction(parameters, propertySpec, stops, default
 function convertPropertyFunction(parameters, propertySpec, stops, defaultExpression) {
     const type = getFunctionType(parameters, propertySpec);
 
-    const inputType = typeof stops[0][0];
-    assert(
-        inputType === 'string' ||
-        inputType === 'number' ||
-        inputType === 'boolean'
-    );
-
-    let input = [inputType, ['get', parameters.property]];
-
     let expression;
     let isStep = false;
-    if (type === 'categorical' && inputType === 'boolean') {
+    if (type === 'categorical' && typeof stops[0][0] === 'boolean') {
         assert(parameters.stops.length > 0 && parameters.stops.length <= 2);
-        if (parameters.stops[0][0] === false) {
-            input = ['!', input];
+        expression = ['case'];
+        for (const stop of stops) {
+            expression.push(['==', ['get', parameters.property], stop[0]], stop[1]);
         }
-        expression = [ 'case', input, parameters.stops[0][1] ];
-        if (parameters.stops.length > 1) {
-            expression.push(parameters.stops[1][1]);
-        } else {
-            expression.push(defaultExpression);
-        }
+        expression.push(defaultExpression);
         return expression;
     } else if (type === 'categorical') {
-        expression = ['match', input];
+        expression = ['match', ['get', parameters.property]];
     } else if (type === 'interval') {
-        expression = ['step', input];
+        expression = ['step', ['number', ['get', parameters.property]]];
         isStep = true;
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
-        expression = ['interpolate', ['exponential', base], input];
+        expression = ['interpolate', ['exponential', base], ['number', ['get', parameters.property]]];
     } else {
         throw new Error(`Unknown property function type ${type}`);
     }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2321,7 +2321,7 @@
         }
       },
       "match": {
-        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The `input` can be any string or number expression (e.g. `[\"get\", \"building_type\"]`). Each label can either be a single literal value or an array of values.",
+        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must either be a single literal value or an array of literal values (e.g. `\"a\"` or `[\"c\", \"b\"]`), and those values must be all strings or all numbers. (The values `\"1\"` and `1` cannot both be labels in the same match expression.) If the input type does not match the type of the labels, the result will be the fallback value.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {

--- a/test/integration/expression-tests/match/basic/test.json
+++ b/test/integration/expression-tests/match/basic/test.json
@@ -4,7 +4,8 @@
     [{}, {"properties": {"x": "a"}}],
     [{}, {"properties": {"x": "b"}}],
     [{}, {"properties": {"x": "c"}}],
-    [{}, {"properties": {"x": 0}}]
+    [{}, {"properties": {"x": 0}}],
+    [{}, {"properties": {}}]
   ],
   "expected": {
     "compiled": {
@@ -17,13 +18,12 @@
       "Apple",
       "Banana",
       "Kumquat",
-      {
-        "error": "Expected value to be of type string, but found number instead."
-      }
+      "Kumquat",
+      "Kumquat"
     ],
     "serialized": [
       "match",
-      ["string", ["get", "x"]],
+      ["get", "x"],
       "a",
       "Apple",
       "b",

--- a/test/integration/expression-tests/match/label-number/test.json
+++ b/test/integration/expression-tests/match/label-number/test.json
@@ -20,15 +20,11 @@
       "match",
       "otherwise",
       "otherwise",
-      {
-        "error": "Expected value to be of type number, but found string instead."
-      },
-      {
-        "error": "Expected value to be of type number, but found boolean instead."
-      },
-      {"error": "Expected value to be of type number, but found null instead."},
-      {"error": "Expected value to be of type number, but found null instead."}
+      "otherwise",
+      "otherwise",
+      "otherwise",
+      "otherwise"
     ],
-    "serialized": ["match", ["number", ["get", "x"]], 0, "match", "otherwise"]
+    "serialized": ["match", ["get", "x"], 0, "match", "otherwise"]
   }
 }

--- a/test/unit/style-spec/convert_function.test.js
+++ b/test/unit/style-spec/convert_function.test.js
@@ -2,6 +2,51 @@ import { test } from 'mapbox-gl-js-test';
 import convertFunction from '../../../src/style-spec/function/convert';
 
 test('convertFunction', (t) => {
+    t.test('boolean categorical', (t) => {
+        const fn = {
+            type: 'categorical',
+            property: 'p',
+            stops: [
+                [true, 'true'],
+                [false, 'false']
+            ],
+            default: 'default'
+        };
+
+        t.deepEqual(convertFunction(fn, {}), [
+            'case',
+            ['==', ['get', 'p'], true],
+            'true',
+            ['==', ['get', 'p'], false],
+            'false',
+            'default'
+        ]);
+
+        t.end();
+    });
+
+    t.test('numeric categorical', (t) => {
+        const fn = {
+            type: 'categorical',
+            property: 'p',
+            stops: [
+                [0, '0'],
+                [1, '1']
+            ],
+            default: 'default'
+        };
+
+        t.deepEqual(convertFunction(fn, {}), [
+            'match',
+            ['get', 'p'],
+            0, '0',
+            1, '1',
+            'default'
+        ]);
+
+        t.end();
+    });
+
     t.test('feature-constant text-field with token replacement', (t) => {
         const functionValue = {
             stops: [


### PR DESCRIPTION
Makes `["match", ["get", k], label, match, otherwise]` equivalent to `["case", ["==", ["get", k], label], match, otherwise]`. This changes the behavior of match expressions where the runtime type of the input does not match the type of the labels: previously such expressions produced a runtime type error and then fell back to the property default value; now they produce the fallback value from the match expression.

Fixes #6680.

cc @mapbox/studio @mapbox/maps-design @mapbox/ios @mapbox/android 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
