### PR TITLE
remove Level subclass of DEMData

### DIFF
--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -4,18 +4,62 @@ import { RGBAImage } from '../util/image';
 import { warnOnce, clamp } from '../util/util';
 import { register } from '../util/web_worker_transfer';
 
-export class Level {
-    dim: number;
+// DEMData is a data structure for decoding, backfilling, and storing elevation data for processing in the hillshade shaders
+// data can be populated either from a pngraw image tile or from serliazed data sent back from a worker. When data is initially
+// loaded from a image tile, we decode the pixel values using the appropriate decoding formula, but we store the
+// elevation data as an Int32 value. we add 65536 (2^16) to eliminate negative values and enable the use of
+// integer overflow when creating the texture used in the hillshadePrepare step.
+
+// DEMData also handles the backfilling of data from a tile's neighboring tiles. This is necessary because we use a pixel's 8
+// surrounding pixel values to compute the slope at that pixel, and we cannot accurately calculate the slope at pixels on a
+// tile's edge without backfilling from neighboring tiles.
+
+export default class DEMData {
+    uid: string;
+    data: Int32Array;
     border: number;
     stride: number;
-    data: Int32Array;
+    dim: number;
 
-    constructor(dim: number, border: number, data: ?Int32Array) {
-        if (dim <= 0) throw new RangeError('Level must have positive dimension');
-        this.dim = dim;
-        this.border = border;
+    constructor(uid: string, data: RGBAImage, encoding: "mapbox" | "terrarium") {
+        this.uid = uid;
+        if (data.height !== data.width) throw new RangeError('DEM tiles must be square');
+        if (encoding && encoding !== "mapbox" && encoding !== "terrarium") return warnOnce(
+            `"${encoding}" is not a valid encoding type. Valid types include "mapbox" and "terrarium".`
+        );
+        const dim = this.dim = data.height;
+        this.border = Math.max(Math.ceil(data.height / 2), 1);
         this.stride = this.dim + 2 * this.border;
-        this.data = data || new Int32Array((this.dim + 2 * this.border) * (this.dim + 2 * this.border));
+        this.data = new Int32Array(this.stride * this.stride);
+
+        const pixels = data.data;
+        const unpack = encoding === "terrarium" ? this._unpackTerrarium : this._unpackMapbox;
+        for (let y = 0; y < dim; y++) {
+            for (let x = 0; x < dim; x++) {
+                const i = y * dim + x;
+                const j = i * 4;
+                this.set(x, y, unpack(pixels[j], pixels[j + 1], pixels[j + 2]));
+            }
+        }
+
+        // in order to avoid flashing seams between tiles, here we are initially populating a 1px border of pixels around the image
+        // with the data of the nearest pixel from the image. this data is eventually replaced when the tile's neighboring
+        // tiles are loaded and the accurate data can be backfilled using DEMData#backfillBorder
+        for (let x = 0; x < dim; x++) {
+            // left vertical border
+            this.set(-1, x, this.get(0, x));
+            // right vertical border
+            this.set(dim, x, this.get(dim - 1, x));
+            // left horizontal border
+            this.set(x, -1, this.get(x, 0));
+            // right horizontal border
+            this.set(x, dim, this.get(x, dim - 1));
+        }
+        // corners
+        this.set(-1, -1, this.get(0, 0));
+        this.set(dim, -1, this.get(dim - 1, 0));
+        this.set(-1, dim, this.get(0, dim - 1));
+        this.set(dim, dim, this.get(dim - 1, dim - 1));
     }
 
     set(x: number, y: number, value: number) {
@@ -30,65 +74,6 @@ export class Level {
         if (x < -this.border || x >= this.dim + this.border ||  y < -this.border || y >= this.dim + this.border) throw new RangeError('out of range source coordinates for DEM data');
         return (y + this.border) * this.stride + (x + this.border);
     }
-}
-
-register('Level', Level);
-
-// DEMData is a data structure for decoding, backfilling, and storing elevation data for processing in the hillshade shaders
-// data can be populated either from a pngraw image tile or from serliazed data sent back from a worker. When data is initially
-// loaded from a image tile, we decode the pixel values using the mapbox terrain-rgb tileset decoding formula, but we store the
-// elevation data in a Level as an Int32 value. we add 65536 (2^16) to eliminate negative values and enable the use of
-// integer overflow when creating the texture used in the hillshadePrepare step.
-
-// DEMData also handles the backfilling of data from a tile's neighboring tiles. This is necessary because we use a pixel's 8
-// surrounding pixel values to compute the slope at that pixel, and we cannot accurately calculate the slope at pixels on a
-// tile's edge without backfilling from neighboring tiles.
-
-export default class DEMData {
-    uid: string;
-    scale: number;
-    level: Level;
-    loaded: boolean;
-
-    constructor(uid: string, scale: ?number, data: ?Level) {
-        this.uid = uid;
-        this.scale = scale || 1;
-        // if no data is provided, use a temporary empty level to satisfy flow
-        this.level = data || new Level(1, 0);
-        this.loaded = !!data;
-    }
-
-    loadFromImage(data: RGBAImage, encoding: "mapbox" | "terrarium") {
-        if (data.height !== data.width) throw new RangeError('DEM tiles must be square');
-        if (encoding && encoding !== "mapbox" && encoding !== "terrarium") return warnOnce(
-            `"${encoding}" is not a valid encoding type. Valid types include "mapbox" and "terrarium".`
-        );
-        // Build level 0
-        const level = this.level = new Level(data.width, data.width / 2);
-        const pixels = data.data;
-
-        this._unpackData(level, pixels, encoding || "mapbox");
-
-        // in order to avoid flashing seams between tiles, here we are initially populating a 1px border of pixels around the image
-        // with the data of the nearest pixel from the image. this data is eventually replaced when the tile's neighboring
-        // tiles are loaded and the accurate data can be backfilled using DEMData#backfillBorder
-        for (let x = 0; x < level.dim; x++) {
-            // left vertical border
-            level.set(-1, x, level.get(0, x));
-            // right vertical border
-            level.set(level.dim, x, level.get(level.dim - 1, x));
-            // left horizontal border
-            level.set(x, -1, level.get(x, 0));
-            // right horizontal border
-            level.set(x, level.dim, level.get(x, level.dim - 1));
-        }
-        // corners
-        level.set(-1, -1, level.get(0, 0));
-        level.set(level.dim, -1, level.get(level.dim - 1, 0));
-        level.set(-1, level.dim, level.get(0, level.dim - 1));
-        level.set(level.dim, level.dim, level.get(level.dim - 1, level.dim - 1));
-        this.loaded = true;
-    }
 
     _unpackMapbox(r: number, g: number, b: number) {
         // unpacking formula for mapbox.terrain-rgb:
@@ -102,32 +87,17 @@ export default class DEMData {
         return ((r * 256 + g + b / 256) - 32768.0);
     }
 
-    _unpackData(level: Level, pixels: Uint8Array | Uint8ClampedArray, encoding: string) {
-        const unpackFunctions = {"mapbox": this._unpackMapbox, "terrarium": this._unpackTerrarium};
-        const unpack = unpackFunctions[encoding];
-        for (let y = 0; y < level.dim; y++) {
-            for (let x = 0; x < level.dim; x++) {
-                const i = y * level.dim + x;
-                const j = i * 4;
-                level.set(x, y, this.scale * unpack(pixels[j], pixels[j + 1], pixels[j + 2]));
-            }
-        }
-    }
-
     getPixels() {
-        return new RGBAImage({width: this.level.dim + 2 * this.level.border, height: this.level.dim + 2 * this.level.border}, new Uint8Array(this.level.data.buffer));
+        return new RGBAImage({width: this.dim + 2 * this.border, height: this.dim + 2 * this.border}, new Uint8Array(this.data.buffer));
     }
 
     backfillBorder(borderTile: DEMData, dx: number, dy: number) {
-        const t = this.level;
-        const o = borderTile.level;
+        if (this.dim !== borderTile.dim) throw new Error('dem dimension mismatch');
 
-        if (t.dim !== o.dim) throw new Error('level mismatch (dem dimension)');
-
-        let _xMin = dx * t.dim,
-            _xMax = dx * t.dim + t.dim,
-            _yMin = dy * t.dim,
-            _yMax = dy * t.dim + t.dim;
+        let _xMin = dx * this.dim,
+            _xMax = dx * this.dim + this.dim,
+            _yMin = dy * this.dim,
+            _yMax = dy * this.dim + this.dim;
 
         switch (dx) {
         case -1:
@@ -147,16 +117,16 @@ export default class DEMData {
             break;
         }
 
-        const xMin = clamp(_xMin, -t.border, t.dim + t.border);
-        const xMax = clamp(_xMax, -t.border, t.dim + t.border);
-        const yMin = clamp(_yMin, -t.border, t.dim + t.border);
-        const yMax = clamp(_yMax, -t.border, t.dim + t.border);
+        const xMin = clamp(_xMin, -this.border, this.dim + this.border);
+        const xMax = clamp(_xMax, -this.border, this.dim + this.border);
+        const yMin = clamp(_yMin, -this.border, this.dim + this.border);
+        const yMax = clamp(_yMax, -this.border, this.dim + this.border);
 
-        const ox = -dx * t.dim;
-        const oy = -dy * t.dim;
+        const ox = -dx * this.dim;
+        const oy = -dy * this.dim;
         for (let y = yMin; y < yMax; y++) {
             for (let x = xMin; x < xMax; x++) {
-                t.set(x, y, o.get(x + ox, y + oy));
+                this.set(x, y, borderTile.get(x + ox, y + oy));
             }
         }
     }

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -110,8 +110,8 @@ function prepareHillshade(painter, tile, sourceMaxZoom) {
     // base 10 - 0, 1, 6, 236 (this order is reversed in the resulting array via the overflow.
     // first 8 bits represent 236, so the r component of the texture pixel will be 236 etc.)
     // base 2 - 0000 0000, 0000 0001, 0000 0110, 1110 1100
-    if (tile.dem && tile.dem.level) {
-        const tileSize = tile.dem.level.dim;
+    if (tile.dem && tile.dem.data) {
+        const tileSize = tile.dem.dim;
 
         const pixelData = tile.dem.getPixels();
         context.activeTexture.set(gl.TEXTURE1);

--- a/src/source/raster_dem_tile_worker_source.js
+++ b/src/source/raster_dem_tile_worker_source.js
@@ -12,22 +12,15 @@ import type {
 
 class RasterDEMTileWorkerSource {
     actor: Actor;
-    loading: {[string]: DEMData};
     loaded: {[string]: DEMData};
 
     constructor() {
-        this.loading = {};
         this.loaded = {};
     }
 
     loadTile(params: WorkerDEMTileParameters, callback: WorkerDEMTileCallback) {
-        const uid = params.uid,
-            encoding = params.encoding;
-
-        const dem = new DEMData(uid);
-        this.loading[uid] = dem;
-        dem.loadFromImage(params.rawImageData, encoding);
-        delete this.loading[uid];
+        const {uid, encoding, rawImageData} = params;
+        const dem = new DEMData(uid, rawImageData, encoding);
 
         this.loaded = this.loaded || {};
         this.loaded[uid] = dem;

--- a/test/unit/data/dem_data.test.js
+++ b/test/unit/data/dem_data.test.js
@@ -1,5 +1,5 @@
 import { test } from 'mapbox-gl-js-test';
-import DEMData, { Level } from '../../../src/data/dem_data';
+import DEMData from '../../../src/data/dem_data';
 import { RGBAImage } from '../../../src/util/image';
 import { serialize, deserialize } from '../../../src/util/web_worker_transfer';
 
@@ -11,77 +11,32 @@ function createMockImage(height, width) {
     return new RGBAImage({height: height, width: width}, pixels);
 }
 
-test('Level', (t)=>{
 
-    t.test('constructor correctly creates Level', (t) => {
-        const level = new Level(4, 2);
-        t.equal(level.dim, 4);
-        t.equal(level.border, 2);
-        t.equal(level.stride, 8);
-
-        t.deepEqual(level.data, new Int32Array(8 * 8));
-        t.end();
-    });
-
-    t.test('setters and getters return correct values', (t) => {
-        const level = new Level(4, 2);
-
-        t.deepEqual(level.data, new Int32Array(8 * 8));
-        level.set(0, 0, 255);
-        t.equal(level.get(0, 0), 255);
+test('DEMData', (t) => {
+    t.test('constructor', (t) => {
+        const dem = new DEMData(0, {width: 4, height: 4, data: new Uint8ClampedArray(4 * 4 * 4)});
+        t.equal(dem.uid, 0);
+        t.equal(dem.dim, 4);
+        t.equal(dem.border, 2);
+        t.equal(dem.stride, 8);
+        t.true(dem.data instanceof Int32Array);
         t.end();
     });
 
     t.test('setters and getters throw for invalid data coordinates', (t) => {
-        const level = new Level(4, 2);
+        const dem = new DEMData(0, {width: 4, height: 4, data: new Uint8ClampedArray(4 * 4 * 4)});
 
-        t.deepEqual(level.data, new Int32Array(8 * 8));
-        t.throws(()=>level.set(20, 0, 255), 'out of range source coordinates for DEM data', 'detects and throws on invalid input');
-        t.throws(()=>level.set(10, 20, 255), 'out of range source coordinates for DEM data', 'detects and throws on invalid input');
-
-        t.end();
-    });
-
-    t.end();
-});
-
-
-test('DEMData', (t) => {
-    t.test('constructor', (t) => {
-        const dem = new DEMData(0, 1);
-        t.false(dem.loaded);
-        t.equal(dem.uid, 0);
-
-        dem.loadFromImage({width: 4, height: 4, data: new Uint8ClampedArray(4 * 4 * 4)});
-        t.true(dem.level instanceof Level, 'dem loads in data from typed array of pixel data');
-        t.end();
-    });
-
-    t.test('constructor defaults', (t) => {
-        const dem = new DEMData(0);
-        t.false(dem.loaded);
-        t.equal(dem.uid, 0);
-        t.equal(dem.scale, 1);
-
-        t.end();
-    });
-
-    t.test('constructor with data', (t) => {
-        const data = new Level(16, 8, new Int32Array(32 * 32));
-        const dem = new DEMData(0, 1, data);
-        t.equal(dem.level.dim, 16);
-        t.equal(dem.level.border, 8);
+        t.throws(()=>dem.set(20, 0, 255), 'out of range source coordinates for DEM data', 'detects and throws on invalid input');
+        t.throws(()=>dem.set(10, 20, 255), 'out of range source coordinates for DEM data', 'detects and throws on invalid input');
 
         t.end();
     });
 
     t.test('loadFromImage with invalid encoding', (t) => {
-        const dem = new DEMData(0, 1);
         t.stub(console, 'warn');
-        t.false(dem.loaded);
-        t.equal(dem.uid, 0);
 
-        dem.loadFromImage({width: 4, height: 4, data: new Uint8ClampedArray(4 * 4 * 4)}, "derp");
+        const dem = new DEMData(0, {width: 4, height: 4, data: new Uint8ClampedArray(4 * 4 * 4)}, "derp");
+        t.equal(dem.uid, 0);
         t.ok(console.warn.calledOnce);
         t.ok(console.warn.getCall(0).calledWithMatch(/"derp" is not a valid encoding type/));
         t.end();
@@ -92,20 +47,14 @@ test('DEMData', (t) => {
 
 
 test('DEMData#backfillBorder', (t) => {
-    const imageData0 = createMockImage(4, 4);
-    const dem0 = new DEMData(0);
-    const imageData1 = createMockImage(4, 4);
-    const dem1 = new DEMData(1);
-
-    dem0.loadFromImage(imageData0);
-    dem1.loadFromImage(imageData1);
+    const dem0 = new DEMData(0, createMockImage(4, 4));
+    const dem1 = new DEMData(1, createMockImage(4, 4));
 
     t.test('border region is initially populated with neighboring data', (t)=>{
-        const level0 = dem0.level;
         let nonempty = true;
         for (let x = -1; x < 5; x++) {
             for (let y = -1; y < 5; y++) {
-                if (level0.get(x, y) === -65536) {
+                if (dem0.get(x, y) === -65536) {
                     nonempty = false;
                     break;
                 }
@@ -116,7 +65,7 @@ test('DEMData#backfillBorder', (t) => {
         let verticalBorderMatch = true;
         for (const x of [-1, 4]) {
             for (let y = 0; y < 4; y++) {
-                if (level0.get(x, y) !== level0.get(x < 0 ? x + 1 : x - 1, y)) {
+                if (dem0.get(x, y) !== dem0.get(x < 0 ? x + 1 : x - 1, y)) {
                     verticalBorderMatch = false;
                     break;
                 }
@@ -128,7 +77,7 @@ test('DEMData#backfillBorder', (t) => {
         let horizontalBorderMatch = true;
         for (const y of [-1, 4]) {
             for (let x = 0; x < 4; x++) {
-                if (level0.get(x, y) !== level0.get(x, y < 0 ? y + 1 : y - 1)) {
+                if (dem0.get(x, y) !== dem0.get(x, y < 0 ? y + 1 : y - 1)) {
                     horizontalBorderMatch = false;
                     break;
                 }
@@ -136,51 +85,48 @@ test('DEMData#backfillBorder', (t) => {
         }
         t.true(horizontalBorderMatch, 'horizontal border of DEM data is initially equal to next row of data');
 
-        t.true(level0.get(-1, 4) === level0.get(0, 3), '-1, 1 corner initially equal to closest corner data');
-        t.true(level0.get(4, 4) === level0.get(3, 3), '1, 1 corner initially equal to closest corner data');
-        t.true(level0.get(-1, -1) === level0.get(0, 0), '-1, -1 corner initially equal to closest corner data');
-        t.true(level0.get(4, -1) === level0.get(3, 0), '-1, 1 corner initially equal to closest corner data');
-
+        t.true(dem0.get(-1, 4) === dem0.get(0, 3), '-1, 1 corner initially equal to closest corner data');
+        t.true(dem0.get(4, 4) === dem0.get(3, 3), '1, 1 corner initially equal to closest corner data');
+        t.true(dem0.get(-1, -1) === dem0.get(0, 0), '-1, -1 corner initially equal to closest corner data');
+        t.true(dem0.get(4, -1) === dem0.get(3, 0), '-1, 1 corner initially equal to closest corner data');
 
         t.end();
     });
 
     t.test('backfillBorder correctly populates borders with neighboring data', (t)=>{
-        const level0 = dem0.level;
-
         dem0.backfillBorder(dem1, -1, 0);
         for (let y = 0; y < 4; y++) {
             // dx = -1, dy = 0, so the left edge of dem1 should equal the right edge of dem0
-            t.true(level0.get(-1, y) === dem1.level.get(3, y), 'backfills neighbor -1, 0');
+            t.true(dem0.get(-1, y) === dem1.get(3, y), 'backfills neighbor -1, 0');
 
         }
 
         dem0.backfillBorder(dem1, 0, -1);
         for (let x = 0; x < 4; x++) {
-            t.true(level0.get(x, -1) === dem1.level.get(x, 3), 'backfills neighbor 0, -1');
+            t.true(dem0.get(x, -1) === dem1.get(x, 3), 'backfills neighbor 0, -1');
         }
 
         dem0.backfillBorder(dem1, 1, 0);
         for (let y = 0; y < 4; y++) {
-            t.true(level0.get(4, y) === dem1.level.get(0, y), 'backfills neighbor 1, 0');
+            t.true(dem0.get(4, y) === dem1.get(0, y), 'backfills neighbor 1, 0');
         }
 
         dem0.backfillBorder(dem1, 0, 1);
         for (let x = 0; x < 4; x++) {
-            t.true(level0.get(x, 4) === dem1.level.get(x, 0), 'backfills neighbor 0, 1');
+            t.true(dem0.get(x, 4) === dem1.get(x, 0), 'backfills neighbor 0, 1');
         }
 
         dem0.backfillBorder(dem1, -1, 1);
-        t.true(level0.get(-1, 4) === dem1.level.get(3, 0), 'backfills neighbor -1, 1');
+        t.true(dem0.get(-1, 4) === dem1.get(3, 0), 'backfills neighbor -1, 1');
 
         dem0.backfillBorder(dem1, 1, 1);
-        t.true(level0.get(4, 4) === dem1.level.get(0, 0), 'backfills neighbor 1, 1');
+        t.true(dem0.get(4, 4) === dem1.get(0, 0), 'backfills neighbor 1, 1');
 
         dem0.backfillBorder(dem1, -1, -1);
-        t.true(level0.get(-1, -1) === dem1.level.get(3, 3), 'backfills neighbor -1, -1');
+        t.true(dem0.get(-1, -1) === dem1.get(3, 3), 'backfills neighbor -1, -1');
 
         dem0.backfillBorder(dem1, 1, -1);
-        t.true(level0.get(4, -1) === dem1.level.get(0, 3), 'backfills neighbor -1, 1');
+        t.true(dem0.get(4, -1) === dem1.get(0, 3), 'backfills neighbor -1, 1');
 
 
         t.end();
@@ -188,42 +134,30 @@ test('DEMData#backfillBorder', (t) => {
 
     t.test('DEMData is correctly serialized', (t)=>{
         const imageData0 = createMockImage(4, 4);
-        const dem0 = new DEMData(0);
-
-        dem0.loadFromImage(imageData0);
-
+        const dem0 = new DEMData(0, imageData0);
         const serialized = serialize(dem0);
 
         t.deepEqual(serialized, {
             name: 'DEMData',
             properties: {
                 uid: 0,
-                scale: 1,
-                level: {
-                    name: 'Level',
-                    properties: {
-                        dim: 4,
-                        border: 2,
-                        stride: 8,
-                        data: dem0.level.data,
-                    }
-                },
-                loaded: true
+                dim: 4,
+                border: 2,
+                stride: 8,
+                data: dem0.data,
             }
         }, 'serializes DEM');
 
         const transferrables = [];
         serialize(dem0, transferrables);
-        t.deepEqual(new Uint32Array(transferrables[0]), dem0.level.data, 'populates transferrables with correct data');
+        t.deepEqual(new Uint32Array(transferrables[0]), dem0.data, 'populates transferrables with correct data');
 
         t.end();
     });
 
     t.test('DEMData is correctly deserialized', (t)=>{
         const imageData0 = createMockImage(4, 4);
-        const dem0 = new DEMData(0);
-
-        dem0.loadFromImage(imageData0);
+        const dem0 = new DEMData(0, imageData0);
         const serialized = serialize(dem0);
 
         const deserialized = deserialize(serialized);

--- a/test/unit/source/raster_dem_tile_worker_source.test.js
+++ b/test/unit/source/raster_dem_tile_worker_source.test.js
@@ -14,7 +14,7 @@ test('loadTile', (t) => {
             dim: 256
         }, (err, data)=>{
             if (err) t.fail();
-            t.deepEqual(source.loading, {});
+            t.deepEqual(Object.keys(source.loaded), [0]);
             t.ok(data instanceof DEMData, 'returns DEM data');
 
             t.end();


### PR DESCRIPTION
This brings the `DEMData` class more in line with the gl-native implementation. This refactor does not affect user-facing APIs.

ref https://github.com/mapbox/mapbox-gl-js/pull/7009#pullrequestreview-139673687

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~document any changes to public APIs~
 - [ ] ~post benchmark scores~
 - [x] manually test the debug page
 - [ ] ~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~
