### PR TITLE
Fix sporadical "cannot read property _values of undefined" error

### DIFF
--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -17,7 +17,7 @@ import type { FeatureState } from '../style-spec/expression';
 import type {Bucket} from '../data/bucket';
 import type Point from '@mapbox/point-geometry';
 import type {FeatureFilter} from '../style-spec/feature_filter';
-import type {TransitionParameters} from './properties';
+import type { TransitionParameters, PossiblyEvaluated } from './properties';
 import type EvaluationParameters, {CrossfadeParameters} from './evaluation_parameters';
 import type Transform from '../geo/transform';
 import type {
@@ -42,11 +42,11 @@ class StyleLayer extends Evented {
     _crossfadeParameters: CrossfadeParameters;
 
     _unevaluatedLayout: Layout<any>;
-    +layout: mixed;
+    +layout: ?PossiblyEvaluated<any>;
 
     _transitionablePaint: Transitionable<any>;
     _transitioningPaint: Transitioning<any>;
-    +paint: mixed;
+    +paint: ?PossiblyEvaluated<any>;
 
     _featureFilter: FeatureFilter;
 
@@ -245,8 +245,11 @@ class StyleLayer extends Evented {
     }
 
     isStateDependent() {
-        for (const property in (this: any).paint._values) {
-            const value = (this: any).paint.get(property);
+        if (!this.paint)
+            return false;
+
+        for (const property in this.paint._values) {
+            const value = this.paint.get(property);
             if (!(value instanceof PossiblyEvaluatedPropertyValue) || !supportsPropertyExpression(value.property.specification)) {
                 continue;
             }


### PR DESCRIPTION
Closes #7523. I'm not able to trace the exact race condition that causes the error, but it should be fixed with this change. Also slightly improves typing, which would catch the potential error if we didn't use the `(obj: any).property` hack there.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
