### PR TITLE
Less verbose function -> expression conversion

### DIFF
--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -5,6 +5,10 @@ import type {StylePropertySpecification} from '../style-spec';
 
 export default convertFunction;
 
+function convertLiteral(value) {
+    return typeof value === 'object' ? ['literal', value] : value;
+}
+
 function convertFunction(parameters: any, propertySpec: StylePropertySpecification) {
     let stops = parameters.stops;
     if (!stops) {
@@ -20,7 +24,7 @@ function convertFunction(parameters: any, propertySpec: StylePropertySpecificati
         if (!featureDependent && propertySpec.tokens && typeof stop[1] === 'string') {
             return [stop[0], convertTokenString(stop[1])];
         }
-        return [stop[0], ['literal', stop[1]]];
+        return [stop[0], convertLiteral(stop[1])];
     });
 
     if (zoomAndFeatureDependent) {
@@ -48,7 +52,7 @@ function convertIdentityFunction(parameters, propertySpec): Array<mixed> {
             parameters.default
         ];
     } else {
-        const expression = [propertySpec.type === 'color' ? 'to-color' : propertySpec.type, get, ['literal', parameters.default]];
+        const expression = [propertySpec.type === 'color' ? 'to-color' : propertySpec.type, get, convertLiteral(parameters.default)];
         if (propertySpec.type === 'array') {
             expression.splice(1, 0, propertySpec.value, propertySpec.length || null);
         }
@@ -126,14 +130,14 @@ function convertPropertyFunction(parameters, propertySpec, stops) {
         for (const stop of stops) {
             expression.push(['==', get, stop[0]], stop[1]);
         }
-        expression.push(['literal', coalesce(parameters.default, propertySpec.default)]);
+        expression.push(convertLiteral(coalesce(parameters.default, propertySpec.default)));
         return expression;
     } else if (type === 'categorical') {
         const expression = ['match', get];
         for (const stop of stops) {
             appendStopPair(expression, stop[0], stop[1], false);
         }
-        expression.push(['literal', coalesce(parameters.default, propertySpec.default)]);
+        expression.push(convertLiteral(coalesce(parameters.default, propertySpec.default)));
         return expression;
     } else if (type === 'interval') {
         const expression = ['step', ['number', get]];
@@ -145,7 +149,7 @@ function convertPropertyFunction(parameters, propertySpec, stops) {
             'case',
             ['==', ['typeof', get], 'number'],
             expression,
-            ['literal', parameters.default]
+            convertLiteral(parameters.default)
         ];
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
@@ -157,7 +161,7 @@ function convertPropertyFunction(parameters, propertySpec, stops) {
             'case',
             ['==', ['typeof', get], 'number'],
             expression,
-            ['literal', parameters.default]
+            convertLiteral(parameters.default)
         ];
     } else {
         throw new Error(`Unknown property function type ${type}`);

--- a/test/unit/style-spec/migrate.test.js
+++ b/test/unit/style-spec/migrate.test.js
@@ -44,6 +44,50 @@ t('converts token strings to expressions', (t) => {
     t.end();
 });
 
+t('converts stop functions to expressions', (t) => {
+    const migrated = migrate({
+        version: 8,
+        layers: [{
+            id: '1',
+            type: 'background',
+            paint: {
+                'background-opacity': {
+                    base: 1.0,
+                    stops: [[0, 1], [10, 0.72]]
+                }
+            }
+        }, {
+            id: '2',
+            type: 'background',
+            paint: {
+                'background-opacity': {
+                    base: 1.0,
+                    stops: [[0, [1, 2]], [10, [0.72, 0.98]]]
+                }
+            }
+        }]
+    }, spec.latest.$version);
+    t.deepEqual(migrated.layers[0].paint['background-opacity'], [
+        'interpolate',
+        ['exponential', 1],
+        ['zoom'],
+        0,
+        1,
+        10,
+        0.72
+    ]);
+    t.deepEqual(migrated.layers[1].paint['background-opacity'], [
+        'interpolate',
+        ['exponential', 1],
+        ['zoom'],
+        0,
+        ['literal', [1, 2]],
+        10,
+        ['literal', [0.72, 0.98]]
+    ]);
+    t.end();
+});
+
 glob.sync(`${__dirname}/fixture/v7-migrate/*.input.json`).forEach((file) => {
     t(path.basename(file), (t) => {
         const outputfile = file.replace('.input', '.output');


### PR DESCRIPTION
Fixes #7336. Note that `typeof obj === 'object'` should be true for all non-primitive values in the spec (including arrays), so we don't need more exhaustive checks.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~ covered by existing tests
 - [x] ~~document any changes to public APIs~~
 - [x] ~~post benchmark scores~~ n/a
 - [x] manually test the debug page
 - [x] tagged @mapbox/studio if this PR includes style spec changes
