### PR TITLE
Eliminate fs and path dependencies from style-spec bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=6.4.0"
   },
   "dependencies": {
-    "@mapbox/jsonlint-lines-primitives": "^2.0.1",
+    "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^1.4.0",
     "@mapbox/point-geometry": "^0.1.0",
     "@mapbox/shelf-pack": "^3.1.0",

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -27,7 +27,7 @@
     "gl-style-composite": "bin/gl-style-composite"
   },
   "dependencies": {
-    "@mapbox/jsonlint-lines-primitives": "~2.0.1",
+    "@mapbox/jsonlint-lines-primitives": "~2.0.2",
     "@mapbox/unitbezier": "^0.0.0",
     "csscolorparser": "~1.0.2",
     "minimist": "0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,9 +97,9 @@
   dependencies:
     wgs84 "0.0.0"
 
-"@mapbox/jsonlint-lines-primitives@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.1.tgz#bc4c1593e2ec2371e2771c518068d6eab8eeae58"
+"@mapbox/jsonlint-lines-primitives@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
 
 "@mapbox/jsxtreme-markdown-loader@^0.5.3":
   version "0.5.3"


### PR DESCRIPTION
Fixes #6984 by updating our patched version of jsonlint to one that removes a few more unnecessary dependencies (https://github.com/mapbox/jsonlint/pull/4).
