### PR TITLE
[docs] Update SDK compatibility versions for line-gradient

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -4082,7 +4082,10 @@
       ],
       "sdk-support": {
         "basic functionality": {
-          "js": "0.45.0"
+          "js": "0.45.0",
+          "android": "6.5.0",
+          "ios": "4.4.0",
+          "macos": "0.11.0"
         },
         "data-driven styling": {}
       },


### PR DESCRIPTION
Updates the SDK compatibility table for the new `line-gradient` property introduced in https://github.com/mapbox/mapbox-gl-native/pull/12575/.