### PR TITLE
Fix broken benchmarks deploy

### DIFF
--- a/bench/rollup_config_benchmarks.js
+++ b/bench/rollup_config_benchmarks.js
@@ -17,7 +17,8 @@ const config = [{
     output: {
         dir: 'rollup/build/benchmarks',
         format: 'amd',
-        sourcemap: 'inline'
+        sourcemap: 'inline',
+        chunkFileNames: 'shared.js'
     },
     experimentalCodeSplitting: true,
     plugins: plugins()

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ const config = [{
     // First, use code splitting to bundle GL JS into three "chunks":
     // - rollup/build/index.js: the main module, plus all its dependencies not shared by the worker module
     // - rollup/build/worker.js: the worker module, plus all dependencies not shared by the main module
-    // - rollup/build/chunk1.js: the set of modules that are dependencies of both the main module and the worker module
+    // - rollup/build/shared.js: the set of modules that are dependencies of both the main module and the worker module
     //
     // This is also where we do all of our source transformations: removing
     // flow annotations, transpiling ES6 features using buble, inlining shader

--- a/rollup/benchmarks.js
+++ b/rollup/benchmarks.js
@@ -1,4 +1,4 @@
-import './build/benchmarks/chunk1';
+import './build/benchmarks/shared';
 import './build/benchmarks/worker';
 import './build/benchmarks/benchmarks';
 


### PR DESCRIPTION
Benchmarks deploy got broken after #7024 but we haven't noticed because the build only failed on master, not in PRs. This fixes it.