### PR TITLE
Ignore spurious move events in drag handlers

### DIFF
--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -19,7 +19,8 @@ class BoxZoomHandler {
     _container: HTMLElement;
     _enabled: boolean;
     _active: boolean;
-    _startPos: any;
+    _startPos: Point;
+    _lastPos: Point;
     _box: HTMLElement;
 
     /**
@@ -86,13 +87,19 @@ class BoxZoomHandler {
         window.document.addEventListener('mouseup', this._onMouseUp, false);
 
         DOM.disableDrag();
-        this._startPos = DOM.mousePos(this._el, e);
+        this._startPos = this._lastPos = DOM.mousePos(this._el, e);
         this._active = true;
     }
 
     _onMouseMove(e: MouseEvent) {
-        const p0 = this._startPos,
-            p1 = DOM.mousePos(this._el, e);
+        const pos = DOM.mousePos(this._el, e);
+
+        if (this._lastPos.equals(pos)) {
+            return;
+        }
+
+        const p0 = this._startPos;
+        this._lastPos = pos;
 
         if (!this._box) {
             this._box = DOM.create('div', 'mapboxgl-boxzoom', this._container);
@@ -100,10 +107,10 @@ class BoxZoomHandler {
             this._fireEvent('boxzoomstart', e);
         }
 
-        const minX = Math.min(p0.x, p1.x),
-            maxX = Math.max(p0.x, p1.x),
-            minY = Math.min(p0.y, p1.y),
-            maxY = Math.max(p0.y, p1.y);
+        const minX = Math.min(p0.x, pos.x),
+            maxX = Math.max(p0.x, pos.x),
+            minY = Math.min(p0.y, pos.y),
+            maxY = Math.max(p0.y, pos.y);
 
         DOM.setTransform(this._box, `translate(${minX}px,${minY}px)`);
 
@@ -155,6 +162,9 @@ class BoxZoomHandler {
         }
 
         DOM.enableDrag();
+
+        delete this._startPos;
+        delete this._lastPos;
     }
 
     _fireEvent(type: string, e: *) {

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -105,3 +105,31 @@ test('BoxZoomHandler does not begin a box zoom if preventDefault is called on th
     map.remove();
     t.end();
 });
+
+test('BoxZoomHandler does not begin a box zoom on spurious mousemove events', (t) => {
+    const map = createMap();
+
+    const boxzoomstart = t.spy();
+    const boxzoomend   = t.spy();
+
+    map.on('boxzoomstart', boxzoomstart);
+    map.on('boxzoomend',   boxzoomend);
+
+    simulate.mousedown(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
+    map._renderTaskQueue.run();
+    t.equal(boxzoomstart.callCount, 0);
+    t.equal(boxzoomend.callCount, 0);
+
+    simulate.mousemove(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
+    map._renderTaskQueue.run();
+    t.equal(boxzoomstart.callCount, 0);
+    t.equal(boxzoomend.callCount, 0);
+
+    simulate.mouseup(map.getCanvas(), {shiftKey: true, clientX: 0, clientY: 0});
+    map._renderTaskQueue.run();
+    t.equal(boxzoomstart.callCount, 0);
+    t.equal(boxzoomend.callCount, 0);
+
+    map.remove();
+    t.end();
+});

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -25,7 +25,7 @@ test('DragPanHandler fires dragstart, drag, and dragend events at appropriate ti
     t.equal(drag.callCount, 0);
     t.equal(dragend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 1);
     t.equal(drag.callCount, 1);
@@ -58,7 +58,7 @@ test('DragPanHandler captures mousemove events during a mouse-triggered drag (re
     t.equal(drag.callCount, 0);
     t.equal(dragend.callCount, 0);
 
-    simulate.mousemove(window.document.body);
+    simulate.mousemove(window.document.body, {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 1);
     t.equal(drag.callCount, 1);
@@ -91,7 +91,7 @@ test('DragPanHandler fires dragstart, drag, and dragend events at appropriate ti
     t.equal(drag.callCount, 0);
     t.equal(dragend.callCount, 0);
 
-    simulate.touchmove(map.getCanvas());
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 10, clientY: 10}]});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 1);
     t.equal(drag.callCount, 1);
@@ -124,7 +124,7 @@ test('DragPanHandler captures touchmove events during a mouse-triggered drag (re
     t.equal(drag.callCount, 0);
     t.equal(dragend.callCount, 0);
 
-    simulate.touchmove(window.document.body);
+    simulate.touchmove(window.document.body, {touches: [{clientX: 10, clientY: 10}]});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 1);
     t.equal(drag.callCount, 1);
@@ -149,7 +149,7 @@ test('DragPanHandler prevents mousemove events from firing during a drag (#1555)
     simulate.mousedown(map.getCanvasContainer());
     map._renderTaskQueue.run();
 
-    simulate.mousemove(map.getCanvasContainer());
+    simulate.mousemove(map.getCanvasContainer(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvasContainer());
@@ -170,7 +170,7 @@ test('DragPanHandler ends a mouse-triggered drag if the window blurs', (t) => {
     simulate.mousedown(map.getCanvas());
     map._renderTaskQueue.run();
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     simulate.blur(window);
@@ -189,7 +189,7 @@ test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
     simulate.touchstart(map.getCanvas());
     map._renderTaskQueue.run();
 
-    simulate.touchmove(map.getCanvas());
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 10, clientY: 10}]});
     map._renderTaskQueue.run();
 
     simulate.blur(window);
@@ -204,14 +204,14 @@ test('DragPanHandler requests a new render frame after each mousemove event', (t
     const requestFrame = t.spy(map, '_requestRenderFrame');
 
     simulate.mousedown(map.getCanvas());
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     t.ok(requestFrame.callCount > 0);
 
     map._renderTaskQueue.run();
 
     // https://github.com/mapbox/mapbox-gl-js/issues/6063
     requestFrame.reset();
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 20, clientY: 20});
     t.equal(requestFrame.callCount, 1);
 
     map.remove();
@@ -236,7 +236,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
     t.equal(drag.callCount, 0);
     t.equal(dragend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 1);
     t.equal(drag.callCount, 1);
@@ -249,7 +249,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
     t.equal(drag.callCount, 1);
     t.equal(dragend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 20, clientY: 20});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 1);
     t.equal(drag.callCount, 2);
@@ -284,7 +284,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
         t.equal(drag.callCount, 0);
         t.equal(dragend.callCount, 0);
 
-        simulate.mousemove(map.getCanvas(), {[`${modifier}Key`]: true});
+        simulate.mousemove(map.getCanvas(), {[`${modifier}Key`]: true, clientX: 10, clientY: 10});
         map._renderTaskQueue.run();
         t.equal(dragstart.callCount, 0);
         t.equal(drag.callCount, 0);
@@ -324,7 +324,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
         t.equal(drag.callCount, 0);
         t.equal(dragend.callCount, 0);
 
-        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
         map._renderTaskQueue.run();
         t.equal(dragstart.callCount, 0);
         t.equal(drag.callCount, 0);
@@ -353,7 +353,7 @@ test('DragPanHandler does not begin a drag on right button mousedown', (t) => {
     t.equal(drag.callCount, 0);
     t.equal(dragend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 0);
     t.equal(drag.callCount, 0);
@@ -387,7 +387,7 @@ test('DragPanHandler does not end a drag on right button mouseup', (t) => {
     t.equal(drag.callCount, 0);
     t.equal(dragend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 1);
     t.equal(drag.callCount, 1);
@@ -405,7 +405,7 @@ test('DragPanHandler does not end a drag on right button mouseup', (t) => {
     t.equal(drag.callCount, 1);
     t.equal(dragend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 20, clientY: 20});
     map._renderTaskQueue.run();
     t.equal(dragstart.callCount, 1);
     t.equal(drag.callCount, 2);
@@ -437,7 +437,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the mo
     simulate.mousedown(map.getCanvas());
     map._renderTaskQueue.run();
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas());
@@ -467,7 +467,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the to
     simulate.touchstart(map.getCanvas());
     map._renderTaskQueue.run();
 
-    simulate.touchmove(map.getCanvas());
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 10, clientY: 10}]});
     map._renderTaskQueue.run();
 
     simulate.touchend(map.getCanvas());
@@ -504,7 +504,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the to
     simulate.touchstart(map.getCanvas());
     map._renderTaskQueue.run();
 
-    simulate.touchmove(map.getCanvas());
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 10, clientY: 10}]});
     map._renderTaskQueue.run();
 
     simulate.touchend(map.getCanvas());
@@ -535,7 +535,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the to
         simulate.mousedown(map.getCanvas());
         map._renderTaskQueue.run();
 
-        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
         map._renderTaskQueue.run();
 
         t.equal(dragstart.callCount, 1);
@@ -574,7 +574,7 @@ test(`DragPanHandler can be disabled after mousedown (#2419)`, (t) => {
 
     map.dragPan.disable();
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     t.equal(dragstart.callCount, 0);
@@ -591,6 +591,73 @@ test(`DragPanHandler can be disabled after mousedown (#2419)`, (t) => {
     t.equal(dragend.callCount, 0);
     t.equal(map.isMoving(), false);
     t.equal(map.dragPan.isEnabled(), false);
+
+    map.remove();
+    t.end();
+});
+
+test('DragPanHandler does not begin a drag on spurious mousemove events', (t) => {
+    const map = createMap();
+    map.dragRotate.disable();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    map.on('dragstart', dragstart);
+    map.on('drag',      drag);
+    map.on('dragend',   dragend);
+
+    simulate.mousedown(map.getCanvas(), {clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.mouseup(map.getCanvas(), {clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    map.remove();
+    t.end();
+});
+
+test('DragPanHandler does not begin a drag on spurious touchmove events', (t) => {
+    const map = createMap();
+
+    const dragstart = t.spy();
+    const drag      = t.spy();
+    const dragend   = t.spy();
+
+    map.on('dragstart', dragstart);
+    map.on('drag',      drag);
+    map.on('dragend',   dragend);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 10, clientY: 10}]});
+    map._renderTaskQueue.run();
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 10, clientY: 10}]});
+    map._renderTaskQueue.run();
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
+
+    simulate.touchend(map.getCanvas(), {touches: []});
+    map._renderTaskQueue.run();
+    t.equal(dragstart.callCount, 0);
+    t.equal(drag.callCount, 0);
+    t.equal(dragend.callCount, 0);
 
     map.remove();
     t.end();

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -4,6 +4,7 @@ import window from '../../../../src/util/window';
 import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
+import browser from '../../../../src/util/browser';
 
 function createMap(options) {
     return new Map(extend({ container: DOM.create('div', '', window.document.body) }, options));
@@ -11,6 +12,9 @@ function createMap(options) {
 
 test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a right-click drag', (t) => {
     const map = createMap();
+
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
 
     const rotatestart = t.spy();
     const rotate      = t.spy();
@@ -26,7 +30,7 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
@@ -45,19 +49,22 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
 test('DragRotateHandler stops firing events after mouseup', (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const spy = t.spy();
     map.on('rotatestart', spy);
     map.on('rotate',      spy);
     map.on('rotateend',   spy);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
     t.equal(spy.callCount, 3);
 
     spy.reset();
-    simulate.mousemove(map.getCanvas(), {buttons: 0});
+    simulate.mousemove(map.getCanvas(), {buttons: 0, clientX: 20, clientY: 20});
     map._renderTaskQueue.run();
     t.equal(spy.callCount, 0);
 
@@ -67,6 +74,9 @@ test('DragRotateHandler stops firing events after mouseup', (t) => {
 
 test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a control-left-click drag', (t) => {
     const map = createMap();
+
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
 
     const rotatestart = t.spy();
     const rotate      = t.spy();
@@ -82,7 +92,7 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
@@ -101,6 +111,9 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
 test('DragRotateHandler pitches in response to a right-click drag by default', (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const pitchstart = t.spy();
     const pitch      = t.spy();
     const pitchend   = t.spy();
@@ -110,7 +123,7 @@ test('DragRotateHandler pitches in response to a right-click drag by default', (
     map.on('pitchend',   pitchend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(pitchstart.callCount, 1);
     t.equal(pitch.callCount, 1);
@@ -125,6 +138,9 @@ test('DragRotateHandler pitches in response to a right-click drag by default', (
 test('DragRotateHandler pitches in response to a control-left-click drag', (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const pitchstart = t.spy();
     const pitch      = t.spy();
     const pitchend   = t.spy();
@@ -134,7 +150,7 @@ test('DragRotateHandler pitches in response to a control-left-click drag', (t) =
     map.on('pitchend',   pitchend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
-    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(pitchstart.callCount, 1);
     t.equal(pitch.callCount, 1);
@@ -156,12 +172,12 @@ test('DragRotateHandler does not pitch if given pitchWithRotate: false', (t) => 
     map.on('pitchend',    spy);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
     simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
-    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 0, ctrlKey: true});
 
@@ -186,7 +202,7 @@ test('DragRotateHandler does not rotate or pitch when disabled', (t) => {
     map.on('pitchend',    spy);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
@@ -201,7 +217,7 @@ test('DragRotateHandler ensures that map.isMoving() returns true during drag', (
     const map = createMap({bearingSnap: 0});
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     t.ok(map.isMoving());
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
@@ -215,6 +231,9 @@ test('DragRotateHandler fires move events', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
     const map = createMap({bearingSnap: 0});
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const movestart = t.spy();
     const move      = t.spy();
     const moveend   = t.spy();
@@ -224,7 +243,7 @@ test('DragRotateHandler fires move events', (t) => {
     map.on('moveend',   moveend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(movestart.callCount, 1);
     t.equal(move.callCount, 1);
@@ -239,6 +258,9 @@ test('DragRotateHandler fires move events', (t) => {
 test('DragRotateHandler includes originalEvent property in triggered events', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
     const map = createMap({bearingSnap: 0});
+
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
 
     const rotatestart = t.spy();
     const rotate      = t.spy();
@@ -262,7 +284,7 @@ test('DragRotateHandler includes originalEvent property in triggered events', (t
     map.on('moveend',   moveend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
 
@@ -285,6 +307,9 @@ test('DragRotateHandler includes originalEvent property in triggered events', (t
 test('DragRotateHandler responds to events on the canvas container (#1301)', (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const rotatestart = t.spy();
     const rotate      = t.spy();
     const rotateend   = t.spy();
@@ -294,7 +319,7 @@ test('DragRotateHandler responds to events on the canvas container (#1301)', (t)
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvasContainer(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvasContainer(), {buttons: 2});
+    simulate.mousemove(map.getCanvasContainer(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
@@ -309,11 +334,14 @@ test('DragRotateHandler responds to events on the canvas container (#1301)', (t)
 test('DragRotateHandler prevents mousemove events from firing during a drag (#1555)', (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const mousemove = t.spy();
     map.on('mousemove', mousemove);
 
     simulate.mousedown(map.getCanvasContainer(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvasContainer(), {buttons: 2});
+    simulate.mousemove(map.getCanvasContainer(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     simulate.mouseup(map.getCanvasContainer(),   {buttons: 0, button: 2});
 
@@ -326,6 +354,9 @@ test('DragRotateHandler prevents mousemove events from firing during a drag (#15
 test('DragRotateHandler ends a control-left-click drag on mouseup even when the control key was previously released (#1888)', (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const rotatestart = t.spy();
     const rotate      = t.spy();
     const rotateend   = t.spy();
@@ -335,7 +366,7 @@ test('DragRotateHandler ends a control-left-click drag on mouseup even when the 
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 1, button: 0, ctrlKey: true});
-    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
@@ -350,6 +381,9 @@ test('DragRotateHandler ends a control-left-click drag on mouseup even when the 
 test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const rotatestart = t.spy();
     const rotate      = t.spy();
     const rotateend   = t.spy();
@@ -359,7 +393,7 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
     map.on('rotateend',   rotateend);
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
@@ -375,15 +409,18 @@ test('DragRotateHandler requests a new render frame after each mousemove event',
     const map = createMap();
     const requestRenderFrame = t.spy(map, '_requestRenderFrame');
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     t.ok(requestRenderFrame.callCount > 0);
 
     map._renderTaskQueue.run();
 
     // https://github.com/mapbox/mapbox-gl-js/issues/6063
     requestRenderFrame.reset();
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 20, clientY: 20});
     t.equal(requestRenderFrame.callCount, 1);
 
     map.remove();
@@ -393,6 +430,9 @@ test('DragRotateHandler requests a new render frame after each mousemove event',
 test('DragRotateHandler can interleave with another handler', (t) => {
     // https://github.com/mapbox/mapbox-gl-js/issues/6106
     const map = createMap();
+
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
 
     const rotatestart = t.spy();
     const rotate      = t.spy();
@@ -408,7 +448,7 @@ test('DragRotateHandler can interleave with another handler', (t) => {
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
@@ -422,7 +462,7 @@ test('DragRotateHandler can interleave with another handler', (t) => {
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 20, clientY: 20});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
@@ -456,7 +496,7 @@ test('DragRotateHandler does not begin a drag on left-button mousedown without t
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 0);
     t.equal(rotate.callCount, 0);
@@ -476,6 +516,9 @@ test('DragRotateHandler does not end a right-button drag on left-button mouseup'
     const map = createMap();
     map.dragPan.disable();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const rotatestart = t.spy();
     const rotate      = t.spy();
     const rotateend   = t.spy();
@@ -490,7 +533,7 @@ test('DragRotateHandler does not end a right-button drag on left-button mouseup'
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
@@ -508,7 +551,7 @@ test('DragRotateHandler does not end a right-button drag on left-button mouseup'
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 20, clientY: 20});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
@@ -528,6 +571,9 @@ test('DragRotateHandler does not end a control-left-button drag on right-button 
     const map = createMap();
     map.dragPan.disable();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const rotatestart = t.spy();
     const rotate      = t.spy();
     const rotateend   = t.spy();
@@ -542,7 +588,7 @@ test('DragRotateHandler does not end a control-left-button drag on right-button 
     t.equal(rotate.callCount, 0);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 1);
@@ -560,7 +606,7 @@ test('DragRotateHandler does not end a control-left-button drag on right-button 
     t.equal(rotate.callCount, 1);
     t.equal(rotateend.callCount, 0);
 
-    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true});
+    simulate.mousemove(map.getCanvas(), {buttons: 1,            ctrlKey: true, clientX: 20, clientY: 20});
     map._renderTaskQueue.run();
     t.equal(rotatestart.callCount, 1);
     t.equal(rotate.callCount, 2);
@@ -592,7 +638,7 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     map._renderTaskQueue.run();
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
@@ -610,6 +656,9 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
     test(`DragRotateHandler can be disabled on ${event} (#2419)`, (t) => {
         const map = createMap();
 
+        // Prevent inertial rotation.
+        t.stub(browser, 'now').returns(0);
+
         map.on(event, () => map.dragRotate.disable());
 
         const rotatestart = t.spy();
@@ -623,7 +672,7 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
         simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
         map._renderTaskQueue.run();
 
-        simulate.mousemove(map.getCanvas(), {buttons: 2});
+        simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
         map._renderTaskQueue.run();
 
         t.equal(rotatestart.callCount, 1);
@@ -649,6 +698,9 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
 test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     const rotatestart = t.spy();
     const rotate      = t.spy();
     const rotateend   = t.spy();
@@ -662,7 +714,7 @@ test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
 
     map.dragRotate.disable();
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     t.equal(rotatestart.callCount, 0);
@@ -679,6 +731,39 @@ test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
     t.equal(rotateend.callCount, 0);
     t.equal(map.isMoving(), false);
     t.equal(map.dragRotate.isEnabled(), false);
+
+    map.remove();
+    t.end();
+});
+
+test('DragRotateHandler does not begin rotation on spurious mousemove events', (t) => {
+    const map = createMap();
+
+    const rotatestart = t.spy();
+    const rotate      = t.spy();
+    const rotateend   = t.spy();
+
+    map.on('rotatestart', rotatestart);
+    map.on('rotate',      rotate);
+    map.on('rotateend',   rotateend);
+
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2, clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
+
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
+
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2, clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
 
     map.remove();
     t.end();

--- a/test/unit/ui/map/isMoving.test.js
+++ b/test/unit/ui/map/isMoving.test.js
@@ -48,7 +48,7 @@ test('Map#isMoving returns true when drag panning', (t) => {
     simulate.mousedown(map.getCanvas());
     map._renderTaskQueue.run();
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas());
@@ -57,6 +57,9 @@ test('Map#isMoving returns true when drag panning', (t) => {
 
 test('Map#isMoving returns true when drag rotating', (t) => {
     const map = createMap();
+
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
 
     map.on('rotatestart', () => {
         t.equal(map.isMoving(), true);
@@ -71,7 +74,7 @@ test('Map#isMoving returns true when drag rotating', (t) => {
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     map._renderTaskQueue.run();
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
@@ -131,7 +134,7 @@ test('Map#isMoving returns true when drag panning and scroll zooming interleave'
     simulate.mousedown(map.getCanvas());
     map._renderTaskQueue.run();
 
-    simulate.mousemove(map.getCanvas());
+    simulate.mousemove(map.getCanvas(), {clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     const browserNow = t.stub(browser, 'now');

--- a/test/unit/ui/map/isRotating.test.js
+++ b/test/unit/ui/map/isRotating.test.js
@@ -3,6 +3,7 @@ import window from '../../../../src/util/window';
 import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
+import browser from '../../../../src/util/browser';
 
 function createMap() {
     return new Map({ container: DOM.create('div', '', window.document.body) });
@@ -34,6 +35,9 @@ test('Map#isRotating returns true during a camera rotate animation', (t) => {
 test('Map#isRotating returns true when drag rotating', (t) => {
     const map = createMap();
 
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
     map.on('rotatestart', () => {
         t.equal(map.isRotating(), true);
     });
@@ -47,7 +51,7 @@ test('Map#isRotating returns true when drag rotating', (t) => {
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     map._renderTaskQueue.run();
 
-    simulate.mousemove(map.getCanvas(), {buttons: 2});
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
     map._renderTaskQueue.run();
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});


### PR DESCRIPTION
Fixes #6730 by ignoring mousemove events in the drag pan, drag rotate, and box zoom handlers when the position does not differ from the previous event.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page