### PR TITLE
Espresso: Revert feature state reset

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -217,9 +217,6 @@ class SourceCache extends Evented {
         }
 
         this._cache.reset();
-        //Reset the SourceCache when the source has been reloaded. For GeoJSON sources, 
-        // the `id`  of features is not guaranteed to be identical when updated
-        this._state = new SourceFeatureState();
 
         for (const i in this._tiles) {
             if (this._tiles[i].state !== "errored") this._reloadTile(i, 'reloading');

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1348,8 +1348,8 @@ class Map extends Camera {
      * This method requires the `feature.id` attribute on data sets. For GeoJSON sources without 
      * feature ids, set the `generateIds` option in the `GeoJSONSourceSpecification` to auto-assign them. This 
      * option assigns ids based on a feature's index in the source data. Changing the feature data using 
-     * `map.getSource('some id').setData(..)` resets the cache of feature states and requires the 
-     * caller re-apply the state as needed with the updated `id` values.
+     * `map.getSource('some id').setData(..)` may change the index of features requiring feature states to 
+     * re-applied as needed with the updated `id` values.
      */
     setFeatureState(feature: { source: string; sourceLayer?: string; id: string; }, state: Object) {
         this.style.setFeatureState(feature, state);


### PR DESCRIPTION
#7043 added a reset of a source's feature state every time it was reloaded. This was meant to target only `GeoJSONSource#setData` but inadvertently also reset the feature data when a source went through a relayout. This was originally reported in [#62889(comment)(https://github.com/mapbox/mapbox-gl-js/pull/6289#issuecomment-411186302) and a fix was put into `master` via #7129.

For the espresso release, revert this behavior entirely.  A more inclusive fix is being researched for `master` along the lines of #6889.

cc @jfirebaugh @mollymerp 