### PR TITLE
Fix flyTo when the final zoom value is not the requested one (#7222)

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -957,8 +957,8 @@ class Camera extends Evented {
         this._ease((k) => {
             // s: The distance traveled along the flight path, measured in ρ-screenfuls.
             const s = k * S;
-            const scale = k === 1 ? tr.zoomScale(zoom - startZoom) : 1 / w(s);
-            tr.zoom = startZoom + tr.scaleZoom(scale);
+            const scale = 1 / w(s);
+            tr.zoom = k === 1 ? zoom : startZoom + tr.scaleZoom(scale);
 
             if (this._rotating) {
                 tr.bearing = interpolate(startBearing, bearing, k);
@@ -967,7 +967,7 @@ class Camera extends Evented {
                 tr.pitch = interpolate(startPitch, pitch, k);
             }
 
-            const newCenter = tr.unproject(from.add(delta.mult(u(s))).mult(scale));
+            const newCenter = k === 1 ? center : tr.unproject(from.add(delta.mult(u(s))).mult(scale));
             tr.setLocationAtPoint(tr.renderWorldCopies ? newCenter.wrap() : newCenter, pointAtOffset);
 
             this._fireMoveEvents(eventData);

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -957,8 +957,8 @@ class Camera extends Evented {
         this._ease((k) => {
             // s: The distance traveled along the flight path, measured in ρ-screenfuls.
             const s = k * S;
-            const scale = 1 / w(s);
-            tr.zoom = k === 1 ? zoom : startZoom + tr.scaleZoom(scale);
+            const scale = k === 1 ? tr.zoomScale(zoom - startZoom) : 1 / w(s);
+            tr.zoom = startZoom + tr.scaleZoom(scale);
 
             if (this._rotating) {
                 tr.bearing = interpolate(startBearing, bearing, k);

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -919,6 +919,24 @@ test('camera', (t) => {
             t.end();
         });
 
+        t.test('Zoom out from the same position to the same position with animation', (t) => {
+            const pos = { lng: 0, lat: 0 };
+            const camera = createCamera({zoom: 20, center: pos});
+            const stub = t.stub(browser, 'now');
+
+            camera.once('zoomend', () => {
+                t.deepEqual(fixedLngLat(camera.getCenter()), fixedLngLat(pos));
+                t.equal(camera.getZoom(), 19);
+                t.end();
+            });
+
+            stub.callsFake(() => 0);
+            camera.flyTo({ zoom: 19, center: pos, duration: 2 });
+
+            stub.callsFake(() => 3);
+            camera.simulateFrame();
+        });
+
         t.test('rotates to specified bearing', (t) => {
             const camera = createCamera();
             camera.flyTo({ bearing: 90, animate: false });


### PR DESCRIPTION
This complete the fix for #6828 when the final zoom value is different from the requested zoom.
