### PR TITLE
Include `bindVertexBuffer` in Context.setDirty()

### DIFF
--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -135,6 +135,7 @@ class Context {
         this.program.dirty = true;
         this.activeTexture.dirty = true;
         this.viewport.dirty = true;
+        this.bindVertexBuffer.dirty = true;
         this.bindFramebuffer.dirty = true;
         this.bindRenderbuffer.dirty = true;
         this.bindTexture.dirty = true;


### PR DESCRIPTION
While doing a PoC of integrating CARTO VL with Mapbox GL using this new API we found a flickering issue (the screen was cleared to white intermittently sometimes).

The problem only happened when using WebGL outside the rendering loop (async).

We discovered that `BindVertexBuffer.set()` was being called after our async code executed and that the `if (this.current !== v || this.dirty === true) {` didn't pass in the first time `set` was called after our code, which made our buffers bound and MGL buffers unbound, causing the problems.

Adding `this.bindVertexBuffer.dirty = true;` to `Context.setDirty()` seems to fix the issue.

Thank you!