### PR TITLE
Adds warning to geolocate control when unsupported

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -259,7 +259,10 @@ class GeolocateControl extends Evented {
     }
 
     _setupUI(supported: boolean) {
-        if (supported === false) return;
+        if (supported === false) {
+            warnOnce('Geolocation not supported. The Mapbox geolocate control will not be rendered.');
+            return;
+        }
         this._container.addEventListener('contextmenu', (e: MouseEvent) => e.preventDefault());
         this._geolocateButton = DOM.create('button',
             `${className}-icon ${className}-geolocate`,

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -260,7 +260,7 @@ class GeolocateControl extends Evented {
 
     _setupUI(supported: boolean) {
         if (supported === false) {
-            warnOnce('Geolocation not supported. The Mapbox geolocate control will not be rendered.');
+            warnOnce('Geolocation support is not available, the GeolocateControl will not be visible.');
             return;
         }
         this._container.addEventListener('contextmenu', (e: MouseEvent) => e.preventDefault());


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes

This is a really basic pull request that adds a simple warning to the geolocate control when it's added to a map in a context that is unsupported.

Mainly submitting this because I couldn't figure out for the life of me why the control wasn't displaying, turns out I was serving the page over HTTP. Adding a warning informs the developer that this is indeed the expected behaviour. 