### PR TITLE
android-v6.4.0, ios-v4.4.0, macos-v0.10.0 in style specification

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -889,7 +889,10 @@
           "macos": "0.1.0"
         },
         "`line-center` value": {
-          "js": "0.47.0"
+          "js": "0.47.0",
+          "android": "6.4.0",
+          "ios": "4.3.0",
+          "macos": "0.10.0"
         },
         "data-driven styling": {}
       },


### PR DESCRIPTION
Updated the style specification to note native support for `symbol-placement: line-center` in the Espresso releases. At some point these changes should also go into master so that clients of the mapbox-gl-style-spec package, such as Studio, can reflect this support in their compatibility features.

/cc @ChrisLoer @captainbarbosa @LukasPaczos