### PR TITLE
Workaround for failure to clear depth buffer on some Android devices.

### DIFF
--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -189,6 +189,11 @@ class Context {
 
         if (typeof depth !== 'undefined') {
             mask |= gl.DEPTH_BUFFER_BIT;
+
+            // Workaround for platforms where clearDepth doesn't seem to work
+            // without reseting the depthRange. See https://github.com/mapbox/mapbox-gl-js/issues/3437
+            this.depthRange.set([0, 1]);
+
             this.clearDepth.set(depth);
             this.depthMask.set(true);
         }


### PR DESCRIPTION
Fixes issue #3437.

We don't expect `gl.depthRange` to affect the behavior of `gl.clearDepth`, but experimentally, it appears that we're failing to clear the depth buffer on some Android devices, and resetting the depth range before the clear call appears to fix the problem (maybe because some drivers implement `clearDepth` in terms of just drawing a full screen quad to the depth buffer?). This only happens once per frame, so should be negligibly expensive.

The only place I could reproduce this issue was on a BrowserStack Galaxy S6 image running Chrome 68.0.3440.85/Android 5.0.2 -- we'll need to collect feedback from other people who have encountered #3437 to see how full a fix this is. 

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

/cc @ansis @mollymerp @chloekraw 