### PR TITLE
Publish flow types

### DIFF
--- a/build/mapbox-gl.js.flow
+++ b/build/mapbox-gl.js.flow
@@ -1,0 +1,3 @@
+// @flow
+/* eslint-disable */
+export * from '../src/index.js';

--- a/circle.yml
+++ b/circle.yml
@@ -132,6 +132,7 @@ jobs:
       - run: yarn run build-dev
       - run: yarn run build-css
       - run: yarn run build-style-spec
+      - run: yarn run build-flow-types
       - run: yarn run test-build
       - persist_to_workspace:
           root: .

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "build-dev": "rollup -c --environment BUILD:dev",
     "watch-dev": "rollup -c --environment BUILD:dev --watch",
     "build-min": "rollup -c --environment BUILD:production",
+    "build-flow-types": "cp build/mapbox-gl.js.flow dist/mapbox-gl.js.flow && cp build/mapbox-gl.js.flow dist/mapbox-gl-dev.js.flow",
     "build-css": "postcss -o dist/mapbox-gl.css src/css/mapbox-gl.css",
     "build-style-spec": "cd src/style-spec && npm run build && cd ../.. && mkdir -p dist/style-spec && cp src/style-spec/dist/* dist/style-spec",
     "watch-css": "postcss --watch -o dist/mapbox-gl.css src/css/mapbox-gl.css",
@@ -139,7 +140,7 @@
     "test-flow": "build/run-node build/generate-flow-typed-style-spec && flow .",
     "test-flow-cov": "flow-coverage-report -i 'src/**/*.js' -t html",
     "test-cov": "nyc --require=@mapbox/flow-remove-types/register --reporter=text-summary --reporter=lcov --cache run-s test-unit test-expressions test-query test-render",
-    "prepublishOnly": "run-s build-dev build-min build-css build-style-spec test-build",
+    "prepublishOnly": "run-s build-flow-types build-dev build-min build-css build-style-spec test-build",
     "codegen": "build/run-node build/generate-style-code.js && build/run-node build/generate-struct-arrays.js"
   },
   "files": [

--- a/test/build/downstream-flow-fixture/.flowconfig
+++ b/test/build/downstream-flow-fixture/.flowconfig
@@ -11,7 +11,15 @@
 .*/node_modules/@mapbox/geojson-types/fixtures/.*
 .*/test/unit/style-spec/fixture/invalidjson.input.json
 .*/test/integration/render-tests/.*
-.*/test/build/downstream-flow-fixture/.*
 
-[version]
-0.77.0
+[include]
+../../..
+
+[libs]
+../../../flow-typed
+
+[lints]
+
+[options]
+
+[strict]

--- a/test/build/downstream-flow-fixture/invalid.js
+++ b/test/build/downstream-flow-fixture/invalid.js
@@ -1,0 +1,5 @@
+// @flow
+/* eslint-disable */
+import mapboxgl from '../../..';
+const Map = mapboxgl.Map;
+const map = new Map({});

--- a/test/build/downstream-flow-fixture/valid.js
+++ b/test/build/downstream-flow-fixture/valid.js
@@ -1,0 +1,7 @@
+// @flow
+/* eslint-disable */
+import mapboxgl from '../../..';
+const Map = mapboxgl.Map;
+const map = new Map({
+    container: document.getElementById('map')
+});

--- a/test/build/published-flow-types.js
+++ b/test/build/published-flow-types.js
@@ -1,0 +1,15 @@
+import { test } from 'mapbox-gl-js-test';
+import cp from 'child_process';
+
+test('downstream projects can consume published flow types', (t) => {
+    cp.exec(`${__dirname}/../../node_modules/.bin/flow check --strip-root --json ${__dirname}/downstream-flow-fixture`, {}, (error, stdout) => {
+        const result = JSON.parse(stdout);
+        t.equal(result.errors.length, 1);
+        for (const error of result.errors) {
+            for (const message of error.message) {
+                t.notEqual(message.path, 'valid.js');
+            }
+        }
+        t.end();
+    });
+});


### PR DESCRIPTION
Closes #6963

Downstream projects using Flow should now get typing for gl-js. However,
you'll need to include libdefs for some of our dependencies. Our libdefs are
included with the `mapbox-gl` NPM package, so you can get them by adding:

```
[libs]
node_modules/mapbox-gl/flow-typed
```

You'll also need to add an ignore for one of our dependencies that causes
Flow errors:

```
[ignore]
.*/node_modules/@mapbox/jsonlint-lines-primitives/.*
```