### PR TITLE
set default map style option to an empty style #6748

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -98,6 +98,11 @@ type MapOptions = {
 const defaultMinZoom = 0;
 const defaultMaxZoom = 22;
 const defaultOptions = {
+    style: {
+        version: 8,
+        sources: {},
+        layers: []
+    },
     center: [0, 0],
     zoom: 0,
     bearing: 0,


### PR DESCRIPTION
This PR sets the default map style option to an empty style according to https://github.com/mapbox/mapbox-gl-js/issues/6748
I'm not sure about hardcoding `version`, maybe there is a more convenient way?

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
