### PR TITLE
Retain bearing on geolocate

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -187,8 +187,10 @@ class GeolocateControl extends Evented {
     _updateCamera(position: Position) {
         const center = new LngLat(position.coords.longitude, position.coords.latitude);
         const radius = position.coords.accuracy;
+        const bearing = this._map.getBearing();
+        const options = extend({bearing}, this.options.fitBoundsOptions);
 
-        this._map.fitBounds(center.toBounds(radius), this.options.fitBoundsOptions, {
+        this._map.fitBounds(center.toBounds(radius), options, {
             geolocateSource: true // tag this camera change so it won't cause the control to change to background state
         });
     }

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -116,6 +116,32 @@ test('GeolocateControl geolocate fitBoundsOptions', (t) => {
     geolocation.send({latitude: 10, longitude: 20, accuracy: 1});
 });
 
+test('GeolocateControl non-zero bearing', (t) => {
+    t.plan(3);
+
+    const map = createMap(t);
+    map.setBearing(45);
+    const geolocate = new GeolocateControl({
+        fitBoundsOptions: {
+            linear: true,
+            duration: 0,
+            maxZoom: 10
+        }
+    });
+    map.addControl(geolocate);
+
+    const click = new window.Event('click');
+
+    map.once('moveend', () => {
+        t.deepEqual(lngLatAsFixed(map.getCenter(), 4), { lat: 10, lng: 20 }, 'map centered on location');
+        t.equal(map.getBearing(), 45, 'map bearing retained');
+        t.equal(map.getZoom(), 10, 'geolocate fitBounds maxZoom');
+        t.end();
+    });
+    geolocate._geolocateButton.dispatchEvent(click);
+    geolocation.send({latitude: 10, longitude: 20, accuracy: 1});
+});
+
 test('GeolocateControl no watching map camera on geolocation', (t) => {
     t.plan(6);
 


### PR DESCRIPTION
Retains the map bearing when the camera transitions to the user location (closes #7783). If the developer wants to reset north like the old behaviour, they can use `bearing: 0` in `fitBoundsOptions`.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page

@andrewharvey