### PR TITLE
to-color should be idempotent

### DIFF
--- a/src/style-spec/expression/definitions/coercion.js
+++ b/src/style-spec/expression/definitions/coercion.js
@@ -60,7 +60,9 @@ class Coercion implements Expression {
             for (const arg of this.args) {
                 input = arg.evaluate(ctx);
                 error = null;
-                if (typeof input === 'string') {
+                if (input instanceof Color) {
+                    return input;
+                } else if (typeof input === 'string') {
                     const c = ctx.parseColor(input);
                     if (c) return c;
                 } else if (Array.isArray(input)) {

--- a/test/integration/expression-tests/to-color/color/test.json
+++ b/test/integration/expression-tests/to-color/color/test.json
@@ -1,0 +1,18 @@
+{
+  "expression": ["to-color", ["rgba", 0, 0, 0, 1]],
+  "inputs": [
+    [{}, {}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "color"
+    },
+    "outputs": [
+      [0, 0, 0, 1]
+    ],
+    "serialized": ["rgba", 0, 0, 0, 1]
+  }
+}


### PR DESCRIPTION
Previously `"to-color"` applied to a color was an error.