### PR TITLE
alternative: advance the image request queue when aborting

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -149,6 +149,11 @@ function makeXMLHttpRequest(requestParameters: RequestParameters, callback: Resp
             callback(new AJAXError(xhr.statusText, xhr.status, requestParameters.url));
         }
     };
+
+    xhr.onabort = () => {
+        callback(new Error('The user aborted a request.'));
+    }
+
     xhr.send(requestParameters.body);
     return { cancel: () => xhr.abort() };
 }
@@ -175,8 +180,12 @@ function sameOrigin(url) {
 
 const transparentPngUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=';
 
-const imageQueue = [];
-let numImageRequests = 0;
+let imageQueue, numImageRequests;
+export const resetImageRequestQueue = () => {
+    imageQueue = [];
+    numImageRequests = 0;
+};
+resetImageRequestQueue();
 
 export const getImage = function(requestParameters: RequestParameters, callback: Callback<HTMLImageElement>): Cancelable {
     // limit concurrent image loads to help with raster sources performance on big screens

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -3,6 +3,7 @@ import {
     getArrayBuffer,
     getJSON,
     postData,
+    resetImageRequestQueue,
     getImage
 } from '../../../src/util/ajax';
 import window from '../../../src/util/window';
@@ -126,6 +127,25 @@ test('ajax', (t) => {
         t.equals(window.server.requests.length, maxRequests);
 
         window.server.requests[0].respond();
+    });
+
+    t.test('getImage cancelling frees up request for maxParallelImageRequests', (t) => {
+        resetImageRequestQueue();
+        window.server.respondWith(request => request.respond(200, {'Content-Type': 'image/png'}, ''));
+        const maxRequests = config.MAX_PARALLEL_IMAGE_REQUESTS;
+        // jsdom doesn't call image onload; fake it https://github.com/jsdom/jsdom/issues/1816
+        const jsdomImage = window.Image;
+        window.Image = class {
+            set src(src) {
+                setTimeout(() => this.onload());
+            }
+        };
+        for (let i = 0; i < maxRequests + 1; i++) {
+            getImage({url: ''}, () => t.fail).cancel();
+        }
+        t.equals(window.server.requests.length, maxRequests + 1);
+        window.Image = jsdomImage;
+        t.end();
     });
 
     t.end();


### PR DESCRIPTION
fix #7637

alternative to https://github.com/mapbox/mapbox-gl-js/pull/7641

The fetch api triggers errors for aborted requests and that seems to not be causing problems so I think it should be safe to do that for xmlhttprequests.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page