### PR TITLE
Update yarn install instructions for Linux in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,17 @@ yarn install
 
 ### Linux
 
-Install [git](https://git-scm.com/), [node.js](https://nodejs.org/) (version 6 or greater), [yarn](https://yarnpkg.com/en/docs/install#linux-tab), [GNU Make](http://www.gnu.org/software/make/), and libglew-dev
+Install [git](https://git-scm.com/), [node.js](https://nodejs.org/) (version 6 or greater), [GNU Make](http://www.gnu.org/software/make/), and libglew-dev
 ```bash
 sudo apt-get update &&
-sudo apt-get install build-essential git nodejs yarn libglew-dev libxi-dev
+sudo apt-get install build-essential git nodejs libglew-dev libxi-dev
 ```
+
+Install [yarn](https://yarnpkg.com/en/docs/install#linux-tab)
+```bash
+curl -o- -L https://yarnpkg.com/install.sh | bash
+```
+(It is also possible to install yarn from Debian/Ubuntu packages. See [yarn's install instructions](https://yarnpkg.com/en/docs/install#linux-tab)).
 
 Clone the repository
 ```bash


### PR DESCRIPTION
Since Ubuntu version 18.04 (and possibly as early as 17.04), the package
cmdtest has a "Provides: yarn" entry, so it gets installed when one runs
`sudo apt-get install yarn`. It also doesn't seen Ubuntu ever had a
package for yarn, so add instructions to install it from the right
sources.