### PR TITLE
Fix DEPLOY_ENV for website staging builds

### DIFF
--- a/build/set-deploy-env.sh
+++ b/build/set-deploy-env.sh
@@ -1,0 +1,21 @@
+# Establish environment variables based on the branch name.
+#
+# This is an sh script (instead of Node or bash) because it needs to run in the
+# top-level process so the environment variables it creates are available to
+# all children processes (e.g. `x && y && z`). `npm run` executes in an `sh`
+# environment -- so, sh it is.
+
+# `git symbolic-ref HEAD` outputs `refs/head/{your-branch-name}`.
+branch=`git symbolic-ref HEAD | sed "s/refs\/heads\/\(.*\)/\1/"`
+
+if [ -z "$DEPLOY_ENV" ]
+  then
+    if [ "$branch" = "mb-pages" ]
+      then
+        export DEPLOY_ENV=production
+      else
+        export DEPLOY_ENV=staging
+    fi
+fi
+
+echo "DEPLOY_ENV set to $DEPLOY_ENV"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "start-debug": "run-p build-token watch-dev start-server",
     "start-bench": "run-p build-token watch-benchmarks watch-benchmarks-view start-server",
     "build-docs": "documentation build --github --format json --config ./docs/documentation.yml --output docs/components/api.json src/index.js",
-    "build": "run-s build-docs && DEPLOY_ENV=production batfish build # invoked by publisher when publishing docs on the mb-pages branch",
+    "build": "run-s build-docs && build/set-deploy-env.sh && batfish build # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "run-s build-min build-docs && DEPLOY_ENV=local batfish start",
     "lint": "eslint --cache --ignore-path .gitignore src test bench docs docs/pages/example/*.html debug/*.html",
     "lint-docs": "documentation lint src/index.js",


### PR DESCRIPTION
@samanpwbb noticed that the staging docs are being included in Google search results.

Although our staging site has a `robots.txt` that discourages crawlers, that will not always prevent indexing if the page is linked to or otherwise attracts the great spider. I think the next measure to take is to add a `<meta name="robots" content="noindex">` to the page.

dotcom-page-shell is set up to add this meta tag if `DEPLOY_ENV=staging`. However, right now for this site `DEPLOY_ENV` is set to `production` for every build, even on staging.

This PR adds a script that determines whether to set `DEPLOY_ENV=staging` based on the Git branch name. I used a shell script in order to avoid adding an npm dependency — but if you'd prefer, I can use the git-branch package or something and make it a Node script.

Notice that this branch merges into dev-pages. I'm not sure whether you'd rather modify dev-pages first, or modify mb-pages then update dev-pages from it. 🤷‍♂️ 