### PR TITLE
Use updateData instead of re-creating buffers for repopulated paint arrays

### DIFF
--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -185,7 +185,11 @@ class SourceExpressionBinder<T> implements Binder<T> {
 
     upload(context: Context) {
         if (this.paintVertexArray && this.paintVertexArray.arrayBuffer) {
-            this.paintVertexBuffer = context.createVertexBuffer(this.paintVertexArray, this.paintVertexAttributes, this.expression.isStateDependent);
+            if (this.paintVertexBuffer && this.paintVertexBuffer.buffer) {
+                this.paintVertexBuffer.updateData(this.paintVertexArray);
+            } else {
+                this.paintVertexBuffer = context.createVertexBuffer(this.paintVertexArray, this.paintVertexAttributes, this.expression.isStateDependent);
+            }
         }
     }
 
@@ -280,7 +284,11 @@ class CompositeExpressionBinder<T> implements Binder<T> {
 
     upload(context: Context) {
         if (this.paintVertexArray && this.paintVertexArray.arrayBuffer) {
-            this.paintVertexBuffer = context.createVertexBuffer(this.paintVertexArray, this.paintVertexAttributes, this.expression.isStateDependent);
+            if (this.paintVertexBuffer && this.paintVertexBuffer.buffer) {
+                this.paintVertexBuffer.updateData(this.paintVertexArray);
+            } else {
+                this.paintVertexBuffer = context.createVertexBuffer(this.paintVertexArray, this.paintVertexAttributes, this.expression.isStateDependent);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes issue #6839 (memory leak on frequent calls to setFeatureState). The leak was caused by mismatched calls to "createVertexBuffer" and "destroy". We didn't see the leak on most machines, presumably due to differences in how different GPU drivers handled re-creating the buffers. @ryanbaumann could reproduce the problem on one of his Windows machines, and verified the problem went away with these changes.

Improves performance of PaintStates benchmark. The performance improvement is presumably because we're able to take advantage of the DYNAMIC_DRAW option intended for frequently updated buffers. I ran the benchmarks multiple times and saw the same pattern: it looks like the PaintStates benchmark has much less variability after this change (and it looks like before the change there was actually a pattern in which progressive iterations of the bench seemed to slow down -- note the way the dots slope up to the right).

<img width="1064" alt="screenshot 2018-06-22 13 11 18" src="https://user-images.githubusercontent.com/375121/41797156-d259dfbc-761d-11e8-9cba-31eaf6e776f5.png">

There are a couple things that bothered me a little but don't seem too serious:

- Duplication between CompositeExpressionBinder and SourceExpressionBinder
- Peaking inside the `VertexBuffer` to test if it's "live" (e.g. `this.paintVertexBuffer.buffer`) -- it kind of feels like this should be handled by `VertexBuffer` somehow. If `buffer` is null, that means `destroy()` has already been called, and it needs to be re-recreated (I don't actually know of a pathway that would cause this to happen).
- We call `updateData` regardless of whether DYNAMIC_DRAW is enabled (it's cued off `expression.isStateDependent`). But I believe `updateData` is still fine if it ends up getting called on a STATIC_DRAW buffer (should be no worse than destroying and re-creating the buffer).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~ (no explicit behavior change)
 - [ ] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

/cc @asheemmamoowala @ryanbaumann @mollymerp @ansis 
