### PR TITLE
do not reload errored tiles

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -215,7 +215,7 @@ class SourceCache extends Evented {
         this._cache.reset();
 
         for (const i in this._tiles) {
-            if (this._tiles[i] && this._tiles[i].state !== "errored") this._reloadTile(i, 'reloading');
+            if (this._tiles[i].state !== "errored") this._reloadTile(i, 'reloading');
         }
     }
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -215,7 +215,7 @@ class SourceCache extends Evented {
         this._cache.reset();
 
         for (const i in this._tiles) {
-            this._reloadTile(i, 'reloading');
+            if (this._tiles[i] && this._tiles[i].state !== "errored") this._reloadTile(i, 'reloading');
         }
     }
 

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -401,6 +401,32 @@ test('SourceCache / Source lifecycle', (t) => {
         sourceCache.onAdd();
     });
 
+    t.test('does not reload errored tiles', (t) => {
+        const transform = new Transform();
+        transform.resize(511, 511);
+        transform.zoom = 0;
+
+        const sourceCache = createSourceCache({
+            loadTile: function (tile, callback) {
+                tile.state = 'errored';
+                callback();
+            }
+        });
+
+        const reloadTileSpy = t.spy(sourceCache, '_reloadTile');
+        sourceCache.on('data', (e) => {
+            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+                sourceCache.update(transform);
+                sourceCache.getSource().fire(new Event('data', {dataType: 'source', sourceDataType: 'content'}));
+            }
+        });
+        sourceCache.onAdd();
+
+        t.ok(reloadTileSpy.notCalled);
+
+        t.end();
+    });
+
     t.end();
 });
 

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -404,11 +404,13 @@ test('SourceCache / Source lifecycle', (t) => {
     t.test('does not reload errored tiles', (t) => {
         const transform = new Transform();
         transform.resize(511, 511);
-        transform.zoom = 0;
+        transform.zoom = 1;
 
         const sourceCache = createSourceCache({
             loadTile: function (tile, callback) {
-                tile.state = 'errored';
+                // this transform will try to load the four tiles at z1 and a single z0 tile
+                // we only expect _reloadTile to be called with the 'loaded' z0 tile
+                tile.state = tile.tileID.canonical.z === 1 ? 'errored' : 'loaded';
                 callback();
             }
         });
@@ -421,8 +423,9 @@ test('SourceCache / Source lifecycle', (t) => {
             }
         });
         sourceCache.onAdd();
-
-        t.ok(reloadTileSpy.notCalled);
+        // we expect the source cache to have five tiles, but only to have reloaded one
+        t.equal(Object.keys(sourceCache._tiles).length, 5);
+        t.ok(reloadTileSpy.calledOnce);
 
         t.end();
     });


### PR DESCRIPTION
fix #6783 

errored tiles were being reloaded, and their state was being changed from `errored` -> `reloading` which results in `tile.hasData()` to return `true`, preventing the existing parent tiles from being retained correctly. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] post benchmark scores
 - [x] manually test the debug page
