### PR TITLE
Fix Safari bug which mistakenly requested WebP images

### DIFF
--- a/src/util/webp_supported.js
+++ b/src/util/webp_supported.js
@@ -12,12 +12,14 @@ export default exported;
 let glForTesting;
 let webpCheckComplete = false;
 let webpImgTest;
+let webpImgTestOnloadComplete = false;
 
 if (window.document) {
     webpImgTest = window.document.createElement('img');
     webpImgTest.onload = function() {
         if (glForTesting) testWebpTextureUpload(glForTesting);
         glForTesting = null;
+        webpImgTestOnloadComplete = true;
     };
     webpImgTest.onerror = function() {
         webpCheckComplete = true;
@@ -34,7 +36,15 @@ function testSupport(gl: WebGLRenderingContext) {
         return;
     }
 
-    testWebpTextureUpload(gl);
+    // HTMLImageElement.complete is set when an image is done loading it's source
+    // regardless of whether the load was successful or not.
+    // It's possible for an error to set HTMLImageElement.complete to true which would trigger
+    // testWebpTextureUpload and mistakenly set exported.supported to true in browsers which don't support webp
+    // To avoid this, we set a flag in the image's onload handler and only call testWebpTextureUpload
+    // after a successful image load event
+    if (webpImgTestOnloadComplete) {
+        testWebpTextureUpload(gl);
+    }
 }
 
 function testWebpTextureUpload(gl: WebGLRenderingContext) {

--- a/src/util/webp_supported.js
+++ b/src/util/webp_supported.js
@@ -41,6 +41,7 @@ function testSupport(gl: WebGLRenderingContext) {
         testWebpTextureUpload(gl);
     } else {
         glForTesting = gl;
+        return;
     }
 }
 

--- a/src/util/webp_supported.js
+++ b/src/util/webp_supported.js
@@ -31,19 +31,16 @@ if (window.document) {
 function testSupport(gl: WebGLRenderingContext) {
     if (webpCheckComplete || !webpImgTest) return;
 
-    if (!webpImgTest.complete) {
-        glForTesting = gl;
-        return;
-    }
-
     // HTMLImageElement.complete is set when an image is done loading it's source
     // regardless of whether the load was successful or not.
     // It's possible for an error to set HTMLImageElement.complete to true which would trigger
     // testWebpTextureUpload and mistakenly set exported.supported to true in browsers which don't support webp
     // To avoid this, we set a flag in the image's onload handler and only call testWebpTextureUpload
-    // after a successful image load event
+    // after a successful image load event.
     if (webpImgTestOnloadComplete) {
         testWebpTextureUpload(gl);
+    } else {
+        glForTesting = gl;
     }
 }
 

--- a/src/util/webp_supported.js
+++ b/src/util/webp_supported.js
@@ -41,7 +41,7 @@ function testSupport(gl: WebGLRenderingContext) {
         testWebpTextureUpload(gl);
     } else {
         glForTesting = gl;
-        return;
+
     }
 }
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->
I uncovered a bug while testing iOS Safari in which WebP images would occasionally be requested. This PR fixes that bug by waiting until the image's onload event fires to check for WebP support.

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
