### PR TITLE
Auto set .cn EVENTS_URL endpoint by api url

### DIFF
--- a/src/util/config.js
+++ b/src/util/config.js
@@ -6,7 +6,6 @@ const EventsUrlOptions = {
 };
 
 type Config = {|
-  _API_URL: string,
   API_URL: string,
   EVENTS_URL: string,
   REQUIRE_ACCESS_TOKEN: boolean,
@@ -14,7 +13,6 @@ type Config = {|
 |};
 
 const config: Config = {
-    _API_URL: 'https://api.mapbox.com',
     API_URL: 'https://api.mapbox.com',
     EVENTS_URL: EventsUrlOptions.DefaultEventsUrl,
     REQUIRE_ACCESS_TOKEN: true,
@@ -22,16 +20,12 @@ const config: Config = {
 };
 
 const defineProperty = Object.defineProperty;
-defineProperty(config, 'API_URL', {
+defineProperty(config, 'EVENTS_URL', {
     get: function() {
-        return this._API_URL;
-    },
-    set: function(apiurl: string) {
-        this._API_URL = apiurl;
-        if (this._API_URL.indexOf('https://api.mapbox.cn') === 0) {
-            this.EVENTS_URL = EventsUrlOptions.ChinaEventsUrl;
+        if (this.API_URL.indexOf('https://api.mapbox.cn') === 0) {
+            return EventsUrlOptions.ChinaEventsUrl;
         } else {
-            this.EVENTS_URL = EventsUrlOptions.DefaultEventsUrl;
+            return EventsUrlOptions.DefaultEventsUrl;
         }
     }
 });

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,10 +1,5 @@
 // @flow
 
-const EventsUrlOptions = {
-    DefaultEventsUrl: 'https://events.mapbox.com/events/v2',
-    ChinaEventsUrl: 'https://events.mapbox.cn/events/v2'
-};
-
 type Config = {|
   API_URL: string,
   EVENTS_URL: string,
@@ -14,20 +9,15 @@ type Config = {|
 
 const config: Config = {
     API_URL: 'https://api.mapbox.com',
-    EVENTS_URL: EventsUrlOptions.DefaultEventsUrl,
+    get EVENTS_URL() {
+        if (this.API_URL.indexOf('https://api.mapbox.cn') === 0) {
+            return 'https://events.mapbox.cn/events/v2';
+        } else {
+            return 'https://events.mapbox.com/events/v2';
+        }
+    },
     REQUIRE_ACCESS_TOKEN: true,
     ACCESS_TOKEN: null
 };
-
-const defineProperty = Object.defineProperty;
-defineProperty(config, 'EVENTS_URL', {
-    get: function() {
-        if (this.API_URL.indexOf('https://api.mapbox.cn') === 0) {
-            return EventsUrlOptions.ChinaEventsUrl;
-        } else {
-            return EventsUrlOptions.DefaultEventsUrl;
-        }
-    }
-});
 
 export default config;

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -15,22 +15,23 @@ type Config = {|
 
 const config: Config = {
     _API_URL: 'https://api.mapbox.com',
+    API_URL: 'https://api.mapbox.com',
     EVENTS_URL: EventsUrlOptions.DefaultEventsUrl,
     REQUIRE_ACCESS_TOKEN: true,
     ACCESS_TOKEN: null
 };
 
-Object.defineProperty(config,'API_URL',{
-    get: function(){
+const defineProperty = Object.defineProperty;
+defineProperty(config, 'API_URL', {
+    get: function() {
         return this._API_URL;
     },
-    set: function(apiurl: string){
+    set: function(apiurl: string) {
         this._API_URL = apiurl;
-        if(this._API_URL.indexOf('https://api.mapbox.cn') === 0){
-          this.EVENTS_URL = EventsUrlOptions.ChinaEventsUrl;
-        }
-        else {
-          this.EVENTS_URL = EventsUrlOptions.DefaultEventsUrl;
+        if (this._API_URL.indexOf('https://api.mapbox.cn') === 0) {
+            this.EVENTS_URL = EventsUrlOptions.ChinaEventsUrl;
+        } else {
+            this.EVENTS_URL = EventsUrlOptions.DefaultEventsUrl;
         }
     }
 });

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,6 +1,12 @@
 // @flow
 
+const EventsUrlOptions = {
+    DefaultEventsUrl: 'https://events.mapbox.com/events/v2',
+    ChinaEventsUrl: 'https://events.mapbox.cn/events/v2'
+};
+
 type Config = {|
+  _API_URL: string,
   API_URL: string,
   EVENTS_URL: string,
   REQUIRE_ACCESS_TOKEN: boolean,
@@ -8,10 +14,25 @@ type Config = {|
 |};
 
 const config: Config = {
-    API_URL: 'https://api.mapbox.com',
-    EVENTS_URL: 'https://events.mapbox.com/events/v2',
+    _API_URL: 'https://api.mapbox.com',
+    EVENTS_URL: EventsUrlOptions.DefaultEventsUrl,
     REQUIRE_ACCESS_TOKEN: true,
     ACCESS_TOKEN: null
 };
+
+Object.defineProperty(config,'API_URL',{
+    get: function(){
+        return this._API_URL;
+    },
+    set: function(apiurl: string){
+        this._API_URL = apiurl;
+        if(this._API_URL.indexOf('https://api.mapbox.cn') === 0){
+          this.EVENTS_URL = EventsUrlOptions.ChinaEventsUrl;
+        }
+        else {
+          this.EVENTS_URL = EventsUrlOptions.DefaultEventsUrl;
+        }
+    }
+});
 
 export default config;

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -313,6 +313,20 @@ test("mapbox", (t) => {
             t.end();
         });
 
+        t.test('POSTs cn event when API_URL change to cn endpoint', (t) => {
+            const previousUrl = config.API_URL;
+            config.API_URL = 'https://api.mapbox.cn';
+
+            event.postTurnstileEvent(['a.tiles.mapbox.cn']);
+
+            const req = window.server.requests[0];
+            req.respond(200);
+
+            t.true(req.url.indexOf('https://events.mapbox.cn') > -1);
+            config.API_URL = previousUrl;
+            t.end();
+        });
+
         t.test('with LocalStorage available', (t) => {
             let prevLocalStorage;
             t.beforeEach((callback) => {


### PR DESCRIPTION
**Auto set cn EVENTS_URL endpoint by api url**

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

This PR made a configuration change on our backend that as long as the customer points to `api.mapbox.cn` then their turnstile events will automatically be set to `events.mapbox.cn`, without needing to ask them change this by themselves. This logic is same with that in iOS sdk.