### PR TITLE
Remove deprecated benchmark scripts from yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "watch-benchmarks": "BENCHMARK_VERSION=${BENCHMARK_VERSION:-\"$(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short=7 HEAD)\"} rollup -c bench/versions/rollup_config_benchmarks.js --watch",
     "watch-style-benchmarks": "BENCHMARK_VERSION=${BENCHMARK_VERSION:-\"$(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short=7 HEAD)\"} rollup -c bench/styles/rollup_config_benchmarks.js --watch",
     "start-server": "st --no-cache -H 0.0.0.0 --port 9966 --index index.html .",
-    "start": "run-p build-token watch-css watch-dev watch-benchmarks watch-benchmarks-view watch-style-benchmarks watch-style-benchmarks-view start-server",
+    "start": "run-p build-token watch-css watch-dev watch-benchmarks watch-style-benchmarks start-server",
     "start-debug": "run-p build-token watch-css watch-dev start-server",
     "start-bench": "run-p build-token watch-benchmarks watch-style-benchmarks start-server",
     "build-docs": "documentation build --github --format json --config ./docs/documentation.yml --output docs/components/api.json src/index.js",


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - two benchmark scripts were deprecated in the refactor. this PR removes them from `yarn start`
 - [X] manually test the debug page
