### PR TITLE
Remove Array.find so IE11 works ok

### DIFF
--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -108,7 +108,7 @@ export function deserialize(input: Array<Bucket>, style: Style): {[string]: Buck
         // want to waste time serializing/copying them from the worker)
         (bucket: any).layers = layers;
         if ((bucket: any).stateDependentLayerIds) {
-            (bucket: any).stateDependentLayers = (bucket: any).stateDependentLayerIds.map((lId) => layers.find((l) => l.id === lId));
+            (bucket: any).stateDependentLayers = (bucket: any).stateDependentLayerIds.map((lId) => layers.filter((l) => l.id === lId)[0]);
         }
         for (const layer of layers) {
             output[layer.id] = bucket;


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->
Removes a reference to Array.find that was causing bugs in IE11. Will need to be cherry-picked to the release branch

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality