### PR TITLE
Limit parallel image requests for raster performance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ const exported = {
      * mapboxgl.accessToken = myAccessToken;
      * @see [Display a map](https://www.mapbox.com/mapbox-gl-js/examples/)
      */
-    get accessToken() {
+    get accessToken(): string {
         return config.ACCESS_TOKEN;
     },
 
@@ -56,12 +56,20 @@ const exported = {
         config.ACCESS_TOKEN = token;
     },
 
-    get workerCount() {
+    get workerCount(): number {
         return WorkerPool.workerCount;
     },
 
     set workerCount(count: number) {
         WorkerPool.workerCount = count;
+    },
+
+    get maxParallelImageRequests(): number {
+        return config.MAX_PARALLEL_IMAGE_REQUESTS;
+    },
+
+    set maxParallelImageRequests(numRequests: number) {
+        config.MAX_PARALLEL_IMAGE_REQUESTS = numRequests;
     },
 
     workerUrl: ''

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ const exported = {
      * mapboxgl.accessToken = myAccessToken;
      * @see [Display a map](https://www.mapbox.com/mapbox-gl-js/examples/)
      */
-    get accessToken(): string {
+    get accessToken(): ?string {
         return config.ACCESS_TOKEN;
     },
 

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -4,7 +4,8 @@ type Config = {|
   API_URL: string,
   EVENTS_URL: string,
   REQUIRE_ACCESS_TOKEN: boolean,
-  ACCESS_TOKEN: ?string
+  ACCESS_TOKEN: ?string,
+  MAX_PARALLEL_IMAGE_REQUESTS: number
 |};
 
 const config: Config = {
@@ -17,7 +18,8 @@ const config: Config = {
         }
     },
     REQUIRE_ACCESS_TOKEN: true,
-    ACCESS_TOKEN: null
+    ACCESS_TOKEN: null,
+    MAX_PARALLEL_IMAGE_REQUESTS: 16
 };
 
 export default config;

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -2,9 +2,11 @@ import { test } from 'mapbox-gl-js-test';
 import {
     getArrayBuffer,
     getJSON,
-    postData
+    postData,
+    getImage
 } from '../../../src/util/ajax';
 import window from '../../../src/util/window';
+import config from '../../../src/util/config';
 
 test('ajax', (t) => {
     t.beforeEach(callback => {
@@ -95,6 +97,35 @@ test('ajax', (t) => {
             t.end();
         });
         window.server.respond();
+    });
+
+    t.test('getImage respects maxParallelImageRequests', (t) => {
+        window.server.respondWith(request => request.respond(200, {'Content-Type': 'image/png'}, ''));
+
+        const maxRequests = config.MAX_PARALLEL_IMAGE_REQUESTS;
+
+        // jsdom doesn't call image onload; fake it https://github.com/jsdom/jsdom/issues/1816
+        const jsdomImage = window.Image;
+        window.Image = class {
+            set src(src) {
+                setTimeout(() => this.onload());
+            }
+        };
+
+        function callback(err) {
+            if (err) return;
+            // last request is only added after we got a response from one of the previous ones
+            t.equals(window.server.requests.length, maxRequests + 1);
+            window.Image = jsdomImage;
+            t.end();
+        }
+
+        for (let i = 0; i < maxRequests + 1; i++) {
+            getImage({url: ''}, callback);
+        }
+        t.equals(window.server.requests.length, maxRequests);
+
+        window.server.requests[0].respond();
     });
 
     t.end();


### PR DESCRIPTION
Fixes #7460, improving raster sources performance on big screens by setting a global limit on how many image requests can happen in parallel, and queueing all the rest.

Similarly to `workerCount`, the PR exposes the limit as `mapboxgl.maxParallelImageRequests` which you can change (`16` by default).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~ (probably not worth publicly documenting?)
 - [ ] ~~post benchmark scores~~ benchmarks don't exercise big-screen tile loading
 - [x] manually test the debug page
