### PR TITLE
[WIP] Support benchmarking styles from file paths

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -21,9 +21,9 @@ By default, the benchmark page will compare the local branch against `master` an
 Start the benchmark server
 
 ```bash
-MAPBOX_ACCESS_TOKEN={YOUR MAPBOX ACCESS TOKEN} MAPBOX_STYLE_URL={YOUR STYLES HERE} yarn start
+MAPBOX_ACCESS_TOKEN={YOUR MAPBOX ACCESS TOKEN} MAPBOX_STYLES={YOUR STYLES HERE} yarn start
 ```
-Note: `MAPBOX_STYLE_URL` takes a comma-separated list of up to 3 Mapbox style URLs (e.g. `mapbox://styles/mapbox/streets-v10,mapbox://styles/mapbox/streets-v9`)
+Note: `MAPBOX_STYLES` takes a comma-separated list of up to 3 Mapbox styles provided as a style URL or file system path (e.g. `./path/to/style.json,mapbox://styles/mapbox/streets-v10` or `mapbox://styles/mapbox/streets-v10,mapbox://styles/mapbox/streets-v9`)
 
 To run all benchmarks, open [the benchmark page, `http://localhost:9966/bench/styles`](http://localhost:9966/bench/styles).
 

--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -6,8 +6,9 @@ import spec from '../../src/style-spec/reference/latest';
 import convertFunction from '../../src/style-spec/function/convert';
 import { isFunction, createFunction } from '../../src/style-spec/function';
 import { createPropertyExpression } from '../../src/style-spec/expression';
-import { normalizeStyleURL } from '../../src/util/mapbox';
+import fetchStyle from '../lib/fetch_style';
 
+import type {StyleSpecification} from '../../src/style-spec/types';
 import type {StylePropertySpecification} from '../../src/style-spec/style-spec';
 import type {StylePropertyExpression} from '../../src/style-spec/expression';
 
@@ -19,16 +20,15 @@ class ExpressionBenchmark extends Benchmark {
         compiledFunction: StylePropertyExpression,
         compiledExpression: StylePropertyExpression
     }>;
-    style: string;
+    style: string | StyleSpecification;
 
-    constructor(style: string) {
+    constructor(style: string | StyleSpecification) {
         super();
         this.style = style;
     }
 
     setup() {
-        return fetch(normalizeStyleURL(this.style))
-            .then(response => response.json())
+        return fetchStyle(this.style)
             .then(json => {
                 this.data = [];
 

--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -33,10 +33,6 @@ class ExpressionBenchmark extends Benchmark {
                 this.data = [];
 
                 for (const layer of json.layers) {
-                    if (layer.ref) {
-                        continue;
-                    }
-
                     const expressionData = function(rawValue, propertySpec: StylePropertySpecification) {
                         const rawExpression = convertFunction(rawValue, propertySpec);
                         const compiledFunction = createFunction(rawValue, propertySpec);

--- a/bench/benchmarks/layout.js
+++ b/bench/benchmarks/layout.js
@@ -1,5 +1,6 @@
 // @flow
 
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import fetchStyle from '../lib/fetch_style';
 import TileParser from '../lib/tile_parser';
@@ -8,10 +9,10 @@ import { OverscaledTileID } from '../../src/source/tile_id';
 export default class Layout extends Benchmark {
     tiles: Array<{tileID: OverscaledTileID, buffer: ArrayBuffer}>;
     parser: TileParser;
-    style: string;
+    style: string | StyleSpecification;
     locations: Array<OverscaledTileID>;
 
-    constructor(style: string, locations: ?Array<OverscaledTileID>) {
+    constructor(style: string | StyleSpecification, locations: ?Array<OverscaledTileID>) {
         super();
         this.style = style;
         this.locations = locations || this.tileIDs();

--- a/bench/benchmarks/style_layer_create.js
+++ b/bench/benchmarks/style_layer_create.js
@@ -1,22 +1,22 @@
 // @flow
 
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import createStyleLayer from '../../src/style/create_style_layer';
 import deref from '../../src/style-spec/deref';
-import { normalizeStyleURL } from '../../src/util/mapbox';
+import fetchStyle from '../lib/fetch_style';
 
 export default class StyleLayerCreate extends Benchmark {
-    style: string;
+    style: string | StyleSpecification;
     layers: Array<Object>;
 
-    constructor(style: string) {
+    constructor(style: string | StyleSpecification) {
         super();
         this.style = style;
     }
 
     setup(): Promise<void> {
-        return fetch(normalizeStyleURL(this.style))
-            .then(response => response.json())
+        return fetchStyle(this.style)
             .then(json => { this.layers = deref(json.layers); });
     }
 

--- a/bench/benchmarks/style_validate.js
+++ b/bench/benchmarks/style_validate.js
@@ -1,12 +1,13 @@
 // @flow
 
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import validateStyle from '../../src/style-spec/validate_style.min';
-import { normalizeStyleURL } from '../../src/util/mapbox';
+import fetchStyle from '../lib/fetch_style';
 
 export default class StyleValidate extends Benchmark {
-    style: string;
-    json: Object;
+    style: string | StyleSpecification;
+    json: StyleSpecification;
 
     constructor(style: string) {
         super();
@@ -14,8 +15,7 @@ export default class StyleValidate extends Benchmark {
     }
 
     setup(): Promise<void> {
-        return fetch(normalizeStyleURL(this.style))
-            .then(response => response.json())
+        return fetchStyle(this.style)
             .then(json => { this.json = json; });
     }
 

--- a/bench/benchmarks/worker_transfer.js
+++ b/bench/benchmarks/worker_transfer.js
@@ -1,5 +1,6 @@
 // @flow
 
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import fetchStyle from '../lib/fetch_style';
 import TileParser from '../lib/tile_parser';
@@ -12,9 +13,9 @@ export default class WorkerTransfer extends Benchmark {
     payloadTiles: Array<any>;
     payloadJSON: Array<any>;
     worker: Worker;
-    style: string;
+    style: string | StyleSpecification;
 
-    constructor(style: string) {
+    constructor(style: string | StyleSpecification) {
         super();
         this.style = style;
     }

--- a/bench/lib/fetch_style.js
+++ b/bench/lib/fetch_style.js
@@ -3,7 +3,8 @@
 import type {StyleSpecification} from '../../src/style-spec/types';
 import {normalizeStyleURL} from '../../src/util/mapbox';
 
-export default function fetchStyle(url: string): Promise<StyleSpecification> {
-    return fetch(normalizeStyleURL(url))
-        .then(response => response.json());
+export default function fetchStyle(value: string | StyleSpecification): Promise<StyleSpecification> {
+    return typeof value === 'string' ?
+        fetch(normalizeStyleURL(value)).then(response => response.json()) :
+        Promise.resolve(value);
 }

--- a/bench/styles/benchmarks.js
+++ b/bench/styles/benchmarks.js
@@ -6,7 +6,6 @@ import updateUI from '../benchmarks_view';
 
 mapboxgl.accessToken = accessToken;
 
-const urls = (process.env.MAPBOX_STYLE_URL || 'mapbox://styles/mapbox/streets-v10').split(',');
 const benchmarks = [];
 const filter = window.location.hash.substr(1);
 
@@ -23,9 +22,10 @@ function register(Benchmark, locations, options) {
 
     if (options) Object.assign(benchmark, options);
 
-    urls.forEach(style => {
+    process.env.MAPBOX_STYLES.forEach(style => {
+        const { name } = style;
         benchmark.versions.push({
-            name: style.replace("mapbox://styles/", ""),
+            name: name ? name : style.replace('mapbox://styles/', ''),
             bench: new Benchmark(style, locations),
             status: 'waiting',
             logs: [],

--- a/bench/styles/rollup_config_benchmarks.js
+++ b/bench/styles/rollup_config_benchmarks.js
@@ -3,13 +3,20 @@ import sourcemaps from 'rollup-plugin-sourcemaps';
 import replace from 'rollup-plugin-replace';
 import {plugins as basePlugins} from '../../build/rollup_plugins';
 
+let styles = ['mapbox://styles/mapbox/streets-v10'];
+
+if (process.env.MAPBOX_STYLES) {
+    styles = process.env.MAPBOX_STYLES
+        .split(',')
+        .map(style => style.match(/\.json$/) ? require(style) : style);
+}
+
 const plugins = () => basePlugins().concat(
     replace({
         'process.env.BENCHMARK_VERSION': JSON.stringify(process.env.BENCHMARK_VERSION),
         'process.env.MAPBOX_ACCESS_TOKEN': JSON.stringify(process.env.MAPBOX_ACCESS_TOKEN),
         'process.env.MapboxAccessToken': JSON.stringify(process.env.MapboxAccessToken),
-        'process.env.MAPBOX_STYLE_URL': JSON.stringify(process.env.MAPBOX_STYLE_URL),
-        'process.env.MapboxStyleURL': JSON.stringify(process.env.MapboxStyleURL),
+        'process.env.MAPBOX_STYLES': JSON.stringify(styles),
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
     })
 );


### PR DESCRIPTION
Detects stylesheets originating from local paths at the rollup config stage and inlines them into the environment variable.

Also:

- Renamed `MAPBOX_STYLE_URL` to `MAPBOX_STYLES` which aligns better with what is now supported.
- Flow flagged `layer.ref` not being type defined which I think is accurate (it should not exist) so I removed the conditional in https://github.com/mapbox/mapbox-gl-js/pull/7611/commits/a8a0d78c682aeed53653d697f5e8d58bcfaa80ad
- I can leave it out of this PR but I noticed an [environment variable defined](https://github.com/mapbox/mapbox-gl-js/pull/7611/files#diff-eba31f50800e4aa9b1dca219296e584aL12) that is never used so I removed it.

---

Lastly, I created a branch from this that fetched all stylesheets during the rollup config step which omitted the need for `bench/lib/fetch_style.js` or a distinction between string urls or style objects but ran into a few difficulties getting it to work and punted.
