### PR TITLE
Convert offsetHeight/Width to clientHeight/Width

### DIFF
--- a/src/style-spec/types.js
+++ b/src/style-spec/types.js
@@ -408,3 +408,4 @@ export type LayerSpecification =
     | RasterLayerSpecification
     | HillshadeLayerSpecification
     | BackgroundLayerSpecification;
+

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1414,8 +1414,8 @@ class Map extends Camera {
         let height = 0;
 
         if (this._container) {
-            width = this._container.offsetWidth || 400;
-            height = this._container.offsetHeight || 300;
+            width = this._container.clientWidth || 400;
+            height = this._container.clientHeight || 300;
         }
 
         return [width, height];

--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -30,8 +30,8 @@ module.exports = function(style, options, _callback) { // eslint-disable-line im
     window.devicePixelRatio = options.pixelRatio;
 
     const container = window.document.createElement('div');
-    Object.defineProperty(container, 'offsetWidth', {value: options.width});
-    Object.defineProperty(container, 'offsetHeight', {value: options.height});
+    Object.defineProperty(container, 'clientWidth', {value: options.width});
+    Object.defineProperty(container, 'clientHeight', {value: options.height});
 
     // We are self-hosting test files.
     config.REQUIRE_ACCESS_TOKEN = false;

--- a/test/unit/ui/hash.test.js
+++ b/test/unit/ui/hash.test.js
@@ -12,8 +12,8 @@ test('hash', (t) => {
 
     function createMap(t) {
         const container = window.document.createElement('div');
-        Object.defineProperty(container, 'offsetWidth', {value: 512});
-        Object.defineProperty(container, 'offsetHeight', {value: 512});
+        Object.defineProperty(container, 'clientWidth', {value: 512});
+        Object.defineProperty(container, 'clientHeight', {value: 512});
         return globalCreateMap(t, {container: container});
     }
 
@@ -151,8 +151,8 @@ test('hash', (t) => {
 
     t.test('map#remove', (t) => {
         const container = window.document.createElement('div');
-        Object.defineProperty(container, 'offsetWidth', {value: 512});
-        Object.defineProperty(container, 'offsetHeight', {value: 512});
+        Object.defineProperty(container, 'clientWidth', {value: 512});
+        Object.defineProperty(container, 'clientHeight', {value: 512});
 
         const map = createMap(t, { hash: true });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -465,12 +465,12 @@ test('Map', (t) => {
     });
 
     t.test('#resize', (t) => {
-        t.test('sets width and height from container offsets', (t) => {
+        t.test('sets width and height from container clients', (t) => {
             const map = createMap(t),
                 container = map.getContainer();
 
-            Object.defineProperty(container, 'offsetWidth', {value: 250});
-            Object.defineProperty(container, 'offsetHeight', {value: 250});
+            Object.defineProperty(container, 'clientWidth', {value: 250});
+            Object.defineProperty(container, 'clientHeight', {value: 250});
             map.resize();
 
             t.equal(map.transform.width, 250);
@@ -1562,8 +1562,8 @@ test('Map', (t) => {
 
         map.flyTo({ center: [200, 0], duration: 100 });
 
-        Object.defineProperty(container, 'offsetWidth', {value: 250});
-        Object.defineProperty(container, 'offsetHeight', {value: 250});
+        Object.defineProperty(container, 'clientWidth', {value: 250});
+        Object.defineProperty(container, 'clientHeight', {value: 250});
         map.resize();
 
         t.ok(map.isMoving(), 'map is still moving after resize due to camera animation');

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -9,8 +9,8 @@ import simulate from 'mapbox-gl-js-test/simulate_interaction';
 
 function createMap(t) {
     const container = window.document.createElement('div');
-    Object.defineProperty(container, 'offsetWidth', {value: 512});
-    Object.defineProperty(container, 'offsetHeight', {value: 512});
+    Object.defineProperty(container, 'clientWidth', {value: 512});
+    Object.defineProperty(container, 'clientHeight', {value: 512});
     return globalCreateMap(t, {container: container});
 }
 
@@ -193,7 +193,7 @@ test('Popup anchors around default Marker', (t) => {
     // open the popup
     marker.togglePopup();
 
-    const mapHeight = map.getContainer().offsetHeight;
+    const mapHeight = map.getContainer().clientHeight;
     const markerTop = -marker.getPopup().options.offset.bottom[1]; // vertical distance from tip of marker to the top in pixels
     const markerRight = -marker.getPopup().options.offset.right[0]; // horizontal distance from the tip of the marker to the right in pixels
 
@@ -206,7 +206,7 @@ test('Popup anchors around default Marker', (t) => {
 
     // move marker to the top forcing the popup to below
     marker.setLngLat(map.unproject([mapHeight / 2, markerTop]));
-    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-top'), 'popup anchors bolow marker');
+    t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-top'), 'popup anchors below marker');
 
     // move marker to the right forcing the popup to the left
     marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight / 2]));

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -12,8 +12,8 @@ const containerHeight = 512;
 function createMap(t, options) {
     options = options || {};
     const container = window.document.createElement('div');
-    Object.defineProperty(container, 'offsetWidth', {value: options.width || containerWidth});
-    Object.defineProperty(container, 'offsetHeight', {value: options.height || containerHeight});
+    Object.defineProperty(container, 'clientWidth', {value: options.width || containerWidth});
+    Object.defineProperty(container, 'clientHeight', {value: options.height || containerHeight});
     return globalCreateMap(t, { container: container });
 }
 

--- a/test/util.js
+++ b/test/util.js
@@ -5,8 +5,8 @@ import { extend} from '../src/util/util';
 export function createMap(t, options, callback) {
     const container = window.document.createElement('div');
 
-    Object.defineProperty(container, 'offsetWidth', {value: 200, configurable: true});
-    Object.defineProperty(container, 'offsetHeight', {value: 200, configurable: true});
+    Object.defineProperty(container, 'clientWidth', {value: 200, configurable: true});
+    Object.defineProperty(container, 'clientHeight', {value: 200, configurable: true});
 
     if (!options || !options.skipCSSStub) t.stub(Map.prototype, '_detectMissingCSS');
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - Converts `offset{Height/Width}` to `client{Height/Width}`
    - Fixes #6848  
 - [x] manually test the debug page

`master with offset{Height/Width}`
> ![screen shot 2018-08-14 at 1 16 23 pm](https://user-images.githubusercontent.com/4523080/44116273-f0ec7748-9fc4-11e8-905c-45c3b9bd6c73.png)

`canvas-hw with client{Height/Width}`
> ![screen shot 2018-08-14 at 1 17 08 pm](https://user-images.githubusercontent.com/4523080/44116274-f10e5944-9fc4-11e8-898c-7e0d5003f59a.png)

