### PR TITLE
Remove 'mouseover' as synonym for 'mouseenter'

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -26,7 +26,6 @@ export class MapMouseEvent extends Event {
         | 'mouseover'
         | 'mouseenter'
         | 'mouseleave'
-        | 'mouseover'
         | 'mouseout'
         | 'contextmenu';
 
@@ -358,16 +357,6 @@ export type MapEvent =
      * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
      */
     | 'mouseleave'
-
-    /**
-     * Synonym for `mouseenter`.
-     *
-     * @event mouseover
-     * @memberof Map
-     * @instance
-     * @property {MapMouseEvent} data
-     */
-    | 'mouseover'
 
     /**
      * Fired when a point device (usually a mouse) leaves the map's canvas.


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - removes duplicative `mouseover` event that says its a synonym for `mouseenter`
 - [x] manually test the debug page

Closes https://github.com/mapbox/mapbox-gl-js/issues/7295

This looks like an oversight to me. The synonym was added in August 2017 https://github.com/mapbox/mapbox-gl-js/commit/8a68233f4371a6ff3b65c0a1822586b15d8688bd while the actual `mouseover` event was added in January 2018 https://github.com/mapbox/mapbox-gl-js/commit/35138df78e1200109940fac68ad588ff2a58d9e0 I'm guessing the synonym should have been removed at that time.
