### PR TITLE
Upload one raster tile texture per render frame

### DIFF
--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -19,7 +19,6 @@ import type {RasterDEMSourceSpecification} from '../style-spec/types';
 
 class RasterDEMTileSource extends RasterTileSource implements Source {
     encoding: "mapbox" | "terrarium";
-    textureQueue: Array<Object>;
 
     constructor(id: string, options: RasterDEMSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
         super(id, options, dispatcher, eventedParent);
@@ -27,7 +26,6 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
         this.maxzoom = 22;
         this._options = extend({}, options);
         this.encoding = options.encoding || "mapbox";
-        this.textureQueue = [];
     }
 
     serialize() {
@@ -58,8 +56,7 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
                 if (this.map._refreshExpiredTiles) tile.setExpiryData(img);
                 delete (img: any).cacheControl;
                 delete (img: any).expires;
-
-                this.textureQueue.push({tile, img, callback: textureCallback.bind(this)});
+                this.map.style.textureQueue.push({tile, img, callback: textureCallback.bind(this)});
             }
         }
 
@@ -90,21 +87,6 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
                 tile.state = 'loaded';
                 callback(null);
             }
-        }
-    }
-
-    createTexture(tile: Tile, img: any) {
-        const rawImageData = browser.getImageData(img);
-        const params = {
-            uid: tile.uid,
-            coord: tile.tileID,
-            source: this.id,
-            rawImageData,
-            encoding: this.encoding
-        };
-
-        if (!tile.workerID || tile.state === 'expired') {
-            tile.workerID = this.dispatcher.send('loadDEMTile', params, done.bind(this));
         }
     }
 

--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -40,11 +40,13 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
     }
 
     loadTile(tile: Tile, callback: Callback<void>) {
+        console.log('loadTile', tile);
         const url = normalizeURL(tile.tileID.canonical.url(this.tiles, this.scheme), this.url, this.tileSize);
         tile.request = getImage(this.map._transformRequest(url, ResourceType.Tile), imageLoaded.bind(this));
 
         tile.neighboringTiles = this._getNeighboringTiles(tile.tileID);
         function imageLoaded(err, img) {
+            console.log('imageLoaded', img);
             delete tile.request;
             if (tile.aborted) {
                 tile.state = 'unloaded';
@@ -57,7 +59,9 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
                 delete (img: any).cacheControl;
                 delete (img: any).expires;
                 this.map.style._textureQueue.push({tile, img, callback: textureCallback.bind(this)});
+                callback(null);
             }
+            console.log('queue', this.map.style._textureQueue);
         }
 
         function textureCallback(tile, img) {

--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -56,7 +56,7 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
                 if (this.map._refreshExpiredTiles) tile.setExpiryData(img);
                 delete (img: any).cacheControl;
                 delete (img: any).expires;
-                this.map.style.textureQueue.push({tile, img, callback: textureCallback.bind(this)});
+                this.map.style._textureQueue.push({tile, img, callback: textureCallback.bind(this)});
             }
         }
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -36,6 +36,7 @@ class RasterTileSource extends Evented implements Source {
     dispatcher: Dispatcher;
     map: Map;
     tiles: Array<string>;
+    _textureQueue: Array<Object>;
 
     _loaded: boolean;
     _options: RasterSourceSpecification | RasterDEMSourceSpecification;
@@ -54,6 +55,7 @@ class RasterTileSource extends Evented implements Source {
         this.scheme = 'xyz';
         this.tileSize = 512;
         this._loaded = false;
+        this._textureQueue = [];
 
         this._options = extend({}, options);
         extend(this, pick(options, ['url', 'scheme', 'tileSize']));
@@ -118,7 +120,7 @@ class RasterTileSource extends Evented implements Source {
                 delete (img: any).cacheControl;
                 delete (img: any).expires;
 
-                this.map.style._textureQueue.push({tile, img, callback: textureCallback.bind(this)});
+                this._textureQueue.push({tileKey: tile.tileID.key, img, callback: textureCallback.bind(this)});
                 callback(null);
             }
 

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -118,7 +118,7 @@ class RasterTileSource extends Evented implements Source {
                 delete (img: any).cacheControl;
                 delete (img: any).expires;
 
-                this.map.style.textureQueue.push({tile, img, callback: textureCallback.bind(this)});
+                this.map.style._textureQueue.push({tile, img, callback: textureCallback.bind(this)});
                 callback(null);
             }
 

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -48,6 +48,7 @@ export interface Source {
     tileID?: CanonicalTileID;
     reparseOverscaled?: boolean,
     vectorLayerIds?: Array<string>,
+    _textureQueue?: Array<Object>;
 
     hasTransition(): boolean;
 

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -48,6 +48,7 @@ export interface Source {
     tileID?: CanonicalTileID;
     reparseOverscaled?: boolean,
     vectorLayerIds?: Array<string>,
+    +textureQueue?: Array<Object>,
 
     hasTransition(): boolean;
 

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -48,7 +48,6 @@ export interface Source {
     tileID?: CanonicalTileID;
     reparseOverscaled?: boolean,
     vectorLayerIds?: Array<string>,
-    +textureQueue?: Array<Object>,
 
     hasTransition(): boolean;
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -119,6 +119,7 @@ class Style extends Evented {
     _removedLayers: {[string]: StyleLayer};
     _updatedPaintProps: {[layer: string]: true};
     _layerOrderChanged: boolean;
+    textureQueue: Array<Object>;
 
     crossTileSymbolIndex: CrossTileSymbolIndex;
     pauseablePlacement: PauseablePlacement;
@@ -145,6 +146,7 @@ class Style extends Evented {
         this.sourceCaches = {};
         this.zoomHistory = new ZoomHistory();
         this._loaded = false;
+        this.textureQueue = [];
 
         this._resetUpdates();
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -119,7 +119,7 @@ class Style extends Evented {
     _removedLayers: {[string]: StyleLayer};
     _updatedPaintProps: {[layer: string]: true};
     _layerOrderChanged: boolean;
-    textureQueue: Array<Object>;
+    _textureQueue: Array<Object>;
 
     crossTileSymbolIndex: CrossTileSymbolIndex;
     pauseablePlacement: PauseablePlacement;
@@ -146,7 +146,7 @@ class Style extends Evented {
         this.sourceCaches = {};
         this.zoomHistory = new ZoomHistory();
         this._loaded = false;
-        this.textureQueue = [];
+        this._textureQueue = [];
 
         this._resetUpdates();
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -119,7 +119,6 @@ class Style extends Evented {
     _removedLayers: {[string]: StyleLayer};
     _updatedPaintProps: {[layer: string]: true};
     _layerOrderChanged: boolean;
-    _textureQueue: Array<Object>;
 
     crossTileSymbolIndex: CrossTileSymbolIndex;
     pauseablePlacement: PauseablePlacement;
@@ -146,7 +145,6 @@ class Style extends Evented {
         this.sourceCaches = {};
         this.zoomHistory = new ZoomHistory();
         this._loaded = false;
-        this._textureQueue = [];
 
         this._resetUpdates();
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1683,15 +1683,20 @@ class Map extends Camera {
         this._placementDirty = this.style && this.style._updatePlacement(this.painter.transform, this.showCollisionBoxes, this._fadeDuration, this._crossSourceCollisions);
 
         // For performance reasons, we limit texture uploading to the GPU to
-        // one upload per animation frame
+        // a max of two uploads per animation frame
         let continueRenderingTextures = false;
-        const queued = this.style._textureQueue.shift();
-        if (queued) {
+        console.log('render called');
+        let max = Math.min(2, this.style._textureQueue.length);
+        for (let i = 0; i < max; i++) {
+          const queued = this.style._textureQueue.shift();
+          console.log('upload texture*********', this.style._textureQueue.length, queued);
+          if (queued) {
             const {tile, img, callback} = queued;
             // do not upload aborted tiles to the GPU
             if (tile && !tile.aborted) {
-                callback(tile, img);
+              callback(tile, img);
             }
+          }
         }
 
         if (this.style._textureQueue.length > 0) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1685,14 +1685,15 @@ class Map extends Camera {
         let continueRenderingTextures = false;
         for (const id in this.style.sourceCaches) {
             const source = this.style.sourceCaches[id]._source;
-            if (source.type === 'raster') {
-                const queued = source._textureQueue.pop();
+            if (source.type === 'raster' || source.type === 'raster-dem') {
+                const queued = source.textureQueue.shift();
                 if (queued) {
-                    source.createTexture(queued.tile, queued.img);
+                    const cb = queued.callback;
+                    cb(queued.tile, queued.img);
                 }
-            }
-            if (source._textureQueue.length > 0) {
-                continueRenderingTextures = true;
+                if (source.textureQueue.length > 0) {
+                    continueRenderingTextures = true;
+                }
             }
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1685,13 +1685,15 @@ class Map extends Camera {
         // For performance reasons, we limit texture uploading to the GPU to
         // one upload per animation frame
         let continueRenderingTextures = false;
-        // shift() causes the textures to be drawn from the center of the screen -> edges
-        // pop() would have the opposite animation effect
         const queued = this.style.textureQueue.shift();
         if (queued) {
-            const cb = queued.callback;
-            cb(queued.tile, queued.img);
+            const {tile, img, callback} = queued;
+            // do not upload aborted tiles to the GPU
+            if (tile && !tile.aborted) {
+                callback(tile, img);
+            }
         }
+
         if (this.style.textureQueue.length > 0) {
             continueRenderingTextures = true;
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1685,7 +1685,7 @@ class Map extends Camera {
         // For performance reasons, we limit texture uploading to the GPU to
         // one upload per animation frame
         let continueRenderingTextures = false;
-        const queued = this.style.textureQueue.shift();
+        const queued = this.style._textureQueue.shift();
         if (queued) {
             const {tile, img, callback} = queued;
             // do not upload aborted tiles to the GPU
@@ -1694,7 +1694,7 @@ class Map extends Camera {
             }
         }
 
-        if (this.style.textureQueue.length > 0) {
+        if (this.style._textureQueue.length > 0) {
             continueRenderingTextures = true;
         }
 


### PR DESCRIPTION
## Launch Checklist

This closes https://github.com/mapbox/mapbox-gl-js/issues/7451

It also completes some of the work in https://github.com/mapbox/mapbox-gl-js/issues/7405

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - introduces a queue to limit raster tile texture upload to the GPU to one texture per render frame
 - [ ] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page

![screen shot 2018-11-14 at 3 42 03 pm](https://user-images.githubusercontent.com/4523080/48648230-71069d00-e9a3-11e8-9335-da57491c6093.png)

Benchmarks don't show any major performance improvement or degradation

<img width="990" alt="screen shot 2018-11-20 at 4 31 39 pm" src="https://user-images.githubusercontent.com/4523080/48811330-1c845a00-ece2-11e8-9f78-57e08d7d9041.png">
<img width="983" alt="screen shot 2018-11-20 at 4 31 49 pm" src="https://user-images.githubusercontent.com/4523080/48811331-1d1cf080-ece2-11e8-93e1-0db77536974a.png">
<img width="1046" alt="screen shot 2018-11-20 at 4 32 19 pm" src="https://user-images.githubusercontent.com/4523080/48811333-1d1cf080-ece2-11e8-9d8b-d97fcb7de5a8.png">
<img width="981" alt="screen shot 2018-11-20 at 4 32 27 pm" src="https://user-images.githubusercontent.com/4523080/48811334-1d1cf080-ece2-11e8-8d53-df4d53b76ef7.png">
