### PR TITLE
Update symbol-z-order support on iOS v4.5.0.

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -972,7 +972,8 @@
       "doc": "Controls the order in which overlapping symbols in the same layer are rendered",
       "sdk-support": {
         "basic functionality": {
-          "js": "0.49.0"
+          "js": "0.49.0",
+          "ios": "4.5.0"
         },
         "data-driven styling": {}
       },


### PR DESCRIPTION
Updates the style spec with the changes added to maps sdk for iOS v4.5.0