### PR TITLE
Optimize and simplify tile retention logic

### DIFF
--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -51,7 +51,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
 
         gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
 
-        const parentTile = sourceCache.findLoadedParent(coord, 0, {}),
+        const parentTile = sourceCache.findLoadedParent(coord, 0),
             fade = getFadeValues(tile, parentTile, sourceCache, layer, painter.transform);
 
         let parentScaleBy, parentTL;

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -327,7 +327,7 @@ class SourceCache extends Evented {
      * Retain children of the given set of tiles (up to maxCoveringZoom) that are already loaded;
      */
     _retainLoadedChildren(
-        tiles: {[any]: OverscaledTileID},
+        idealTiles: {[any]: OverscaledTileID},
         zoom: number,
         maxCoveringZoom: number,
         retain: {[any]: OverscaledTileID}
@@ -359,7 +359,7 @@ class SourceCache extends Evented {
             while (tileID.overscaledZ > zoom) {
                 tileID = tileID.scaledTo(tileID.overscaledZ - 1);
 
-                if (tiles[tileID.key]) {
+                if (idealTiles[tileID.key]) {
                     // found a parent that needed a loaded child; retain that child
                     retain[topmostLoadedID.key] = topmostLoadedID;
                     break;
@@ -575,7 +575,7 @@ class SourceCache extends Evented {
             }
         }
 
-        // retain any loaded children of ideal riles up to maxCoveringZoom
+        // retain any loaded children of ideal tiles up to maxCoveringZoom
         this._retainLoadedChildren(missingTiles, zoom, maxCoveringZoom, retain);
 
         for (const tileID of idealTileIDs) {
@@ -583,8 +583,8 @@ class SourceCache extends Evented {
 
             if (tile.hasData()) continue;
 
-            // The tile we require is not yet loaded or does not exist.
-            // We are now attempting to load a parent tile if children are not enough.
+            // The tile we require is not yet loaded or does not exist;
+            // Attempt to find children that fully cover it.
 
             if (zoom + 1 > this._source.maxzoom) {
                 // We're looking for an overzoomed child tile.
@@ -604,10 +604,10 @@ class SourceCache extends Evented {
                     retain[children[3].key]) continue; // tile is covered by children
             }
 
-            // We couldn't find child tiles that entirely cover the ideal tile.
+            // We couldn't find child tiles that entirely cover the ideal tile; look for parents now.
 
             // As we ascend up the tile pyramid of the ideal tile, we check whether the parent
-            // tile has been previously requested (and errored in this case due to the previous conditional)
+            // tile has been previously requested (and errored because we only loop over tiles with no data)
             // in order to determine if we need to request its parent.
             let parentWasRequested = tile.wasRequested();
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -324,7 +324,8 @@ class SourceCache extends Evented {
     }
 
     /**
-     * Retain children of the given set of tiles (up to maxCoveringZoom) that are already loaded;
+     * For a given set of tiles, retain children that are loaded and have a zoom
+     * between `zoom` (exclusive) and `maxCoveringZoom` (inclusive)
      */
     _retainLoadedChildren(
         idealTiles: {[any]: OverscaledTileID},
@@ -369,8 +370,7 @@ class SourceCache extends Evented {
     }
 
     /**
-     * Find a loaded parent of the given tile (up to minCoveringZoom);
-     * adds the found tile to retain object and returns the tile if found
+     * Find a loaded parent of the given tile (up to minCoveringZoom)
      */
     findLoadedParent(tileID: OverscaledTileID, minCoveringZoom: number): ?Tile {
         for (let z = tileID.overscaledZ - 1; z >= minCoveringZoom; z--) {

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -327,9 +327,7 @@ class SourceCache extends Evented {
      * Recursively find children of the given tile (up to maxCoveringZoom) that are already loaded;
      * adds found tiles to retain object; returns true if any child is found.
      */
-    _findLoadedChildren(tileID: OverscaledTileID, maxCoveringZoom: number, retain: {[any]: OverscaledTileID}): boolean {
-        let found = false;
-
+    _findLoadedChildren(tileID: OverscaledTileID, maxCoveringZoom: number, retain: {[any]: OverscaledTileID}) {
         for (const id in this._tiles) {
             let tile = this._tiles[id];
 
@@ -342,23 +340,20 @@ class SourceCache extends Evented {
                 Math.floor(tile.tileID.canonical.y / z2) !== tileID.canonical.y)
                 continue;
 
-            // found loaded child
-            retain[id] = tile.tileID;
-            found = true;
-
-            // loop through parents; retain the topmost loaded one if found
+            // found loaded child; loop through parents and retain the topmost loaded one if found
+            let topmostLoadedID = tile.tileID;
             while (tile && tile.tileID.overscaledZ - 1 > tileID.overscaledZ) {
-                const parent = tile.tileID.scaledTo(tile.tileID.overscaledZ - 1);
-                if (!parent) break;
+                const parentID = tile.tileID.scaledTo(tile.tileID.overscaledZ - 1);
+                if (!parentID) break;
 
-                tile = this._tiles[parent.key];
+                tile = this._tiles[parentID.key];
                 if (tile && tile.hasData()) {
-                    delete retain[id];
-                    retain[parent.key] = parent;
+                    topmostLoadedID = parentID;
                 }
             }
+
+            retain[topmostLoadedID.key] = topmostLoadedID;
         }
-        return found;
     }
 
     /**

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -197,7 +197,7 @@ class SourceCache extends Evented {
     }
 
     hasRenderableParent(tileID: OverscaledTileID) {
-        const parentTile = this.findLoadedParent(tileID, 0, {});
+        const parentTile = this.findLoadedParent(tileID, 0);
         if (parentTile) {
             return this._isIdRenderable(parentTile.tileID.key);
         }
@@ -372,18 +372,16 @@ class SourceCache extends Evented {
      * Find a loaded parent of the given tile (up to minCoveringZoom);
      * adds the found tile to retain object and returns the tile if found
      */
-    findLoadedParent(tileID: OverscaledTileID, minCoveringZoom: number, retain: {[any]: OverscaledTileID}): ?Tile {
+    findLoadedParent(tileID: OverscaledTileID, minCoveringZoom: number): ?Tile {
         for (let z = tileID.overscaledZ - 1; z >= minCoveringZoom; z--) {
             const parent = tileID.scaledTo(z);
             if (!parent) return;
             const id = String(parent.key);
             const tile = this._tiles[id];
             if (tile && tile.hasData()) {
-                retain[id] = parent;
                 return tile;
             }
             if (this._cache.has(parent)) {
-                retain[id] = parent;
                 return this._cache.get(parent);
             }
         }
@@ -509,9 +507,10 @@ class SourceCache extends Evented {
                 if (!tile || tile.fadeEndTime && tile.fadeEndTime <= browser.now()) continue;
 
                 // if the tile is loaded but still fading in, find parents to cross-fade with it
-                const parentTile = this.findLoadedParent(tileID, minCoveringZoom, parentsForFading);
+                const parentTile = this.findLoadedParent(tileID, minCoveringZoom);
                 if (parentTile) {
                     this._addTile(parentTile.tileID);
+                    parentsForFading[parentTile.tileID.key] = parentTile.tileID;
                 }
 
                 fadingTiles[id] = tileID;

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -1443,13 +1443,8 @@ test('SourceCache#findLoadedParent', (t) => {
 
         sourceCache._tiles[tile.tileID.key] = tile;
 
-        const retain = {};
-        const expectedRetain = {};
-        expectedRetain[tile.tileID.key] = tile.tileID;
-
-        t.equal(sourceCache.findLoadedParent(new OverscaledTileID(2, 0, 2, 3, 3), 0, retain), undefined);
-        t.deepEqual(sourceCache.findLoadedParent(new OverscaledTileID(2, 0, 2, 0, 0), 0, retain), tile);
-        t.deepEqual(retain, expectedRetain);
+        t.equal(sourceCache.findLoadedParent(new OverscaledTileID(2, 0, 2, 3, 3), 0), undefined);
+        t.deepEqual(sourceCache.findLoadedParent(new OverscaledTileID(2, 0, 2, 0, 0), 0), tile);
         t.end();
     });
 
@@ -1464,13 +1459,8 @@ test('SourceCache#findLoadedParent', (t) => {
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 0, 0), 512, 22);
         sourceCache._cache.add(tile.tileID, tile);
 
-        const retain = {};
-        const expectedRetain = {};
-        expectedRetain[tile.tileID.key] = tile.tileID;
-
-        t.equal(sourceCache.findLoadedParent(new OverscaledTileID(2, 0, 2, 3, 3), 0, retain), undefined);
-        t.equal(sourceCache.findLoadedParent(new OverscaledTileID(2, 0, 2, 0, 0), 0, retain), tile);
-        t.deepEqual(retain, expectedRetain);
+        t.equal(sourceCache.findLoadedParent(new OverscaledTileID(2, 0, 2, 3, 3), 0), undefined);
+        t.equal(sourceCache.findLoadedParent(new OverscaledTileID(2, 0, 2, 0, 0), 0), tile);
         t.equal(sourceCache._cache.order.length, 1);
 
         t.end();


### PR DESCRIPTION
While investigating #6643, I noticed that our tile retention logic (and `_findLoadedChildren` use in particular) was [accidentally quadratic](https://accidentallyquadratic.tumblr.com/). It didn't manifest with vector tiles because they're big and there are only 6–8 at the time, but with small raster tile layers, where there can be 40–80 tiles loading at the same time, it blows up.

This PR brings down children retention CPU time on a test fly animation from the #6643 case down from 812ms to 37ms (from quadratic to linear). This somewhat reduces jank overall (maybe 20%), but there's still a lot of remaining jank which is almost fully dominated by XHR image requests — I'll explore whether we can do something about it in another PR.

Commits in the PR are self-contained so it's easier to review them one by one, and let's rebase-merge, not squash.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~ already covered
 - [x] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
