### PR TITLE
Avoid allocating huge empty arrays for DEM data

### DIFF
--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -54,7 +54,7 @@ export default class DEMData {
         this.uid = uid;
         this.scale = scale || 1;
         // if no data is provided, use a temporary empty level to satisfy flow
-        this.level = data || new Level(256, 512);
+        this.level = data || new Level(1, 0);
         this.loaded = !!data;
     }
 


### PR DESCRIPTION
`new Level(256, 512)`, which is used as a placeholder to avoid flow type errors, actually allocates a `(256 + 512 * 2)^2` = a 1,638,400-item Int32Array for every tile. The easiest fix to avoid this expensive allocation is passing a smaller placeholder.

@mollymerp BTW, is there a reason for `DEMData` not to accept image data in the constructor, and instead only populate it in `loadFromImage`? We could refactor this to simplify the code. It also seems that the `Level` class could be merged into `DEMData`, since there's only one instance per `DEMData`.