### PR TITLE
Remove popups on Map#remove

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -84,7 +84,7 @@ export default class Popup extends Evented {
     constructor(options: PopupOptions) {
         super();
         this.options = extend(Object.create(defaultOptions), options);
-        bindAll(['_update', '_onClickClose'], this);
+        bindAll(['_update', '_onClickClose', 'remove'], this);
     }
 
     /**
@@ -99,6 +99,7 @@ export default class Popup extends Evented {
         if (this.options.closeOnClick) {
             this._map.on('click', this._onClickClose);
         }
+        this._map.on('remove', this.remove);
         this._update();
 
         /**
@@ -143,6 +144,7 @@ export default class Popup extends Evented {
         if (this._map) {
             this._map.off('move', this._update);
             this._map.off('click', this._onClickClose);
+            this._map.off('remove', this.remove);
             delete this._map;
         }
 

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -459,3 +459,16 @@ test('Popup adds classes from className option', (t) => {
     t.ok(popupContainer.classList.contains('classes'));
     t.end();
 });
+
+test('Popup closes on Map#remove', (t) => {
+    const map = createMap(t);
+    const popup = new Popup()
+        .setText("Test")
+        .setLngLat([0, 0])
+        .addTo(map);
+
+    map.remove();
+
+    t.ok(!popup.isOpen());
+    t.end();
+});


### PR DESCRIPTION
This PR fixes #7744.

Popups are responsible for adding and removing themselves (the map object has no knowledge of popups that have been added to it). Therefore, the simplest solution is for the popup to listen for the map 'remove' event and remove itself.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
