### PR TITLE
Fix test-suite-clean to work with nested folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "open-changed-examples": "git diff --name-only publisher-production HEAD -- docs/pages/example/*.html | awk '{print \"http://127.0.0.1:4000/mapbox-gl-js/example/\" substr($0,33,length($0)-37)}' | xargs open",
     "test": "run-s lint lint-css test-flow test-unit",
     "test-suite": "run-s test-render test-query",
-    "test-suite-clean": "find test/integration/{render,query}-tests -mindepth 2 -type d  -not \\( -exec test -e \"{}/style.json\" \\; \\) -print | xargs -t rm -r",
+    "test-suite-clean": "find test/integration/{render,query}-tests -mindepth 2 -type d -exec test -e \"{}/actual.png\" \\; -not \\( -exec test -e \"{}/style.json\" \\; \\) -print | xargs -t rm -r",
     "test-unit": "build/run-tap --reporter classic --no-coverage test/unit",
     "test-build": "build/run-tap --no-coverage test/build/**/*.test.js",
     "test-render": "node --max-old-space-size=2048 test/render.test.js",


### PR DESCRIPTION
Closes #7242. Now it will only remove a folder which has an `actual.png` but not `style.json`. As far as I understand, we're not interested in cleaning folders without `actual.png` because only uncommitted files (generated by the test suite) would be a problem when switching branches with different sets of tests. The original script was introduced [here](https://github.com/mapbox/mapbox-gl-test-suite/pull/117#discussion_r68839368).