### PR TITLE
release-drink backport: Fix Webpack production mode compatibility

### DIFF
--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -29,6 +29,8 @@ export const plugins = () => [
         include: 'src/shaders/index.js'
     }),
     commonjs({
+        // global keyword handling causes Webpack compatibility issues, so we disabled it:
+        // https://github.com/mapbox/mapbox-gl-js/pull/6956
         ignoreGlobal: true,
         namedExports: {
             '@mapbox/whoots-js': ['getTileBBox']

--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -29,6 +29,7 @@ export const plugins = () => [
         include: 'src/shaders/index.js'
     }),
     commonjs({
+        ignoreGlobal: true,
         namedExports: {
             '@mapbox/whoots-js': ['getTileBBox']
         }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "rollup": "^0.57.0",
     "rollup-plugin-browserify-transform": "^1.0.1",
     "rollup-plugin-buble": "^0.18.0",
-    "rollup-plugin-commonjs": "^8.2.6",
+    "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-json": "^2.3.0",
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-replace": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3843,9 +3843,9 @@ estree-walker@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
 
-estree-walker@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.1.tgz#64fc375053abc6f57d73e9bd2f004644ad3c5854"
+estree-walker@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -8762,14 +8762,13 @@ rollup-plugin-buble@^0.18.0:
     buble "^0.18.0"
     rollup-pluginutils "^2.0.1"
 
-rollup-plugin-commonjs@^8.2.6:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.3.0.tgz#91b4ba18f340951e39ed7b1901f377a80ab3f9c3"
+rollup-plugin-commonjs@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.3.tgz#37bfbf341292ea14f512438a56df8f9ca3ba4d67"
   dependencies:
-    acorn "^5.2.1"
-    estree-walker "^0.5.0"
+    estree-walker "^0.5.1"
     magic-string "^0.22.4"
-    resolve "^1.4.0"
+    resolve "^1.5.0"
     rollup-pluginutils "^2.0.1"
 
 rollup-plugin-json@^2.3.0:


### PR DESCRIPTION
Backports #6956 to release-drink
----
A proposal for fixing #4359. Sets `ignoreGlobal: true` option for `rollup-plugin-commonjs` plugin, turning off its handling of the `global` keyword in CommonJS modules, and upgrades the plugin to the latest version (because the option didn't work properly in the previous one). In particular, it stops transforming top-level `this` reference into a variable that contains the `typeof global` check (which consequently triggered Webpack issues). 

One consequence of the fix is that GL JS will throw a runtime error when it encounters a reference to the `global` keyword. However, there are no such instances in the bundle currently — the only real reference I found (in the browserified node `assert` module) gets treeshaken away because it's in unused methods. So in theory this fix won't bring much trouble unless we plan on using Node-targeted modules with the `global` keyword in future.

Thanks a lot to @aendrew who provided a minimal repro that helped me find this fix.