### PR TITLE
add instructions on running individual tests

### DIFF
--- a/build/run-tap
+++ b/build/run-tap
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
+if [ "$#" == 5 ]; then
+  arg="${@:0:4} ${BASH_ARGV[1]}/${BASH_ARGV[0]}"
+else
+  arg="${@}"
+fi
 
-node_modules/.bin/tap --node-arg -r --node-arg @mapbox/flow-remove-types/register --node-arg -r --node-arg @std/esm ${@}
+node_modules/.bin/tap --node-arg -r --node-arg @mapbox/flow-remove-types/register --node-arg -r --node-arg @std/esm $arg

--- a/test/README.md
+++ b/test/README.md
@@ -10,6 +10,11 @@ There are two test suites associated with Mapbox GL JS
  - `yarn test` runs quick unit tests
  - `yarn run test-suite` runs slower integration tests
 
+ To run individual tests:
+
+ - Unit tests: `yarn test-unit path/to/file.test.js` where the path begins within the `/test/unit/` directory
+ - Render tests: `yarn test-render render-test-name`
+
 ## Writing Unit Tests
 
  - **You must not share variables between test cases.** All test fixtures must be wrapped in `create` functions. This ensures each test is run in an isolated environment.


### PR DESCRIPTION
I have no idea what I'm doing when it comes to bash but this seems to work... 

Adds the ability to run individual tests or tests by folder to unit tests, and documents the existing behavior for render tests

cc @ryanhamley 