### PR TITLE
Add scheme option to vector source

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -150,6 +150,19 @@
       ],
       "doc": "An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL."
     },
+    "scheme": {
+      "type": "enum",
+      "values": {
+        "xyz": {
+          "doc": "Slippy map tilenames scheme."
+        },
+        "tms": {
+          "doc": "OSGeo spec scheme."
+        }
+      },
+      "default": "xyz",
+      "doc": "Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed."
+    },
     "minzoom": {
       "type": "number",
       "default": 0,


### PR DESCRIPTION
this is already implemented:

https://github.com/mapbox/mapbox-gl-js/blob/bf88cd735b06eacc607c188a2508c9912140768d/src/source/vector_tile_source.js#L53

and tested:

https://github.com/mapbox/mapbox-gl-js/blob/bf88cd735b06eacc607c188a2508c9912140768d/test/unit/source/vector_tile_source.test.js#L137-L162

just not documented 📝


ref https://github.com/mapbox/mapbox-gl-js/pull/2565#issuecomment-399176949
## Launch Checklist
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR