### PR TITLE
Add an explicit test for array assertion fallback behavior

### DIFF
--- a/test/integration/expression-tests/array/default-value/test.json
+++ b/test/integration/expression-tests/array/default-value/test.json
@@ -1,0 +1,22 @@
+{
+  "expression": ["array", "number", null, ["get", "x"], ["literal", [0]]],
+  "inputs": [
+    [{}, {}],
+    [{}, {"properties": {"x": []}}],
+    [{}, {"properties": {"x": ["1"]}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "array<number>"
+    },
+    "outputs": [
+      [0],
+      [],
+      [0]
+    ],
+    "serialized": ["array", "number", null, ["get", "x"], ["literal", [0]]]
+  }
+}


### PR DESCRIPTION
This is tested implicitly via legacy function conversion tests added in #7095, but it's proving difficult to get those passing on native, and we should test this in isolation anyway.