### PR TITLE
Limit the number of workers that can be spawned

### DIFF
--- a/src/util/worker_pool.js
+++ b/src/util/worker_pool.js
@@ -43,4 +43,5 @@ export default class WorkerPool {
     }
 }
 
-WorkerPool.workerCount = Math.max(Math.floor(browser.hardwareConcurrency / 2), 1);
+const availableLogicalProcessors = Math.floor(browser.hardwareConcurrency / 2);
+WorkerPool.workerCount = Math.max(Math.min(availableLogicalProcessors, 4), 1);

--- a/src/util/worker_pool.js
+++ b/src/util/worker_pool.js
@@ -44,4 +44,4 @@ export default class WorkerPool {
 }
 
 const availableLogicalProcessors = Math.floor(browser.hardwareConcurrency / 2);
-WorkerPool.workerCount = Math.max(Math.min(availableLogicalProcessors, 4), 1);
+WorkerPool.workerCount = Math.max(Math.min(availableLogicalProcessors, 6), 1);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - Fixes https://github.com/mapbox/mapbox-gl-js/issues/7407
    - This came up recently when a user had a machine with 32 cores which spawned 16 workers, most of which weren't used but which degraded performance significantly
 - [ ] write tests for all new functionality
    - Do we need tests for this? And how would we test it?
