### PR TITLE
document that sprite and glyphs style-spec properties must be absolute

### DIFF
--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -777,7 +777,7 @@ export default class extends React.Component {
                             <p>
                                 A style's <code>sprite</code> property supplies a URL template for loading small images to use in
                                 rendering <code>background-pattern</code>, <code>fill-pattern</code>, <code>line-pattern</code>,
-                                and <code>icon-image</code> style properties.
+                                <code>fill-extrusion-pattern</code> and <code>icon-image</code> style properties.
                             </p>
                             <div className='space-bottom1 pad2x clearfix'>
                                 {highlightJSON(`"sprite": ${JSON.stringify(ref.$root.sprite.example, null, 2)}`)}

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -70,12 +70,12 @@
     },
     "sprite": {
       "type": "string",
-      "doc": "A base URL for retrieving the sprite image and metadata. The extensions `.png`, `.json` and scale factor `@2x.png` will be automatically appended. This property is required if any layer uses the `background-pattern`, `fill-pattern`, `line-pattern`, `fill-extrusion-pattern`, or `icon-image` properties.",
+      "doc": "A base URL for retrieving the sprite image and metadata. The extensions `.png`, `.json` and scale factor `@2x.png` will be automatically appended. This property is required if any layer uses the `background-pattern`, `fill-pattern`, `line-pattern`, `fill-extrusion-pattern`, or `icon-image` properties. The URL must be absolute, containing the [scheme, authority and path components](https://en.wikipedia.org/wiki/URL#Syntax).",
       "example": "mapbox://sprites/mapbox/bright-v8"
     },
     "glyphs": {
       "type": "string",
-      "doc": "A URL template for loading signed-distance-field glyph sets in PBF format. The URL must include `{fontstack}` and `{range}` tokens. This property is required if any layer uses the `text-field` layout property.",
+      "doc": "A URL template for loading signed-distance-field glyph sets in PBF format. The URL must include `{fontstack}` and `{range}` tokens. This property is required if any layer uses the `text-field` layout property. The URL must be absolute, containing the [scheme, authority and path components](https://en.wikipedia.org/wiki/URL#Syntax).",
       "example": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf"
     },
     "transition": {


### PR DESCRIPTION
## Launch Checklist

This PR aims to document that the `sprite` and `glyphs` style-spec properties must be absolute URLs as noted at https://github.com/mapbox/mapbox-gl-js/issues/4416#issuecomment-286454759 and https://github.com/mapbox/mapbox-gl-js/issues/4201#issuecomment-277305583.

Currently an error will be emitted if `sprite` is not absolute, but things seem to work with relative `glyphs`, though given the intention that these always be absolute I think this documentation change alone without the validation of an absolute `glyphs` URL is enough to close #4141.

I've chosen to make the note about this in the Root section rather than down in the individual Sprite and Glyphs section as the latter focuses on the content behind the URL.

It also addresses an inconsistancy @ryanhamley identified in #6832