### PR TITLE
make sure worker sends response after reloading 'empty' tile

### DIFF
--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -110,6 +110,8 @@ class VectorTileWorkerSource implements WorkerSource {
             delete this.loading[uid];
 
             if (err || !response) {
+                workerTile.status = 'done';
+                this.loaded[uid] = workerTile;
                 return callback(err);
             }
 
@@ -163,7 +165,12 @@ class VectorTileWorkerSource implements WorkerSource {
             if (workerTile.status === 'parsing') {
                 workerTile.reloadCallback = done;
             } else if (workerTile.status === 'done') {
-                workerTile.parse(workerTile.vectorTile, this.layerIndex, this.actor, done);
+                // if there was no vector tile data on the initial load, don't try and re-parse tile
+                if (workerTile.vectorTile) {
+                    workerTile.parse(workerTile.vectorTile, this.layerIndex, this.actor, done);
+                } else {
+                    done();
+                }
             }
         }
     }

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -58,6 +58,7 @@ test('VectorTileWorkerSource#reloadTile reloads a previously-loaded tile', (t) =
     source.loaded = {
         '0': {
             status: 'done',
+            vectorTile: {},
             parse
         }
     };
@@ -79,6 +80,7 @@ test('VectorTileWorkerSource#reloadTile queues a reload when parsing is in progr
     source.loaded = {
         '0': {
             status: 'done',
+            vectorTile: {},
             parse
         }
     };
@@ -112,6 +114,7 @@ test('VectorTileWorkerSource#reloadTile handles multiple pending reloads', (t) =
     source.loaded = {
         '0': {
             status: 'done',
+            vectorTile: {},
             parse
         }
     };
@@ -151,6 +154,27 @@ test('VectorTileWorkerSource#reloadTile handles multiple pending reloads', (t) =
 
     t.end();
 });
+
+test('VectorTileWorkerSource#reloadTile does not reparse tiles with no vectorTile data but does call callback', (t) => {
+    const source = new VectorTileWorkerSource(null, new StyleLayerIndex());
+    const parse = t.spy();
+
+    source.loaded = {
+        '0': {
+            status: 'done',
+            parse
+        }
+    };
+
+    const callback = t.spy();
+
+    source.reloadTile({ uid: 0 }, callback);
+    t.ok(parse.notCalled);
+    t.ok(callback.calledOnce);
+
+    t.end();
+});
+
 
 test('VectorTileWorkerSource provides resource timing information', (t) => {
     const rawTileData = fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'));


### PR DESCRIPTION
This is an alternative to #7348 to fix #7346 that does not require adding an additional tile `state` value, and prevents us from guessing whether a reload is necessary based on data returned from the initial worker parse. This is also nice because now the WorkerTile's `loaded:{}` object should match the tiles marked as `state: 'loaded'` in the foreground.

Prior to this, a reload request for a tile that 404'd or otherwise returned no data from the AJAX request would never call its callback and prevented `map.loaded()` from ever returning `true` due to tiles hanging with `state: 'reloading'`.
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~
