### PR TITLE
add `showCompassWhenNorth` option to NavigationControl

### DIFF
--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -13,7 +13,8 @@ type Options = {
 
 const defaultOptions: Options = {
     showCompass: true,
-    showZoom: true
+    showCompassWhenNorth: true,
+    showZoom: true,
 };
 
 /**
@@ -22,6 +23,7 @@ const defaultOptions: Options = {
  * @implements {IControl}
  * @param {Object} [options]
  * @param {Boolean} [options.showCompass=true] If `true` the compass button is included.
+ * @param {Boolean} [options.showCompassWhenNorth=true] If `true` the compass button is shown even when the map is not rotated.
  * @param {Boolean} [options.showZoom=true] If `true` the zoom-in and zoom-out buttons are included.
  * @example
  * var nav = new mapboxgl.NavigationControl();
@@ -61,6 +63,15 @@ class NavigationControl {
     _rotateCompassArrow() {
         const rotate = `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
         this._compassArrow.style.transform = rotate;
+
+        if (!this.options.showCompassWhenNorth) {
+            const display = this._map.getBearing() === 0 ? 'none' : '';
+            if (this.options.showZoom) {
+                this._compass.style.display = display;
+            } else {
+                this._container.style.display = display;
+            }
+        }
     }
 
     onAdd(map: Map) {


### PR DESCRIPTION
When the option is false the compass is hidden when the map is not rotated. This option keeps the UI cleaner while still providing a way to reset bearing after a user has rotated.

Suggested in #7115.

**I'm not sure we should add this. I think it is a minor improvement but I'm not sure whether we should support this in core. I threw this together so it would be easier to 👍 or 👎 this feature request.**

If we do want to do this, is the naming good? Any other ides? Would negating it (`hideCompassWhenNorth`) be clearer?

![screen shot 2018-10-08 at 3 52 07 pm](https://user-images.githubusercontent.com/1421652/46630435-31ca6e00-cb12-11e8-81d4-950689395567.png) ![screen shot 2018-10-08 at 3 52 22 pm](https://user-images.githubusercontent.com/1421652/46630436-31ca6e00-cb12-11e8-985d-a87299c18211.png)
unrotated and rotated appearance

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] manually test the debug page
