### PR TITLE
tighten validation to disallow expressions as stop values

### DIFF
--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -1,6 +1,7 @@
 
 import ValidationError from '../error/validation_error';
 import getType from '../util/get_type';
+import extend from '../util/extend';
 import validate from './validate';
 import validateObject from './validate_object';
 import validateArray from './validate_array';
@@ -138,10 +139,15 @@ export default function validateFunction(options) {
             }, value));
         }
 
+        // Remove `expression` from the value spec because expressions
+        // and functions are not allowed as values within functions.
+        const stopValueSpec = extend({}, functionValueSpec);
+        delete stopValueSpec.expression;
+
         return errors.concat(validate({
             key: `${key}[1]`,
             value: value[1],
-            valueSpec: functionValueSpec,
+            valueSpec: stopValueSpec,
             style: options.style,
             styleSpec: options.styleSpec
         }));

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -1,7 +1,6 @@
 
 import ValidationError from '../error/validation_error';
 import getType from '../util/get_type';
-import extend from '../util/extend';
 import validate from './validate';
 import validateObject from './validate_object';
 import validateArray from './validate_array';
@@ -142,7 +141,7 @@ export default function validateFunction(options) {
 
         if (isExpression(deepUnbundle(value[1]))) {
             return errors.concat([new ValidationError(`${key}[1]`, value[1], 'expressions are not allowed in function stops.')]);
-        };
+        }
 
         return errors.concat(validate({
             key: `${key}[1]`,

--- a/src/style-spec/validate/validate_function.js
+++ b/src/style-spec/validate/validate_function.js
@@ -6,7 +6,8 @@ import validate from './validate';
 import validateObject from './validate_object';
 import validateArray from './validate_array';
 import validateNumber from './validate_number';
-import { unbundle } from '../util/unbundle_jsonlint';
+import { isExpression } from '../expression';
+import { unbundle, deepUnbundle } from '../util/unbundle_jsonlint';
 import {
     supportsPropertyExpression,
     supportsZoomExpression,
@@ -139,15 +140,14 @@ export default function validateFunction(options) {
             }, value));
         }
 
-        // Remove `expression` from the value spec because expressions
-        // and functions are not allowed as values within functions.
-        const stopValueSpec = extend({}, functionValueSpec);
-        delete stopValueSpec.expression;
+        if (isExpression(deepUnbundle(value[1]))) {
+            return errors.concat([new ValidationError(`${key}[1]`, value[1], 'expressions are not allowed in function stops.')]);
+        };
 
         return errors.concat(validate({
             key: `${key}[1]`,
             value: value[1],
-            valueSpec: stopValueSpec,
+            valueSpec: functionValueSpec,
             style: options.style,
             styleSpec: options.styleSpec
         }));

--- a/test/unit/style-spec/fixture/functions.input.json
+++ b/test/unit/style-spec/fixture/functions.input.json
@@ -967,6 +967,25 @@
         "layout": {
           "line-join": [ "coalesce", ["feature-state", "myState"], "bevel"]
         }
+    }, {
+      "id": "invalid function - expression as stop value",
+      "type": "line",
+      "source": "source",
+      "source-layer": "layer",
+      "paint": {
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              6,
+              [
+                "literal",
+                3
+              ]
+            ]
+          ]
+        }
       }
+    }
   ]
 }

--- a/test/unit/style-spec/fixture/functions.output.json
+++ b/test/unit/style-spec/fixture/functions.output.json
@@ -198,5 +198,9 @@
   {                                                                                                                     
     "message": "layers[55].layout.line-join: \"feature-state\" data expressions are not supported with layout properties.",
     "line": 968
+  },
+  {
+    "message": "layers[56].paint.line-width.stops[0][1]: number expected, array found",
+    "line": 981
   }
 ]

--- a/test/unit/style-spec/fixture/functions.output.json
+++ b/test/unit/style-spec/fixture/functions.output.json
@@ -200,7 +200,7 @@
     "line": 968
   },
   {
-    "message": "layers[56].paint.line-width.stops[0][1]: number expected, array found",
+    "message": "layers[56].paint.line-width.stops[0][1]: expressions are not allowed in function stops.",
     "line": 981
   }
 ]


### PR DESCRIPTION
This fixes #7387 by tightening validation to not allow expressions within the old-style functions. It does this by passing a more limited valueSpec which disallows expressions while validation stop values.

@emilymdubois @asheemmamoowala @mollymerp could I get a pretty careful review of this? This is my first time working on style validation. I'm not sure if this could have unintended consequences. I know we have had issues with tightened validation in the past.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
