### PR TITLE
Add `SymbolLayout` benchmark

### DIFF
--- a/bench/benchmarks/symbol_layout.js
+++ b/bench/benchmarks/symbol_layout.js
@@ -1,0 +1,47 @@
+// @flow
+
+import Layout from './layout';
+import SymbolBucket from '../../src/data/bucket/symbol_bucket';
+import { performSymbolLayout } from '../../src/symbol/symbol_layout';
+import { OverscaledTileID } from '../../src/source/tile_id';
+
+export default class SymbolLayout extends Layout {
+    parsedTiles: Array<any>;
+
+    constructor(style: string, locations: ?Array<OverscaledTileID>) {
+        super(style, locations);
+        this.parsedTiles = [];
+    }
+
+    setup(): Promise<void> {
+        return super.setup().then(() => {
+            // Do initial load/parse of tiles and hold onto all the glyph/icon
+            // dependencies so that we can re-do symbol layout in isolation
+            // during the bench step.
+            return Promise.all(this.tiles.map(tile =>
+                this.parser.parseTile(tile, true).then((tileResult) => {
+                    this.parsedTiles.push(tileResult);
+                })
+            )).then(() => {});
+        });
+    }
+
+    bench() {
+        let promise = Promise.resolve();
+        for (const tileResult of this.parsedTiles) {
+            promise = promise.then(() => {
+                for (const bucket of tileResult.buckets) {
+                    if (bucket instanceof SymbolBucket) {
+                        performSymbolLayout(bucket,
+                                            tileResult.glyphMap,
+                                            tileResult.glyphPositions,
+                                            tileResult.iconMap,
+                                            tileResult.imageAtlas.iconPositions,
+                                            false);
+                    }
+                }
+            });
+        }
+        return promise;
+    }
+}

--- a/bench/lib/tile_parser.js
+++ b/bench/lib/tile_parser.js
@@ -108,7 +108,7 @@ export default class TileParser {
             .then(buffer => ({tileID, buffer}));
     }
 
-    parseTile(tile: {tileID: OverscaledTileID, buffer: ArrayBuffer}): Promise<?WorkerTileResult> {
+    parseTile(tile: {tileID: OverscaledTileID, buffer: ArrayBuffer}, returnDependencies?: boolean): Promise<?WorkerTileResult> {
         const workerTile = new WorkerTile({
             tileID: tile.tileID,
             zoom: tile.tileID.overscaledZ,
@@ -123,7 +123,8 @@ export default class TileParser {
             angle: 0,
             pitch: 0,
             cameraToCenterDistance: 0,
-            cameraToTileDistance: 0
+            cameraToTileDistance: 0,
+            returnDependencies: returnDependencies
         });
 
         const vectorTile = new VT.VectorTile(new Protobuf(tile.buffer));

--- a/bench/versions/benchmarks.js
+++ b/bench/versions/benchmarks.js
@@ -2,6 +2,7 @@ import mapboxgl from '../../src';
 import accessToken from '../lib/access_token';
 import { summaryStatistics, regression } from '../lib/statistics';
 import updateUI from '../benchmarks_view';
+import styleLocations from '../lib/style_locations';
 
 mapboxgl.accessToken = accessToken;
 
@@ -17,6 +18,7 @@ function register(benchmark) {
 
 import Layout from '../benchmarks/layout';
 import LayoutDDS from '../benchmarks/layout_dds';
+import SymbolLayout from '../benchmarks/symbol_layout';
 import WorkerTransfer from '../benchmarks/worker_transfer';
 import Paint from '../benchmarks/paint';
 import PaintStates from '../benchmarks/paint_states';
@@ -47,6 +49,7 @@ register(new PaintStates(center));
 LayerBenchmarks.forEach((Bench) => register(new Bench()));
 register(new Load());
 register(new LayoutDDS());
+register(new SymbolLayout(style, styleLocations.map(location => location.tileID[0])));
 register(new FilterCreate());
 register(new FilterEvaluate());
 

--- a/src/render/glyph_atlas.js
+++ b/src/render/glyph_atlas.js
@@ -20,9 +20,11 @@ export type GlyphPosition = {
     metrics: GlyphMetrics
 };
 
+export type GlyphPositions = { [string]: { [number]: GlyphPosition } }
+
 export default class GlyphAtlas {
     image: AlphaImage;
-    positions: { [string]: { [number]: GlyphPosition } };
+    positions: GlyphPositions;
 
     constructor(stacks: { [string]: { [number]: ?StyleGlyph } }) {
         const positions = {};

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -2,6 +2,7 @@
 
 import type {RequestParameters} from '../util/ajax';
 import type {RGBAImage, AlphaImage} from '../util/image';
+import type { GlyphPositions } from '../render/glyph_atlas';
 import type ImageAtlas from '../render/image_atlas';
 import type {OverscaledTileID} from './tile_id';
 import type {Bucket} from '../data/bucket';
@@ -9,6 +10,8 @@ import type FeatureIndex from '../data/feature_index';
 import type {CollisionBoxArray} from '../data/array_types';
 import type DEMData from '../data/dem_data';
 import type {PerformanceResourceTiming} from '../types/performance_resource_timing';
+import type { StyleGlyph } from '../style/style_glyph';
+import type { StyleImage } from '../style/style_image';
 
 export type TileParameters = {
     source: string,
@@ -23,7 +26,8 @@ export type WorkerTileParameters = TileParameters & {
     tileSize: number,
     pixelRatio: number,
     showCollisionBoxes: boolean,
-    collectResourceTiming?: boolean
+    collectResourceTiming?: boolean,
+    returnDependencies?: boolean
 };
 
 export type WorkerDEMTileParameters = TileParameters & {
@@ -39,7 +43,11 @@ export type WorkerTileResult = {
     featureIndex: FeatureIndex,
     collisionBoxArray: CollisionBoxArray,
     rawTileData?: ArrayBuffer,
-    resourceTiming?: Array<PerformanceResourceTiming>
+    resourceTiming?: Array<PerformanceResourceTiming>,
+    // Only used for benchmarking:
+    glyphMap?: {[string]: {[number]: ?StyleGlyph}} | null,
+    iconMap?: {[string]: StyleImage} | null,
+    glyphPositions?: GlyphPositions | null
 };
 
 export type WorkerTileCallback = (error: ?Error, result: ?WorkerTileResult) => void;

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -37,6 +37,7 @@ class WorkerTile {
     overscaling: number;
     showCollisionBoxes: boolean;
     collectResourceTiming: boolean;
+    returnDependencies: boolean;
 
     status: 'parsing' | 'done';
     data: VectorTile;
@@ -56,6 +57,7 @@ class WorkerTile {
         this.overscaling = this.tileID.overscaleFactor();
         this.showCollisionBoxes = params.showCollisionBoxes;
         this.collectResourceTiming = !!params.collectResourceTiming;
+        this.returnDependencies = !!params.returnDependencies;
     }
 
     parse(data: VectorTile, layerIndex: StyleLayerIndex, actor: Actor, callback: WorkerTileCallback) {
@@ -196,7 +198,11 @@ class WorkerTile {
                     featureIndex,
                     collisionBoxArray: this.collisionBoxArray,
                     glyphAtlasImage: glyphAtlas.image,
-                    imageAtlas: imageAtlas
+                    imageAtlas: imageAtlas,
+                    // Only used for benchmarking:
+                    glyphMap: this.returnDependencies ? glyphMap : null,
+                    iconMap: this.returnDependencies ? iconMap : null,
+                    glyphPositions: this.returnDependencies ? glyphAtlas.positions : null
                 });
             }
         }


### PR DESCRIPTION
This benchmark has the same setup as `Layout`, but narrows in to focus on `performSymbolLayout` -- essentially text shaping and line breaking. These show up as a pretty big chunk of layout time, so I think it makes sense to try to bench them separately so we can detect changes that might be harder to see in the Layout benchmark as a whole. I may try to retroactively apply this bench to the recent `format` changes, and I expect this bench would be a good one to watch with any changes we make for "dynamic label placement".

I had to change the `WorkerTile` interface a little in order to pass the glyph/icon dependencies back to the benchmark -- hopefully that doesn't have any discernible effect on how the callbacks work in production.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

<img width="851" alt="screenshot 2018-10-04 12 17 45" src="https://user-images.githubusercontent.com/375121/46497465-85b21b80-c7cf-11e8-9f91-3210e5c68549.png">
<img width="860" alt="screenshot 2018-10-04 12 17 37" src="https://user-images.githubusercontent.com/375121/46497466-85b21b80-c7cf-11e8-8eb7-03b2b2016e3e.png">


cc @mourner @mollymerp @ryanhamley 