### PR TITLE
Improve wording and syntax definition of "case" and "match".

### DIFF
--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -88,7 +88,7 @@ const types = {
     case: [{
         type: 'OutputType',
         parameters: [
-            'condition: boolean, output: OutputType', 
+            'condition: boolean, output: OutputType',
             'condition: boolean, output: OutputType',
             '...',
             'fallback: OutputType']
@@ -153,7 +153,7 @@ const types = {
         parameters: [
             'input: InputType (number or string)',
             'label: InputType | [InputType, InputType, ...], output: OutputType',
-            'label: InputType | [InputType, InputType, ...], output: OutputType', 
+            'label: InputType | [InputType, InputType, ...], output: OutputType',
             '...',
             'fallback: OutputType'
         ]

--- a/docs/components/expression-metadata.js
+++ b/docs/components/expression-metadata.js
@@ -87,7 +87,11 @@ const types = {
     }],
     case: [{
         type: 'OutputType',
-        parameters: [{ repeat: ['condition: boolean', 'output: OutputType'] }, 'default: OutputType']
+        parameters: [
+            'condition: boolean, output: OutputType', 
+            'condition: boolean, output: OutputType',
+            '...',
+            'fallback: OutputType']
     }],
     coalesce: [{
         type: 'OutputType',
@@ -148,9 +152,10 @@ const types = {
         type: 'OutputType',
         parameters: [
             'input: InputType (number or string)',
-            'label_1: InputType | [InputType, InputType, ...], output_1: OutputType',
-            'label_n: InputType | [InputType, InputType, ...], output_n: OutputType, ...',
-            'default: OutputType'
+            'label: InputType | [InputType, InputType, ...], output: OutputType',
+            'label: InputType | [InputType, InputType, ...], output: OutputType', 
+            '...',
+            'fallback: OutputType'
         ]
     }],
     var: [{

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2378,7 +2378,7 @@
         }
       },
       "case": {
-        "doc": "Selects the first output whose corresponding test condition evaluates to true.",
+        "doc": "Selects the first output whose corresponding test condition evaluates to true, or the fallback value otherwise.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2390,7 +2390,7 @@
         }
       },
       "match": {
-        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must either be a single literal value or an array of literal values (e.g. `\"a\"` or `[\"c\", \"b\"]`), and those values must be all strings or all numbers. (The values `\"1\"` and `1` cannot both be labels in the same match expression.) Each label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.",
+        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n * a single literal value; or\n * an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the deprecated `\"in\"` operator.\n\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
Fixes #7779.
Using 'fallback' rather than 'default' in code to avoid syntax highlighting
issue where 'default' is detected as a reserved word.

Also I tweaked `case` a bit to make the two as consistent as possible. Using `...` rather than the `repeat: []` construct seems to give better output, with better controlled line breaks.