### PR TITLE
Upgrade supercluster to v6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "potpack": "^1.0.1",
     "quickselect": "^2.0.0",
     "rw": "^1.3.3",
-    "supercluster": "^6.0.0",
+    "supercluster": "^6.0.1",
     "tinyqueue": "^2.0.0",
     "vt-pbf": "^3.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11651,10 +11651,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-supercluster@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-6.0.0.tgz#7058b45545f8bacafb917a66ff2d4d36f74fd2ba"
-  integrity sha512-Jw0KG1zheUvNWYyl1NPb3yUURq6j6Q8rm+maY18+DDrJKmhkz0oxXoWQLf2usXVFJ0urQ8h0gh24yYV8y74WEg==
+supercluster@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-6.0.1.tgz#4c0177d96daa195d58a5bad9f55dbf12fb727a4c"
+  integrity sha512-NTth/FBFUt9mwW03+Z6Byscex+UHu0utroIe6uXjGu9PrTuWtW70LYv9I1vPSYYIHQL74S5zAkrXrHEk0L7dGA==
   dependencies:
     kdbush "^3.0.0"
 


### PR DESCRIPTION
Fixes an important bug in cluster aggregation (https://github.com/mapbox/supercluster/pull/116). Should be cherry-picked into `release-java` too.