### PR TITLE
Add an unminified production build to the NPM package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist/
 /docs/pages/dist/mapbox-gl-dev.js
 /docs/pages/dist/mapbox-gl.js
+/docs/pages/dist/mapbox-gl-unminified.js
 *.js.map
 node_modules
 package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ A standalone build allows you to turn the contents of this repository into `mapb
 
 To create a standalone build, run
 ```bash
-yarn run build-min
+yarn run build-prod-min
 yarn run build-css
 ```
 

--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -9,9 +9,9 @@ import uglify from 'rollup-plugin-uglify';
 import minifyStyleSpec from './rollup_plugin_minify_style_spec';
 import { createFilter } from 'rollup-pluginutils';
 
-const {BUILD} = process.env;
-const minified = BUILD === 'production';
-const production = BUILD === 'production' || BUILD === 'production-unminified';
+const {BUILD, MINIFY} = process.env;
+const minified = MINIFY === 'true';
+const production = BUILD === 'production';
 
 // Common set of plugins/transformations shared across different rollup
 // builds (main mapboxgl bundle, style-spec package, benchmarks bundle)

--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -9,7 +9,9 @@ import uglify from 'rollup-plugin-uglify';
 import minifyStyleSpec from './rollup_plugin_minify_style_spec';
 import { createFilter } from 'rollup-pluginutils';
 
-const production = process.env.BUILD === 'production';
+const {BUILD} = process.env;
+const minified = BUILD === 'production';
+const production = BUILD === 'production' || BUILD === 'production-unminified';
 
 // Common set of plugins/transformations shared across different rollup
 // builds (main mapboxgl bundle, style-spec package, benchmarks bundle)
@@ -30,7 +32,7 @@ export const plugins = () => [
         // https://github.com/mapbox/mapbox-gl-js/pull/6956
         ignoreGlobal: true
     }),
-    production ? uglify() : false
+    minified ? uglify() : false
 ].filter(Boolean);
 
 // Using this instead of rollup-plugin-flow due to

--- a/circle.yml
+++ b/circle.yml
@@ -134,7 +134,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: yarn run build-min
+      - run: yarn run build-prod-min
       - run: yarn run build-dev
       - run: yarn run build-css
       - run: yarn run build-style-spec

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   "scripts": {
     "build-dev": "rollup -c --environment BUILD:dev",
     "watch-dev": "rollup -c --environment BUILD:dev --watch",
+    "build-alt": "rollup -c --environment BUILD:production-unminified",
     "build-min": "rollup -c --environment BUILD:production",
     "build-flow-types": "cp build/mapbox-gl.js.flow dist/mapbox-gl.js.flow && cp build/mapbox-gl.js.flow dist/mapbox-gl-dev.js.flow",
     "build-css": "postcss -o dist/mapbox-gl.css src/css/mapbox-gl.css",
@@ -141,7 +142,7 @@
     "test-flow": "build/run-node build/generate-flow-typed-style-spec && flow .",
     "test-flow-cov": "flow-coverage-report -i 'src/**/*.js' -t html",
     "test-cov": "nyc --require=@mapbox/flow-remove-types/register --reporter=text-summary --reporter=lcov --cache run-s test-unit test-expressions test-query test-render",
-    "prepublishOnly": "run-s build-flow-types build-dev build-min build-css build-style-spec test-build",
+    "prepublishOnly": "run-s build-flow-types build-dev build-min build-alt build-css build-style-spec test-build",
     "codegen": "build/run-node build/generate-style-code.js && build/run-node build/generate-struct-arrays.js"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -110,8 +110,8 @@
   "scripts": {
     "build-dev": "rollup -c --environment BUILD:dev",
     "watch-dev": "rollup -c --environment BUILD:dev --watch",
-    "build-alt": "rollup -c --environment BUILD:production-unminified",
-    "build-min": "rollup -c --environment BUILD:production",
+    "build-prod": "rollup -c --environment BUILD:production",
+    "build-prod-min": "rollup -c --environment BUILD:production,MINIFY:true",
     "build-flow-types": "cp build/mapbox-gl.js.flow dist/mapbox-gl.js.flow && cp build/mapbox-gl.js.flow dist/mapbox-gl-dev.js.flow",
     "build-css": "postcss -o dist/mapbox-gl.css src/css/mapbox-gl.css",
     "build-style-spec": "cd src/style-spec && npm run build && cd ../.. && mkdir -p dist/style-spec && cp src/style-spec/dist/* dist/style-spec",
@@ -126,7 +126,7 @@
     "start-bench": "run-p build-token watch-benchmarks watch-style-benchmarks start-server",
     "build-docs": "documentation build --github --format json --config ./docs/documentation.yml --output docs/components/api.json src/index.js",
     "build": "run-s build-docs && . build/set-deploy-env.sh && batfish build # invoked by publisher when publishing docs on the mb-pages branch",
-    "start-docs": "run-s build-min build-css build-docs && DEPLOY_ENV=local batfish start",
+    "start-docs": "run-s build-prod-min build-css build-docs && DEPLOY_ENV=local batfish start",
     "lint": "eslint --cache --ignore-path .gitignore src test bench docs docs/pages/example/*.html debug/*.html",
     "lint-docs": "documentation lint src/index.js",
     "lint-css": "stylelint 'src/css/mapbox-gl.css'",
@@ -142,7 +142,7 @@
     "test-flow": "build/run-node build/generate-flow-typed-style-spec && flow .",
     "test-flow-cov": "flow-coverage-report -i 'src/**/*.js' -t html",
     "test-cov": "nyc --require=@mapbox/flow-remove-types/register --reporter=text-summary --reporter=lcov --cache run-s test-unit test-expressions test-query test-render",
-    "prepublishOnly": "run-s build-flow-types build-dev build-min build-alt build-css build-style-spec test-build",
+    "prepublishOnly": "run-s build-flow-types build-dev build-prod-min build-prod build-css build-style-spec test-build",
     "codegen": "build/run-node build/generate-style-code.js && build/run-node build/generate-struct-arrays.js"
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,8 +7,8 @@ const {BUILD, MINIFY} = process.env;
 const minified = MINIFY === 'true';
 const production = BUILD === 'production';
 const outputFile =
-    production && minified ? 'dist/mapbox-gl.js' :
-    production ? 'dist/mapbox-gl-unminified.js' : 'dist/mapbox-gl-dev.js';
+    !production ? 'dist/mapbox-gl-dev.js' :
+    minified ? 'dist/mapbox-gl.js' : 'dist/mapbox-gl-unminified.js';
 
 const config = [{
     // First, use code splitting to bundle GL JS into three "chunks":

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,11 +3,11 @@ import sourcemaps from 'rollup-plugin-sourcemaps';
 import {plugins} from './build/rollup_plugins';
 
 const version = JSON.parse(fs.readFileSync('package.json')).version;
-const {BUILD} = process.env;
-const minified = BUILD === 'production';
-const production = BUILD === 'production' || BUILD === 'production-unminified';
+const {BUILD, MINIFY} = process.env;
+const minified = MINIFY === 'true';
+const production = BUILD === 'production';
 const outputFile =
-    minified ? 'dist/mapbox-gl.js' :
+    production && minified ? 'dist/mapbox-gl.js' :
     production ? 'dist/mapbox-gl-unminified.js' : 'dist/mapbox-gl-dev.js';
 
 const config = [{

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,9 +3,12 @@ import sourcemaps from 'rollup-plugin-sourcemaps';
 import {plugins} from './build/rollup_plugins';
 
 const version = JSON.parse(fs.readFileSync('package.json')).version;
-
-const production = process.env.BUILD === 'production';
-const outputFile = production ? 'dist/mapbox-gl.js' : 'dist/mapbox-gl-dev.js';
+const {BUILD} = process.env;
+const minified = BUILD === 'production';
+const production = BUILD === 'production' || BUILD === 'production-unminified';
+const outputFile =
+    minified ? 'dist/mapbox-gl.js' :
+    production ? 'dist/mapbox-gl-unminified.js' : 'dist/mapbox-gl-dev.js';
 
 const config = [{
     // First, use code splitting to bundle GL JS into three "chunks":


### PR DESCRIPTION
Provides an alternative build in the published NPM package which is like the production build but unminified (e.g. for use with custom minifiers).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~ not sure if we should document anywhere
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
