### PR TITLE
Rotated filtered symbol sort test

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -671,8 +671,8 @@ class SymbolBucket implements Bucket {
         symbolInstanceIndexes.sort((aIndex, bIndex) => {
             const a = this.symbolInstances[aIndex];
             const b = this.symbolInstances[bIndex];
-            const aRotated = (sin * a.anchor.x + cos * a.anchor.y) | 0;
-            const bRotated = (sin * b.anchor.x + cos * b.anchor.y) | 0;
+            const aRotated = Math.round(sin * a.anchor.x + cos * a.anchor.y) | 0;
+            const bRotated = Math.round(sin * b.anchor.x + cos * b.anchor.y) | 0;
             return (aRotated - bRotated) || (b.featureIndex - a.featureIndex);
         });
 

--- a/test/integration/data/121points.geojson
+++ b/test/integration/data/121points.geojson
@@ -4,6 +4,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 121,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -15,6 +16,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 1,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -26,6 +28,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 2,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -37,6 +40,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 3,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -48,6 +52,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 4,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -59,6 +64,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 5,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -70,6 +76,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 6,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -81,6 +88,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 7,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -92,6 +100,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 8,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -103,6 +112,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 9,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -114,6 +124,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 10,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -125,6 +136,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 11,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -136,6 +148,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 119,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -147,6 +160,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 12,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -158,6 +172,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 13,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -169,6 +184,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 14,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -180,6 +196,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 15,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -191,6 +208,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 16,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -202,6 +220,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 17,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -213,6 +232,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 18,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -224,6 +244,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 19,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -235,6 +256,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 20,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -246,6 +268,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 21,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -257,6 +280,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 22,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -268,6 +292,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 23,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -279,6 +304,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 24,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -290,6 +316,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 25,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -301,6 +328,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 26,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -312,6 +340,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 27,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -323,6 +352,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 28,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -334,6 +364,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 29,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -345,6 +376,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 30,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -356,6 +388,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 31,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -367,6 +400,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 32,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -378,6 +412,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 33,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -389,6 +424,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 34,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -400,6 +436,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 35,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -411,6 +448,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 36,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -422,6 +460,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 37,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -433,6 +472,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 38,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -444,6 +484,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 39,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -455,6 +496,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 40,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -466,6 +508,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 41,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -477,6 +520,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 42,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -488,6 +532,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 43,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -499,6 +544,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 44,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -510,6 +556,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 45,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -521,6 +568,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 46,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -532,6 +580,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 47,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -543,6 +592,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 48,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -554,6 +604,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 49,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -565,6 +616,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 50,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -576,6 +628,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 51,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -587,6 +640,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 52,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -598,6 +652,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 53,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -609,6 +664,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 54,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -620,6 +676,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 55,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -631,6 +688,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 56,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -642,6 +700,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 57,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -653,6 +712,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 58,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -664,6 +724,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 59,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -675,6 +736,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 60,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -686,6 +748,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 61,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -697,6 +760,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 62,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -708,6 +772,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 63,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -719,6 +784,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 64,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -730,6 +796,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 65,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -741,6 +808,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 66,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -752,6 +820,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 67,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -763,6 +832,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 68,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -774,6 +844,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 69,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -785,6 +856,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 70,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -796,6 +868,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 71,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -807,6 +880,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 72,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -818,6 +892,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 73,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -829,6 +904,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 74,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -840,6 +916,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 75,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -851,6 +928,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 76,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -862,6 +940,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 77,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -873,6 +952,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 78,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -884,6 +964,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 79,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -895,6 +976,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 80,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -906,6 +988,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 81,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -917,6 +1000,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 82,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -928,6 +1012,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 83,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -939,6 +1024,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 84,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -950,6 +1036,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 85,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -961,6 +1048,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 86,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -972,6 +1060,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 87,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -983,6 +1072,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 88,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -994,6 +1084,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 89,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1005,6 +1096,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 90,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1016,6 +1108,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 91,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1027,6 +1120,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 92,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1038,6 +1132,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 93,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1049,6 +1144,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 94,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1060,6 +1156,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 95,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1071,6 +1168,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 96,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1082,6 +1180,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 97,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1093,6 +1192,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 98,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1104,6 +1204,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 99,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1115,6 +1216,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 100,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1126,6 +1228,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 101,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1137,6 +1240,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 102,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1148,6 +1252,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 103,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1159,6 +1264,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 104,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1170,6 +1276,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 105,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1181,6 +1288,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 106,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1192,6 +1300,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 107,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1203,6 +1312,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 108,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1214,6 +1324,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 109,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1225,6 +1336,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 110,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1236,6 +1348,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 111,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1247,6 +1360,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 112,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1258,6 +1372,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 113,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1269,6 +1384,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 114,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1280,6 +1396,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 115,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1291,6 +1408,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 116,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1302,6 +1420,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 117,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1313,6 +1432,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 118,
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -1324,6 +1444,7 @@
     {
       "type": "Feature",
       "properties": {},
+      "id": 119,
       "geometry": {
         "type": "Point",
         "coordinates": [

--- a/test/integration/query-tests/symbol-features-in/pitched-screen/expected.json
+++ b/test/integration/query-tests/symbol-features-in/pitched-screen/expected.json
@@ -9,6 +9,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 108,
     "source": "geojson",
     "state": {}
   },
@@ -22,6 +23,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 119,
     "source": "geojson",
     "state": {}
   },
@@ -35,6 +37,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 107,
     "source": "geojson",
     "state": {}
   },
@@ -48,6 +51,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 106,
     "source": "geojson",
     "state": {}
   },
@@ -61,6 +65,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 96,
     "source": "geojson",
     "state": {}
   },
@@ -74,6 +79,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 118,
     "source": "geojson",
     "state": {}
   }

--- a/test/integration/query-tests/symbol/filtered-rotated-after-insert/expected.json
+++ b/test/integration/query-tests/symbol/filtered-rotated-after-insert/expected.json
@@ -1,0 +1,828 @@
+[
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -4.998779296875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 6,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 16,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -4.998779296875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 8,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 18,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 28,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 38,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -4.998779296875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 10,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 20,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 30,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 40,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 50,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 42,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 52,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 60,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 62,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 72,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 82,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 84,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 94,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        0.9997051308419742
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 104,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 64,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 74,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 106,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 116,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 86,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 96,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 108,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 118,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -4.998779296875,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 2,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 22,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 32,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 12,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -4.998779296875,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 4,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 44,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -3.9990234375,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 14,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 24,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 34,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 26,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 36,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 46,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 48,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 54,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 66,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 76,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 56,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 58,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 68,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 78,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 88,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 98,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 110,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 70,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 80,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 90,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 100,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 92,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 102,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 112,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        4.998779296875,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 114,
+    "source": "geojson",
+    "state": {}
+  }
+]

--- a/test/integration/query-tests/symbol/filtered-rotated-after-insert/style.json
+++ b/test/integration/query-tests/symbol/filtered-rotated-after-insert/style.json
@@ -1,0 +1,58 @@
+{
+  "version": 8,
+  "metadata": {
+    "test": {
+      "width": 256,
+      "height": 256,
+      "operations": [
+        [
+          "setBearing",
+          45
+        ],
+        [
+          "wait"
+        ]
+      ],
+      "queryGeometry": [
+        [
+          0,
+          0
+        ],
+        [
+          256,
+          256
+        ]
+      ]
+    }
+  },
+  "center": [
+    0,
+    0
+  ],
+  "zoom": 3,
+  "sources": {
+    "geojson": {
+      "type": "geojson",
+      "data": "local://data/121points.geojson"
+    }
+  },
+  "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
+  "sprite": "local://sprites/sprite",
+  "layers": [
+    {
+      "id": "symbol",
+      "type": "symbol",
+      "source": "geojson",
+      "filter": ["==", ["%", ["id"], 2], 0],
+      "layout": {
+        "text-field": ".",
+        "text-size": 6,
+        "text-allow-overlap": true,
+        "text-font": [
+          "Open Sans Semibold",
+          "Arial Unicode MS Bold"
+        ]
+      }
+    }
+  ]
+}

--- a/test/integration/query-tests/symbol/panned-after-insert/expected.json
+++ b/test/integration/query-tests/symbol/panned-after-insert/expected.json
@@ -9,6 +9,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 53,
     "source": "geojson",
     "state": {}
   },
@@ -22,6 +23,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 52,
     "source": "geojson",
     "state": {}
   },
@@ -35,6 +37,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 51,
     "source": "geojson",
     "state": {}
   },
@@ -48,6 +51,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 50,
     "source": "geojson",
     "state": {}
   },
@@ -61,6 +65,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 49,
     "source": "geojson",
     "state": {}
   },
@@ -74,6 +79,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 42,
     "source": "geojson",
     "state": {}
   },
@@ -87,6 +93,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 41,
     "source": "geojson",
     "state": {}
   },
@@ -100,6 +107,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 40,
     "source": "geojson",
     "state": {}
   },
@@ -113,6 +121,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 39,
     "source": "geojson",
     "state": {}
   },
@@ -126,6 +135,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 38,
     "source": "geojson",
     "state": {}
   },
@@ -139,6 +149,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 31,
     "source": "geojson",
     "state": {}
   },
@@ -152,6 +163,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 30,
     "source": "geojson",
     "state": {}
   },
@@ -165,6 +177,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 29,
     "source": "geojson",
     "state": {}
   },
@@ -178,6 +191,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 28,
     "source": "geojson",
     "state": {}
   },
@@ -191,6 +205,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 27,
     "source": "geojson",
     "state": {}
   },
@@ -204,6 +219,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 20,
     "source": "geojson",
     "state": {}
   },
@@ -217,6 +233,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 19,
     "source": "geojson",
     "state": {}
   },
@@ -230,6 +247,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 18,
     "source": "geojson",
     "state": {}
   },
@@ -243,6 +261,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 17,
     "source": "geojson",
     "state": {}
   },
@@ -256,6 +275,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 16,
     "source": "geojson",
     "state": {}
   },
@@ -269,6 +289,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 10,
     "source": "geojson",
     "state": {}
   },
@@ -282,6 +303,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 9,
     "source": "geojson",
     "state": {}
   },
@@ -295,6 +317,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 8,
     "source": "geojson",
     "state": {}
   },
@@ -308,6 +331,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 7,
     "source": "geojson",
     "state": {}
   },
@@ -321,6 +345,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 6,
     "source": "geojson",
     "state": {}
   },
@@ -334,6 +359,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 119,
     "source": "geojson",
     "state": {}
   },
@@ -347,6 +373,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 118,
     "source": "geojson",
     "state": {}
   },
@@ -360,6 +387,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 117,
     "source": "geojson",
     "state": {}
   },
@@ -373,6 +401,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 116,
     "source": "geojson",
     "state": {}
   },
@@ -386,6 +415,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 115,
     "source": "geojson",
     "state": {}
   },
@@ -399,6 +429,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 108,
     "source": "geojson",
     "state": {}
   },
@@ -412,6 +443,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 107,
     "source": "geojson",
     "state": {}
   },
@@ -425,6 +457,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 106,
     "source": "geojson",
     "state": {}
   },
@@ -438,6 +471,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 105,
     "source": "geojson",
     "state": {}
   },
@@ -451,6 +485,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 104,
     "source": "geojson",
     "state": {}
   },
@@ -464,6 +499,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 97,
     "source": "geojson",
     "state": {}
   },
@@ -477,6 +513,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 96,
     "source": "geojson",
     "state": {}
   },
@@ -490,6 +527,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 95,
     "source": "geojson",
     "state": {}
   },
@@ -503,6 +541,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 94,
     "source": "geojson",
     "state": {}
   },
@@ -516,6 +555,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 93,
     "source": "geojson",
     "state": {}
   },
@@ -529,6 +569,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 86,
     "source": "geojson",
     "state": {}
   },
@@ -542,6 +583,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 85,
     "source": "geojson",
     "state": {}
   },
@@ -555,6 +597,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 84,
     "source": "geojson",
     "state": {}
   },
@@ -568,6 +611,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 83,
     "source": "geojson",
     "state": {}
   },
@@ -581,6 +625,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 82,
     "source": "geojson",
     "state": {}
   },
@@ -594,6 +639,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 75,
     "source": "geojson",
     "state": {}
   },
@@ -607,6 +653,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 74,
     "source": "geojson",
     "state": {}
   },
@@ -620,6 +667,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 73,
     "source": "geojson",
     "state": {}
   },
@@ -633,6 +681,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 72,
     "source": "geojson",
     "state": {}
   },
@@ -646,6 +695,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 71,
     "source": "geojson",
     "state": {}
   },
@@ -659,6 +709,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 64,
     "source": "geojson",
     "state": {}
   },
@@ -672,6 +723,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 63,
     "source": "geojson",
     "state": {}
   },
@@ -685,6 +737,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 62,
     "source": "geojson",
     "state": {}
   },
@@ -698,6 +751,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 61,
     "source": "geojson",
     "state": {}
   },
@@ -711,6 +765,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 60,
     "source": "geojson",
     "state": {}
   },
@@ -724,6 +779,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 48,
     "source": "geojson",
     "state": {}
   },
@@ -737,6 +793,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 47,
     "source": "geojson",
     "state": {}
   },
@@ -750,6 +807,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 46,
     "source": "geojson",
     "state": {}
   },
@@ -763,6 +821,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 45,
     "source": "geojson",
     "state": {}
   },
@@ -776,6 +835,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 44,
     "source": "geojson",
     "state": {}
   },
@@ -789,6 +849,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 43,
     "source": "geojson",
     "state": {}
   },
@@ -802,6 +863,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 37,
     "source": "geojson",
     "state": {}
   },
@@ -815,6 +877,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 36,
     "source": "geojson",
     "state": {}
   },
@@ -828,6 +891,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 35,
     "source": "geojson",
     "state": {}
   },
@@ -841,6 +905,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 34,
     "source": "geojson",
     "state": {}
   },
@@ -854,6 +919,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 33,
     "source": "geojson",
     "state": {}
   },
@@ -867,6 +933,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 32,
     "source": "geojson",
     "state": {}
   },
@@ -880,6 +947,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 26,
     "source": "geojson",
     "state": {}
   },
@@ -893,6 +961,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 25,
     "source": "geojson",
     "state": {}
   },
@@ -906,6 +975,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 24,
     "source": "geojson",
     "state": {}
   },
@@ -919,6 +989,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 23,
     "source": "geojson",
     "state": {}
   },
@@ -932,6 +1003,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 22,
     "source": "geojson",
     "state": {}
   },
@@ -945,6 +1017,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 21,
     "source": "geojson",
     "state": {}
   },
@@ -958,6 +1031,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 15,
     "source": "geojson",
     "state": {}
   },
@@ -971,6 +1045,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 14,
     "source": "geojson",
     "state": {}
   },
@@ -984,6 +1059,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 13,
     "source": "geojson",
     "state": {}
   },
@@ -997,6 +1073,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 12,
     "source": "geojson",
     "state": {}
   },
@@ -1010,6 +1087,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 119,
     "source": "geojson",
     "state": {}
   },
@@ -1023,6 +1101,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 11,
     "source": "geojson",
     "state": {}
   },
@@ -1036,6 +1115,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 5,
     "source": "geojson",
     "state": {}
   },
@@ -1049,6 +1129,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 4,
     "source": "geojson",
     "state": {}
   },
@@ -1062,6 +1143,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 3,
     "source": "geojson",
     "state": {}
   },
@@ -1075,6 +1157,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 2,
     "source": "geojson",
     "state": {}
   },
@@ -1088,6 +1171,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 1,
     "source": "geojson",
     "state": {}
   },
@@ -1101,6 +1185,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 121,
     "source": "geojson",
     "state": {}
   },
@@ -1114,6 +1199,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 114,
     "source": "geojson",
     "state": {}
   },
@@ -1127,6 +1213,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 113,
     "source": "geojson",
     "state": {}
   },
@@ -1140,6 +1227,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 112,
     "source": "geojson",
     "state": {}
   },
@@ -1153,6 +1241,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 111,
     "source": "geojson",
     "state": {}
   },
@@ -1166,6 +1255,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 110,
     "source": "geojson",
     "state": {}
   },
@@ -1179,6 +1269,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 109,
     "source": "geojson",
     "state": {}
   },
@@ -1192,6 +1283,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 103,
     "source": "geojson",
     "state": {}
   },
@@ -1205,6 +1297,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 102,
     "source": "geojson",
     "state": {}
   },
@@ -1218,6 +1311,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 101,
     "source": "geojson",
     "state": {}
   },
@@ -1231,6 +1325,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 100,
     "source": "geojson",
     "state": {}
   },
@@ -1244,6 +1339,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 99,
     "source": "geojson",
     "state": {}
   },
@@ -1257,6 +1353,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 98,
     "source": "geojson",
     "state": {}
   },
@@ -1270,6 +1367,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 92,
     "source": "geojson",
     "state": {}
   },
@@ -1283,6 +1381,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 91,
     "source": "geojson",
     "state": {}
   },
@@ -1296,6 +1395,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 90,
     "source": "geojson",
     "state": {}
   },
@@ -1309,6 +1409,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 89,
     "source": "geojson",
     "state": {}
   },
@@ -1322,6 +1423,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 88,
     "source": "geojson",
     "state": {}
   },
@@ -1335,6 +1437,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 87,
     "source": "geojson",
     "state": {}
   },
@@ -1348,6 +1451,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 81,
     "source": "geojson",
     "state": {}
   },
@@ -1361,6 +1465,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 80,
     "source": "geojson",
     "state": {}
   },
@@ -1374,6 +1479,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 79,
     "source": "geojson",
     "state": {}
   },
@@ -1387,6 +1493,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 78,
     "source": "geojson",
     "state": {}
   },
@@ -1400,6 +1507,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 77,
     "source": "geojson",
     "state": {}
   },
@@ -1413,6 +1521,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 76,
     "source": "geojson",
     "state": {}
   },
@@ -1426,6 +1535,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 70,
     "source": "geojson",
     "state": {}
   },
@@ -1439,6 +1549,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 69,
     "source": "geojson",
     "state": {}
   },
@@ -1452,6 +1563,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 68,
     "source": "geojson",
     "state": {}
   },
@@ -1465,6 +1577,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 67,
     "source": "geojson",
     "state": {}
   },
@@ -1478,6 +1591,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 66,
     "source": "geojson",
     "state": {}
   },
@@ -1491,6 +1605,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 65,
     "source": "geojson",
     "state": {}
   },
@@ -1504,6 +1619,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 59,
     "source": "geojson",
     "state": {}
   },
@@ -1517,6 +1633,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 58,
     "source": "geojson",
     "state": {}
   },
@@ -1530,6 +1647,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 57,
     "source": "geojson",
     "state": {}
   },
@@ -1543,6 +1661,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 56,
     "source": "geojson",
     "state": {}
   },
@@ -1556,6 +1675,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 55,
     "source": "geojson",
     "state": {}
   },
@@ -1569,6 +1689,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 54,
     "source": "geojson",
     "state": {}
   }

--- a/test/integration/query-tests/symbol/rotated-after-insert/expected.json
+++ b/test/integration/query-tests/symbol/rotated-after-insert/expected.json
@@ -9,6 +9,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 53,
     "source": "geojson",
     "state": {}
   },
@@ -22,6 +23,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 52,
     "source": "geojson",
     "state": {}
   },
@@ -35,6 +37,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 51,
     "source": "geojson",
     "state": {}
   },
@@ -48,6 +51,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 50,
     "source": "geojson",
     "state": {}
   },
@@ -61,6 +65,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 49,
     "source": "geojson",
     "state": {}
   },
@@ -74,6 +79,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 42,
     "source": "geojson",
     "state": {}
   },
@@ -87,6 +93,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 41,
     "source": "geojson",
     "state": {}
   },
@@ -100,6 +107,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 40,
     "source": "geojson",
     "state": {}
   },
@@ -113,6 +121,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 39,
     "source": "geojson",
     "state": {}
   },
@@ -126,6 +135,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 38,
     "source": "geojson",
     "state": {}
   },
@@ -139,6 +149,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 31,
     "source": "geojson",
     "state": {}
   },
@@ -152,6 +163,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 30,
     "source": "geojson",
     "state": {}
   },
@@ -165,6 +177,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 29,
     "source": "geojson",
     "state": {}
   },
@@ -178,6 +191,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 28,
     "source": "geojson",
     "state": {}
   },
@@ -191,6 +205,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 27,
     "source": "geojson",
     "state": {}
   },
@@ -204,6 +219,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 20,
     "source": "geojson",
     "state": {}
   },
@@ -217,6 +233,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 19,
     "source": "geojson",
     "state": {}
   },
@@ -230,6 +247,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 18,
     "source": "geojson",
     "state": {}
   },
@@ -243,6 +261,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 17,
     "source": "geojson",
     "state": {}
   },
@@ -256,6 +275,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 16,
     "source": "geojson",
     "state": {}
   },
@@ -269,6 +289,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 10,
     "source": "geojson",
     "state": {}
   },
@@ -282,6 +303,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 9,
     "source": "geojson",
     "state": {}
   },
@@ -295,6 +317,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 8,
     "source": "geojson",
     "state": {}
   },
@@ -308,6 +331,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 7,
     "source": "geojson",
     "state": {}
   },
@@ -321,6 +345,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 6,
     "source": "geojson",
     "state": {}
   },
@@ -334,6 +359,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 119,
     "source": "geojson",
     "state": {}
   },
@@ -347,6 +373,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 118,
     "source": "geojson",
     "state": {}
   },
@@ -360,6 +387,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 117,
     "source": "geojson",
     "state": {}
   },
@@ -373,6 +401,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 116,
     "source": "geojson",
     "state": {}
   },
@@ -386,6 +415,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 115,
     "source": "geojson",
     "state": {}
   },
@@ -399,6 +429,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 108,
     "source": "geojson",
     "state": {}
   },
@@ -412,6 +443,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 107,
     "source": "geojson",
     "state": {}
   },
@@ -425,6 +457,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 106,
     "source": "geojson",
     "state": {}
   },
@@ -438,6 +471,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 105,
     "source": "geojson",
     "state": {}
   },
@@ -451,6 +485,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 104,
     "source": "geojson",
     "state": {}
   },
@@ -464,6 +499,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 97,
     "source": "geojson",
     "state": {}
   },
@@ -477,6 +513,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 96,
     "source": "geojson",
     "state": {}
   },
@@ -490,6 +527,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 95,
     "source": "geojson",
     "state": {}
   },
@@ -503,6 +541,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 94,
     "source": "geojson",
     "state": {}
   },
@@ -516,6 +555,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 93,
     "source": "geojson",
     "state": {}
   },
@@ -529,6 +569,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 86,
     "source": "geojson",
     "state": {}
   },
@@ -542,6 +583,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 85,
     "source": "geojson",
     "state": {}
   },
@@ -555,6 +597,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 84,
     "source": "geojson",
     "state": {}
   },
@@ -568,6 +611,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 83,
     "source": "geojson",
     "state": {}
   },
@@ -581,6 +625,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 82,
     "source": "geojson",
     "state": {}
   },
@@ -594,6 +639,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 75,
     "source": "geojson",
     "state": {}
   },
@@ -607,6 +653,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 74,
     "source": "geojson",
     "state": {}
   },
@@ -620,6 +667,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 73,
     "source": "geojson",
     "state": {}
   },
@@ -633,6 +681,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 72,
     "source": "geojson",
     "state": {}
   },
@@ -646,6 +695,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 71,
     "source": "geojson",
     "state": {}
   },
@@ -659,6 +709,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 64,
     "source": "geojson",
     "state": {}
   },
@@ -672,6 +723,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 63,
     "source": "geojson",
     "state": {}
   },
@@ -685,6 +737,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 62,
     "source": "geojson",
     "state": {}
   },
@@ -698,6 +751,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 61,
     "source": "geojson",
     "state": {}
   },
@@ -711,6 +765,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 60,
     "source": "geojson",
     "state": {}
   },
@@ -724,6 +779,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 48,
     "source": "geojson",
     "state": {}
   },
@@ -737,6 +793,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 47,
     "source": "geojson",
     "state": {}
   },
@@ -750,6 +807,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 46,
     "source": "geojson",
     "state": {}
   },
@@ -763,6 +821,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 45,
     "source": "geojson",
     "state": {}
   },
@@ -776,6 +835,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 44,
     "source": "geojson",
     "state": {}
   },
@@ -789,6 +849,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 43,
     "source": "geojson",
     "state": {}
   },
@@ -802,6 +863,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 37,
     "source": "geojson",
     "state": {}
   },
@@ -815,6 +877,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 36,
     "source": "geojson",
     "state": {}
   },
@@ -828,6 +891,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 35,
     "source": "geojson",
     "state": {}
   },
@@ -841,6 +905,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 34,
     "source": "geojson",
     "state": {}
   },
@@ -854,6 +919,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 33,
     "source": "geojson",
     "state": {}
   },
@@ -867,6 +933,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 32,
     "source": "geojson",
     "state": {}
   },
@@ -880,6 +947,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 26,
     "source": "geojson",
     "state": {}
   },
@@ -893,6 +961,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 25,
     "source": "geojson",
     "state": {}
   },
@@ -906,6 +975,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 24,
     "source": "geojson",
     "state": {}
   },
@@ -919,6 +989,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 23,
     "source": "geojson",
     "state": {}
   },
@@ -932,6 +1003,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 22,
     "source": "geojson",
     "state": {}
   },
@@ -945,6 +1017,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 21,
     "source": "geojson",
     "state": {}
   },
@@ -958,6 +1031,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 15,
     "source": "geojson",
     "state": {}
   },
@@ -971,6 +1045,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 14,
     "source": "geojson",
     "state": {}
   },
@@ -984,6 +1059,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 13,
     "source": "geojson",
     "state": {}
   },
@@ -997,6 +1073,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 12,
     "source": "geojson",
     "state": {}
   },
@@ -1010,6 +1087,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 119,
     "source": "geojson",
     "state": {}
   },
@@ -1023,6 +1101,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 11,
     "source": "geojson",
     "state": {}
   },
@@ -1036,6 +1115,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 5,
     "source": "geojson",
     "state": {}
   },
@@ -1049,6 +1129,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 4,
     "source": "geojson",
     "state": {}
   },
@@ -1062,6 +1143,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 3,
     "source": "geojson",
     "state": {}
   },
@@ -1075,6 +1157,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 2,
     "source": "geojson",
     "state": {}
   },
@@ -1088,6 +1171,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 1,
     "source": "geojson",
     "state": {}
   },
@@ -1101,6 +1185,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 121,
     "source": "geojson",
     "state": {}
   },
@@ -1114,6 +1199,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 114,
     "source": "geojson",
     "state": {}
   },
@@ -1127,6 +1213,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 113,
     "source": "geojson",
     "state": {}
   },
@@ -1140,6 +1227,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 112,
     "source": "geojson",
     "state": {}
   },
@@ -1153,6 +1241,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 111,
     "source": "geojson",
     "state": {}
   },
@@ -1166,6 +1255,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 110,
     "source": "geojson",
     "state": {}
   },
@@ -1179,6 +1269,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 109,
     "source": "geojson",
     "state": {}
   },
@@ -1192,6 +1283,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 103,
     "source": "geojson",
     "state": {}
   },
@@ -1205,6 +1297,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 102,
     "source": "geojson",
     "state": {}
   },
@@ -1218,6 +1311,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 101,
     "source": "geojson",
     "state": {}
   },
@@ -1231,6 +1325,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 100,
     "source": "geojson",
     "state": {}
   },
@@ -1244,6 +1339,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 99,
     "source": "geojson",
     "state": {}
   },
@@ -1257,6 +1353,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 98,
     "source": "geojson",
     "state": {}
   },
@@ -1270,6 +1367,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 92,
     "source": "geojson",
     "state": {}
   },
@@ -1283,6 +1381,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 91,
     "source": "geojson",
     "state": {}
   },
@@ -1296,6 +1395,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 90,
     "source": "geojson",
     "state": {}
   },
@@ -1309,6 +1409,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 89,
     "source": "geojson",
     "state": {}
   },
@@ -1322,6 +1423,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 88,
     "source": "geojson",
     "state": {}
   },
@@ -1335,6 +1437,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 87,
     "source": "geojson",
     "state": {}
   },
@@ -1348,6 +1451,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 81,
     "source": "geojson",
     "state": {}
   },
@@ -1361,6 +1465,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 80,
     "source": "geojson",
     "state": {}
   },
@@ -1374,6 +1479,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 79,
     "source": "geojson",
     "state": {}
   },
@@ -1387,6 +1493,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 78,
     "source": "geojson",
     "state": {}
   },
@@ -1400,6 +1507,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 77,
     "source": "geojson",
     "state": {}
   },
@@ -1413,6 +1521,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 76,
     "source": "geojson",
     "state": {}
   },
@@ -1426,6 +1535,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 70,
     "source": "geojson",
     "state": {}
   },
@@ -1439,6 +1549,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 69,
     "source": "geojson",
     "state": {}
   },
@@ -1452,6 +1563,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 68,
     "source": "geojson",
     "state": {}
   },
@@ -1465,6 +1577,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 67,
     "source": "geojson",
     "state": {}
   },
@@ -1478,6 +1591,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 66,
     "source": "geojson",
     "state": {}
   },
@@ -1491,6 +1605,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 65,
     "source": "geojson",
     "state": {}
   },
@@ -1504,6 +1619,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 59,
     "source": "geojson",
     "state": {}
   },
@@ -1517,6 +1633,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 58,
     "source": "geojson",
     "state": {}
   },
@@ -1530,6 +1647,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 57,
     "source": "geojson",
     "state": {}
   },
@@ -1543,6 +1661,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 56,
     "source": "geojson",
     "state": {}
   },
@@ -1556,6 +1675,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 55,
     "source": "geojson",
     "state": {}
   },
@@ -1569,6 +1689,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 54,
     "source": "geojson",
     "state": {}
   }

--- a/test/integration/query-tests/symbol/rotated-sort/expected.json
+++ b/test/integration/query-tests/symbol/rotated-sort/expected.json
@@ -9,6 +9,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 6,
     "source": "geojson",
     "state": {}
   },
@@ -22,6 +23,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 7,
     "source": "geojson",
     "state": {}
   },
@@ -35,6 +37,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 16,
     "source": "geojson",
     "state": {}
   },
@@ -48,6 +51,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 8,
     "source": "geojson",
     "state": {}
   },
@@ -61,6 +65,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 17,
     "source": "geojson",
     "state": {}
   },
@@ -74,6 +79,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 27,
     "source": "geojson",
     "state": {}
   },
@@ -87,6 +93,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 18,
     "source": "geojson",
     "state": {}
   },
@@ -100,6 +107,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 28,
     "source": "geojson",
     "state": {}
   },
@@ -113,6 +121,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 38,
     "source": "geojson",
     "state": {}
   },
@@ -126,32 +135,7 @@
     },
     "type": "Feature",
     "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        -4.998779296875,
-        4.997922089609858
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        -3.9990234375,
-        4.001260305845264
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
+    "id": 9,
     "source": "geojson",
     "state": {}
   },
@@ -165,6 +149,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 29,
     "source": "geojson",
     "state": {}
   },
@@ -178,6 +163,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 39,
     "source": "geojson",
     "state": {}
   },
@@ -191,6 +177,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 49,
     "source": "geojson",
     "state": {}
   },
@@ -198,12 +185,13 @@
     "geometry": {
       "type": "Point",
       "coordinates": [
-        -1.99951171875,
-        2.9978987411030573
+        -4.998779296875,
+        4.997922089609858
       ]
     },
     "type": "Feature",
     "properties": {},
+    "id": 10,
     "source": "geojson",
     "state": {}
   },
@@ -211,12 +199,13 @@
     "geometry": {
       "type": "Point",
       "coordinates": [
-        -0.999755859375,
-        1.9991059831233287
+        -3.9990234375,
+        4.001260305845264
       ]
     },
     "type": "Feature",
     "properties": {},
+    "id": 19,
     "source": "geojson",
     "state": {}
   },
@@ -230,6 +219,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 20,
     "source": "geojson",
     "state": {}
   },
@@ -243,6 +233,35 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 30,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 40,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        1.9991059831233287
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 50,
     "source": "geojson",
     "state": {}
   },
@@ -256,6 +275,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 51,
     "source": "geojson",
     "state": {}
   },
@@ -269,6 +289,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 31,
     "source": "geojson",
     "state": {}
   },
@@ -282,6 +303,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 41,
     "source": "geojson",
     "state": {}
   },
@@ -295,6 +317,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 42,
     "source": "geojson",
     "state": {}
   },
@@ -308,6 +331,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 52,
     "source": "geojson",
     "state": {}
   },
@@ -321,6 +345,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 53,
     "source": "geojson",
     "state": {}
   },
@@ -334,6 +359,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 60,
     "source": "geojson",
     "state": {}
   },
@@ -347,6 +373,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 61,
     "source": "geojson",
     "state": {}
   },
@@ -360,6 +387,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 71,
     "source": "geojson",
     "state": {}
   },
@@ -373,6 +401,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 62,
     "source": "geojson",
     "state": {}
   },
@@ -386,6 +415,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 72,
     "source": "geojson",
     "state": {}
   },
@@ -399,19 +429,7 @@
     },
     "type": "Feature",
     "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        0,
-        4.001260305845264
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
+    "id": 82,
     "source": "geojson",
     "state": {}
   },
@@ -425,6 +443,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 73,
     "source": "geojson",
     "state": {}
   },
@@ -438,6 +457,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 83,
     "source": "geojson",
     "state": {}
   },
@@ -451,6 +471,21 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 93,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 63,
     "source": "geojson",
     "state": {}
   },
@@ -464,6 +499,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 84,
     "source": "geojson",
     "state": {}
   },
@@ -477,6 +513,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 94,
     "source": "geojson",
     "state": {}
   },
@@ -490,6 +527,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 104,
     "source": "geojson",
     "state": {}
   },
@@ -503,6 +541,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 64,
     "source": "geojson",
     "state": {}
   },
@@ -516,6 +555,35 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 74,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 75,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 85,
     "source": "geojson",
     "state": {}
   },
@@ -529,6 +597,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 95,
     "source": "geojson",
     "state": {}
   },
@@ -542,6 +611,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 105,
     "source": "geojson",
     "state": {}
   },
@@ -555,58 +625,7 @@
     },
     "type": "Feature",
     "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        0.999755859375,
-        4.997922089609858
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        1.99951171875,
-        4.001260305845264
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        1.99951171875,
-        4.997922089609858
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        2.999267578125,
-        4.001260305845264
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
+    "id": 115,
     "source": "geojson",
     "state": {}
   },
@@ -620,6 +639,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 106,
     "source": "geojson",
     "state": {}
   },
@@ -633,6 +653,35 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 116,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        4.997922089609858
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 86,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        4.001260305845264
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 96,
     "source": "geojson",
     "state": {}
   },
@@ -646,6 +695,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 117,
     "source": "geojson",
     "state": {}
   },
@@ -659,6 +709,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 97,
     "source": "geojson",
     "state": {}
   },
@@ -672,6 +723,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 107,
     "source": "geojson",
     "state": {}
   },
@@ -685,6 +737,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 108,
     "source": "geojson",
     "state": {}
   },
@@ -698,6 +751,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 118,
     "source": "geojson",
     "state": {}
   },
@@ -711,6 +765,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 119,
     "source": "geojson",
     "state": {}
   },
@@ -724,6 +779,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 121,
     "source": "geojson",
     "state": {}
   },
@@ -737,6 +793,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 1,
     "source": "geojson",
     "state": {}
   },
@@ -750,6 +807,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 11,
     "source": "geojson",
     "state": {}
   },
@@ -763,6 +821,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 119,
     "source": "geojson",
     "state": {}
   },
@@ -776,6 +835,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 21,
     "source": "geojson",
     "state": {}
   },
@@ -789,6 +849,35 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 2,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -2.999267578125,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 22,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 32,
     "source": "geojson",
     "state": {}
   },
@@ -802,6 +891,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 3,
     "source": "geojson",
     "state": {}
   },
@@ -815,58 +905,7 @@
     },
     "type": "Feature",
     "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        -2.999267578125,
-        -4.00126030584525
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        -1.99951171875,
-        -4.997922089609844
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        -1.99951171875,
-        -4.00126030584525
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        -0.999755859375,
-        -4.997922089609844
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
+    "id": 12,
     "source": "geojson",
     "state": {}
   },
@@ -880,6 +919,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 4,
     "source": "geojson",
     "state": {}
   },
@@ -893,6 +933,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 13,
     "source": "geojson",
     "state": {}
   },
@@ -906,6 +947,35 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 23,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -1.99951171875,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 33,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.999755859375,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 43,
     "source": "geojson",
     "state": {}
   },
@@ -919,6 +989,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 44,
     "source": "geojson",
     "state": {}
   },
@@ -932,6 +1003,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 5,
     "source": "geojson",
     "state": {}
   },
@@ -945,6 +1017,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 14,
     "source": "geojson",
     "state": {}
   },
@@ -958,6 +1031,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 24,
     "source": "geojson",
     "state": {}
   },
@@ -971,6 +1045,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 34,
     "source": "geojson",
     "state": {}
   },
@@ -984,6 +1059,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 15,
     "source": "geojson",
     "state": {}
   },
@@ -997,6 +1073,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 25,
     "source": "geojson",
     "state": {}
   },
@@ -1010,6 +1087,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 35,
     "source": "geojson",
     "state": {}
   },
@@ -1023,6 +1101,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 45,
     "source": "geojson",
     "state": {}
   },
@@ -1036,6 +1115,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 26,
     "source": "geojson",
     "state": {}
   },
@@ -1049,6 +1129,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 36,
     "source": "geojson",
     "state": {}
   },
@@ -1062,6 +1143,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 46,
     "source": "geojson",
     "state": {}
   },
@@ -1075,6 +1157,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 37,
     "source": "geojson",
     "state": {}
   },
@@ -1088,6 +1171,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 47,
     "source": "geojson",
     "state": {}
   },
@@ -1101,6 +1185,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 48,
     "source": "geojson",
     "state": {}
   },
@@ -1114,6 +1199,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 54,
     "source": "geojson",
     "state": {}
   },
@@ -1127,6 +1213,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 55,
     "source": "geojson",
     "state": {}
   },
@@ -1140,6 +1227,35 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 65,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        -4.00126030584525
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 66,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 76,
     "source": "geojson",
     "state": {}
   },
@@ -1153,32 +1269,7 @@
     },
     "type": "Feature",
     "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        0.999755859375,
-        -4.00126030584525
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        1.99951171875,
-        -4.997922089609844
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
+    "id": 56,
     "source": "geojson",
     "state": {}
   },
@@ -1192,6 +1283,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 77,
     "source": "geojson",
     "state": {}
   },
@@ -1205,6 +1297,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 87,
     "source": "geojson",
     "state": {}
   },
@@ -1218,6 +1311,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 57,
     "source": "geojson",
     "state": {}
   },
@@ -1231,32 +1325,7 @@
     },
     "type": "Feature",
     "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        2.999267578125,
-        -4.00126030584525
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        3.9990234375,
-        -4.997922089609844
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
+    "id": 67,
     "source": "geojson",
     "state": {}
   },
@@ -1270,6 +1339,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 58,
     "source": "geojson",
     "state": {}
   },
@@ -1283,6 +1353,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 68,
     "source": "geojson",
     "state": {}
   },
@@ -1296,45 +1367,7 @@
     },
     "type": "Feature",
     "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        0,
-        0
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        0.999755859375,
-        -0.99970513084196
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
-    "source": "geojson",
-    "state": {}
-  },
-  {
-    "geometry": {
-      "type": "Point",
-      "coordinates": [
-        1.99951171875,
-        -1.9991059831233144
-      ]
-    },
-    "type": "Feature",
-    "properties": {},
+    "id": 78,
     "source": "geojson",
     "state": {}
   },
@@ -1343,11 +1376,26 @@
       "type": "Point",
       "coordinates": [
         2.999267578125,
-        -2.9978987411030573
+        -4.00126030584525
       ]
     },
     "type": "Feature",
     "properties": {},
+    "id": 88,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3.9990234375,
+        -4.997922089609844
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 98,
     "source": "geojson",
     "state": {}
   },
@@ -1361,6 +1409,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 99,
     "source": "geojson",
     "state": {}
   },
@@ -1374,6 +1423,63 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 109,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        0
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 59,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0.999755859375,
+        -0.99970513084196
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 69,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1.99951171875,
+        -1.9991059831233144
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 79,
+    "source": "geojson",
+    "state": {}
+  },
+  {
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2.999267578125,
+        -2.9978987411030573
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 89,
     "source": "geojson",
     "state": {}
   },
@@ -1387,6 +1493,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 110,
     "source": "geojson",
     "state": {}
   },
@@ -1400,6 +1507,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 70,
     "source": "geojson",
     "state": {}
   },
@@ -1413,6 +1521,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 80,
     "source": "geojson",
     "state": {}
   },
@@ -1426,6 +1535,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 90,
     "source": "geojson",
     "state": {}
   },
@@ -1439,6 +1549,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 100,
     "source": "geojson",
     "state": {}
   },
@@ -1452,6 +1563,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 81,
     "source": "geojson",
     "state": {}
   },
@@ -1465,6 +1577,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 91,
     "source": "geojson",
     "state": {}
   },
@@ -1478,6 +1591,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 101,
     "source": "geojson",
     "state": {}
   },
@@ -1491,6 +1605,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 111,
     "source": "geojson",
     "state": {}
   },
@@ -1504,6 +1619,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 92,
     "source": "geojson",
     "state": {}
   },
@@ -1517,6 +1633,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 102,
     "source": "geojson",
     "state": {}
   },
@@ -1530,6 +1647,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 112,
     "source": "geojson",
     "state": {}
   },
@@ -1543,6 +1661,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 103,
     "source": "geojson",
     "state": {}
   },
@@ -1556,6 +1675,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 113,
     "source": "geojson",
     "state": {}
   },
@@ -1569,6 +1689,7 @@
     },
     "type": "Feature",
     "properties": {},
+    "id": 114,
     "source": "geojson",
     "state": {}
   }


### PR DESCRIPTION
This PR basically just adds a symbol sorting test designed to catch https://github.com/mapbox/mapbox-gl-native/issues/12104. However, because of precision issues, I had to make a small change to get native and JS to have the same results for this (previously untested) case.

Our symbol sorting algorithm (only used for figuring out how to display overlapping symbols) is "sort by y-position first, and if the y-position is the same, sort by the order the underlying feature appeared in the data". Before, y-position could only be "the same" if it was _exactly_ the same, which meant that due to precision issues there could be small differences in order between gl-native and gl-js. This PR rounds to the nearest integer (in tile coordinates) to solve that problem.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [ ] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

/cc @julianrex @asheemmamoowala 