### PR TITLE
advance image request queue when request aborted

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -4,6 +4,7 @@ import window from './window';
 import { extend } from './util';
 import { isMapboxHTTPURL } from './mapbox';
 import config from './config';
+import assert from 'assert';
 
 import type { Callback } from '../types/callback';
 import type { Cancelable } from '../types/cancelable';
@@ -175,8 +176,12 @@ function sameOrigin(url) {
 
 const transparentPngUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=';
 
-const imageQueue = [];
-let numImageRequests = 0;
+let imageQueue, numImageRequests;
+export const resetImageRequestQueue = () => {
+    imageQueue = [];
+    numImageRequests = 0;
+};
+resetImageRequestQueue();
 
 export const getImage = function(requestParameters: RequestParameters, callback: Callback<HTMLImageElement>): Cancelable {
     // limit concurrent image loads to help with raster sources performance on big screens
@@ -187,17 +192,25 @@ export const getImage = function(requestParameters: RequestParameters, callback:
     }
     numImageRequests++;
 
-    // request the image with XHR to work around caching issues
-    // see https://github.com/mapbox/mapbox-gl-js/issues/1470
-    return getArrayBuffer(requestParameters, (err: ?Error, data: ?ArrayBuffer, cacheControl: ?string, expires: ?string) => {
-
+    let advanced = false;
+    const advanceImageRequestQueue = () => {
+        if (advanced) return;
+        advanced = true;
         numImageRequests--;
+        assert(numImageRequests >= 0);
         while (imageQueue.length && numImageRequests < config.MAX_PARALLEL_IMAGE_REQUESTS) { // eslint-disable-line
             const {requestParameters, callback, cancelled} = imageQueue.shift();
             if (!cancelled) {
                 getImage(requestParameters, callback);
             }
         }
+    };
+
+    // request the image with XHR to work around caching issues
+    // see https://github.com/mapbox/mapbox-gl-js/issues/1470
+    const request = getArrayBuffer(requestParameters, (err: ?Error, data: ?ArrayBuffer, cacheControl: ?string, expires: ?string) => {
+
+        advanceImageRequestQueue();
 
         if (err) {
             callback(err);
@@ -215,6 +228,13 @@ export const getImage = function(requestParameters: RequestParameters, callback:
             img.src = data.byteLength ? URL.createObjectURL(blob) : transparentPngUrl;
         }
     });
+
+    return {
+        cancel: () => {
+            request.cancel();
+            advanceImageRequestQueue();
+        }
+    };
 };
 
 export const getVideo = function(urls: Array<string>, callback: Callback<HTMLVideoElement>): Cancelable {

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -111,6 +111,10 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
             callback(new AJAXError(response.statusText, response.status, requestParameters.url));
         }
     }).catch((error) => {
+        if (error.code === 20) {
+            // silence expected AbortError
+            return;
+        }
         callback(new Error(error.message));
     });
 


### PR DESCRIPTION
fixes #7637

Aborted requests never decremented the number of active requests because the main callback is never called. This fixes that by making `getImage` return a wrapped version of the `getArrayBuffer` return value that also advances the queue.

Within `advanceImageRequestQueue` we need to change that it hasn't already been advanced for that request because sometimes `cancel()` is called after the request has completed.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page