### PR TITLE
Source DEPLOY_ENV into shell for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "start-debug": "run-p build-token watch-css watch-dev start-server",
     "start-bench": "run-p build-token watch-benchmarks watch-benchmarks-view start-server",
     "build-docs": "documentation build --github --format json --config ./docs/documentation.yml --output docs/components/api.json src/index.js",
-    "build": "run-s build-docs && build/set-deploy-env.sh && batfish build # invoked by publisher when publishing docs on the mb-pages branch",
+    "build": "run-s build-docs && . build/set-deploy-env.sh && batfish build # invoked by publisher when publishing docs on the mb-pages branch",
     "start-docs": "run-s build-min build-css build-docs && DEPLOY_ENV=local batfish start",
     "lint": "eslint --cache --ignore-path .gitignore src test bench docs docs/pages/example/*.html debug/*.html",
     "lint-docs": "documentation lint src/index.js",


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-js/pull/6792 introduced the `DEPLOY_ENV` variable in order to manage staging's relationship with the Great Spider. But I made a mistake and forgot that exporting the variables from that `.sh` script won't make a difference to `batfish build` unless the `build/set-deploy-env.sh` command is invoked with `.`, so the variables it exports are sourced into the shell for all subsequent commands.

The way I verified that this fix worked: 

- When the branch's name is `mb-pages` and you `npm run build`, there's no `<meta name="robots" content="noindex">`.
- When the branch's name is anything else, there is `<meta name="robots" content="noindex">`.

Sorry about this mistake. cc @mapbox/frontend-platform for context.

@jfirebaugh for review, please.