### PR TITLE
Use absolute asset URL in hover-styles example

### DIFF
--- a/docs/pages/example/hover-styles.html
+++ b/docs/pages/example/hover-styles.html
@@ -11,7 +11,7 @@ var hoveredStateId =  null;
 map.on('load', function () {
     map.addSource("states", {
         "type": "geojson",
-        "data": "/mapbox-gl-js/assets/us_states.geojson"
+        "data": "https://www.mapbox.com/mapbox-gl-js/assets/us_states.geojson"
     });
 
     // The feature-state dependent fill-opacity expression will render the hover effect


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR

I think this was missed in #6834 but we should use an absolute URL for assets on all the example pages so that they can be copied over to JSBin or wherever
