### PR TITLE
 Add support for LngLat conversion from {lat, lon}. Fixes #7090

### DIFF
--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -92,11 +92,12 @@ class LngLat {
     }
 
     /**
-     * Converts an array of two numbers to a `LngLat` object.
+     * Converts an array of two numbers or an object with `lng` and `lat` or `lon` and `lat` properties
+     * to a `LngLat` object.
      *
      * If a `LngLat` object is passed in, the function returns it unchanged.
      *
-     * @param {LngLatLike} input An array of two numbers to convert, or a `LngLat` object to return.
+     * @param {LngLatLike} input An array of two numbers or object to convert, or a `LngLat` object to return.
      * @returns {LngLat} A new `LngLat` object, if a conversion occurred, or the original `LngLat` object.
      * @example
      * var arr = [-73.9749, 40.7736];

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -111,21 +111,26 @@ class LngLat {
             return new LngLat(Number(input[0]), Number(input[1]));
         }
         if (!Array.isArray(input) && typeof input === 'object' && input !== null) {
-            return new LngLat(Number(input.lng), Number(input.lat));
+            return new LngLat(
+                // flow can't refine this to have one of lng or lat, so we have to cast to any
+                Number('lng' in input ? (input: any).lng : (input: any).lon),
+                Number(input.lat)
+            );
         }
-        throw new Error("`LngLatLike` argument must be specified as a LngLat instance, an object {lng: <lng>, lat: <lat>}, or an array of [<lng>, <lat>]");
+        throw new Error("`LngLatLike` argument must be specified as a LngLat instance, an object {lng: <lng>, lat: <lat>}, an object {lon: <lng>, lat: <lat>}, or an array of [<lng>, <lat>]");
     }
 }
 
 /**
  * A {@link LngLat} object, an array of two numbers representing longitude and latitude,
- * or an object with `lng` and `lat` properties.
+ * or an object with `lng` and `lat` or `lon` and `lat` properties.
  *
- * @typedef {LngLat | {lng: number, lat: number} | [number, number]} LngLatLike
+ * @typedef {LngLat | {lng: number, lat: number} | {lon: number, lat: number} | [number, number]} LngLatLike
  * @example
  * var v1 = new mapboxgl.LngLat(-122.420679, 37.772537);
  * var v2 = [-122.420679, 37.772537];
+ * var v3 = {lon: -122.420679, lat: 37.772537};
  */
-export type LngLatLike = LngLat | {lng: number, lat: number} | [number, number];
+export type LngLatLike = LngLat | {lng: number, lat: number} | {lon: number, lat: number} | [number, number];
 
 export default LngLat;

--- a/test/unit/geo/lng_lat.test.js
+++ b/test/unit/geo/lng_lat.test.js
@@ -28,10 +28,13 @@ test('LngLat', (t) => {
         t.ok(LngLat.convert({lng: 0, lat: 10}) instanceof LngLat, 'convert creates a LngLat instance');
         t.ok(LngLat.convert({lng: 0, lat: 0}) instanceof LngLat, 'convert creates a LngLat instance');
         t.ok(LngLat.convert({lng: 0, lat: 0, elev: 0}) instanceof LngLat, 'convert creates a LngLat instance');
+        t.ok(LngLat.convert({lon: 0, lat: 10}) instanceof LngLat, 'convert creates a LngLat instance');
+        t.ok(LngLat.convert({lon: 0, lat: 0}) instanceof LngLat, 'convert creates a LngLat instance');
+        t.ok(LngLat.convert({lon: 0, lat: 0, elev: 0}) instanceof LngLat, 'convert creates a LngLat instance');
         t.ok(LngLat.convert(new LngLat(0, 0)) instanceof LngLat, 'convert creates a LngLat instance');
         t.throws(() => {
             LngLat.convert(0, 10);
-        }, "`LngLatLike` argument must be specified as a LngLat instance, an object {lng: <lng>, lat: <lat>}, or an array of [<lng>, <lat>]", 'detects and throws on invalid input');
+        }, "`LngLatLike` argument must be specified as a LngLat instance, an object {lng: <lng>, lat: <lat>}, an object {lon: <lng>, lat: <lat>}, or an array of [<lng>, <lat>]", 'detects and throws on invalid input');
         t.end();
     });
 


### PR DESCRIPTION
This pull request adds support for converting from `{lon: number; lat: number}` objects to `LngLat.convert`, as discussed in #7090.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
