### PR TITLE
Keep multitouch center at start center location when pinching (#6722)

### DIFF
--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -115,9 +115,11 @@ class TouchZoomRotateHandler {
         if (e.touches.length !== 2) return;
 
         const p0 = DOM.mousePos(this._el, e.touches[0]),
-            p1 = DOM.mousePos(this._el, e.touches[1]);
+            p1 = DOM.mousePos(this._el, e.touches[1]),
+            center = p0.add(p1).div(2);
 
         this._startVec = p0.sub(p1);
+        this._startAround = this._map.transform.pointLocation(center);
         this._gestureIntent = undefined;
         this._inertia = [];
 
@@ -193,7 +195,7 @@ class TouchZoomRotateHandler {
 
         tr.zoom = tr.scaleZoom(this._startScale * scale);
 
-        tr.setLocationAtPoint(around, aroundPoint);
+        tr.setLocationAtPoint(this._startAround, aroundPoint);
 
         this._map.fire(new Event(gestureIntent, {originalEvent: this._lastTouchEvent}));
         this._map.fire(new Event('move', {originalEvent: this._lastTouchEvent}));

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -8,6 +8,7 @@ import { Event } from '../../util/evented';
 
 import type Map from '../map';
 import type Point from '@mapbox/point-geometry';
+import type LngLat from '../../geo/lng_lat';
 import type {TaskID} from '../../util/task_queue';
 
 const inertiaLinearity = 0.15,
@@ -28,6 +29,7 @@ class TouchZoomRotateHandler {
     _aroundCenter: boolean;
     _rotationDisabled: boolean;
     _startVec: Point;
+    _startAround: LngLat;
     _startScale: number;
     _startBearing: number;
     _gestureIntent: 'rotate' | 'zoom' | void;


### PR DESCRIPTION
This is a simple solution for #6722. Just save start center location and keep multicouch center point at that location while pinching. Works with and without rotation without issues.