### PR TITLE
Add check for layer 'type' property

### DIFF
--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -33,6 +33,8 @@ class ExpressionBenchmark extends Benchmark {
                 this.data = [];
 
                 for (const layer of json.layers) {
+                    // some older layers still use the deprecated `ref property` instead of `type`
+                    // if we don't filter out these older layers, the logic below will cause a fatal error
                     if (!layer.type) {
                         continue;
                     }

--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -55,17 +55,13 @@ class ExpressionBenchmark extends Benchmark {
 
                     for (const key in layer.paint) {
                         if (isFunction(layer.paint[key])) {
-                            // if (layer.type) {
-                                this.data.push(expressionData(layer.paint[key], spec[`paint_${layer.type}`][key]));
-                            // }
+                            this.data.push(expressionData(layer.paint[key], spec[`paint_${layer.type}`][key]));
                         }
                     }
 
                     for (const key in layer.layout) {
                         if (isFunction(layer.layout[key])) {
-                            // if (layer.type) {
-                                this.data.push(expressionData(layer.layout[key], spec[`layout_${layer.type}`][key]));
-                            // }
+                            this.data.push(expressionData(layer.layout[key], spec[`layout_${layer.type}`][key]));
                         }
                     }
                 }

--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -33,6 +33,10 @@ class ExpressionBenchmark extends Benchmark {
                 this.data = [];
 
                 for (const layer of json.layers) {
+                    if (layer.ref) {
+                        continue;
+                    }
+
                     const expressionData = function(rawValue, propertySpec: StylePropertySpecification) {
                         const rawExpression = convertFunction(rawValue, propertySpec);
                         const compiledFunction = createFunction(rawValue, propertySpec);

--- a/bench/benchmarks/expressions.js
+++ b/bench/benchmarks/expressions.js
@@ -33,7 +33,7 @@ class ExpressionBenchmark extends Benchmark {
                 this.data = [];
 
                 for (const layer of json.layers) {
-                    if (layer.ref) {
+                    if (!layer.type) {
                         continue;
                     }
 
@@ -55,13 +55,17 @@ class ExpressionBenchmark extends Benchmark {
 
                     for (const key in layer.paint) {
                         if (isFunction(layer.paint[key])) {
-                            this.data.push(expressionData(layer.paint[key], spec[`paint_${layer.type}`][key]));
+                            // if (layer.type) {
+                                this.data.push(expressionData(layer.paint[key], spec[`paint_${layer.type}`][key]));
+                            // }
                         }
                     }
 
                     for (const key in layer.layout) {
                         if (isFunction(layer.layout[key])) {
-                            this.data.push(expressionData(layer.layout[key], spec[`layout_${layer.type}`][key]));
+                            // if (layer.type) {
+                                this.data.push(expressionData(layer.layout[key], spec[`layout_${layer.type}`][key]));
+                            // }
                         }
                     }
                 }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - filters out layers using the deprecated `ref` property. this check is necessary to avoid a crash in certain tests that check for the `type` property that older layers lack. (this used to check for `layer.ref` but a PR that allows for using local style JSON files in the style benchmarks changed the Flow type of `layer` so that checking for `layer.ref` explicitly will cause a Flow error. inverting the check achieves the same goal while avoiding the Flow issue)