### PR TITLE
remove controls before destroying map

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1664,6 +1664,10 @@ class Map extends Camera {
      */
     remove() {
         if (this._hash) this._hash.remove();
+
+        for (const control of this._controls) control.onRemove(this);
+        this._controls = [];
+
         if (this._frame) {
             this._frame.cancel();
             this._frame = null;
@@ -1674,9 +1678,6 @@ class Map extends Camera {
             window.removeEventListener('resize', this._onWindowResize, false);
             window.removeEventListener('online', this._onWindowOnline, false);
         }
-
-        for (const control of this._controls) control.onRemove(this);
-        this._controls = [];
 
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -817,6 +817,30 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('#remove calls onRemove on added controls before style is destroyed', (t) => {
+        const map = createMap(t);
+        let onRemoveCalled = 0;
+        let style;
+        const control = {
+            onRemove: function(map) {
+                onRemoveCalled++;
+                t.deepEqual(map.getStyle(), style);
+            },
+            onAdd: function (_) {
+                return window.document.createElement('div');
+            }
+        };
+
+        map.addControl(control);
+
+        map.on('style.load', () => {
+            style = map.getStyle();
+            map.remove();
+            t.equal(onRemoveCalled, 1);
+            t.end();
+        });
+    });
+
     t.test('#addControl', (t) => {
         const map = createMap(t);
         const control = {


### PR DESCRIPTION

This removes the controls before destroying the map so that:
- the map is in a valid state when `onRemove` is called for each control
- so that the frame can be cancelled after removal in case `onRemove` triggers a render frame

fix #7478 

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page