### PR TITLE
Cache hillshade textures based on texture size, not tile size.

### DIFF
--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -80,6 +80,7 @@ function prepareHillshade(painter, tile, layer, sourceMaxZoom, depthMode, stenci
     // base 2 - 0000 0000, 0000 0001, 0000 0110, 1110 1100
     if (tile.dem && tile.dem.data) {
         const tileSize = tile.dem.dim;
+        const textureStride = tile.dem.stride;
 
         const pixelData = tile.dem.getPixels();
         context.activeTexture.set(gl.TEXTURE1);
@@ -88,7 +89,7 @@ function prepareHillshade(painter, tile, layer, sourceMaxZoom, depthMode, stenci
         // tiles will appear blank, because as you can see above the alpha value for these textures
         // is always 0
         context.pixelStoreUnpackPremultiplyAlpha.set(false);
-        tile.demTexture = tile.demTexture || painter.getTileTexture(tile.tileSize);
+        tile.demTexture = tile.demTexture || painter.getTileTexture(textureStride);
         if (tile.demTexture) {
             const demTexture = tile.demTexture;
             demTexture.update(pixelData, { premultiply: false });


### PR DESCRIPTION
Fixes #7690 -- hillshade layers leak GPU memory.

I tested this manually by panning around in the `hillshade.html` debug page. Before the change, you can see `painter._tileTextures` fill up with an unbounded set of textures and watch memory use grow. After the change, memory use stabilizes after panning around for a while, and you can watch textures getting re-used in `Painter#getTileTexture`.

@mollymerp it doesn't look to me like native has the same problem, but not sure if the logic could be hidden somewhere else -- does that sound right to you?

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~~