### PR TITLE
Limit pitch to 60 degrees in render tests

### DIFF
--- a/test/integration/render-tests/circle-pitch-alignment/map-scale-map/style.json
+++ b/test/integration/render-tests/circle-pitch-alignment/map-scale-map/style.json
@@ -11,7 +11,7 @@
     0
   ],
   "zoom": 0,
-  "pitch": 90,
+  "pitch": 60,
   "sources": {
     "geojson": {
       "type": "geojson",

--- a/test/integration/render-tests/circle-pitch-alignment/map-scale-viewport/style.json
+++ b/test/integration/render-tests/circle-pitch-alignment/map-scale-viewport/style.json
@@ -11,7 +11,7 @@
     0
   ],
   "zoom": 0,
-  "pitch": 90,
+  "pitch": 60,
   "sources": {
     "geojson": {
       "type": "geojson",

--- a/test/integration/render-tests/circle-pitch-alignment/viewport-scale-map/style.json
+++ b/test/integration/render-tests/circle-pitch-alignment/viewport-scale-map/style.json
@@ -11,7 +11,7 @@
     0
   ],
   "zoom": 0,
-  "pitch": 90,
+  "pitch": 60,
   "sources": {
     "geojson": {
       "type": "geojson",

--- a/test/integration/render-tests/circle-pitch-alignment/viewport-scale-viewport/style.json
+++ b/test/integration/render-tests/circle-pitch-alignment/viewport-scale-viewport/style.json
@@ -11,7 +11,7 @@
     0
   ],
   "zoom": 0,
-  "pitch": 90,
+  "pitch": 60,
   "sources": {
     "geojson": {
       "type": "geojson",

--- a/test/integration/render-tests/circle-pitch-scale/default/style.json
+++ b/test/integration/render-tests/circle-pitch-scale/default/style.json
@@ -11,7 +11,7 @@
     0
   ],
   "zoom": 0,
-  "pitch": 90,
+  "pitch": 60,
   "sources": {
     "geojson": {
       "type": "geojson",

--- a/test/integration/render-tests/circle-pitch-scale/map/style.json
+++ b/test/integration/render-tests/circle-pitch-scale/map/style.json
@@ -11,7 +11,7 @@
     0
   ],
   "zoom": 0,
-  "pitch": 90,
+  "pitch": 60,
   "sources": {
     "geojson": {
       "type": "geojson",

--- a/test/integration/render-tests/circle-pitch-scale/viewport/style.json
+++ b/test/integration/render-tests/circle-pitch-scale/viewport/style.json
@@ -11,7 +11,7 @@
     0
   ],
   "zoom": 0,
-  "pitch": 90,
+  "pitch": 60,
   "sources": {
     "geojson": {
       "type": "geojson",

--- a/test/integration/render-tests/fill-extrusion-base/default/style.json
+++ b/test/integration/render-tests/fill-extrusion-base/default/style.json
@@ -136,7 +136,7 @@
       }
     }
   },
-  "pitch": 80,
+  "pitch": 60,
   "zoom": 18,
   "layers": [
     {

--- a/test/integration/render-tests/fill-extrusion-base/function/style.json
+++ b/test/integration/render-tests/fill-extrusion-base/function/style.json
@@ -136,7 +136,7 @@
       }
     }
   },
-  "pitch": 80,
+  "pitch": 60,
   "zoom": 18,
   "layers": [
     {

--- a/test/integration/render-tests/fill-extrusion-base/literal/style.json
+++ b/test/integration/render-tests/fill-extrusion-base/literal/style.json
@@ -136,7 +136,7 @@
       }
     }
   },
-  "pitch": 80,
+  "pitch": 60,
   "zoom": 18,
   "layers": [
     {

--- a/test/integration/render-tests/fill-extrusion-base/negative/style.json
+++ b/test/integration/render-tests/fill-extrusion-base/negative/style.json
@@ -136,7 +136,7 @@
       }
     }
   },
-  "pitch": 80,
+  "pitch": 60,
   "zoom": 18,
   "layers": [
     {

--- a/test/integration/render-tests/fill-extrusion-base/property-function/style.json
+++ b/test/integration/render-tests/fill-extrusion-base/property-function/style.json
@@ -136,7 +136,7 @@
       }
     }
   },
-  "pitch": 80,
+  "pitch": 60,
   "zoom": 18,
   "layers": [
     {

--- a/test/integration/render-tests/fill-extrusion-base/zoom-and-property-function/style.json
+++ b/test/integration/render-tests/fill-extrusion-base/zoom-and-property-function/style.json
@@ -136,7 +136,7 @@
       }
     }
   },
-  "pitch": 90,
+  "pitch": 60,
   "zoom": 18,
   "layers": [
     {

--- a/test/integration/render-tests/line-pattern/pitch/style.json
+++ b/test/integration/render-tests/line-pattern/pitch/style.json
@@ -10,7 +10,7 @@
     52.499167
   ],
   "zoom": 17,
-  "pitch": 90,
+  "pitch": 60,
   "sources": {
     "mapbox": {
       "type": "vector",

--- a/test/integration/render-tests/regressions/mapbox-gl-js#3548/style.json
+++ b/test/integration/render-tests/regressions/mapbox-gl-js#3548/style.json
@@ -153,7 +153,7 @@
       }
     }
   },
-  "pitch": 80,
+  "pitch": 60,
   "zoom": 18,
   "layers": [
     {


### PR DESCRIPTION
The maximum pitch between GL JS and GL native might differ, thus we now limit the maximum pitch to 60 degrees (GL JS maximum pitch) in render tests.

These changes shouldn't affect expectations, as it only modifies pitch values that were already > 60 degrees (and were clamped internally).

Ref: https://github.com/mapbox/mapbox-gl-native/pull/12310