### PR TITLE
Map constructor should fail if WebGL init fails.

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -339,6 +339,9 @@ class Map extends Camera {
 
         this._setupContainer();
         this._setupPainter();
+        if (this.painter === undefined) {
+            throw new Error(`Failed to initialize WebGL.`);
+        }
 
         this.on('move', this._update.bind(this, false));
         this.on('zoom', this._update.bind(this, true));


### PR DESCRIPTION
## Description
Currently, it's possible for the constructor to complete successfully but the painter not be defined.

This is because setupPainter doesn't throw an exception, but instead emits an ErrorEvent. The problem is that in the constructor() call, no listeners have been set up yet, so the user wouldn't be able to listen to this error and respond appropriately.

Later on, resize events cause the map to error, because painter.resize doesn't exist.

I'm open to suggestions, like:
- it's possible this is desired behavior
- right now, this would throw an error, _and_ _setupPainter would emit an error event. we may want to dedupe this.
- this could actually be a bug in mapboxgl.isSupported(). We are checking this before instantiating the map, however, the _setupPainter call is still failing. Perhaps there are additional checks mapboxgl.isSupported should be making.

Keep me posted,
Thanks!

## Error logs
Error seen on Sentry:
`Cannot read property 'resize' of undefined`

This is occurring in the constructor.