### PR TITLE
release-drink backport: Add `symbol-placement: line-center` to symbol_style_layer_properties.

### DIFF
--- a/src/style/style_layer/symbol_style_layer_properties.js
+++ b/src/style/style_layer/symbol_style_layer_properties.js
@@ -15,7 +15,7 @@ import {
 import type Color from '../../style-spec/util/color';
 
 export type LayoutProps = {|
-    "symbol-placement": DataConstantProperty<"point" | "line">,
+    "symbol-placement": DataConstantProperty<"point" | "line" | "line-center">,
     "symbol-spacing": DataConstantProperty<number>,
     "symbol-avoid-edges": DataConstantProperty<boolean>,
     "icon-allow-overlap": DataConstantProperty<boolean>,


### PR DESCRIPTION
Backports #6943 to release-drink
----
Thanks @andrewharvey for pointing out I forgot to run `yarn run codegen` when updating the style spec to include `symbol-placement: line-center`. I believe the impact would have been flow warnings in some cases?

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [ ] ~~manually test the debug page~~
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

/cc @jfirebaugh 