### PR TITLE
[WIP] Global coordinates for circle layers

### DIFF
--- a/build/generate-struct-arrays.js
+++ b/build/generate-struct-arrays.js
@@ -124,6 +124,7 @@ createStructArrayType('pos', posAttributes);
 createStructArrayType('raster_bounds', rasterBoundsAttributes);
 
 const circleAttributes = require('../src/data/bucket/circle_attributes').default;
+const heatmapAttributes = require('../src/data/bucket/heatmap_attributes').default;
 const fillAttributes = require('../src/data/bucket/fill_attributes').default;
 const fillExtrusionAttributes = require('../src/data/bucket/fill_extrusion_attributes').default;
 const lineAttributes = require('../src/data/bucket/line_attributes').default;
@@ -134,7 +135,7 @@ const layoutAttributes = {
     circle: circleAttributes,
     fill: fillAttributes,
     'fill-extrusion': fillExtrusionAttributes,
-    heatmap: circleAttributes,
+    heatmap: heatmapAttributes,
     line: lineAttributes,
     pattern: patternAttributes
 };

--- a/debug/circles.html
+++ b/debug/circles.html
@@ -26,6 +26,7 @@ var map = window.map = new mapboxgl.Map({
     hash: true
 });
 
+map.showTileBoundaries = true;
 map.addControl(new mapboxgl.NavigationControl());
 map.addControl(new mapboxgl.GeolocateControl());
 
@@ -41,23 +42,25 @@ map.on('load', function() {
         "type": "circle",
         "source": "circles",
         "paint": {
-            "circle-radius": [
-                "interpolate",
-                ["exponential", 2.0],
-                ["zoom"],
-                0, 5,
-                5, ['*', ["get", "scalerank"], 20],
-            ],
-            "circle-color": [
-                "match",
-                ["get", "featureclass"],
-                "cape", "orange",
-                "island", "#0088ff",
-                "plain", "yellow",
-                "pole", "white",
-                "waterfall", "blue",
-                "red"
-            ],
+            "circle-radius": 15,
+            "circle-color": "blue",
+            // "circle-radius": [
+            //     "interpolate",
+            //     ["exponential", 2.0],
+            //     ["zoom"],
+            //     0, 5,
+            //     5, ['*', ["get", "scalerank"], 20],
+            // ],
+            // "circle-color": [
+            //     "match",
+            //     ["get", "featureclass"],
+            //     "cape", "orange",
+            //     "island", "#0088ff",
+            //     "plain", "yellow",
+            //     "pole", "white",
+            //     "waterfall", "blue",
+            //     "red"
+            // ],
             "circle-pitch-scale": "map",
             "circle-pitch-alignment": "map",
             "circle-stroke-width": 1
@@ -73,22 +76,24 @@ map.on('load', function() {
         },
         'source-layer': 'sf2010',
         'paint': {
-            // make circles larger as the user zooms from z12 to z22
-            'circle-radius': {
-                'base': 1.75,
-                'stops': [[12, 2], [22, 180]]
-            },
-            // color circles by ethnicity, using a match expression
-            // https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-match
-            'circle-color': [
-                'match',
-                ['get', 'ethnicity'],
-                'White', '#fbb03b',
-                'Black', '#223b53',
-                'Hispanic', '#e55e5e',
-                'Asian', '#3bb2d0',
-                /* other */ '#ccc'
-            ]
+            'circle-radius': 2,
+            'circle-color': "gray"
+            // // make circles larger as the user zooms from z12 to z22
+            // 'circle-radius': {
+            //     'base': 1.75,
+            //     'stops': [[12, 2], [22, 180]]
+            // },
+            // // color circles by ethnicity, using a match expression
+            // // https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-match
+            // 'circle-color': [
+            //     'match',
+            //     ['get', 'ethnicity'],
+            //     'White', '#fbb03b',
+            //     'Black', '#223b53',
+            //     'Hispanic', '#e55e5e',
+            //     'Asian', '#3bb2d0',
+            //     /* other */ '#ccc'
+            // ]
         }
     });
 

--- a/debug/circles.html
+++ b/debug/circles.html
@@ -22,7 +22,7 @@ var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 3,
     center: [-77.01866, 38.888],
-    style: 'mapbox://styles/mapbox/streets-v9',
+    style: 'mapbox://styles/mapbox/light-v9',
     hash: true
 });
 
@@ -59,7 +59,36 @@ map.on('load', function() {
                 "red"
             ],
             "circle-pitch-scale": "map",
-            "circle-pitch-alignment": "map"
+            "circle-pitch-alignment": "map",
+            "circle-stroke-width": 1
+        }
+    });
+
+    map.addLayer({
+        'id': 'population',
+        'type': 'circle',
+        'source': {
+            type: 'vector',
+            url: 'mapbox://examples.8fgz4egr'
+        },
+        'source-layer': 'sf2010',
+        'paint': {
+            // make circles larger as the user zooms from z12 to z22
+            'circle-radius': {
+                'base': 1.75,
+                'stops': [[12, 2], [22, 180]]
+            },
+            // color circles by ethnicity, using a match expression
+            // https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-match
+            'circle-color': [
+                'match',
+                ['get', 'ethnicity'],
+                'White', '#fbb03b',
+                'Black', '#223b53',
+                'Hispanic', '#e55e5e',
+                'Asian', '#3bb2d0',
+                /* other */ '#ccc'
+            ]
         }
     });
 

--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -77,6 +77,41 @@ register('StructArrayLayout4i8', StructArrayLayout4i8);
 
 /**
  * Implementation of the StructArray layout:
+ * [0]: Uint16[4]
+ *
+ * @private
+ */
+class StructArrayLayout4ui8 extends StructArray {
+    uint8: Uint8Array;
+    uint16: Uint16Array;
+
+    _refreshViews() {
+        this.uint8 = new Uint8Array(this.arrayBuffer);
+        this.uint16 = new Uint16Array(this.arrayBuffer);
+    }
+
+    emplaceBack(v0: number, v1: number, v2: number, v3: number) {
+        const i = this.length;
+        this.resize(i + 1);
+        return this.emplace(i, v0, v1, v2, v3);
+    }
+
+    emplace(i: number, v0: number, v1: number, v2: number, v3: number) {
+        const o2 = i * 4;
+        this.uint16[o2 + 0] = v0;
+        this.uint16[o2 + 1] = v1;
+        this.uint16[o2 + 2] = v2;
+        this.uint16[o2 + 3] = v3;
+        return i;
+    }
+}
+
+StructArrayLayout4ui8.prototype.bytesPerElement = 8;
+register('StructArrayLayout4ui8', StructArrayLayout4ui8);
+
+
+/**
+ * Implementation of the StructArray layout:
  * [0]: Int16[2]
  * [4]: Int16[4]
  *
@@ -1100,6 +1135,7 @@ register('FeatureIndexArray', FeatureIndexArray);
 export {
     StructArrayLayout2i4,
     StructArrayLayout4i8,
+    StructArrayLayout4ui8,
     StructArrayLayout2i4i12,
     StructArrayLayout4i4ub12,
     StructArrayLayout8ui16,
@@ -1121,7 +1157,7 @@ export {
     StructArrayLayout4f16,
     StructArrayLayout2i4 as PosArray,
     StructArrayLayout4i8 as RasterBoundsArray,
-    StructArrayLayout2i4 as CircleLayoutArray,
+    StructArrayLayout4ui8 as CircleLayoutArray,
     StructArrayLayout2i4 as FillLayoutArray,
     StructArrayLayout2i4i12 as FillExtrusionLayoutArray,
     StructArrayLayout2i4 as HeatmapLayoutArray,

--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -7,6 +7,7 @@ import type FeatureIndex from './feature_index';
 import type Context from '../gl/context';
 import type {FeatureStates} from '../source/source_state';
 import type {ImagePosition} from '../render/image_atlas';
+import type { OverscaledTileID } from '../source/tile_id';
 
 export type BucketParameters<Layer: TypedStyleLayer> = {
     index: number,
@@ -16,7 +17,8 @@ export type BucketParameters<Layer: TypedStyleLayer> = {
     overscaling: number,
     collisionBoxArray: CollisionBoxArray,
     sourceLayerIndex: number,
-    sourceID: string
+    sourceID: string,
+    tileID: OverscaledTileID
 }
 
 export type PopulateParameters = {

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -17,7 +17,6 @@ import type {
     PopulateParameters
 } from '../bucket';
 import type CircleStyleLayer from '../../style/style_layer/circle_style_layer';
-import type Context from '../../gl/context';
 import type Point from '@mapbox/point-geometry';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
@@ -111,7 +110,7 @@ class CircleBucket implements Bucket {
         return !this.uploaded || this.programConfigurations.needsUpload;
     }
 
-    upload(context: Context) {
+    upload() {
         this.uploaded = true;
     }
 

--- a/src/data/bucket/global_circle_bucket.js
+++ b/src/data/bucket/global_circle_bucket.js
@@ -6,14 +6,12 @@ import { members as layoutAttributes } from './circle_attributes';
 import SegmentVector from '../segment';
 import { ProgramConfigurationSet } from '../program_configuration';
 import { TriangleIndexArray } from '../index_array_type';
-import EXTENT from '../extent';
 import CircleBucket from './circle_bucket';
 
 import type CircleStyleLayer from '../../style/style_layer/circle_style_layer';
 import type Context from '../../gl/context';
 import type IndexBuffer from '../../gl/index_buffer';
 import type VertexBuffer from '../../gl/vertex_buffer';
-import type {FeatureStates} from '../../source/source_state';
 
 /**
  * See CircleBucket for per-tile implementation
@@ -61,7 +59,7 @@ class GlobalCircleBucket {
         this._usedTileBuckets = {};
     }
 
-    update(states: ?FeatureStates, vtLayer: ?VectorTileLayer) {
+    update() {
         // TODO: Actually hook up all the plumbing to update in place
         // For now, count on the per-tile buckets re-generating, and just copy everything over
         // again.

--- a/src/data/bucket/global_circle_bucket.js
+++ b/src/data/bucket/global_circle_bucket.js
@@ -1,0 +1,250 @@
+// @flow
+
+import { CircleLayoutArray } from '../array_types';
+
+import { members as layoutAttributes } from './circle_attributes';
+import SegmentVector from '../segment';
+import { ProgramConfigurationSet } from '../program_configuration';
+import { TriangleIndexArray } from '../index_array_type';
+import EXTENT from '../extent';
+import CircleBucket from './circle_bucket';
+
+import type CircleStyleLayer from '../../style/style_layer/circle_style_layer';
+import type Context from '../../gl/context';
+import type IndexBuffer from '../../gl/index_buffer';
+import type VertexBuffer from '../../gl/vertex_buffer';
+import type {FeatureStates} from '../../source/source_state';
+
+/**
+ * See CircleBucket for per-tile implementation
+ * GlobalCircleBucket is different from other buckets in that it is dynamically
+ * generated on the foreground out of a set of individual CircleBuckets
+ *
+ * @private
+ */
+class GlobalCircleBucket {
+    layerIds: Array<string>;
+    layers: Array<CircleStyleLayer>;
+    stateDependentLayers: Array<CircleStyleLayer>;
+
+    layoutVertexArray: CircleLayoutArray;
+    layoutVertexBuffer: VertexBuffer;
+
+    indexArray: TriangleIndexArray;
+    indexBuffer: IndexBuffer;
+
+    programConfigurations: ProgramConfigurationSet<CircleStyleLayer>;
+
+    segments: SegmentVector;
+    uploaded: boolean
+
+    zoom: number;
+
+    _tileBuckets: {[string]: CircleBucket};
+    _tileLayoutVertexArrays: {[string]: CircleLayoutArray};
+    _tileProgramConfigurations: {[string]: ProgramConfigurationSet<CircleStyleLayer>};
+    _usedTileBuckets: {[string]: boolean};
+
+    constructor(options: any) {
+        this.layerIds = options.layerIds;
+        this.layers = options.layers;
+        this.zoom = options.zoom;
+
+        this.layoutVertexArray = new CircleLayoutArray();
+        this.indexArray = new TriangleIndexArray();
+        this.segments = new SegmentVector();
+        this.programConfigurations = new ProgramConfigurationSet(layoutAttributes, options.layers, options.zoom);
+
+        this._tileBuckets = {};
+        this._tileLayoutVertexArrays = {};
+        this._tileProgramConfigurations = {};
+        this._usedTileBuckets = {};
+    }
+
+    update(states: ?FeatureStates, vtLayer: ?VectorTileLayer) {
+        // TODO: Actually hook up all the plumbing to update in place
+        // For now, count on the per-tile buckets re-generating, and just copy everything over
+        // again.
+        this.uploaded = false;
+    }
+
+    isEmpty() {
+        return this.layoutVertexArray.length === 0;
+    }
+
+    uploadPending() {
+        return !this.uploaded || this.programConfigurations.needsUpload;
+    }
+
+    addTileBucket(bucket: CircleBucket) {
+        const key = bucket.tileID.toString();
+        // TODO: This breaks in the case runtime styling changes cause
+        // buckets within a single layer to have divergent properties
+        this.layers = bucket.layers;
+        this.layerIds = bucket.layerIds;
+        this.stateDependentLayers = bucket.stateDependentLayers;
+
+        this.uploaded = false;
+
+        this._tileLayoutVertexArrays[key] = bucket.layoutVertexArray;
+        this._tileProgramConfigurations[key] = bucket.programConfigurations;
+
+        this._tileBuckets[key] = bucket;
+    }
+
+    // The set of loaded buckets in the source cache can change indpendently
+    // of which tiles are actually renderable. For the purposes of the global
+    // circle bucket, we care about which tiles are actually rendering.
+    // The approach here is to hold onto the source tile buckets and dynamically
+    // include or exclude them from the global bucket based on what's being rendered
+    // This allows us to sidestep tracking the wrap value for the buckets that
+    // have been added (which gets pretty complicated because of the "wrap jump"
+    // behavior). On the other hand, we can't throw away data when a tile bucket is
+    // removed from the source cache because we don't have a way to track if
+    // the same bucket is "used" by another wrap value.
+    // TODO: The only way tile buckets actually get removed from memory is if
+    // the entire global bucket for their zoom level is garbage collected.
+    markUsed(bucket: CircleBucket) {
+        const key = bucket.tileID.toString();
+        this._usedTileBuckets[key] = true;
+    }
+
+    upload(context: Context) {
+        for (const key in this._tileLayoutVertexArrays) {
+            if (!this._usedTileBuckets[key]) {
+                this.uploaded = false;
+                delete this._tileLayoutVertexArrays[key];
+                delete this._tileProgramConfigurations[key];
+            }
+        }
+        for (const key in this._tileBuckets) {
+            if (this._usedTileBuckets[key]) {
+                const tileBucket = this._tileBuckets[key];
+                if (!this._tileLayoutVertexArrays[key]) {
+                    this.uploaded = false;
+                    this._tileLayoutVertexArrays[key] = tileBucket.layoutVertexArray;
+                }
+                if (!this._tileProgramConfigurations[key]) {
+                    this.uploaded = false;
+                    this._tileProgramConfigurations[key] = tileBucket.programConfigurations;
+                }
+            }
+        }
+        if (!this.uploaded) {
+            this.generateArrays();
+            this.layoutVertexBuffer = context.createVertexBuffer(this.layoutVertexArray, layoutAttributes);
+            this.indexBuffer = context.createIndexBuffer(this.indexArray);
+        }
+        this.programConfigurations.upload(context);
+        this.uploaded = true;
+        this._usedTileBuckets = {};
+    }
+
+    tileCount() {
+        return Object.keys(this._tileLayoutVertexArrays).length;
+    }
+
+    destroy() {
+        if (!this.layoutVertexBuffer) return;
+        this.layoutVertexBuffer.destroy();
+        this.indexBuffer.destroy();
+        this.programConfigurations.destroy();
+        this.segments.destroy();
+    }
+
+    copyLayoutVertex(tileLayoutVertexArray: CircleLayoutArray, i: number) {
+        this.layoutVertexArray.emplaceBack(
+            tileLayoutVertexArray.uint16[i],
+            tileLayoutVertexArray.uint16[i + 1],
+            tileLayoutVertexArray.uint16[i + 2],
+            tileLayoutVertexArray.uint16[i + 3]
+        );
+    }
+
+    generateArrays() {
+        // TODO: Resetting all state, Copying and reuploading everything is the least efficient way to do this!
+        if (this.programConfigurations) {
+            this.programConfigurations.destroy();
+        }
+        if (this.segments) {
+            this.segments.destroy();
+        }
+        if (this.layoutVertexBuffer) {
+            this.layoutVertexBuffer.destroy();
+        }
+        if (this.indexBuffer) {
+            this.indexBuffer.destroy();
+        }
+
+        this.segments = new SegmentVector();
+        this.layoutVertexArray = new CircleLayoutArray();
+        this.indexArray = new TriangleIndexArray();
+        this.programConfigurations = new ProgramConfigurationSet(layoutAttributes, this.layers, this.zoom);
+
+        for (const layerId of this.layerIds) {
+            const circles = this.programConfigurations.programConfigurations[layerId];
+            for (const property in circles.binders) {
+                const binder = (circles.binders[property]: any);
+                if (!binder.paintVertexArray) continue;
+                for (const key in this._tileProgramConfigurations) {
+                    binder.paintVertexArray._trim();
+                    const tileProgramConfiguration = this._tileProgramConfigurations[key];
+                    const tileBinder = (tileProgramConfiguration.programConfigurations[layerId].binders[property]: any);
+                    binder.maxValue = Math.max(binder.maxValue, tileBinder.maxValue);
+                    const tilePaintVertexArray = tileBinder.paintVertexArray;
+                    const baseIndex = binder.paintVertexArray.length;
+                    const baseIndexUint8 = binder.paintVertexArray.uint8.length;
+                    binder.paintVertexArray.resize(baseIndex + tilePaintVertexArray.length);
+                    binder.paintVertexArray._trim();
+                    for (let i = 0; i < tilePaintVertexArray.uint8.length; i++) {
+                        binder.paintVertexArray.uint8[baseIndexUint8 + i] = tilePaintVertexArray.uint8[i];
+                    }
+                }
+            }
+        }
+        this.programConfigurations.needsUpload = true;
+
+        let combinedLength = 0;
+        for (const key in this._tileLayoutVertexArrays) {
+            combinedLength += this._tileLayoutVertexArrays[key].length;
+        }
+        this.layoutVertexArray.reserve(combinedLength);
+
+        const indexPositions = [];
+        for (const key in this._tileLayoutVertexArrays) {
+            const tileLayoutVertexArray = this._tileLayoutVertexArrays[key];
+            for (let i = 0; i < tileLayoutVertexArray.length * 4; i += 16) {
+                const segment = this.segments.prepareSegment(4, this.layoutVertexArray, this.indexArray);
+                const index = segment.vertexLength;
+
+                this.copyLayoutVertex(tileLayoutVertexArray, i);
+                this.copyLayoutVertex(tileLayoutVertexArray, i + 4);
+                this.copyLayoutVertex(tileLayoutVertexArray, i + 8);
+                this.copyLayoutVertex(tileLayoutVertexArray, i + 12);
+
+                // TODO: this is a poor-man's low precision, no rotation y-sort
+                const y = tileLayoutVertexArray.uint16[i + 1];
+
+                indexPositions.push({ y, index });
+
+                segment.vertexLength += 4;
+                segment.primitiveLength += 2; // Is it OK that we add these later?
+            }
+        }
+        if (indexPositions.length * 4 < SegmentVector.MAX_VERTEX_ARRAY_LENGTH) {
+            // Sorting only works if all circles fit inside a single segment.
+            indexPositions.sort((a, b) => {
+                return a.y - b.y;
+            });
+        }
+        for (const indexPosition of indexPositions) {
+            const index = indexPosition.index;
+            this.indexArray.emplaceBack(index, index + 1, index + 2);
+            this.indexArray.emplaceBack(index, index + 3, index + 2);
+        }
+        this.indexArray._trim();
+        this.layoutVertexArray._trim();
+    }
+}
+
+export default GlobalCircleBucket;

--- a/src/data/bucket/heatmap_attributes.js
+++ b/src/data/bucket/heatmap_attributes.js
@@ -2,7 +2,7 @@
 import { createLayout } from '../../util/struct_array';
 
 const layout = createLayout([
-    {name: 'a_pos', components: 4, type: 'Uint16'}
+    {name: 'a_pos', components: 2, type: 'Int16'}
 ], 4);
 
 export default layout;

--- a/src/data/bucket/heatmap_bucket.js
+++ b/src/data/bucket/heatmap_bucket.js
@@ -1,15 +1,160 @@
 // @flow
 
-import CircleBucket from './circle_bucket';
+import { HeatmapLayoutArray } from '../array_types';
 
+import { members as layoutAttributes } from './heatmap_attributes';
+import SegmentVector from '../segment';
+import { ProgramConfigurationSet } from '../program_configuration';
+import { TriangleIndexArray } from '../index_array_type';
+import loadGeometry from '../load_geometry';
+import EXTENT from '../extent';
 import { register } from '../../util/web_worker_transfer';
+import EvaluationParameters from '../../style/evaluation_parameters';
 
+import type {
+    Bucket,
+    BucketParameters,
+    IndexedFeature,
+    PopulateParameters
+} from '../bucket';
 import type HeatmapStyleLayer from '../../style/style_layer/heatmap_style_layer';
+import type Context from '../../gl/context';
+import type IndexBuffer from '../../gl/index_buffer';
+import type VertexBuffer from '../../gl/vertex_buffer';
+import type Point from '@mapbox/point-geometry';
+import type {FeatureStates} from '../../source/source_state';
+import type {ImagePosition} from '../../render/image_atlas';
 
-class HeatmapBucket extends CircleBucket<HeatmapStyleLayer> {
-    // Needed for flow to accept omit: ['layers'] below, due to
-    // https://github.com/facebook/flow/issues/4262
+
+function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
+    layoutVertexArray.emplaceBack(
+        (x * 2) + ((extrudeX + 1) / 2),
+        (y * 2) + ((extrudeY + 1) / 2));
+}
+
+
+/**
+ * Heatmaps use the same geometry as circles, but we forked HeatmapBucket
+ * from CircleBucket because the global coordinates necessary for sorting
+ * at tile boundaries are irrelevant for heatmaps.
+ *
+ * Circles are represented by two triangles.
+ *
+ * Each corner has a pos that is the center of the circle and an extrusion
+ * vector that is where it points.
+ * @private
+ */
+class HeatmapBucket implements Bucket {
+    index: number;
+    zoom: number;
+    overscaling: number;
+    layerIds: Array<string>;
     layers: Array<HeatmapStyleLayer>;
+    stateDependentLayers: Array<HeatmapStyleLayer>;
+
+    layoutVertexArray: HeatmapLayoutArray;
+    layoutVertexBuffer: VertexBuffer;
+
+    indexArray: TriangleIndexArray;
+    indexBuffer: IndexBuffer;
+
+    hasPattern: boolean;
+    programConfigurations: ProgramConfigurationSet<HeatmapStyleLayer>;
+    segments: SegmentVector;
+    uploaded: boolean;
+
+    constructor(options: BucketParameters<HeatmapStyleLayer>) {
+        this.zoom = options.zoom;
+        this.overscaling = options.overscaling;
+        this.layers = options.layers;
+        this.layerIds = this.layers.map(layer => layer.id);
+        this.index = options.index;
+        this.hasPattern = false;
+
+        this.layoutVertexArray = new HeatmapLayoutArray();
+        this.indexArray = new TriangleIndexArray();
+        this.segments = new SegmentVector();
+        this.programConfigurations = new ProgramConfigurationSet(layoutAttributes, options.layers, options.zoom);
+    }
+
+    // TODO: Logic can still be shared with CircleBucket
+    populate(features: Array<IndexedFeature>, options: PopulateParameters) {
+        for (const {feature, index, sourceLayerIndex} of features) {
+            if (this.layers[0]._featureFilter(new EvaluationParameters(this.zoom), feature)) {
+                const geometry = loadGeometry(feature);
+                this.addFeature(feature, geometry, index);
+                options.featureIndex.insert(feature, geometry, index, sourceLayerIndex, this.index);
+            }
+        }
+    }
+
+    update(states: FeatureStates, vtLayer: VectorTileLayer, imagePositions: {[string]: ImagePosition}) {
+        if (!this.stateDependentLayers.length) return;
+        this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, imagePositions);
+    }
+
+    isEmpty() {
+        return this.layoutVertexArray.length === 0;
+    }
+
+    uploadPending() {
+        return !this.uploaded || this.programConfigurations.needsUpload;
+    }
+
+    upload(context: Context) {
+        if (!this.uploaded) {
+            this.layoutVertexBuffer = context.createVertexBuffer(this.layoutVertexArray, layoutAttributes);
+            this.indexBuffer = context.createIndexBuffer(this.indexArray);
+        }
+        this.programConfigurations.upload(context);
+        this.uploaded = true;
+    }
+
+    destroy() {
+        if (!this.layoutVertexBuffer) return;
+        this.layoutVertexBuffer.destroy();
+        this.indexBuffer.destroy();
+        this.programConfigurations.destroy();
+        this.segments.destroy();
+    }
+
+    // TODO: Logic can still be shared with CircleBucket
+    addFeature(feature: VectorTileFeature, geometry: Array<Array<Point>>, index: number) {
+        for (const ring of geometry) {
+            for (const point of ring) {
+                const x = point.x;
+                const y = point.y;
+
+                // Do not include points that are outside the tile boundaries.
+                if (x < 0 || x >= EXTENT || y < 0 || y >= EXTENT) continue;
+
+                // this geometry will be of the Point type, and we'll derive
+                // two triangles from it.
+                //
+                // ┌─────────┐
+                // │ 3     2 │
+                // │         │
+                // │ 0     1 │
+                // └─────────┘
+
+                const segment = this.segments.prepareSegment(4, this.layoutVertexArray, this.indexArray);
+                const index = segment.vertexLength;
+
+                addCircleVertex(this.layoutVertexArray, x, y, -1, -1);
+                addCircleVertex(this.layoutVertexArray, x, y, 1, -1);
+                addCircleVertex(this.layoutVertexArray, x, y, 1, 1);
+                addCircleVertex(this.layoutVertexArray, x, y, -1, 1);
+
+                this.indexArray.emplaceBack(index, index + 1, index + 2);
+                this.indexArray.emplaceBack(index, index + 3, index + 2);
+
+                segment.vertexLength += 4;
+                segment.primitiveLength += 2;
+            }
+        }
+
+        this.programConfigurations.populatePaintArrays(this.layoutVertexArray.length, feature, index, {});
+    }
 }
 
 register('HeatmapBucket', HeatmapBucket, {omit: ['layers']});

--- a/src/gl/global_vertex_buffer.js
+++ b/src/gl/global_vertex_buffer.js
@@ -1,0 +1,324 @@
+// @flow
+
+import assert from 'assert';
+
+import type {
+    StructArray,
+    StructArrayMember
+} from '../util/struct_array';
+
+import type Program from '../render/program';
+import type Context from '../gl/context';
+
+/**
+ * @enum {string} AttributeType
+ * @private
+ * @readonly
+ */
+const AttributeType = {
+    Int8:   'BYTE',
+    Uint8:  'UNSIGNED_BYTE',
+    Int16:  'SHORT',
+    Uint16: 'UNSIGNED_SHORT',
+    Int32:  'INT',
+    Uint32: 'UNSIGNED_INT',
+    Float32: 'FLOAT'
+};
+
+export type BufferSection = {
+    start: number,
+    length: number,
+    index: number,
+    array: ?StructArray
+};
+
+/**
+ * The `VertexBuffer` class turns a `StructArray` into a WebGL buffer. Each member of the StructArray's
+ * Struct type is converted to a WebGL atribute.
+ * @private
+ */
+class GlobalVertexBuffer {
+    length: number;
+    attributes: $ReadOnlyArray<StructArrayMember>;
+    itemSize: number;
+    context: Context;
+    buffer: WebGLBuffer;
+    sections: {[number]: BufferSection};
+    sectionOrder: Array<number>;
+    nextIndex: number;
+    allocatedLength: number;
+
+    constructor(context: Context, initialLength: number, itemSize: number, attributes: $ReadOnlyArray<StructArrayMember>) {
+        this.length = initialLength;
+        this.attributes = attributes;
+        this.itemSize = itemSize;
+        this.sections = {};
+        this.sectionOrder = [];
+        this.nextIndex = 0;
+        this.allocatedLength = 0;
+
+        this.context = context;
+        const gl = context.gl;
+        this.buffer = gl.createBuffer();
+        context.bindVertexBuffer.set(this.buffer);
+        gl.bufferData(gl.ARRAY_BUFFER, initialLength * itemSize, gl.DYNAMIC_DRAW);
+    }
+
+    bind() {
+        this.context.bindVertexBuffer.set(this.buffer);
+    }
+
+    addSection(array: StructArray, currentIndex: ?number) {
+        const gl = this.context.gl;
+        this.bind();
+        let section;
+        if (currentIndex && this.sections[currentIndex].length === array.length) {
+            // Update an existing section
+            //console.log(`Updating ${currentIndex} in place`);
+            section = this.sections[currentIndex];
+        } else if (currentIndex) {
+            // Changed length -> need to find a new space for this section
+            //console.log(`Removing section ${currentIndex} because of length change`);
+            this.removeSection(currentIndex);
+        }
+        if (!section) {
+            // Find a new space
+            section = this.getNewSection(array);
+        }
+
+        this.testContinuity();
+
+        gl.bufferSubData(gl.ARRAY_BUFFER, section.start * this.itemSize, array.arrayBuffer);
+        return section.index;
+    }
+
+    getNewSection(array: StructArray) {
+        for (const index of this.sectionOrder) {
+            const existingSection = this.sections[index];
+            if (!existingSection.array && array.length <= existingSection.length) {
+                // Found an existing section we can use
+                const remainderLength = existingSection.length - array.length;
+                existingSection.length = array.length;
+                existingSection.array = array;
+                if (remainderLength) {
+                    // Space left over, mark it as a "free" section
+                    const remainderSection = {
+                        start: existingSection.start + array.length,
+                        length: remainderLength,
+                        index: this.nextIndex++
+                    };
+                    if (remainderSection.start > this.allocatedLength) {
+                        console.log(`${remainderSection.start} > ${this.allocatedLength}!`);
+                    }
+                    this.sections[remainderSection.index] = remainderSection;
+                    this.sectionOrder.splice(this.sectionOrder.indexOf(index) + 1, 0, remainderSection.index);
+                    //console.log(`${this.key}: Added remainder section index ${remainderSection.index} to ${this.sectionOrder.join(", ")}`);
+                    this.joinEmptySections(remainderSection.index);
+                }
+                return existingSection;
+            }
+        }
+        // Couldn't find an existing section to use, allocate a new one,
+        // growing buffer to hold it if necessary
+        if (this.length - this.allocatedLength < array.length) {
+            this.growBuffer(array.length);
+        }
+        const newSection = {
+            start: this.allocatedLength,
+            length: array.length,
+            array,
+            index: this.nextIndex++
+        };
+        if (newSection.start > this.allocatedLength) {
+            console.log(`${newSection.start} > ${this.allocatedLength}!`);
+        }
+        this.allocatedLength += array.length;
+        this.sections[newSection.index] = newSection;
+        this.sectionOrder.push(newSection.index);
+        //console.log(`${this.key}: Add ${array.length} to end, allocated length ${this.allocatedLength}, section order: ${this.sectionOrder.join(", ")}`);
+
+        return newSection;
+    }
+
+    growBuffer(addedLength: number) {
+        // Growing the buffer requires re-copying all the individual arrays
+        // It compacts the layout and doubles the reserved size
+        let currentLength = 0;
+        for (const index in this.sections) {
+            currentLength += this.sections[index].length;
+        }
+        this.length = (currentLength + addedLength) * 2;
+
+        const gl = this.context.gl;
+        gl.bufferData(gl.ARRAY_BUFFER, this.length * this.itemSize, gl.DYNAMIC_DRAW);
+
+        this.allocatedLength = 0;
+        const newSectionOrder = [];
+        for (const index of this.sectionOrder) {
+            const section = this.sections[index];
+            if (section.array) {
+                newSectionOrder.push(index);
+                section.start = this.allocatedLength;
+                gl.bufferSubData(gl.ARRAY_BUFFER, this.allocatedLength * this.itemSize, section.array.arrayBuffer);
+                this.allocatedLength += section.length;
+                //console.log(`${this.key}: Copied section ${index} of length ${section.length} (${section.array.length}), new allocated length ${this.allocatedLength}`);
+            } else {
+                //console.log(`${this.key}: Discarded section ${index}`);
+                delete this.sections[index];
+            }
+        }
+        this.sectionOrder = newSectionOrder;
+        //console.log(`${this.key}: Compacted section order: ${this.sectionOrder.join(", ")}`);
+    }
+
+    joinEmptySections(index: number) {
+        // Join adjacent empty sections
+        const section = this.sections[index];
+        const orderIndex = this.sectionOrder.indexOf(index);
+        const prevSectionIndex = orderIndex >= 1 ? this.sectionOrder[orderIndex - 1] : undefined;
+        const nextSectionIndex = orderIndex + 1 < this.sectionOrder.length ? this.sectionOrder[orderIndex + 1] : undefined;
+        const prevSection = prevSectionIndex ? this.sections[prevSectionIndex] : undefined;
+        const nextSection = nextSectionIndex ? this.sections[nextSectionIndex] : undefined;
+        if (prevSectionIndex && !prevSection.array && nextSectionIndex && !nextSection.array) {
+            section.start -= prevSection.length;
+            section.length += prevSection.length + nextSection.length;
+            delete this.sections[prevSectionIndex];
+            delete this.sections[nextSectionIndex];
+            this.sectionOrder.splice(orderIndex - 1, 3, index);
+            //console.log(`${this.key}: Deleted prev ${prevSectionIndex} and next ${nextSectionIndex}, leaving ${this.sectionOrder.join(", ")}`);
+        } else if (prevSectionIndex && !prevSection.array) {
+            section.start -= prevSection.length;
+            section.length += prevSection.length;
+            delete this.sections[prevSectionIndex];
+            this.sectionOrder.splice(orderIndex - 1, 1);
+            //console.log(`${this.key}: Deleted prev ${prevSectionIndex}, leaving ${this.sectionOrder.join(", ")}`);
+        } else if (nextSectionIndex && !nextSection.array) {
+            section.length += nextSection.length;
+            delete this.sections[nextSectionIndex];
+            this.sectionOrder.splice(orderIndex + 1, 1);
+            //console.log(`${this.key}: Deleted next ${nextSectionIndex}, leaving ${this.sectionOrder.join(", ")}`);
+        }
+
+        if (!nextSection) {
+            // If the section is at the end of the list, merge with the
+            // unallocated space.
+            if (nextSectionIndex) {
+                console.log("Next section index but no section??");
+            }
+            this.allocatedLength -= section.length;
+            //console.log(`${this.key}: Delete ${section.length} from end, allocated length ${this.allocatedLength}`);
+            this.sectionOrder.pop();
+            delete this.sections[index];
+            //console.log(`${this.key}: Deleted ${index} from end of list, leaving ${this.sectionOrder.join(", ")}`);
+        }
+    }
+
+    removeSection(index: number) {
+        // We don't actually remove the data from the uploaded buffer
+        // We just mark the space available for future adds
+        const section = this.sections[index];
+        if (!section) {
+            return;
+        }
+        section.array = undefined;
+        //console.log(`Removing section ${index}`);
+        this.joinEmptySections(index);
+        this.testContinuity();
+    }
+
+    buildIndexPositions(segments: SegmentVector) {
+        const indexPositions = [];
+        const dummyLayoutVertexArray = { length: 0 };
+        const dummyIndexArray = { length: 0 };
+        for (const index of this.sectionOrder) {
+            const section = this.sections[index];
+            if (!section.array) {
+                const segment = segments.prepareSegment(section.length, dummyLayoutVertexArray, dummyIndexArray);
+                dummyLayoutVertexArray.length += section.length;
+                segment.vertexLength += section.length;
+                continue;
+            }
+            for (let i = 0; i < section.array.length * 4; i += 16) {
+                const segment = segments.prepareSegment(4, dummyLayoutVertexArray, dummyIndexArray);
+                const index = segment.vertexLength;
+                dummyLayoutVertexArray.length += 4;
+                dummyIndexArray.length += 2;
+
+                // TODO: this is a poor-man's low precision, no rotation y-sort
+                const y = section.array.uint16[i + 1];
+
+                indexPositions.push({ y, index });
+
+                segment.vertexLength += 4;
+                segment.primitiveLength += 2; // Is it OK that we add these later?
+            }
+        }
+
+        return indexPositions;
+    }
+
+    testContinuity() {
+        // let start = 0;
+        // for (const index of this.sectionOrder) {
+        //     const section = this.sections[index];
+        //     if (section.start !== start) {
+        //         console.log("continuity break!");
+        //     }
+        //     start += section.length;
+        // }
+    }
+
+    updateData(array: StructArray) {
+        assert(array.length === this.length);
+        const gl = this.context.gl;
+        this.bind();
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, array.arrayBuffer);
+    }
+
+    enableAttributes(gl: WebGLRenderingContext, program: Program<*>) {
+        for (let j = 0; j < this.attributes.length; j++) {
+            const member = this.attributes[j];
+            const attribIndex: number | void = program.attributes[member.name];
+            if (attribIndex !== undefined) {
+                gl.enableVertexAttribArray(attribIndex);
+            }
+        }
+    }
+
+    /**
+     * Set the attribute pointers in a WebGL context
+     * @param gl The WebGL context
+     * @param program The active WebGL program
+     * @param vertexOffset Index of the starting vertex of the segment
+     */
+    setVertexAttribPointers(gl: WebGLRenderingContext, program: Program<*>, vertexOffset: ?number) {
+        for (let j = 0; j < this.attributes.length; j++) {
+            const member = this.attributes[j];
+            const attribIndex: number | void = program.attributes[member.name];
+
+            if (attribIndex !== undefined) {
+                gl.vertexAttribPointer(
+                    attribIndex,
+                    member.components,
+                    (gl: any)[AttributeType[member.type]],
+                    false,
+                    this.itemSize,
+                    member.offset + (this.itemSize * (vertexOffset || 0))
+                );
+            }
+        }
+    }
+
+    /**
+     * Destroy the GL buffer bound to the given WebGL context
+     */
+    destroy() {
+        const gl = this.context.gl;
+        if (this.buffer) {
+            gl.deleteBuffer(this.buffer);
+            delete this.buffer;
+        }
+    }
+}
+
+export default GlobalVertexBuffer;

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -8,12 +8,10 @@ import { circleUniformValues } from './program/circle_program';
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
 import type CircleStyleLayer from '../style/style_layer/circle_style_layer';
-import type GlobalCircleBucket from '../data/bucket/global_circle_bucket';
-import type {OverscaledTileID} from '../source/tile_id';
 
 export default drawCircles;
 
-function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>) {
+function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer) {
     if (painter.renderPass !== 'translucent') return;
 
     const opacity = layer.paint.get('circle-opacity');

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -452,6 +452,21 @@ class Painter {
         return translatedMatrix;
     }
 
+    relativeToEyeMatrix(wrap: number, translate: [number, number], translateAnchor: 'map' | 'viewport'): Float32Array {
+        const angle = translateAnchor === 'viewport' ? -this.transform.angle : 0;
+
+        if (angle) {
+            const sinA = Math.sin(angle);
+            const cosA = Math.cos(angle);
+            translate = [
+                translate[0] * cosA - translate[1] * sinA,
+                translate[0] * sinA + translate[1] * cosA
+            ];
+        }
+
+        return this.transform.relativeToEyeMatrix(wrap, translate);
+    }
+
     saveTileTexture(texture: Texture) {
         const textures = this._tileTextures[texture.size[0]];
         if (!textures) {

--- a/src/render/program/circle_program.js
+++ b/src/render/program/circle_program.js
@@ -4,14 +4,12 @@ import {
     Uniform1i,
     Uniform1f,
     Uniform2f,
+    Uniform4f,
     UniformMatrix4f
 } from '../uniform_binding';
-import pixelsToTileUnits from '../../source/pixels_to_tile_units';
 
 import type Context from '../../gl/context';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
-import type {OverscaledTileID} from '../../source/tile_id';
-import type Tile from '../../source/tile';
 import type CircleStyleLayer from '../../style/style_layer/circle_style_layer';
 import type Painter from '../painter';
 
@@ -20,7 +18,8 @@ export type CircleUniformsType = {|
     'u_scale_with_map': Uniform1i,
     'u_pitch_with_map': Uniform1i,
     'u_extrude_scale': Uniform2f,
-    'u_matrix': UniformMatrix4f
+    'u_matrix': UniformMatrix4f,
+    'u_center_pos': Uniform4f
 |};
 
 const circleUniforms = (context: Context, locations: UniformLocations): CircleUniformsType => ({
@@ -28,20 +27,20 @@ const circleUniforms = (context: Context, locations: UniformLocations): CircleUn
     'u_scale_with_map': new Uniform1i(context, locations.u_scale_with_map),
     'u_pitch_with_map': new Uniform1i(context, locations.u_pitch_with_map),
     'u_extrude_scale': new Uniform2f(context, locations.u_extrude_scale),
-    'u_matrix': new UniformMatrix4f(context, locations.u_matrix)
+    'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
+    'u_center_pos': new Uniform4f(context, locations.u_center_pos)
 });
 
 const circleUniformValues = (
     painter: Painter,
-    coord: OverscaledTileID,
-    tile: Tile,
+    wrap: number,
     layer: CircleStyleLayer
 ): UniformValues<CircleUniformsType> => {
     const transform = painter.transform;
 
     let pitchWithMap: boolean, extrudeScale: [number, number];
     if (layer.paint.get('circle-pitch-alignment') === 'map') {
-        const pixelRatio = pixelsToTileUnits(tile, 1, transform.zoom);
+    const pixelRatio = transform.globalPixelRatio();
         pitchWithMap = true;
         extrudeScale = [pixelRatio, pixelRatio];
     } else {
@@ -49,16 +48,18 @@ const circleUniformValues = (
         extrudeScale = transform.pixelsToGLUnits;
     }
 
+    const matrix = painter.relativeToEyeMatrix(
+        wrap,
+        layer.paint.get('circle-translate'),
+        layer.paint.get('circle-translate-anchor'));
+
     return {
         'u_camera_to_center_distance': transform.cameraToCenterDistance,
         'u_scale_with_map': +(layer.paint.get('circle-pitch-scale') === 'map'),
-        'u_matrix': painter.translatePosMatrix(
-            coord.posMatrix,
-            tile,
-            layer.paint.get('circle-translate'),
-            layer.paint.get('circle-translate-anchor')),
+        'u_matrix': matrix,
         'u_pitch_with_map': +(pitchWithMap),
-        'u_extrude_scale': extrudeScale
+        'u_extrude_scale': extrudeScale,
+        'u_center_pos': transform.globalCenterPos
     };
 };
 

--- a/src/render/program/circle_program.js
+++ b/src/render/program/circle_program.js
@@ -40,7 +40,7 @@ const circleUniformValues = (
 
     let pitchWithMap: boolean, extrudeScale: [number, number];
     if (layer.paint.get('circle-pitch-alignment') === 'map') {
-    const pixelRatio = transform.globalPixelRatio();
+        const pixelRatio = transform.globalPixelRatio();
         pitchWithMap = true;
         extrudeScale = [pixelRatio, pixelRatio];
     } else {

--- a/src/shaders/circle.vertex.glsl
+++ b/src/shaders/circle.vertex.glsl
@@ -3,8 +3,9 @@ uniform bool u_scale_with_map;
 uniform bool u_pitch_with_map;
 uniform vec2 u_extrude_scale;
 uniform highp float u_camera_to_center_distance;
+uniform vec4 u_center_pos;
 
-attribute vec2 a_pos;
+attribute vec4 a_pos;
 
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define mediump float radius
@@ -26,26 +27,25 @@ void main(void) {
     #pragma mapbox: initialize lowp float stroke_opacity
 
     // unencode the extrusion vector that we snuck into the a_pos vector
-    vec2 extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
+    vec2 extrude = vec2(mod(a_pos.zw, 2.0) * 2.0 - 1.0);
+    vec2 pos_low = floor(a_pos.zw * 0.5);
+    vec2 pos_relative_to_center = (a_pos.xy - u_center_pos.xy) * pow(2.0, 15.0) + (pos_low - u_center_pos.zw);
 
-    // multiply a_pos by 0.5, since we had it * 2 in order to sneak
-    // in extrusion data
-    vec2 circle_center = floor(a_pos * 0.5);
     if (u_pitch_with_map) {
-        vec2 corner_position = circle_center;
+        vec2 corner_position = pos_relative_to_center;
         if (u_scale_with_map) {
             corner_position += extrude * (radius + stroke_width) * u_extrude_scale;
         } else {
             // Pitching the circle with the map effectively scales it with the map
             // To counteract the effect for pitch-scale: viewport, we rescale the
             // whole circle based on the pitch scaling effect at its central point
-            vec4 projected_center = u_matrix * vec4(circle_center, 0, 1);
+            vec4 projected_center = u_matrix * vec4(pos_relative_to_center, 0, 1);
             corner_position += extrude * (radius + stroke_width) * u_extrude_scale * (projected_center.w / u_camera_to_center_distance);
         }
 
         gl_Position = u_matrix * vec4(corner_position, 0, 1);
     } else {
-        gl_Position = u_matrix * vec4(circle_center, 0, 1);
+        gl_Position = u_matrix * vec4(pos_relative_to_center, 0, 1);
 
         if (u_scale_with_map) {
             gl_Position.xy += extrude * (radius + stroke_width) * u_extrude_scale * u_camera_to_center_distance;

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -205,13 +205,13 @@ class SourceCache extends Evented {
                 }
             }
         }
-        for (const empty of emptyGlobalBuckets) {
-            // TODO: There are edge cases where this will cause us to discard
-            // tile buckets that are still in the source cache, because none
-            // of them are being rendered. Since they're already loaded, nothing
-            // gets re-added to the global bucket when they start rendering again.
-            //delete this._globalBuckets[empty.layer][empty.key];
-        }
+        // TODO: There are edge cases where this will cause us to discard
+        // tile buckets that are still in the source cache, because none
+        // of them are being rendered. Since they're already loaded, nothing
+        // gets re-added to the global bucket when they start rendering again.
+        // for (const empty of emptyGlobalBuckets) {
+        //     delete this._globalBuckets[empty.layer][empty.key];
+        // }
     }
 
     /**
@@ -303,7 +303,7 @@ class SourceCache extends Evented {
             // Only add to global bucket if we're still rendering this tile
             this._addToGlobalBuckets(tile);
         }
-        this._source.fire(new Event('data', {dataType: 'source', tile: tile, coord: tile.tileID}));
+        this._source.fire(new Event('data', {dataType: 'source', tile, coord: tile.tileID}));
     }
 
     _addToGlobalBuckets(tile: ?Tile) {
@@ -914,7 +914,7 @@ class SourceCache extends Evented {
         this._state.updateState(sourceLayer, feature, state);
         for (const layer in this._globalBuckets) {
             for (const key in this._globalBuckets[layer]) {
-                this._globalBuckets[layer][key].update(null, null);
+                this._globalBuckets[layer][key].update();
             }
         }
     }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -180,11 +180,13 @@ class SourceCache extends Evented {
             this._tiles[i].upload(context);
 
         }
+        const usedTiles = [];
         for (const tileID of this.getRenderableIds()) {
             const tile = this._tiles[tileID];
             for (const bucketId in tile.buckets) {
                 const bucket = tile.buckets[bucketId];
                 if (bucket instanceof CircleBucket) {
+                    usedTiles.push(tile.tileID.toString());
                     const bucketKey = bucket.zoom;
                     const leaderId = bucket.layerIds[0];
                     if (this._globalBuckets[leaderId] && this._globalBuckets[leaderId][bucketKey]) {
@@ -193,6 +195,7 @@ class SourceCache extends Evented {
                 }
             }
         }
+        //console.log(`Used tiles ${usedTiles.join(", ")}`);
         const emptyGlobalBuckets = [];
         for (const layer in this._globalBuckets) {
             for (const key in this._globalBuckets[layer]) {

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -298,7 +298,6 @@ class SourceCache extends Evented {
         if (this.getSource().type === 'raster-dem' && tile.dem) this._backfillDEM(tile);
         this._state.initializeTileState(tile, this.map ? this.map.painter : null);
 
-        this._source.fire(new Event('data', {dataType: 'source', tile, coord: tile.tileID}));
         if (this._tiles[id] && !tile.holdingForFade()) {
             // Only add to global bucket if we're still rendering this tile
             this._addToGlobalBuckets(tile);

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -116,7 +116,8 @@ class WorkerTile {
                     overscaling: this.overscaling,
                     collisionBoxArray: this.collisionBoxArray,
                     sourceLayerIndex,
-                    sourceID: this.source
+                    sourceID: this.source,
+                    tileID: this.tileID
                 });
 
                 bucket.populate(features, options);

--- a/src/style/query_utils.js
+++ b/src/style/query_utils.js
@@ -7,7 +7,7 @@ import type StyleLayer from '../style/style_layer';
 import type CircleBucket from '../data/bucket/circle_bucket';
 import type LineBucket from '../data/bucket/line_bucket';
 
-export function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: CircleBucket<*> | LineBucket): number {
+export function getMaximumPaintValue(property: string, layer: StyleLayer, bucket: CircleBucket | LineBucket): number {
     const value = ((layer.paint: any).get(property): PossiblyEvaluatedPropertyValue<any>).value;
     if (value.kind === 'constant') {
         return value.value;

--- a/src/style/style_layer/circle_style_layer.js
+++ b/src/style/style_layer/circle_style_layer.js
@@ -30,7 +30,7 @@ class CircleStyleLayer extends StyleLayer {
     }
 
     queryRadius(bucket: Bucket): number {
-        const circleBucket: CircleBucket<CircleStyleLayer> = (bucket: any);
+        const circleBucket: CircleBucket = (bucket: any);
         return getMaximumPaintValue('circle-radius', this, circleBucket) +
             getMaximumPaintValue('circle-stroke-width', this, circleBucket) +
             translateDistance(this.paint.get('circle-translate'));

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -140,7 +140,7 @@ class StructArray {
      * Resize the array to discard unused capacity.
      */
     _trim() {
-        if (this.length !== this.capacity) {
+        if (this.arrayBuffer && this.capacity > this.length) {
             this.capacity = this.length;
             this.arrayBuffer = this.arrayBuffer.slice(0, this.length * this.bytesPerElement);
             this._refreshViews();


### PR DESCRIPTION
WIP PR for prototyping work described in https://github.com/mapbox/mapbox-gl-js/issues/7449.

TODO:

- [x] Handle pitch, pitch-alignment, and pitch-scaling
- [x] Handle world-wrapping. Since circle layers don't change between wrapped versions of a tile, I'm thinking I can get away with just doing extra draw calls for whichever wrapped versions of the world are showing and apply a different translation matrix for each.
- [x] Initial merging into a single bucket: just concatenate all the individual buffers together, and upload them in their entirety on any changes.
- [ ] More performant bucket-merging? Come up with an allocation scheme for doing partial vertex buffer updates with `bufferSubData`. I'm not sure how hard dealing with fragmentation will be (and also how bad the performance implications will be if we have chunks of "unused" areas in the vertex buffer due to removed tiles/fragmentation).
- [ ] Implement an index-buffer based sorting mechanism for circles, similar to `SymbolBucket#sortFeatures`. We'll also have the limitation that sorting can only be done within a single segment (so ~16,384 circles). I don't think there's a good way around this unless we re-upload everything on every sort change?
- [ ] Get heatmap layer ported to new circle base layer, fix flow, tests, etc.

/cc @ansis 