### PR TITLE
Allow browser context menu when possible

### DIFF
--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -178,7 +178,11 @@ export default function bindHandlers(map: Map, options: {interactive: boolean, c
             contextMenuEvent = e;
         }
 
-        e.preventDefault();
+        // prevent browser context menu when necessary; we don't allow it with rotation
+        // because we can't discern rotation gesture start from contextmenu on Mac
+        if (map.dragRotate.isEnabled() || map.listens('contextmenu')) {
+            e.preventDefault();
+        }
     }
 
     function onWheel(e: WheelEvent) {


### PR DESCRIPTION
Closes #2301. Enables standard browser context menu on maps where rotation is disabled and there are no `contextmenu` listeners. 

Unfortunately I don't see a way to enable it by default because it's not compatible with rotation — on Mac, `contextmenu` is fired together with `mousedown` (not `mouseup` like in other browsers), and at this point we don't know if it's a start of a rotation gesture or a simple right click. cc @jplante

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~
 - [x] ~~document any changes to public APIs~~
 - [x] ~~post benchmark scores~~
 - [x] manually test the debug page
