### PR TITLE
[Geolocate control] Fix removing

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -129,7 +129,7 @@ class GeolocateControl extends Evented {
         }
 
         // clear the marker from the map
-        if (this.options.showUserLocation) {
+        if (this.options.showUserLocation && this._userLocationDotMarker) {
             this._userLocationDotMarker.remove();
         }
 


### PR DESCRIPTION
Fix removing of `Geolocate` control for situations when user denied location and `_setupUI` has not been called.

It fails in `onRemove`, because `this._userLocationDotMarker` is `undefined`.


Here is [demo video](https://drive.google.com/file/d/1qDkh01MX76JsBs4Oh5i7gzqSg2G4VwhO/view?usp=sharing) when user' location is **available**.

And here is [demo video](https://drive.google.com/file/d/1-7dF0xVBNMkm56IH785_rFML087qXx0J/view?usp=sharing) when user **denied** location tracking.

Here is [demo pen](https://codepen.io/sergei-zelinsky/pen/VBaRZv) which reproduces the bug.



