### PR TITLE
Use Fetch API in browsers that support it

### DIFF
--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -20,7 +20,7 @@ import type Actor from '../util/actor';
 import type StyleLayerIndex from '../style/style_layer_index';
 
 import type {LoadVectorDataCallback} from './vector_tile_worker_source';
-import type {RequestParameters} from '../util/ajax';
+import type { RequestParameters, ResponseCallback } from '../util/ajax';
 import type { Callback } from '../types/callback';
 import type {GeoJSONFeature} from '@mapbox/geojson-types';
 
@@ -33,7 +33,7 @@ export type LoadGeoJSONParameters = {
     geojsonVtOptions?: Object
 };
 
-export type LoadGeoJSON = (params: LoadGeoJSONParameters, callback: Callback<mixed>) => void;
+export type LoadGeoJSON = (params: LoadGeoJSONParameters, callback: ResponseCallback<Object>) => void;
 
 export interface GeoJSONIndex {
     getTile(z: number, x: number, y: number): Object;
@@ -161,7 +161,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
         const perf = (params && params.request && params.request.collectResourceTiming) ?
             new performance.Performance(params.request) : false;
 
-        this.loadGeoJSON(params, (err, data) => {
+        this.loadGeoJSON(params, (err: ?Error, data: ?Object) => {
             if (err || !data) {
                 return callback(err);
             } else if (typeof data !== 'object') {
@@ -254,7 +254,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * @param [params.url] A URL to the remote GeoJSON data.
      * @param [params.data] Literal GeoJSON data. Must be provided if `params.url` is not.
      */
-    loadGeoJSON(params: LoadGeoJSONParameters, callback: Callback<mixed>) {
+    loadGeoJSON(params: LoadGeoJSONParameters, callback: ResponseCallback<Object>) {
         // Because of same origin issues, urls must either include an explicit
         // origin or absolute path.
         // ie: /foo/bar.json or http://example.com/bar.json

--- a/src/source/load_tilejson.js
+++ b/src/source/load_tilejson.js
@@ -12,7 +12,7 @@ import type {TileJSON} from '../types/tilejson';
 import type {Cancelable} from '../types/cancelable';
 
 export default function(options: any, requestTransformFn: RequestTransformFunction, callback: Callback<TileJSON>): Cancelable {
-    const loaded = function(err, tileJSON: any) {
+    const loaded = function(err: ?Error, tileJSON: ?Object) {
         if (err) {
             return callback(err);
         } else if (tileJSON) {

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {getArrayBuffer} from '../util/ajax';
+import { getArrayBuffer } from '../util/ajax';
 
 import vt from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
@@ -43,15 +43,15 @@ export type LoadVectorData = (params: WorkerTileParameters, callback: LoadVector
  * @private
  */
 function loadVectorTile(params: WorkerTileParameters, callback: LoadVectorDataCallback) {
-    const request = getArrayBuffer(params.request, (err, response) => {
+    const request = getArrayBuffer(params.request, (err: ?Error, data: ?ArrayBuffer, cacheControl: ?string, expires: ?string) => {
         if (err) {
             callback(err);
-        } else if (response) {
+        } else if (data) {
             callback(null, {
-                vectorTile: new vt.VectorTile(new Protobuf(response.data)),
-                rawData: response.data,
-                cacheControl: response.cacheControl,
-                expires: response.expires
+                vectorTile: new vt.VectorTile(new Protobuf(data)),
+                rawData: data,
+                cacheControl: cacheControl,
+                expires: expires
             });
         }
     });

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -32,6 +32,7 @@ export default class Worker {
     workerSourceTypes: { [string]: Class<WorkerSource> };
     workerSources: { [string]: { [string]: { [string]: WorkerSource } } };
     demWorkerSources: { [string]: { [string]: RasterDEMTileWorkerSource } };
+    referrer: ?string;
 
     constructor(self: WorkerGlobalScopeInterface) {
         this.self = self;
@@ -63,6 +64,10 @@ export default class Worker {
             globalRTLTextPlugin['processBidirectionalText'] = rtlTextPlugin.processBidirectionalText;
             globalRTLTextPlugin['processStyledBidirectionalText'] = rtlTextPlugin.processStyledBidirectionalText;
         };
+    }
+
+    setReferrer(mapID: string, referrer: string) {
+        this.referrer = referrer;
     }
 
     setLayers(mapId: string, layers: Array<LayerSpecification>, callback: WorkerTileCallback) {
@@ -196,5 +201,5 @@ export default class Worker {
 if (typeof WorkerGlobalScope !== 'undefined' &&
     typeof self !== 'undefined' &&
     self instanceof WorkerGlobalScope) {
-    new Worker(self);
+    self.worker = new Worker(self);
 }

--- a/src/style/load_glyph_range.js
+++ b/src/style/load_glyph_range.js
@@ -3,6 +3,7 @@
 import { normalizeGlyphsURL } from '../util/mapbox';
 
 import { getArrayBuffer, ResourceType } from '../util/ajax';
+
 import parseGlyphPBF from './parse_glyph_pbf';
 
 import type {StyleGlyph} from './style_glyph';
@@ -23,13 +24,13 @@ export default function (fontstack: string,
             .replace('{range}', `${begin}-${end}`),
         ResourceType.Glyphs);
 
-    getArrayBuffer(request, (err, response) => {
+    getArrayBuffer(request, (err: ?Error, data: ?ArrayBuffer) => {
         if (err) {
             callback(err);
-        } else if (response) {
+        } else if (data) {
             const glyphs = {};
 
-            for (const glyph of parseGlyphPBF(response.data)) {
+            for (const glyph of parseGlyphPBF(data)) {
                 glyphs[glyph.id] = glyph;
             }
 

--- a/src/style/load_sprite.js
+++ b/src/style/load_sprite.js
@@ -17,7 +17,7 @@ export default function(baseURL: string,
     let json: any, image, error;
     const format = browser.devicePixelRatio > 1 ? '@2x' : '';
 
-    let jsonRequest = getJSON(transformRequestCallback(normalizeSpriteURL(baseURL, format, '.json'), ResourceType.SpriteJSON), (err, data) => {
+    let jsonRequest = getJSON(transformRequestCallback(normalizeSpriteURL(baseURL, format, '.json'), ResourceType.SpriteJSON), (err: ?Error, data: ?Object) => {
         jsonRequest = null;
         if (!error) {
             error = err;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -11,7 +11,7 @@ import GlyphManager from '../render/glyph_manager';
 import Light from './light';
 import LineAtlas from '../render/line_atlas';
 import { pick, clone, extend, deepEqual, filterObject, mapObject } from '../util/util';
-import { getJSON, ResourceType } from '../util/ajax';
+import { getJSON, getReferrer, ResourceType } from '../util/ajax';
 import { isMapboxURL, normalizeStyleURL } from '../util/mapbox';
 import browser from '../util/browser';
 import Dispatcher from '../util/dispatcher';
@@ -143,6 +143,8 @@ class Style extends Evented {
         this._loaded = false;
 
         this._resetUpdates();
+
+        this.dispatcher.broadcast('setReferrer', getReferrer());
 
         const self = this;
         this._rtlTextPluginCallback = Style.registerForPluginAvailability((args) => {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -188,12 +188,12 @@ class Style extends Evented {
         url = normalizeStyleURL(url, options.accessToken);
         const request = this.map._transformRequest(url, ResourceType.Style);
 
-        this._request = getJSON(request, (error, json) => {
+        this._request = getJSON(request, (error: ?Error, json: ?Object) => {
             this._request = null;
             if (error) {
                 this.fire(new ErrorEvent(error));
             } else if (json) {
-                this._load((json: any), validate);
+                this._load(json, validate);
             }
         });
     }

--- a/src/types/window.js
+++ b/src/types/window.js
@@ -18,6 +18,7 @@ export interface Window extends EventTarget, IDBEnvironment {
     +isSecureContext: boolean;
     +length: number;
     +location: Location;
+    +origin: string;
     name: string;
     +navigator: Navigator;
     offscreenBuffering: string | boolean;
@@ -131,6 +132,8 @@ export interface Window extends EventTarget, IDBEnvironment {
     WheelEvent: typeof WheelEvent;
     Worker: typeof Worker;
     XMLHttpRequest: typeof XMLHttpRequest;
+    Request: typeof Request;
+    AbortController: any;
 
     alert(message?: any): void;
     blur(): void;

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -199,25 +199,25 @@ export class TurnstileEvent {
             return this.processRequests();
         }
 
-        const evenstUrlObject: UrlObject = parseUrl(config.EVENTS_URL);
-        evenstUrlObject.params.push(`access_token=${config.ACCESS_TOKEN || ''}`);
+        const eventsUrlObject: UrlObject = parseUrl(config.EVENTS_URL);
+        eventsUrlObject.params.push(`access_token=${config.ACCESS_TOKEN || ''}`);
+
         const request: RequestParameters = {
-            url: formatUrl(evenstUrlObject),
+            url: formatUrl(eventsUrlObject),
             headers: {
-                'Content-Type': 'text/plain' //Skip the pre-flight OPTIONS request
-            }
+                'Content-Type': 'text/plain' // Skip the pre-flight OPTIONS request
+            },
+            body: JSON.stringify([{
+                event: 'appUserTurnstile',
+                created: (new Date(nextUpdate)).toISOString(),
+                sdkIdentifier: 'mapbox-gl-js',
+                sdkVersion: version,
+                'enabled.telemetry': false,
+                userId: this.eventData.anonId
+            }])
         };
 
-        const payload = JSON.stringify([{
-            event: 'appUserTurnstile',
-            created: (new Date(nextUpdate)).toISOString(),
-            sdkIdentifier: 'mapbox-gl-js',
-            sdkVersion: version,
-            'enabled.telemetry': false,
-            userId: this.eventData.anonId
-        }]);
-
-        this.pendingRequest = postData(request, payload, (error) => {
+        this.pendingRequest = postData(request, (error: ?Error) => {
             this.pendingRequest = null;
             if (!error) {
                 this.eventData.lastSuccess = nextUpdate;

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -46,7 +46,12 @@ function isMapboxURL(url: string) {
     return url.indexOf('mapbox:') === 0;
 }
 
-export { isMapboxURL };
+const mapboxHTTPURLRe = /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/|\?|$)/i;
+function isMapboxHTTPURL(url: string): boolean {
+    return mapboxHTTPURLRe.test(url);
+}
+
+export { isMapboxURL, isMapboxHTTPURL };
 
 export const normalizeStyleURL = function(url: string, accessToken?: string): string {
     if (!isMapboxURL(url)) return url;
@@ -146,7 +151,7 @@ export class TurnstileEvent {
         // mapbox tiles.
         if (config.ACCESS_TOKEN &&
             Array.isArray(tileUrls) &&
-            tileUrls.some((url) => { return /(mapbox\.c)(n|om)/i.test(url); })) {
+            tileUrls.some(url => isMapboxHTTPURL(url))) {
             this.queueRequest(browser.now());
         }
     }

--- a/test/ajax_stubs.js
+++ b/test/ajax_stubs.js
@@ -56,8 +56,8 @@ export const getArrayBuffer = function({ url }, callback) {
     if (cache[url]) return cached(cache[url], callback);
     return request({ url, encoding: null }, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
-            cache[url] = {data: body};
-            callback(null, {data: body});
+            cache[url] = body;
+            callback(null, body);
         } else {
             if (!error) error = { status: +response.statusCode };
             callback(error);
@@ -65,10 +65,10 @@ export const getArrayBuffer = function({ url }, callback) {
     });
 };
 
-export const postData = function({ url }, payload, callback) {
-    return request.post(url, payload, (error, response, body) => {
+export const postData = function({ url, body }, callback) {
+    return request.post(url, body, (error, response, body) => {
         if (!error && response.statusCode >= 200 && response.statusCode < 300) {
-            callback(null, {data: body});
+            callback(null, body);
         } else {
             callback(error || new Error(response.statusCode));
         }

--- a/test/ajax_stubs.js
+++ b/test/ajax_stubs.js
@@ -34,6 +34,8 @@ function cached(data, callback) {
     });
 }
 
+export const getReferrer = () => undefined;
+
 export const getJSON = function({ url }, callback) {
     if (cache[url]) return cached(cache[url], callback);
     return request(url, (error, response, body) => {

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -17,18 +17,6 @@ test('ajax', (t) => {
         callback();
     });
 
-    t.test('getArrayBuffer, no content error', (t) => {
-        window.server.respondWith(request => {
-            request.respond(200, {'Content-Type': 'image/png'}, '');
-        });
-        getArrayBuffer({ url:'' }, (error) => {
-            t.pass('called getArrayBuffer');
-            t.ok(error, 'should error when the status is 200 without content.');
-            t.end();
-        });
-        window.server.respond();
-    });
-
     t.test('getArrayBuffer, 404', (t) => {
         window.server.respondWith(request => {
             request.respond(404);
@@ -102,7 +90,7 @@ test('ajax', (t) => {
         window.server.respondWith(request => {
             request.respond(204);
         });
-        postData({ url:'api.mapbox.com' }, {}, (error) => {
+        postData({ url:'api.mapbox.com' }, (error) => {
             t.equal(error, null);
             t.end();
         });


### PR DESCRIPTION
We're currently using the [XmlHttpRequest](https://github.com/mapbox/mapbox-gl-js/blob/53cf0d6f565e7dbb9bac803e8e067b7cb614895d/src/util/ajax.js#L64-L73) to retrieve data like tiles from the backend server.

This PR switches to the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) where it is supported to enable sending correct referrers from the worker bundle. XHR requests don't send a correct referrer for code from a blob URL worker bundle in Safari, Chrome and Edge (and the `Referer` header is disallowed in this API), while the Fetch API allows us to correctly set the page's referrer URL, as demonstrated by this small snippet:

```html
<script>
let worker = new Worker(window.URL.createObjectURL(new Blob([`
const referrer = "${document.location.href}";
const url = 'https://example.com'

const xhr = new XMLHttpRequest();
xhr.open('GET', url, true);
xhr.send();

fetch(new Request(url, { referrer }))
`], { type: 'text/javascript' })));
</script>
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page