### PR TITLE
["to-array", <item type>, <empty array>] should work for any item type

### DIFF
--- a/src/style-spec/expression/types.js
+++ b/src/style-spec/expression/types.js
@@ -82,7 +82,7 @@ export function checkSubtype(expected: Type, t: Type): ?string {
         return null;
     } else if (expected.kind === 'array') {
         if (t.kind === 'array' &&
-            !checkSubtype(expected.itemType, t.itemType) &&
+            ((t.N === 0 && t.itemType.kind === 'value') || !checkSubtype(expected.itemType, t.itemType)) &&
             (typeof expected.N !== 'number' || expected.N === t.N)) {
             return null;
         }

--- a/test/integration/expression-tests/array/item-type/test.json
+++ b/test/integration/expression-tests/array/item-type/test.json
@@ -3,7 +3,8 @@
   "inputs": [
     [{}, {"properties": {"x": ["a", "b"]}}],
     [{}, {"properties": {"x": [1, 2]}}],
-    [{}, {"properties": {"x": [1, "b"]}}]
+    [{}, {"properties": {"x": [1, "b"]}}],
+    [{}, {"properties": {"x": []}}]
   ],
   "expected": {
     "compiled": {
@@ -19,7 +20,8 @@
       },
       {
         "error": "Expected value to be of type array<string>, but found array<value, 2> instead."
-      }
+      },
+      []
     ],
     "serialized": ["array", "string", ["get", "x"]]
   }


### PR DESCRIPTION
Previously it was a type error because the runtime type of an empty array is inferred as `array<value, 0>`.