### PR TITLE
avoid incomplete webp support in Edge 18

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -25,7 +25,7 @@ import { RGBAImage } from '../util/image';
 import { Event, ErrorEvent } from '../util/evented';
 import { MapMouseEvent } from './events';
 import TaskQueue from '../util/task_queue';
-import testWebp from '../util/test_webp';
+import webpSupported from '../util/webp_supported';
 
 import type {PointLike} from '@mapbox/point-geometry';
 import type {LngLatLike} from '../geo/lng_lat';
@@ -1541,7 +1541,7 @@ class Map extends Camera {
 
         this.painter = new Painter(gl, this.transform);
 
-        testWebp(gl);
+        webpSupported.testSupport(gl);
     }
 
     _contextLost(event: *) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -25,6 +25,7 @@ import { RGBAImage } from '../util/image';
 import { Event, ErrorEvent } from '../util/evented';
 import { MapMouseEvent } from './events';
 import TaskQueue from '../util/task_queue';
+import testWebp from '../util/test_webp';
 
 import type {PointLike} from '@mapbox/point-geometry';
 import type {LngLatLike} from '../geo/lng_lat';
@@ -1539,6 +1540,8 @@ class Map extends Camera {
         }
 
         this.painter = new Painter(gl, this.transform);
+
+        testWebp(gl);
     }
 
     _contextLost(event: *) {

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -56,33 +56,3 @@ const exported = {
 };
 
 export default exported;
-
-if (window.document) {
-    testWebp();
-}
-
-function testWebp() {
-    const webpImgTest = window.document.createElement('img');
-    webpImgTest.onload = function() {
-
-        // Edge 18 supports WebP but not uploading a WebP image to a gl texture
-        // Test support for this before allowing WebP images.
-        // https://github.com/mapbox/mapbox-gl-js/issues/7671
-        const canvas = window.document.createElement('canvas');
-        const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-        const texture = gl.createTexture();
-        gl.bindTexture(gl.TEXTURE_2D, texture);
-
-        try {
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, webpImgTest);
-            exported.supportsWebp = true;
-        } catch (e) {
-            // Catch "Unspecified Error." in Edge 18.
-        }
-
-        gl.deleteTexture(texture);
-        const extension = gl.getExtension('WEBGL_lose_context');
-        if (extension) extension.loseContext();
-    };
-    webpImgTest.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';
-}

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -58,9 +58,31 @@ const exported = {
 export default exported;
 
 if (window.document) {
+    testWebp();
+}
+
+function testWebp() {
     const webpImgTest = window.document.createElement('img');
     webpImgTest.onload = function() {
-        exported.supportsWebp = true;
+
+        // Edge 18 supports WebP but not uploading a WebP image to a gl texture
+        // Test support for this before allowing WebP images.
+        // https://github.com/mapbox/mapbox-gl-js/issues/7671
+        const canvas = window.document.createElement('canvas');
+        const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+        const texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+
+        try {
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, webpImgTest);
+            exported.supportsWebp = true;
+        } catch (e) {
+            // Catch "Unspecified Error." in Edge 18.
+        }
+
+        gl.deleteTexture(texture);
+        const extension = gl.getExtension('WEBGL_lose_context');
+        if (extension) extension.loseContext();
     };
     webpImgTest.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';
 }

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -51,8 +51,7 @@ const exported = {
     },
 
     hardwareConcurrency: window.navigator.hardwareConcurrency || 4,
-    get devicePixelRatio() { return window.devicePixelRatio; },
-    supportsWebp: false
+    get devicePixelRatio() { return window.devicePixelRatio; }
 };
 
 export default exported;

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -3,6 +3,7 @@
 import config from './config';
 
 import browser from './browser';
+import webpSupported from './webp_supported';
 import window from './window';
 import { version } from '../../package.json';
 import { uuid, validateUuid, storageAvailable, warnOnce, extend } from './util';
@@ -101,7 +102,7 @@ export const normalizeTileURL = function(tileURL: string, sourceURL?: ?string, t
     // is appended to the tile URL. If `tileSize: 512` is specified for
     // a Mapbox raster source force the @2x suffix even if a non hidpi device.
     const suffix = browser.devicePixelRatio >= 2 || tileSize === 512 ? '@2x' : '';
-    const extension = browser.supportsWebp ? '.webp' : '$1';
+    const extension = webpSupported.supported ? '.webp' : '$1';
     urlObject.path = urlObject.path.replace(imageExtensionRe, `${suffix}${extension}`);
     urlObject.path = `/v4${urlObject.path}`;
 

--- a/src/util/test_webp.js
+++ b/src/util/test_webp.js
@@ -1,0 +1,52 @@
+// @flow
+
+import browser from './browser';
+
+let glForTesting;
+let webpCheckComplete = false;
+let webpImgTest;
+
+if (window.document) {
+    webpImgTest = window.document.createElement('img');
+    webpImgTest.onload = function() {
+        if (glForTesting) testWebpTextureUpload(glForTesting);
+        glForTesting = null;
+    }
+    webpImgTest.onerror = function() {
+        webpCheckComplete = true;
+        glForTesting = null;
+    }
+    webpImgTest.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';
+}
+
+export default testWebp;
+
+function testWebp(gl: WebGLRenderingContext) {
+    if (webpCheckComplete || !webpImgTest) return;
+
+    if (!webpImgTest.complete) {
+        glForTesting = gl;
+        return;
+    }
+
+    testWebpTextureUpload(gl);
+}
+
+function testWebpTextureUpload(gl: WebGLRenderingContext) {
+    // Edge 18 supports WebP but not uploading a WebP image to a gl texture
+    // Test support for this before allowing WebP images.
+    // https://github.com/mapbox/mapbox-gl-js/issues/7671
+    const texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+
+    try {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, webpImgTest);
+        browser.supportsWebp = true;
+    } catch (e) {
+        // Catch "Unspecified Error." in Edge 18.
+    }
+
+    gl.deleteTexture(texture);
+
+    webpCheckComplete = true;
+}

--- a/src/util/test_webp.js
+++ b/src/util/test_webp.js
@@ -1,5 +1,6 @@
 // @flow
 
+import window from './window';
 import browser from './browser';
 
 let glForTesting;
@@ -11,11 +12,11 @@ if (window.document) {
     webpImgTest.onload = function() {
         if (glForTesting) testWebpTextureUpload(glForTesting);
         glForTesting = null;
-    }
+    };
     webpImgTest.onerror = function() {
         webpCheckComplete = true;
         glForTesting = null;
-    }
+    };
     webpImgTest.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';
 }
 

--- a/src/util/webp_supported.js
+++ b/src/util/webp_supported.js
@@ -1,7 +1,13 @@
 // @flow
 
 import window from './window';
-import browser from './browser';
+
+const exported = {
+    supported: false,
+    testSupport
+};
+
+export default exported;
 
 let glForTesting;
 let webpCheckComplete = false;
@@ -20,9 +26,7 @@ if (window.document) {
     webpImgTest.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';
 }
 
-export default testWebp;
-
-function testWebp(gl: WebGLRenderingContext) {
+function testSupport(gl: WebGLRenderingContext) {
     if (webpCheckComplete || !webpImgTest) return;
 
     if (!webpImgTest.complete) {
@@ -42,7 +46,11 @@ function testWebpTextureUpload(gl: WebGLRenderingContext) {
 
     try {
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, webpImgTest);
-        browser.supportsWebp = true;
+
+        // The error does not get triggered in Edge if the context is lost
+        if (gl.isContextLost()) return;
+
+        exported.supported = true;
     } catch (e) {
         // Catch "Unspecified Error." in Edge 18.
     }

--- a/test/unit/util/browser.test.js
+++ b/test/unit/util/browser.test.js
@@ -33,10 +33,5 @@ test('browser', (t) => {
         t.end();
     });
 
-    t.test('supportsWebp', (t) => {
-        t.equal(typeof browser.supportsWebp, 'boolean');
-        t.end();
-    });
-
     t.end();
 });

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -2,6 +2,7 @@ import { test } from 'mapbox-gl-js-test';
 import * as mapbox from '../../../src/util/mapbox';
 import config from '../../../src/util/config';
 import browser from '../../../src/util/browser';
+import webpSupported from '../../../src/util/webp_supported';
 import window from '../../../src/util/window';
 import { uuid } from '../../../src/util/util';
 import { version } from '../../../package.json';
@@ -287,7 +288,7 @@ test("mapbox", (t) => {
     });
 
     t.test('.normalizeTileURL', (t) => {
-        browser.supportsWebp = false;
+        webpSupported.supported = false;
 
         t.test('does nothing on 1x devices', (t) => {
             config.API_URL = 'http://path.png';
@@ -321,14 +322,14 @@ test("mapbox", (t) => {
         });
 
         t.test('replaces img extension with webp on supporting devices', (t) => {
-            browser.supportsWebp = true;
+            webpSupported.supported = true;
             config.API_URL = 'http://path.png';
             config.REQUIRE_ACCESS_TOKEN = false;
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png', mapboxSource), 'http://path.png/v4/tile.webp');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png32', mapboxSource), 'http://path.png/v4/tile.webp');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.jpg70', mapboxSource), 'http://path.png/v4/tile.webp');
             t.equal(mapbox.normalizeTileURL('http://path.png/tile.png?access_token=foo', mapboxSource), 'http://path.png/v4/tile.webp?access_token=foo');
-            browser.supportsWebp = false;
+            webpSupported.supported = false;
             t.end();
         });
 
@@ -372,7 +373,7 @@ test("mapbox", (t) => {
             t.end();
         });
 
-        browser.supportsWebp = true;
+        webpSupported.supported = true;
         t.end();
     });
 

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -1,7 +1,6 @@
 import { test } from 'mapbox-gl-js-test';
 import * as mapbox from '../../../src/util/mapbox';
 import config from '../../../src/util/config';
-import browser from '../../../src/util/browser';
 import webpSupported from '../../../src/util/webp_supported';
 import window from '../../../src/util/window';
 import { uuid } from '../../../src/util/util';


### PR DESCRIPTION
Edge 18 supports WebP but not uploading WebP images to gl textures. Avoid this bug by testing support for this before enabling WebP loading.

fix #7671 

The one downside of this approach is that once per page load we create a gl context and throw it away. I haven't seen this be a problem though. We could wait until a map is initialized and use that context but that would be more complex.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page

We can't add automated testing because we don't do any of that in Edge. Manually testing the satellite map example does test this.
