### PR TITLE
Properly sort new map options in docs nav

### DIFF
--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -1,7 +1,9 @@
 toc:
   - Map
   - accessToken
-  - url
+  - baseApiUrl
+  - workerCount
+  - maxParallelImageRequests
   - supported
   - version
   - setRTLTextPlugin


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->
`url` was changed to `baseApiUrl` and `workerCount` and `maxParallelImageRequests` were added to the map API documentation but not the table of contents so they weren't being sorted properly

