### PR TITLE
Include bench directory in package files published

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "codegen": "build/run-node build/generate-style-code.js && build/run-node build/generate-struct-arrays.js"
   },
   "files": [
+    "bench/",
     "build/",
     "dist/",
     "flow-typed/",


### PR DESCRIPTION
Not sure what the consequences are including the `bench/` in the files array but I would like to consume it for another project so I'm proposing a change that its added to the published dependency.