### PR TITLE
Fixes bugs in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ Mapbox GL JS is licensed under the [3-Clause BSD license](https://github.com/map
 The licenses of its dependencies are tracked via [FOSSA](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-js):
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-js.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-js?ref=badge_large)
+a

--- a/README.md
+++ b/README.md
@@ -33,4 +33,3 @@ Mapbox GL JS is licensed under the [3-Clause BSD license](https://github.com/map
 The licenses of its dependencies are tracked via [FOSSA](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-js):
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-js.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-js?ref=badge_large)
-a

--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -1,6 +1,7 @@
 toc:
   - Map
   - accessToken
+  - url
   - supported
   - version
   - setRTLTextPlugin

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -218,16 +218,13 @@ export class MapWheelEvent extends Event {
 /**
  * @typedef {Object} MapBoxZoomEvent
  * @property {MouseEvent} originalEvent
- * @property {LngLatBounds} boxZoomBounds The bounding box of the "box zoom" interaction.
- *   This property is only provided for `boxzoomend` events.
  */
 export type MapBoxZoomEvent = {
     type: 'boxzoomstart'
         | 'boxzoomend'
         | 'boxzoomcancel',
     map: Map,
-    originalEvent: MouseEvent,
-    boxZoomBounds: LngLatBounds
+    originalEvent: MouseEvent
 };
 
 /**

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -8,7 +8,6 @@ import { extend } from '../util/util';
 
 import type Map from './map';
 import type LngLat from '../geo/lng_lat';
-import type LngLatBounds from '../geo/lng_lat_bounds';
 
 /**
  * `MapMouseEvent` is the event type for mouse-related map events.


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->
Closes #7736 and #7739 

 - [x] briefly describe the changes in this PR
    - Moves `baseApiUrl` under the `Map` header where it should be
    - Removes the `boxZoomBounds` property from the documentation for `MapBoxZoomEvent` which was removed in #6894 