### PR TITLE
OverscaledTileID#isChildOf shouldn't include tiles with different wrap.

### DIFF
--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -92,6 +92,10 @@ export class OverscaledTileID {
     }
 
     isChildOf(parent: OverscaledTileID) {
+        if (parent.wrap !== this.wrap) {
+            // We can't be a child if we're in a different world copy
+            return false;
+        }
         const zDifference = this.canonical.z - parent.canonical.z;
         // We're first testing for z == 0, to avoid a 32 bit shift, which is undefined.
         return parent.overscaledZ === 0 || (

--- a/test/unit/source/tile_id.test.js
+++ b/test/unit/source/tile_id.test.js
@@ -113,5 +113,11 @@ test('OverscaledTileID', (t) => {
         t.end();
     });
 
+    t.test('.isChildOf', (t) => {
+        t.ok(new OverscaledTileID(2, 0, 2, 0, 0).isChildOf(new OverscaledTileID(0, 0, 0, 0, 0)), "child of z0 tile");
+        t.notOk(new OverscaledTileID(2, 0, 2, 0, 0).isChildOf(new OverscaledTileID(0, 1, 0, 0, 0)), "not child of tile with different wrap");
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
Fixes issue #7639, which happened because the `CrossTileSymbolIndex` would incorrectly treat a tile in a different world copy as a child, causing two different symbols to share the same `crossTileID`.

## Launch Checklist

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~

cc @ansis