### PR TITLE
Upgrade ESM

### DIFF
--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -30,7 +30,8 @@ export const plugins = () => [
     }),
     commonjs({
         namedExports: {
-            '@mapbox/gl-matrix': ['vec3', 'vec4', 'mat2', 'mat3', 'mat4']
+            '@mapbox/gl-matrix': ['vec3', 'vec4', 'mat2', 'mat3', 'mat4'],
+            '@mapbox/whoots-js': ['getTileBBox']
         }
     }),
     production ? uglify() : false

--- a/build/run-node
+++ b/build/run-node
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-node -r @mapbox/flow-remove-types/register -r @std/esm ${@}
+node -r @mapbox/flow-remove-types/register -r esm ${@}

--- a/build/run-tap
+++ b/build/run-tap
@@ -5,4 +5,4 @@ else
   arg="${@}"
 fi
 
-node_modules/.bin/tap --node-arg -r --node-arg @mapbox/flow-remove-types/register --node-arg -r --node-arg @std/esm $arg
+node_modules/.bin/tap --node-arg -r --node-arg @mapbox/flow-remove-types/register --node-arg -r --node-arg esm $arg --node-arg

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@mapbox/flow-remove-types": "^1.3.0-await.upstream.1",
     "@mapbox/mapbox-gl-rtl-text": "^0.1.2",
     "@mapbox/mapbox-gl-test-suite": "file:test/integration",
-    "@std/esm": "^0.21.7",
     "babel-eslint": "^7.0.0",
     "benchmark": "~2.1.0",
     "browserify": "^16.1.0",
@@ -60,6 +59,7 @@
     "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-react": "^7.3.0",
+    "esm": "^3.0.39",
     "execcommand-copy": "^1.1.0",
     "flow-bin": "^0.69.0",
     "flow-coverage-report": "^0.3.0",
@@ -110,11 +110,7 @@
     "./src/util/window.js": "./src/util/browser/window.js",
     "./src/util/web_worker.js": "./src/util/browser/web_worker.js"
   },
-  "@std/esm": {
-    "cjs": true,
-    "esm": "js",
-    "sourceCache": true
-  },
+  "esm": true,
   "scripts": {
     "build-dev": "rollup -c --environment BUILD:dev",
     "watch-dev": "rollup -c --environment BUILD:dev --watch",

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -1,6 +1,6 @@
 // @flow
 
-import WhooTS from '@mapbox/whoots-js';
+import {getTileBBox} from '@mapbox/whoots-js';
 
 import assert from 'assert';
 import { register } from '../util/web_worker_transfer';
@@ -28,7 +28,7 @@ export class CanonicalTileID {
 
     // given a list of urls, choose a url template and return a tile URL
     url(urls: Array<string>, scheme: ?string) {
-        const bbox = WhooTS.getTileBBox(this.x, this.y, this.z);
+        const bbox = getTileBBox(this.x, this.y, this.z);
         const quadkey = getQuadkey(this.z, this.x, this.y);
 
         return urls[(this.x + this.y) % urls.length]

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -2,7 +2,7 @@
 
 require('./stub_loader');
 require('@mapbox/flow-remove-types/register');
-require = require("@std/esm")(module, true);
+require = require("esm")(module, true);
 
 const querySuite = require('./integration').query;
 const suiteImplementation = require('./suite_implementation');

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -2,7 +2,7 @@
 
 require('./stub_loader');
 require('@mapbox/flow-remove-types/register');
-require = require("@std/esm")(module, true);
+require = require("esm")(module, true);
 
 const suite = require('./integration').render;
 const suiteImplementation = require('./suite_implementation');

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,10 +239,6 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@std/esm@^0.21.7":
-  version "0.21.7"
-  resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.21.7.tgz#492d7931aed03e91a133deac4d9062fbfce5fd6b"
-
 "@types/acorn@^4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.3.tgz#d1f3e738dde52536f9aad3d3380d14e448820afd"
@@ -3790,6 +3786,10 @@ eslint@4.1.1:
     strip-json-comments "~2.0.1"
     table "^4.0.1"
     text-table "~0.2.0"
+
+esm@^3.0.39:
+  version "3.0.39"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.39.tgz#076e6a2f846bb579e0b82c494091a0687b494b48"
 
 espree@^3.4.3:
   version "3.5.3"


### PR DESCRIPTION
`@std/esm` is deprecated, so let's upgrade to `esm`.