### PR TITLE
make texture pos epsilon highp for hillshade on gl-native

### DIFF
--- a/src/shaders/hillshade_prepare.vertex.glsl
+++ b/src/shaders/hillshade_prepare.vertex.glsl
@@ -9,7 +9,7 @@ varying vec2 v_pos;
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
-    vec2 epsilon = 1.0 / u_dimension;
+    highp vec2 epsilon = 1.0 / u_dimension;
     float scale = (u_dimension.x - 2.0) / u_dimension.x;
     v_pos = (a_texture_pos / 8192.0) * scale + epsilon;
 }


### PR DESCRIPTION

This value needs to be highp for native to work with the change at #7683.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
