### PR TITLE
Don't use fetch API when protocol is file:

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -158,7 +158,12 @@ function makeXMLHttpRequest(requestParameters: RequestParameters, callback: Resp
     return { cancel: () => xhr.abort() };
 }
 
-const makeRequest = window.fetch && window.Request && window.AbortController ? makeFetchRequest : makeXMLHttpRequest;
+const makeRequest = window.fetch &&
+                    window.Request &&
+                    window.AbortController &&
+                    window.location.protocol !== 'file:' ?
+    makeFetchRequest :
+    makeXMLHttpRequest;
 
 export const getJSON = function(requestParameters: RequestParameters, callback: ResponseCallback<Object>): Cancelable {
     return makeRequest(extend(requestParameters, { type: 'json' }), callback);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

Closes #7603 

This PR adds the condition that the protocol is not `file:` to use the fetch API

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
