### PR TITLE
Document global "fadeDuration" option for collision animations.

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -194,6 +194,7 @@ const defaultOptions = {
  * @param {RequestTransformFunction} [options.transformRequest=null] A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
  *   Expected to return an object with a `url` property and optionally `headers` and `credentials` properties.
  * @param {boolean} [options.collectResourceTiming=false] If `true`, Resource Timing API information will be collected for requests made by GeoJSON and Vector Tile web workers (this information is normally inaccessible from the main Javascript thread). Information will be returned in a `resourceTiming` property of relevant `data` events.
+ * @param {number} [options.fadeDuration=300] Controls the duration of the fade-in/fade-out animation for label collisions, in milliseconds. This setting affects all symbol layers. This setting does not affect the duration of runtime styling transitions or raster tile cross-fading.
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',


### PR DESCRIPTION
As discussed in https://github.com/mapbox/mapbox-gl-js/issues/6694:

We added the global "fadeDuration" option primarily for (1) automated testing and (2) collision debugging, but it's publicly accessible, users are starting to find it, and it could plausibly be useful for them to modify. Although we don't really want to promote using it, we also don't want the hidden option to be a source of confusion for users trying to control other animation durations.

Tagging @mapbox/studio and @mapbox/maps-design just in case -- this isn't a style spec change, but it's a map option that controls the kind of behavior that someone might _expect_ to be in the style spec.

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] manually test the docs page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes

@lbud @ansis @jfirebaugh 