### PR TITLE
Fix  "localStorage is not available for opaque origins" error when using mapbox-gl-js-mock

### DIFF
--- a/src/util/window.js
+++ b/src/util/window.js
@@ -9,6 +9,7 @@ import { extend } from './util';
 import type {Window} from '../types/window';
 
 const { window: _window } = new jsdom.JSDOM('', {
+    url: 'http://localhost',
     virtualConsole: new jsdom.VirtualConsole().sendTo(console)
 });
 

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -29,6 +29,7 @@ function restore(): Window {
 
     // Create new window and inject into exported object
     const { window } = new jsdom.JSDOM('', {
+        url: 'http://localhost',
         // Send jsdom console output to the node console object.
         virtualConsole: new jsdom.VirtualConsole().sendTo(console)
     });


### PR DESCRIPTION
When running a test from jest and in the context it's being ran, it needs a URL to be set on the jsdom (it defaults to 'about:blank')...
Reference to a lengthy discussion about it: https://github.com/jsdom/jsdom/issues/2304

I'll admit this is a bit of a workaround but here is no other way to set the options for jsdom and trying the suggestions to lock in a specific version of jsdom didn't work for me (and the other suggestions for changing jest didn't matter since jsdom is instantiated from this changed file).

Here is a reproduction based off create-react-app:
https://github.com/fc/mapbox-gl-js-mock-repro

Here is the test:
https://github.com/fc/mapbox-gl-js-mock-repro/blob/master/src/App.test.js

```
import mapboxgl from 'mapbox-gl-js-mock';

it('renders without crashing', () => {
    const map = new mapboxgl.map();
});
```

Run this command after a yarn install:
```
yarn test
```

Error output is:
```
 FAIL  src/App.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

    > 1 | import mapboxgl from 'mapbox-gl-js-mock';
        | ^
      2 |
      3 | it('renders without crashing', () => {
      4 |     const map = new mapboxgl.map();

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
      at Object.<anonymous>.exports.extend (node_modules/mapbox-gl/src/util/util.js:154:26)
      at extend (node_modules/mapbox-gl/src/util/window.js:61:10)
      at Object.restore (node_modules/mapbox-gl/src/util/window.js:66:18)
      at Object.require (node_modules/mapbox-gl/src/util/web_worker_transfer.js:16:21)
      at Object.require (node_modules/mapbox-gl/src/source/tile_id.js:5:20)
      at Object.require (node_modules/mapbox-gl/src/util/tile_cover.js:4:28)
      at Object.require (node_modules/mapbox-gl/src/geo/transform.js:8:17)
      at Object.require (node_modules/mapbox-gl-js-mock/classes/map.js:9:17)
      at Object.require (node_modules/mapbox-gl-js-mock/index.js:10:8)
      at Object.<anonymous> (src/App.test.js:1:1)
```