### PR TITLE
Add geojson linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
   },
   "plugins": [
     "flowtype",
-    "import"
+    "import",
+    "geojson"
   ],
   "rules": {
     "array-bracket-spacing": "off",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint": "4.1.1",
     "eslint-config-mourner": "^2.0.0",
     "eslint-plugin-flowtype": "^2.34.0",
+    "eslint-plugin-geojson": "^1.3.0",
     "eslint-plugin-html": "^3.0.0",
     "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-react": "^7.3.0",


### PR DESCRIPTION
What it says on the tin. We should be properly formatting geojson. Linter doesn't actually yell on any existing code with this change but we should proactively encourage it.