### PR TITLE
Add support for #map= hash prefix

### DIFF
--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -78,7 +78,7 @@ class Hash {
     }
 
     _onHashChange() {
-        const loc = window.location.hash.replace('#map=','').replace('#', '').split('/');
+        const loc = window.location.hash.replace('#map=', '').replace('#', '').split('/');
         if (loc.length >= 3) {
             this._map.jumpTo({
                 center: [+loc[2], +loc[1]],

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -78,7 +78,7 @@ class Hash {
     }
 
     _onHashChange() {
-        const loc = window.location.hash.replace('#', '').split('/');
+        const loc = window.location.hash.replace('#map=','').replace('#', '').split('/');
         if (loc.length >= 3) {
             this._map.jumpTo({
                 center: [+loc[2], +loc[1]],

--- a/test/unit/ui/hash.test.js
+++ b/test/unit/ui/hash.test.js
@@ -58,7 +58,7 @@ test('hash', (t) => {
         t.equal(map.getBearing(), 0);
         t.equal(map.getPitch(), 0);
 
-        window.location.hash = '#5/1.00/0.50/30/60';
+        window.location.hash = '#map=5/1.00/0.50/30/60';
 
         hash._onHashChange();
 


### PR DESCRIPTION
This enables URLs used by OSM to be copied directly, without breakage.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs **(there are none)**
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes **(it doesn't)**
