### PR TITLE
show attribution only for used sources, fix #6281

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -343,6 +343,7 @@ class Style extends Evented {
             return;
         }
 
+        const changed = this._changed;
         if (this._changed) {
             const updatedIds = Object.keys(this._updatedLayers);
             const removedIds = Object.keys(this._removedLayers);
@@ -367,8 +368,6 @@ class Style extends Evented {
             this.light.updateTransitions(parameters);
 
             this._resetUpdates();
-
-            this.fire(new Event('data', {dataType: 'style'}));
         }
 
         for (const sourceId in this.sourceCaches) {
@@ -386,6 +385,11 @@ class Style extends Evented {
 
         this.light.recalculate(parameters);
         this.z = parameters.zoom;
+
+        if (changed) {
+            this.fire(new Event('data', {dataType: 'style'}));
+        }
+
     }
 
     _updateWorkerLayers(updatedIds: Array<string>, removedIds: Array<string>) {

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -59,6 +59,7 @@ class AttributionControl {
         this._updateAttributions();
         this._updateEditLink();
 
+        this._map.on('styledata', this._updateData);
         this._map.on('sourcedata', this._updateData);
         this._map.on('moveend', this._updateEditLink);
 
@@ -73,6 +74,7 @@ class AttributionControl {
     onRemove() {
         DOM.remove(this._container);
 
+        this._map.off('styledata', this._updateData);
         this._map.off('sourcedata', this._updateData);
         this._map.off('moveend', this._updateEditLink);
         this._map.off('resize', this._updateCompact);
@@ -104,7 +106,7 @@ class AttributionControl {
     }
 
     _updateData(e: any) {
-        if (e && e.sourceDataType === 'metadata') {
+        if (e && (e.sourceDataType === 'metadata' || e.dataType === 'style')) {
             this._updateAttributions();
             this._updateEditLink();
         }
@@ -129,9 +131,12 @@ class AttributionControl {
 
         const sourceCaches = this._map.style.sourceCaches;
         for (const id in sourceCaches) {
-            const source = sourceCaches[id].getSource();
-            if (source.attribution && attributions.indexOf(source.attribution) < 0) {
-                attributions.push(source.attribution);
+            const sourceCache = sourceCaches[id];
+            if (sourceCache.used) {
+                const source = sourceCache.getSource();
+                if (source.attribution && attributions.indexOf(source.attribution) < 0) {
+                    attributions.push(source.attribution);
+                }
             }
         }
 


### PR DESCRIPTION
fixes #6281

Sources are sometimes used by no layers or are used only by layers that are disabled with `visibility: 'none'`. This hides attribution for these sources. This makes the attribution more relevant for cases where the map contains many layers are toggled on and off.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
