### PR TITLE
Add 'idle' event: fires when no further rendering is expected without further interaction.

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -678,6 +678,20 @@ export type MapEvent =
     | 'render'
 
     /**
+     * Fired after the last frame rendered before the map enters an
+     * "idle" state:
+     *
+     * - No camera transitions are in progress
+     * - All currently requested tiles have loaded
+     * - All fade/transition animations have completed
+     *
+     * @event idle
+     * @memberof Map
+     * @instance
+     */
+    | 'idle'
+
+    /**
      * Fired immediately after the map has been removed with {@link Map.event:remove}.
      *
      * @event remove

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1692,6 +1692,8 @@ class Map extends Camera {
         // Style#_updateSources could have caused them to be set again.
         if (this._sourcesDirty || this._repaint || this._styleDirty || this._placementDirty) {
             this.triggerRepaint();
+        } else if (!this.isMoving() && this.loaded()) {
+            this.fire(new Event('idle'));
         }
 
         return this;

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1518,6 +1518,30 @@ test('Map', (t) => {
         });
     });
 
+    t.test('no render after idle event', (t) => {
+        const style = createStyle();
+        const map = createMap(t, { style });
+        map.on('idle', () => {
+            map.on('render', t.fail);
+            setTimeout(() => {
+                t.end();
+            }, 100);
+        });
+    });
+
+    t.test('no idle event during move', (t) => {
+        const style = createStyle();
+        const map = createMap(t, { style, fadeDuration: 0 });
+        map.once('idle', () => {
+            map.zoomTo(0.5, { duration: 100 });
+            t.ok(map.isMoving(), "map starts moving immediately after zoomTo");
+            map.once('idle', () => {
+                t.ok(!map.isMoving(), "map stops moving before firing idle event");
+                t.end();
+            });
+        });
+    });
+
     t.test('#removeLayer restores Map#loaded() to true', (t) => {
         const map = createMap(t, {
             style: extend(createStyle(), {


### PR DESCRIPTION
We fairly frequently receive requests for a map event that fires when the map is "done rendering". This is a kind of squishy concept because so many things can cause the map to change. Even if there's no user interaction with the map, tiles can update at any time and trigger map updates. However, we have a pretty good idea of when we're entering an idle state:

- All requested tiles are loaded
- No transitions are in progress
- No camera animations are in progress

This PR fires an `idle` event in that condition. One reason someone might want to use this event is to make changes to the map, and then do a canvas capture after everything has finished rendering.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

cc @kkaefer @1ec5 @tmpsantos @mourner @ryanhamley @mollymerp 
