### PR TITLE
Clarify that Node-specific files are replaced by Rollup in browser environments

### DIFF
--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -1,5 +1,9 @@
+// This file is intended for use in the GL-JS test suite
+// It provides the shaders entry point for Node (tests and GL Native)
+// In a browser environment, this file is replaced with ./src/shaders/shaders.js
+// when Rollup builds the main bundle.
+// See https://github.com/mapbox/mapbox-gl-js/blob/master/package.json#L104-L108
 
-// Shaders entry point for Node (tests and GL Native)
 /* eslint-disable import/unambiguous, import/no-commonjs, flowtype/require-valid-file-annotation, no-global-assign */
 
 const fs = require('fs');

--- a/src/util/web_worker.js
+++ b/src/util/web_worker.js
@@ -1,5 +1,11 @@
 // @flow
 
+// This file is intended for use in the GL-JS test suite
+// It implements a MessageBus main thread interface for use in Node environments
+// In a browser environment, this file is replaced with ./src/util/browser/web_worker.js
+// when Rollup builds the main bundle.
+// See https://github.com/mapbox/mapbox-gl-js/blob/master/package.json#L104-L108
+
 import Worker from '../source/worker';
 
 import type {WorkerSource} from '../source/worker_source';

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -1,5 +1,11 @@
 // @flow
 
+// This file is intended for use in the GL-JS test suite
+// It implements a JSDOM window object for use in Node environments
+// In a browser environment, this file is replaced with ./src/util/browser/window.js
+// when Rollup builds the main bundle
+// See https://github.com/mapbox/mapbox-gl-js/blob/master/package.json#L104-L108
+
 import jsdom from 'jsdom';
 
 import gl from 'gl';


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
There was significant confusion when investigating https://github.com/mapbox/mapbox-gl-js/pull/7455 because it was not obvious how the JSDOM `window` in `src/util/window.js` was being replaced by the browser `window`. These comments are intended to make the workflow clearer when reading the code.
