### PR TITLE
add 'empty' tile state to prevent unnecessary reloads

### DIFF
--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -136,6 +136,7 @@ class VectorTileSource extends Evented implements Source {
                 return callback(err);
             }
 
+
             if (data && data.resourceTiming)
                 tile.resourceTiming = data.resourceTiming;
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1038,7 +1038,7 @@ class Map extends Camera {
             const tiles = source._tiles;
             for (const t in tiles) {
                 const tile = tiles[t];
-                if (!(tile.state === 'loaded' || tile.state === 'errored')) return false;
+                if (!(tile.state === 'loaded' || tile.state === 'errored' || tile.state === 'empty')) return false;
             }
         }
         return true;


### PR DESCRIPTION
fix #7346 

Since #6803 changed 404 tiles to not be treated as errored, the benefits of #6813 regressed for tiles that error with 404, and this causes unnecessary tile reloads that prevent map state from returning to `true`. 

Alternatives:
I think adding an `empty` state adds some clarity to TileState, but this issue could also be fixed in one line by checking if a tile has any buckets before reloading. Curious if the team would prefer that approach. 

cc @lobenichou 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page