### PR TITLE
Avoid unnecessary image decode.

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -79,7 +79,7 @@ class ImageSource extends Evented implements Source {
     dispatcher: Dispatcher;
     map: Map;
     texture: Texture | null;
-    image: ImageData;
+    image: HTMLImageElement;
     tileID: CanonicalTileID;
     _boundsArray: RasterBoundsArray;
     boundsBuffer: VertexBuffer;
@@ -114,7 +114,7 @@ class ImageSource extends Evented implements Source {
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (image) {
-                this.image = browser.getImageData(image);
+                this.image = image;
                 if (newCoordinates) {
                     this.coordinates = newCoordinates;
                 }

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -3,7 +3,6 @@
 import { CanonicalTileID } from './tile_id';
 import { Event, ErrorEvent, Evented } from '../util/evented';
 import { getImage, ResourceType } from '../util/ajax';
-import browser from '../util/browser';
 import EXTENT from '../data/extent';
 import { RasterBoundsArray } from '../data/array_types';
 import rasterBoundsAttributes from '../data/raster_bounds_attributes';


### PR DESCRIPTION
`image_source.js` unnecessarily decodes image data via JavaScript before creating a `Texture` from the image data.

The `Texture` class can handle a native `HTMLImageElement` directly and then the browser can decode the image much more quickly and with less memory.

For my use case, this results in about a 10-20% reduction in scripting time.
