### PR TITLE
Fix custom attribution strings in compact mode

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -228,11 +228,11 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         visibility: visible;
     }
 
-    .mapboxgl-ctrl-attrib.mapboxgl-compact > a {
+    .mapboxgl-ctrl-attrib.mapboxgl-compact > * {
         display: none;
     }
 
-    .mapboxgl-ctrl-attrib.mapboxgl-compact:hover > a {
+    .mapboxgl-ctrl-attrib.mapboxgl-compact:hover > * {
         display: inline;
     }
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -120,7 +120,7 @@ class AttributionControl {
                 attributions = attributions.concat(
                     this.options.customAttribution.map(attribution => {
                         if (typeof attribution !== 'string') return '';
-                        return `<a>${attribution}</a>`
+                        return `<p>${attribution}</p>`;
                     })
                 );
             } else if (typeof this.options.customAttribution === 'string') {

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -117,9 +117,14 @@ class AttributionControl {
         let attributions: Array<string> = [];
         if (this.options.customAttribution) {
             if (Array.isArray(this.options.customAttribution)) {
-                attributions = attributions.concat(this.options.customAttribution);
+                attributions = attributions.concat(
+                    this.options.customAttribution.map(attribution => {
+                        if (typeof attribution !== 'string') return '';
+                        return `<a>${attribution}</a>`
+                    })
+                );
             } else if (typeof this.options.customAttribution === 'string') {
-                attributions.push(this.options.customAttribution);
+                attributions.push(`<p>${this.options.customAttribution}</p>`);
             }
         }
 
@@ -150,7 +155,7 @@ class AttributionControl {
             return true;
         });
         if (attributions.length) {
-            this._container.innerHTML = attributions.join(' | ');
+            this._container.innerHTML = attributions.join('<p> | </p>');
             this._container.classList.remove('mapboxgl-attrib-empty');
         } else {
             this._container.classList.add('mapboxgl-attrib-empty');

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -101,7 +101,7 @@ test('AttributionControl dedupes attributions that are substrings of others', (t
     map.on('data', (e) => {
         if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
             if (++times === 7) {
-                t.equal(attribution._container.innerHTML, 'Hello World | Another Source | GeoJSON Source');
+                t.equal(attribution._container.innerHTML, 'Hello World<p> | </p>Another Source<p> | </p>GeoJSON Source');
                 t.end();
             }
         }
@@ -171,9 +171,22 @@ test('AttributionControl shows custom attribution if customAttribution option is
     });
     map.addControl(attributionControl);
 
-    t.equal(attributionControl._container.innerHTML, 'Custom string');
+    t.equal(attributionControl._container.innerHTML, '<p>Custom string</p>');
     t.end();
 });
+
+test('AttributionControl in compact mode shows custom attribution if customAttribution option is provided', (t) => {
+    const map = createMap(t);
+    const attributionControl = new AttributionControl({
+        customAttribution: 'Custom string',
+        compact: true
+    });
+    map.addControl(attributionControl);
+
+    t.equal(attributionControl._container.innerHTML, '<p>Custom string</p>');
+    t.end();
+});
+
 
 test('AttributionControl shows all custom attributions if customAttribution array of strings is provided', (t) => {
     const map = createMap(t);
@@ -184,7 +197,7 @@ test('AttributionControl shows all custom attributions if customAttribution arra
 
     t.equal(
         attributionControl._container.innerHTML,
-        'Custom string | Another custom string | Some very long custom string'
+        '<p>Custom string</p><p> | </p><p>Another custom string</p><p> | </p><p>Some very long custom string</p>'
     );
     t.end();
 });


### PR DESCRIPTION
Fix #7440 

Custom attribution strings weren't declared as HTML elements, and therefore were not hidden by the compact attribution CSS

verified in IE and FF: 
![image](https://user-images.githubusercontent.com/2425307/47185832-7eb4fe00-d2e3-11e8-9cec-7b5878f589a8.png)

![image](https://user-images.githubusercontent.com/2425307/47185818-7066e200-d2e3-11e8-870d-fd47a41f427b.png)



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~
