### PR TITLE
Fix querySourceFeatures returning bad results on zooms past maxZoom

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -284,12 +284,13 @@ class Tile {
         if (!layer) return;
 
         const filter = featureFilter(params && params.filter);
-        const coord = { z: this.tileID.overscaledZ, x: this.tileID.canonical.x, y: this.tileID.canonical.y };
+        const {z, x, y} = this.tileID.canonical;
+        const coord = {z, x, y};
 
         for (let i = 0; i < layer.length; i++) {
             const feature = layer.feature(i);
             if (filter(new EvaluationParameters(this.tileID.overscaledZ), feature)) {
-                const geojsonFeature = new GeoJSONFeature(feature, coord.z, coord.x, coord.y);
+                const geojsonFeature = new GeoJSONFeature(feature, z, x, y);
                 (geojsonFeature: any).tile = coord;
                 result.push(geojsonFeature);
             }

--- a/test/unit/source/tile.test.js
+++ b/test/unit/source/tile.test.js
@@ -20,7 +20,7 @@ test('querySourceFeatures', (t) => {
 
 
     t.test('geojson tile', (t) => {
-        const tile = new Tile(new OverscaledTileID(1, 0, 1, 1, 1));
+        const tile = new Tile(new OverscaledTileID(3, 0, 2, 1, 2));
         let result;
 
         result = [];
@@ -37,6 +37,7 @@ test('querySourceFeatures', (t) => {
         result = [];
         tile.querySourceFeatures(result);
         t.equal(result.length, 1);
+        t.deepEqual(result[0].geometry.coordinates[0], [-90, 0]);
         result = [];
         tile.querySourceFeatures(result, {});
         t.equal(result.length, 1);


### PR DESCRIPTION
Fixes #2868. Fixes #3722. 

~~I also removed the `reparseOverscaled` source option because it doesn't seem useful — we always want to reparse overscaled tiles for correct layout values, and we don't need to worry about performance because parsing overscaled tiles is very fast anyway (there's only a few on the screen and they're small).~~

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] ~~document any changes to public APIs~~
 - [x] ~~post benchmark scores~~
 - [x] manually test the debug page
