### PR TITLE
Add CameraForBoxAndBearing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master
+### ✨ Features and improvements
+* Add `Map#fitScreenCoordinates`: fits viewport to two points, similar to `Map#fitBounds` but uses screen coordinates and supports non-zero map bearings. ([#6894](https://github.com/mapbox/mapbox-gl-js/pull/6894))
+
+
 ## 0.47.0
 
 ## ✨ Features and improvements

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -11,8 +11,8 @@ import {
 } from '../util/util';
 import { number as interpolate } from '../style-spec/util/interpolate';
 import browser from '../util/browser';
-import LngLatBounds from '../geo/lng_lat_bounds';
 import LngLat from '../geo/lng_lat';
+import LngLatBounds from '../geo/lng_lat_bounds';
 import Point from '@mapbox/point-geometry';
 import { Event, Evented } from '../util/evented';
 

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -393,6 +393,7 @@ class Camera extends Evented {
      * @returns {CameraOptions | void} If map is able to fit to provided bounds, returns `CameraOptions` with
      *      at least `center`, `zoom`, `bearing`, `offset`, `padding`, and `maxZoom`, as well as any other
      *      `options` provided in arguments. If map is unable to fit, method will warn and return undefined.
+     * @private
      * @example
      * var p0 = [-79, 43];
      * var p1 = [-73, 45];
@@ -401,7 +402,7 @@ class Camera extends Evented {
      *   padding: {top: 10, bottom:25, left: 15, right: 5}
      * });
      */
-    cameraForBoxAndBearing(p0: LngLatLike, p1: LngLatLike, bearing: number, options?: CameraOptions): void | CameraOptions & AnimationOptions {
+    _cameraForBoxAndBearing(p0: LngLatLike, p1: LngLatLike, bearing: number, options?: CameraOptions): void | CameraOptions & AnimationOptions {
         options = extend({
             padding: {
                 top: 0,

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -375,7 +375,7 @@ class Camera extends Evented {
      */
     cameraForBounds(bounds: LngLatBoundsLike, options?: CameraOptions): void | CameraOptions & AnimationOptions {
         bounds = LngLatBounds.convert(bounds);
-        return this.cameraForBoxAndBearing(bounds.getNorthWest(), bounds.getSouthEast(), 0, options);
+        return this._cameraForBoxAndBearing(bounds.getNorthWest(), bounds.getSouthEast(), 0, options);
     }
 
     /**
@@ -398,7 +398,7 @@ class Camera extends Evented {
      * var p0 = [-79, 43];
      * var p1 = [-73, 45];
      * var bearing = 90;
-     * var newCameraTransform = map.cameraForBoxAndBearing(p0, p1, bearing, {
+     * var newCameraTransform = map._cameraForBoxAndBearing(p0, p1, bearing, {
      *   padding: {top: 10, bottom:25, left: 15, right: 5}
      * });
      */
@@ -536,7 +536,7 @@ class Camera extends Evented {
      */
     fitScreenCoordinates(p0: PointLike, p1: PointLike, bearing: number, options?: AnimationOptions & CameraOptions, eventData?: Object) {
         return this._fitInternal(
-            this.cameraForBoxAndBearing(
+            this._cameraForBoxAndBearing(
                 this.transform.pointLocation(Point.convert(p0)),
                 this.transform.pointLocation(Point.convert(p1)),
                 bearing,

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -2,7 +2,6 @@
 
 import DOM from '../../util/dom';
 
-import LngLatBounds from '../../geo/lng_lat_bounds';
 import { bindAll } from '../../util/util';
 import window from '../../util/window';
 import { Event } from '../../util/evented';
@@ -126,10 +125,7 @@ class BoxZoomHandler {
         if (e.button !== 0) return;
 
         const p0 = this._startPos,
-            p1 = DOM.mousePos(this._el, e),
-            bounds = new LngLatBounds()
-                .extend(this._map.unproject(p0))
-                .extend(this._map.unproject(p1));
+            p1 = DOM.mousePos(this._el, e);
 
         this._finish();
 
@@ -139,8 +135,8 @@ class BoxZoomHandler {
             this._fireEvent('boxzoomcancel', e);
         } else {
             this._map
-                .fitBounds(bounds, {linear: true})
-                .fire(new Event('boxzoomend', { originalEvent: e, boxZoomBounds: bounds }));
+                .fitScreenCoordinates(p0, p1, this._map.getBearing(), {linear: true})
+                .fire(new Event('boxzoomend', { originalEvent: e}));
         }
     }
 

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1737,5 +1737,50 @@ test('camera', (t) => {
         t.end();
     });
 
+    t.test('#fitScreenCoordinates', (t) => {
+        t.test('bearing 225', (t) => {
+            const camera = createCamera();
+            const p0 = [128, 128];
+            const p1 = [256, 256];
+            const bearing = 225;
+
+            camera.fitScreenCoordinates(p0, p1, bearing, {duration:0});
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), { lng: -45, lat: 40.9799 }, 'centers, rotates 225 degrees, and zooms based on screen coordinates');
+            t.equal(fixedNum(camera.getZoom(), 3), 1.5);
+            t.equal(camera.getBearing(), -135);
+            t.end();
+        });
+
+        t.test('bearing 0', (t) => {
+            const camera = createCamera();
+
+            const p0 = [128, 128];
+            const p1 = [256, 256];
+            const bearing = 0;
+
+            camera.fitScreenCoordinates(p0, p1, bearing, {duration:0});
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), { lng: -45, lat: 40.9799 }, 'centers and zooms in based on screen coordinates');
+            t.equal(fixedNum(camera.getZoom(), 3), 2);
+            t.equal(camera.getBearing(), 0);
+            t.end();
+        });
+
+        t.test('inverted points', (t) => {
+            const camera = createCamera();
+            const p1 = [128, 128];
+            const p0 = [256, 256];
+            const bearing = 0;
+
+            camera.fitScreenCoordinates(p0, p1, bearing, {duration:0});
+            t.deepEqual(fixedLngLat(camera.getCenter(), 4), { lng: -45, lat: 40.9799 }, 'centers and zooms based on screen coordinates in opposite order');
+            t.equal(fixedNum(camera.getZoom(), 3), 2);
+            t.equal(camera.getBearing(), 0);
+            t.end();
+        });
+
+        t.end();
+    });
+
+
     t.end();
 });


### PR DESCRIPTION
fixes https://github.com/mapbox/mapbox-gl-js/issues/4221

Working with @ChrisLoer on adding CameraForBoxAndBearing() and fitScreenCoordinates() to have box zoom behavior without reset map bearing. We tested this manually on the debug page and ran the unit and integration tests. Still working on tests for new functionality and documentation for changes. 

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
