### PR TITLE
Video source update

### DIFF
--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -181,7 +181,7 @@ class VideoSource extends ImageSource {
     }
 
     hasTransition() {
-        var result = this.video && (!this.video.paused || this.videoSeeked);
+        let result = this.video && (!this.video.paused || this.videoSeeked);
         if (this.videoSeeked && this.textureDrawn) {
             this.videoSeeked = false;
             this.textureDrawn = false;

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -181,7 +181,7 @@ class VideoSource extends ImageSource {
     }
 
     hasTransition() {
-        let result = this.video && (!this.video.paused || this.videoSeeked);
+        const result = this.video && (!this.video.paused || this.videoSeeked);
         if (this.videoSeeked && this.textureDrawn) {
             this.videoSeeked = false;
             this.textureDrawn = false;

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -51,6 +51,7 @@ class VideoSource extends ImageSource {
     video: HTMLVideoElement;
     roundZoom: boolean;
     videoSeeked: boolean;
+    textureDrawn: boolean;
 
     /**
      * @private
@@ -60,6 +61,8 @@ class VideoSource extends ImageSource {
         this.roundZoom = true;
         this.type = 'video';
         this.options = options;
+        this.videoSeeked = false;
+        this.textureDrawn = false;
     }
 
     load() {
@@ -156,6 +159,10 @@ class VideoSource extends ImageSource {
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, this.video);
         }
 
+        if (this.videoSeeked) {
+            this.textureDrawn = true;
+        }
+
         for (const w in this.tiles) {
             const tile = this.tiles[w];
             if (tile.state !== 'loaded') {
@@ -175,8 +182,9 @@ class VideoSource extends ImageSource {
 
     hasTransition() {
         var result = this.video && (!this.video.paused || this.videoSeeked);
-        if (this.videoSeeked) {
+        if (this.videoSeeked && this.textureDrawn) {
             this.videoSeeked = false;
+            this.textureDrawn = false;
         }
         return result;
     }

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -50,7 +50,7 @@ class VideoSource extends ImageSource {
     urls: Array<string>;
     video: HTMLVideoElement;
     roundZoom: boolean;
-    videoSeeked: boolean;
+    needsUpdate: boolean;
     textureDrawn: boolean;
 
     /**
@@ -61,7 +61,7 @@ class VideoSource extends ImageSource {
         this.roundZoom = true;
         this.type = 'video';
         this.options = options;
-        this.videoSeeked = false;
+        this.needsUpdate = false;
         this.textureDrawn = false;
     }
 
@@ -89,7 +89,7 @@ class VideoSource extends ImageSource {
                 // After video is seeked and ready to be shown, start repainting and set flag
                 // hasTransition() will return true to trigger a single frame repaint, then remove flag
                 this.video.addEventListener('seeked', () => {
-                    this.videoSeeked = true;
+                    this.needsUpdate = true;
                     this.map.triggerRepaint();
                 });
 
@@ -154,12 +154,12 @@ class VideoSource extends ImageSource {
         if (!this.texture) {
             this.texture = new Texture(context, this.video, gl.RGBA);
             this.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
-        } else if (!this.video.paused || this.videoSeeked) {
+        } else if (!this.video.paused || this.needsUpdate) {
             this.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, this.video);
         }
 
-        if (this.videoSeeked) {
+        if (this.needsUpdate) {
             this.textureDrawn = true;
         }
 
@@ -181,9 +181,9 @@ class VideoSource extends ImageSource {
     }
 
     hasTransition() {
-        const result = this.video && (!this.video.paused || this.videoSeeked);
-        if (this.videoSeeked && this.textureDrawn) {
-            this.videoSeeked = false;
+        const result = this.video && (!this.video.paused || this.needsUpdate);
+        if (this.needsUpdate && this.textureDrawn) {
+            this.needsUpdate = false;
             this.textureDrawn = false;
         }
         return result;


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Potential fix for issue #7647 this would allow for a video to be redrawn once it has been seeked to a different time regardless of whether the video is playing or not.

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
