### PR TITLE
don't fire click event if default is prevented on mousedown for a drag event

### DIFF
--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -25,6 +25,7 @@ export default function bindHandlers(map: Map, options: {interactive: boolean}) 
     const el = map.getCanvasContainer();
     let contextMenuEvent = null;
     let mouseDown = false;
+    let startPos = null;
 
     for (const name in handlers) {
         (map: any)[name] = new handlers[name](map, options);
@@ -56,6 +57,7 @@ export default function bindHandlers(map: Map, options: {interactive: boolean}) 
 
     function onMouseDown(e: MouseEvent) {
         mouseDown = true;
+        startPos = DOM.mousePos(el, e);
 
         const mapEvent = new MapMouseEvent('mousedown', map, e);
         map.fire(mapEvent);
@@ -149,7 +151,10 @@ export default function bindHandlers(map: Map, options: {interactive: boolean}) 
     }
 
     function onClick(e: MouseEvent) {
-        map.fire(new MapMouseEvent('click', map, e));
+        const pos = DOM.mousePos(el, e);
+        if (pos.equals(startPos)) {
+            map.fire(new MapMouseEvent('click', map, e));
+        }
     }
 
     function onDblClick(e: MouseEvent) {

--- a/test/node_modules/mapbox-gl-js-test/simulate_interaction.js
+++ b/test/node_modules/mapbox-gl-js-test/simulate_interaction.js
@@ -18,6 +18,15 @@ exports.click = function (target, options) {
     target.dispatchEvent(new MouseEvent('click', options));
 };
 
+exports.drag = function (target, mousedownOptions, mouseUpOptions) {
+    mousedownOptions = Object.assign({bubbles: true}, mousedownOptions);
+    mouseUpOptions = Object.assign({bubbles: true}, mouseUpOptions);
+    const MouseEvent = window(target).MouseEvent;
+    target.dispatchEvent(new MouseEvent('mousedown', mousedownOptions));
+    target.dispatchEvent(new MouseEvent('mouseup', mouseUpOptions));
+    target.dispatchEvent(new MouseEvent('click', mouseUpOptions));
+};
+
 exports.dblclick = function (target, options) {
     options = Object.assign({bubbles: true}, options);
     const MouseEvent = window(target).MouseEvent;

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -544,3 +544,19 @@ test(`Map#on mousedown can have default behavior prevented and still fire subseq
     map.remove();
     t.end();
 });
+
+test(`Map#on mousedown doesn't fire subsequent click event if mousepos changes`, (t) => {
+    const map = createMap();
+
+    map.on('mousedown', e => e.preventDefault());
+
+    const click = t.spy();
+    map.on('click', click);
+    const canvas = map.getCanvas();
+
+    simulate.drag(canvas, {}, {clientX: 100, clientY: 100});
+    t.ok(click.notCalled);
+
+    map.remove();
+    t.end();
+});


### PR DESCRIPTION
fix #6642

in #6218 we stopped checking if the mouse position had changed before firing a click event. the `DragPanHandler` suppresses its associated `click` event on `mouseup`

https://github.com/mapbox/mapbox-gl-js/blob/a5a8dfe5b90737dbb295eaca7f41c667ae4060a8/src/ui/handler/drag_pan.js#L191

but if `preventDefault()` is called on `mousedown` the click was no longer being suppressed after a drag which caused the change in behavior in #6642 

I added a `drag` simulation that allows you to specify different options for mousedown/mouseup but I'm open to other ideas on how to test this. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [x] manually test the debug page
