### PR TITLE
Upgrade geojson-vt to 3.1.4 (backport)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "csscolorparser": "~1.0.2",
     "earcut": "^2.1.3",
     "geojson-rewind": "^0.3.0",
-    "geojson-vt": "^3.1.2",
+    "geojson-vt": "^3.1.4",
     "gl-matrix": "^2.6.1",
     "gray-matter": "^3.0.8",
     "grid-index": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4369,9 +4369,9 @@ geojson-rewind@^0.3.0:
     concat-stream "~1.6.0"
     minimist "1.2.0"
 
-geojson-vt@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.1.2.tgz#ea98849bd7717979db4c86fed8ef4e47475e4bab"
+geojson-vt@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.1.4.tgz#c8ffefbe3613d3ad2747e963b0b63b9e62ff11b8"
 
 get-caller-file@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Backports #6938. github-release-tools created this branch but failed to submit a PR with some http error, so doing this manually.