### PR TITLE
Feature/draggable markers

### DIFF
--- a/debug/markers.html
+++ b/debug/markers.html
@@ -42,7 +42,8 @@ function addRandomMarker() {
     var b = Math.round(Math.random() * 255);
 
     var marker = new mapboxgl.Marker({
-        color: `rgb(${r}, ${g}, ${b})`
+        color: `rgb(${r}, ${g}, ${b})`,
+        draggable: true
     })
         .setLngLat([lng, lat])
         .setPopup(popup)

--- a/docs/pages/example/drag-a-marker.html
+++ b/docs/pages/example/drag-a-marker.html
@@ -1,0 +1,43 @@
+
+<style>
+.coordinates {
+    background: rgba(0,0,0,0.5);
+    color: #fff;
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    padding:5px 10px;
+    margin: 0;
+    font-size: 11px;
+    line-height: 18px;
+    border-radius: 3px;
+    display: none;
+}
+</style>
+
+<div id='map'></div>
+<pre id='coordinates' class='coordinates'></pre>
+
+<script>
+var coordinates = document.getElementById('coordinates');
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v9',
+    center: [0, 0],
+    zoom: 2
+});
+
+var marker = new mapboxgl.Marker({
+    draggable: true
+})
+    .setLngLat([0, 0])
+    .addTo(map);
+
+function onDragEnd() {
+    var lngLat = marker.getLngLat();
+    coordinates.style.display = 'block';
+    coordinates.innerHTML = 'Longitude: ' + lngLat.lng + '<br />Latitude: ' + lngLat.lat;
+}
+
+marker.on('dragend', onDragEnd);
+</script>

--- a/docs/pages/example/drag-a-marker.js
+++ b/docs/pages/example/drag-a-marker.js
@@ -1,0 +1,12 @@
+/*---
+title: Create a draggable marker
+description: >-
+  Drag the marker to a new location on a map and populates its coordinates in a
+  display.
+tags:
+  - user-interaction
+pathname: /mapbox-gl-js/example/drag-a-marker/
+---*/
+import Example from '../../components/example';
+import html from './drag-a-marker.html';
+export default Example(html);

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -6,8 +6,11 @@ type Listener = (Object) => any;
 type Listeners = { [string]: Array<Listener> };
 
 function _addEventListener(type: string, listener: Listener, listenerList: Listeners) {
-    listenerList[type] = listenerList[type] || [];
-    listenerList[type].push(listener);
+    const listenerExists = listenerList[type] && listenerList[type].indexOf(listener) !== -1;
+    if (!listenerExists) {
+        listenerList[type] = listenerList[type] || [];
+        listenerList[type].push(listener);
+    }
 }
 
 function _removeEventListener(type: string, listener: Listener, listenerList: Listeners) {

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -5,6 +5,7 @@ import Marker from '../../../src/ui/marker';
 import Popup from '../../../src/ui/popup';
 import LngLat from '../../../src/geo/lng_lat';
 import Point from '@mapbox/point-geometry';
+import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
 function createMap() {
     const container = window.document.createElement('div');
@@ -26,7 +27,7 @@ test('Marker uses a default marker element with custom color', (t) => {
     t.end();
 });
 
-test('Marker uses a default marker with custom offest', (t) => {
+test('Marker uses a default marker with custom offset', (t) => {
     const marker = new Marker({ offset: [1, 2] });
     t.ok(marker.getElement());
     t.ok(marker.getOffset().equals(new Point(1, 2)));
@@ -231,5 +232,222 @@ test('Popup anchors around default Marker', (t) => {
     marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight]));
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-bottom-right'), 'popup anchors top left of marker');
 
+    t.end();
+});
+
+test('Marker drag functionality can be added with drag option', (t) => {
+    const map = createMap();
+    const marker = new Marker({draggable: true})
+        .setLngLat([0, 0])
+        .addTo(map);
+
+    t.equal(marker.isDraggable(), true);
+
+    map.remove();
+    t.end();
+});
+
+test('Marker#setDraggable adds drag functionality', (t) => {
+    const map = createMap();
+    const marker = new Marker()
+        .setLngLat([0, 0])
+        .setDraggable(true)
+        .addTo(map);
+
+    t.equal(marker.isDraggable(), true);
+
+    map.remove();
+    t.end();
+});
+
+test('Marker#setDraggable turns off drag functionality', (t) => {
+    const map = createMap();
+    const marker = new Marker({draggable: true})
+        .setLngLat([0, 0])
+        .addTo(map);
+
+    t.equal(marker.isDraggable(), true);
+
+    marker.setDraggable(false);
+
+    t.equal(marker.isDraggable(), false);
+
+    map.remove();
+    t.end();
+});
+
+test('Marker with draggable:true fires dragstart, drag, and dragend events at appropriate times in response to a mouse-triggered drag', (t) => {
+    const map = createMap();
+    const marker = new Marker({draggable: true})
+        .setLngLat([0, 0])
+        .addTo(map);
+    const el = marker.getElement();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    marker.on('dragstart', dragstart);
+    marker.on('drag',      drag);
+    marker.on('dragend',   dragend);
+
+    simulate.mousedown(el);
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.mousemove(el);
+    t.equal(dragstart.callCount, 1);
+    t.equal(drag.callCount, 1);
+    t.equal(dragend.callCount, 0);
+
+    simulate.mouseup(el);
+    t.equal(dragstart.callCount, 1);
+    t.equal(drag.callCount, 1);
+    t.equal(dragend.callCount, 1);
+
+    map.remove();
+    t.end();
+});
+
+test('Marker with draggable:false does not fire dragstart, drag, and dragend events in response to a mouse-triggered drag', (t) => {
+    const map = createMap();
+    const marker = new Marker({})
+        .setLngLat([0, 0])
+        .addTo(map);
+    const el = marker.getElement();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    marker.on('dragstart', dragstart);
+    marker.on('drag',      drag);
+    marker.on('dragend',   dragend);
+
+    simulate.mousedown(el);
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.mousemove(el);
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.mouseup(el);
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    map.remove();
+    t.end();
+});
+
+test('Marker with draggable:true fires dragstart, drag, and dragend events at appropriate times in response to a touch-triggered drag', (t) => {
+    const map = createMap();
+    const marker = new Marker({draggable: true})
+        .setLngLat([0, 0])
+        .addTo(map);
+    const el = marker.getElement();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    marker.on('dragstart', dragstart);
+    marker.on('drag',      drag);
+    marker.on('dragend',   dragend);
+
+    simulate.touchstart(el);
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.touchmove(el);
+    t.equal(dragstart.callCount, 1);
+    t.equal(drag.callCount, 1);
+    t.equal(dragend.callCount, 0);
+
+    simulate.touchend(el);
+    t.equal(dragstart.callCount, 1);
+    t.equal(drag.callCount, 1);
+    t.equal(dragend.callCount, 1);
+
+    map.remove();
+    t.end();
+});
+
+test('Marker with draggable:false does not fire dragstart, drag, and dragend events in response to a touch-triggered drag', (t) => {
+    const map = createMap();
+    const marker = new Marker({})
+        .setLngLat([0, 0])
+        .addTo(map);
+    const el = marker.getElement();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    marker.on('dragstart', dragstart);
+    marker.on('drag',      drag);
+    marker.on('dragend',   dragend);
+
+    simulate.touchstart(el);
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.touchmove(el);
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.touchend(el);
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    map.remove();
+    t.end();
+});
+
+test('Marker with draggable:true moves to new position in response to a mouse-triggered drag', (t) => {
+    const map = createMap();
+    const marker = new Marker({draggable: true})
+        .setLngLat([0, 0])
+        .addTo(map);
+    const el = marker.getElement();
+    const startPos = map.project(marker.getLngLat());
+    simulate.mousedown(el);
+    simulate.mousemove(el, {clientX: 10, clientY: 10});
+    simulate.mouseup(el);
+
+    const endPos = map.project(marker.getLngLat());
+    t.equal(Math.floor(endPos.x), startPos.x + 10);
+    t.equal(Math.floor(endPos.y), startPos.y + 10);
+
+    map.remove();
+    t.end();
+});
+
+test('Marker with draggable:false does not move to new position in response to a mouse-triggered drag', (t) => {
+    const map = createMap();
+    const marker = new Marker({})
+        .setLngLat([0, 0])
+        .addTo(map);
+    const el = marker.getElement();
+    const startPos = map.project(marker.getLngLat());
+
+    simulate.mousedown(el);
+    simulate.mousemove(el);
+    simulate.mouseup(el);
+
+    const endPos = map.project(marker.getLngLat());
+
+    t.equal(startPos.x, endPos.x);
+    t.equal(startPos.y, endPos.y);
+
+    map.remove();
     t.end();
 });

--- a/test/unit/util/evented.test.js
+++ b/test/unit/util/evented.test.js
@@ -119,6 +119,19 @@ test('Evented', (t) => {
         t.end();
     });
 
+    t.test('on is idempotent', (t) => {
+        const evented = new Evented();
+        const listenerA = t.spy();
+        const listenerB = t.spy();
+        evented.on('a', listenerA);
+        evented.on('a', listenerB);
+        evented.on('a', listenerA);
+        evented.fire(new Event('a'));
+        t.ok(listenerA.calledOnce);
+        t.ok(listenerA.calledBefore(listenerB));
+        t.end();
+    });
+
     t.test('evented parents', (t) => {
 
         t.test('adds parents with "setEventedParent"', (t) => {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

- Adds drag functionality to markers either via a `draggable` option or a `setDraggable` method
- Adds `dragstart`, `drag` and `dragend` events on Marker
- Updates JSDocs
- Adds new drag-a-marker example (leaves drag-a-point example as is)
- Adds tests for dragging a marker
- Makes `evented._addEventListener` idempotent to avoid adding the same listener multiple times

 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page

Closes #6102 
Closes #3087 
Closes #4597