### PR TITLE
Better feature-state documentation in style-spec

### DIFF
--- a/flow-typed/style-spec.js
+++ b/flow-typed/style-spec.js
@@ -349,6 +349,7 @@ declare type RasterLayerSpecification = {|
         "raster-brightness-max"?: PropertyValueSpecification<number>,
         "raster-saturation"?: PropertyValueSpecification<number>,
         "raster-contrast"?: PropertyValueSpecification<number>,
+        "raster-resampling"?: PropertyValueSpecification<"linear" | "nearest">,
         "raster-fade-duration"?: PropertyValueSpecification<number>
     |}
 |}

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -563,7 +563,7 @@
     },
     "filter": {
       "type": "filter",
-      "doc": "A expression specifying conditions on source features. Only features that match the filter are displayed."
+      "doc": "A expression specifying conditions on source features. Only features that match the filter are displayed. The `feature-state` expression is not supported in filter expressions."
     },
     "layout": {
       "type": "layout",
@@ -3259,7 +3259,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3292,7 +3293,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3327,7 +3329,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3466,7 +3469,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3577,7 +3581,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3610,7 +3615,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3642,7 +3648,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3675,7 +3682,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3765,7 +3773,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3795,7 +3804,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3824,7 +3834,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3854,7 +3865,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3968,7 +3980,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -3996,7 +4009,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4024,7 +4038,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4054,7 +4069,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4202,7 +4218,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4230,7 +4247,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4260,7 +4278,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4292,7 +4311,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4321,7 +4341,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4445,7 +4466,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4476,7 +4498,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4507,7 +4530,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4540,7 +4564,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4573,7 +4598,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4670,7 +4696,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4701,7 +4728,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4732,7 +4760,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4765,7 +4794,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"
@@ -4798,7 +4828,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "feature"
+          "feature",
+          "feature-state"
         ]
       },
       "property-type": "data-driven"

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 type ExpressionType = 'data-driven' | 'cross-faded' | 'cross-faded-data-driven' | 'color-ramp' | 'data-constant' | 'constant';
-type ExpressionParameters = Array<'zoom' | 'feature' | 'heatmap-density' | 'line-progress'>;
+type ExpressionParameters = Array<'zoom' | 'feature' | 'feature-state' | 'heatmap-density' | 'line-progress'>;
 
 type ExpressionSpecification = {
     interpolated: boolean,

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -130,7 +130,7 @@ function validSchema(k, t, obj, ref, version, kind) {
             t.ok(ref['property-type'][obj['property-type']], `${k}.expression: property-type: ${obj['property-type']}`);
             t.equal('boolean', typeof expression.interpolated, `${k}.expression.interpolated.required (boolean)`);
             t.equal(true, Array.isArray(expression.parameters), `${k}.expression.parameters array`);
-            if (obj['property-type'] !== 'color-ramp') t.equal(true, expression.parameters.every(k => k === 'zoom' || k === 'feature'));
+            if (obj['property-type'] !== 'color-ramp') t.equal(true, expression.parameters.every(k => k === 'zoom' || k === 'feature' || k === 'feature-state'));
         }
 
         // schema key required checks


### PR DESCRIPTION
Closes #6724.

Add 'feature-state' as a known `ExpressionParameter` and document where the expression is valid. Specifically - this includes all data-driven paint properties. 

I also added a note that `feature-data` cannot be used with Filter expressions. 

Also includes flow type update for `raster-resampling`.

cc @jfirebaugh @samanpwbb 