### PR TITLE
Data-driven format option expression tests

### DIFF
--- a/test/integration/expression-tests/format/data-driven-font/test.json
+++ b/test/integration/expression-tests/format/data-driven-font/test.json
@@ -1,0 +1,48 @@
+{
+  "expression": [
+    "format",
+    "a",
+    {
+      "font-scale": ["get", "font-scale"]
+    }
+  ],
+  "inputs": [
+    [{}, {"properties": {"font-scale": 1.5}}],
+    [{}, {"properties": {"font-scale": 0.5}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "formatted"
+    },
+    "outputs": [
+      {
+        "sections": [
+          {
+            "text": "a",
+            "scale": 1.5,
+            "fontStack": null
+          }
+        ]
+      },
+      {
+        "sections": [
+          {
+            "text": "a",
+            "scale": 0.5,
+            "fontStack": null
+          }
+        ]
+      }
+    ],
+    "serialized": [
+      "format",
+      "a",
+      {
+        "font-scale": ["number", ["get", "font-scale"]]
+      }
+    ]
+  }
+}

--- a/test/integration/expression-tests/format/data-driven-scale/test.json
+++ b/test/integration/expression-tests/format/data-driven-scale/test.json
@@ -1,0 +1,23 @@
+{
+  "expression": [
+    "format",
+    "a",
+    {
+      "text-font": ["array", ["string", ["get", "text-font"]]]
+    }
+  ],
+  "inputs": [
+    [{}, {"properties": {"text-font": "test"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [
+       {
+         "error": "Expected array<string> but found array instead.",
+         "key": "[1]"
+       }
+     ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a simple test for the non-feature-constant `font-scale` case within `format` expressions. `text-font` is actually required to be feature-constant because we need to be able to statically analyze the set of fonts required by a style.

cc @asheemmamoowala 