### PR TITLE
add marker from a place name using forward geocoder api example

### DIFF
--- a/docs/pages/example/marker-from-geocode.html
+++ b/docs/pages/example/marker-from-geocode.html
@@ -1,0 +1,28 @@
+<div id='map'></div>
+<script src='https://unpkg.com/es6-promise@4.2.4/dist/es6-promise.auto.min.js'></script>
+<script src="https://unpkg.com/@mapbox/mapbox-sdk/umd/mapbox-sdk.min.js"></script>
+<script>
+var mapboxClient = mapboxSdk({ accessToken: mapboxgl.accessToken });
+mapboxClient.geocoding.forwardGeocode({
+    query: 'Wellington, New Zealand',
+    autocomplete: false,
+    limit: 1
+})
+    .send()
+    .then(function (response) {
+        if (response && response.body && response.body.features && response.body.features.length) {
+            var feature = response.body.features[0];
+
+            var map = new mapboxgl.Map({
+                container: 'map',
+                style: 'mapbox://styles/mapbox/streets-v9',
+                center: feature.center,
+                zoom: 10
+            });
+            new mapboxgl.Marker()
+                .setLngLat(feature.center)
+                .addTo(map);
+        }
+    });
+
+</script>

--- a/docs/pages/example/marker-from-geocode.js
+++ b/docs/pages/example/marker-from-geocode.js
@@ -1,0 +1,10 @@
+/*---
+title: Add a marker using a place name
+description: Add a [`Marker`](/mapbox-gl-js/api#marker) using a place name or address for its location using the [forward geocoder](https://www.mapbox.com/api-documentation/#geocoding)
+tags:
+  - controls-and-overlays
+pathname: /mapbox-gl-js/example/marker-from-geocode/
+---*/
+import Example from '../../components/example';
+import html from './marker-from-geocode.html';
+export default Example(html);


### PR DESCRIPTION
## Launch Checklist

closes #5030

 - [x] briefly describe the changes in this PR

Adds an example of using the Mapbox Geocoding API to place a marker on the map from a place name or address.

Side affect is it shows how to use mapbox-sdk-js in combination with a mapbox-gl-js map.