### PR TITLE
Add map.load telemetry event

### DIFF
--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -5,7 +5,7 @@ import { extend, pick } from '../util/util';
 import { getImage, ResourceType } from '../util/ajax';
 import { Event, ErrorEvent, Evented } from '../util/evented';
 import loadTileJSON from './load_tilejson';
-import { normalizeTileURL as normalizeURL, postTurnstileEvent } from '../util/mapbox';
+import { normalizeTileURL as normalizeURL, postTurnstileEvent, postMapLoadEvent } from '../util/mapbox';
 import TileBounds from './tile_bounds';
 import Texture from '../render/texture';
 
@@ -70,6 +70,7 @@ class RasterTileSource extends Evented implements Source {
                 if (tileJSON.bounds) this.tileBounds = new TileBounds(tileJSON.bounds, this.minzoom, this.maxzoom);
 
                 postTurnstileEvent(tileJSON.tiles);
+                postMapLoadEvent(tileJSON.tiles, this.map._getMapId());
 
                 // `content` is included here to prevent a race condition where `Style#_updateSources` is called
                 // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -4,7 +4,7 @@ import { Event, ErrorEvent, Evented } from '../util/evented';
 
 import { extend, pick } from '../util/util';
 import loadTileJSON from './load_tilejson';
-import { normalizeTileURL as normalizeURL, postTurnstileEvent } from '../util/mapbox';
+import { normalizeTileURL as normalizeURL, postTurnstileEvent, postMapLoadEvent } from '../util/mapbox';
 import TileBounds from './tile_bounds';
 import { ResourceType } from '../util/ajax';
 import browser from '../util/browser';
@@ -74,6 +74,7 @@ class VectorTileSource extends Evented implements Source {
                 if (tileJSON.bounds) this.tileBounds = new TileBounds(tileJSON.bounds, this.minzoom, this.maxzoom);
 
                 postTurnstileEvent(tileJSON.tiles);
+                postMapLoadEvent(tileJSON.tiles, this.map._getMapId());
 
                 // `content` is included here to prevent a race condition where `Style#_updateSources` is called
                 // before the TileJSON arrives. this makes sure the tiles needed are loaded once TileJSON arrives

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { extend, bindAll, warnOnce } from '../util/util';
+import { extend, bindAll, warnOnce, uniqueId } from '../util/util';
 
 import browser from '../util/browser';
 import window from '../util/window';
@@ -262,6 +262,7 @@ class Map extends Camera {
     _collectResourceTiming: boolean;
     _renderTaskQueue: TaskQueue;
     _controls: Array<IControl>;
+    _mapId: number;
 
     /**
      * The map's {@link ScrollZoomHandler}, which implements zooming in and out with a scroll wheel or trackpad.
@@ -323,6 +324,7 @@ class Map extends Camera {
         this._collectResourceTiming = options.collectResourceTiming;
         this._renderTaskQueue = new TaskQueue();
         this._controls = [];
+        this._mapId = uniqueId();
 
         const transformRequestFn = options.transformRequest;
         this._transformRequest = transformRequestFn ?
@@ -404,6 +406,16 @@ class Map extends Camera {
         this.on('dataloading', (event: MapDataEvent) => {
             this.fire(new Event(`${event.dataType}dataloading`, event));
         });
+    }
+
+    /*
+    * Returns a unique number for this map instance which is used for the MapLoadEvent
+    * to make sure we only fire one event per instantiated map object.
+    * @private
+    * @returns {number}
+    */
+    _getMapId() {
+        return this._mapId;
     }
 
     /**

--- a/test/unit/source/raster_dem_tile_source.test.js
+++ b/test/unit/source/raster_dem_tile_source.test.js
@@ -7,6 +7,7 @@ function createSource(options, transformCallback) {
     const source = new RasterDEMTileSource('id', options, { send: function() {} }, options.eventedParent);
     source.onAdd({
         transform: { angle: 0, pitch: 0, showCollisionBoxes: false },
+        _getMapId: () => 1,
         _transformRequest: transformCallback ? transformCallback : (url) => { return { url }; }
     });
 

--- a/test/unit/source/raster_tile_source.test.js
+++ b/test/unit/source/raster_tile_source.test.js
@@ -7,6 +7,7 @@ function createSource(options, transformCallback) {
     const source = new RasterTileSource('id', options, { send: function() {} }, options.eventedParent);
     source.onAdd({
         transform: { angle: 0, pitch: 0, showCollisionBoxes: false },
+        _getMapId: () => 1,
         _transformRequest: transformCallback ? transformCallback : (url) => { return { url }; }
     });
 

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -8,6 +8,7 @@ function createSource(options, transformCallback) {
     const source = new VectorTileSource('id', options, { send: function() {} }, options.eventedParent);
     source.onAdd({
         transform: { showCollisionBoxes: false },
+        _getMapId: () => 1,
         _transformRequest: transformCallback ? transformCallback : (url) => { return { url }; }
     });
 

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -52,6 +52,10 @@ class StubMap extends Evented {
     _transformRequest(url) {
         return { url };
     }
+
+    _getMapId() {
+        return 1;
+    }
 }
 
 test('Style', (t) => {

--- a/test/unit/ui/control/logo.test.js
+++ b/test/unit/ui/control/logo.test.js
@@ -25,7 +25,8 @@ function createMap(t, logoPosition, logoRequired) {
 function createSource(options, logoRequired) {
     const source = new VectorTileSource('id', options, { send: function () {} });
     source.onAdd({
-        transform: { angle: 0, pitch: 0, showCollisionBoxes: false }
+        transform: { angle: 0, pitch: 0, showCollisionBoxes: false },
+        _getMapId: () => 1
     });
     source.on('error', (e) => {
         throw e.error;

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -382,14 +382,13 @@ test("mapbox", (t) => {
             t.test('does not POST event when previously stored data is on the same day', (t) => {
                 const now = +Date.now();
 
-                window.localStorage.setItem(`mapbox.turnstileEventData:${config.ACCESS_TOKEN}`, JSON.stringify({
+                window.localStorage.setItem(`mapbox.eventData:${config.ACCESS_TOKEN}`, JSON.stringify({
                     anonId: uuid(),
                     lastSuccess: now
                 }));
 
                 // Post 5 seconds later
                 withFixedDate(t, now + 5, () => event.postTurnstileEvent(mapboxTileURLs));
-
                 t.false(window.server.requests.length);
                 t.end();
             });
@@ -607,6 +606,248 @@ test("mapbox", (t) => {
                 reqTomorrow.respond(200);
                 reqBody = JSON.parse(reqTomorrow.requestBody)[0];
                 t.equal(reqBody.created, new Date(tomorrow).toISOString());
+
+                t.end();
+            });
+
+            t.end();
+        });
+
+        t.end();
+    });
+    t.test('MapLoadEvent', (t) => {
+        let event;
+        t.beforeEach((callback) => {
+            window.useFakeXMLHttpRequest();
+            event = new mapbox.MapLoadEvent();
+            callback();
+        });
+
+        t.afterEach((callback) => {
+            window.restore();
+            callback();
+        });
+
+        t.test('mapbox.postMapLoadEvent', (t) => {
+            t.ok(mapbox.postMapLoadEvent);
+            t.end();
+        });
+
+        t.test('does not POST when mapboxgl.ACCESS_TOKEN is not set', (t) => {
+            config.ACCESS_TOKEN = null;
+
+            event.postMapLoadEvent(mapboxTileURLs, 1);
+            t.equal(window.server.requests.length, 0);
+            t.end();
+        });
+
+        t.test('does not POST when url does not point to mapbox.com', (t) => {
+            event.postMapLoadEvent(nonMapboxTileURLs, 1);
+
+            t.equal(window.server.requests.length, 0);
+            t.end();
+        });
+
+        t.test('POSTs cn event when API_URL changes to cn endpoint', (t) => {
+            const previousUrl = config.API_URL;
+            config.API_URL = 'https://api.mapbox.cn';
+
+            event.postMapLoadEvent(mapboxTileURLs, 1);
+
+            const req = window.server.requests[0];
+            req.respond(200);
+
+            t.true(req.url.indexOf('https://events.mapbox.cn') > -1);
+            config.API_URL = previousUrl;
+            t.end();
+        });
+
+        t.test('with LocalStorage available', (t) => {
+            let prevLocalStorage;
+            t.beforeEach((callback) => {
+                prevLocalStorage = window.localStorage;
+                window.localStorage = {
+                    data: {},
+                    setItem: function (id, val) {
+                        this.data[id] = String(val);
+                    },
+                    getItem: function (id) {
+                        return this.data.hasOwnProperty(id) ? this.data[id] : undefined;
+                    },
+                    removeItem: function (id) {
+                        if (this.hasOwnProperty(id)) delete this[id];
+                    }
+                };
+                callback();
+            });
+
+            t.afterEach((callback) => {
+                window.localStorage = prevLocalStorage;
+                callback();
+            });
+
+            t.test('POSTs event when previously stored anonId is not a valid uuid', (t) => {
+                window.localStorage.setItem(`mapbox.turnstileEventData:${config.ACCESS_TOKEN}`, JSON.stringify({
+                    anonId: 'anonymous'
+                }));
+
+                event.postMapLoadEvent(mapboxTileURLs, 1);
+                const req = window.server.requests[0];
+                req.respond(200);
+
+                const reqBody = JSON.parse(req.requestBody)[0];
+                t.notEqual(reqBody.userId, 'anonymous');
+                t.end();
+            });
+
+            t.test('does not POST map.load event second time within same calendar day', (t) => {
+                let now = +Date.now();
+                withFixedDate(t, now, () => event.postMapLoadEvent(mapboxTileURLs, 1));
+
+                //Post second event
+                const firstEvent = now;
+                now += (60 * 1000); // A bit later
+                withFixedDate(t, now, () => event.postMapLoadEvent(mapboxTileURLs, 1));
+
+                const req = window.server.requests[0];
+                req.respond(200);
+
+                t.equal(window.server.requests.length, 1);
+
+                const reqBody = JSON.parse(req.requestBody)[0];
+                t.equal(reqBody.created, new Date(firstEvent).toISOString());
+
+                t.end();
+            });
+
+            t.test('does not POST map.load event second time when clock goes backwards less than a day', (t) => {
+                let now = +Date.now();
+                withFixedDate(t, now, () => event.postMapLoadEvent(mapboxTileURLs, 1));
+
+                //Post second event
+                const firstEvent = now;
+                now -= (60 * 1000); // A bit earlier
+                withFixedDate(t, now, () => event.postMapLoadEvent(mapboxTileURLs, 1));
+
+                const req = window.server.requests[0];
+                req.respond(200);
+
+                t.equal(window.server.requests.length, 1);
+
+                const reqBody = JSON.parse(req.requestBody)[0];
+                t.equal(reqBody.created, new Date(firstEvent).toISOString());
+
+                t.end();
+            });
+
+            t.test('POSTs map.load event when access token changes', (t) => {
+                config.ACCESS_TOKEN = 'pk.new.*';
+
+                event.postMapLoadEvent(mapboxTileURLs, 1);
+
+                const req = window.server.requests[0];
+                req.respond(200);
+
+                t.equal(req.url, `${config.EVENTS_URL}?access_token=pk.new.*`);
+
+                t.end();
+            });
+
+            t.end();
+        });
+
+        t.test('when LocalStorage is not available', (t) => {
+            t.test('POSTs map.load event', (t) => {
+                event.postMapLoadEvent(mapboxTileURLs, 1);
+
+                const req = window.server.requests[0];
+                req.respond(200);
+
+                const reqBody = JSON.parse(req.requestBody)[0];
+                t.equal(req.url, `${config.EVENTS_URL}?access_token=key`);
+                t.equal(req.method, 'POST');
+                t.equal(reqBody.event, 'map.load');
+                t.equal(reqBody.sdkVersion, version);
+                t.ok(reqBody.userId);
+
+                t.end();
+            });
+
+            t.test('does not POST map.load multiple times for the same map instance', (t) => {
+                const now = Date.now();
+                withFixedDate(t, now, () => event.postMapLoadEvent(mapboxTileURLs, 1));
+                withFixedDate(t, now + 5, () => event.postMapLoadEvent(mapboxTileURLs, 1));
+
+                const req = window.server.requests[0];
+                req.respond(200);
+
+                t.equal(window.server.requests.length, 1);
+
+                const reqBody = JSON.parse(req.requestBody)[0];
+                t.equal(reqBody.created, new Date(now).toISOString());
+
+                t.end();
+            });
+
+            t.test('POSTs map.load event when access token changes', (t) => {
+                config.ACCESS_TOKEN = 'pk.new.*';
+
+                event.postMapLoadEvent(mapboxTileURLs, 1);
+
+                const req = window.server.requests[0];
+                req.respond(200);
+
+                const reqBody = JSON.parse(req.requestBody)[0];
+                t.equal(req.url, `${config.EVENTS_URL}?access_token=pk.new.*`);
+                t.equal(req.method, 'POST');
+                t.equal(reqBody.event, 'map.load');
+                t.equal(reqBody.sdkVersion, version);
+                t.ok(reqBody.userId);
+
+                t.end();
+            });
+
+            t.test('POSTs distinct map.load for multiple maps', (t) => {
+                event.postMapLoadEvent(mapboxTileURLs, 1);
+                const now = +Date.now();
+                withFixedDate(t, now, ()=> event.postMapLoadEvent(mapboxTileURLs, 2));
+
+                let req = window.server.requests[0];
+                req.respond(200);
+
+                req = window.server.requests[1];
+                req.respond(200);
+                const reqBody = JSON.parse(req.requestBody)[0];
+                t.equal(req.url, `${config.EVENTS_URL}?access_token=key`);
+                t.equal(req.method, 'POST');
+                t.equal(reqBody.event, 'map.load');
+                t.equal(reqBody.sdkVersion, version);
+                t.ok(reqBody.userId);
+                t.equal(reqBody.created, new Date(now).toISOString());
+
+                t.end();
+            });
+
+            t.test('Queues and POSTs map.load events when triggerred in quick succession by different maps', (t) => {
+                const now = Date.now();
+                withFixedDate(t, now, () => event.postMapLoadEvent(mapboxTileURLs, 1));
+                withFixedDate(t, now, () => event.postMapLoadEvent(mapboxTileURLs, 2));
+                withFixedDate(t, now, () => event.postMapLoadEvent(mapboxTileURLs, 3));
+
+                const reqOne = window.server.requests[0];
+                reqOne.respond(200);
+                let reqBody = JSON.parse(reqOne.requestBody)[0];
+                t.equal(reqBody.created, new Date(now).toISOString());
+
+                const reqTwo = window.server.requests[1];
+                reqTwo.respond(200);
+                reqBody = JSON.parse(reqTwo.requestBody)[0];
+                t.equal(reqBody.created, new Date(now).toISOString());
+
+                const reqThree = window.server.requests[2];
+                reqThree.respond(200);
+                reqBody = JSON.parse(reqThree.requestBody)[0];
+                t.equal(reqBody.created, new Date(now).toISOString());
 
                 t.end();
             });


### PR DESCRIPTION
Adds a `map.load` telemetry event for Mapbox analytics if and only if:
- a mapbox access token is set AND
- tiles are being requested from a mapbox api endpoint

I'm open to better ideas for keeping track of distinct `Map` instances than adding a unique id on the map state 💭

fix #7297 

cc @chloekraw 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~
