### PR TITLE
Force full placement on every frame when fadeDuration === 0

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1101,7 +1101,9 @@ class Style extends Evented {
         // to start over. When we start over, we do a full placement instead of incremental
         // to prevent starvation.
         // We need to restart placement to keep layer indices in sync.
-        const forceFullPlacement = this._layerOrderChanged;
+        // Also force full placement when fadeDuration === 0 to ensure that newly loaded
+        // tiles will fully display symbols in their first frame
+        const forceFullPlacement = this._layerOrderChanged || fadeDuration === 0;
 
         if (forceFullPlacement || !this.pauseablePlacement || (this.pauseablePlacement.isDone() && !this.placement.stillRecent(browser.now()))) {
             this.pauseablePlacement = new PauseablePlacement(transform, this._order, forceFullPlacement, showCollisionBoxes, fadeDuration, crossSourceCollisions);


### PR DESCRIPTION
Fixes issue #7609: fadeDuration 0 didn't ensure every symbol would render immediately, if collision detection took longer than 2ms.

This change will potentially make each frame more expensive to render with `frameDuration: 0`, but that option already makes frames more expensive, and the whole point is to make symbol collision changes instant.

This issue technically affects our test suite, but because it depends on collision detection going longer than 2ms, we've never (or perhaps very rarely?) seen it. The test suite doesn't have tests with large enough viewport/complex-enough style to get near that limit during normal operation.

I can't think of a satisfying non-contrived automated test for this change. I manually tested the change on a debug page with a large viewport that reliably pushed collision detection over 2ms. The key visual thing I was looking at was making sure that symbols were fully rendered in the frame drawn before we fire the `load` event.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] document any changes to public APIs
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

cc @ansis @mollymerp @mzdraper @tristen 