### PR TITLE
set zoom guard, fixing illegal matrix errors

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -158,6 +158,7 @@ class Transform {
 
     get zoom(): number { return this._zoom; }
     set zoom(zoom: number) {
+        if (typeof zoom !== 'number' || !isFinite(zoom)) return;
         const z = Math.min(Math.max(zoom, this.minZoom), this.maxZoom);
         if (this._zoom === z) return;
         this._unmodified = false;


### PR DESCRIPTION
## Launch Checklist
 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes

No changes, no new functionality, just a guard to make sure that zoom cannot be set to NaN, and thus turn the map into a frozen state.

Detailed description about how can set zoom receive a NaN value:
https://github.com/mapbox/mapbox-gl-js/issues/6782

Those issues can be fixed in the future, if needed, but this one makes sure that the map never ends up in a broken "illegal matrix" state.