### PR TITLE
Update style spec compatibility tables for Horchata

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -973,7 +973,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.49.0",
-          "ios": "4.5.0"
+          "ios": "4.5.0",
+          "macos": "0.12.0"
         },
         "data-driven styling": {}
       },
@@ -2566,7 +2567,10 @@
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.48.0"
+            "js": "0.48.0",
+            "android": "6.7.0",
+            "ios": "4.6.0",
+            "macos": "0.12.0"
           }
         }
       },

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -973,6 +973,7 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.49.0",
+          "android": "6.6.0",
           "ios": "4.5.0",
           "macos": "0.12.0"
         },


### PR DESCRIPTION
Updated the style specification’s compatibility tables for Android map SDK v6.7.0, iOS map SDK v4.5.0–v4.6.0, and macOS map SDK v0.12.0.

/cc @fabian-guerra @ChrisLoer