### PR TITLE
Update animate-point-along-route example to use icon-ignore-placement

### DIFF
--- a/docs/pages/example/animate-point-along-route.html
+++ b/docs/pages/example/animate-point-along-route.html
@@ -123,7 +123,8 @@ map.on('load', function () {
             "icon-image": "airport-15",
             "icon-rotate": ["get", "bearing"],
             "icon-rotation-alignment": "map",
-            "icon-allow-overlap": true
+            "icon-allow-overlap": true,
+            "icon-ignore-placement": true
         }
     });
 


### PR DESCRIPTION
This ensures the labels don't flash in and out as the aeroplane icon moves over them.

 - [x] manually test the debug page