### PR TITLE
update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [<img width="400" alt="Mapbox" src="docs/pages/assets/logo.png">](https://www.mapbox.com/)
 
 **Mapbox GL JS** is a JavaScript library for interactive, customizable vector maps on the web. It takes map styles that conform to the
-[Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-js/style-spec), applies them to vector tiles that
+[Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/), applies them to vector tiles that
 conform to the [Mapbox Vector Tile Specification](https://github.com/mapbox/vector-tile-spec), and renders them using
 WebGL.
 
 Mapbox GL JS is part of the [cross-platform Mapbox GL ecosystem](https://www.mapbox.com/maps/), which also includes
-compatible native SDKs for applications on [Android](https://www.mapbox.com/android-sdk/),
-[iOS](https://www.mapbox.com/ios-sdk/), [macOS](http://mapbox.github.io/mapbox-gl-native/macos),
+compatible native SDKs for applications on [Android](https://docs.mapbox.com/android/maps/overview/),
+[iOS](https://docs.mapbox.com/ios/maps/overview/), [macOS](http://mapbox.github.io/mapbox-gl-native/macos),
 [Qt](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/qt), and [React Native](https://github.com/mapbox/react-native-mapbox-gl/). Mapbox provides building blocks to add location features like maps, search, and navigation into any experience you
 create. To get started with GL JS or any of our other building blocks,
 [sign up for a Mapbox account](https://www.mapbox.com/signup/).
@@ -16,13 +16,12 @@ In addition to GL JS, this repository contains code, issues, and test fixtures t
 native SDKs. For code and issues specific to the native SDKs, see the
 [mapbox/mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native/) repository.
 
-- [Getting started with Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/api/)
-- [Tutorials](https://www.mapbox.com/help/tutorials/#web-apps)
-- [API documentation](https://www.mapbox.com/mapbox-gl-js/api/)
-- [Examples](https://www.mapbox.com/mapbox-gl-js/examples/)
-- [Style documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/)
+- [Getting started with Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js/overview/)
+- [Tutorials](https://docs.mapbox.com/help/tutorials/#web-apps)
+- [API documentation](https://docs.mapbox.com/mapbox-gl-js/api/)
+- [Examples](https://docs.mapbox.com/mapbox-gl-js/examples/)
+- [Style documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/)
 - [Open source styles](https://github.com/mapbox/mapbox-gl-styles)
-- [Roadmap](https://www.mapbox.com/mapbox-gl-js/roadmap/)
 - [Contributor documentation](https://github.com/mapbox/mapbox-gl-js/blob/master/CONTRIBUTING.md)
 
 [<img width="981" alt="Mapbox GL gallery" src="docs/pages/assets/gallery.png">](https://www.mapbox.com/gallery/)


### PR DESCRIPTION
## Launch Checklist

- Further followup to #7850 and #7847 removing the broken link to the roadmap.
- Updated other links, to shortcut the 301 Moved Permanently redirect.
- Updated the getting started link to the quickstart rather than the in depth api docs