### PR TITLE
Add ember-mapbox-gl to Framework Integrations

### DIFF
--- a/docs/pages/plugins.js
+++ b/docs/pages/plugins.js
@@ -71,6 +71,10 @@ const plugins = {
         "angular-mapboxgl-directive": {
             "website": "https://github.com/Naimikan/angular-mapboxgl-directive",
             "description": md`provides an [Angular](https://angularjs.org/) directive for Mapbox GL JS`
+        },
+        "ember-mapbox-gl": {
+            "website": "https://github.com/kturney/ember-mapbox-gl",
+            "description": md`provides an [Ember](http://emberjs.com) integration for Mapbox GL JS`
         }
     },
     "Utility Libraries": {


### PR DESCRIPTION
This PR adds [`ember-mapbox-gl`](https://github.com/kturney/ember-mapbox-gl) to the list of Framework integrations. 

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - ~write tests for all new functionality~
 - ~document any changes to public APIs~
 - ~post benchmark scores~
 - ~manually test the debug page~
 - ~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~
