### PR TITLE
replace deprecated filter syntax

### DIFF
--- a/docs/pages/example/cluster.html
+++ b/docs/pages/example/cluster.html
@@ -70,7 +70,7 @@ map.on('load', function() {
         id: "unclustered-point",
         type: "circle",
         source: "earthquakes",
-        filter: ["!has", "point_count"],
+        filter: ["!", ["has", "point_count"]],
         paint: {
             "circle-color": "#11b4da",
             "circle-radius": 4,


### PR DESCRIPTION
"!has" is deprecated and does not evaluate if mixed with the updated filter syntax.