### PR TITLE
Fix terrarium source on hillshade debug page

### DIFF
--- a/debug/hillshade.html
+++ b/debug/hillshade.html
@@ -92,7 +92,8 @@ map.on('load', function () {
         "tiles": [
             "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png"
         ],
-        "tileSize": 256
+        "tileSize": 128,
+        "maxzoom": 15
     });
     map.addLayer({
         "id": "Terrarium data",


### PR DESCRIPTION
Terrarium data is rendering incorrectly on the hillshade debug page because the source doesn't provide a `maxzoom`. This property is used by the hillshadePrepare shader to properly calculate hillshade exaggeration. I fixed this and also changed `tileSize` to reflect the fact that terrarium tiles are 256px and not 512px.

Before:

<img width="1280" alt="terrarium-dem-before" src="https://user-images.githubusercontent.com/28855024/49590865-a73ea780-f9b8-11e8-9a33-a478652eec6a.png">

After:

<img width="1280" alt="terrarium-dem-after" src="https://user-images.githubusercontent.com/28855024/49591723-f4237d80-f9ba-11e8-8440-edf2b73f3c17.png">

