### PR TITLE
Final versions for v0.46.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.46.0-beta.1
+## 0.46.0
 
 ### ⚠️ Breaking changes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "0.46.0-beta.1",
+  "version": "0.46.0",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 13.0.0-beta.1
+## 13.0.0
 
 ### ⚠️ Breaking changes
 * Align implicit type behavior of `match` expressions with with `case/==` ([#6684](https://github.com/mapbox/mapbox-gl-js/pull/6684))

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/mapbox-gl-style-spec",
   "description": "a specification for mapbox gl styles",
-  "version": "13.0.0-beta.1",
+  "version": "13.0.0",
   "author": "Mapbox",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
There were no code changes from v0.46.0-beta.1, so this commit just strips the `beta.1` from the gl-js and style-spec versions.