### PR TITLE
Fix popup shaking

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -314,7 +314,7 @@ export default class Popup extends Evented {
             }
         }
 
-        const offsetedPos = pos.add(offset[anchor]).round();
+        const offsetedPos = pos.add(offset[anchor]);
 
         DOM.setTransform(this._container, `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
         applyAnchorClass(this._container, anchor, 'popup');


### PR DESCRIPTION
Removed round() from transform: translate.

This round() was causing the random shaking after camera animations (panBy, panTo, easeTo, etc.)

I believe there is no need to have this rounded, the browser will handle it. In current Chrome this gets rounded to 3 decimal digits.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
