### PR TITLE
only align raster sources to pixel grid when map is idle to prevent shaking

### DIFF
--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -28,8 +28,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
     const stencilMode = StencilMode.disabled;
     const colorMode = painter.colorModeForRenderPass();
     const minTileZ = coords.length && coords[0].overscaledZ;
-    const align = !painter.options.moving && (Math.round(painter.transform.zoom) === painter.transform.zoom);
-
+    const align = !painter.options.moving;
     for (const coord of coords) {
         // Set the lower zoom level to sublayer 0, and higher zoom levels to higher sublayers
         // Use gl.LESS to prevent double drawing in areas where tiles overlap.

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -28,6 +28,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
     const stencilMode = StencilMode.disabled;
     const colorMode = painter.colorModeForRenderPass();
     const minTileZ = coords.length && coords[0].overscaledZ;
+    const align = !painter.options.moving && (Math.round(painter.transform.zoom) === painter.transform.zoom);
 
     for (const coord of coords) {
         // Set the lower zoom level to sublayer 0, and higher zoom levels to higher sublayers
@@ -36,7 +37,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
             layer.paint.get('raster-opacity') === 1 ? DepthMode.ReadWrite : DepthMode.ReadOnly, gl.LESS);
 
         const tile = sourceCache.getTile(coord);
-        const posMatrix = painter.transform.calculatePosMatrix(coord.toUnwrapped(), true);
+        const posMatrix = painter.transform.calculatePosMatrix(coord.toUnwrapped(), align);
 
         tile.registerFadeDuration(layer.paint.get('raster-fade-duration'));
 

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -70,6 +70,7 @@ type PainterOptions = {
     showTileBoundaries: boolean,
     rotating: boolean,
     zooming: boolean,
+    moving: boolean,
     fadeDuration: number
 }
 

--- a/src/render/program/hillshade_program.js
+++ b/src/render/program/hillshade_program.js
@@ -71,9 +71,9 @@ const hillshadeUniformValues = (
     if (layer.paint.get('hillshade-illumination-anchor') === 'viewport') {
         azimuthal -= painter.transform.angle;
     }
-
+    const align = !painter.options.moving && (Math.round(painter.transform.zoom) === painter.transform.zoom);
     return {
-        'u_matrix': painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped(), true),
+        'u_matrix': painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped(), align),
         'u_image': 0,
         'u_latrange': getTileLatRange(painter, tile.tileID),
         'u_light': [layer.paint.get('hillshade-exaggeration'), azimuthal],

--- a/src/render/program/hillshade_program.js
+++ b/src/render/program/hillshade_program.js
@@ -71,7 +71,7 @@ const hillshadeUniformValues = (
     if (layer.paint.get('hillshade-illumination-anchor') === 'viewport') {
         azimuthal -= painter.transform.angle;
     }
-    const align = !painter.options.moving && (Math.round(painter.transform.zoom) === painter.transform.zoom);
+    const align = !painter.options.moving;
     return {
         'u_matrix': painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped(), align),
         'u_image': 0,

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1664,6 +1664,7 @@ class Map extends Camera {
             showOverdrawInspector: this._showOverdrawInspector,
             rotating: this.isRotating(),
             zooming: this.isZooming(),
+            moving: this.isMoving(),
             fadeDuration: this._fadeDuration
         });
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -360,6 +360,7 @@ class Map extends Camera {
         }
 
         this.on('move', () => this._update(false));
+        this.on('moveend', () => this._update(false));
         this.on('zoom', () => this._update(true));
 
         if (typeof window !== 'undefined') {


### PR DESCRIPTION
fix #6150

~~one note: `map.isZooming()` was never returning true inside the `map._render()` function when using the `ScrollZoomHandler` because that handler returns to `active: false` before render is called, whereas `zoomend` is on a timeout so it is only called once if many scroll frames are triggered in succession. I mutated the `map._zooming` state to account for that, but I'm open to other ideas on how to handle it.~~ removed this change for a separate PR

Any ideas on how to test this? 💭

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~
