### PR TITLE
Avoid XHR when possible for faster raster tile loading

### DIFF
--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -38,6 +38,7 @@ class RasterTileSource extends Evented implements Source {
     tiles: Array<string>;
 
     _loaded: boolean;
+    _avoidXHR: boolean;
     _options: RasterSourceSpecification | RasterDEMSourceSpecification;
     _tileJSONRequest: ?Cancelable;
 
@@ -56,6 +57,7 @@ class RasterTileSource extends Evented implements Source {
         this._loaded = false;
 
         this._options = extend({}, options);
+        this._avoidXHR = false;
         extend(this, pick(options, ['url', 'scheme', 'tileSize']));
     }
 
@@ -114,6 +116,13 @@ class RasterTileSource extends Evented implements Source {
                 delete (img: any).cacheControl;
                 delete (img: any).expires;
 
+                // if the tiles have aggressive caching (retained for at least 1 hour),
+                // switch to faster image loading technique for subsequent tile loads
+                const timeout = tile.getExpiryTimeout();
+                if (timeout === undefined || timeout > 1000 * 60 * 60) {
+                    this._avoidXHR = true;
+                }
+
                 const context = this.map.painter.context;
                 const gl = context.gl;
                 tile.texture = this.map.painter.getTileTexture(img.width);
@@ -132,7 +141,7 @@ class RasterTileSource extends Evented implements Source {
 
                 callback(null);
             }
-        });
+        }, this._avoidXHR);
     }
 
     abortTile(tile: Tile, callback: Callback<void>) {

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -123,25 +123,29 @@ class RasterTileSource extends Evented implements Source {
                     this._avoidXHR = true;
                 }
 
-                const context = this.map.painter.context;
-                const gl = context.gl;
-                tile.texture = this.map.painter.getTileTexture(img.width);
-                if (tile.texture) {
-                    tile.texture.update(img, { useMipmap: true });
-                } else {
-                    tile.texture = new Texture(context, img, gl.RGBA, { useMipmap: true });
-                    tile.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_NEAREST);
-
-                    if (context.extTextureFilterAnisotropic) {
-                        gl.texParameterf(gl.TEXTURE_2D, context.extTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, context.extTextureFilterAnisotropicMax);
-                    }
-                }
-
-                tile.state = 'loaded';
-
-                callback(null);
+                this.onTileLoad(tile, img, callback);
             }
         }, this._avoidXHR);
+    }
+
+    onTileLoad(tile: Tile, img: HTMLImageElement, callback: Callback<void>) {
+        const context = this.map.painter.context;
+        const gl = context.gl;
+        tile.texture = this.map.painter.getTileTexture(img.width);
+        if (tile.texture) {
+            tile.texture.update(img, { useMipmap: true });
+        } else {
+            tile.texture = new Texture(context, img, gl.RGBA, { useMipmap: true });
+            tile.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_NEAREST);
+
+            if (context.extTextureFilterAnisotropic) {
+                gl.texParameterf(gl.TEXTURE_2D, context.extTextureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, context.extTextureFilterAnisotropicMax);
+            }
+        }
+
+        tile.state = 'loaded';
+
+        callback(null);
     }
 
     abortTile(tile: Tile, callback: Callback<void>) {

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -139,6 +139,7 @@ export const getImage = function(requestParameters: RequestParameters, callback:
         if (!sameOrigin(url)) {
             img.crossOrigin = 'Anonymous';
         }
+        img.onerror = () => callback(new Error(`Could not load image: ${url}`));
         img.onload = () => callback(null, img);
         img.src = url;
         return {cancel: () => { img.src = transparentPngUrl; }};

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -142,7 +142,7 @@ export const getImage = function(requestParameters: RequestParameters, callback:
         img.onerror = () => callback(new Error(`Could not load image: ${url}`));
         img.onload = () => callback(null, img);
         img.src = url;
-        return {cancel: () => { img.src = transparentPngUrl; }};
+        return {cancel: () => { img.onload = null; img.src = transparentPngUrl; }};
     }
 
     // otherwise request the image with XHR to work around caching issues


### PR DESCRIPTION
A proposal for addressing #6643. If we see that a raster tile we requested with XHR should be cached for a long time (currently set to 1 hr), we switch from XHR to simple `new Image` tile loads for that source. This fixes a lot of the jank when using raster tile sources.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~ (we don't have tests for image loading, and they probably won't be useful anyway as long as we use `jsdom` and stubbing)
 - [x] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
