### PR TITLE
Fix broken WMS example by adding transparent parameter to URL

### DIFF
--- a/debug/wms.html
+++ b/debug/wms.html
@@ -31,7 +31,7 @@ map.addControl(new mapboxgl.NavigationControl());
 map.on('load', function() {
     map.addSource('wms-test', {
         "type": "raster",
-        "tiles": ['http://geodata.state.nj.us/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&width=256&height=256&layers=Natural2015'
+        "tiles": ['https://geodata.state.nj.us/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&layers=Natural2015'
         ],
         "tileSize": 256
     });

--- a/docs/pages/example/wms.html
+++ b/docs/pages/example/wms.html
@@ -15,7 +15,7 @@ map.on('load', function() {
         'source': {
             'type': 'raster',
             'tiles': [
-                'https://geodata.state.nj.us/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&width=256&height=256&layers=Natural2015'
+                'https://geodata.state.nj.us/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&layers=Natural2015'
             ],
             'tileSize': 256
         },


### PR DESCRIPTION
Ref: https://github.com/mapbox/mapbox-gl-js/issues/7188

The [WMS example](https://www.mapbox.com/mapbox-gl-js/example/wms/) is currently broken - zoom out and you'll see that the map is eventually consumed by all white tiles, save for the WMS tiles themselves. This is because the `transparent=true` parameter is not added to the URL. Adding it fixes the issue.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
