### PR TITLE
Only render control-group box-shadow when the control-group has child controls

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -64,11 +64,14 @@
 
 .mapboxgl-ctrl-group {
     border-radius: 4px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.mapboxgl-ctrl-group:not(:empty) {
     -moz-box-shadow: 0 0 2px rgba(0, 0, 0, 0.1);
     -webkit-box-shadow: 0 0 2px rgba(0, 0, 0, 0.1);
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
-    overflow: hidden;
-    background: #fff;
 }
 
 .mapboxgl-ctrl-group > button {


### PR DESCRIPTION
This adds a `:not(:empty)` selector to the `.mapbopx-ctrl-group` selectors box-shadow definition.

Fixes #7303

[Browser Support for `:not()`](https://caniuse.com/#feat=css-sel3)
[Browser Support for `:empty`](https://caniuse.com/#feat=css-sel3)


## Launch Checklist
 - [ChYAH] briefly describe the changes in this PR
 - [NA] write tests for all new functionality
 - [NA] document any changes to public APIs
 - [MA] post benchmark scores
 - [CHYAH] manually test the debug page
 - [NA] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
