### PR TITLE
Mark WebGL state as dirty on `Map._render()`

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -275,10 +275,6 @@ class Painter {
         this.imageManager = style.imageManager;
         this.glyphManager = style.glyphManager;
 
-        // A custom layer may have used the context asynchronously. Mark the state as dirty.
-        this.context.setDirty();
-        this.setBaseState();
-
         this.symbolFadeChange = style.placement.symbolFadeChange(browser.now());
 
         const layerIds = this.style._order;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1624,6 +1624,10 @@ class Map extends Camera {
      * @private
      */
     _render() {
+        // A custom layer may have used the context asynchronously. Mark the state as dirty.
+        this.painter.context.setDirty();
+        this.painter.setBaseState();
+
         this._renderTaskQueue.run();
 
         let crossFading = false;


### PR DESCRIPTION
After https://github.com/mapbox/mapbox-gl-js/pull/7080 we still saw some WebGL warnings in Chrome's console:
![mgl-bug](https://user-images.githubusercontent.com/1692175/43711966-d14ddb3a-9974-11e8-95e8-cefd608481df.png)

When debugging it (see picture), we saw that Mapbox GL were doing some WebGL calls before setting the state as dirty.

This PR moves the "setDirty" code from `Painter` to `Map`.

Thanks!