### PR TITLE
Fix MercatorCoordinate#toLngLat docs

### DIFF
--- a/src/geo/mercator_coordinate.js
+++ b/src/geo/mercator_coordinate.js
@@ -89,12 +89,12 @@ class MercatorCoordinate {
     }
 
     /**
-     * Returns the `LatLng` for the coordinate.
+     * Returns the `LngLat` for the coordinate.
      *
      * @returns {LngLat} The `LngLat` object.
      * @example
      * var coord = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
-     * var latLng = coord.toLatLng(); // LngLat(0, 0)
+     * var latLng = coord.toLngLat(); // LngLat(0, 0)
      */
     toLngLat() {
         return new LngLat(


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
A customer reported that the `MercatorCoordinate#toLngLat` docs mixed up `LngLat` and `LatLng`.
<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
