### PR TITLE
Reduce worker payload

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -70,10 +70,7 @@ export type SymbolInstance = {
     textBoxEndIndex: number,
     iconBoxStartIndex: number,
     iconBoxEndIndex: number,
-    textOffset: [number, number],
-    iconOffset: [number, number],
     anchor: Anchor,
-    line: Array<Point>,
     featureIndex: number,
     textCollisionFeature?: {boxStartIndex: number, boxEndIndex: number},
     iconCollisionFeature?: {boxStartIndex: number, boxEndIndex: number},
@@ -82,7 +79,6 @@ export type SymbolInstance = {
     numVerticalGlyphVertices: number;
     numIconVertices: number;
     // Populated/modified on foreground during placement
-    isDuplicate: boolean;
     crossTileID: number;
     collisionArrays?: CollisionArrays;
     placedText?: boolean;

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -70,7 +70,7 @@ function packColor(color: Color): [number, number] {
  */
 
 interface Binder<T> {
-    statistics: { max: number };
+    maxValue: number;
     uniformName: string;
 
     populatePaintArray(length: number, feature: Feature): void;
@@ -89,7 +89,7 @@ interface Binder<T> {
 class ConstantBinder<T> implements Binder<T> {
     value: T;
     name: string;
-    statistics: { max: number };
+    maxValue: number;
     type: string;
     uniformName: string;
 
@@ -98,7 +98,7 @@ class ConstantBinder<T> implements Binder<T> {
         this.name = name;
         this.uniformName = `u_${this.name}`;
         this.type = type;
-        this.statistics = { max: -Infinity };
+        this.maxValue = -Infinity;
     }
 
     defines() {
@@ -127,7 +127,7 @@ class SourceExpressionBinder<T> implements Binder<T> {
     name: string;
     uniformName: string;
     type: string;
-    statistics: { max: number };
+    maxValue: number;
 
     paintVertexArray: StructArray;
     paintVertexAttributes: Array<StructArrayMember>;
@@ -138,7 +138,7 @@ class SourceExpressionBinder<T> implements Binder<T> {
         this.name = name;
         this.type = type;
         this.uniformName = `a_${name}`;
-        this.statistics = { max: -Infinity };
+        this.maxValue = -Infinity;
         const PaintVertexArray = type === 'color' ? StructArrayLayout2f8 : StructArrayLayout1f4;
         this.paintVertexAttributes = [{
             name: `a_${name}`,
@@ -171,7 +171,7 @@ class SourceExpressionBinder<T> implements Binder<T> {
                 paintArray.emplaceBack(value);
             }
 
-            this.statistics.max = Math.max(this.statistics.max, value);
+            this.maxValue = Math.max(this.maxValue, value);
         }
     }
 
@@ -189,7 +189,7 @@ class SourceExpressionBinder<T> implements Binder<T> {
                 paintArray.emplace(i, value);
             }
 
-            this.statistics.max = Math.max(this.statistics.max, value);
+            this.maxValue = Math.max(this.maxValue, value);
         }
     }
 
@@ -225,7 +225,7 @@ class CompositeExpressionBinder<T> implements Binder<T> {
     type: string;
     useIntegerZoom: boolean;
     zoom: number;
-    statistics: { max: number };
+    maxValue: number;
 
     paintVertexArray: StructArray;
     paintVertexAttributes: Array<StructArrayMember>;
@@ -238,7 +238,7 @@ class CompositeExpressionBinder<T> implements Binder<T> {
         this.type = type;
         this.useIntegerZoom = useIntegerZoom;
         this.zoom = zoom;
-        this.statistics = { max: -Infinity };
+        this.maxValue = -Infinity;
         const PaintVertexArray = type === 'color' ? StructArrayLayout4f16 : StructArrayLayout2f8;
         this.paintVertexAttributes = [{
             name: `a_${name}`,
@@ -272,8 +272,7 @@ class CompositeExpressionBinder<T> implements Binder<T> {
             for (let i = start; i < newLength; i++) {
                 paintArray.emplaceBack(min, max);
             }
-
-            this.statistics.max = Math.max(this.statistics.max, min, max);
+            this.maxValue = Math.max(this.maxValue, min, max);
         }
     }
 
@@ -293,8 +292,7 @@ class CompositeExpressionBinder<T> implements Binder<T> {
             for (let i = start; i < end; i++) {
                 paintArray.emplace(i, min, max);
             }
-
-            this.statistics.max = Math.max(this.statistics.max, min, max);
+            this.maxValue = Math.max(this.maxValue, min, max);
         }
     }
 

--- a/src/style/query_utils.js
+++ b/src/style/query_utils.js
@@ -13,7 +13,7 @@ export function getMaximumPaintValue(property: string, layer: StyleLayer, bucket
         return value.value;
     } else {
         const binders = bucket.programConfigurations.get(layer.id).binders;
-        return binders[property].statistics.max;
+        return binders[property].maxValue;
     }
 }
 

--- a/src/symbol/symbol_layout.js
+++ b/src/symbol/symbol_layout.js
@@ -4,7 +4,6 @@ import Anchor from './anchor';
 
 import { getAnchors, getCenterAnchor } from './get_anchors';
 import clipLine from './clip_line';
-import OpacityState from './opacity_state';
 import { shapeText, shapeIcon, WritingMode } from './shaping';
 import { getGlyphQuads, getIconQuads } from './quads';
 import CollisionFeature from './collision_feature';
@@ -411,26 +410,17 @@ function addSymbol(bucket: SymbolBucket,
         "Too many glyphs being rendered in a tile. See https://github.com/mapbox/mapbox-gl-js/issues/2907"
     );
 
-    const textOpacityState = new OpacityState();
-    const iconOpacityState = new OpacityState();
-
     return {
         key,
         textBoxStartIndex,
         textBoxEndIndex,
         iconBoxStartIndex,
         iconBoxEndIndex,
-        textOffset,
-        iconOffset,
         anchor,
-        line,
         featureIndex,
         numGlyphVertices,
         numVerticalGlyphVertices,
         numIconVertices,
-        textOpacityState,
-        iconOpacityState,
-        isDuplicate: false,
         placedTextSymbolIndices,
         crossTileID: 0
     };

--- a/test/unit/data/dem_data.test.js
+++ b/test/unit/data/dem_data.test.js
@@ -138,14 +138,12 @@ test('DEMData#backfillBorder', (t) => {
         const serialized = serialize(dem0);
 
         t.deepEqual(serialized, {
-            name: 'DEMData',
-            properties: {
-                uid: 0,
-                dim: 4,
-                border: 2,
-                stride: 8,
-                data: dem0.data,
-            }
+            $name: 'DEMData',
+            uid: 0,
+            dim: 4,
+            border: 2,
+            stride: 8,
+            data: dem0.data,
         }, 'serializes DEM');
 
         const transferrables = [];

--- a/test/unit/util/web_worker_transfer.test.js
+++ b/test/unit/util/web_worker_transfer.test.js
@@ -64,11 +64,11 @@ test('custom serialization', (t) => {
         }
 
         static serialize(b: Bar): Serialized {
-            return `custom serialization,${b.id}`;
+            return {foo: `custom serialization,${b.id}`};
         }
 
         static deserialize(input: Serialized): Bar {
-            const b = new Bar((input: any).split(',')[1]);
+            const b = new Bar((input: any).foo.split(',')[1]);
             b._deserialized = true;
             return b;
         }


### PR DESCRIPTION
Reduces the size of the JSON (excluding transferred arrays) that gets sent from the worker to the main thread, reducing lags during tile loading (in theory). Partially addresses #7011.

For a dense z11 Mapbox Streets v10 tile in DC, the payload is reduced by ~44%. For the expressions-based Basic style, the reduction is 39%.

See individual commits. The first one has the biggest impact (~28%) — it converts serialized form from `{name: 'Object', properties: {foo: 'bar'}}` to `{foo: 'bar}` for simple objects and `{$name: 'Foo', foo: 'bar'}` for both registered classes and custom-serialized ones.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~
 - [x] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
