### PR TITLE
Ditch gl-matrix fork in favor of the original package

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,6 @@
   ],
   "settings": {
     "import/ignore": [
-        "@mapbox/gl-matrix",
         "@mapbox/shelf-pack",
         "@mapbox/whoots-js"
     ]

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -28,32 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -------------------------------------------------------------------------------
 
-Contains glmatrix.js
-
-Copyright (c) 2013, Brandon Jones, Colin MacKenzie IV. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-  * Redistributions of source code must retain the above copyright notice, this
-    list of conditions and the following disclaimer.
-  * Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
--------------------------------------------------------------------------------
-
 Contains Hershey Simplex Font: http://paulbourke.net/dataformats/hershey/
 
 -------------------------------------------------------------------------------

--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -30,7 +30,6 @@ export const plugins = () => [
     }),
     commonjs({
         namedExports: {
-            '@mapbox/gl-matrix': ['vec3', 'vec4', 'mat2', 'mat3', 'mat4'],
             '@mapbox/whoots-js': ['getTileBBox']
         }
     }),

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "node": ">=6.4.0"
   },
   "dependencies": {
-    "@mapbox/gl-matrix": "^0.0.1",
     "@mapbox/jsonlint-lines-primitives": "^2.0.1",
     "@mapbox/mapbox-gl-supported": "^1.3.1",
     "@mapbox/point-geometry": "^0.1.0",
@@ -27,6 +26,7 @@
     "earcut": "^2.1.3",
     "geojson-rewind": "^0.3.0",
     "geojson-vt": "^3.1.2",
+    "gl-matrix": "^2.6.1",
     "gray-matter": "^3.0.8",
     "grid-index": "^1.0.0",
     "minimist": "0.0.8",

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -9,11 +9,7 @@ import {number as interpolate} from '../style-spec/util/interpolate';
 import tileCover from '../util/tile_cover';
 import { CanonicalTileID, UnwrappedTileID } from '../source/tile_id';
 import EXTENT from '../data/extent';
-import glmatrix from '@mapbox/gl-matrix';
-
-const vec4 = glmatrix.vec4,
-    mat4 = glmatrix.mat4,
-    mat2 = glmatrix.mat2;
+import { vec4, mat4, mat2 } from 'gl-matrix';
 
 /**
  * A single transform, generally used for a single tile to be

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -2,7 +2,7 @@
 
 import browser from '../util/browser';
 
-import { mat4 } from '@mapbox/gl-matrix';
+import { mat4 } from 'gl-matrix';
 import EXTENT from '../data/extent';
 import VertexArrayObject from './vertex_array_object';
 import { PosArray } from '../data/array_types';

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -1,6 +1,6 @@
 // @flow
 
-import glMatrix from '@mapbox/gl-matrix';
+import { mat3, mat4, vec3 } from 'gl-matrix';
 
 import {
     isPatternMissing,
@@ -10,9 +10,6 @@ import {
 import Texture from './texture';
 import Color from '../style-spec/util/color';
 import DepthMode from '../gl/depth_mode';
-const mat3 = glMatrix.mat3;
-const mat4 = glMatrix.mat4;
-const vec3 = glMatrix.vec3;
 import StencilMode from '../gl/stencil_mode';
 
 import type Painter from './painter';

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { mat4 } from '@mapbox/gl-matrix';
+import { mat4 } from 'gl-matrix';
 
 import Texture from './texture';
 import pixelsToTileUnits from '../source/pixels_to_tile_units';

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -3,7 +3,7 @@ import Coordinate from '../geo/coordinate';
 
 import Texture from './texture';
 import EXTENT from '../data/extent';
-import { mat4 } from '@mapbox/gl-matrix';
+import { mat4 } from 'gl-matrix';
 import StencilMode from '../gl/stencil_mode';
 import DepthMode from '../gl/depth_mode';
 

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -5,7 +5,7 @@ import drawCollisionDebug from './draw_collision_debug';
 import pixelsToTileUnits from '../source/pixels_to_tile_units';
 import * as symbolProjection from '../symbol/projection';
 import * as symbolSize from '../symbol/symbol_size';
-import { mat4 } from '@mapbox/gl-matrix';
+import { mat4 } from 'gl-matrix';
 const identityMat4 = mat4.identity(new Float32Array(16));
 import properties from '../style/style_layer/symbol_style_layer_properties';
 const symbolLayoutProperties = properties.layout;

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -2,7 +2,7 @@
 
 import browser from '../util/browser';
 
-import { mat4 } from '@mapbox/gl-matrix';
+import { mat4 } from 'gl-matrix';
 import SourceCache from '../source/source_cache';
 import EXTENT from '../data/extent';
 import pixelsToTileUnits from '../source/pixels_to_tile_units';

--- a/src/style/style_layer/circle_style_layer.js
+++ b/src/style/style_layer/circle_style_layer.js
@@ -7,7 +7,7 @@ import { multiPolygonIntersectsBufferedPoint } from '../../util/intersection_tes
 import { getMaximumPaintValue, translateDistance, translate } from '../query_utils';
 import properties from './circle_style_layer_properties';
 import { Transitionable, Transitioning, PossiblyEvaluated } from '../properties';
-import {vec4} from '@mapbox/gl-matrix';
+import { vec4 } from 'gl-matrix';
 import Point from '@mapbox/point-geometry';
 
 import type { FeatureState } from '../../style-spec/expression';

--- a/src/symbol/collision_index.js
+++ b/src/symbol/collision_index.js
@@ -4,9 +4,7 @@ import Point from '@mapbox/point-geometry';
 
 import * as intersectionTests from '../util/intersection_tests';
 import Grid from './grid_index';
-import glmatrix from '@mapbox/gl-matrix';
-
-const mat4 = glmatrix.mat4;
+import { mat4 } from 'gl-matrix';
 
 import * as projection from '../symbol/projection';
 

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -14,7 +14,7 @@ import type Transform from '../geo/transform';
 import type StyleLayer from '../style/style_layer';
 import type Tile from '../source/tile';
 import type SymbolBucket from '../data/bucket/symbol_bucket';
-import type mat4 from '@mapbox/gl-matrix';
+import type {mat4} from 'gl-matrix';
 import type {CollisionBoxArray, CollisionVertexArray} from '../data/array_types';
 import type FeatureIndex from '../data/feature_index';
 import type {OverscaledTileID} from '../source/tile_id';

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -2,7 +2,7 @@
 
 import Point from '@mapbox/point-geometry';
 
-import { mat4, vec4 } from '@mapbox/gl-matrix';
+import { mat4, vec4 } from 'gl-matrix';
 import * as symbolSize from './symbol_size';
 import { addDynamicAttributes } from '../data/bucket/symbol_bucket';
 import properties from '../style/style_layer/symbol_style_layer_properties';

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,10 +97,6 @@
   dependencies:
     wgs84 "0.0.0"
 
-"@mapbox/gl-matrix@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz#e5126aab4d64c36b81c7a97d0ae0dddde5773d2b"
-
 "@mapbox/jsonlint-lines-primitives@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.1.tgz#bc4c1593e2ec2371e2771c518068d6eab8eeae58"
@@ -4459,6 +4455,10 @@ github-slugger@1.2.0, github-slugger@^1.0.0, github-slugger@^1.1.1:
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.0.tgz#8ada3286fd046d8951c3c952a8d7854cfd90fd9a"
   dependencies:
     emoji-regex ">=6.0.0 <=6.1.1"
+
+gl-matrix@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-2.6.1.tgz#1bc7f7b396f4ae80abdb4db9a98cd07d170b9004"
 
 gl@^4.0.1:
   version "4.0.4"


### PR DESCRIPTION
Ditches our fork (`@mapbox/gl-matrix`) in favor of the original package, `gl-matrix`, which got fully modernized. Combined with treeshaking by Rollup, it makes the fork obsolete. Made sure the build size doesn't increase.