### PR TITLE
[docs] updates examples to use docs subdomain

### DIFF
--- a/docs/pages/example/3d-extrusion-floorplan.html
+++ b/docs/pages/example/3d-extrusion-floorplan.html
@@ -17,11 +17,11 @@ map.on('load', function() {
             // GeoJSON Data source used in vector tiles, documented at
             // https://gist.github.com/ryanbaumann/a7d970386ce59d11c16278b90dde094d
             'type': 'geojson',
-            'data': 'https://www.mapbox.com/mapbox-gl-js/assets/indoor-3d-map.geojson'
+            'data': 'https://docs.mapbox.com/mapbox-gl-js/assets/indoor-3d-map.geojson'
         },
         'paint': {
             // See the Mapbox Style Specification for details on data expressions.
-            // https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions
+            // https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions
 
             // Get the fill-extrusion-color from the source 'color' property.
             'fill-extrusion-color': ['get', 'color'],

--- a/docs/pages/example/animate-images.html
+++ b/docs/pages/example/animate-images.html
@@ -13,7 +13,7 @@ var frameCount = 5;
 var currentImage = 0;
 
 function getPath() {
-    return "https://www.mapbox.com/mapbox-gl-js/assets/radar" + currentImage + ".gif";
+    return "https://docs.mapbox.com/mapbox-gl-js/assets/radar" + currentImage + ".gif";
 }
 
 map.on('load', function() {

--- a/docs/pages/example/change-case-of-labels.html
+++ b/docs/pages/example/change-case-of-labels.html
@@ -15,7 +15,7 @@ map.on('load', function() {
         // data from opendata.cityofboise.org/
         'source': {
             'type': 'geojson',
-            'data': 'https://www.mapbox.com/mapbox-gl-js/assets/boise.geojson'
+            'data': 'https://docs.mapbox.com/mapbox-gl-js/assets/boise.geojson'
 
         },
         "layout": {

--- a/docs/pages/example/cluster.html
+++ b/docs/pages/example/cluster.html
@@ -16,7 +16,7 @@ map.on('load', function() {
         type: "geojson",
         // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes
         // from 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
-        data: "https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson",
+        data: "https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson",
         cluster: true,
         clusterMaxZoom: 14, // Max zoom to cluster points on
         clusterRadius: 50 // Radius of each cluster when clustering points (defaults to 50)
@@ -28,7 +28,7 @@ map.on('load', function() {
         source: "earthquakes",
         filter: ["has", "point_count"],
         paint: {
-            // Use step expressions (https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
+            // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
             // with three steps to implement three types of circles:
             //   * Blue, 20px circles when point count is less than 100
             //   * Yellow, 30px circles when point count is between 100 and 750

--- a/docs/pages/example/data-driven-circle-colors.html
+++ b/docs/pages/example/data-driven-circle-colors.html
@@ -24,7 +24,7 @@ map.on('load', function () {
                 'stops': [[12, 2], [22, 180]]
             },
             // color circles by ethnicity, using a match expression
-            // https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-match
+            // https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-match
             'circle-color': [
                 'match',
                 ['get', 'ethnicity'],

--- a/docs/pages/example/data-driven-lines.html
+++ b/docs/pages/example/data-driven-lines.html
@@ -72,7 +72,7 @@ map.on('load', function() {
         },
         'paint': {
             'line-width': 3,
-            // Use a get expression (https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-get)
+            // Use a get expression (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-get)
             // to set the line-color to a feature property value.
             'line-color': ['get', 'color']
         }

--- a/docs/pages/example/heatmap-layer.html
+++ b/docs/pages/example/heatmap-layer.html
@@ -14,7 +14,7 @@ map.on('load', function() {
     // Heatmap layers also work with a vector tile source.
     map.addSource('earthquakes', {
         "type": "geojson",
-        "data": "https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"
+        "data": "https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"
     });
 
     map.addLayer({

--- a/docs/pages/example/hover-styles.html
+++ b/docs/pages/example/hover-styles.html
@@ -11,7 +11,7 @@ var hoveredStateId =  null;
 map.on('load', function () {
     map.addSource("states", {
         "type": "geojson",
-        "data": "https://www.mapbox.com/mapbox-gl-js/assets/us_states.geojson"
+        "data": "https://docs.mapbox.com/mapbox-gl-js/assets/us_states.geojson"
     });
 
     // The feature-state dependent fill-opacity expression will render the hover effect

--- a/docs/pages/example/image-on-a-map.html
+++ b/docs/pages/example/image-on-a-map.html
@@ -10,7 +10,7 @@ var mapStyle = {
         },
         "overlay": {
             "type": "image",
-            "url": "https://www.mapbox.com/mapbox-gl-js/assets/radar.gif",
+            "url": "https://docs.mapbox.com/mapbox-gl-js/assets/radar.gif",
             "coordinates": [
                 [-80.425, 46.437],
                 [-71.516, 46.437],

--- a/docs/pages/example/live-update-feature.html
+++ b/docs/pages/example/live-update-feature.html
@@ -12,7 +12,7 @@ map.on('load', function () {
     // We use D3 to fetch the JSON here so that we can parse and use it separately
     // from GL JS's use in the added source. You can use any request method (library
     // or otherwise) that you want.
-    d3.json('https://www.mapbox.com/mapbox-gl-js/assets/hike.geojson', function(err, data) {
+    d3.json('https://docs.mapbox.com/mapbox-gl-js/assets/hike.geojson', function(err, data) {
         if (err) throw err;
 
         // save full coordinate list for later

--- a/docs/pages/example/restrict-bounds.js
+++ b/docs/pages/example/restrict-bounds.js
@@ -1,7 +1,7 @@
 /*---
 title: Restrict map panning to an area
 description: >-
-  Prevent a map from being panned to a different place by setting [`maxBounds`](https://www.mapbox.com/mapbox-gl-js/api#map#setmaxbounds).
+  Prevent a map from being panned to a different place by setting [`maxBounds`](https://docs.mapbox.com/mapbox-gl-js/api#map#setmaxbounds).
 tags:
   - user-interaction
 pathname: /mapbox-gl-js/example/restrict-bounds/

--- a/docs/pages/example/set-popup.html
+++ b/docs/pages/example/set-popup.html
@@ -1,7 +1,7 @@
 <style>
 
 #marker {
-    background-image: url('https://www.mapbox.com/mapbox-gl-js/assets/washington-monument.jpg');
+    background-image: url('https://docs.mapbox.com/mapbox-gl-js/assets/washington-monument.jpg');
     background-size: cover;
     width: 50px;
     height: 50px;

--- a/docs/pages/example/timeline-animation.html
+++ b/docs/pages/example/timeline-animation.html
@@ -100,7 +100,7 @@ map.on('load', function() {
     //
     // Here we're using d3 to help us make the ajax request but you can use
     // Any request method (library or otherwise) you wish.
-    d3.json('https://www.mapbox.com/mapbox-gl-js/assets/significant-earthquakes-2015.geojson', function(err, data) {
+    d3.json('https://docs.mapbox.com/mapbox-gl-js/assets/significant-earthquakes-2015.geojson', function(err, data) {
         if (err) throw err;
 
         // Create a month property value based on time

--- a/docs/pages/example/visualize-population-density.html
+++ b/docs/pages/example/visualize-population-density.html
@@ -14,7 +14,7 @@ map.on('load', function () {
         'type': 'fill',
         'source': {
             'type': 'geojson',
-            'data': 'https://www.mapbox.com/mapbox-gl-js/assets/rwanda-provinces.geojson'
+            'data': 'https://docs.mapbox.com/mapbox-gl-js/assets/rwanda-provinces.geojson'
         },
         'layout': {},
         'paint': {

--- a/docs/pages/plugins.js
+++ b/docs/pages/plugins.js
@@ -120,7 +120,7 @@ const plugins = {
         },
         "expression-jamsession": {
             "website": "https://github.com/mapbox/expression-jamsession/",
-            "description": md`converts [Mapbox Studio formulas](https://www.mapbox.com/help/studio-manual-styles/#use-a-formula) into [expressions](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions)`
+            "description": md`converts [Mapbox Studio formulas](https://www.mapbox.com/help/studio-manual-styles/#use-a-formula) into [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions)`
         },
         "simplespec-to-gl-style": {
             "website": "https://github.com/mapbox/simplespec-to-gl-style",

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -440,7 +440,7 @@ export default class extends React.Component {
                                 <li>Advanced designers and cartographers who want to write styles by hand rather
                                     than use <a href='https://www.mapbox.com/studio'>Mapbox Studio</a></li>
                                 <li>Developers using style-related features of <a
-                                    href='https://www.mapbox.com/mapbox-gl-js/'>Mapbox GL JS</a> or the <a
+                                    href='https://docs.mapbox.com/mapbox-gl-js/'>Mapbox GL JS</a> or the <a
                                     href='https://www.mapbox.com/android-sdk/'>Mapbox Maps SDK for Android</a></li>
                                 <li>Authors of software that generates or processes Mapbox styles.</li>
                             </ul>
@@ -712,7 +712,7 @@ export default class extends React.Component {
                                         {highlightJSON(`
                                             "image": {
                                                 "type": "image",
-                                                "url": "https://www.mapbox.com/mapbox-gl-js/assets/radar.gif",
+                                                "url": "https://docs.mapbox.com/mapbox-gl-js/assets/radar.gif",
                                                 "coordinates": [
                                                     [-80.425, 46.437],
                                                     [-71.516, 46.437],


### PR DESCRIPTION
We had a CORS issue earlier on some examples that loaded resources because they were pointing at **www**.mapbox.com/mapbox-gl-js/. We've updated the configuration on Fastly to fix this. This PR updates all examples to use the docs subdomain.