### PR TITLE
Avoid TypedArray#slice (not available in IE11)

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1147,7 +1147,7 @@ class Map extends Camera {
                 'or object with `width`, `height`, and `data` properties with the same format as `ImageData`')));
         } else {
             const {width, height, data} = image;
-            this.style.addImage(id, { data: new RGBAImage({width, height}, data.slice(0)), pixelRatio, sdf });
+            this.style.addImage(id, { data: new RGBAImage({width, height}, new Uint8Array(data)), pixelRatio, sdf });
         }
     }
 


### PR DESCRIPTION
Fixes #6718.

See #5858 for a previous instance of this issue. In the past I've looked into whether there are any static analysis tools that could catch browser compatibility issues (e.g. https://github.com/amilajack/eslint-plugin-compat), but not found anything sophisticated enough to be able to catch issues like this.