### PR TITLE
ScrollZoomHandler: allow to set zoomRate

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -87,7 +87,7 @@ class ScrollZoomHandler {
 
     /**
      * Set the zoom rate of a mouse wheel
-     * @param {number} [zoomRate = 1/450]
+     * @param {number} [wheelZoomRate = 1/450]
      */
     setWheelZoomRate(wheelZoomRate: number) {
         this._wheelZoomRate = wheelZoomRate;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -16,6 +16,7 @@ import type {TaskID} from '../../util/task_queue';
 
 // deltaY value for mouse scroll wheel identification
 const wheelZoomDelta = 4.000244140625;
+
 // These magic numbers control the rate of zoom. Trackpad events fire at a greater
 // frequency than mouse scroll wheel, so reduce the zoom rate per wheel tick
 const defaultZoomRate = 1 / 100;
@@ -65,8 +66,6 @@ class ScrollZoomHandler {
 
         this._delta = 0;
 
-        // These magic numbers control the rate of zoom. Trackpad events fire at a greater
-        // frequency than mouse scroll wheel, so reduce the zoom rate per wheel tick
         this._defaultZoomRate = defaultZoomRate;
         this._wheelZoomRate = wheelZoomRate;
 
@@ -79,16 +78,16 @@ class ScrollZoomHandler {
     }
 
     /**
-     * Override default zoomRate value
-     * @param {number} zoomRate
+     * Set the zoom rate of a trackpad
+     * @param {number} [zoomRate = 1/100]
      */
     setZoomRate(zoomRate: number) {
         this._defaultZoomRate = zoomRate;
     }
 
     /**
-     * Override default wheelZoomRate value
-     * @param {number} wheelZoomRate
+     * Set the zoom rate of a mouse wheel
+     * @param {number} [zoomRate = 1/450]
      */
     setWheelZoomRate(wheelZoomRate: number) {
         this._wheelZoomRate = wheelZoomRate;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -18,8 +18,8 @@ import type {TaskID} from '../../util/task_queue';
 const wheelZoomDelta = 4.000244140625;
 // These magic numbers control the rate of zoom. Trackpad events fire at a greater
 // frequency than mouse scroll wheel, so reduce the zoom rate per wheel tick
-const defaultZoomRate = 0.3; // 1 / 100;
-const wheelZoomRate = 0.1; // 1 / 450;
+const defaultZoomRate = 1 / 100;
+const wheelZoomRate = 1 / 450;
 
 // upper bound on how much we scale the map in any single render frame; this
 // is used to limit zoom rate in the case of very fast scrolling
@@ -70,8 +70,8 @@ class ScrollZoomHandler {
 
         // These magic numbers control the rate of zoom. Trackpad events fire at a greater
         // frequency than mouse scroll wheel, so reduce the zoom rate per wheel tick
-        this._defaultZoomRate = options.defaultZoomRate || defaultZoomRate; // 1 / 450;
-        this._wheelZoomRate = options.wheelZoomRate || wheelZoomRate; // 1 / 100;
+        this._defaultZoomRate = options.defaultZoomRate || defaultZoomRate;
+        this._wheelZoomRate = options.wheelZoomRate || wheelZoomRate;
 
         bindAll([
             '_onWheel',

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -59,10 +59,7 @@ class ScrollZoomHandler {
     /**
      * @private
      */
-    constructor(map: Map, options?: {
-        defaultZoomRate: number,
-        wheelZoomRate: number
-    }) {
+    constructor(map: Map) {
         this._map = map;
         this._el = map.getCanvasContainer();
 
@@ -70,8 +67,8 @@ class ScrollZoomHandler {
 
         // These magic numbers control the rate of zoom. Trackpad events fire at a greater
         // frequency than mouse scroll wheel, so reduce the zoom rate per wheel tick
-        this._defaultZoomRate = options.defaultZoomRate || defaultZoomRate;
-        this._wheelZoomRate = options.wheelZoomRate || wheelZoomRate;
+        this._defaultZoomRate = defaultZoomRate;
+        this._wheelZoomRate = wheelZoomRate;
 
         bindAll([
             '_onWheel',
@@ -85,7 +82,7 @@ class ScrollZoomHandler {
      * Override default zoomRate value
      * @param {number} zoomRate
      */
-    setZoomRate(zoomRate) {
+    setZoomRate(zoomRate: number) {
         this._defaultZoomRate = zoomRate;
     }
 
@@ -93,7 +90,7 @@ class ScrollZoomHandler {
      * Override default wheelZoomRate value
      * @param {number} wheelZoomRate
      */
-    setWheelZoomRate(wheelZoomRate) {
+    setWheelZoomRate(wheelZoomRate: number) {
         this._wheelZoomRate = wheelZoomRate;
     }
 


### PR DESCRIPTION
Hello there, first PR here, I hope I'm doing it right.

I noticed that scroll zoom on desktop browsers is really slow when using mouse since you need to 'wheel' so many times. I didn't find a way to set 'scroll/zoom sensibility' so I've edited ScrollZoomHandler class and added setZoomRate(number) and setWheelZoomRate(number) methods.
These basically allow to set/override default values of 'defaultZoomRate' and 'wheelZoomRate'.

It seems to work pretty well, I'm sending this PR to let you know about this possiblity in case you want to include that in the library.

Thanks for your work!




## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
