### PR TITLE
Add 'to-json' expression

### DIFF
--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -73,6 +73,10 @@ const types = {
         type: 'color',
         parameters: ['value', { repeat: [ 'fallback: value' ] }]
     }],
+    'to-json': [{
+        type: 'json',
+        parameters: ['string']
+    }],
     'to-number': [{
         type: 'number',
         parameters: ['value', { repeat: [ 'fallback: value' ] }]

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -73,6 +73,7 @@ const expressions: ExpressionRegistry = {
     'string': Assertion,
     'to-boolean': Coercion,
     'to-color': Coercion,
+    'to-json': Coercion,
     'to-number': Coercion,
     'to-string': Coercion,
     'var': Var

--- a/src/style-spec/expression/types.js
+++ b/src/style-spec/expression/types.js
@@ -37,6 +37,7 @@ export const NumberType = { kind: 'number' };
 export const StringType = { kind: 'string' };
 export const BooleanType = { kind: 'boolean' };
 export const ColorType = { kind: 'color' };
+export const JsonType = { kind: 'json' };
 export const ObjectType = { kind: 'object' };
 export const ValueType = { kind: 'value' };
 export const ErrorType = { kind: 'error' };
@@ -68,6 +69,7 @@ const valueMemberTypes = [
     StringType,
     BooleanType,
     ColorType,
+    JsonType,
     FormattedType,
     ObjectType,
     array(ValueType)

--- a/src/style-spec/expression/types.js
+++ b/src/style-spec/expression/types.js
@@ -5,6 +5,7 @@ export type NumberTypeT = { kind: 'number' };
 export type StringTypeT = { kind: 'string' };
 export type BooleanTypeT = { kind: 'boolean' };
 export type ColorTypeT = { kind: 'color' };
+export type JsonTypeT = { kind: 'json' };
 export type ObjectTypeT = { kind: 'object' };
 export type ValueTypeT = { kind: 'value' };
 export type ErrorTypeT = { kind: 'error' };
@@ -19,6 +20,7 @@ export type Type =
     StringTypeT |
     BooleanTypeT |
     ColorTypeT |
+    JsonTypeT |
     ObjectTypeT |
     ValueTypeT |
     ArrayType | // eslint-disable-line no-use-before-define

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2606,6 +2606,15 @@
           }
         }
       },
+      "to-json": {
+        "doc": "Converts the input value to a JSON. The input is converted to a JSON using the [`JSON.parse`](https://tc39.github.io/ecma262/#sec-json.parse) function of the ECMAScript Language Specification.",
+        "group": "Types",
+        "sdk-support": {
+          "basic functionality": {
+            "js": "0.52.0"
+          }
+        }
+      },
       "to-string": {
         "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a boolean, the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a color, it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
         "group": "Types",

--- a/test/integration/expression-tests/to-json/2-ary/test.json
+++ b/test/integration/expression-tests/to-json/2-ary/test.json
@@ -1,0 +1,10 @@
+{
+  "expression": ["to-json", ["get", "x"], ["get", "y"]],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [{"key": "", "error": "Expected one argument."}]
+    }
+  }
+}

--- a/test/integration/expression-tests/to-json/basic/test.json
+++ b/test/integration/expression-tests/to-json/basic/test.json
@@ -1,0 +1,21 @@
+{
+  "expression": ["to-json", ["get", "x"]],
+  "inputs": [
+    [{}, {"properties": {"x": "1"}}],
+    [{}, {"properties": {"x": "false"}}],
+    [{}, {"properties": {"x": "null"}}],
+    [{}, {"properties": {"x": "string"}}],
+    [{}, {"properties": {"x": "[1, 2]"}}],
+    [{}, {"properties": {"x": "{\"y\":1}"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "json"
+    },
+    "outputs": [1, false, null, {"error":{}}, [1, 2], {"y": 1}],
+    "serialized": ["to-json", ["get", "x"]]
+  }
+}


### PR DESCRIPTION
Hi there!

Sometimes there is a need to encode some structured data in a feature property. Current vector tiles spec does not support compound properties, such as arrays and objects. We can encode such properties as a stringified JSON.

This PR adds `to-json` expression, that allows parsing stringified JSON.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page

Consider example:

If you have a features with stringified object or array properties, you can use the following expressions to obtain JSON values:

```js
["object", ["to-json", ["get", "stringified-object-property"]]]
```

```js
["array", ["to-json", ["get", "stringified-array-property"]]]
```

What do you think of this?