### PR TITLE
deregister marker mouseup and touchend when removing marker

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -221,6 +221,8 @@ export default class Marker extends Evented {
             this._map.off('moveend', this._update);
             this._map.off('mousedown', this._addDragHandler);
             this._map.off('touchstart', this._addDragHandler);
+            this._map.off('mouseup', this._onUp);
+            this._map.off('touchend', this._onUp);
             delete this._map;
         }
         DOM.remove(this._element);

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -451,3 +451,17 @@ test('Marker with draggable:false does not move to new position in response to a
     map.remove();
     t.end();
 });
+
+test('Marker with draggable:true does not error if removed on mousedown', (t) => {
+    const map = createMap(t);
+    const marker = new Marker({draggable: true})
+        .setLngLat([0, 0])
+        .addTo(map);
+    const el = marker.getElement();
+    simulate.mousedown(el);
+    simulate.mousemove(el, {clientX: 10, clientY: 10});
+
+    marker.remove();
+    t.ok(map.fire('mouseup'));
+    t.end();
+});


### PR DESCRIPTION
We have run into scenarios where we remove a draggable marker before `mouseup` is ever fired and, because mouseup/touchend never fired once, `_onUp` is called but the marker has already been torn down, leading to errors.

Ensuring these listeners are deregistered when tearing down the marker will ensure that doesn't happen.

~I didn't see any tests in the marker unit test file that ensure that listeners are being deregistered, so I did not add any tests with this. Let me know if I missed anything.~ Tests added.
