### PR TITLE
update octokit

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@mapbox/flow-remove-types": "^1.3.0-await.upstream.1",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.0",
     "@mapbox/mapbox-gl-test-suite": "file:test/integration",
-    "@octokit/rest": "^15.9.5",
+    "@octokit/rest": "^15.15.1",
     "babel-eslint": "^10.0.1",
     "benchmark": "~2.1.0",
     "browserify": "^16.1.0",


### PR DESCRIPTION
to fix breaking change in createInstallationToken endpoint used in the size checker app


