### PR TITLE
Support collators in feature filter expressions.

### DIFF
--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -28,7 +28,7 @@ function isExpressionFilter(filter: any) {
     case '>=':
     case '<':
     case '<=':
-        return filter.length === 3 && (Array.isArray(filter[1]) || Array.isArray(filter[2]));
+        return filter.length !== 3 || (Array.isArray(filter[1]) || Array.isArray(filter[2]));
 
     case 'any':
     case 'all':
@@ -153,4 +153,3 @@ function convertHasOp(property: string) {
 function convertNegation(filter: mixed) {
     return ['!', filter];
 }
-

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -24,6 +24,19 @@ test('filter', (t) => {
         t.end();
     });
 
+    t.test('expression, collator comparison', (t) => {
+        const caseSensitive = filter(['==', ['string', ['get', 'x']], ['string', ['get', 'y']], ['collator', { 'case-sensitive': true }]]);
+        t.equal(caseSensitive({zoom: 0}, {properties: {x: 'a', y: 'b'}}), false);
+        t.equal(caseSensitive({zoom: 0}, {properties: {x: 'a', y: 'A'}}), false);
+        t.equal(caseSensitive({zoom: 0}, {properties: {x: 'a', y: 'a'}}), true);
+
+        const caseInsensitive = filter(['==', ['string', ['get', 'x']], ['string', ['get', 'y']], ['collator', { 'case-sensitive': false }]]);
+        t.equal(caseInsensitive({zoom: 0}, {properties: {x: 'a', y: 'b'}}), false);
+        t.equal(caseInsensitive({zoom: 0}, {properties: {x: 'a', y: 'A'}}), true);
+        t.equal(caseInsensitive({zoom: 0}, {properties: {x: 'a', y: 'a'}}), true);
+        t.end();
+    });
+
     t.test('expression, any/all', (t) => {
         t.equal(filter(['all'])(), true);
         t.equal(filter(['all', true])(), true);
@@ -51,7 +64,6 @@ test('filter', (t) => {
 
         t.end();
     });
-
 
     t.test('degenerate', (t) => {
         t.equal(filter()(), true);

--- a/test/unit/style-spec/fixture/filters.output.json
+++ b/test/unit/style-spec/fixture/filters.output.json
@@ -12,11 +12,11 @@
     "line": 29
   },
   {
-    "message": "layers[3].filter: filter array for operator \"==\" must have 3 elements",
+    "message": "layers[3].filter: Expected two or three arguments.",
     "line": 40
   },
   {
-    "message": "layers[4].filter: filter array for operator \"==\" must have 3 elements",
+    "message": "layers[4].filter: Expected two or three arguments." ,
     "line": 47
   },
   {


### PR DESCRIPTION
Fixes issue #6920: feature filters using collator expressions would incorrectly be treated as legacy filters.

This was a pretty easy piece of functionality to miss when adding the `collator` expression, since it's separate from the rest of the expression code. Is there a way we could surface the legacy feature filter support more, or automatically test it against new expressions? Or is it reasonable to say this won't happen very often because most expression work won't overlap with the legacy filter syntax?

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [ ] ~~manually test the debug page~~
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

/cc @anandthakker @1ec5 