### PR TITLE
Require feature id in Map#setFeatureState

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -794,6 +794,10 @@ class Style extends Evented {
             this.fire(new ErrorEvent(new Error(`The sourceLayer parameter must be provided for vector source types.`)));
             return;
         }
+        if (feature.id == null || feature.id === "") {
+            this.fire(new ErrorEvent(new Error(`The feature id parameter must be provided.`)));
+            return;
+        }
 
         sourceCache.setFeatureState(sourceLayer, feature.id, state);
     }

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1298,7 +1298,27 @@ test('Map', (t) => {
                 map.setFeatureState({ source: 'vector', sourceLayer: 0, id: '12345'}, {'hover': true});
             });
         });
-
+        t.test('fires an error if id not provided', (t) => {
+            const map = createMap(t, {
+                style: {
+                    "version": 8,
+                    "sources": {
+                        "vector": {
+                            "type": "vector",
+                            "tiles": ["http://example.com/{z}/{x}/{y}.png"]
+                        }
+                    },
+                    "layers": []
+                }
+            });
+            map.on('load', () => {
+                map.on('error', ({ error }) => {
+                    t.match(error.message, /id/);
+                    t.end();
+                });
+                map.setFeatureState({ source: 'vector', sourceLayer: "1"}, {'hover': true});
+            });
+        });
         t.end();
     });
 


### PR DESCRIPTION
`Map#setFeatureState` should validate the input feature identifier object for the `id` field, in addition to `source` and `sourceLayer`.
