### PR TITLE
fix: map's pitch resets to 0 if initial bounds is set  #7597

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -373,16 +373,16 @@ class Map extends Camera {
         this._hash = options.hash && (new Hash()).addTo(this);
         // don't set position from options if set through hash
         if (!this._hash || !this._hash._onHashChange()) {
+            this.jumpTo({
+                center: options.center,
+                zoom: options.zoom,
+                bearing: options.bearing,
+                pitch: options.pitch
+            });
+
             if (options.bounds) {
                 this.resize();
                 this.fitBounds(options.bounds, { duration: 0 });
-            } else {
-                this.jumpTo({
-                    center: options.center,
-                    zoom: options.zoom,
-                    bearing: options.bearing,
-                    pitch: options.pitch
-                });
             }
         }
 


### PR DESCRIPTION
This fixes map's pitch reset to 0 according to #7597 