### PR TITLE
Fix send / remove timing bug in Dispatcher

### DIFF
--- a/src/util/dispatcher.js
+++ b/src/util/dispatcher.js
@@ -50,6 +50,10 @@ class Dispatcher {
      * @returns The ID of the worker to which the message was sent.
      */
     send(type: string, data: mixed, callback?: ?Function, targetID?: number): number {
+        if (this.actors.length === 0) {
+            // an async send call is getting executed but remove has been called
+            return -1;
+        }
         if (typeof targetID !== 'number' || isNaN(targetID)) {
             // Use round robin to send requests to web workers.
             targetID = this.currentActor = (this.currentActor + 1) % this.actors.length;


### PR DESCRIPTION
## Description
I _believe_ there is a JavaScript worker timing bug in dispatcher.js. On our Flexport Sentry, we are seeing infrequent bugs like this:
`Unable to get property 'send' of undefined or null reference`, with a fuller stack trace:

```
TypeError: Unable to get property 'send' of undefined or null reference
  at e(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:517:481)
  at t.prototype.loadTile(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:231:2184)
  at t.prototype._loadTile(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:223:2168)
  at h(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:223:8194)
  at n(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:223:7400)
  at o(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:223:6566)
  at r(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:223:795)
  at this(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:521:839)
  at e(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:521:1045)
  at o(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:231:1210)
  at t(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:207:438)
  at n.onload(/home/app/flexport/node_modules/mapbox-gl/dist/mapbox-gl.js:503:1103)
```

The TypeError is occurring on this line [here](https://github.com/mapbox/mapbox-gl-js/blob/master/src/util/dispatcher.js#L58).

It appears that the way this error is getting caused is:
* In componentWillUnmount, the implementor calls "map.remove()"
* A web worker running a task calls "Dispatcher.send", or a previously running broadcast call called `asyncAll(Dispatcher.send(payload...`.
* Dispatcher.send tries to access the 0th index of an empty array, because remove() has already been completed.
TypeError.

Open to suggestions on how to improve this PR. One thing I'm curious about is:
**Is it possible for Dispatcher.remove() to be called, but an async process then tries to call Dispatcher.send()?**

It's totally possible that this is somehow user error, and that the user is somehow dispatching an action after having called map.remove(), but looking through the code (especially the Dispatcher broadcast function earlier in the file), it seems like like the answer is "yes".

Another question: Does anyone depend on the actor ID being returned? Will -1 have any negative downstream impact?