### PR TITLE
Update repo url to correct one

### DIFF
--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:mapbox/mapbox-gl-style-spec.git"
+    "url": "git@github.com:mapbox/mapbox-gl-js.git"
   },
   "bin": {
     "gl-style-migrate": "bin/gl-style-migrate",


### PR DESCRIPTION
The url points to the old outdated repo and I am hoping that yarn uses this for the URL column when running yarn outdated :)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [ ] ~~manually test the debug page~~
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

