### PR TITLE
Make 'formatted' serialization slightly less verbose.

### DIFF
--- a/src/style-spec/expression/types/formatted.js
+++ b/src/style-spec/expression/types/formatted.js
@@ -31,10 +31,14 @@ export default class Formatted {
         const serialized = ["format"];
         for (const section of this.sections) {
             serialized.push(section.text);
-            const fontStack = section.fontStack ?
-                ["literal", section.fontStack.split(',')] :
-                null;
-            serialized.push({ "text-font": fontStack, "font-scale": section.scale });
+            const options = {};
+            if (section.fontStack) {
+                options["text-font"] = ["literal", section.fontStack.split(',')];
+            }
+            if (section.scale) {
+                options["font-scale"] = section.scale;
+            }
+            serialized.push(options);
         }
         return serialized;
     }

--- a/test/integration/expression-tests/format/basic/test.json
+++ b/test/integration/expression-tests/format/basic/test.json
@@ -55,18 +55,13 @@
     "serialized": [
       "format",
       "a",
-      {
-        "font-scale": null,
-        "text-font": null
-      },
+      {},
       "b",
       {
-        "font-scale": 2,
-        "text-font": null
+        "font-scale": 2
       },
       "c",
       {
-        "font-scale": null,
         "text-font": [
           "literal",
           [


### PR DESCRIPTION
Omit "font-scale" and "text-font" from serialization if they're unused.

This is a pretty minor change, but I think it brings us closer to the behavior of the rest of our serializations. I noticed it because on the native side the expression type checking would fail on a `null` `font-scale` because it expects a number type if the field is defined.

Technically this changes our public interface, so tagging in studio and design, but I wouldn't expect this to be a breaking change for most consumers of the serialization (maybe I'm not thinking broadly enough?).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [x] tagged @mapbox/studio and/or @mapbox/maps-design 
 if this PR includes style spec changes

/cc @mollymerp @ryanhamley 