### PR TITLE
Fix flyTo not zooming to exact given zoom

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -852,7 +852,7 @@ class Camera extends Evented {
             // s: The distance traveled along the flight path, measured in ρ-screenfuls.
             const s = k * S;
             const scale = 1 / w(s);
-            tr.zoom = startZoom + tr.scaleZoom(scale);
+            tr.zoom = k === 1 ? zoom : startZoom + tr.scaleZoom(scale);
 
             if (this._rotating) {
                 tr.bearing = interpolate(startBearing, bearing, k);

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -912,6 +912,13 @@ test('camera', (t) => {
             t.end();
         });
 
+        t.test('zooms to integer level without floating point errors', (t) => {
+            const camera = createCamera({zoom: 0.6});
+            camera.flyTo({ zoom: 2, animate: false });
+            t.equal(camera.getZoom(), 2);
+            t.end();
+        });
+
         t.test('rotates to specified bearing', (t) => {
             const camera = createCamera();
             camera.flyTo({ bearing: 90, animate: false });


### PR DESCRIPTION
Currently, if you call `flyTo` with an integer `zoom`, you're not guaranteed to land on the exact zoom after the animation because of floating point errors. E.g. `map.flyTo({zoom: 2})` when starting on zoom 0.6 will end up on zoom `1.999999999996`, which is problematic if you wish to get on the exact zoom for corresponding tiles to load. Discovered this while implementing the `getClusterExpansionZoom` API.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] (n/a) ~~document any changes to public APIs~~
 - [x] (n/a) ~~post benchmark scores~~
 - [x] manually test the debug page

closes #6191
