### PR TITLE
Increase fill_extrusion base/height precision.

### DIFF
--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -1,13 +1,6 @@
 varying vec4 v_color;
-#pragma mapbox: define lowp float base
-#pragma mapbox: define lowp float height
-#pragma mapbox: define highp vec4 color
 
 void main() {
-    #pragma mapbox: initialize lowp float base
-    #pragma mapbox: initialize lowp float height
-    #pragma mapbox: initialize highp vec4 color
-
     gl_FragColor = v_color;
 
 #ifdef OVERDRAW_INSPECTOR

--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -8,14 +8,14 @@ attribute vec4 a_normal_ed;
 
 varying vec4 v_color;
 
-#pragma mapbox: define lowp float base
-#pragma mapbox: define lowp float height
+#pragma mapbox: define highp float base
+#pragma mapbox: define highp float height
 
 #pragma mapbox: define highp vec4 color
 
 void main() {
-    #pragma mapbox: initialize lowp float base
-    #pragma mapbox: initialize lowp float height
+    #pragma mapbox: initialize highp float base
+    #pragma mapbox: initialize highp float height
     #pragma mapbox: initialize highp vec4 color
 
     vec3 normal = a_normal_ed.xyz;


### PR DESCRIPTION
Fixes issue #7247: heights over 65,536 meters don't render on some devices (tested against iOS Safari). We were using the `lowp` precision qualifier for the `fill-extrusion-base` and `fill-extrusion-height` attributes. GLSL allows implementations to use _really_ low precision (and small range) for lowp floats, although most implementations don't go down to the limits.

See discussion in issue #2096: as a rule of thumb we want to standardize on using `highp` precision qualifiers in our shaders unless there's a specific reason we know (1) low precision won't break anything we depend on, and (2) low precision is likely to be a useful performance optimization.

I tested this against a simple "landcover" extrusion layer set to 70,000 meters on iOS 11 Safari running on an iPhone 8.

**Before:**
![image from ios 1](https://user-images.githubusercontent.com/375121/45712194-88124580-bb40-11e8-99a2-72b7e7039075.png)

**After:**
![image from ios](https://user-images.githubusercontent.com/375121/45712178-7e88dd80-bb40-11e8-8333-bb24fb088367.png)


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~ (Failing test depends on a hardware configuration we can't do on CI)
 - [ ] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

/cc @mollymerp @mourner @mzdraper 