### PR TITLE
make yarn test-unit command more cross-platform

### DIFF
--- a/build/run-tap
+++ b/build/run-tap
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [ "$#" == 5 ]; then
-  arg="${@:0:4} ${BASH_ARGV[1]}/${BASH_ARGV[0]}"
+  arg="${@:1:3} ${4}/${5}"
 else
   arg="${@}"
 fi


### PR DESCRIPTION
The first variable is the script name. Don't pass the script name as
argument. If we pass the script name as argument the command hangs with:

  Reading TAP data from stdin (use "-" argument to suppress)

Don't pass the fourth argument ("test/unit") to the tap script.
Otherwise we execute all test scripts in "test/unit".

The shell sets BASH_ARGV only when in extended debugging mode. Use the
argument indices to access them. This increases readability too.

## Launch Checklist

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality

What about test-build? It uses run-tap too. Calling test-build fails in my environment. I guess I have trigger an actual build first.