### PR TITLE
Upgrade Earcut to v2.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",
     "csscolorparser": "~1.0.2",
-    "earcut": "^2.1.4",
+    "earcut": "^2.1.5",
     "esm": "^3.0.84",
     "geojson-vt": "^3.2.1",
     "gl-matrix": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,10 +4066,10 @@ duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-earcut@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.4.tgz#6b161f89bfe4bb08576b9e8af165e1477d6a1c02"
-  integrity sha512-ttRjmPD5oaTtXOoxhFp9aZvMB14kBjapYaiBuzBB1elOgSLU9P2Ev86G2OClBg+uspUXERsIzXKpUWweH2K4Xg==
+earcut@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.5.tgz#829280a9a3a0f5fee0529f0a47c3e4eff09b21e4"
+  integrity sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA==
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Fixes #7806 (a rare bug with polygon rendering). Also worth cherry-picking into release branch after merging.