### PR TITLE
Filter validation should enforce lack of feature-state support

### DIFF
--- a/src/style-spec/validate/validate_expression.js
+++ b/src/style-spec/validate/validate_expression.js
@@ -23,5 +23,10 @@ export default function validateExpression(options: any) {
         (!isStateConstant((expression.value: any)._styleExpression.expression))) {
         return [new ValidationError(options.key, options.value, '"feature-state" data expressions are not supported with layout properties.')];
     }
+
+    if (options.expressionContext === 'filter' && !isStateConstant((expression.value: any).expression)) {
+        return [new ValidationError(options.key, options.value, '"feature-state" data expressions are not supported with filters.')];
+    }
+
     return [];
 }

--- a/test/unit/style-spec/fixture/filters.input.json
+++ b/test/unit/style-spec/fixture/filters.input.json
@@ -150,6 +150,13 @@
       "source": "source",
       "source-layer": "source-layer",
       "filter": ["all", [">=", "Constructi", 1930], [">=", ["zoom"], 10]]
+    },
+    {
+      "id": "filter expressions with feature-state",
+      "type": "line",
+      "source": "source",
+      "source-layer": "source-layer",
+      "filter": ["<=" , ["feature-state", "height"], 10]
     }
   ]
 }

--- a/test/unit/style-spec/fixture/filters.output.json
+++ b/test/unit/style-spec/fixture/filters.output.json
@@ -54,5 +54,9 @@
   {
     "message": "layers[14].filter[2][1]: string expected, array found",
     "line": 152
+  },
+  {
+    "message": "layers[15].filter: \"feature-state\" data expressions are not supported with filters.",
+    "line": 159
   }
 ]


### PR DESCRIPTION
Closes #7352.

Style Filters cannot accept `feature-state` expressions and should not validate when used with such expressions.