### PR TITLE
make sure the correct style is used for style benchmarks

### DIFF
--- a/bench/styles/benchmarks.js
+++ b/bench/styles/benchmarks.js
@@ -24,9 +24,9 @@ function register(Benchmark, locations, options) {
     if (options) Object.assign(benchmark, options);
 
     urls.forEach(style => {
-        benchmark.bench = new Benchmark(style, locations);
         benchmark.versions.push({
-            name: style,
+            name: style.replace("mapbox://styles/", ""),
+            bench: new Benchmark(style, locations),
             status: 'waiting',
             logs: [],
             samples: [],
@@ -61,14 +61,13 @@ promise = promise.then(() => {
     // URL has been set up, which happens after this module is executed.
     getWorkerPool().acquire(-1);
 });
-
 benchmarks.forEach(bench => {
     bench.versions.forEach(version => {
         promise = promise.then(() => {
             version.status = 'running';
             updateUI(benchmarks);
 
-            return bench.bench.run()
+            return version.bench.run()
                 .then(measurements => {
                     // scale measurements down by iteration count, so that
                     // they represent (average) time for a single iteration


### PR DESCRIPTION
While benchmarking some styles and looking at the network tab I noticed that some style-ids weren't showing up as requested, and others were being doubled. Turns out we were always using the last style in the list as the benchmarked style.

This PR fixes that 🙃

@ryanhamley @nickidlugash 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
