### PR TITLE
Simplify clusterProperties expression

### DIFF
--- a/debug/cluster.html
+++ b/debug/cluster.html
@@ -33,9 +33,9 @@ map.on('load', () => {
         "cluster": true,
         "clusterRadius": 50,
         "clusterProperties": {
-            "max": ["max", 0, ["get", "scalerank"]],
-            "sum": ["+", 0, ["get", "scalerank"]],
-            "has_island": ["any", false, ["==", ["get", "featureclass"], "island"]]
+            "max": ["max", ["get", "scalerank"]],
+            "sum": ["+", ["get", "scalerank"]],
+            "has_island": ["any", ["==", ["get", "featureclass"], "island"]]
         }
     });
     map.addLayer({

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "potpack": "^1.0.1",
     "quickselect": "^1.0.0",
     "rw": "^1.3.3",
-    "supercluster": "^5.0.0",
+    "supercluster": "^6.0.0",
     "tinyqueue": "^1.1.0",
     "vt-pbf": "^3.0.1"
   },

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -298,7 +298,6 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
 function getSuperclusterOptions({superclusterOptions, clusterProperties}) {
     if (!clusterProperties || !superclusterOptions) return superclusterOptions;
 
-    const initialValues = {};
     const mapExpressions = {};
     const reduceExpressions = {};
     const globals = {accumulated: null, zoom: 0};
@@ -306,29 +305,19 @@ function getSuperclusterOptions({superclusterOptions, clusterProperties}) {
     const propertyNames = Object.keys(clusterProperties);
 
     for (const key of propertyNames) {
-        const [operator, initialExpression, mapExpression] = clusterProperties[key];
+        const [operator, mapExpression] = clusterProperties[key];
 
-        const initialExpressionParsed = createExpression(initialExpression);
         const mapExpressionParsed = createExpression(mapExpression);
         const reduceExpressionParsed = createExpression(
             typeof operator === 'string' ? [operator, ['accumulated'], ['get', key]] : operator);
 
-        assert(initialExpressionParsed.result === 'success');
         assert(mapExpressionParsed.result === 'success');
         assert(reduceExpressionParsed.result === 'success');
 
-        initialValues[key] = (initialExpressionParsed.value: any).evaluate(globals);
         mapExpressions[key] = mapExpressionParsed.value;
         reduceExpressions[key] = reduceExpressionParsed.value;
     }
 
-    superclusterOptions.initial = () => {
-        const properties = {};
-        for (const key of propertyNames) {
-            properties[key] = initialValues[key];
-        }
-        return properties;
-    };
     superclusterOptions.map = (pointProperties) => {
         feature.properties = pointProperties;
         const properties = {};

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -375,7 +375,7 @@
     },
     "clusterProperties": {
       "type": "*",
-      "doc": "An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from clustered points. Has the form `{\"property_name\": [operator, initial_expression, map_expression]}`. `operator` is any expression function that accepts at least 2 operands (e.g. `\"+\"` or `\"max\"`) — it accumulates the property value from clusters/points the cluster contains; `initial_expression` evaluates the initial value of the property before accummulating other points/clusters; `map_expression` produces the value of a single point.\n\nExample: `{\"sum\": [\"+\", 0, [\"get\", \"scalerank\"]]}`.\n\nFor more advanced use cases, in place of `operator`, you can use a custom reduce expression that references a special `[\"accumulated\"]` value, e.g.:\n`{\"sum\": [[\"+\", [\"accumulated\"], [\"get\", \"sum\"]], 0, [\"get\", \"scalerank\"]]}`"
+      "doc": "An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from clustered points. Has the form `{\"property_name\": [operator, map_expression]}`. `operator` is any expression function that accepts at least 2 operands (e.g. `\"+\"` or `\"max\"`) — it accumulates the property value from clusters/points the cluster contains; `map_expression` produces the value of a single point.\n\nExample: `{\"sum\": [\"+\", [\"get\", \"scalerank\"]]}`.\n\nFor more advanced use cases, in place of `operator`, you can use a custom reduce expression that references a special `[\"accumulated\"]` value, e.g.:\n`{\"sum\": [[\"+\", [\"accumulated\"], [\"get\", \"sum\"]], [\"get\", \"scalerank\"]]}`"
     },
     "lineMetrics": {
       "type": "boolean",

--- a/src/style-spec/validate/validate_source.js
+++ b/src/style-spec/validate/validate_source.js
@@ -48,14 +48,9 @@ export default function validateSource(options) {
         });
         if (value.cluster) {
             for (const prop in value.clusterProperties) {
-                const [operator, initialExpr, mapExpr] = value.clusterProperties[prop];
+                const [operator, mapExpr] = value.clusterProperties[prop];
                 const reduceExpr = typeof operator === 'string' ? [operator, ['accumulated'], ['get', prop]] : operator;
 
-                errors.push(...validateExpression({
-                    key: `${key}.${prop}.initial`,
-                    value: initialExpr,
-                    expressionContext: 'cluster-initial'
-                }));
                 errors.push(...validateExpression({
                     key: `${key}.${prop}.map`,
                     value: mapExpr,

--- a/test/integration/render-tests/geojson/clustered-properties/style.json
+++ b/test/integration/render-tests/geojson/clustered-properties/style.json
@@ -20,7 +20,7 @@
       "clusterProperties": {
         "max": ["max", ["get", "scalerank"]],
         "sum": ["+", ["get", "scalerank"]],
-        "has_island": ["any", false, ["==", ["get", "featureclass"], "island"]]
+        "has_island": ["any", ["==", ["get", "featureclass"], "island"]]
       }
     }
   },

--- a/test/integration/render-tests/geojson/clustered-properties/style.json
+++ b/test/integration/render-tests/geojson/clustered-properties/style.json
@@ -18,8 +18,8 @@
       "cluster": true,
       "clusterRadius": 50,
       "clusterProperties": {
-        "max": ["max", 0, ["get", "scalerank"]],
-        "sum": ["+", 0, ["get", "scalerank"]],
+        "max": ["max", ["get", "scalerank"]],
+        "sum": ["+", ["get", "scalerank"]],
         "has_island": ["any", false, ["==", ["get", "featureclass"], "island"]]
       }
     }

--- a/test/unit/style-spec/fixture/sources.input.json
+++ b/test/unit/style-spec/fixture/sources.input.json
@@ -46,9 +46,8 @@
       "data": "/test/integration/data/places.geojson",
       "cluster": true,
       "clusterProperties": {
-        "initial": ["+", ["get", "scalerank"], 0],
-        "zoom": ["+", 0, ["zoom"]],
-        "state": ["+", 0, ["feature-state", "foo"]]
+        "zoom": ["+", ["zoom"]],
+        "state": ["+", ["feature-state", "foo"]]
       }
     }
   },

--- a/test/unit/style-spec/fixture/sources.output.json
+++ b/test/unit/style-spec/fixture/sources.output.json
@@ -40,15 +40,11 @@
     "identifier": "source.canvas"
   },
   {
-    "message": "sources.cluster-properties.initial.initial: Feature data expressions are not supported with initial expression part of cluster properties.",
+    "message": "sources.cluster-properties.zoom.map: \"zoom\" and \"feature-state\" expressions are not supported with cluster properties.",
     "line": 49
   },
   {
-    "message": "sources.cluster-properties.zoom.map: \"zoom\" and \"feature-state\" expressions are not supported with cluster properties.",
-    "line": 50
-  },
-  {
     "message": "sources.cluster-properties.state.map: \"zoom\" and \"feature-state\" expressions are not supported with cluster properties.",
-    "line": 51
+    "line": 50
   }
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -11535,10 +11535,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-supercluster@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-5.0.0.tgz#2a5a9b1ffbd0d6180dea10039d78b5d95fdb8f27"
-  integrity sha512-9eeD5Q3908+tqdz+wYHHzi5mLKgnqtpO5mrjUfqr67UmGuOwBtVoQ9pJJrfcVHwMwC0wEBvfNRF9PgFOZgsOpw==
+supercluster@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-6.0.0.tgz#7058b45545f8bacafb917a66ff2d4d36f74fd2ba"
+  integrity sha512-Jw0KG1zheUvNWYyl1NPb3yUURq6j6Q8rm+maY18+DDrJKmhkz0oxXoWQLf2usXVFJ0urQ8h0gh24yYV8y74WEg==
   dependencies:
     kdbush "^3.0.0"
 


### PR DESCRIPTION
Removes the `initial` part of `clusterProperties` expressions. See the following discussions for context: 

- https://github.com/mapbox/supercluster/pull/114#issuecomment-454392054
- https://github.com/mapbox/mapbox-gl-js/pull/7584#issuecomment-454388022

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~ already covered
 - [x] document any changes to public APIs
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
