### PR TITLE
Bump style-spec version to 13.0.1 to allow re-publishing to NPM.

### DIFF
--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 13.0.0
+## 13.0.1
 
 ### ⚠️ Breaking changes
 * Align implicit type behavior of `match` expressions with with `case/==` ([#6684](https://github.com/mapbox/mapbox-gl-js/pull/6684))
@@ -11,6 +11,9 @@
 
 ### 🐛 Bug fixes
 * Use named exports for style-spec entrypoint module ([#6601](https://github.com/mapbox/mapbox-gl-js/issues/6601)
+
+## 13.0.0
+Malformed package published to NPM.
 
 ## 12.0.0
 

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/mapbox-gl-style-spec",
   "description": "a specification for mapbox gl styles",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "author": "Mapbox",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
Version 13.0.0 was published to NPM a week ago, but something in the build process failed and `index.js` was not included in the package.

/cc @ian29 @mollymerp 