### PR TITLE
add RTL plugin to rich text label example

### DIFF
--- a/docs/pages/example/display-and-style-rich-text-labels.html
+++ b/docs/pages/example/display-and-style-rich-text-labels.html
@@ -1,5 +1,7 @@
 <div id='map'></div>
 <script>
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js');
+
 var map = new mapboxgl.Map({
     container: 'map', // container id
     style: 'mapbox://styles/mapbox/streets-v10', // stylesheet location


### PR DESCRIPTION
Adds the RTL plugin to the example to make RTL text readable.