### PR TITLE
Don't use gl_PointSize, since it sometimes crashes in Edge

### DIFF
--- a/docs/pages/example/custom-style-layer.html
+++ b/docs/pages/example/custom-style-layer.html
@@ -8,8 +8,8 @@ var map = window.map = new mapboxgl.Map({
 });
 
 
-var nullIslandLayer = {
-    id: 'null-island',
+var highlightLayer = {
+    id: 'highlight',
     type: 'custom',
 
     onAdd: function (map, gl) {
@@ -17,13 +17,12 @@ var nullIslandLayer = {
         "uniform mat4 u_matrix;" +
         "attribute vec2 a_pos;" +
         "void main() {" +
-        "    gl_Position = u_matrix * vec4(a_pos, 0.0, 1.0);" +
-        "    gl_PointSize = 100.0;" +
+        "    gl_Position = vec4(a_pos, 0.0, 1.0);" +
         "}";
 
         var fragmentSource = "" +
         "void main() {" +
-        "    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);" +
+        "    gl_FragColor = vec4(1.0, 0.0, 0.0, 0.5);" +
         "}";
 
         var vertexShader = gl.createShader(gl.VERTEX_SHADER);
@@ -42,7 +41,12 @@ var nullIslandLayer = {
 
         this.buffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
-        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([0.5, 0.5]), gl.STATIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+            -0.5, -0.5,
+            -0.5, 0.5,
+            0.5, -0.5,
+            0.5, 0.5
+        ]), gl.STATIC_DRAW);
     },
 
     render: function(gl, matrix) {
@@ -51,11 +55,13 @@ var nullIslandLayer = {
         gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
         gl.enableVertexAttribArray(this.aPos);
         gl.vertexAttribPointer(this.aPos, 2, gl.FLOAT, false, 0, 0);
-        gl.drawArrays(gl.POINTS, 0, 1);
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
     }
 };
 
 map.on('load', function() {
-    map.addLayer(nullIslandLayer);
+    map.addLayer(highlightLayer, 'waterway-river-canal');
 });
 </script>

--- a/docs/pages/example/custom-style-layer.js
+++ b/docs/pages/example/custom-style-layer.js
@@ -1,6 +1,6 @@
 /*---
 title: Add a custom style layer
-description: Use a custom style layer to add custom gl rendering.
+description: Use a custom style layer to render custom WebGL content.
 tags:
   - layers
 pathname: /mapbox-gl-js/example/custom-style-layer/


### PR DESCRIPTION
MS Edge crashes when using `gl_PointSize` on some devices. Just the presence is enough, regardless of the value it is set to. This bug is captured in https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4468541/ but still unresolved. The JSFiddle linked there also crashes on the machine I'm using.

The Windows crashlog shows this:
```
Fault bucket 1474035799637301183, type 5
Event Name: MoAppCrash
Response: Not available
Cab Id: 0

Problem signature:
P1: Microsoft.MicrosoftEdge_42.17134.1.0_neutral__8wekyb3d8bbwe
P2: praid:ContentProcess
P3: 11.0.17134.48
P4: 5ae3f17b
P5: ntdll.dll
P6: 10.0.17134.254
P7: a5a334d4
P8: c0000008
P9: 000000000009dcda
P10: 
```

This PR fixes our example by removing the use of `gl_PointSize` and using a triangle strip instead.