### PR TITLE
Fix omitted word on the style spec documentation page

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3025,7 +3025,7 @@
           "!": "fill-pattern"
         },
         {
-          "fill-antialias": true
+          "fill-antialias": "true"
         }
       ],
       "sdk-support": {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/6796
 - [x] manually test the debug page

