### PR TITLE
avoid SecurityError in IE for custom layers example

### DIFF
--- a/docs/pages/example/custom-style-layer.html
+++ b/docs/pages/example/custom-style-layer.html
@@ -4,8 +4,7 @@ var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 4,
     center: [0, 0],
-    style: 'mapbox://styles/mapbox/light-v9',
-    hash: true
+    style: 'mapbox://styles/mapbox/light-v9'
 });
 
 


### PR DESCRIPTION
Updating the hash was triggering a SecurityError in IE and breaking the map. We need to look into fixing this properly but this workaround gets rid of the pressure to do that. This will need to be cherry-picked to the release branch after it is merged.