### PR TITLE
popup: closeOnClick can be dynamic

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -95,9 +95,7 @@ export default class Popup extends Evented {
     addTo(map: Map) {
         this._map = map;
         this._map.on('move', this._update);
-        if (this.options.closeOnClick) {
-            this._map.on('click', this._onClickClose);
-        }
+        this._map.on('click', this._onClickClose);
         this._update();
 
         /**
@@ -321,7 +319,9 @@ export default class Popup extends Evented {
     }
 
     _onClickClose() {
-        this.remove();
+        if (this.options.closeOnClick) {
+            this.remove();
+        }
     }
 }
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -323,6 +323,15 @@ export default class Popup extends Evented {
             this.remove();
         }
     }
+
+    getCloseOnClick() {
+        return this.options.closeOnClick;
+    }
+
+    setCloseOnClick(val: boolean) {
+        this.options.closeOnClick = val;
+        return this;
+    }
 }
 
 function normalizeOffset(offset: ?Offset) {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -324,10 +324,21 @@ export default class Popup extends Evented {
         }
     }
 
+    /**
+     * Returns the closeOnClick option of the popup
+     *
+     * @returns {boolean} the closeOnClick option
+     */
     getCloseOnClick() {
         return this.options.closeOnClick;
     }
 
+    /**
+     * Sets the closeOnClick option of the popup
+     *
+     * @param val The closeOnClick option to set to the popup
+     * @returns {Popup} `this`
+     */
     setCloseOnClick(val: boolean) {
         this.options.closeOnClick = val;
         return this;

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -49,13 +49,16 @@ test('Popup options.closeOnClick can be dynamic', (t) => {
         .setLngLat([0, 0])
         .addTo(map);
 
+    // initial closeOnClick = true
+    t.ok(popup.getCloseOnClick());
+
     // set closeOnClick => false
-    popup.options.closeOnClick = false;
+    popup.setCloseOnClick(false);
     simulateClick(map.getCanvas());
     t.ok(popup.isOpen());
 
     // set closeOnClick => true
-    popup.options.closeOnClick = true;
+    popup.setCloseOnClick(true);
     simulateClick(map.getCanvas());
     t.ok(!popup.isOpen());
 

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -42,6 +42,26 @@ test('Popup closes on map click events by default', (t) => {
     t.end();
 });
 
+test('Popup options.closeOnClick can be dynamic', (t) => {
+    const map = createMap(t);
+    const popup = new Popup()
+        .setText("Test")
+        .setLngLat([0, 0])
+        .addTo(map);
+
+    // set closeOnClick => false
+    popup.options.closeOnClick = false;
+    simulateClick(map.getCanvas());
+    t.ok(popup.isOpen());
+
+    // set closeOnClick => true
+    popup.options.closeOnClick = true;
+    simulateClick(map.getCanvas());
+    t.ok(!popup.isOpen());
+
+    t.end();
+});
+
 test('Popup does not close on map click events when the closeOnClick option is false', (t) => {
     const map = createMap(t);
     const popup = new Popup({closeOnClick: false})


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes


## popup
get the `popup.options.closeOnClick` value when click happened. 
This makes the popup `closeOnClick` dynamic and can be changed later.
