### PR TITLE
Allow user to define element other than map container for full screen control

### DIFF
--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -7,26 +7,36 @@ import window from '../../util/window';
 
 import type Map from '../map';
 
+type Options = {
+    source?: HTMLElement
+};
+
 /**
  * A `FullscreenControl` control contains a button for toggling the map in and out of fullscreen mode.
  *
  * @implements {IControl}
+ * @param {Object} [options]
+ * @param {HTMLElement} [options.source] `source` is the [compatible DOM element](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen#Compatible_elements) which should be made full screen. By default, the map container element will be made full screen.
+ *
  * @example
- * map.addControl(new mapboxgl.FullscreenControl());
+ * map.addControl(new mapboxgl.FullscreenControl({source: document.querySelector('body')}));
  * @see [View a fullscreen map](https://www.mapbox.com/mapbox-gl-js/example/fullscreen/)
  */
 
 class FullscreenControl {
     _map: Map;
-    _mapContainer: HTMLElement;
     _container: HTMLElement;
     _fullscreen: boolean;
     _fullscreenchange: string;
     _fullscreenButton: HTMLElement;
     _className: string;
+    _source: HTMLElement;
 
-    constructor() {
+    constructor(options: Options) {
         this._fullscreen = false;
+        if (options && options.source) {
+            this._source = options.source;
+        }
         bindAll([
             '_onClickFullscreen',
             '_changeIcon'
@@ -45,7 +55,7 @@ class FullscreenControl {
 
     onAdd(map: Map) {
         this._map = map;
-        this._mapContainer = this._map.getContainer();
+        if (!this._source) this._source = this._map.getContainer();
         this._container = DOM.create('div', `${this._className} mapboxgl-ctrl-group`);
         if (this._checkFullscreenSupport()) {
             this._setupUI();
@@ -90,7 +100,7 @@ class FullscreenControl {
             (window.document: any).webkitFullscreenElement ||
             (window.document: any).msFullscreenElement;
 
-        if ((fullscreenElement === this._mapContainer) !== this._fullscreen) {
+        if ((fullscreenElement === this._source) !== this._fullscreen) {
             this._fullscreen = !this._fullscreen;
             this._fullscreenButton.classList.toggle(`${this._className}-shrink`);
             this._fullscreenButton.classList.toggle(`${this._className}-fullscreen`);
@@ -108,14 +118,14 @@ class FullscreenControl {
             } else if (window.document.webkitCancelFullScreen) {
                 (window.document: any).webkitCancelFullScreen();
             }
-        } else if (this._mapContainer.requestFullscreen) {
-            this._mapContainer.requestFullscreen();
-        } else if ((this._mapContainer: any).mozRequestFullScreen) {
-            (this._mapContainer: any).mozRequestFullScreen();
-        } else if ((this._mapContainer: any).msRequestFullscreen) {
-            (this._mapContainer: any).msRequestFullscreen();
-        } else if ((this._mapContainer: any).webkitRequestFullscreen) {
-            (this._mapContainer: any).webkitRequestFullscreen();
+        } else if (this._source.requestFullscreen) {
+            this._source.requestFullscreen();
+        } else if ((this._source: any).mozRequestFullScreen) {
+            (this._source: any).mozRequestFullScreen();
+        } else if ((this._source: any).msRequestFullscreen) {
+            (this._source: any).msRequestFullscreen();
+        } else if ((this._source: any).webkitRequestFullscreen) {
+            (this._source: any).webkitRequestFullscreen();
         }
     }
 }

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -35,7 +35,7 @@ class FullscreenControl {
     constructor(options: Options) {
         this._fullscreen = false;
         if (options && options.container) {
-            if (options.container instanceof HTMLElement) {
+            if (options.container instanceof window.HTMLElement) {
                 this._container = options.container;
             } else {
                 warnOnce('Full screen control \'container\' must be a DOM element.');

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -8,7 +8,7 @@ import window from '../../util/window';
 import type Map from '../map';
 
 type Options = {
-    source?: HTMLElement
+    container?: HTMLElement
 };
 
 /**
@@ -16,29 +16,29 @@ type Options = {
  *
  * @implements {IControl}
  * @param {Object} [options]
- * @param {HTMLElement} [options.source] `source` is the [compatible DOM element](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen#Compatible_elements) which should be made full screen. By default, the map container element will be made full screen.
+ * @param {HTMLElement} [options.container] `container` is the [compatible DOM element](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen#Compatible_elements) which should be made full screen. By default, the map container element will be made full screen.
  *
  * @example
- * map.addControl(new mapboxgl.FullscreenControl({source: document.querySelector('body')}));
+ * map.addControl(new mapboxgl.FullscreenControl({container: document.querySelector('body')}));
  * @see [View a fullscreen map](https://www.mapbox.com/mapbox-gl-js/example/fullscreen/)
  */
 
 class FullscreenControl {
     _map: Map;
-    _container: HTMLElement;
+    _controlContainer: HTMLElement;
     _fullscreen: boolean;
     _fullscreenchange: string;
     _fullscreenButton: HTMLElement;
     _className: string;
-    _source: HTMLElement;
+    _container: HTMLElement;
 
     constructor(options: Options) {
         this._fullscreen = false;
-        if (options && options.source) {
-            if (options.source instanceof HTMLElement) {
-                this._source = options.source;
+        if (options && options.container) {
+            if (options.container instanceof HTMLElement) {
+                this._container = options.container;
             } else {
-                warnOnce('Full screen control \'source\' must be a DOM element.');
+                warnOnce('Full screen control \'container\' must be a DOM element.');
             }
         }
         bindAll([
@@ -59,19 +59,19 @@ class FullscreenControl {
 
     onAdd(map: Map) {
         this._map = map;
-        if (!this._source) this._source = this._map.getContainer();
-        this._container = DOM.create('div', `${this._className} mapboxgl-ctrl-group`);
+        if (!this._container) this._container = this._map.getContainer();
+        this._controlContainer = DOM.create('div', `${this._className} mapboxgl-ctrl-group`);
         if (this._checkFullscreenSupport()) {
             this._setupUI();
         } else {
-            this._container.style.display = 'none';
+            this._controlContainer.style.display = 'none';
             warnOnce('This device does not support fullscreen mode.');
         }
-        return this._container;
+        return this._controlContainer;
     }
 
     onRemove() {
-        DOM.remove(this._container);
+        DOM.remove(this._controlContainer);
         this._map = (null: any);
         window.document.removeEventListener(this._fullscreenchange, this._changeIcon);
     }
@@ -86,7 +86,7 @@ class FullscreenControl {
     }
 
     _setupUI() {
-        const button = this._fullscreenButton = DOM.create('button', (`${this._className}-icon ${this._className}-fullscreen`), this._container);
+        const button = this._fullscreenButton = DOM.create('button', (`${this._className}-icon ${this._className}-fullscreen`), this._controlContainer);
         button.setAttribute("aria-label", "Toggle fullscreen");
         button.type = 'button';
         this._fullscreenButton.addEventListener('click', this._onClickFullscreen);
@@ -104,7 +104,7 @@ class FullscreenControl {
             (window.document: any).webkitFullscreenElement ||
             (window.document: any).msFullscreenElement;
 
-        if ((fullscreenElement === this._source) !== this._fullscreen) {
+        if ((fullscreenElement === this._container) !== this._fullscreen) {
             this._fullscreen = !this._fullscreen;
             this._fullscreenButton.classList.toggle(`${this._className}-shrink`);
             this._fullscreenButton.classList.toggle(`${this._className}-fullscreen`);
@@ -122,14 +122,14 @@ class FullscreenControl {
             } else if (window.document.webkitCancelFullScreen) {
                 (window.document: any).webkitCancelFullScreen();
             }
-        } else if (this._source.requestFullscreen) {
-            this._source.requestFullscreen();
-        } else if ((this._source: any).mozRequestFullScreen) {
-            (this._source: any).mozRequestFullScreen();
-        } else if ((this._source: any).msRequestFullscreen) {
-            (this._source: any).msRequestFullscreen();
-        } else if ((this._source: any).webkitRequestFullscreen) {
-            (this._source: any).webkitRequestFullscreen();
+        } else if (this._container.requestFullscreen) {
+            this._container.requestFullscreen();
+        } else if ((this._container: any).mozRequestFullScreen) {
+            (this._container: any).mozRequestFullScreen();
+        } else if ((this._container: any).msRequestFullscreen) {
+            (this._container: any).msRequestFullscreen();
+        } else if ((this._container: any).webkitRequestFullscreen) {
+            (this._container: any).webkitRequestFullscreen();
         }
     }
 }

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -35,7 +35,11 @@ class FullscreenControl {
     constructor(options: Options) {
         this._fullscreen = false;
         if (options && options.source) {
-            this._source = options.source;
+            if (options.source instanceof HTMLElement) {
+                this._source = options.source;
+            } else {
+                warnOnce('Full screen control \'source\' must be a DOM element.');
+            }
         }
         bindAll([
             '_onClickFullscreen',

--- a/test/unit/ui/control/fullscreen.test.js
+++ b/test/unit/ui/control/fullscreen.test.js
@@ -27,3 +27,14 @@ test('FullscreenControl does not appears when fullscreen is not enabled', (t) =>
     t.equal(consoleWarn.getCall(0).args[0], 'This device does not support fullscreen mode.');
     t.end();
 });
+
+test('FullscreenControl works with source element other than map container', (t) => {
+    window.document.fullscreenEnabled = true;
+
+    const map = createMap(t);
+    const fullscreen = new FullscreenControl({source: 'body'});
+    map.addControl(fullscreen);
+
+    t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-fullscreen').length, 1);
+    t.end();
+});

--- a/test/unit/ui/control/fullscreen.test.js
+++ b/test/unit/ui/control/fullscreen.test.js
@@ -14,7 +14,7 @@ test('FullscreenControl appears when fullscreen is enabled', (t) => {
     t.end();
 });
 
-test('FullscreenControl does not appears when fullscreen is not enabled', (t) => {
+test('FullscreenControl does not appear when fullscreen is not enabled', (t) => {
     window.document.fullscreenEnabled = false;
 
     const consoleWarn = t.stub(console, 'warn');
@@ -25,16 +25,5 @@ test('FullscreenControl does not appears when fullscreen is not enabled', (t) =>
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-fullscreen').length, 0);
     t.equal(consoleWarn.getCall(0).args[0], 'This device does not support fullscreen mode.');
-    t.end();
-});
-
-test('FullscreenControl works with source element other than map container', (t) => {
-    window.document.fullscreenEnabled = true;
-
-    const map = createMap(t);
-    const fullscreen = new FullscreenControl({source: 'body'});
-    map.addControl(fullscreen);
-
-    t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-fullscreen').length, 1);
     t.end();
 });

--- a/test/unit/ui/control/fullscreen.test.js
+++ b/test/unit/ui/control/fullscreen.test.js
@@ -27,3 +27,18 @@ test('FullscreenControl does not appear when fullscreen is not enabled', (t) => 
     t.equal(consoleWarn.getCall(0).args[0], 'This device does not support fullscreen mode.');
     t.end();
 });
+
+test('FullscreenControl makes optional container element full screen', (t) => {
+    window.document.fullscreenEnabled = true;
+
+    const map = createMap(t);
+    const fullscreen = new FullscreenControl({container: window.document.querySelector('body')});
+    map.addControl(fullscreen);
+    const control = map._controls.find((ctrl) => {
+        return ctrl.hasOwnProperty('_fullscreen');
+    });
+    control._onClickFullscreen();
+
+    t.equal(control._container.tagName, 'BODY');
+    t.end();
+});


### PR DESCRIPTION
fixes https://github.com/mapbox/mapbox-gl-js/issues/7544

## Launch Checklist

The intended use case is for displaying a map with an overlaid element that works with the map, such as radio buttons to toggle styles or a banner element with a legend. The current behavior of making the map container element full screen will not show these elements. I can't really think of any particular reason to disallow this behavior but let me know if there's a reason not to implement this.

Full screen with `{source: body}`
![screen shot 2018-11-02 at 12 40 43 pm](https://user-images.githubusercontent.com/4523080/47937034-ca97a380-de9c-11e8-8fdb-b3bc948800b8.png)

Default behavior (notice that the debug control in the upper left corner is not displayed)
![screen shot 2018-11-02 at 12 42 00 pm](https://user-images.githubusercontent.com/4523080/47937036-ca97a380-de9c-11e8-9819-55e4c7a3e7ab.png)

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page

