### PR TITLE
add capability to inspect a cluster on click to cluster example

### DIFF
--- a/docs/pages/example/cluster.html
+++ b/docs/pages/example/cluster.html
@@ -78,5 +78,27 @@ map.on('load', function() {
             "circle-stroke-color": "#fff"
         }
     });
+
+    // inspect a cluster on click
+    map.on('click', 'clusters', function (e) {
+        var features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
+        var clusterId = features[0].properties.cluster_id;
+        map.getSource('earthquakes').getClusterExpansionZoom(clusterId, function (err, zoom) {
+            if (err)
+                return;
+
+            map.easeTo({
+                center: features[0].geometry.coordinates,
+                zoom: zoom
+            });
+        });
+    });
+
+    map.on('mouseenter', 'clusters', function () {
+        map.getCanvas().style.cursor = 'pointer';
+    });
+    map.on('mouseleave', 'clusters', function () {
+        map.getCanvas().style.cursor = '';
+    });
 });
 </script>

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -58,6 +58,7 @@ import type {PerformanceResourceTiming} from '../types/performance_resource_timi
  * @see [Draw GeoJSON points](https://www.mapbox.com/mapbox-gl-js/example/geojson-markers/)
  * @see [Add a GeoJSON line](https://www.mapbox.com/mapbox-gl-js/example/geojson-line/)
  * @see [Create a heatmap from points](https://www.mapbox.com/mapbox-gl-js/example/heatmap/)
+ * @see [Create and style clusters](https://www.mapbox.com/mapbox-gl-js/example/cluster/)
  */
 class GeoJSONSource extends Evented implements Source {
     type: 'geojson';


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

Methods for inspecting GeoJSON clusters were introduced in #6829, and now in 0.47.0. This PR adds to the [cluster example](https://www.mapbox.com/mapbox-gl-js/example/cluster/) the `getClusterExpansionZoom` method so when you click on a cluster the map zooms in to expand it.

 - n/a write tests for all new functionality
 - n/a document any changes to public APIs
 - n/a post benchmark scores
 - [x] manually test the debug page
 - n/a tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes

I wasn't able to get the shorthand click features to work, not sure why. :thinking: 

```js
 map.on('click', 'clusters', function (e) {
    console.log(e.features)
}
```
