### PR TITLE
User turnstile event

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "glob": "^7.0.3",
     "in-publish": "^2.0.0",
     "is-builtin-module": "^1.0.0",
-    "jsdom": "^11.6.2",
+    "jsdom": "^11.11.0",
     "json-stringify-pretty-compact": "^1.0.4",
     "lodash": "^4.16.0",
     "mock-geolocation": "^1.0.11",

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -5,7 +5,7 @@ import { extend, pick } from '../util/util';
 import { getImage, ResourceType } from '../util/ajax';
 import { Event, ErrorEvent, Evented } from '../util/evented';
 import loadTileJSON from './load_tilejson';
-import { normalizeTileURL as normalizeURL } from '../util/mapbox';
+import { normalizeTileURL as normalizeURL, postTurnstileEvent } from '../util/mapbox';
 import TileBounds from './tile_bounds';
 import Texture from '../render/texture';
 
@@ -64,6 +64,8 @@ class RasterTileSource extends Evented implements Source {
             } else if (tileJSON) {
                 extend(this, tileJSON);
                 if (tileJSON.bounds) this.tileBounds = new TileBounds(tileJSON.bounds, this.minzoom, this.maxzoom);
+
+                postTurnstileEvent(tileJSON.tiles);
 
                 // `content` is included here to prevent a race condition where `Style#_updateSources` is called
                 // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -4,7 +4,7 @@ import { Event, ErrorEvent, Evented } from '../util/evented';
 
 import { extend, pick } from '../util/util';
 import loadTileJSON from './load_tilejson';
-import { normalizeTileURL as normalizeURL } from '../util/mapbox';
+import { normalizeTileURL as normalizeURL, postTurnstileEvent } from '../util/mapbox';
 import TileBounds from './tile_bounds';
 import { ResourceType } from '../util/ajax';
 import browser from '../util/browser';
@@ -71,6 +71,8 @@ class VectorTileSource extends Evented implements Source {
             } else if (tileJSON) {
                 extend(this, tileJSON);
                 if (tileJSON.bounds) this.tileBounds = new TileBounds(tileJSON.bounds, this.minzoom, this.maxzoom);
+
+                postTurnstileEvent(tileJSON.tiles);
 
                 // `content` is included here to prevent a race condition where `Style#_updateSources` is called
                 // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -134,11 +134,7 @@ export const postData = function(requestParameters: RequestParameters, payload: 
         if (xhr.status >= 200 && xhr.status < 300) {
             callback(null, xhr.response);
         } else {
-            if (xhr.status === 401 && requestParameters.url.match(/mapbox.com/)) {
-                callback(new AJAXError(`${xhr.statusText}: you may have provided an invalid Mapbox access token. See https://www.mapbox.com/api-documentation/#access-tokens`, xhr.status, requestParameters.url));
-            } else {
-                callback(new AJAXError(xhr.statusText, xhr.status, requestParameters.url));
-            }
+            callback(new AJAXError(xhr.statusText, xhr.status, requestParameters.url));
         }
     };
     xhr.send(payload);

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -37,6 +37,7 @@ if (typeof Object.freeze == 'function') {
 export type RequestParameters = {
     url: string,
     headers?: Object,
+    method?: 'GET' | 'POST' | 'PUT',
     credentials?: 'same-origin' | 'include',
     collectResourceTiming?: boolean
 };
@@ -62,7 +63,7 @@ class AJAXError extends Error {
 function makeRequest(requestParameters: RequestParameters): XMLHttpRequest {
     const xhr: XMLHttpRequest = new window.XMLHttpRequest();
 
-    xhr.open('GET', requestParameters.url, true);
+    xhr.open(requestParameters.method || 'GET', requestParameters.url, true);
     for (const k in requestParameters.headers) {
         xhr.setRequestHeader(k, requestParameters.headers[k]);
     }
@@ -119,6 +120,28 @@ export const getArrayBuffer = function(requestParameters: RequestParameters, cal
         }
     };
     xhr.send();
+    return { cancel: () => xhr.abort() };
+};
+
+export const postData = function(requestParameters: RequestParameters, payload: string, callback: Callback<mixed>): Cancelable {
+    requestParameters.method = 'POST';
+    const xhr = makeRequest(requestParameters);
+
+    xhr.onerror = function() {
+        callback(new Error(xhr.statusText));
+    };
+    xhr.onload = function() {
+        if (xhr.status >= 200 && xhr.status < 300) {
+            callback(null, xhr.response);
+        } else {
+            if (xhr.status === 401 && requestParameters.url.match(/mapbox.com/)) {
+                callback(new AJAXError(`${xhr.statusText}: you may have provided an invalid Mapbox access token. See https://www.mapbox.com/api-documentation/#access-tokens`, xhr.status, requestParameters.url));
+            } else {
+                callback(new AJAXError(xhr.statusText, xhr.status, requestParameters.url));
+            }
+        }
+    };
+    xhr.send(payload);
     return { cancel: () => xhr.abort() };
 };
 

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -1,6 +1,7 @@
 // @flow
 
 import window from './window';
+import { extend } from './util';
 
 import type { Callback } from '../types/callback';
 import type { Cancelable } from '../types/cancelable';
@@ -124,8 +125,7 @@ export const getArrayBuffer = function(requestParameters: RequestParameters, cal
 };
 
 export const postData = function(requestParameters: RequestParameters, payload: string, callback: Callback<mixed>): Cancelable {
-    requestParameters.method = 'POST';
-    const xhr = makeRequest(requestParameters);
+    const xhr = makeRequest(extend(requestParameters, {method: 'POST'}));
 
     xhr.onerror = function() {
         callback(new Error(xhr.statusText));

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -2,12 +2,14 @@
 
 type Config = {|
   API_URL: string,
+  EVENTS_URL: string,
   REQUIRE_ACCESS_TOKEN: boolean,
   ACCESS_TOKEN: ?string
 |};
 
 const config: Config = {
     API_URL: 'https://api.mapbox.com',
+    EVENTS_URL: 'https://events.mapbox.com/events/v2',
     REQUIRE_ACCESS_TOKEN: true,
     ACCESS_TOKEN: null
 };

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -134,7 +134,7 @@ export const postTurnstileEvent = function(tileUrls: Array<string>) {
     // mapbox tiles.
     if (!config.ACCESS_TOKEN ||
         !tileUrls ||
-        !tileUrls.some((url) => { return /mapbox.com/i.test(url); })) {
+        !tileUrls.some((url) => { return /mapbox.c(n)|(om)/i.test(url); })) {
         return;
     }
 

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -13,7 +13,6 @@ import type { Cancelable } from '../types/cancelable';
 
 const help = 'See https://www.mapbox.com/api-documentation/#access-tokens';
 const turnstileEventStorageKey = 'mapbox.turnstileEventData';
-const isLocalStorageAvailable = storageAvailable('localStorage');
 
 type UrlObject = {|
     protocol: string,
@@ -152,13 +151,14 @@ class TurnstileEvent {
             return;
         }
         const storageKey = `${turnstileEventStorageKey}:${config.ACCESS_TOKEN || ''}`;
-        let dueForEvent = (this.eventData.accessToken !== config.ACCESS_TOKEN);
+        const isLocalStorageAvailable = storageAvailable('localStorage');
+        let dueForEvent = this.eventData.accessToken ? (this.eventData.accessToken !== config.ACCESS_TOKEN) : false;
 
         //Reset event data cache if the access token changed.
         if (dueForEvent) {
             this.eventData.anonId = this.eventData.lastSuccess = null;
         }
-        if (!this.eventData.anonId || !this.eventData.lastSuccess &&
+        if ((!this.eventData.anonId || !this.eventData.lastSuccess) &&
             isLocalStorageAvailable) {
             //Retrieve cached data
             try {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -4,6 +4,7 @@ import UnitBezier from '@mapbox/unitbezier';
 
 import Coordinate from '../geo/coordinate';
 import Point from '@mapbox/point-geometry';
+import window from './window';
 
 import type {Callback} from '../types/callback';
 
@@ -194,6 +195,27 @@ let id = 1;
  */
 export function uniqueId(): number {
     return id++;
+}
+
+/**
+ * Return a random UUID (v4). Taken from: https://gist.github.com/jed/982883
+ */
+export function uuid(): string {
+    function b(a) {
+        return a ? (a ^ Math.random() * 16 >> a / 4).toString(16) :
+        //$FlowFixMe
+        ([1e7] + -[1e3] + -4e3 + -8e3 + -1e11).replace(/[018]/g, b);
+    }
+    return b();
+}
+
+/**
+ * Validate a string to match UUID(v4) of the
+ * form: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx
+ * @param str string to validate.
+ */
+export function validateUuid(str: ?string): boolean {
+    return str ? /^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(str) : false;
 }
 
 /**
@@ -439,4 +461,15 @@ export function parseCacheControl(cacheControl: string): Object {
     }
 
     return header;
+}
+
+export function storageAvailable(type: string): boolean {
+    try {
+        const storage = window[type];
+        storage.setItem('_mapbox_test_', 1);
+        storage.removeItem('_mapbox_test_');
+        return true;
+    } catch (e) {
+        return false;
+    }
 }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -203,7 +203,7 @@ export function uniqueId(): number {
 export function uuid(): string {
     function b(a) {
         return a ? (a ^ Math.random() * 16 >> a / 4).toString(16) :
-        //$FlowFixMe
+        //$FlowFixMe: Flow doesn't like the implied array literal conversion here
         ([1e7] + -[1e3] + -4e3 + -8e3 + -1e11).replace(/[018]/g, b);
     }
     return b();

--- a/test/ajax_stubs.js
+++ b/test/ajax_stubs.js
@@ -65,10 +65,8 @@ export const getArrayBuffer = function({ url }, callback) {
 };
 
 export const postData = function({ url }, payload, callback) {
-    if (cache[url]) return cached(cache[url], callback);
     return request.post(url, payload, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
-            cache[url] = {data: body};
             callback(null, {data: body});
         } else {
             callback(error || new Error(response.statusCode));

--- a/test/ajax_stubs.js
+++ b/test/ajax_stubs.js
@@ -64,6 +64,18 @@ export const getArrayBuffer = function({ url }, callback) {
     });
 };
 
+export const postData = function({ url }, payload, callback) {
+    if (cache[url]) return cached(cache[url], callback);
+    return request.post(url, payload, (error, response, body) => {
+        if (!error && response.statusCode >= 200 && response.statusCode < 300) {
+            cache[url] = {data: body};
+            callback(null, {data: body});
+        } else {
+            callback(error || new Error(response.statusCode));
+        }
+    });
+};
+
 export const getImage = function({ url }, callback) {
     if (cache[url]) return cached(cache[url], callback);
     return request({ url, encoding: null }, (error, response, body) => {

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -1,7 +1,8 @@
 import { test } from 'mapbox-gl-js-test';
 import {
     getArrayBuffer,
-    getJSON
+    getJSON,
+    postData
 } from '../../../src/util/ajax';
 import window from '../../../src/util/window';
 
@@ -90,6 +91,41 @@ test('ajax', (t) => {
             request.respond(401);
         });
         getJSON({ url:'api.mapbox.com' }, (error) => {
+            t.equal(error.status, 401);
+            t.equal(error.message, "Unauthorized: you may have provided an invalid Mapbox access token. See https://www.mapbox.com/api-documentation/#access-tokens");
+            t.end();
+        });
+        window.server.respond();
+    });
+
+    t.test('postData, 204(no content): no error', (t) => {
+        window.server.respondWith(request => {
+            request.respond(204);
+        });
+        postData({ url:'api.mapbox.com' }, {}, (error) => {
+            t.equal(error, null);
+            t.end();
+        });
+        window.server.respond();
+    });
+
+    t.test('postData, 401: non-Mapbox domain', (t) => {
+        window.server.respondWith(request => {
+            request.respond(401);
+        });
+        postData({ url:'' }, {}, (error) => {
+            t.equal(error.status, 401);
+            t.equal(error.message, "Unauthorized");
+            t.end();
+        });
+        window.server.respond();
+    });
+
+    t.test('postData, 401: Mapbox domain', (t) => {
+        window.server.respondWith(request => {
+            request.respond(401);
+        });
+        postData({ url:'api.mapbox.com' }, {}, (error) => {
             t.equal(error.status, 401);
             t.equal(error.message, "Unauthorized: you may have provided an invalid Mapbox access token. See https://www.mapbox.com/api-documentation/#access-tokens");
             t.end();

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -109,29 +109,5 @@ test('ajax', (t) => {
         window.server.respond();
     });
 
-    t.test('postData, 401: non-Mapbox domain', (t) => {
-        window.server.respondWith(request => {
-            request.respond(401);
-        });
-        postData({ url:'' }, {}, (error) => {
-            t.equal(error.status, 401);
-            t.equal(error.message, "Unauthorized");
-            t.end();
-        });
-        window.server.respond();
-    });
-
-    t.test('postData, 401: Mapbox domain', (t) => {
-        window.server.respondWith(request => {
-            request.respond(401);
-        });
-        postData({ url:'api.mapbox.com' }, {}, (error) => {
-            t.equal(error.status, 401);
-            t.equal(error.message, "Unauthorized: you may have provided an invalid Mapbox access token. See https://www.mapbox.com/api-documentation/#access-tokens");
-            t.end();
-        });
-        window.server.respond();
-    });
-
     t.end();
 });

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -284,6 +284,23 @@ test("mapbox", (t) => {
             callback();
         });
 
+        t.test('POSTs appuserTurnstile event', (t) => {
+            config.ACCESS_TOKEN = 'pk.*';
+
+            mapbox.postTurnstileEvent(['a.tiles.mapbox.com']);
+
+            const req = window.server.requests[0];
+            const reqBody = JSON.parse(req.requestBody)[0];
+            console.log(req.url);
+            t.equal(req.url, `${config.EVENTS_URL}?access_token=pk.*`);
+            t.equal(req.method, 'POST');
+            t.equal(reqBody.event, 'appUserTurnstile');
+            t.equal(reqBody.sdkVersion, version);
+            t.ok(reqBody.userId);
+
+            t.end();
+        });
+
         t.test('does not POST when mapboxgl.ACCESS_TOKEN is not set', (t) => {
             config.ACCESS_TOKEN = null;
 
@@ -296,26 +313,20 @@ test("mapbox", (t) => {
         t.test('does not POST when urls does not point to mapbox.com', (t) => {
             config.ACCESS_TOKEN = 'pk.*';
 
-            mapbox.postTurnstileEvent([' a.tiles.mapxbox.cn']);
+            mapbox.postTurnstileEvent(['a.tiles.boxmap.com']);
 
             t.equal(window.server.requests.length, 0);
             t.end();
         });
 
-        t.test('POSTs appuserTurnstile event', (t) => {
+        t.test('Doesnt POST appuserTurnstile event second time', (t) => {
+            //Depend on having a successful POST in a prior test.
             config.ACCESS_TOKEN = 'pk.*';
 
             mapbox.postTurnstileEvent(['a.tiles.mapbox.com']);
-            window.server.respond();
 
             const req = window.server.requests[0];
-            const reqBody = JSON.parse(req.requestBody)[0];
-
-            t.equal(req.url, `${config.EVENTS_URL}?access_token=pk.*`);
-            t.equal(req.method, 'POST');
-            t.equal(reqBody.event, 'appUserTurnstile');
-            t.equal(reqBody.sdkVersion, version);
-            t.ok(reqBody.userId);
+            t.false(req);
 
             t.end();
         });

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -388,7 +388,7 @@ test("mapbox", (t) => {
                 const req = window.server.requests[0];
                 req.respond(200);
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.ok(reqBody.created, new Date(now).toISOString());
+                t.equal(reqBody.created, new Date(now).toISOString());
 
                 t.end();
             });
@@ -409,7 +409,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.ok(reqBody.created, new Date(firstEvent).toISOString());
+                t.equal(reqBody.created, new Date(firstEvent).toISOString());
 
                 t.end();
             });
@@ -430,7 +430,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.ok(reqBody.created, new Date(firstEvent).toISOString());
+                t.equal(reqBody.created, new Date(firstEvent).toISOString());
 
                 t.end();
             });
@@ -484,7 +484,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.ok(reqBody.created, new Date(firstEvent).toISOString());
+                t.equal(reqBody.created, new Date(firstEvent).toISOString());
 
                 t.end();
             });
@@ -505,7 +505,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.ok(reqBody.created, new Date(firstEvent).toISOString());
+                t.equal(reqBody.created, new Date(firstEvent).toISOString());
 
                 t.end();
             });
@@ -538,16 +538,18 @@ test("mapbox", (t) => {
                 const tomorrow = now;
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
 
-                const req = window.server.requests[0];
+                let req = window.server.requests[0];
                 req.respond(200);
 
+                req = window.server.requests[1];
+                req.respond(200);
                 const reqBody = JSON.parse(req.requestBody)[0];
                 t.equal(req.url, `${config.EVENTS_URL}?access_token=key`);
                 t.equal(req.method, 'POST');
                 t.equal(reqBody.event, 'appUserTurnstile');
                 t.equal(reqBody.sdkVersion, version);
                 t.ok(reqBody.userId);
-                t.ok(reqBody.created, new Date(tomorrow).toISOString());
+                t.equal(reqBody.created, new Date(tomorrow).toISOString());
 
                 t.end();
             });
@@ -570,12 +572,12 @@ test("mapbox", (t) => {
                 const reqToday = window.server.requests[0];
                 reqToday.respond(200);
                 let reqBody = JSON.parse(reqToday.requestBody)[0];
-                t.ok(reqBody.created, new Date(today).toISOString());
+                t.equal(reqBody.created, new Date(today).toISOString());
 
                 const reqTomorrow = window.server.requests[1];
                 reqTomorrow.respond(200);
                 reqBody = JSON.parse(reqTomorrow.requestBody)[0];
-                t.ok(reqBody.created, new Date(tomorrow).toISOString());
+                t.equal(reqBody.created, new Date(tomorrow).toISOString());
 
                 t.end();
             });

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -3,7 +3,7 @@
 import { test } from 'mapbox-gl-js-test';
 
 import Coordinate from '../../../src/geo/coordinate';
-import { easeCubicInOut, keysDifference, extend, pick, uniqueId, getCoordinatesCenter, bindAll, asyncAll, clamp, wrap, bezier, endsWith, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl } from '../../../src/util/util';
+import { easeCubicInOut, keysDifference, extend, pick, uniqueId, getCoordinatesCenter, bindAll, asyncAll, clamp, wrap, bezier, endsWith, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl, uuid, validateUuid } from '../../../src/util/util';
 import Point from '@mapbox/point-geometry';
 
 test('util', (t) => {
@@ -297,6 +297,14 @@ test('util', (t) => {
             t.end();
         });
 
+        t.end();
+    });
+
+    t.test('validateUuid', (t) => {
+        t.true(validateUuid(uuid()));
+        t.false(validateUuid(uuid().substr(0, 10)));
+        t.false(validateUuid('foobar'));
+        t.false(validateUuid(null));
         t.end();
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,10 +2443,6 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
-content-type-parser@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
-
 continuable-cache@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/continuable-cache/-/continuable-cache-0.3.1.tgz#bd727a7faed77e71ff3985ac93351a912733ad0f"
@@ -2710,9 +2706,15 @@ cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0", "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.21 < 0.3.0", "cssstyle@>= 0.2.37 < 0.3.0":
+"cssstyle@>= 0.2.21 < 0.3.0":
   version "0.2.37"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+  dependencies:
+    cssom "0.3.x"
+
+"cssstyle@>= 0.3.1 < 0.4.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.3.1.tgz#6da9b4cff1bc5d716e6e5fe8e04fcb1b50a49adf"
   dependencies:
     cssom "0.3.x"
 
@@ -2957,6 +2959,14 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+data-urls@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.0.tgz#24802de4e81c298ea8a9388bb0d8e461c774684f"
+  dependencies:
+    abab "^1.0.4"
+    whatwg-mimetype "^2.0.0"
+    whatwg-url "^6.4.0"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -5747,23 +5757,22 @@ jsdom-no-contextify@~3.1.0:
     xml-name-validator "^1.0.0"
     xmlhttprequest ">= 1.6.0 < 2.0.0"
 
-jsdom@^11.6.2:
-  version "11.6.2"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.2.tgz#25d1ef332d48adf77fc5221fe2619967923f16bb"
+jsdom@^11.11.0:
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.11.0.tgz#df486efad41aee96c59ad7a190e2449c7eb1110e"
   dependencies:
     abab "^1.0.4"
     acorn "^5.3.0"
     acorn-globals "^4.1.0"
     array-equal "^1.0.0"
-    browser-process-hrtime "^0.1.2"
-    content-type-parser "^1.0.2"
     cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
+    cssstyle ">= 0.3.1 < 0.4.0"
+    data-urls "^1.0.0"
     domexception "^1.0.0"
     escodegen "^1.9.0"
     html-encoding-sniffer "^1.0.2"
     left-pad "^1.2.0"
-    nwmatcher "^1.4.3"
+    nwsapi "^2.0.0"
     parse5 "4.0.0"
     pn "^1.1.0"
     request "^2.83.0"
@@ -5774,7 +5783,8 @@ jsdom@^11.6.2:
     w3c-hr-time "^1.0.1"
     webidl-conversions "^4.0.2"
     whatwg-encoding "^1.0.3"
-    whatwg-url "^6.4.0"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
     ws "^4.0.0"
     xml-name-validator "^3.0.0"
 
@@ -6997,9 +7007,13 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.4 < 2.0.0", nwmatcher@^1.4.3:
+"nwmatcher@>= 1.3.4 < 2.0.0":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
+
+nwsapi@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.5.tgz#3998cfe7a014600e5e30dedb1fef2a4404b2871f"
 
 nyc@^10.1.2:
   version "10.3.2"
@@ -9990,7 +10004,7 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.
   dependencies:
     punycode "^1.4.1"
 
-tr46@^1.0.0:
+tr46@^1.0.0, tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   dependencies:
@@ -10617,6 +10631,10 @@ whatwg-fetch@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
 
+whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
+
 whatwg-url@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
@@ -10624,6 +10642,14 @@ whatwg-url@^6.4.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.0"
     webidl-conversions "^4.0.1"
+
+whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What is in this change?
Just like the mapbox-gl-native mobile SDKs, mapbox-gl-js will send a turnstile event, once per calendar day, when (and only when) the Mapbox access token is set and resources are loaded from a Mapbox API. No turnstile event will be sent for maps that use only third-party styles and tiles. This is the same behavior as the mapbox-gl-native mobile SDKs.

The turnstile event generates a random id that is persisted in the browser's [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) (when available). No other personal identifiable information is sent as part of this event. The subdomain that processes the event is distinct from the tiles API servers and Mapbox does not connect events between the two. There is no way for us to connect style and tile requests to an individual user.

You can view the part of our privacy policy that covers random identifiers [here](https://www.mapbox.com/privacy/#%5BAaMSWwdt%5D)

### Why is this needed? 
Today, the way that Mapbox determines distinct users of the gl-js sdk is imprecise. A turnstile event helps get more accurate information about things like:

- How many users are active on an account monthly. Our licensing incorporates end user limits for commercial applications; this change will allow us to closely track these numbers and make them visible to customers.
- What versions of gl-js are being used by end-users, and what browsers are being used. This will help us prioritize browser compatibility issues and support for cutting-edge technologies such as WebGL 2.

Additionally, as a company we want to use consistent metrics across all our platforms. This change brings the web platform in sync with our mobile platforms.

### Can I opt out of this tracking?
If your use of mapbox-gl-js does not set the access token (using `mapboxgl.accessToken`) then this code is always disabled. When the access token is set, there is no option to disable the turnstile event.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~document any changes to public APIs~
 - [ ] ~post benchmark scores~
 - [x] manually test the debug page

cc @jfirebaugh @anandthakker 