### PR TITLE
[docs]Add mapbox events domain to CSP directives

### DIFF
--- a/docs/components/quickstart.js
+++ b/docs/components/quickstart.js
@@ -140,7 +140,7 @@ export default class extends React.Component {
 
                         <p>Requesting styles from Mapbox or other services will require additional
                             directives. For Mapbox, you can use this <code>connect-src</code> directive:</p>
-                        <pre><code>{`connect-src https://*.tiles.mapbox.com https://api.mapbox.com`}</code></pre>
+                        <pre><code>{`connect-src https://*.tiles.mapbox.com https://api.mapbox.com https://events.mapbox.com`}</code></pre>
                     </div>
                     <div>
                         <h2 className='strong' id='mapbox-css'>Mapbox CSS</h2>


### PR DESCRIPTION
In #6980 and #7431, new events POST to `https://events.mapbox.com`. This domain needs to be whitelisted in the CSP directives to allow event requests to go through.

cc @springmeyer @mollymerp 