### PR TITLE
Warn user if required sprite property is not present or non-existent image is requested from sprite

### DIFF
--- a/src/render/image_manager.js
+++ b/src/render/image_manager.js
@@ -3,6 +3,7 @@
 import potpack from 'potpack';
 
 import { RGBAImage } from '../util/image';
+import { warnOnce } from '../util/util';
 import { ImagePosition } from './image_atlas';
 import Texture from './texture';
 import assert from 'assert';
@@ -93,7 +94,7 @@ class ImageManager {
 
     getImages(ids: Array<string>, callback: Callback<{[string]: StyleImage}>) {
         // If the sprite has been loaded, or if all the icon dependencies are already present
-        // (i.e. if they've been addeded via runtime styling), then notify the requestor immediately.
+        // (i.e. if they've been added via runtime styling), then notify the requestor immediately.
         // Otherwise, delay notification until the sprite is loaded. At that point, if any of the
         // dependencies are still unavailable, we'll just assume they are permanently missing.
         let hasAllDependencies = true;
@@ -104,6 +105,7 @@ class ImageManager {
                 }
             }
         }
+
         if (this.isLoaded() || hasAllDependencies) {
             this._notify(ids, callback);
         } else {
@@ -123,6 +125,8 @@ class ImageManager {
                     pixelRatio: image.pixelRatio,
                     sdf: image.sdf
                 };
+            } else {
+                warnOnce(`Image "${id}" could not be loaded. Please make sure you have added the image with map.addImage(), an image source or a "sprite" property in your style before using it in a layer.`);
             }
         }
 

--- a/src/style-spec/util/util.js
+++ b/src/style-spec/util/util.js
@@ -6,7 +6,7 @@
  */
 const warnOnceHistory = {};
 
-export function warnOnce(message) {
+export function styleWarnOnce(message) {
     if (!warnOnceHistory[message]) {
         // console isn't defined in some WebWorkers, see #2558
         if (typeof console !== "undefined") console.warn(message);

--- a/src/style-spec/util/util.js
+++ b/src/style-spec/util/util.js
@@ -1,0 +1,15 @@
+/**
+ * Print a warning message to the console and ensure duplicate warning messages
+ * are not printed.
+ *
+ * @private
+ */
+const warnOnceHistory = {};
+
+export function warnOnce(message) {
+    if (!warnOnceHistory[message]) {
+        // console isn't defined in some WebWorkers, see #2558
+        if (typeof console !== "undefined") console.warn(message);
+        warnOnceHistory[message] = true;
+    }
+}

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -1,5 +1,3 @@
-
-import { warnOnce } from '../../util/util';
 import validate from './validate';
 import ValidationError from '../error/validation_error';
 import getType from '../util/get_type';

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -6,6 +6,7 @@ import getType from '../util/get_type';
 import { isFunction } from '../function';
 import { unbundle, deepUnbundle } from '../util/unbundle_jsonlint';
 import { supportsPropertyExpression } from '../util/properties';
+import { warnOnce } from '../util/util';
 
 export default function validateProperty(options, propertyType) {
     const key = options.key;

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -6,7 +6,7 @@ import getType from '../util/get_type';
 import { isFunction } from '../function';
 import { unbundle, deepUnbundle } from '../util/unbundle_jsonlint';
 import { supportsPropertyExpression } from '../util/properties';
-import { warnOnce } from '../util/util';
+import { styleWarnOnce } from '../util/util';
 
 export default function validateProperty(options, propertyType) {
     const key = options.key;
@@ -55,7 +55,7 @@ export default function validateProperty(options, propertyType) {
 
     if (options.layerType === 'background' || options.layerType === 'fill' || options.layerType === 'fill-extrusion' || options.layerType === 'line' || options.layerType === 'symbol') {
         if (propsThatRequireSprite.indexOf(propertyKey) > -1 && style && !style.sprite) {
-            warnOnce(`Use of "${propertyKey}" in style "${style.name}" may require a style "sprite" property. If you're experiencing a problem, please ensure that your image has loaded correctly.`);
+            styleWarnOnce(`Use of "${propertyKey}" in style "${style.name}" may require a style "sprite" property. If you're experiencing a problem, please ensure that your image has loaded correctly.`);
         }
     }
 

--- a/src/style-spec/validate/validate_property.js
+++ b/src/style-spec/validate/validate_property.js
@@ -1,4 +1,5 @@
 
+import { warnOnce } from '../../util/util';
 import validate from './validate';
 import ValidationError from '../error/validation_error';
 import getType from '../util/get_type';
@@ -13,7 +14,7 @@ export default function validateProperty(options, propertyType) {
     const value = options.value;
     const propertyKey = options.objectKey;
     const layerSpec = styleSpec[`${propertyType}_${options.layerType}`];
-
+    const propsThatRequireSprite = ['background-pattern', 'fill-pattern', 'fill-extrusion-pattern', 'line-pattern', 'icon-image'];
     if (!layerSpec) return [];
 
     const transitionMatch = propertyKey.match(/^(.*)-transition$/);
@@ -48,6 +49,12 @@ export default function validateProperty(options, propertyType) {
         }
         if (propertyKey === 'text-font' && isFunction(deepUnbundle(value)) && unbundle(value.type) === 'identity') {
             errors.push(new ValidationError(key, value, '"text-font" does not support identity functions'));
+        }
+    }
+
+    if (options.layerType === 'background' || options.layerType === 'fill' || options.layerType === 'fill-extrusion' || options.layerType === 'line' || options.layerType === 'symbol') {
+        if (propsThatRequireSprite.indexOf(propertyKey) > -1 && style && !style.sprite) {
+            warnOnce(`Use of "${propertyKey}" in style "${style.name}" may require a style "sprite" property. If you're experiencing a problem, please ensure that your image has loaded correctly.`);
         }
     }
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - logs a console warning if sprite URL is not defined and a property that requires sprites is used
    - logs a console warning if an image not in the sprite is requested
 - [ ] write tests for all new functionality
    - i don't see tests for the existing glyph validation. do we think unit tests are necessary for this? if so, i can add them for both sprite and glyph validation
 - [x] manually test the debug page
![screen shot 2018-11-01 at 5 42 27 pm](https://user-images.githubusercontent.com/4523080/47887604-8a351880-ddfd-11e8-9d61-296160b10697.png)
![screen shot 2018-11-01 at 5 48 21 pm](https://user-images.githubusercontent.com/4523080/47887764-60c8bc80-ddfe-11e8-980c-d141035bde98.png)



Closes #6823 