### PR TITLE
Bump version to 0.51.0-beta.2 to accommodate yarn.lock update.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "0.51.0-beta.1",
+  "version": "0.51.0-beta.2",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
cc @asheemmamoowala @ryanhamley 