### PR TITLE
use absolute URLs for example assets for portability

### DIFF
--- a/docs/components/example.js
+++ b/docs/components/example.js
@@ -53,10 +53,7 @@ export default function (html) {
 </head>
 <body>
 
-${html
-        .replace("<script>", `<script>\nmapboxgl.accessToken = '${this.state.token}';`)
-        .replace("/mapbox-gl-js/assets/", "https://www.mapbox.com/mapbox-gl-js/assets/")
-}
+${html.replace("<script>", `<script>\nmapboxgl.accessToken = '${this.state.token}';`)}
 </body>
 </html>`;
         }

--- a/docs/components/example.js
+++ b/docs/components/example.js
@@ -53,7 +53,10 @@ export default function (html) {
 </head>
 <body>
 
-${html.replace("<script>", `<script>\nmapboxgl.accessToken = '${this.state.token}';`)}
+${html
+        .replace("<script>", `<script>\nmapboxgl.accessToken = '${this.state.token}';`)
+        .replace("/mapbox-gl-js/assets/", "https://www.mapbox.com/mapbox-gl-js/assets/")
+}
 </body>
 </html>`;
         }

--- a/docs/pages/example/3d-extrusion-floorplan.html
+++ b/docs/pages/example/3d-extrusion-floorplan.html
@@ -17,7 +17,7 @@ map.on('load', function() {
             // GeoJSON Data source used in vector tiles, documented at
             // https://gist.github.com/ryanbaumann/a7d970386ce59d11c16278b90dde094d
             'type': 'geojson',
-            'data': '/mapbox-gl-js/assets/indoor-3d-map.geojson'
+            'data': 'https://www.mapbox.com/mapbox-gl-js/assets/indoor-3d-map.geojson'
         },
         'paint': {
             // See the Mapbox Style Specification for details on data expressions.

--- a/docs/pages/example/animate-images.html
+++ b/docs/pages/example/animate-images.html
@@ -18,7 +18,7 @@ map.on('load', function() {
             id: 'radar' + i,
             source: {
                 type: 'image',
-                url: '/mapbox-gl-js/assets/radar' + i + '.gif',
+                url: 'https://www.mapbox.com/mapbox-gl-js/assets/radar' + i + '.gif',
                 coordinates: [
                     [-80.425, 46.437],
                     [-71.516, 46.437],

--- a/docs/pages/example/cluster.html
+++ b/docs/pages/example/cluster.html
@@ -16,7 +16,7 @@ map.on('load', function() {
         type: "geojson",
         // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes
         // from 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
-        data: "/mapbox-gl-js/assets/earthquakes.geojson",
+        data: "https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson",
         cluster: true,
         clusterMaxZoom: 14, // Max zoom to cluster points on
         clusterRadius: 50 // Radius of each cluster when clustering points (defaults to 50)

--- a/docs/pages/example/heatmap-layer.html
+++ b/docs/pages/example/heatmap-layer.html
@@ -14,7 +14,7 @@ map.on('load', function() {
     // Heatmap layers also work with a vector tile source.
     map.addSource('earthquakes', {
         "type": "geojson",
-        "data": "/mapbox-gl-js/assets/earthquakes.geojson"
+        "data": "https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"
     });
 
     map.addLayer({

--- a/docs/pages/example/image-on-a-map.html
+++ b/docs/pages/example/image-on-a-map.html
@@ -10,7 +10,7 @@ var mapStyle = {
         },
         "overlay": {
             "type": "image",
-            "url": "/mapbox-gl-js/assets/radar.gif",
+            "url": "https://www.mapbox.com/mapbox-gl-js/assets/radar.gif",
             "coordinates": [
                 [-80.425, 46.437],
                 [-71.516, 46.437],

--- a/docs/pages/example/live-update-feature.html
+++ b/docs/pages/example/live-update-feature.html
@@ -12,7 +12,7 @@ map.on('load', function () {
     // We use D3 to fetch the JSON here so that we can parse and use it separately
     // from GL JS's use in the added source. You can use any request method (library
     // or otherwise) that you want.
-    d3.json('/mapbox-gl-js/assets/hike.geojson', function(err, data) {
+    d3.json('https://www.mapbox.com/mapbox-gl-js/assets/hike.geojson', function(err, data) {
         if (err) throw err;
 
         // save full coordinate list for later

--- a/docs/pages/example/set-popup.html
+++ b/docs/pages/example/set-popup.html
@@ -1,7 +1,7 @@
 <style>
 
 #marker {
-    background-image: url('/mapbox-gl-js/assets/washington-monument.jpg');
+    background-image: url('https://www.mapbox.com/mapbox-gl-js/assets/washington-monument.jpg');
     background-size: cover;
     width: 50px;
     height: 50px;

--- a/docs/pages/example/timeline-animation.html
+++ b/docs/pages/example/timeline-animation.html
@@ -100,7 +100,7 @@ map.on('load', function() {
     //
     // Here we're using d3 to help us make the ajax request but you can use
     // Any request method (library or otherwise) you wish.
-    d3.json('/mapbox-gl-js/assets/significant-earthquakes-2015.geojson', function(err, data) {
+    d3.json('https://www.mapbox.com/mapbox-gl-js/assets/significant-earthquakes-2015.geojson', function(err, data) {
         if (err) throw err;
 
         // Create a month property value based on time

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -784,7 +784,7 @@ export default class extends React.Component {
                                         {highlightJSON(`
                                             "image": {
                                                 "type": "image",
-                                                "url": "/mapbox-gl-js/assets/radar.gif",
+                                                "url": "https://www.mapbox.com/mapbox-gl-js/assets/radar.gif",
                                                 "coordinates": [
                                                     [-80.425, 46.437],
                                                     [-71.516, 46.437],


### PR DESCRIPTION
## Launch Checklist

closes #6511

 - [x] briefly describe the changes in this PR

Examples are designed to be copy pasted, but all the asset URLs were relative which most of the time means the examples didn't work when running locally or on jsbin, etc.

I'd still like the ability for new examples being developed before being published to be run so don't think we should simply hardcode the absolute URLs. This PR instead transforms the assets URLs to be absolute for the copy paste code only (not the code that's driving the live example).

It looks like the ACAO header is present on the assets now, so I couldn't see any issues.
