### PR TITLE
update PULL_REQUEST_TEMPLATE.md noting when to use mb-pages as the base branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 <!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 
+<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->
+
  - [ ] briefly describe the changes in this PR
  - [ ] write tests for all new functionality
  - [ ] document any changes to public APIs


### PR DESCRIPTION
## Launch Checklist

It's recurring that PRs which should target `mb-pages` are targeting `master`, I suggest we add an extra note about this in the PR template.

 - [x] briefly describe the changes in this PR

ref #6887 #6903 #6657 and many others.