### PR TITLE
fix compact attribution positioning

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -228,6 +228,18 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         visibility: visible;
     }
 
+    .mapboxgl-ctrl-top-left > .mapboxgl-ctrl-attrib,
+    .mapboxgl-ctrl-top-right > .mapboxgl-ctrl-attrib,
+    .mapboxgl-ctrl-bottom-left > .mapboxgl-ctrl-attrib {
+        margin: 5px;
+    }
+
+    .mapboxgl-ctrl-top-left > .mapboxgl-ctrl-attrib.mapboxgl-compact:hover,
+    .mapboxgl-ctrl-bottom-left > .mapboxgl-ctrl-attrib.mapboxgl-compact:hover {
+        padding: 2px 4px 2px 24px;
+        border-radius: 12px 3px 3px 12px;
+    }
+
     .mapboxgl-ctrl-attrib.mapboxgl-compact > * {
         display: none;
     }
@@ -240,14 +252,32 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         content: '';
         cursor: pointer;
         position: absolute;
-        bottom: 0;
-        right: 0;
         background-image: svg-load('svg/mapboxgl-ctrl-attrib.svg');
         background-color: rgba(255, 255, 255, 0.5);
         width: 24px;
         height: 24px;
         box-sizing: border-box;
         border-radius: 12px;
+    }
+
+    .mapboxgl-ctrl-bottom-right > .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+        bottom: 0;
+        right: 0;
+    }
+
+    .mapboxgl-ctrl-top-right > .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+        top: 0;
+        right: 0;
+    }
+
+    .mapboxgl-ctrl-top-left > .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+        top: 0;
+        left: 0;
+    }
+
+    .mapboxgl-ctrl-bottom-left > .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+        bottom: 0;
+        left: 0;
     }
 }
 

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -217,7 +217,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
 @media screen {
     .mapboxgl-ctrl-attrib.mapboxgl-compact {
-        margin: 0 10px 10px;
+        margin: 10px;
         position: relative;
         background-color: #fff;
         border-radius: 3px 12px 12px 3px;
@@ -226,12 +226,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     .mapboxgl-ctrl-attrib.mapboxgl-compact:hover {
         padding: 2px 24px 2px 4px;
         visibility: visible;
-    }
-
-    .mapboxgl-ctrl-top-left > .mapboxgl-ctrl-attrib,
-    .mapboxgl-ctrl-top-right > .mapboxgl-ctrl-attrib,
-    .mapboxgl-ctrl-bottom-left > .mapboxgl-ctrl-attrib {
-        margin: 5px;
     }
 
     .mapboxgl-ctrl-top-left > .mapboxgl-ctrl-attrib.mapboxgl-compact:hover,


### PR DESCRIPTION
fix #7439 

![image](https://user-images.githubusercontent.com/2425307/47191556-09562700-d2fd-11e8-85a2-4ed5a790b2aa.png)

![image](https://user-images.githubusercontent.com/2425307/47191578-2c80d680-d2fd-11e8-92a8-e29e41ddef7b.png)

![image](https://user-images.githubusercontent.com/2425307/47191600-3dc9e300-d2fd-11e8-87c7-eb63f47cc76f.png)

note: the 10px margin that the `bottom-right` compact control has looks odd when applied to the other control locations, so I reduced it to 5px. I would be in favor of  making them all consistent at 5px – thoughts? 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page

