### PR TITLE
Remove repetition in array_types.js

### DIFF
--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -25,10 +25,7 @@ class StructArrayLayout2i4 extends StructArray {
     emplaceBack(v0: number, v1: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 2;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        return i;
+        return this.emplace(i, v0, v1);
     }
 
     emplace(i: number, v0: number, v1: number) {
@@ -61,12 +58,7 @@ class StructArrayLayout4i8 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 4;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number) {
@@ -102,14 +94,7 @@ class StructArrayLayout2i4i12 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 6;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        this.int16[o2 + 4] = v4;
-        this.int16[o2 + 5] = v5;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3, v4, v5);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number) {
@@ -147,17 +132,7 @@ class StructArrayLayout4i4ub12 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 6;
-        const o1 = i * 12;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        this.uint8[o1 + 8] = v4;
-        this.uint8[o1 + 9] = v5;
-        this.uint8[o1 + 10] = v6;
-        this.uint8[o1 + 11] = v7;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
@@ -197,16 +172,7 @@ class StructArrayLayout8ui16 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 8;
-        this.uint16[o2 + 0] = v0;
-        this.uint16[o2 + 1] = v1;
-        this.uint16[o2 + 2] = v2;
-        this.uint16[o2 + 3] = v3;
-        this.uint16[o2 + 4] = v4;
-        this.uint16[o2 + 5] = v5;
-        this.uint16[o2 + 6] = v6;
-        this.uint16[o2 + 7] = v7;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
@@ -248,16 +214,7 @@ class StructArrayLayout4i4ui16 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 8;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        this.uint16[o2 + 4] = v4;
-        this.uint16[o2 + 5] = v5;
-        this.uint16[o2 + 6] = v6;
-        this.uint16[o2 + 7] = v7;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
@@ -296,11 +253,7 @@ class StructArrayLayout3f12 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o4 = i * 3;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
-        return i;
+        return this.emplace(i, v0, v1, v2);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number) {
@@ -334,9 +287,7 @@ class StructArrayLayout1ul4 extends StructArray {
     emplaceBack(v0: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o4 = i * 1;
-        this.uint32[o4 + 0] = v0;
-        return i;
+        return this.emplace(i, v0);
     }
 
     emplace(i: number, v0: number) {
@@ -375,20 +326,7 @@ class StructArrayLayout6i1ul2ui2i24 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 12;
-        const o4 = i * 6;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        this.int16[o2 + 4] = v4;
-        this.int16[o2 + 5] = v5;
-        this.uint32[o4 + 3] = v6;
-        this.uint16[o2 + 8] = v7;
-        this.uint16[o2 + 9] = v8;
-        this.int16[o2 + 10] = v9;
-        this.int16[o2 + 11] = v10;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number) {
@@ -433,14 +371,7 @@ class StructArrayLayout2i2i2i12 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 6;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        this.int16[o2 + 4] = v4;
-        this.int16[o2 + 5] = v5;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3, v4, v5);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number) {
@@ -475,10 +406,7 @@ class StructArrayLayout2ub4 extends StructArray {
     emplaceBack(v0: number, v1: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o1 = i * 4;
-        this.uint8[o1 + 0] = v0;
-        this.uint8[o1 + 1] = v1;
-        return i;
+        return this.emplace(i, v0, v1);
     }
 
     emplace(i: number, v0: number, v1: number) {
@@ -522,24 +450,7 @@ class StructArrayLayout2i2ui3ul3ui2f2ub40 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 20;
-        const o4 = i * 10;
-        const o1 = i * 40;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.uint16[o2 + 2] = v2;
-        this.uint16[o2 + 3] = v3;
-        this.uint32[o4 + 2] = v4;
-        this.uint32[o4 + 3] = v5;
-        this.uint32[o4 + 4] = v6;
-        this.uint16[o2 + 10] = v7;
-        this.uint16[o2 + 11] = v8;
-        this.uint16[o2 + 12] = v9;
-        this.float32[o4 + 7] = v10;
-        this.float32[o4 + 8] = v11;
-        this.uint8[o1 + 36] = v12;
-        this.uint8[o1 + 37] = v13;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number) {
@@ -592,23 +503,7 @@ class StructArrayLayout4i9ui1ul32 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 16;
-        const o4 = i * 8;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        this.int16[o2 + 3] = v3;
-        this.uint16[o2 + 4] = v4;
-        this.uint16[o2 + 5] = v5;
-        this.uint16[o2 + 6] = v6;
-        this.uint16[o2 + 7] = v7;
-        this.uint16[o2 + 8] = v8;
-        this.uint16[o2 + 9] = v9;
-        this.uint16[o2 + 10] = v10;
-        this.uint16[o2 + 11] = v11;
-        this.uint16[o2 + 12] = v12;
-        this.uint32[o4 + 7] = v13;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number) {
@@ -654,9 +549,7 @@ class StructArrayLayout1f4 extends StructArray {
     emplaceBack(v0: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o4 = i * 1;
-        this.float32[o4 + 0] = v0;
-        return i;
+        return this.emplace(i, v0);
     }
 
     emplace(i: number, v0: number) {
@@ -688,11 +581,7 @@ class StructArrayLayout3i6 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 3;
-        this.int16[o2 + 0] = v0;
-        this.int16[o2 + 1] = v1;
-        this.int16[o2 + 2] = v2;
-        return i;
+        return this.emplace(i, v0, v1, v2);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number) {
@@ -729,12 +618,7 @@ class StructArrayLayout1ul2ui8 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o4 = i * 2;
-        const o2 = i * 4;
-        this.uint32[o4 + 0] = v0;
-        this.uint16[o2 + 2] = v1;
-        this.uint16[o2 + 3] = v2;
-        return i;
+        return this.emplace(i, v0, v1, v2);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number) {
@@ -769,11 +653,7 @@ class StructArrayLayout3ui6 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 3;
-        this.uint16[o2 + 0] = v0;
-        this.uint16[o2 + 1] = v1;
-        this.uint16[o2 + 2] = v2;
-        return i;
+        return this.emplace(i, v0, v1, v2);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number) {
@@ -807,10 +687,7 @@ class StructArrayLayout2ui4 extends StructArray {
     emplaceBack(v0: number, v1: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 2;
-        this.uint16[o2 + 0] = v0;
-        this.uint16[o2 + 1] = v1;
-        return i;
+        return this.emplace(i, v0, v1);
     }
 
     emplace(i: number, v0: number, v1: number) {
@@ -843,9 +720,7 @@ class StructArrayLayout1ui2 extends StructArray {
     emplaceBack(v0: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o2 = i * 1;
-        this.uint16[o2 + 0] = v0;
-        return i;
+        return this.emplace(i, v0);
     }
 
     emplace(i: number, v0: number) {
@@ -877,10 +752,7 @@ class StructArrayLayout2f8 extends StructArray {
     emplaceBack(v0: number, v1: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o4 = i * 2;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        return i;
+        return this.emplace(i, v0, v1);
     }
 
     emplace(i: number, v0: number, v1: number) {
@@ -913,12 +785,7 @@ class StructArrayLayout4f16 extends StructArray {
     emplaceBack(v0: number, v1: number, v2: number, v3: number) {
         const i = this.length;
         this.resize(i + 1);
-        const o4 = i * 4;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
-        this.float32[o4 + 3] = v3;
-        return i;
+        return this.emplace(i, v0, v1, v2, v3);
     }
 
     emplace(i: number, v0: number, v1: number, v2: number, v3: number) {

--- a/src/util/struct_array_layout.js.ejs
+++ b/src/util/struct_array_layout.js.ejs
@@ -46,6 +46,7 @@ for (const type of usedTypes) {
 const bytesPerElement = size;
 const usedTypeSizes = [];
 const argNames = [];
+const argNamesTyped = [];
 for (const member of members) {
     if (usedTypeSizes.indexOf(member.size) < 0) {
         usedTypeSizes.push(member.size);
@@ -53,38 +54,19 @@ for (const member of members) {
     for (let c = 0; c < member.components; c++) {
         // arguments v0, v1, v2, ... are, in order, the components of
         // member 0, then the components of member 1, etc.
-        argNames.push(`v${argNames.length}: number`);
+        const name = `v${argNames.length}`;
+        argNames.push(name);
+        argNamesTyped.push(`${name}: number`);
     }
 }
 -%>
-    emplaceBack(<%=argNames.join(', ')%>) {
+    emplaceBack(<%=argNamesTyped.join(', ')%>) {
         const i = this.length;
         this.resize(i + 1);
-<%
-for (const size of usedTypeSizes) {
--%>
-        const o<%=size.toFixed(0)%> = i * <%=(bytesPerElement / size).toFixed(0)%>;
-<%
-}
-
-let argIndex = 0;
-for (const member of members) {
-    for (let c = 0; c < member.components; c++) {
-        // The index for `member` component `c` into the appropriate type array is:
-        // this.{TYPE}[o{SIZE} + MEMBER_OFFSET + {c}] = v{X}
-        // where MEMBER_OFFSET = ROUND(member.offset / size) is the per-element
-        // offset of this member into the array
-        const index = `o${member.size.toFixed(0)} + ${(member.offset / member.size + c).toFixed(0)}`;
--%>
-        this.<%=member.view%>[<%=index%>] = v<%=argIndex++%>;
-<%
-    }
-}
--%>
-        return i;
+        return this.emplace(i, <%=argNames.join(', ')%>);
     }
 
-    emplace(i: number, <%=argNames.join(', ')%>) {
+    emplace(i: number, <%=argNamesTyped.join(', ')%>) {
 <%
 {
 for (const size of usedTypeSizes) {
@@ -92,7 +74,7 @@ for (const size of usedTypeSizes) {
         const o<%=size.toFixed(0)%> = i * <%=(bytesPerElement / size).toFixed(0)%>;
 <%
 }
-        
+
 let argIndex = 0;
 for (const member of members) {
     for (let c = 0; c < member.components; c++) {


### PR DESCRIPTION
Removed some repetition in the generated array_types.js code, slightly reducing bundle size. Doesn't seem to affect performance (emplace should get inlined at runtime).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~
 - [x] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page

![image](https://user-images.githubusercontent.com/25395/46480514-0f76de80-c7fa-11e8-80a7-540742086113.png)

