### PR TITLE
fix disabling repaint within custom layer `render`

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1828,7 +1828,12 @@ class Map extends Camera {
      * @memberof Map
      */
     get repaint(): boolean { return !!this._repaint; }
-    set repaint(value: boolean) { this._repaint = value; this._update(); }
+    set repaint(value: boolean) {
+        if (this._repaint !== value) {
+            this._repaint = value;
+            this.triggerRepaint();
+        }
+    }
 
     // show vertices
     get vertices(): boolean { return !!this._vertices; }


### PR DESCRIPTION
fix #7649

make `map.repaint = value` only trigger a repaint when it changes the value.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page