### PR TITLE
map.getLayer() handles undefined style 7775

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1257,7 +1257,7 @@ class Map extends Camera {
      * @see [Filter symbols by text input](https://www.mapbox.com/mapbox-gl-js/example/filter-markers-by-input/)
      */
     getLayer(id: string) {
-        return this.style.getLayer(id);
+        return this.style && this.style.getLayer(id);
     }
 
     /**


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

map.getLayer throws TypeError if map style is undefined. Added check for this.style before calling this.style.getLayer.
