### PR TITLE
Add default support for IE11 in docs server

### DIFF
--- a/batfish.config.js
+++ b/batfish.config.js
@@ -37,7 +37,8 @@ module.exports = () => {
                     .filter(({path, frontMatter}) => /\/example\//.test(path) && frontMatter.tags)
                     .map(({frontMatter}) => frontMatter);
             }
-        }
+        },
+        devBrowserslist: false
     };
 
     // Local builds treat the `dist` directory as static assets, allowing you to test examples against the


### PR DESCRIPTION
The docs server for internal testing uses `batfish start` which defaults to support the most common browsers and excludes IE11. 

From @davidtheclark:
> here's the issue: https://github.com/mapbox/batfish/blob/master/docs/configuration.md#devbrowserslist
>
> in order to speed up development builds and reduce the sourcemap burden, right now batfish is defaulting during `start` to a browserslist that does not support IE11. `batfish build` still will support IE11. if that is a source of confusion or you don't like the default, you can turn it off with `devBrowserslist: false` — then `start` will use the same browserslist as `build`.

I'm seeing a 20% (1sec) increase in building the batfish site, which I think is reasonable against the alternative: a separate step to enable IE11 support. 

cc @mollymerp @davidtheclark