### PR TITLE
Update location of drone video used in examples.

### DIFF
--- a/debug/video.html
+++ b/debug/video.html
@@ -28,7 +28,7 @@ var videoStyle = {
         },
         "video": {
             "type": "video",
-            "urls": [ "https://www.mapbox.com/drone/video/drone.mp4", "https://www.mapbox.com/drone/video/drone.webm" ],
+            "urls": [ "https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4", "https://static-assets.mapbox.com/mapbox-gl-js/drone.webm" ],
             "coordinates": [
                 [-122.51596391201019, 37.56238816766053],
                 [-122.51467645168304, 37.56410183312965],

--- a/docs/pages/example/video-on-a-map.html
+++ b/docs/pages/example/video-on-a-map.html
@@ -10,7 +10,7 @@ var videoStyle = {
         },
         "video": {
             "type": "video",
-            "urls": ["https://www.mapbox.com/drone/video/drone.mp4", "https://www.mapbox.com/drone/video/drone.webm"],
+            "urls": ["https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4", "https://static-assets.mapbox.com/mapbox-gl-js/drone.webm"],
             "coordinates": [
                 [-122.51596391201019, 37.56238816766053],
                 [-122.51467645168304, 37.56410183312965],

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -752,8 +752,8 @@ export default class extends React.Component {
                                             "video": {
                                                 "type": "video",
                                                 "urls": [
-                                                    "https://www.mapbox.com/drone/video/drone.mp4",
-                                                    "https://www.mapbox.com/drone/video/drone.webm"
+                                                    "https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4",
+                                                    "https://static-assets.mapbox.com/mapbox-gl-js/drone.webm"
                                                 ],
                                                 "coordinates": [
                                                     [-122.51596391201019, 37.56238816766053],


### PR DESCRIPTION
Our video examples relied on a "drone" example that was part of the mapbox.com web page and was recently taken down. We re-posted the video to a hopefully longer-lived static asset location, and this PR updates the URLs in the examples accordingly.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

cc @ansis @davidtheclark 
