### PR TITLE
Update style spec for gl-native's release-horchata

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2764,7 +2764,7 @@
       },
       "line-progress": {
         "doc": "Gets the progress along a gradient line. Can only be used in the `line-gradient` property.",
-        "group": "Heatmap",
+        "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
             "js": "0.45.0",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2566,7 +2566,10 @@
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.48.0"
+            "js": "0.48.0",
+            "android": "6.7.0",
+            "ios": "4.6.0",
+            "macos": "0.12.0"
           }
         }
       },
@@ -2761,7 +2764,15 @@
       },
       "line-progress": {
         "doc": "Gets the progress along a gradient line. Can only be used in the `line-gradient` property.",
-        "group": "Heatmap"
+        "group": "Heatmap",
+        "sdk-support": {
+          "basic functionality": {
+            "js": "0.45.0",
+            "android": "6.5.0",
+            "ios": "4.6.0",
+            "macos": "0.12.0"
+          }
+        }
       },
       "+": {
         "doc": "Returns the sum of the inputs.",


### PR DESCRIPTION
Updates the SDK support tables for `release-horchata`, which added support for:

- https://github.com/mapbox/mapbox-gl-native/pull/13192 — `line-progress` on darwin platforms.
- https://github.com/mapbox/mapbox-gl-native/pull/12624 — `format` expression operator on all platforms.

`line-progress` didn’t have an `sdk-support` property, so this adds one and backfills it. Work on that feature originally happened in https://github.com/mapbox/mapbox-gl-js/pull/6303 and https://github.com/mapbox/mapbox-gl-native/pull/12575.

/cc @ChrisLoer @asheemmamoowala @LukasPaczos @1ec5 @pozdnyakov 