### PR TITLE
begin touch zoom immediately when rotation disabled

### DIFF
--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -150,7 +150,8 @@ class TouchZoomRotateHandler {
         // Determine 'intent' by whichever threshold is surpassed first,
         // then keep that state for the duration of this gesture.
         if (!this._gestureIntent) {
-            const scalingSignificantly = (Math.abs(1 - scale) > significantScaleThreshold),
+            // when rotation is disabled, any scale change triggers the zoom gesture to start
+            const scalingSignificantly = (this._rotationDisabled && scale !== 1) || (Math.abs(1 - scale) > significantScaleThreshold),
                 rotatingSignificantly = (Math.abs(bearing) > significantRotateThreshold);
 
             if (rotatingSignificantly) {

--- a/test/unit/ui/handler/touch_zoom_rotate.test.js
+++ b/test/unit/ui/handler/touch_zoom_rotate.test.js
@@ -109,3 +109,43 @@ test('TouchZoomRotateHandler does not begin a gesture if preventDefault is calle
     map.remove();
     t.end();
 });
+
+test('TouchZoomRotateHandler starts zoom immediately when rotation disabled', (t) => {
+    const map = createMap(t);
+    map.touchZoomRotate.disableRotation();
+
+    const zoomstart = t.spy();
+    const zoom      = t.spy();
+    const zoomend   = t.spy();
+
+    map.on('zoomstart', zoomstart);
+    map.on('zoom',      zoom);
+    map.on('zoomend',   zoomend);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: -5}, {clientX: 0, clientY: 5}]});
+    map._renderTaskQueue.run();
+    t.equal(zoomstart.callCount, 0);
+    t.equal(zoom.callCount, 0);
+    t.equal(zoomend.callCount, 0);
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: -5}, {clientX: 0, clientY: 6}]});
+    map._renderTaskQueue.run();
+    t.equal(zoomstart.callCount, 1);
+    t.equal(zoom.callCount, 1);
+    t.equal(zoomend.callCount, 0);
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: -5}, {clientX: 0, clientY: 5}]});
+    map._renderTaskQueue.run();
+    t.equal(zoomstart.callCount, 1);
+    t.equal(zoom.callCount, 2);
+    t.equal(zoomend.callCount, 0);
+
+    simulate.touchend(map.getCanvas(), {touches: []});
+    map._renderTaskQueue.run();
+    t.equal(zoomstart.callCount, 1);
+    t.equal(zoom.callCount, 2);
+    t.equal(zoomend.callCount, 1);
+
+    map.remove();
+    t.end();
+});


### PR DESCRIPTION
## Launch Checklist

When touch rotation is disabled, there is a lag between when you start pinching to zoom in or out and when the zoom starts happening. This is because the touch zoom rotate handler has a zoom and rotate threshold to disambiguate between the two cases. This threshold is not needed if rotation is disabled. This makes the pinch to zoom behavior comparable with leaflet. There's still a bit of weirdness due do #7196 but it seems to be an improvement.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
