### PR TITLE
android-v6.3.0, ios-v4.2.0, macos-v0.9.0 in style spec

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -5121,6 +5121,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.47.0",
+          "android": "6.3.0",
           "ios": "4.2.0",
           "macos": "0.9.0"
         },

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2501,7 +2501,9 @@
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.45.0"
+            "js": "0.45.0",
+            "ios": "4.2.0",
+            "macos": "0.9.0"
           }
         }
       },
@@ -2971,6 +2973,11 @@
             "android": "6.0.0",
             "ios": "4.0.0",
             "macos": "0.7.0"
+          },
+          "collator": {
+            "js": "0.45.0",
+            "ios": "4.2.0",
+            "macos": "0.9.0"
           }
         }
       },
@@ -2983,6 +2990,11 @@
             "android": "6.0.0",
             "ios": "4.0.0",
             "macos": "0.7.0"
+          },
+          "collator": {
+            "js": "0.45.0",
+            "ios": "4.2.0",
+            "macos": "0.9.0"
           }
         }
       },
@@ -2995,6 +3007,11 @@
             "android": "6.0.0",
             "ios": "4.0.0",
             "macos": "0.7.0"
+          },
+          "collator": {
+            "js": "0.45.0",
+            "ios": "4.2.0",
+            "macos": "0.9.0"
           }
         }
       },
@@ -3007,6 +3024,11 @@
             "android": "6.0.0",
             "ios": "4.0.0",
             "macos": "0.7.0"
+          },
+          "collator": {
+            "js": "0.45.0",
+            "ios": "4.2.0",
+            "macos": "0.9.0"
           }
         }
       },
@@ -3019,6 +3041,11 @@
             "android": "6.0.0",
             "ios": "4.0.0",
             "macos": "0.7.0"
+          },
+          "collator": {
+            "js": "0.45.0",
+            "ios": "4.2.0",
+            "macos": "0.9.0"
           }
         }
       },
@@ -3031,6 +3058,11 @@
             "android": "6.0.0",
             "ios": "4.0.0",
             "macos": "0.7.0"
+          },
+          "collator": {
+            "js": "0.45.0",
+            "ios": "4.2.0",
+            "macos": "0.9.0"
           }
         }
       },
@@ -3115,7 +3147,9 @@
         "group": "String",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.45.0"
+            "js": "0.45.0",
+            "ios": "4.2.0",
+            "macos": "0.9.0"
           }
         }
       }
@@ -5086,7 +5120,9 @@
       "default": "linear",
       "sdk-support": {
         "basic functionality": {
-          "js": "0.47.0"
+          "js": "0.47.0",
+          "ios": "4.2.0",
+          "macos": "0.9.0"
         },
         "data-driven styling": {}
       },


### PR DESCRIPTION
Updated the style specification compatibility tables to reflect mapbox/mapbox-gl-native#12176 mapbox/mapbox-gl-native#11869 mapbox/mapbox-gl-native#12329 in Android map SDK v6.3.0, iOS map SDK v4.2.0, and macOS map SDK v0.9.0.

/cc @ChrisLoer @mollymerp @friedbunny