### PR TITLE
Much nicer integration tests pages

### DIFF
--- a/test/integration/expression-tests/result_item.html.tmpl
+++ b/test/integration/expression-tests/result_item.html.tmpl
@@ -1,22 +1,16 @@
-<tr class="<%- r.status %> <%- (hasFailedTests && /passed/.test(r.status) || /ignored/.test(r.status)) ? 'hide' : '' %>">
-    <td>
-        <h2 style="text-align:center; background:<%- r.color %>"><a href="<%- r.id %>/case.json">&nbsp;</a></h2>
-        <pre><%- r.expression %></pre>
-    </td>
-    <td>
-        <h2 style="text-align:center; background:<%- r.color %>"><a href="<%- r.id %>/case.json"><%- r.id %> <% if (!r.ok) { %>(<%=r.status%>)<% } %></a></h2>
-        <% if (r.error) { %><div>error: <%- r.error.message %></div><% } %>
-        <div style="font-family: monospace; white-space: pre"><%= r.difference %></div>
-    </td>
-    <td>
-        <h2 style="text-align:center; background:<%- r.color %>"><a href="<%- r.id %>/case.json">&nbsp;</a></h2>
-        <div>
-<% if (r.serialized) { %>
-            Serialized:
-            <pre>
-<%- r.serialized %>
-            </pre>
-<% } %>
-        </div>
-    </td>
-</tr>
+<div class="test <%- r.status %> <%- (hasFailedTests && /passed/.test(r.status) || /ignored/.test(r.status)) ? 'hide' : '' %>">
+    <h2><span class="label" style="background: <%- r.color %>"><%- r.status %></span> <%- r.id %></h2>
+    <pre><%- r.expression %></pre>
+
+    <% if (r.error) { %><p style="color: red"><strong>Error:</strong> <%- r.error.message %></p><% } %>
+
+    <% if (r.difference) { %>
+    <strong>Difference:</strong>
+    <pre><%- r.difference %></pre>
+    <% } %>
+
+    <% if (r.serialized) { %>
+    <strong>Serialized:</strong>
+    <pre><%- r.serialized %></pre>
+    <% } %>
+</div>

--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -179,10 +179,15 @@ export default function (directory, implementation, options, run) {
         const resultsTemplate = template(fs.readFileSync(path.join(__dirname, '..', 'results.html.tmpl'), 'utf8'));
         const itemTemplate = template(fs.readFileSync(path.join(directory, 'result_item.html.tmpl'), 'utf8'));
 
+        const stats = {};
+        for (const test of tests) {
+            stats[test.status] = (stats[test.status] || 0) + 1;
+        }
+
         const unsuccessful = tests.filter(test =>
             test.status === 'failed' || test.status === 'errored');
 
-        const resultsShell = resultsTemplate({ unsuccessful, tests, shuffle: options.shuffle, seed: options.seed })
+        const resultsShell = resultsTemplate({ unsuccessful, tests, stats, shuffle: options.shuffle, seed: options.seed })
             .split('<!-- results go here -->');
 
         const p = path.join(directory, options.recycleMap ? 'index-recycle-map.html' : 'index.html');

--- a/test/integration/query-tests/result_item.html.tmpl
+++ b/test/integration/query-tests/result_item.html.tmpl
@@ -1,17 +1,10 @@
-<tr class="<%- r.status %> <%- (hasFailedTests && /passed/.test(r.status) || /ignored/.test(r.status)) ? 'hide' : '' %>">
-    <td>
-    <% if (r.status !== 'errored') { %><img src="data:image/png;base64,<%- r.actual %>"><% } %>
-    </td>
-    <td>
-        <h2 style="text-align:center; background:<%- r.color %>"><a href="<%- r.id %>/style.json"><%- r.id %> <% if (!r.ok) { %>(<%=r.status%>)<% } %></a></h2>
-        <ul>
-            <% if (r.error) { %><li>error: <%- r.error.message %></li><% } %>
-            <li>diff: <strong><%- r.difference %></strong></li>
-            <li>zoom: <strong><%- r.zoom %></strong></li>
-            <li>center: <strong><%- r.center %></strong></li>
-            <li>bearing: <strong><%- r.bearing %></strong></li>
-            <li>width: <strong><%- r.width %></strong></li>
-            <li>height: <strong><%- r.height %></strong></li>
-        </ul>
-    </td>
-</tr>
+<div class="test <%- r.status %> <%- (hasFailedTests && /passed/.test(r.status) || /ignored/.test(r.status)) ? 'hide' : '' %>">
+    <h2><span class="label" style="background: <%- r.color %>"><%- r.status %></span> <%- r.id %></h2>
+    <% if (r.status !== 'errored') { %>
+        <img src="data:image/png;base64,<%- r.actual %>">
+    <% } %>
+    <% if (r.error) { %><p style="color: red"><strong>Error:</strong> <%- r.error.message %></p><% } %>
+    <% if (r.difference) { %>
+    <pre><%- r.difference.trim() %></pre>
+    <% } %>
+</div>

--- a/test/integration/render-tests/result_item.html.tmpl
+++ b/test/integration/render-tests/result_item.html.tmpl
@@ -1,23 +1,8 @@
-
-<tr class="<%- r.status %> <%- (hasFailedTests && /passed/.test(r.status) || /ignored/.test(r.status)) ? 'hide' : '' %>">
-
-<% if (r.status !== 'errored') { %>
-    <td><img style="width: <%- r.width %>; height: <%- r.height %>" src="data:image/png;base64,<%- r.actual %>" data-alt-src="data:image/png;base64,<%- r.expected %>"></td>
-    <td><img style="width: <%- r.width %>; height: <%- r.height %>" src="data:image/png;base64,<%- r.diff %>"></td>
-<% } else { %>
-    <td></td><td></td>
-<% } %>
-    <td>
-        <h2 style="background: <%- r.color %>"><a href="<%- r.id %>/style.json"><%- r.id %> <% if (!r.ok) { %>(<%=r.status%>)<% } %></a></h2>
-        <ul>
-            <% if (r.error) { %><li>error: <%- r.error.message %></li><% } %>
-            <li>diff: <strong><%- r.difference %></strong></li>
-            <% if (r.zoom) { %><li>zoom: <strong><%- r.zoom %></strong></li><% } %>
-            <% if (r.center) { %><li>center: <strong><%- r.center %></strong></li><% } %>
-            <% if (r.bearing) { %><li>bearing: <strong><%- r.bearing %></strong></li><% } %>
-            <% if (r.pitch) { %><li>pitch: <strong><%- r.pitch %></strong></li><% } %>
-            <li>width: <strong><%- r.width %></strong></li>
-            <li>height: <strong><%- r.height %></strong></li>
-        </ul>
-    </td>
-</tr>
+<div class="test <%- r.status %> <%- (hasFailedTests && /passed/.test(r.status) || /ignored/.test(r.status)) ? 'hide' : '' %>">
+    <h2><span class="label" style="background: <%- r.color %>"><%- r.status %></span> <%- r.id %></h2>
+    <% if (r.status !== 'errored') { %>
+        <img width="<%- r.width %>" height="<%- r.height %>" src="data:image/png;base64,<%- r.actual %>" data-alt-src="data:image/png;base64,<%- r.expected %>"><img style="width: <%- r.width %>; height: <%- r.height %>" src="data:image/png;base64,<%- r.diff %>">
+    <% } %>
+    <% if (r.error) { %><p style="color: red"><strong>Error:</strong> <%- r.error.message %></p><% } %>
+    <% if (r.difference) { %><p class="diff"><strong>Diff:</strong> <%- r.difference %></p><% } %>
+</div>

--- a/test/integration/results.html.tmpl
+++ b/test/integration/results.html.tmpl
@@ -1,76 +1,73 @@
 <style>
-    body { font-family: Helvetica; }
-    div { color: black; }
-    h2 { text-align: center; margin-bottom: 10px; padding: 2px 5px; font-weight: normal; }
-    h2 a { color: white; text-decoration: none; }
-    table td { vertical-align: top; }
-    ul { margin-top: 0; }
-    .hide { display: none; }
-    del { background-color: #ffeef0; }
-    ins { background-color: #e6ffed; }
-    del,ins { text-decoration: none; }
+body { font: 18px/1.2 -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 10px; }
+h1 { font-size: 32px; margin-bottom: 0; }
+button { vertical-align: middle; }
+h2 { font-size: 24px; font-weight: normal; margin: 10px 0 10px; line-height: 1; }
+img { margin: 0 10px 10px 0; border: 1px dotted #ccc; }
+.stats { margin-top: 10px; }
+.test { border-bottom: 1px dotted #bbb; padding-bottom: 5px; }
+.tests { border-top: 1px dotted #bbb; margin-top: 10px; }
+.diff { color: #777; }
+.test p, .test pre { margin: 0 0 10px; }
+.test pre { font-size: 14px; }
+.label { color: white; font-size: 18px; padding: 2px 6px 3px; border-radius: 3px; margin-right: 3px; vertical-align: bottom; display: inline-block; }
+.hide { display: none; }
 </style>
-<script>
-  document.addEventListener('mouseover', handleHover);
-  document.addEventListener('mouseout', handleHover);
 
-  function handleHover(e) {
+<% if (unsuccessful.length) { %>
+<h1 style="color: red;">
+    <%- unsuccessful.length %> tests failed.
+<% } else { %>
+<h1 style="color: green;">
+    All tests passed!
+<% } %>
+    <button id='toggle-sequence'>Toggle test sequence</button>
+    <button id='toggle-passed'>Toggle passed tests</button>
+    <button id='toggle-ignored'>Toggle ignored tests</button>
+</h1>
+
+<p class="stats"><%- Object.keys(stats).map(status => stats[status] + ' ' + status).join(', ') + '.' %></p>
+
+<div id='test-sequence' class='hide'>
+    <% if (unsuccessful.length) { %>
+    <p><strong>Failed tests:</strong>
+    <% for (const r of unsuccessful) { %><%- r.id %> <% } %></p>
+    <% } %>
+
+    <p><strong>Test sequence:</strong>
+    <% for (const s of tests) { %><%- s.id %> <% } %></p>
+
+    <% if (shuffle) { %><p><strong>Shuffle seed</strong>: <%- seed %></p><% } %>
+</div>
+
+<script>
+document.addEventListener('mouseover', handleHover);
+document.addEventListener('mouseout', handleHover);
+
+function handleHover(e) {
     var el = e.target;
     if (el.tagName === 'IMG' && el.dataset.altSrc) {
-      var tmp = el.src;
-      el.src = el.dataset.altSrc;
-      el.dataset.altSrc = tmp;
+        var tmp = el.src;
+        el.src = el.dataset.altSrc;
+        el.dataset.altSrc = tmp;
     }
-  }
-</script>
-<% if (shuffle) { %>
-<div>Shuffle seed: <%- seed %></div>
-<% } %>
-<% if (unsuccessful.length) { %>
-<div>
-  <strong style="color: darkred;">Failed Tests:</strong>
-  <% for (const r of unsuccessful) { %><%- r.id %> <% } %>
-</div>
-<% } else { %>
-<div><strong style="color: darkgreen;">All tests passed!</div>
-<% } %>
-<% if (tests.length) { %>
-<button id='toggle-sequence'>Toggle showing test sequence</button>
-<div id='test-sequence' style='display:none'>
-    <strong style="color: black;">Test sequence:</strong>
-    <% for (const s of tests) { %><%- s.id %> <% } %>
-</div>
-<% } %>
-<button id='toggle-passed'>Toggle showing passed tests</button>
-<button id='toggle-ignored'>Toggle showing ignored tests</button>
-<script>
-const passedButton = document.getElementById('toggle-passed');
-passedButton.addEventListener('click', function (e) {
-  const passed = document.querySelectorAll('tr.passed');
-  for (const row of passed) {
-    row.classList.toggle('hide');
-  }
-});
+}
 
-const ignoredButton = document.getElementById('toggle-ignored');
-ignoredButton.addEventListener('click', function (e) {
-  const ignored = document.querySelectorAll('tr.ignored');
-  for (const row of ignored) {
-    row.classList.toggle('hide');
-  }
+document.getElementById('toggle-passed').addEventListener('click', function (e) {
+    for (const row of document.querySelectorAll('.test.passed')) {
+        row.classList.toggle('hide');
+    }
 });
-
-const sequenceButton = document.getElementById('toggle-sequence');
-sequenceButton.addEventListener('click', function (e) {
-    const sequence = document.getElementById('test-sequence');
-    sequence.style.display = sequence.style.display == "none" ? "block" : "none";
+document.getElementById('toggle-ignored').addEventListener('click', function (e) {
+    for (const row of document.querySelectorAll('.test.ignored')) {
+        row.classList.toggle('hide');
+    }
+});
+document.getElementById('toggle-sequence').addEventListener('click', function (e) {
+    document.getElementById('test-sequence').classList.toggle('hide');
 });
 </script>
-<table>
-<tr>
-    <th>Actual / Expected</th>
-    <th>Diff</th>
-    <th>Info</th>
-</tr>
+
+<div class="tests">
 <!-- results go here -->
-</table>
+</div>


### PR DESCRIPTION
Our current render/query/expression tests result pages were becoming hard to use because of the table layout and some of the tests being super-wide, so I took a stab at fixing this and fully redesigned the pages in the process. Check it out:

- [ Render tests before](https://37329-8629417-gh.circle-artifacts.com/0/root/mapbox-gl-js/test/integration/render-tests/index.html)
- [Render tests after](https://37348-8629417-gh.circle-artifacts.com/0/root/mapbox-gl-js/test/integration/render-tests/index.html)
- [Query tests before](https://37328-8629417-gh.circle-artifacts.com/0/root/mapbox-gl-js/test/integration/query-tests/index.html)
- [Query tests after](https://37353-8629417-gh.circle-artifacts.com/0/root/mapbox-gl-js/test/integration/query-tests/index.html)

Notes:

- Made the layout list-like rather than columned.
- Overall cleaner look that's much easier to skim.
- Removed a bunch of unnecessary context such as width/height/center/pitch/bearing — you can look it up (along with other style-defining things) in corresponding `style.json` if needed.
- Added stats to see how many tests are passed/failed/ignored-passed/ignored-failed.
- Put shuffle seed and the list of failed tests to the "test sequence" block where it belongs (it shows when you click "Toggle test sequence").
- Fixed diff rendering in query tests.