### PR TITLE
Map class cleanup

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -899,13 +899,15 @@ class Style extends Evented {
         }
 
         const sourceResults = [];
+        const queryCoordinates = queryGeometry.map((p) => transform.pointCoordinate(p));
+
         for (const id in this.sourceCaches) {
             if (params.layers && !includedSources[id]) continue;
             sourceResults.push(
                 queryRenderedFeatures(
                     this.sourceCaches[id],
                     this._layers,
-                    queryGeometry.worldCoordinate,
+                    queryCoordinates,
                     params,
                     transform)
             );
@@ -918,7 +920,7 @@ class Style extends Evented {
                 queryRenderedSymbols(
                     this._layers,
                     this.sourceCaches,
-                    queryGeometry.viewport,
+                    queryGeometry,
                     params,
                     this.placement.collisionIndex,
                     this.placement.retainedQueryData)

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -477,32 +477,16 @@ class Map extends Camera {
     /**
      * Returns the map's geographical bounds. When the bearing or pitch is non-zero, the visible region is not
      * an axis-aligned rectangle, and the result is the smallest bounds that encompasses the visible region.
-     *
-     * @returns {LngLatBounds}
      */
-    getBounds() {
-        return new LngLatBounds()
-            .extend(this.transform.pointLocation(new Point(0, 0)))
-            .extend(this.transform.pointLocation(new Point(this.transform.width, 0)))
-            .extend(this.transform.pointLocation(new Point(this.transform.width, this.transform.height)))
-            .extend(this.transform.pointLocation(new Point(0, this.transform.height)));
+    getBounds(): LngLatBounds {
+        return this.transform.getBounds();
     }
 
     /**
-     * Gets the map's geographical bounds.
-     *
-     * Returns the LngLatBounds by which pan and zoom operations on the map are constrained.
-     *
-     * @returns {LngLatBounds | null} The maximum bounds the map is constrained to, or `null` if none set.
+     * Returns the maximum geographical bounds the map is constrained to, or `null` if none set.
      */
-    getMaxBounds () {
-        if (this.transform.latRange && this.transform.latRange.length === 2 &&
-            this.transform.lngRange && this.transform.lngRange.length === 2) {
-            return new LngLatBounds([this.transform.lngRange[0], this.transform.latRange[0]],
-                [this.transform.lngRange[1], this.transform.latRange[1]]);
-        } else {
-            return null;
-        }
+    getMaxBounds(): LngLatBounds | null {
+        return this.transform.getMaxBounds();
     }
 
     /**
@@ -515,21 +499,12 @@ class Map extends Camera {
      * as close as possible to the operation's request while still
      * remaining within the bounds.
      *
-     * @param {LngLatBoundsLike | null | undefined} lnglatbounds The maximum bounds to set. If `null` or `undefined` is provided, the function removes the map's maximum bounds.
+     * @param {LngLatBoundsLike | null | undefined} bounds The maximum bounds to set. If `null` or `undefined` is provided, the function removes the map's maximum bounds.
      * @returns {Map} `this`
      */
-    setMaxBounds(lnglatbounds: LngLatBoundsLike) {
-        if (lnglatbounds) {
-            const b = LngLatBounds.convert(lnglatbounds);
-            this.transform.lngRange = [b.getWest(), b.getEast()];
-            this.transform.latRange = [b.getSouth(), b.getNorth()];
-            this.transform._constrain();
-        } else if (lnglatbounds === null || lnglatbounds === undefined) {
-            this.transform.lngRange = null;
-            this.transform.latRange = null;
-        }
+    setMaxBounds(bounds: LngLatBoundsLike) {
+        this.transform.setMaxBounds(LngLatBounds.convert(bounds));
         return this._update();
-
     }
 
     /**

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1782,13 +1782,13 @@ test('Style#queryRenderedFeatures', (t) => {
         style._updateSources(transform);
 
         t.test('returns feature type', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, transform);
+            const results = style.queryRenderedFeatures([{x: 0, y: 0}], {}, transform);
             t.equal(results[0].geometry.type, 'Line');
             t.end();
         });
 
         t.test('filters by `layers` option', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land']}, transform);
+            const results = style.queryRenderedFeatures([{x: 0, y: 0}], {layers: ['land']}, transform);
             t.equal(results.length, 2);
             t.end();
         });
@@ -1798,26 +1798,26 @@ test('Style#queryRenderedFeatures', (t) => {
             t.stub(style, 'fire').callsFake((event) => {
                 if (event.error && event.error.message.includes('parameters.layers must be an Array.')) errors++;
             });
-            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:'string'}, transform);
+            style.queryRenderedFeatures([{x: 0, y: 0}], {layers:'string'}, transform);
             t.equals(errors, 1);
             t.end();
         });
 
         t.test('includes layout properties', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, transform);
+            const results = style.queryRenderedFeatures([{x: 0, y: 0}], {}, transform);
             const layout = results[0].layer.layout;
             t.deepEqual(layout['line-cap'], 'round');
             t.end();
         });
 
         t.test('includes paint properties', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, transform);
+            const results = style.queryRenderedFeatures([{x: 0, y: 0}], {}, transform);
             t.deepEqual(results[2].layer.paint['line-color'], 'red');
             t.end();
         });
 
         t.test('includes metadata', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {}, transform);
+            const results = style.queryRenderedFeatures([{x: 0, y: 0}], {}, transform);
 
             const layer = results[1].layer;
             t.equal(layer.metadata.something, 'else');
@@ -1826,14 +1826,14 @@ test('Style#queryRenderedFeatures', (t) => {
         });
 
         t.test('include multiple layers', (t) => {
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land', 'landref']}, transform);
+            const results = style.queryRenderedFeatures([{x: 0, y: 0}], {layers: ['land', 'landref']}, transform);
             t.equals(results.length, 3);
             t.end();
         });
 
         t.test('does not query sources not implicated by `layers` parameter', (t) => {
             style.sourceCaches.mapbox.queryRenderedFeatures = function() { t.fail(); };
-            style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers: ['land--other']}, transform);
+            style.queryRenderedFeatures([{x: 0, y: 0}], {layers: ['land--other']}, transform);
             t.end();
         });
 
@@ -1842,7 +1842,7 @@ test('Style#queryRenderedFeatures', (t) => {
             t.stub(style, 'fire').callsFake((event) => {
                 if (event.error && event.error.message.includes('does not exist in the map\'s style and cannot be queried for features.')) errors++;
             });
-            const results = style.queryRenderedFeatures([{column: 1, row: 1, zoom: 1}], {layers:['merp']}, transform);
+            const results = style.queryRenderedFeatures([{x: 0, y: 0}], {layers:['merp']}, transform);
             t.equals(errors, 1);
             t.equals(results.length, 0);
             t.end();
@@ -1907,6 +1907,7 @@ test('Style#query*Features', (t) => {
 
     t.beforeEach((callback) => {
         transform = new Transform();
+        transform.resize(100, 100);
         style = new Style(new StubMap());
         style.loadJSON({
             "version": 8,
@@ -1935,7 +1936,7 @@ test('Style#query*Features', (t) => {
     });
 
     t.test('queryRenderedFeatures emits an error on incorrect filter', (t) => {
-        t.deepEqual(style.queryRenderedFeatures({ worldCoordinate: [10, 100] }, {filter: 7}, transform), []);
+        t.deepEqual(style.queryRenderedFeatures([{x: 0, y: 0}], {filter: 7}, transform), []);
         t.match(onError.args[0][0].error.message, /queryRenderedFeatures\.filter/);
         t.end();
     });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -12,7 +12,6 @@ import simulate from 'mapbox-gl-js-test/simulate_interaction';
 import fixed from 'mapbox-gl-js-test/fixed';
 const fixedNum = fixed.Num;
 const fixedLngLat = fixed.LngLat;
-const fixedCoord = fixed.Coord;
 
 function createStyleSource() {
     return {
@@ -908,7 +907,7 @@ test('Map', (t) => {
                 const output = map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
 
                 const args = map.style.queryRenderedFeatures.getCall(0).args;
-                t.deepEqual(args[0].worldCoordinate.map(c => fixedCoord(c)), [{ column: 0.5, row: 0.5, zoom: 0 }]); // query geometry
+                t.deepEqual(args[0], [{ x: 100, y: 100 }]); // query geometry
                 t.deepEqual(args[1], {}); // params
                 t.deepEqual(args[2], map.transform); // transform
                 t.deepEqual(output, []);
@@ -956,11 +955,7 @@ test('Map', (t) => {
 
                 map.queryRenderedFeatures(map.project(new LngLat(360, 0)));
 
-                const coords = map.style.queryRenderedFeatures.getCall(0).args[0].worldCoordinate.map(c => fixedCoord(c));
-                t.equal(coords[0].column, 1.5);
-                t.equal(coords[0].row, 0.5);
-                t.equal(coords[0].zoom, 0);
-
+                t.deepEqual(map.style.queryRenderedFeatures.getCall(0).args[0], [{x: 612, y: 100}]);
                 t.end();
             });
         });


### PR DESCRIPTION
A cleanup sweep for the `Map` class. See individual commits. Fixes #2741. I don't think there's much more logic left to move downstream unless we break the API.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] ~~document any changes to public APIs~~
 - [x] ~~post benchmark scores~~
 - [x] manually test the debug page
