### PR TITLE
Clarify transition type + global transition

### DIFF
--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -860,7 +860,11 @@ export default class extends React.Component {
                             <a id='transition' className='anchor'></a>
                             <h2><a href='#transition' title='link to transition'>Transition</a></h2>
                             <p>
-                                A style's <code>transition</code> property provides global transition defaults for that style.
+                                A <code>transition</code> property controls timing for the interpolation between a transitionable style
+                                property's previous value and new value. A style's <a href='#root-transition' title='link to root-transition'>
+                                root <code>transition</code></a> property provides global transition defaults for that style. Any transitionable
+                                style property may also have its own <code>-transition</code> property that defines specific transition timing
+                                for that specific layer property, overriding the global <code>transition</code> values.
                             </p>
                             <div className='space-bottom1 pad2x clearfix'>
                                 {highlightJSON(`"transition": ${JSON.stringify(ref.$root.transition.example, null, 2)}`)}

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -75,7 +75,7 @@
     },
     "transition": {
       "type": "transition",
-      "doc": "A global transition definition to use as a default across properties.",
+      "doc": "A global transition definition to use as a default across properties, to be used for timing transitions between one value and the next when no property-specific transition is set. Collision-based symbol fading is controlled independently of the style's `transition` property.",
       "example": {
         "duration": 300,
         "delay": 0


### PR DESCRIPTION
This adds a bit more description around what a `transition` is, how the global `transition` works, and notes the possibility of property-specific transitions.

`#root-transition`:
![image](https://user-images.githubusercontent.com/3170312/40205190-f4a019ce-59df-11e8-91a0-2632256769e0.png)

`#transition`:
![image](https://user-images.githubusercontent.com/3170312/40205198-02a4fcba-59e0-11e8-878f-5d3c6ccb4e1d.png)

Closes https://github.com/mapbox/mapbox-gl-js/issues/6689.
Ref https://github.com/mapbox/mapbox-gl-js/issues/4081, https://github.com/mapbox/mapbox-gl-js/issues/6519.
