### PR TITLE
Get rid of sort-object dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "quickselect": "^1.0.0",
     "rw": "^1.3.3",
     "shuffle-seed": "^1.1.6",
-    "sort-object": "^0.3.2",
     "supercluster": "^4.0.1",
     "through2": "^2.0.3",
     "tinyqueue": "^1.1.0",

--- a/src/style-spec/format.js
+++ b/src/style-spec/format.js
@@ -1,21 +1,20 @@
 
 import reference from './reference/latest.js';
-import sortObject from 'sort-object';
 import stringifyPretty from 'json-stringify-pretty-compact';
 
-function sameOrderAs(reference) {
-    const keyOrder = {};
-
-    Object.keys(reference).forEach((k, i) => {
-        keyOrder[k] = i + 1;
-    });
-
-    return {
-        sort: function (a, b) {
-            return (keyOrder[a] || Infinity) -
-                   (keyOrder[b] || Infinity);
+function sortKeysBy(obj, reference) {
+    const result = {};
+    for (const key in reference) {
+        if (obj[key] !== undefined) {
+            result[key] = obj[key];
         }
-    };
+    }
+    for (const key in obj) {
+        if (result[key] === undefined) {
+            result[key] = obj[key];
+        }
+    }
+    return result;
 }
 
 /**
@@ -40,10 +39,10 @@ function sameOrderAs(reference) {
  * fs.writeFileSync('./dest.min.json', format(style, 0));
  */
 function format(style, space = 2) {
-    style = sortObject(style, sameOrderAs(reference.$root));
+    style = sortKeysBy(style, reference.$root);
 
     if (style.layers) {
-        style.layers = style.layers.map((layer) => sortObject(layer, sameOrderAs(reference.layer)));
+        style.layers = style.layers.map((layer) => sortKeysBy(layer, reference.layer));
     }
 
     return stringifyPretty(style, {indent: space});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9147,26 +9147,11 @@ socket.io@2.0.4:
     socket.io-client "2.0.4"
     socket.io-parser "~3.1.1"
 
-sort-asc@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/sort-asc/-/sort-asc-0.1.0.tgz#ab799df61fc73ea0956c79c4b531ed1e9e7727e9"
-
-sort-desc@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/sort-desc/-/sort-desc-0.1.1.tgz#198b8c0cdeb095c463341861e3925d4ee359a9ee"
-
 sort-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
   dependencies:
     is-plain-obj "^1.0.0"
-
-sort-object@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/sort-object/-/sort-object-0.3.2.tgz#98e0d199ede40e07c61a84403c61d6c3b290f9e2"
-  dependencies:
-    sort-asc "^0.1.0"
-    sort-desc "^0.1.1"
 
 source-list-map@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Getting rid of dependencies we don't really need during an upgrade pass.