### PR TITLE
Add documentation about CSS inclusion

### DIFF
--- a/docs/components/quickstart.js
+++ b/docs/components/quickstart.js
@@ -142,6 +142,24 @@ export default class extends React.Component {
                             directives. For Mapbox, you can use this <code>connect-src</code> directive:</p>
                         <pre><code>{`connect-src https://*.tiles.mapbox.com https://api.mapbox.com`}</code></pre>
                     </div>
+                    <div>
+                        <h2 className='strong' id='mapbox-css'>Mapbox CSS</h2>
+                        <p>
+                            The CSS referenced in the Quickstart is used to style DOM elements created by Mapbox code.
+                            Without the CSS, elements like Popups and Markers won't work.
+                        </p>
+                        <p>
+                            Including it with a {'<link>'} in the head of the document via the Mapbox CDN is
+                            the simplest and easiest way to provide the CSS,
+                            but it is also bundled in the Mapbox module, meaning that if you have a bundler
+                            that can handle CSS, you can import the CSS from 
+                            <pre><code>{`mapbox-gl/dist/mapbox-gl.css`}</code></pre>.
+                        </p>
+                        <p>
+                            Note too that if the CSS isn't available by the first render, as soon as the CSS is provided,
+                            the DOM elements that depend on this CSS should recover.
+                        </p>
+                    </div>
                 </div>
             </section>
         );

--- a/docs/components/quickstart.js
+++ b/docs/components/quickstart.js
@@ -152,7 +152,7 @@ export default class extends React.Component {
                             Including it with a {'<link>'} in the head of the document via the Mapbox CDN is
                             the simplest and easiest way to provide the CSS,
                             but it is also bundled in the Mapbox module, meaning that if you have a bundler
-                            that can handle CSS, you can import the CSS from 
+                            that can handle CSS, you can import the CSS from
                             <pre><code>{`mapbox-gl/dist/mapbox-gl.css`}</code></pre>.
                         </p>
                         <p>


### PR DESCRIPTION
## Motivation
Our project uses React, Webpack, code-splitting, and ES6 import syntax. Including the Mapbox CSS via the CDN wouldn't have been terrible, but there's a possibility of version mismatch, and we prefer to provide our own assets.

There weren't previously docs for how to go about this. I asked about this in #7338 and received a good answer, and figured I'd document it for people down the road.

## Changes
Add a section after the CSP that documents how Mapbox's CSS works and can/should be included.

## Note
I see I put this on the wrong base; I'll rebase and push shortly.