### PR TITLE
gazpacho backport: send correct timestamp with turnstile event

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -147,7 +147,7 @@ export class TurnstileEvent {
         if (config.ACCESS_TOKEN &&
             Array.isArray(tileUrls) &&
             tileUrls.some((url) => { return /(mapbox\.c)(n|om)/i.test(url); })) {
-            this.queueRequest(browser.now());
+            this.queueRequest(Date.now());
         }
     }
 

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -359,9 +359,9 @@ test("mapbox", (t) => {
                     lastSuccess: now
                 }));
 
-                t.stub(browser, 'now').callsFake(() => now + 5); // A bit later
-
+                const dateNow = t.stub(Date, 'now').callsFake(() => now + 5); // A bit later
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
+                dateNow.restore();
 
                 t.false(window.server.requests.length);
                 t.end();
@@ -375,9 +375,9 @@ test("mapbox", (t) => {
                     lastSuccess: now
                 }));
 
-                t.stub(browser, 'now').callsFake(() => now + ms25Hours); // next day
-
+                const dateNow = t.stub(Date, 'now').callsFake(() => now + ms25Hours);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
+                dateNow.restore();
 
                 const req = window.server.requests[0];
                 req.respond(200);
@@ -395,8 +395,6 @@ test("mapbox", (t) => {
                     lastSuccess: now + ms25Hours // 24-hours later
                 }));
 
-                t.stub(browser, 'now').callsFake(() => now); // Past relative ot lastSuccess
-
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
 
                 const req = window.server.requests[0];
@@ -409,13 +407,14 @@ test("mapbox", (t) => {
 
             t.test('does not POST appuserTurnstile event second time within same calendar day', (t) => {
                 let now = +Date.now();
-                t.stub(browser, 'now').callsFake(() => now);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
 
                 //Post second event
                 const firstEvent = now;
                 now += (60 * 1000); // A bit later
+                const dateNow = t.stub(Date, 'now').callsFake(() => now);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
+                dateNow.restore();
 
                 const req = window.server.requests[0];
                 req.respond(200);
@@ -430,13 +429,14 @@ test("mapbox", (t) => {
 
             t.test('does not POST appuserTurnstile event second time when clock goes backwards less than a day', (t) => {
                 let now = +Date.now();
-                t.stub(browser, 'now').callsFake(() => now);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
 
                 //Post second event
                 const firstEvent = now;
                 now -= (60 * 1000); // A bit earlier
+                const dateNow = t.stub(Date, 'now').callsFake(() => now);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
+                dateNow.restore();
 
                 const req = window.server.requests[0];
                 req.respond(200);
@@ -485,12 +485,13 @@ test("mapbox", (t) => {
             t.test('does not POST appuserTurnstile event second time within same calendar day', (t) => {
                 let now = +Date.now();
                 const firstEvent = now;
-                t.stub(browser, 'now').callsFake(() => now);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
 
                 //Post second event
                 now += (60 * 1000); // A bit later
+                const dateNow = t.stub(Date, 'now').callsFake(() => now);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
+                dateNow.restore();
 
                 const req = window.server.requests[0];
                 req.respond(200);
@@ -506,12 +507,13 @@ test("mapbox", (t) => {
             t.test('does not POST appuserTurnstile event second time when clock goes backwards less than a day', (t) => {
                 let now = +Date.now();
                 const firstEvent = now;
-                t.stub(browser, 'now').callsFake(() => now);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
 
                 //Post second event
                 now -= (60 * 1000); // A bit earlier
+                const dateNow = t.stub(Date, 'now').callsFake(() => now);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
+                dateNow.restore();
 
                 const req = window.server.requests[0];
                 req.respond(200);
@@ -543,14 +545,13 @@ test("mapbox", (t) => {
             });
 
             t.test('POSTs appUserTurnstile event on next calendar day', (t) => {
-                let now = +Date.now();
-                t.stub(browser, 'now').callsFake(() => now);
-
+                const now = +Date.now();
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
-
-                now += ms25Hours; // Add a day
-                const tomorrow = now;
+                // Add a day
+                const tomorrow = now + ms25Hours;
+                const dateNow = t.stub(Date, 'now').callsFake(() => tomorrow);
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
+                dateNow.restore();
 
                 let req = window.server.requests[0];
                 req.respond(200);
@@ -570,18 +571,21 @@ test("mapbox", (t) => {
 
             t.test('Queues and POSTs appuserTurnstile events when triggerred in quick succession', (t) => {
                 let now = Date.now();
-                t.stub(browser, 'now').callsFake(() => now);
 
                 const today = now;
                 event.postTurnstileEvent(['a.tiles.mapbox.com']);
 
                 const laterToday = now + 1;
+                let dateNow = t.stub(Date, 'now').callsFake(() => laterToday);
                 now = laterToday;
                 event.postTurnstileEvent(['b.tiles.mapbox.com']);
+                dateNow.restore();
 
                 const tomorrow = laterToday + ms25Hours; // Add a day
                 now = tomorrow;
+                dateNow = t.stub(Date, 'now').callsFake(() => tomorrow);
                 event.postTurnstileEvent(['c.tiles.mapbox.com']);
+                dateNow.restore();
 
                 const reqToday = window.server.requests[0];
                 reqToday.respond(200);


### PR DESCRIPTION
Backports #7381 to [`release-gazpacho`](https://github.com/mapbox/mapbox-gl-js/tree/release-gazpacho)

---

I noticed while implementing #7297 that our turnstile event is setting the `created` payload property to a value from `browser.now()` which on most browsers is an alias for `performance.now()` which is not the current day/time, but milliseconds since the JS started executing or something along those lines, so our values were always in the 1970s which I don't think is the intended behavior. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
