### PR TITLE
Use a special data structure for transferring feature id maps to the main thread

### DIFF
--- a/src/data/feature_position_map.js
+++ b/src/data/feature_position_map.js
@@ -1,0 +1,112 @@
+// @flow
+
+import { register } from '../util/web_worker_transfer';
+
+type SerializedFeaturePositionMap = {
+    ids: Float64Array;
+    indices: Uint32Array;
+    offsets: Uint16Array;
+};
+
+type FeaturePosition = {
+    index: number;
+    start: number;
+    end: number;
+};
+
+// A transferable data structure that maps feature ids to their indices and buffer offsets
+export default class FeaturePositionMap {
+    ids: Array<number>;
+    indices: Array<number>;
+    offsets: Array<number>;
+    _bufferLen: number;
+
+    constructor() {
+        this.ids = [];
+        this.indices = [];
+        this.offsets = [];
+        this._bufferLen = 0;
+    }
+
+    add(id: number, index: number, newLength: number) {
+        this.ids.push(id);
+        this.indices.push(index);
+        this.offsets.push(this._bufferLen, newLength);
+        this._bufferLen = newLength;
+    }
+
+    getPositions(id: number): Array<FeaturePosition> {
+        // binary search for the first occurrence of id in this.ids
+        let i = 0;
+        let j = this.ids.length - 1;
+        while (i < j) {
+            const m = (i + j) >> 1;
+            if (this.ids[m] >= id) {
+                j = m;
+            } else {
+                i = m + 1;
+            }
+        }
+        const positions = [];
+        while (this.ids[i] === id) {
+            const index = this.indices[i];
+            const start = this.offsets[2 * i];
+            const end = this.offsets[2 * i + 1];
+            positions.push({index, start, end});
+            i++;
+        }
+        return positions;
+    }
+
+    static serialize(map: FeaturePositionMap, transferables: Array<ArrayBuffer>): SerializedFeaturePositionMap {
+        const ids = new Float64Array(map.ids);
+        const indices = new Uint32Array(map.indices);
+        const offsets = new Uint16Array(map.offsets);
+
+        sort(ids, indices, offsets, 0, ids.length - 1);
+
+        transferables.push(ids.buffer, indices.buffer, offsets.buffer);
+
+        return {ids, indices, offsets};
+    }
+
+    static deserialize(obj: SerializedFeaturePositionMap): FeaturePositionMap {
+        const map = new FeaturePositionMap();
+        // after transferring, we only use these arrays statically (no pushes),
+        // so TypedArray vs Array distinction that flow points out doesn't matter
+        map.ids = (obj.ids: any);
+        map.indices = (obj.indices: any);
+        map.offsets = (obj.offsets: any);
+        return map;
+    }
+}
+
+// custom quicksort that sorts ids, indices and offsets together (by ids)
+function sort(ids, indices, offsets, left, right) {
+    if (left >= right) return;
+
+    const pivot = ids[(left + right) >> 1];
+    let i = left - 1;
+    let j = right + 1;
+
+    while (true) {
+        do i++; while (ids[i] < pivot);
+        do j--; while (ids[j] > pivot);
+        if (i >= j) break;
+        swap(ids, i, j);
+        swap(indices, i, j);
+        swap(offsets, 2 * i, 2 * j);
+        swap(offsets, 2 * i + 1, 2 * j + 1);
+    }
+
+    sort(ids, indices, offsets, left, j);
+    sort(ids, indices, offsets, j + 1, right);
+}
+
+function swap(arr, i, j) {
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+}
+
+register('FeaturePositionMap', FeaturePositionMap);

--- a/src/data/feature_position_map.js
+++ b/src/data/feature_position_map.js
@@ -5,7 +5,7 @@ import { register } from '../util/web_worker_transfer';
 type SerializedFeaturePositionMap = {
     ids: Float64Array;
     indices: Uint32Array;
-    offsets: Uint16Array;
+    offsets: Uint32Array;
 };
 
 type FeaturePosition = {
@@ -61,7 +61,7 @@ export default class FeaturePositionMap {
     static serialize(map: FeaturePositionMap, transferables: Array<ArrayBuffer>): SerializedFeaturePositionMap {
         const ids = new Float64Array(map.ids);
         const indices = new Uint32Array(map.indices);
-        const offsets = new Uint16Array(map.offsets);
+        const offsets = new Uint32Array(map.offsets);
 
         sort(ids, indices, offsets, 0, ids.length - 1);
 

--- a/src/data/feature_position_map.js
+++ b/src/data/feature_position_map.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { register } from '../util/web_worker_transfer';
+import assert from 'assert';
 
 type SerializedFeaturePositionMap = {
     ids: Float64Array;
@@ -17,22 +18,24 @@ type FeaturePosition = {
 export default class FeaturePositionMap {
     ids: Array<number>;
     positions: Array<number>;
-    _bufferLen: number;
+    indexed: boolean;
 
     constructor() {
         this.ids = [];
         this.positions = [];
-        this._bufferLen = 0;
+        this.indexed = false;
     }
 
-    add(id: number, index: number, newLength: number) {
+    add(id: number, index: number, start: number, end: number) {
         this.ids.push(id);
-        this.positions.push(index, this._bufferLen, newLength);
-        this._bufferLen = newLength;
+        this.positions.push(index, start, end);
     }
 
     getPositions(id: number): Array<FeaturePosition> {
-        // binary search for the first occurrence of id in this.ids
+        assert(this.indexed);
+
+        // binary search for the first occurrence of id in this.ids;
+        // relies on ids/positions being sorted by id, which happens in serialization
         let i = 0;
         let j = this.ids.length - 1;
         while (i < j) {
@@ -71,6 +74,7 @@ export default class FeaturePositionMap {
         // so TypedArray vs Array distinction that flow points out doesn't matter
         map.ids = (obj.ids: any);
         map.positions = (obj.positions: any);
+        map.indexed = true;
         return map;
     }
 }

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -360,6 +360,7 @@ export default class ProgramConfiguration {
 
     _buffers: Array<VertexBuffer>;
     _featureMap: FeaturePositionMap;
+    _bufferOffset: number;
 
     constructor() {
         this.binders = {};
@@ -367,6 +368,7 @@ export default class ProgramConfiguration {
 
         this._buffers = [];
         this._featureMap = new FeaturePositionMap();
+        this._bufferOffset = 0;
     }
 
     static createDynamic<Layer: TypedStyleLayer>(layer: Layer, zoom: number, filterProperties: (string) => boolean) {
@@ -405,8 +407,9 @@ export default class ProgramConfiguration {
             this.binders[property].populatePaintArray(newLength, feature);
         }
         if (feature.id !== undefined) {
-            this._featureMap.add(+feature.id, index, newLength);
+            this._featureMap.add(+feature.id, index, this._bufferOffset, newLength);
         }
+        this._bufferOffset = newLength;
     }
 
     updatePaintArrays(featureStates: FeatureStates, vtLayer: VectorTileLayer, layer: TypedStyleLayer): boolean {

--- a/test/unit/data/feature_position_map.test.js
+++ b/test/unit/data/feature_position_map.test.js
@@ -1,0 +1,42 @@
+import { test } from 'mapbox-gl-js-test';
+
+import FeatureMap from '../../../src/data/feature_position_map';
+import { serialize, deserialize } from '../../../src/util/web_worker_transfer';
+
+test('FeaturePositionMap', (t) => {
+
+    test('Can be queried after serialization/deserialization', (t) => {
+        const featureMap = new FeatureMap();
+        featureMap.add(7, 1, 0, 1);
+        featureMap.add(3, 2, 1, 2);
+        featureMap.add(7, 3, 2, 3);
+        featureMap.add(4, 4, 3, 4);
+        featureMap.add(2, 5, 4, 5);
+        featureMap.add(7, 6, 5, 7);
+
+        const featureMap2 = deserialize(serialize(featureMap, []));
+
+        const compareIndex = (a, b) => a.index - b.index;
+
+        t.same(featureMap2.getPositions(7).sort(compareIndex), [
+            {index: 1, start: 0, end: 1},
+            {index: 3, start: 2, end: 3},
+            {index: 6, start: 5, end: 7}
+        ].sort(compareIndex));
+
+        t.end();
+    });
+
+    test('Can not be queried before serialization/deserialization', (t) => {
+        const featureMap = new FeatureMap();
+        featureMap.add(0, 1, 2, 3);
+
+        t.throws(() => {
+            featureMap.getPositions(0);
+        });
+
+        t.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Fixes #7110 (not fully but almost there); a part of addressing #7011. An alternative to #7015.

Instead of a struct array that gets deserialized into a JS object on the main thread (which is expensive and causes stutter), this PR introduces a special data structure for storing feature id to position mappings which consists of two typed arrays — ids and positions. Both get sorted by id before transferring, which allows using binary search on the main thread for id lookup (avoiding building a JS object completely).

This brings TTFR for the difficult #7110 case to nearly pre-feature-state levels (10-20% slower instead of 4x slower), while also theoretically reducing stutter (due to elimination of big non-transferable id maps which are very expensive to clone when sending to the main thread). @ryanbaumann's [feature state choropleth](https://bl.ocks.org/ryanbaumann/733ba99c5ca1d9d15259081b395e4b00/414e974f854c20c263edddc6c9cc934d0956a9ac) also speeds a little (20% faster to fully load).

Note that I used `Uint32Array` for buffer offsets instead Uint16 (like in #7015) because the latter overflows (e.g. on Ryan's example).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
