### PR TITLE
Support two-argument shorthand for "match" expression

### DIFF
--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -144,6 +144,12 @@ const types = {
             'label_n: InputType | [InputType, InputType, ...], output_n: OutputType, ...',
             'default: OutputType'
         ]
+    }, {
+        type: 'boolean',
+        parameters: [
+            'input: InputType (number or string)',
+            'label: InputType'
+        ]
     }],
     var: [{
         type: 'the type of the bound expression',

--- a/src/style-spec/expression/definitions/match.js
+++ b/src/style-spec/expression/definitions/match.js
@@ -32,6 +32,8 @@ class Match implements Expression {
     }
 
     static parse(args: Array<mixed>, context: ParsingContext) {
+        if (args.length === 3)
+            args = args.concat(true, false);
         if (args.length < 5)
             return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`);
         if (args.length % 2 !== 1)

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2359,6 +2359,9 @@
             "android": "6.0.0",
             "ios": "4.0.0",
             "macos": "0.7.0"
+          },
+          "two-argument shorthand": {
+            "js": "0.48.0"
           }
         }
       },
@@ -2387,7 +2390,7 @@
         }
       },
       "match": {
-        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must either be a single literal value or an array of literal values (e.g. `\"a\"` or `[\"c\", \"b\"]`), and those values must be all strings or all numbers. (The values `\"1\"` and `1` cannot both be labels in the same match expression.) If the input type does not match the type of the labels, the result will be the fallback value.",
+        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must either be a single literal value or an array of literal values (e.g. `\"a\"` or `[\"c\", \"b\"]`), and those values must be all strings or all numbers. (The values `\"1\"` and `1` cannot both be labels in the same match expression.) If the input type does not match the type of the labels, the result will be the fallback value. A two-argument shorthand form is also supported, `[\"match\", input, label]`, which is equivalent to `[\"match\", input, label, true, false]`.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {

--- a/test/integration/expression-tests/match/arity-2/test.json
+++ b/test/integration/expression-tests/match/arity-2/test.json
@@ -1,12 +1,30 @@
 {
-  "expression": ["match", "x", "y"],
-  "inputs": [[{}, {}]],
+  "expression": ["match", ["get", "x"], [1, 2]],
+  "inputs": [
+    [{}, {"properties": {"x": 0}}],
+    [{}, {"properties": {"x": 1}}],
+    [{}, {"properties": {"x": 2}}],
+    [{}, {"properties": {"x": "1"}}]
+  ],
   "expected": {
     "compiled": {
-      "result": "error",
-      "errors": [
-        {"key": "", "error": "Expected at least 4 arguments, but found only 2."}
-      ]
-    }
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [
+      false,
+      true,
+      true,
+      false
+    ],
+    "serialized": [
+      "match",
+      ["get", "x"],
+      [1, 2],
+      true,
+      false
+    ]
   }
 }


### PR DESCRIPTION
Support two-argument shorthand for "match" expression. Fixes #6950.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] tagged @mapbox/studio and/or @mapbox/maps-design if this PR includes style spec changes
