### PR TITLE
Fix log expressions in IE

### DIFF
--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -280,7 +280,7 @@ CompoundExpression.register(expressions, {
     'log10': [
         NumberType,
         [NumberType],
-        (ctx, [n]) => Math.log10(n.evaluate(ctx))
+        (ctx, [n]) => Math.log(n.evaluate(ctx)) / Math.LN10
     ],
     'ln': [
         NumberType,
@@ -290,7 +290,7 @@ CompoundExpression.register(expressions, {
     'log2': [
         NumberType,
         [NumberType],
-        (ctx, [n]) => Math.log2(n.evaluate(ctx))
+        (ctx, [n]) => Math.log(n.evaluate(ctx)) / Math.LN2
     ],
     'sin': [
         NumberType,


### PR DESCRIPTION
Closes #7318 — IE11 doesn't support `Math.log2` and `Math.log10`.