### PR TITLE
gazpacho backport: Show IE11 compact attribution

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -217,18 +217,23 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
 @media screen {
     .mapboxgl-ctrl-attrib.mapboxgl-compact {
-        padding-top: 2px;
-        padding-bottom: 2px;
         margin: 0 10px 10px;
         position: relative;
-        padding-right: 24px;
         background-color: #fff;
         border-radius: 3px 12px 12px 3px;
-        visibility: hidden;
     }
 
     .mapboxgl-ctrl-attrib.mapboxgl-compact:hover {
+        padding: 2px 24px 2px 4px;
         visibility: visible;
+    }
+
+    .mapboxgl-ctrl-attrib.mapboxgl-compact > a {
+        display: none;
+    }
+
+    .mapboxgl-ctrl-attrib.mapboxgl-compact:hover > a {
+        display: inline;
     }
 
     .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
@@ -242,7 +247,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         width: 24px;
         height: 24px;
         box-sizing: border-box;
-        visibility: visible;
         border-radius: 12px;
     }
 }


### PR DESCRIPTION
Backports #7391 to [`release-gazpacho`](https://github.com/mapbox/mapbox-gl-js/tree/release-gazpacho)

---

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Fixes https://github.com/mapbox/mapbox-gl-js/issues/3945

![screen shot 2018-10-09 at 2 40 20 pm](https://user-images.githubusercontent.com/4523080/46701067-66522e80-cbd3-11e8-9022-27ed6dc6921c.png)

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - IE11 has a rendering bug that was preventing the compact attribution from displaying which could present legal issues for customers
 - [x] manually test the debug page
    - Tested manually on Chrome, Safari, Firefox, Edge and IE11
