### PR TITLE
DragRotateHandler should register mouseDown when used with non-map elements 

### DIFF
--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -69,7 +69,7 @@ class NavigationControl {
             this._map.on('rotate', this._rotateCompassArrow);
             this._rotateCompassArrow();
             this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass});
-            DOM.addEventListener(this._compass, 'mousedown', this._handler.onMouseDown.bind(this._handler));
+            DOM.addEventListener(this._compass, 'mousedown', this._handler.onMouseDown);
             this._handler.enable();
         }
         return this._container;
@@ -79,7 +79,7 @@ class NavigationControl {
         DOM.remove(this._container);
         if (this.options.showCompass) {
             this._map.off('rotate', this._rotateCompassArrow);
-            DOM.removeEventListener(this._compass, 'mousedown', this._handler.onMouseDown.bind(this._handler));
+            DOM.removeEventListener(this._compass, 'mousedown', this._handler.onMouseDown);
             this._handler.disable();
             delete this._handler;
         }

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -69,6 +69,7 @@ class NavigationControl {
             this._map.on('rotate', this._rotateCompassArrow);
             this._rotateCompassArrow();
             this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass});
+            DOM.addEventListener(this._compass, 'mousedown', this._handler.onMouseDown.bind(this._handler));
             this._handler.enable();
         }
         return this._container;
@@ -78,6 +79,7 @@ class NavigationControl {
         DOM.remove(this._container);
         if (this.options.showCompass) {
             this._map.off('rotate', this._rotateCompassArrow);
+            DOM.removeEventListener(this._compass, 'mousedown', this._handler.onMouseDown.bind(this._handler));
             this._handler.disable();
             delete this._handler;
         }

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -59,6 +59,7 @@ class DragRotateHandler {
         this._pitchWithRotate = options.pitchWithRotate !== false;
 
         bindAll([
+            'onMouseDown',
             '_onMouseMove',
             '_onMouseUp',
             '_onBlur',


### PR DESCRIPTION
Fixes #6650 

This regressed as a result of  #6218. When moving the mouse down event registration from the drag handlers to `Map`, the `NavigationControl` button lost the mouse down handling inherited from `DragRotateHandler`

cc @anandthakker @jfirebaugh 