### PR TITLE
Correct feature state id type to number

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -148,7 +148,7 @@ class FeatureIndex {
                     let featureState = {};
                     if (feature.id) {
                         // `feature-state` expression evaluation requires feature state to be available
-                        featureState = sourceFeatureState.getState(styleLayer.sourceLayer || '_geojsonTileLayer', String(feature.id));
+                        featureState = sourceFeatureState.getState(styleLayer.sourceLayer || '_geojsonTileLayer', feature.id);
                     }
                     return styleLayer.queryIntersectsFeature(queryGeometry, feature, featureState, featureGeometry, this.z, args.transform, pixelsToTileUnits, args.posMatrix);
                 }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -818,7 +818,7 @@ class SourceCache extends Evented {
      * Set the value of a particular state for a feature
      * @private
      */
-    setFeatureState(sourceLayer?: string, feature: string, state: Object) {
+    setFeatureState(sourceLayer?: string, feature: number, state: Object) {
         sourceLayer = sourceLayer || '_geojsonTileLayer';
         this._state.updateState(sourceLayer, feature, state);
     }
@@ -827,7 +827,7 @@ class SourceCache extends Evented {
      * Get the entire state object for a feature
      * @private
      */
-    getFeatureState(sourceLayer?: string, feature: string) {
+    getFeatureState(sourceLayer?: string, feature: number) {
         sourceLayer = sourceLayer || '_geojsonTileLayer';
         return this._state.getState(sourceLayer, feature);
     }

--- a/src/source/source_state.js
+++ b/src/source/source_state.js
@@ -22,15 +22,15 @@ class SourceFeatureState {
         this.stateChanges = {};
     }
 
-    updateState(sourceLayer: string, feature: string, state: Object) {
-        feature = String(feature);
+    updateState(sourceLayer: string, featureId: number, state: Object) {
+        const feature = String(featureId);
         this.stateChanges[sourceLayer] = this.stateChanges[sourceLayer] || {};
         this.stateChanges[sourceLayer][feature] = this.stateChanges[sourceLayer][feature] || {};
         extend(this.stateChanges[sourceLayer][feature], state);
     }
 
-    getState(sourceLayer: string, feature: string) {
-        feature = String(feature);
+    getState(sourceLayer: string, featureId: number) {
+        const feature = String(featureId);
         const base = this.state[sourceLayer] || {};
         const changes = this.stateChanges[sourceLayer] || {};
         return extend({}, base[feature], changes[feature]);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -803,7 +803,7 @@ class Style extends Evented {
             return;
         }
         if (feature.id == null || feature.id < 0) {
-            this.fire(new ErrorEvent(new Error(`The feature id parameter must be provided and positive.`)));
+            this.fire(new ErrorEvent(new Error(`The feature id parameter must be provided and non-negative.`)));
             return;
         }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -787,7 +787,7 @@ class Style extends Evented {
         return this.getLayer(layer).getPaintProperty(name);
     }
 
-    setFeatureState(feature: { source: string; sourceLayer?: string; id: string; }, state: Object) {
+    setFeatureState(feature: { source: string; sourceLayer?: string; id: number; }, state: Object) {
         this._checkLoaded();
         const sourceId = feature.source;
         const sourceLayer = feature.sourceLayer;
@@ -802,15 +802,15 @@ class Style extends Evented {
             this.fire(new ErrorEvent(new Error(`The sourceLayer parameter must be provided for vector source types.`)));
             return;
         }
-        if (feature.id == null || feature.id === "") {
-            this.fire(new ErrorEvent(new Error(`The feature id parameter must be provided.`)));
+        if (feature.id == null || feature.id < 0) {
+            this.fire(new ErrorEvent(new Error(`The feature id parameter must be provided and positive.`)));
             return;
         }
 
         sourceCache.setFeatureState(sourceLayer, feature.id, state);
     }
 
-    getFeatureState(feature: { source: string; sourceLayer?: string; id: string; }) {
+    getFeatureState(feature: { source: string; sourceLayer?: string; id: number; }) {
         this._checkLoaded();
         const sourceId = feature.source;
         const sourceLayer = feature.sourceLayer;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -787,11 +787,12 @@ class Style extends Evented {
         return this.getLayer(layer).getPaintProperty(name);
     }
 
-    setFeatureState(feature: { source: string; sourceLayer?: string; id: number; }, state: Object) {
+    setFeatureState(feature: { source: string; sourceLayer?: string; id: string | number; }, state: Object) {
         this._checkLoaded();
         const sourceId = feature.source;
         const sourceLayer = feature.sourceLayer;
         const sourceCache = this.sourceCaches[sourceId];
+        const featureId = parseInt(feature.id, 10);
 
         if (sourceCache === undefined) {
             this.fire(new ErrorEvent(new Error(`The source '${sourceId}' does not exist in the map's style.`)));
@@ -802,19 +803,20 @@ class Style extends Evented {
             this.fire(new ErrorEvent(new Error(`The sourceLayer parameter must be provided for vector source types.`)));
             return;
         }
-        if (feature.id == null || feature.id < 0) {
+        if (isNaN(featureId) || featureId < 0) {
             this.fire(new ErrorEvent(new Error(`The feature id parameter must be provided and non-negative.`)));
             return;
         }
 
-        sourceCache.setFeatureState(sourceLayer, feature.id, state);
+        sourceCache.setFeatureState(sourceLayer, featureId, state);
     }
 
-    getFeatureState(feature: { source: string; sourceLayer?: string; id: number; }) {
+    getFeatureState(feature: { source: string; sourceLayer?: string; id: string | number; }) {
         this._checkLoaded();
         const sourceId = feature.source;
         const sourceLayer = feature.sourceLayer;
         const sourceCache = this.sourceCaches[sourceId];
+        const featureId = parseInt(feature.id, 10);
 
         if (sourceCache === undefined) {
             this.fire(new ErrorEvent(new Error(`The source '${sourceId}' does not exist in the map's style.`)));
@@ -825,8 +827,12 @@ class Style extends Evented {
             this.fire(new ErrorEvent(new Error(`The sourceLayer parameter must be provided for vector source types.`)));
             return;
         }
+        if (isNaN(featureId) || featureId < 0) {
+            this.fire(new ErrorEvent(new Error(`The feature id parameter must be provided and non-negative.`)));
+            return;
+        }
 
-        return sourceCache.getFeatureState(sourceLayer, feature.id);
+        return sourceCache.getFeatureState(sourceLayer, featureId);
     }
 
     getTransition() {

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -170,7 +170,7 @@ class StyleLayer extends Evented {
     }
 
     serialize() {
-        const output : any = {
+        const output: any = {
             'id': this.id,
             'type': this.type,
             'source': this.source,

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1337,10 +1337,10 @@ class Map extends Camera {
     /**
      * Sets the state of a feature. The `state` object is merged in with the existing state of the feature.
      *
-     * @param {Object} [feature] Feature identifier. Feature objects returned from
+     * @param {Object} feature Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
-     * @param {string | number} [feature.id] Unique id of the feature.
-     * @param {string} [feature.source] The Id of the vector source or GeoJSON source for the feature.
+     * @param {string | number} feature.id Unique id of the feature.
+     * @param {string} feature.source The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
      *  required.*
      * @param {Object} state A set of key-value pairs. The values should be valid JSON types.
@@ -1359,12 +1359,12 @@ class Map extends Camera {
     /**
      * Gets the state of a feature.
      *
-     * @param {Object} [feature] Feature identifier. Feature objects returned from
+     * @param {Object} feature Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
-     * @param {string} [feature.source] The Id of the vector source or GeoJSON source for the feature.
+     * @param {string | number} feature.id Unique id of the feature.
+     * @param {string} feature.source The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
      *  required.*
-     * @param {string | number} [feature.id] Unique id of the feature.
      *
      * @returns {Object} The state of the feature.
      */

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1339,7 +1339,7 @@ class Map extends Camera {
      *
      * @param {Object} [feature] Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
-     * @param {number} [feature.id] Unique id of the feature.
+     * @param {string | number} [feature.id] Unique id of the feature.
      * @param {string} [feature.source] The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
      *  required.*
@@ -1351,7 +1351,7 @@ class Map extends Camera {
      * `map.getSource('some id').setData(..)` resets the cache of feature states and requires the 
      * caller re-apply the state as needed with the updated `id` values.
      */
-    setFeatureState(feature: { source: string; sourceLayer?: string; id: number; }, state: Object) {
+    setFeatureState(feature: { source: string; sourceLayer?: string; id: string | number; }, state: Object) {
         this.style.setFeatureState(feature, state);
         return this._update();
     }
@@ -1364,11 +1364,11 @@ class Map extends Camera {
      * @param {string} [feature.source] The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
      *  required.*
-     * @param {number} [feature.id] Unique id of the feature.
+     * @param {string | number} [feature.id] Unique id of the feature.
      *
      * @returns {Object} The state of the feature.
      */
-    getFeatureState(feature: { source: string; sourceLayer?: string; id: number; }): any {
+    getFeatureState(feature: { source: string; sourceLayer?: string; id: string | number; }): any {
         return this.style.getFeatureState(feature);
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1339,7 +1339,7 @@ class Map extends Camera {
      *
      * @param {Object} [feature] Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
-     * @param {string} [feature.id] Unique id of the feature.
+     * @param {number} [feature.id] Unique id of the feature.
      * @param {string} [feature.source] The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
      *  required.*
@@ -1351,7 +1351,7 @@ class Map extends Camera {
      * `map.getSource('some id').setData(..)` resets the cache of feature states and requires the 
      * caller re-apply the state as needed with the updated `id` values.
      */
-    setFeatureState(feature: { source: string; sourceLayer?: string; id: string; }, state: Object) {
+    setFeatureState(feature: { source: string; sourceLayer?: string; id: number; }, state: Object) {
         this.style.setFeatureState(feature, state);
         return this._update();
     }
@@ -1364,11 +1364,11 @@ class Map extends Camera {
      * @param {string} [feature.source] The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
      *  required.*
-     * @param {string} [feature.id] Unique id of the feature.
+     * @param {number} [feature.id] Unique id of the feature.
      *
      * @returns {Object} The state of the feature.
      */
-    getFeatureState(feature: { source: string; sourceLayer?: string; id: string; }): any {
+    getFeatureState(feature: { source: string; sourceLayer?: string; id: number; }): any {
         return this.style.getFeatureState(feature);
     }
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1268,6 +1268,23 @@ test('Map', (t) => {
                 t.end();
             });
         });
+        t.test('parses feature id as an int', (t) => {
+            const map = createMap(t, {
+                style: {
+                    "version": 8,
+                    "sources": {
+                        "geojson": createStyleSource()
+                    },
+                    "layers": []
+                }
+            });
+            map.on('load', () => {
+                map.setFeatureState({ source: 'geojson', id: '12345'}, {'hover': true});
+                const fState = map.getFeatureState({ source: 'geojson', id: 12345});
+                t.equal(fState.hover, true);
+                t.end();
+            });
+        });
 
         t.test('resets state if source data is updated', (t) => {
             const map = createMap(t, {
@@ -1395,6 +1412,27 @@ test('Map', (t) => {
                     t.end();
                 });
                 map.setFeatureState({ source: 'vector', sourceLayer: "1", id: -1}, {'hover': true});
+            });
+        });
+        t.test('fires an error if id cannot be parsed as an int', (t) => {
+            const map = createMap(t, {
+                style: {
+                    "version": 8,
+                    "sources": {
+                        "vector": {
+                            "type": "vector",
+                            "tiles": ["http://example.com/{z}/{x}/{y}.png"]
+                        }
+                    },
+                    "layers": []
+                }
+            });
+            map.on('load', () => {
+                map.on('error', ({ error }) => {
+                    t.match(error.message, /id/);
+                    t.end();
+                });
+                map.setFeatureState({ source: 'vector', sourceLayer: "1", id: 'abc'}, {'hover': true});
             });
         });
         t.end();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1262,8 +1262,8 @@ test('Map', (t) => {
                 }
             });
             map.on('load', () => {
-                map.setFeatureState({ source: 'geojson', id: '12345'}, {'hover': true});
-                const fState = map.getFeatureState({ source: 'geojson', id: '12345'});
+                map.setFeatureState({ source: 'geojson', id: 12345}, {'hover': true});
+                const fState = map.getFeatureState({ source: 'geojson', id: 12345});
                 t.equal(fState.hover, true);
                 t.end();
             });
@@ -1311,7 +1311,7 @@ test('Map', (t) => {
                 }
             });
             t.throws(() => {
-                map.setFeatureState({ source: 'geojson', id: '12345'}, {'hover': true});
+                map.setFeatureState({ source: 'geojson', id: 12345}, {'hover': true});
             }, Error, /load/i);
 
             t.end();
@@ -1331,7 +1331,7 @@ test('Map', (t) => {
                     t.match(error.message, /source/);
                     t.end();
                 });
-                map.setFeatureState({ source: 'vector', id: '12345'}, {'hover': true});
+                map.setFeatureState({ source: 'vector', id: 12345}, {'hover': true});
             });
         });
         t.test('fires an error if sourceLayer not provided for a vector source', (t) => {
@@ -1352,7 +1352,7 @@ test('Map', (t) => {
                     t.match(error.message, /sourceLayer/);
                     t.end();
                 });
-                map.setFeatureState({ source: 'vector', sourceLayer: 0, id: '12345'}, {'hover': true});
+                map.setFeatureState({ source: 'vector', sourceLayer: 0, id: 12345}, {'hover': true});
             });
         });
         t.test('fires an error if id not provided', (t) => {
@@ -1374,6 +1374,27 @@ test('Map', (t) => {
                     t.end();
                 });
                 map.setFeatureState({ source: 'vector', sourceLayer: "1"}, {'hover': true});
+            });
+        });
+        t.test('fires an error if id is less than zero', (t) => {
+            const map = createMap(t, {
+                style: {
+                    "version": 8,
+                    "sources": {
+                        "vector": {
+                            "type": "vector",
+                            "tiles": ["http://example.com/{z}/{x}/{y}.png"]
+                        }
+                    },
+                    "layers": []
+                }
+            });
+            map.on('load', () => {
+                map.on('error', ({ error }) => {
+                    t.match(error.message, /id/);
+                    t.end();
+                });
+                map.setFeatureState({ source: 'vector', sourceLayer: "1", id: -1}, {'hover': true});
             });
         });
         t.end();


### PR DESCRIPTION
Currently, string feature ids are not propagated through the transformation from GeoJSON to vector tiles (#2716, #6960) and are [not supported by vector tiles at all](https://github.com/mapbox/vector-tile-spec/blob/master/2.1/vector_tile.proto#L32). However, `setFeatureState` / `getFeatureState` indicate that they require string ids.

This pull request updates `setFeatureState` / `getFeatureState` to require unsigned numeric ids.

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
