### PR TITLE
Stub local and session storage in JSDOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "gl": "^4.0.1",
     "glob": "^7.0.3",
     "is-builtin-module": "^1.0.0",
-    "jsdom": "11.11.0",
+    "jsdom": "^11.11.0",
     "json-stringify-pretty-compact": "^1.0.4",
     "jsonwebtoken": "^8.3.0",
     "mock-geolocation": "^1.0.11",

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -43,7 +43,7 @@ function restore(): Window {
     // See https://github.com/mapbox/mapbox-gl-js/pull/7455 for discussion
     delete window.localStorage;
     delete window.sessionStorage;
-    window.localStorage = window.sessionStorage = () => console.log('local and session storage not available in Node');
+    window.localStorage = window.sessionStorage = () => console.log('Local and session storage not available in Node. Use a stub implementation if needed for testing.');
 
     window.devicePixelRatio = 1;
 

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -38,11 +38,12 @@ function restore(): Window {
         virtualConsole: new jsdom.VirtualConsole().sendTo(console)
     });
 
-    // Delete local and session storage from JSDOM
+    // Delete local and session storage from JSDOM and stub them out with a warning log
     // Accessing these properties during extend() produces an error in Node environments
     // See https://github.com/mapbox/mapbox-gl-js/pull/7455 for discussion
     delete window.localStorage;
     delete window.sessionStorage;
+    window.localStorage = window.sessionStorage = () => console.log('local and session storage not available in Node');
 
     window.devicePixelRatio = 1;
 

--- a/src/util/window.js
+++ b/src/util/window.js
@@ -38,6 +38,12 @@ function restore(): Window {
         virtualConsole: new jsdom.VirtualConsole().sendTo(console)
     });
 
+    // Delete local and session storage from JSDOM
+    // Accessing these properties during extend() produces an error in Node environments
+    // See https://github.com/mapbox/mapbox-gl-js/pull/7455 for discussion
+    delete window.localStorage;
+    delete window.sessionStorage;
+
     window.devicePixelRatio = 1;
 
     window.requestAnimationFrame = function(callback) {


### PR DESCRIPTION
## Launch Checklist

This replaces https://github.com/mapbox/mapbox-gl-js/pull/7455

JSDOM 11.12 introduced the `localStorage` API. Our codebase copies properties from one JSDOM instance to another which worked fine but when accessing `localStorage` in a Node context where the JSDOM's base URL is not set, an error is thrown. `localStorage` is not used in our tests (we stub it out in a couple of places) so I think this is probably an acceptable workaround. Setting the JSDOM's base URL can cause issues with some tests and creates potential CORS errors that makes testing a pain.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

Tip of the 🎩 to @fc for reporting the original bug and helping figure out what exactly was going wrong.