### PR TITLE
Fix identity functions for 'text-field' (i.e. 'formatted' type)

### DIFF
--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -5,6 +5,7 @@ import extend from '../util/extend';
 import getType from '../util/get_type';
 import * as interpolate from '../util/interpolate';
 import Interpolate from '../expression/definitions/interpolate';
+import Formatted from '../expression/types/formatted';
 import { supportsInterpolation } from '../util/properties';
 
 export function isFunction(value) {
@@ -194,6 +195,8 @@ function evaluateExponentialFunction(parameters, propertySpec, input) {
 function evaluateIdentityFunction(parameters, propertySpec, input) {
     if (propertySpec.type === 'color') {
         input = Color.parse(input);
+    } else if (propertySpec.type === 'formatted') {
+        input = Formatted.fromString(input.toString());
     } else if (getType(input) !== propertySpec.type && (propertySpec.type !== 'enum' || !propertySpec.values[input])) {
         input = undefined;
     }

--- a/test/unit/style-spec/function.test.js
+++ b/test/unit/style-spec/function.test.js
@@ -1,6 +1,7 @@
 import { test } from 'mapbox-gl-js-test';
 import { createFunction } from '../../../src/style-spec/function';
 import Color from '../../../src/style-spec/util/color';
+import Formatted from '../../../src/style-spec/expression/types/formatted';
 
 test('binary search', (t) => {
     t.test('will eventually terminate.', (t) => {
@@ -985,6 +986,22 @@ test('identity function', (t) => {
         }).evaluate;
 
         t.equal(f({zoom: 0}, {properties: {foo: 3}}), 'def');
+
+        t.end();
+    });
+
+    t.test('formatted', (t) => {
+        const f = createFunction({
+            property: 'foo',
+            type: 'identity'
+        }, {
+            type: 'formatted'
+        }).evaluate;
+
+        t.deepEqual(f({zoom: 0}, {properties: {foo: 'foo'}}), Formatted.fromString('foo'));
+        t.deepEqual(f({zoom: 1}, {properties: {foo: 'bar'}}), Formatted.fromString('bar'));
+        t.deepEqual(f({zoom: 2}, {properties: {foo: 2}}), Formatted.fromString('2'));
+        t.deepEqual(f({zoom: 3}, {properties: {foo: true}}), Formatted.fromString('true'));
 
         t.end();
     });


### PR DESCRIPTION
Fixes issue #7311.

An identity function for the `text-field` property would return nothing because the type of the input wouldn't match the 'formatted' type expected for that property.

This PR restores previous behavior by using the `Formatted.fromString` function.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

cc @jplante @ryanhamley @mollymerp 
