### PR TITLE
Add API to list all images/sprites currently available in the map

### DIFF
--- a/src/render/image_manager.js
+++ b/src/render/image_manager.js
@@ -94,6 +94,10 @@ class ImageManager {
         }
     }
 
+    listImages() {
+        return Object.keys(this.images);
+    }
+
     getImages(ids: Array<string>, callback: Callback<{[string]: StyleImage}>) {
         // If the sprite has been loaded, or if all the icon dependencies are already present
         // (i.e. if they've been addeded via runtime styling), then notify the requestor immediately.

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -446,6 +446,12 @@ class Style extends Evented {
         this.fire(new Event('data', {dataType: 'style'}));
     }
 
+    listImages() {
+        this._checkLoaded();
+
+        return this.imageManager.listImages();
+    }
+
     addSource(id: string, source: SourceSpecification, options?: {validate?: boolean}) {
         this._checkLoaded();
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -794,7 +794,7 @@ class Map extends Camera {
      * The `properties` value of each returned feature object contains the properties of its source feature. For GeoJSON sources, only
      * string and numeric property values are supported (i.e. `null`, `Array`, and `Object` values are not supported).
      *
-     * Each feature includes top-level `layer`, `source`, and `sourceLayer` properties. The `layer` property is an object 
+     * Each feature includes top-level `layer`, `source`, and `sourceLayer` properties. The `layer` property is an object
      * representing the style layer to  which the feature belongs. Layout and paint properties in this object contain values
      * which are fully evaluated for the given zoom level and feature.
      *
@@ -1187,6 +1187,16 @@ class Map extends Camera {
     }
 
     /**
+    * Returns an Array of strings containing the names of all sprites/images currently available in the map
+    *
+    * @returns {Array<string>} An Array of strings containing the names of all sprites/images currently available in the map
+    *
+    */
+    listImages() {
+        return this.style.listImages();
+    }
+
+    /**
      * Adds a [Mapbox style layer](https://www.mapbox.com/mapbox-gl-style-spec/#layers)
      * to the map's style.
      *
@@ -1374,12 +1384,12 @@ class Map extends Camera {
 
     /**
      * Sets the state of a feature. The `state` object is merged in with the existing state of the feature.
-     * 
-     * @param {Object} [feature] Feature identifier. Feature objects returned from 
+     *
+     * @param {Object} [feature] Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {string} [feature.source] The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
-     *  required.* 
+     *  required.*
      * @param {string} [feature.id] Unique id of the feature.
      * @param {Object} state A set of key-value pairs. The values should be valid JSON types.
      */
@@ -1390,14 +1400,14 @@ class Map extends Camera {
 
     /**
      * Gets the state of a feature.
-     * 
-     * @param {Object} [feature] Feature identifier. Feature objects returned from 
+     *
+     * @param {Object} [feature] Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {string} [feature.source] The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
-     *  required.* 
+     *  required.*
      * @param {string} [feature.id] Unique id of the feature.
-     * 
+     *
      * @returns {Object} The state of the feature.
      */
     getFeatureState(feature: { source: string; sourceLayer?: string; id: string; }): any {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -842,6 +842,29 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('#listImages', (t) => {
+        const map = createMap();
+
+        map.on('load', () => {
+            t.equals(map.listImages().length, 0);
+
+            map.addImage('img', {width: 1, height: 1, data: new Uint8Array(4)});
+
+            const images = map.listImages();
+            t.equals(images.length, 1);
+            t.equals(images[0], 'img');
+            t.end();
+        });
+    });
+
+    t.test('#listImages throws an error if called before "load"', (t) => {
+        const map = createMap();
+        t.throws(() => {
+            map.listImages();
+        }, Error);
+        t.end();
+    });
+
     t.test('#queryRenderedFeatures', (t) => {
 
         t.test('if no arguments provided', (t) => {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
- Adds method to `Map` to allow user to list all images/sprites available to the map (via the ImageManager)
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page

Closes #6381
