### PR TITLE
fix unregistered serializable error for cancelled request errors

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -104,7 +104,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
         if (response.ok) {
             response[requestParameters.type || 'text']().then(result => {
                 callback(null, result, response.headers.get('Cache-Control'), response.headers.get('Expires'));
-            }).catch(callback);
+            }).catch(err => callback(new Error(err.message)));
         } else {
             callback(new AJAXError(response.statusText, response.status, requestParameters.url));
         }


### PR DESCRIPTION
fix #7435 

Fetch rejects Promises with `DOMException` when `abort()` is called on an in-progress request, which was causing this error. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
