### PR TITLE
Flatten converted all expression filters

### DIFF
--- a/src/style-spec/feature_filter/convert.js
+++ b/src/style-spec/feature_filter/convert.js
@@ -92,7 +92,7 @@ function _convertFilter(filter: FilterSpecification, expectedTypes: ExpectedType
         return ['any'].concat(children);
     } else if (op === 'all') {
         const children = (filter: any).slice(1).map(f => _convertFilter(f, expectedTypes));
-        return ['all'].concat(children);
+        return children.length > 1 ? ['all'].concat(children) : [].concat(...children);
     } else if (op === 'none') {
         return ['!', _convertFilter(['any'].concat(filter.slice(1)), {})];
     } else if (op === 'in') {

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -100,6 +100,45 @@ test('convert legacy filters to expressions', t => {
         t.end();
     });
 
+    t.test('flattens nested, single child all expressions', (t) => {
+        const filter = [
+            "all",
+            [
+                "in",
+                "$type",
+                "Polygon",
+                "LineString",
+                "Point"
+            ],
+            [
+                "all",
+                ["in", "type", "island"]
+            ]
+        ];
+
+        const expected = [
+            "all",
+            [
+                "match",
+                ["geometry-type"],
+                ["Polygon", "LineString", "Point"],
+                true,
+                false
+            ],
+            [
+                "match",
+                ["get", "type"],
+                ["island"],
+                true,
+                false
+            ]
+        ];
+
+        const converted = convertFilter(filter);
+        t.same(converted, expected);
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
When converting a legacy filter to an expressionized all expression filter, you could see nested all expressions with only one element. This PR removes that redundant nested all expression.

I think maybe an example would demonstrate this better:
```js
// Legacy filter
[
  "all",
  [
    "in",
    "$type",
    "Polygon",
    "LineString",
    "Point"
  ],
  [
    "all",
    ["in", "type", "island"]
  ]
]

// Converted (before this PR)
[
  "all",
  [
    "match",
    ["geometry-type"],
    ["Polygon", "LineString", "Point"],
    true,
    false
  ],
  [
    "all",
    [
      "match",
      ["get", "type"],
      ["island"],
      true,
      false
    ]
  ]
]

// Converted (after this PR)
[
  "all",
  [
    "match",
    ["geometry-type"],
    ["Polygon", "LineString", "Point"],
    true,
    false
  ],
  [
    "match",
    ["get", "type"],
    ["island"],
    true,
    false
  ]
]
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes

cc @mapbox/studio @mapbox/maps-design 