### PR TITLE
Use 1px border for DEM backfilling

### DIFF
--- a/src/render/program/hillshade_program.js
+++ b/src/render/program/hillshade_program.js
@@ -87,7 +87,7 @@ const hillshadeUniformPrepareValues = (
     tile: {dem: ?DEMData, tileID: OverscaledTileID}, maxzoom: number
 ): UniformValues<HillshadePrepareUniformsType> => {
     assert(tile.dem);
-    const tileSize = ((tile.dem: any): DEMData).dim;
+    const stride = ((tile.dem: any): DEMData).stride;
     const matrix = mat4.create();
     // Flip rendering at y axis.
     mat4.ortho(matrix, 0, EXTENT, -EXTENT, 0, 0, 1);
@@ -96,7 +96,7 @@ const hillshadeUniformPrepareValues = (
     return {
         'u_matrix': matrix,
         'u_image': 1,
-        'u_dimension': [tileSize * 2, tileSize * 2],
+        'u_dimension': [stride, stride],
         'u_zoom': tile.tileID.overscaledZ,
         'u_maxzoom': maxzoom
     };

--- a/src/shaders/hillshade_prepare.vertex.glsl
+++ b/src/shaders/hillshade_prepare.vertex.glsl
@@ -1,4 +1,5 @@
 uniform mat4 u_matrix;
+uniform vec2 u_dimension;
 
 attribute vec2 a_pos;
 attribute vec2 a_texture_pos;
@@ -7,5 +8,8 @@ varying vec2 v_pos;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
-    v_pos = (a_texture_pos / 8192.0) / 2.0 + 0.25;
+
+    vec2 epsilon = 1.0 / u_dimension;
+    float scale = (u_dimension.x - 2.0) / u_dimension.x;
+    v_pos = (a_texture_pos / 8192.0) * scale + epsilon;
 }

--- a/test/unit/data/dem_data.test.js
+++ b/test/unit/data/dem_data.test.js
@@ -17,8 +17,7 @@ test('DEMData', (t) => {
         const dem = new DEMData(0, {width: 4, height: 4, data: new Uint8ClampedArray(4 * 4 * 4)});
         t.equal(dem.uid, 0);
         t.equal(dem.dim, 4);
-        t.equal(dem.border, 2);
-        t.equal(dem.stride, 8);
+        t.equal(dem.stride, 6);
         t.true(dem.data instanceof Int32Array);
         t.end();
     });
@@ -141,8 +140,7 @@ test('DEMData#backfillBorder', (t) => {
             $name: 'DEMData',
             uid: 0,
             dim: 4,
-            border: 2,
-            stride: 8,
+            stride: 6,
             data: dem0.data,
         }, 'serializes DEM');
 


### PR DESCRIPTION
This PR removes the empty 256 pixels of padding around DEM data. This padding means that the DEMData array buffer is ~4x as big as it needs to be, and we're uploading a ~4x demTexture to the GPU. A one pixel border is all we need for DEM backfilling. The demTexture is not mipmapped so I don't think it needs to be a power-of-two texture. A quick look at Chrome Dev Tools shows a big drop in memory usage on the hillshade debug page (119MB to 47MB). Benchmarks don't show anything notable.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page

![paint](https://user-images.githubusercontent.com/28855024/49670707-48a92480-fab1-11e8-87ec-4448e4f3c974.png)
![layout](https://user-images.githubusercontent.com/28855024/49671054-60cd7380-fab2-11e8-858e-fbc092cb6a90.png)
![layerhillshade](https://user-images.githubusercontent.com/28855024/49671249-f1a44f00-fab2-11e8-810d-bcb14576819a.png)
