### PR TITLE
[docs] style fix for examples code blocks

### DIFF
--- a/docs/components/example.js
+++ b/docs/components/example.js
@@ -68,7 +68,7 @@ ${html}
             const {frontMatter} = this.props;
             return (
                 <PageShell meta={frontMatter}>
-                    <div className='relative'>
+                    <div className='relative prose'>
                         <div className='round bg-white'>
                             <div className='prose'>
                                 <h1 className='mt0-mm txt-fancy'>{frontMatter.title}</h1>

--- a/docs/components/site.css
+++ b/docs/components/site.css
@@ -6,7 +6,7 @@
   padding-top: 0 !important;
 }
 
-.examples-page.prose pre {
+.examples-page .prose pre {
   max-height: none;
 }
 


### PR DESCRIPTION
In #7880, we adjusted the use of `prose` which turned off the class on example pages, as a result the examples pages lost some styling on the code block. This PR fixes the cascade.

![image](https://user-images.githubusercontent.com/2180540/52507897-dcd25d80-2bc0-11e9-94a9-cdfbfb509610.png)


@colleenmcginnis should we also debug the warning note flash that we're seeing on https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-directions/ in this PR or separate one? I'm not seeing it locally, but we could test on staging.


