### PR TITLE
fix #7410: using hash within iframes in IE11

### DIFF
--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -93,7 +93,13 @@ class Hash {
 
     _updateHashUnthrottled() {
         const hash = this.getHashString();
-        window.history.replaceState(window.history.state, '', hash);
+        try {
+            window.history.replaceState(window.history.state, '', hash);
+        } catch (SecurityError) {
+            // IE11 does not allow this if the page is within an iframe created
+            // with iframe.contentWindow.document.write(...).
+            // https://github.com/mapbox/mapbox-gl-js/issues/7410
+        }
     }
 
 }


### PR DESCRIPTION
fix #7410

> If you create a map with the option "hash": true within an iframe, written with iframe.contentWindow.document.write(...) and open it in IE, then the hash control's attempt to replace the history state triggers a SecurityError and breaks the page.

I'm not sure how we could test this.

@kkaefer we could add this to the release but I'm also not seeing much harm from leaving it for the next release.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
