### PR TITLE
fix shaky sprites on scrollZoom

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -33,6 +33,7 @@ class ScrollZoomHandler {
     _el: HTMLElement;
     _enabled: boolean;
     _active: boolean;
+    _zooming: boolean;
     _aroundCenter: boolean;
     _around: Point;
     _aroundPoint: Point;
@@ -78,10 +79,19 @@ class ScrollZoomHandler {
         return !!this._enabled;
     }
 
+    /*
+    * Active state is turned on and off with every scroll wheel event and is set back to false before the map
+    * render is called, so _active is not a good candidate for determining if a scroll zoom animation is in
+    * progress.
+    */
     isActive() {
         return !!this._active;
     }
 
+
+    isZooming() {
+        return !!this._zooming;
+    }
     /**
      * Enables the "scroll to zoom" interaction.
      *
@@ -182,6 +192,7 @@ class ScrollZoomHandler {
         }
 
         this._active = true;
+        this._zooming = true;
         this._map.fire(new Event('movestart', {originalEvent: e}));
         this._map.fire(new Event('zoomstart', {originalEvent: e}));
         if (this._finishTimeout) {
@@ -261,6 +272,7 @@ class ScrollZoomHandler {
         if (finished) {
             this._active = false;
             this._finishTimeout = setTimeout(() => {
+                this._zooming = false;
                 this._map.fire(new Event('zoomend', {originalEvent: this._lastWheelEvent}));
                 this._map.fire(new Event('moveend', {originalEvent: this._lastWheelEvent}));
                 delete this._targetZoom;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -644,7 +644,7 @@ class Map extends Camera {
      */
     isZooming(): boolean {
         return this._zooming ||
-            this.scrollZoom.isActive();
+            this.scrollZoom.isZooming();
     }
 
     /**


### PR DESCRIPTION
Sprites wiggle around on scroll zoom because map.isZooming() always returns false due to the order of operations in the render loop, because it checks `ScrollZoomHandler.isActive()` which is set back to false by the time it is called here

https://github.com/mapbox/mapbox-gl-js/blob/61ae8d29f1c4377463c8f411bfb1f1ad80c52074/src/ui/map.js#L1634

and `painter.options.zooming` is used to choose the texture filter 
https://github.com/mapbox/mapbox-gl-js/blob/e682aa65da789df11fe7e76dbc56ada33e6e56ab/src/render/draw_symbol.js#L111-L112

I don't have many good ideas on how to test this 😬
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
