### PR TITLE
Produce nicer style formatting

### DIFF
--- a/src/style-spec/format.js
+++ b/src/style-spec/format.js
@@ -1,6 +1,7 @@
 
 import reference from './reference/latest.js';
 import sortObject from 'sort-object';
+import stringifyPretty from 'json-stringify-pretty-compact';
 
 function sameOrderAs(reference) {
     const keyOrder = {};
@@ -38,17 +39,14 @@ function sameOrderAs(reference) {
  * fs.writeFileSync('./dest.json', format(style));
  * fs.writeFileSync('./dest.min.json', format(style, 0));
  */
-function format(style, space) {
-    if (space === undefined) space = 2;
+function format(style, space = 2) {
     style = sortObject(style, sameOrderAs(reference.$root));
 
     if (style.layers) {
-        style.layers = style.layers.map((layer) => {
-            return sortObject(layer, sameOrderAs(reference.layer));
-        });
+        style.layers = style.layers.map((layer) => sortObject(layer, sameOrderAs(reference.layer)));
     }
 
-    return JSON.stringify(style, null, space);
+    return stringifyPretty(style, {indent: space});
 }
 
 export default format;

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -30,6 +30,7 @@
     "@mapbox/jsonlint-lines-primitives": "~2.0.2",
     "@mapbox/unitbezier": "^0.0.0",
     "csscolorparser": "~1.0.2",
+    "json-stringify-pretty-compact": "^1.2.0",
     "minimist": "0.0.8",
     "rw": "^1.3.3",
     "sort-object": "^0.3.2"


### PR DESCRIPTION
Makes the `format` function in the `style-spec` package produce nicer, more readable style JSON. Before:

```json
"text-size": [
    "interpolate",
    [
        "linear"
    ],
    [
        "zoom"
    ],
    2,
    [
        "step",
        [
            "get",
            "scalerank"
        ],
        13,
        3,
        11,
        5,
        9
    ],
    9,
    [
        "step",
        [
            "get",
            "scalerank"
        ],
        35,
        3,
        27,
        5,
        22
    ]
]
```

After:

```json
"text-size": [
    "interpolate",
    ["linear"],
    ["zoom"],
    2,
    ["step", ["get", "scalerank"], 13, 3, 11, 5, 9],
    9,
    ["step", ["get", "scalerank"], 35, 3, 27, 5, 22]
]
```

cc @samanpwbb not sure if this needs any actions on the Studio side. Just wanted to make the downloaded styles in Studio easier to read.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~ (formatting doesn't need to be tested)
 - [x] ~~document any changes to public APIs~~ no changes
