### PR TITLE
[WIP] fixes #6884 Option to only enable zooming by scrolling while holding ctrl

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -31,6 +31,7 @@ class ScrollZoomHandler {
     _map: Map;
     _el: HTMLElement;
     _enabled: boolean;
+    _ctrlEnabled: boolean;
     _active: boolean;
     _aroundCenter: boolean;
     _around: Point;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -95,6 +95,7 @@ class ScrollZoomHandler {
      * Enables the "scroll to zoom" interaction.
      *
      * @param {Object} [options]
+     * @param {string} [options.ctrl] If scrolling zooming should work while holding ctrl key
      * @param {string} [options.around] If "center" is passed, map will zoom around center of map
      *
      * @example
@@ -103,24 +104,29 @@ class ScrollZoomHandler {
      *  map.scrollZoom.enable({ around: 'center' })
      */
     enable(options: any) {
-        if (this.isEnabled()) return;
+        if (this.isEnabled() && this.isCtrlEnabled()) return;
+
         this._enabled = true;
+        this._ctrlEnabled = options && options.ctrl === true;
         this._aroundCenter = options && options.around === 'center';
     }
 
     /**
      * Disables the "scroll to zoom" interaction.
      *
+     * @param {boolean} [ctrlEnabled] Enables zooming with scrolling while holding the ctrl key.
+     *
      * @example
      *   map.scrollZoom.disable();
      */
-    disable() {
-        if (!this.isEnabled()) return;
+    disable(ctrlEnabled: boolean = false) {
+        if (!this.isEnabled() && !this.isCtrlEnabled() === ctrlEnabled) return;
         this._enabled = false;
+        this._ctrlEnabled = ctrlEnabled === true
     }
 
     onWheel(e: WheelEvent) {
-        if (!this.isEnabled()) return;
+        if (!this.isEnabled() && !this.isCtrlEnabled() && !e.ctrlKey) return;
 
         // Remove `any` cast when https://github.com/facebook/flow/issues/4879 is fixed.
         let value = e.deltaMode === (window.WheelEvent: any).DOM_DELTA_LINE ? e.deltaY * 40 : e.deltaY;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -107,7 +107,7 @@ class ScrollZoomHandler {
         if (this.isEnabled() && this.isCtrlEnabled()) return;
 
         this._enabled = true;
-        this._ctrlEnabled = options && options.ctrl !== false;
+        this._ctrlEnabled = !(options && options.ctrl === false);
         this._aroundCenter = options && options.around === 'center';
     }
 
@@ -122,7 +122,7 @@ class ScrollZoomHandler {
     disable(ctrlEnabled: boolean = false) {
         if (!this.isEnabled() && !this.isCtrlEnabled() === ctrlEnabled) return;
         this._enabled = false;
-        this._ctrlEnabled = ctrlEnabled === true
+        this._ctrlEnabled = ctrlEnabled === true;
     }
 
     onWheel(e: WheelEvent) {

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -78,6 +78,15 @@ class ScrollZoomHandler {
         return !!this._enabled;
     }
 
+    /**
+     * Returns a Boolean to indicate whether the "scroll with ctrl to zoom" interaction is enabled.
+     *
+     * @returns {boolean} `true` if the "scroll with ctrl to zoom" interaction is enabled.
+     */
+    isCtrlEnabled() {
+        return !!this._ctrlEnabled;
+    }
+
     isActive() {
         return !!this._active;
     }

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -107,7 +107,7 @@ class ScrollZoomHandler {
         if (this.isEnabled() && this.isCtrlEnabled()) return;
 
         this._enabled = true;
-        this._ctrlEnabled = options && options.ctrl === true;
+        this._ctrlEnabled = options && options.ctrl !== false;
         this._aroundCenter = options && options.around === 'center';
     }
 

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -104,9 +104,9 @@ class ScrollZoomHandler {
      *  map.scrollZoom.enable({ around: 'center' })
      */
     enable(options: any) {
-        if (this.isEnabled() && this.isCtrlEnabled()) return;
+        if (this.isEnabled()) return;
 
-        this._enabled = true;
+        this._enabled = !(options && options.ctrl === true);
         this._ctrlEnabled = !(options && options.ctrl === false);
         this._aroundCenter = options && options.around === 'center';
     }
@@ -114,19 +114,17 @@ class ScrollZoomHandler {
     /**
      * Disables the "scroll to zoom" interaction.
      *
-     * @param {boolean} [ctrlEnabled] Enables zooming with scrolling while holding the ctrl key.
-     *
      * @example
      *   map.scrollZoom.disable();
      */
-    disable(ctrlEnabled: boolean = false) {
-        if (!this.isEnabled() && !this.isCtrlEnabled() === ctrlEnabled) return;
+    disable() {
+        if (!this.isEnabled()) return;
         this._enabled = false;
-        this._ctrlEnabled = ctrlEnabled === true;
+        this._ctrlEnabled = false;
     }
 
     onWheel(e: WheelEvent) {
-        if (!this.isEnabled() && !this.isCtrlEnabled() && !e.ctrlKey) return;
+        if (!this.isEnabled() && !(this.isCtrlEnabled() && e.ctrlKey)) return;
 
         // Remove `any` cast when https://github.com/facebook/flow/issues/4879 is fixed.
         let value = e.deltaMode === (window.WheelEvent: any).DOM_DELTA_LINE ? e.deltaY * 40 : e.deltaY;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -95,7 +95,7 @@ class ScrollZoomHandler {
      * Enables the "scroll to zoom" interaction.
      *
      * @param {Object} [options]
-     * @param {string} [options.ctrl] If scrolling zooming should work while holding ctrl key
+     * @param {string} [options.ctrl] If scroll zooming should work while holding ctrl key
      * @param {string} [options.around] If "center" is passed, map will zoom around center of map
      *
      * @example
@@ -104,7 +104,7 @@ class ScrollZoomHandler {
      *  map.scrollZoom.enable({ around: 'center' })
      */
     enable(options: any) {
-        if (this.isEnabled()) return;
+        if (this.isEnabled() || this.isCtrlEnabled()) return;
 
         this._enabled = !(options && options.ctrl === true);
         this._ctrlEnabled = !(options && options.ctrl === false);
@@ -119,6 +119,7 @@ class ScrollZoomHandler {
      */
     disable() {
         if (!this.isEnabled()) return;
+
         this._enabled = false;
         this._ctrlEnabled = false;
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -67,6 +67,7 @@ type MapOptions = {
     refreshExpiredTiles?: boolean,
     maxBounds?: LngLatBoundsLike,
     scrollZoom?: boolean,
+    ctrlScrollZoom?: boolean,
     minZoom?: ?number,
     maxZoom?: ?number,
     boxZoom?: boolean,

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -67,7 +67,6 @@ type MapOptions = {
     refreshExpiredTiles?: boolean,
     maxBounds?: LngLatBoundsLike,
     scrollZoom?: boolean,
-    ctrlScrollZoom?: boolean,
     minZoom?: ?number,
     maxZoom?: ?number,
     boxZoom?: boolean,
@@ -184,7 +183,6 @@ const defaultOptions = {
  * @param {boolean} [options.refreshExpiredTiles=true] If `false`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
  * @param {LngLatBoundsLike} [options.maxBounds] If set, the map will be constrained to the given bounds.
  * @param {boolean|Object} [options.scrollZoom=true] If `true`, the "scroll to zoom" interaction is enabled. An `Object` value is passed as options to {@link ScrollZoomHandler#enable}.
- * @param {boolean} [options.ctrlScrollZoom] If set enables zooming with scrolling while holding the ctrl key, or pinching on the touchpad. The value set overrides the `ctrl` property of the object passed to `scrollZoom`.
  * @param {boolean} [options.boxZoom=true] If `true`, the "box zoom" interaction is enabled (see {@link BoxZoomHandler}).
  * @param {boolean} [options.dragRotate=true] If `true`, the "drag to rotate" interaction is enabled (see {@link DragRotateHandler}).
  * @param {boolean} [options.dragPan=true] If `true`, the "drag to pan" interaction is enabled (see {@link DragPanHandler}).

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -184,6 +184,7 @@ const defaultOptions = {
  * @param {boolean} [options.refreshExpiredTiles=true] If `false`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
  * @param {LngLatBoundsLike} [options.maxBounds] If set, the map will be constrained to the given bounds.
  * @param {boolean|Object} [options.scrollZoom=true] If `true`, the "scroll to zoom" interaction is enabled. An `Object` value is passed as options to {@link ScrollZoomHandler#enable}.
+ * @param {boolean} [options.ctrlScrollZoom] If set enables zooming with scrolling while holding the ctrl key, or pinching on the touchpad. The value set overrides the `ctrl` property of the object passed to `scrollZoom`.
  * @param {boolean} [options.boxZoom=true] If `true`, the "box zoom" interaction is enabled (see {@link BoxZoomHandler}).
  * @param {boolean} [options.dragRotate=true] If `true`, the "drag to rotate" interaction is enabled (see {@link DragRotateHandler}).
  * @param {boolean} [options.dragPan=true] If `true`, the "drag to pan" interaction is enabled (see {@link DragPanHandler}).

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -100,6 +100,7 @@ const defaultOptions = {
     interactive: true,
 
     scrollZoom: true,
+    ctrlScrollZoom: true,
     boxZoom: true,
     dragRotate: true,
     dragPan: true,

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -1,7 +1,7 @@
 import { test } from 'mapbox-gl-js-test';
 import browser from '../../../../src/util/browser';
 import window from '../../../../src/util/window';
-import { extend } from '../../../util/util';
+import { extend } from '../../../../util/util';
 import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -139,13 +139,13 @@ test('ScrollZoomHandler', (t) => {
         map._renderTaskQueue.run();
         const startZoom = map.getZoom();
         // Tick without ctrl key
-        simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta})
+        simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
         map._renderTaskQueue.run();
         // Tick with ctrl key
-        simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta, ctrlKey: true})
+        simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta, ctrlKey: true});
         map._renderTaskQueue.run();
 
-        now += 400
+        now += 400;
         map._renderTaskQueue.run();
 
         t.equalWithPrecision(map.getZoom() - startZoom,  0.0285, 0.001);

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -1,6 +1,7 @@
 import { test } from 'mapbox-gl-js-test';
 import browser from '../../../../src/util/browser';
 import window from '../../../../src/util/window';
+import { extend } from '../../../util/util';
 import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
@@ -125,6 +126,26 @@ test('ScrollZoomHandler', (t) => {
         map._renderTaskQueue.run();
 
         t.equal(map.getZoom(), 0);
+
+        map.remove();
+        t.end();
+    });
+
+    t.test('Still zooms with ctrl key pressed while scrolling if options set', (t) => {
+        const map = createMap(extend(t, { scrollZoom: { ctrl: true }}));
+
+        map._renderTaskQueue.run();
+        const startZoom = map.getZoom();
+        // Tick without ctrl key
+        simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta})
+        // Tick with ctrl key
+        simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta, ctrlKey: true})
+        map._renderTaskQueue.run();
+
+        now += 400
+        map._renderTaskQueue.run();
+
+        t.equalWithPrecision(map.getZoom() - startZoom,  0.0285, 0.001);
 
         map.remove();
         t.end();

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -1,21 +1,23 @@
 import { test } from 'mapbox-gl-js-test';
 import browser from '../../../../src/util/browser';
 import window from '../../../../src/util/window';
-import { extend } from '../../../../util/util';
+import { extend } from '../../../../src/util/util';
 import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
-function createMap(t) {
+function createMap(t, options = {}) {
     t.stub(Map.prototype, '_detectMissingCSS');
-    return new Map({
+    const defaultOptions = {
         container: DOM.create('div', '', window.document.body),
         style: {
             "version": 8,
             "sources": {},
             "layers": []
         }
-    });
+    };
+
+    return new Map(extend(defaultOptions, options));
 }
 
 test('ScrollZoomHandler', (t) => {
@@ -132,12 +134,13 @@ test('ScrollZoomHandler', (t) => {
     });
 
     t.test('Still zooms with ctrl key pressed while scrolling if options set', (t) => {
-        const map = createMap(extend(t, { scrollZoom: { ctrl: true }}));
+        const map = createMap(t, { scrollZoom: { ctrl: true }});
 
         map._renderTaskQueue.run();
         const startZoom = map.getZoom();
         // Tick without ctrl key
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta})
+        map._renderTaskQueue.run();
         // Tick with ctrl key
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta, ctrlKey: true})
         map._renderTaskQueue.run();


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes

Fixes #6884 

While enabling `ScrollZoomHandler`, if an option `Object` is passed, it'll look for the `ctrl` property which if set to `true`, will only allow zooming with scrolling while CTRL key is down.

Some TODO still left, did not want to write documentation until general acceptance.
