### PR TITLE
update style benchmark location descriptions and zoom levels

### DIFF
--- a/bench/lib/style_locations.js
+++ b/bench/lib/style_locations.js
@@ -2,13 +2,13 @@ import { OverscaledTileID } from '../../src/source/tile_id';
 
 export default [
     {
-        "description": "Road labels – Houston, z12",
+        "description": "Roads – Houston, z12",
         "tileID": [new OverscaledTileID(12, 0, 12, 962, 1692)],
         "zoom": 12,
         "center": [-95.392263, 29.799396]
     },
     {
-        "description": "Road labels – Houston, z13",
+        "description": "Roads – Houston, z13",
         "tileID": [new OverscaledTileID(13, 0, 13, 1925, 3386)],
         "zoom": 13,
         "center": [-95.38116, 29.74916]
@@ -20,7 +20,7 @@ export default [
         "center": [-73.984682, 40.757660]
     },
     {
-        "description": "High zoom labels (also: buildings, roads) – New York City, z17",
+        "description": "High zoom labels (also: buildings, roads) – New York City, z17, overzoomed",
         "tileID": [new OverscaledTileID(17, 0, 17, 19299, 24629)],
         "zoom": 17,
         "center": [-73.984682, 40.757660]
@@ -32,7 +32,7 @@ export default [
         "center": [139.759860, 35.69522]
     },
     {
-        "description": "High zoom cjk labels, when using local lang (also: buildings, roads) – Tokyo, z17",
+        "description": "High zoom cjk labels, when using local lang (also: buildings, roads) – Tokyo, z17, overzoomed",
         "tileID": [new OverscaledTileID(17, 0, 17, 58210, 25803)],
         "zoom": 17,
         "center": [139.759860, 35.69522]
@@ -44,7 +44,7 @@ export default [
         "center": [27.602348, 61.520945]
     },
     {
-        "description": "Landuse – Paris, z11",
+        "description": "Landuse and roads – Paris, z11",
         "tileID": [new OverscaledTileID(11, 0, 11, 1036, 705)],
         "zoom": 11,
         "center": [2.209530, 48.745030]
@@ -62,9 +62,9 @@ export default [
         "center": [2.315725, 48.866517]
     },
     {
-        "description": "High zoom (pedestrian polygon fills, roads, paths, landuse, labels) – Paris, z16.25",
-        "tileID": [new OverscaledTileID(17, 0, 17, 33189, 22543)],
-        "zoom": 16.25,
+        "description": "High zoom (pedestrian polygon fills, roads, paths, landuse, labels) – Paris, z16",
+        "tileID": [new OverscaledTileID(16, 0, 16, 33189, 22543)],
+        "zoom": 16,
         "center": [2.315725, 48.866517]
     },
     {


### PR DESCRIPTION
This PR updates some of the style benchmark location descriptions, so that they more accurately reflect what aspect of the style is being reviewed:

- Better description of what map features are prominent in the location
- Explicitly calls out use of overzoomed tiles in location description 

This also changes the zoom level for one location ("High zoom (pedestrian polygon fills, roads, paths, landuse, labels) – Paris, z16.25") from z17 to z16. The original intention for this location was to be at a non-integer zoom level, but since it turned out that that isn't possible, z16 would be preferable to z17.

## Launch Checklist

@ryanhamley is there anything else I should do for this PR?

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page

/cc @dasulit @tristen 
