### PR TITLE
Add error message when trying to use SVG in image source

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -158,9 +158,14 @@ export const getImage = function(requestParameters: RequestParameters, callback:
         } else if (imgData) {
             const img: HTMLImageElement = new window.Image();
             const URL = window.URL || window.webkitURL;
+            console.log('get image', imgData);
             img.onload = () => {
                 callback(null, img);
                 URL.revokeObjectURL(img.src);
+            };
+            img.onerror = (e) => {
+              const err = new Error('Image sources cannot use SVGs');
+              callback(err);
             };
             const blob: Blob = new window.Blob([new Uint8Array(imgData.data)], { type: 'image/png' });
             (img: any).cacheControl = imgData.cacheControl;

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -158,15 +158,11 @@ export const getImage = function(requestParameters: RequestParameters, callback:
         } else if (imgData) {
             const img: HTMLImageElement = new window.Image();
             const URL = window.URL || window.webkitURL;
-            console.log('get image', imgData);
             img.onload = () => {
                 callback(null, img);
                 URL.revokeObjectURL(img.src);
             };
-            img.onerror = () => {
-                const err = new Error('Image sources cannot use SVG files');
-                callback(err);
-            };
+            img.onerror = () => callback(new Error('Image sources cannot use SVG files'));
             const blob: Blob = new window.Blob([new Uint8Array(imgData.data)], { type: 'image/png' });
             (img: any).cacheControl = imgData.cacheControl;
             (img: any).expires = imgData.expires;

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -163,9 +163,9 @@ export const getImage = function(requestParameters: RequestParameters, callback:
                 callback(null, img);
                 URL.revokeObjectURL(img.src);
             };
-            img.onerror = (e) => {
-              const err = new Error('Image sources cannot use SVGs');
-              callback(err);
+            img.onerror = () => {
+                const err = new Error('Image sources cannot use SVG files');
+                callback(err);
             };
             const blob: Blob = new window.Blob([new Uint8Array(imgData.data)], { type: 'image/png' });
             (img: any).cacheControl = imgData.cacheControl;

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -162,7 +162,7 @@ export const getImage = function(requestParameters: RequestParameters, callback:
                 callback(null, img);
                 URL.revokeObjectURL(img.src);
             };
-            img.onerror = () => callback(new Error('Image sources cannot use SVG files'));
+            img.onerror = () => callback(new Error('Could not load image. Please make sure to use a supported image type such as PNG or JPEG. Note that SVGs are not supported.'));
             const blob: Blob = new window.Blob([new Uint8Array(imgData.data)], { type: 'image/png' });
             (img: any).cacheControl = imgData.cacheControl;
             (img: any).expires = imgData.expires;


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page

Fixes https://github.com/mapbox/mapbox-gl-js/issues/7312
Superseding https://github.com/mapbox/mapbox-gl-js/pull/5240

#5240 is out of date and it's easier just to open a new one and close that. JSDom still does not implement `URL.createObjectURL` or `URL.revokeObjectURL` so there's not a good way to add a test for this. It's pretty simple though and worked as expected in manual debugging so I think no test is fine.
