### PR TITLE
Update compatibility matrix for `fill-extrusion-vertical-gradient` for iOS & macOS

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3777,7 +3777,9 @@
       "transition": false,
       "sdk-support": {
         "basic functionality": {
-          "js": "0.50.0"
+          "js": "0.50.0",
+          "ios" : "4.7.0",
+          "macos" : "0.13.0"
         }
       },
       "expression": {


### PR DESCRIPTION
Updates the style spec compatibility matrix for the `fill-extrusion-vertical-gradient` property, as this is now supported in iOS and macOS as `MGLFillExtrusionStyleLayer.fillExtrusionHasVerticalGradient` as of iOS 4.7.0 / macOS 0.13.0

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] ~write tests for all new functionality~
 - [ ] ~document any changes to public APIs~
 - [ ] ~post benchmark scores~
 - [ ] manually test the debug page
 