### PR TITLE
Preserve expected type when parsing 'let' expressions

### DIFF
--- a/src/style-spec/expression/definitions/let.js
+++ b/src/style-spec/expression/definitions/let.js
@@ -49,7 +49,7 @@ class Let implements Expression {
             bindings.push([name, value]);
         }
 
-        const result = context.parse(args[args.length - 1], args.length - 1, undefined, bindings);
+        const result = context.parse(args[args.length - 1], args.length - 1, context.expectedType, bindings);
         if (!result) return null;
 
         return new Let(bindings, result);

--- a/test/integration/expression-tests/let/expected-value/test.json
+++ b/test/integration/expression-tests/let/expected-value/test.json
@@ -6,38 +6,23 @@
     [
       "interpolate",
       ["linear"],
-      ["zoom"],
-      8,
-      [
-        "interpolate",
-        ["linear"],
-        ["var", "density"],
-        1,
-        "#000000",
-        100,
-        "#ffffff"
-      ],
-      10,
-      [
-        "interpolate",
-        ["linear"],
-        ["var", "density"],
-        1,
-        "#000000",
-        100,
-        "#ffffff"
-      ]
+      ["var", "density"],
+      1,
+      "#000000",
+      100,
+      "#ffffff"
     ]
   ],
   "propertySpec": {
     "type": "color"
   },
-  "inputs": [[{"zoom": 9}, {"properties": {"population": 100, "sq-km": 10}}]],
+  "description": "let should preserve expected type for child expressions. If the expected 'color' type in this test were not preserved, it would not get passed into the interpolation and the literal strings wouldn't automatically coerce to the 'color' type",
+  "inputs": [[{}, {"properties": {"population": 100, "sq-km": 10}}]],
   "expected": {
     "compiled": {
       "result": "success",
       "isFeatureConstant": false,
-      "isZoomConstant": false,
+      "isZoomConstant": true,
       "type": "color"
     },
     "outputs": [
@@ -50,50 +35,22 @@
       [
         "interpolate",
         ["linear"],
-        ["zoom"],
-        8,
+        ["var", "density"],
+        1,
         [
-          "interpolate",
-          ["linear"],
-          ["var", "density"],
-          1,
-          [
-            "rgba",
-            0,
-            0,
-            0,
-            1
-          ],
-          100,
-          [
-            "rgba",
-            255,
-            255,
-            255,
-            1
-          ]
+          "rgba",
+          0,
+          0,
+          0,
+          1
         ],
-        10,
+        100,
         [
-          "interpolate",
-          ["linear"],
-          ["var", "density"],
-          1,
-          [
-            "rgba",
-            0,
-            0,
-            0,
-            1
-          ],
-          100,
-          [
-            "rgba",
-            255,
-            255,
-            255,
-            1
-          ]
+          "rgba",
+          255,
+          255,
+          255,
+          1
         ]
       ]
     ]

--- a/test/integration/expression-tests/let/expected-value/test.json
+++ b/test/integration/expression-tests/let/expected-value/test.json
@@ -1,0 +1,75 @@
+{
+  "expression": [
+    "let",
+    "density",
+    ["/", ["get", "population"], ["get", "sq-km"]],
+    [
+      "interpolate",
+      ["linear"],
+      ["zoom"],
+      8,
+      [
+        "interpolate",
+        ["linear"],
+        ["var", "density"],
+        274,
+        "#edf8e9",
+        1551,
+        "#006d2c"
+      ],
+      10,
+      [
+        "interpolate",
+        ["linear"],
+        ["var", "density"],
+        274,
+        "#eff3ff",
+        1551,
+        "#08519c"
+      ]
+    ]
+  ],
+  "propertySpec": {
+    "type": "color"
+  },
+  "inputs": [[{"zoom": 10}, {"properties": {"population": 100, "sq-km": 1000}}]],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": false,
+      "type": "color"
+    },
+    "outputs": [0.9372549019607843,0.9529411764705882,1,1],
+    "serialized": [
+      "let",
+      "density",
+      ["/", ["get", "population"], ["get", "sq-km"]],
+      [
+        "interpolate",
+        ["linear"],
+        ["zoom"],
+        8,
+        [
+          "interpolate",
+          ["linear"],
+          ["var", "density"],
+          274,
+          "#edf8e9",
+          1551,
+          "#006d2c"
+        ],
+        10,
+        [
+          "interpolate",
+          ["linear"],
+          ["var", "density"],
+          274,
+          "#eff3ff",
+          1551,
+          "#08519c"
+        ]
+      ]
+    ]
+  }
+}

--- a/test/integration/expression-tests/let/expected-value/test.json
+++ b/test/integration/expression-tests/let/expected-value/test.json
@@ -12,27 +12,27 @@
         "interpolate",
         ["linear"],
         ["var", "density"],
-        274,
-        "#edf8e9",
-        1551,
-        "#006d2c"
+        1,
+        "#000000",
+        100,
+        "#ffffff"
       ],
       10,
       [
         "interpolate",
         ["linear"],
         ["var", "density"],
-        274,
-        "#eff3ff",
-        1551,
-        "#08519c"
+        1,
+        "#000000",
+        100,
+        "#ffffff"
       ]
     ]
   ],
   "propertySpec": {
     "type": "color"
   },
-  "inputs": [[{"zoom": 10}, {"properties": {"population": 100, "sq-km": 1000}}]],
+  "inputs": [[{"zoom": 9}, {"properties": {"population": 100, "sq-km": 10}}]],
   "expected": {
     "compiled": {
       "result": "success",
@@ -40,11 +40,13 @@
       "isZoomConstant": false,
       "type": "color"
     },
-    "outputs": [0.9372549019607843,0.9529411764705882,1,1],
+    "outputs": [
+      [0.09090909090909091,0.09090909090909091,0.09090909090909091,1]
+    ],
     "serialized": [
       "let",
       "density",
-      ["/", ["get", "population"], ["get", "sq-km"]],
+      ["/", ["number", ["get", "population"]], ["number", ["get", "sq-km"]]],
       [
         "interpolate",
         ["linear"],
@@ -54,20 +56,44 @@
           "interpolate",
           ["linear"],
           ["var", "density"],
-          274,
-          "#edf8e9",
-          1551,
-          "#006d2c"
+          1,
+          [
+            "rgba",
+            0,
+            0,
+            0,
+            1
+          ],
+          100,
+          [
+            "rgba",
+            255,
+            255,
+            255,
+            1
+          ]
         ],
         10,
         [
           "interpolate",
           ["linear"],
           ["var", "density"],
-          274,
-          "#eff3ff",
-          1551,
-          "#08519c"
+          1,
+          [
+            "rgba",
+            0,
+            0,
+            0,
+            1
+          ],
+          100,
+          [
+            "rgba",
+            255,
+            255,
+            255,
+            1
+          ]
         ]
       ]
     ]


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

Fixes https://github.com/mapbox/mapbox-gl-js/issues/7300