### PR TITLE
Allow passing bearing as an option ot fitBounds

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -362,6 +362,7 @@ class Camera extends Evented {
      *      in the viewport. LatLngBounds represent a box that is always axis-aligned with bearing 0.
      * @param options
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
+     * @param {number} [options.bearing=0] Desired map bearing at end of animation, in degrees.
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the camera would transition to the specified bounds.
      * @returns {CameraOptions | void} If map is able to fit to provided bounds, returns `CameraOptions` with
@@ -497,6 +498,7 @@ class Camera extends Evented {
      * @param bounds Center these bounds in the viewport and use the highest
      *      zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
      * @param {Object} [options] Options supports all properties from {@link AnimationOptions} and {@link CameraOptions} in addition to the fields below.
+     * @param {number} [options.bearing=0] Desired map bearing at end of animation, in degrees.
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {boolean} [options.linear=false] If `true`, the map transitions using
      *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -375,7 +375,13 @@ class Camera extends Evented {
      */
     cameraForBounds(bounds: LngLatBoundsLike, options?: CameraOptions): void | CameraOptions & AnimationOptions {
         bounds = LngLatBounds.convert(bounds);
-        return this._cameraForBoxAndBearing(bounds.getNorthWest(), bounds.getSouthEast(), 0, options);
+
+        let bearingForBounds = 0;
+        if (typeof options.bearing === 'number') {
+            bearingForBounds =  options.bearing;
+        }
+
+        return this._cameraForBoxAndBearing(bounds.getNorthWest(), bounds.getSouthEast(), bearingForBounds, options);
     }
 
     /**

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -377,8 +377,15 @@ class Camera extends Evented {
         bounds = LngLatBounds.convert(bounds);
 
         let bearingForBounds = 0;
-        if (typeof options.bearing === 'number') {
-            bearingForBounds =  options.bearing;
+        if (options && options.bearing) {
+            if (typeof options.bearing === 'number') {
+                bearingForBounds =  options.bearing;
+            } else {
+                warnOnce(
+                    "options.bearing must be a number"
+                );
+            }
+
         }
 
         return this._cameraForBoxAndBearing(bounds.getNorthWest(), bounds.getSouthEast(), bearingForBounds, options);

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1690,13 +1690,35 @@ test('camera', (t) => {
     });
 
     t.test('#cameraForBounds', (t) => {
-        t.test('no padding passed', (t) => {
+        t.test('no options passed', (t) => {
             const camera = createCamera();
             const bb = [[-133, 16], [-68, 50]];
 
             const transform = camera.cameraForBounds(bb);
             t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for new bounds');
             t.equal(fixedNum(transform.zoom, 3), 2.469);
+            t.end();
+        });
+
+        t.test('bearing positive number', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            const transform = camera.cameraForBounds(bb, { bearing: 175 });
+            t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for new bounds');
+            t.equal(fixedNum(transform.zoom, 3), 2.558);
+            t.equal(transform.bearing, 175);
+            t.end();
+        });
+
+        t.test('bearing negative number', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            const transform = camera.cameraForBounds(bb, { bearing: -30 });
+            t.deepEqual(fixedLngLat(transform.center, 4), { lng: -100.5, lat: 34.7171 }, 'correctly calculates coordinates for new bounds');
+            t.equal(fixedNum(transform.zoom, 3), 2.392);
+            t.equal(transform.bearing, -30);
             t.end();
         });
 


### PR DESCRIPTION
## Launch Checklist

I know there have been other attempts to get it to `fitBounds`, but I got it working fairly easiy with a following snippet of code (react based), hence decide to file a PR.
```
mapInstance._fitInternal(
  mapInstance._cameraForBoxAndBearing(
    bounds.getNorthWest(),
    bounds.getSouthEast(),
    mapInstance.getBearing(),
    {},
  ),
);
```
I decided not to go with all the other checklist items, before getting any feedback, but surely can add docs and tests if necessary.

Previous art:
https://github.com/mapbox/mapbox-gl-js/pull/1340
https://github.com/mapbox/mapbox-gl-js/issues/1338
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
