### PR TITLE
[WIP] Advanced label formatting using ["text-section"] expression

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -523,8 +523,7 @@ class SymbolBucket implements Bucket {
         const glyphOffsetArrayStart = this.glyphOffsetArray.length;
         const vertexStartIndex = segment.vertexLength;
 
-        for (const symbol of quads) {
-
+        const addSymbol = (symbol: SymbolQuad) => {
             const tl = symbol.tl,
                 tr = symbol.tr,
                 bl = symbol.bl,
@@ -548,6 +547,39 @@ class SymbolBucket implements Bucket {
             segment.primitiveLength += 2;
 
             this.glyphOffsetArray.emplaceBack(symbol.glyphOffset[0]);
+        };
+
+        if (feature.text && feature.text.sections) {
+            const sections = feature.text.sections;
+
+            if (feature.text.hasMultipleUniqueSections()) {
+                let currentSectionIndex;
+                const populatePaintArrayForSection = (sectionIndex?: number, lastSection: boolean) => {
+                    if (currentSectionIndex !== undefined && (currentSectionIndex !== sectionIndex || lastSection)) {
+                        arrays.programConfigurations.populatePaintArrays(arrays.layoutVertexArray.length, feature, feature.index, {}, sections[currentSectionIndex].id);
+                    }
+                    currentSectionIndex = sectionIndex;
+                };
+
+                for (const symbol of quads) {
+                    populatePaintArrayForSection(symbol.sectionIndex, false);
+                    addSymbol(symbol);
+                }
+
+                // Populate paint arrays for the last section.
+                populatePaintArrayForSection(currentSectionIndex, true);
+            } else {
+                for (const symbol of quads) {
+                    addSymbol(symbol);
+                }
+                arrays.programConfigurations.populatePaintArrays(arrays.layoutVertexArray.length, feature, feature.index, {}, sections[0].id);
+            }
+
+        } else {
+            for (const symbol of quads) {
+                addSymbol(symbol);
+            }
+            arrays.programConfigurations.populatePaintArrays(arrays.layoutVertexArray.length, feature, feature.index, {});
         }
 
         arrays.placedSymbolArray.emplaceBack(labelAnchor.x, labelAnchor.y,
@@ -558,8 +590,6 @@ class SymbolBucket implements Bucket {
             writingMode, (false: any),
             // The crossTileID is only filled/used on the foreground for dynamic text anchors
             0);
-
-        arrays.programConfigurations.populatePaintArrays(arrays.layoutVertexArray.length, feature, feature.index, {});
     }
 
     _addCollisionDebugVertex(layoutVertexArray: StructArray, collisionVertexArray: StructArray, point: Point, anchorX: number, anchorY: number, extrude: Point) {

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -32,6 +32,7 @@ import type {
 } from '../style-spec/expression';
 import type {PossiblyEvaluated} from '../style/properties';
 import type {FeatureStates} from '../source/source_state';
+import type { Value } from '../style-spec/expression/values';
 
 export type BinderUniform = {
     name: string,
@@ -78,7 +79,7 @@ interface Binder<T> {
     maxValue: number;
     uniformNames: Array<string>;
 
-    populatePaintArray(length: number, feature: Feature, imagePositions: {[string]: ImagePosition}): void;
+    populatePaintArray(length: number, feature: Feature, imagePositions: {[string]: ImagePosition}, formattedSectionID?: Value): void;
     updatePaintArray(start: number, length: number, feature: Feature, featureState: FeatureState, imagePositions: {[string]: ImagePosition}): void;
     upload(Context): void;
     destroy(): void;
@@ -215,13 +216,13 @@ class SourceExpressionBinder<T> implements Binder<T> {
 
     setConstantPatternPositions() {}
 
-    populatePaintArray(newLength: number, feature: Feature) {
+    populatePaintArray(newLength: number, feature: Feature, imagePositions: {[string]: ImagePosition}, formattedSectionID?: Value) {
         const paintArray = this.paintVertexArray;
 
         const start = paintArray.length;
         paintArray.reserve(newLength);
 
-        const value = this.expression.evaluate(new EvaluationParameters(0), feature, {});
+        const value = this.expression.evaluate(new EvaluationParameters(0), feature, {}, formattedSectionID);
 
         if (this.type === 'color') {
             const color = packColor(value);
@@ -319,14 +320,14 @@ class CompositeExpressionBinder<T> implements Binder<T> {
 
     setConstantPatternPositions() {}
 
-    populatePaintArray(newLength: number, feature: Feature) {
+    populatePaintArray(newLength: number, feature: Feature, imagePositions: {[string]: ImagePosition}, formattedSectionID?: Value) {
         const paintArray = this.paintVertexArray;
 
         const start = paintArray.length;
         paintArray.reserve(newLength);
 
-        const min = this.expression.evaluate(new EvaluationParameters(this.zoom), feature, {});
-        const max = this.expression.evaluate(new EvaluationParameters(this.zoom + 1), feature, {});
+        const min = this.expression.evaluate(new EvaluationParameters(this.zoom), feature, {}, formattedSectionID);
+        const max = this.expression.evaluate(new EvaluationParameters(this.zoom + 1), feature, {}, formattedSectionID);
 
         if (this.type === 'color') {
             const minColor = packColor(min);
@@ -611,10 +612,10 @@ export default class ProgramConfiguration {
         return self;
     }
 
-    populatePaintArrays(newLength: number, feature: Feature, index: number, imagePositions: {[string]: ImagePosition}) {
+    populatePaintArrays(newLength: number, feature: Feature, index: number, imagePositions: {[string]: ImagePosition}, formattedSectionID?: Value) {
         for (const property in this.binders) {
             const binder = this.binders[property];
-            binder.populatePaintArray(newLength, feature, imagePositions);
+            binder.populatePaintArray(newLength, feature, imagePositions, formattedSectionID);
         }
         if (feature.id !== undefined) {
             this._featureMap.add(+feature.id, index, this._bufferOffset, newLength);
@@ -743,9 +744,9 @@ export class ProgramConfigurationSet<Layer: TypedStyleLayer> {
         this.needsUpload = false;
     }
 
-    populatePaintArrays(length: number, feature: Feature, index: number, imagePositions: {[string]: ImagePosition}) {
+    populatePaintArrays(length: number, feature: Feature, index: number, imagePositions: {[string]: ImagePosition}, formattedSectionID?: Value) {
         for (const key in this.programConfigurations) {
-            this.programConfigurations[key].populatePaintArrays(length, feature, index, imagePositions);
+            this.programConfigurations[key].populatePaintArrays(length, feature, index, imagePositions, formattedSectionID);
         }
         this.needsUpload = true;
     }

--- a/src/style-spec/expression/definitions/coercion.js
+++ b/src/style-spec/expression/definitions/coercion.js
@@ -114,7 +114,7 @@ class Coercion implements Expression {
 
     serialize() {
         if (this.type.kind === 'formatted') {
-            return new FormatExpression([{text: this.args[0], scale: null, font: null}]).serialize();
+            return new FormatExpression([{text: this.args[0], scale: null, font: null, id: null}]).serialize();
         }
         const serialized = [`to-${this.type.kind}`];
         this.eachChild(child => { serialized.push(child.serialize()); });

--- a/src/style-spec/expression/definitions/format.js
+++ b/src/style-spec/expression/definitions/format.js
@@ -13,6 +13,7 @@ type FormattedSectionExpression = {
     text: Expression,
     scale: Expression | null;
     font: Expression | null;
+    id: Expression | null;
 }
 
 export default class FormatExpression implements Expression {
@@ -56,7 +57,16 @@ export default class FormatExpression implements Expression {
                 font = context.parse(options['text-font'], 1, array(StringType));
                 if (!font) return null;
             }
-            sections.push({text, scale, font});
+
+            let id = null;
+            if (options['section']) {
+                id = context.parse(options['section'], 1, ValueType);
+                if (!id) return null;
+                if (id.type !== StringType && id.type !== NumberType) {
+                    return context.error(`Format options attribute 'section' must be 'string' or 'number'.`);
+                }
+            }
+            sections.push({text, scale, font, id});
         }
 
         return new FormatExpression(sections);
@@ -68,7 +78,8 @@ export default class FormatExpression implements Expression {
                 new FormattedSection(
                     toString(section.text.evaluate(ctx)),
                     section.scale ? section.scale.evaluate(ctx) : null,
-                    section.font ? section.font.evaluate(ctx).join(',') : null
+                    section.font ? section.font.evaluate(ctx).join(',') : null,
+                    section.id ? section.id.evaluate(ctx) : null
                 )
             )
         );
@@ -82,6 +93,9 @@ export default class FormatExpression implements Expression {
             }
             if (section.font) {
                 fn(section.font);
+            }
+            if (section.id) {
+                fn(section.id);
             }
         }
     }
@@ -102,6 +116,9 @@ export default class FormatExpression implements Expression {
             }
             if (section.font) {
                 options['text-font'] = section.font.serialize();
+            }
+            if (section.id) {
+                options['section'] = section.id.serialize();
             }
             serialized.push(options);
         }

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -206,6 +206,11 @@ CompoundExpression.register(expressions, {
         [],
         (ctx) => ctx.globals.accumulated === undefined ? null : ctx.globals.accumulated
     ],
+    'text-section': [
+        ValueType,
+        [],
+        (ctx) => ctx.formattedSectionID ? ctx.formattedSectionID : null
+    ],
     '+': [
         NumberType,
         varargs(NumberType),

--- a/src/style-spec/expression/evaluation_context.js
+++ b/src/style-spec/expression/evaluation_context.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { Color } from './values';
+import type { Value } from './values';
 
 import type { GlobalProperties, Feature, FeatureState } from './index';
 
@@ -10,6 +11,7 @@ class EvaluationContext {
     globals: GlobalProperties;
     feature: ?Feature;
     featureState: ?FeatureState;
+    formattedSectionID: ?Value;
 
     _parseColorCache: {[string]: ?Color};
 
@@ -17,6 +19,7 @@ class EvaluationContext {
         this.globals = (null: any);
         this.feature = null;
         this.featureState = null;
+        this.formattedSectionID = null;
         this._parseColorCache = {};
     }
 

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -58,18 +58,20 @@ export class StyleExpression {
         this._enumValues = propertySpec && propertySpec.type === 'enum' ? propertySpec.values : null;
     }
 
-    evaluateWithoutErrorHandling(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState): any {
+    evaluateWithoutErrorHandling(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, formattedSectionID?: Value): any {
         this._evaluator.globals = globals;
         this._evaluator.feature = feature;
         this._evaluator.featureState = featureState;
+        this._evaluator.formattedSectionID = formattedSectionID;
 
         return this.expression.evaluate(this._evaluator);
     }
 
-    evaluate(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState): any {
+    evaluate(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, formattedSectionID?: Value): any {
         this._evaluator.globals = globals;
         this._evaluator.feature = feature || null;
         this._evaluator.featureState = featureState || null;
+        this._evaluator.formattedSectionID = formattedSectionID || null;
 
         try {
             const val = this.expression.evaluate(this._evaluator);
@@ -132,12 +134,12 @@ export class ZoomConstantExpression<Kind: EvaluationKind> {
         this.isStateDependent = kind !== ('constant': EvaluationKind) && !isConstant.isStateConstant(expression.expression);
     }
 
-    evaluateWithoutErrorHandling(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState): any {
-        return this._styleExpression.evaluateWithoutErrorHandling(globals, feature, featureState);
+    evaluateWithoutErrorHandling(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, formattedSectionID?: Value): any {
+        return this._styleExpression.evaluateWithoutErrorHandling(globals, feature, featureState, formattedSectionID);
     }
 
-    evaluate(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState): any {
-        return this._styleExpression.evaluate(globals, feature, featureState);
+    evaluate(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, formattedSectionID?: Value): any {
+        return this._styleExpression.evaluate(globals, feature, featureState, formattedSectionID);
     }
 }
 
@@ -159,12 +161,12 @@ export class ZoomDependentExpression<Kind: EvaluationKind> {
         }
     }
 
-    evaluateWithoutErrorHandling(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState): any {
-        return this._styleExpression.evaluateWithoutErrorHandling(globals, feature, featureState);
+    evaluateWithoutErrorHandling(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, formattedSectionID?: Value): any {
+        return this._styleExpression.evaluateWithoutErrorHandling(globals, feature, featureState, formattedSectionID);
     }
 
-    evaluate(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState): any {
-        return this._styleExpression.evaluate(globals, feature, featureState);
+    evaluate(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, formattedSectionID?: Value): any {
+        return this._styleExpression.evaluate(globals, feature, featureState, formattedSectionID);
     }
 
     interpolationFactor(input: number, lower: number, upper: number): number {
@@ -184,7 +186,7 @@ export type ConstantExpression = {
 export type SourceExpression = {
     kind: 'source',
     isStateDependent: boolean,
-    +evaluate: (globals: GlobalProperties, feature?: Feature, featureState?: FeatureState) => any,
+    +evaluate: (globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, formattedSectionID?: Value) => any,
 };
 
 export type CameraExpression = {
@@ -197,7 +199,7 @@ export type CameraExpression = {
 export type CompositeExpression = {
     kind: 'composite',
     isStateDependent: boolean,
-    +evaluate: (globals: GlobalProperties, feature?: Feature, featureState?: FeatureState) => any,
+    +evaluate: (globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, formattedSectionID?: Value) => any,
     +interpolationFactor: (input: number, lower: number, upper: number) => number,
     zoomStops: Array<number>
 };

--- a/src/style-spec/expression/is_constant.js
+++ b/src/style-spec/expression/is_constant.js
@@ -15,7 +15,8 @@ function isFeatureConstant(e: Expression) {
         } else if (
             e.name === 'properties' ||
             e.name === 'geometry-type' ||
-            e.name === 'id'
+            e.name === 'id' ||
+            e.name === 'text-section'
         ) {
             return false;
         } else if (/^filter-/.test(e.name)) {

--- a/src/style-spec/expression/types/formatted.js
+++ b/src/style-spec/expression/types/formatted.js
@@ -1,14 +1,18 @@
 // @flow
 
+import type { Value } from '../values';
+
 export class FormattedSection {
     text: string;
     scale: number | null;
     fontStack: string | null;
+    id: Value;
 
-    constructor(text: string, scale: number | null, fontStack: string | null) {
+    constructor(text: string, scale: number | null, fontStack: string | null, id: Value) {
         this.text = text;
         this.scale = scale;
         this.fontStack = fontStack;
+        this.id = id;
     }
 }
 
@@ -20,11 +24,26 @@ export default class Formatted {
     }
 
     static fromString(unformatted: string): Formatted {
-        return new Formatted([new FormattedSection(unformatted, null, null)]);
+        return new Formatted([new FormattedSection(unformatted, null, null, null)]);
     }
 
     toString(): string {
         return this.sections.map(section => section.text).join('');
+    }
+
+    hasMultipleUniqueSections(): boolean {
+        if (this.sections.length < 2) {
+            return false;
+        }
+
+        const section = this.sections[0].id;
+        for (let i = 1; i < this.sections.length; ++i) {
+            if (section !== this.sections[i].id) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     serialize() {
@@ -37,6 +56,9 @@ export default class Formatted {
             }
             if (section.scale) {
                 options["font-scale"] = section.scale;
+            }
+            if (section.id) {
+                options["section"] = section.id;
             }
             serialized.push(options);
         }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2918,6 +2918,15 @@
           }
         }
       },
+      "text-section": {
+        "doc": "Gets the id of a formatted section from the format expression. Can only be used in the data driven paint properties for Symbol layer.",
+        "group": "Lookup",
+        "sdk-support": {
+          "basic functionality": {
+            "js": "latest"
+          }
+        }
+      },
       "+": {
         "doc": "Returns the sum of the inputs.",
         "group": "Math",

--- a/src/symbol/quads.js
+++ b/src/symbol/quads.js
@@ -35,7 +35,8 @@ export type SymbolQuad = {
         h: number
     },
     writingMode: any | void,
-    glyphOffset: [number, number]
+    glyphOffset: [number, number],
+    sectionIndex: number
 };
 
 /**
@@ -107,7 +108,7 @@ export function getIconQuads(anchor: Anchor,
     }
 
     // Icon quad is padded, so texture coordinates also need to be padded.
-    return [{tl, tr, bl, br, tex: image.paddedRect, writingMode: undefined, glyphOffset: [0, 0]}];
+    return [{tl, tr, bl, br, tex: image.paddedRect, writingMode: undefined, glyphOffset: [0, 0], sectionIndex: 0}];
 }
 
 /**
@@ -189,7 +190,7 @@ export function getGlyphQuads(anchor: Anchor,
             br._matMult(matrix);
         }
 
-        quads.push({tl, tr, bl, br, tex: rect, writingMode: shaping.writingMode, glyphOffset});
+        quads.push({tl, tr, bl, br, tex: rect, writingMode: shaping.writingMode, glyphOffset, sectionIndex: positionedGlyph.sectionIndex});
     }
 
     return quads;

--- a/src/symbol/shaping.js
+++ b/src/symbol/shaping.js
@@ -27,7 +27,8 @@ export type PositionedGlyph = {
     y: number,
     vertical: boolean,
     scale: number,
-    fontStack: string
+    fontStack: string,
+    sectionIndex: number
 };
 
 // A collection of positioned glyphs and some metadata
@@ -78,6 +79,10 @@ class TaggedString {
 
     getSection(index: number): { scale: number, fontStack: string } {
         return this.sections[this.sectionIndex[index]];
+    }
+
+    getSectionIndex(index: number): number {
+        return this.sectionIndex[index];
     }
 
     getCharCode(index: number): number {
@@ -457,6 +462,7 @@ function shapeLines(shaping: Shaping,
         const lineStartIndex = positionedGlyphs.length;
         for (let i = 0; i < line.length(); i++) {
             const section = line.getSection(i);
+            const sectionIndex = line.getSectionIndex(i);
             const codePoint = line.getCharCode(i);
             // We don't know the baseline, but since we're laying out
             // at 24 points, we can calculate how much it will move when
@@ -468,10 +474,10 @@ function shapeLines(shaping: Shaping,
             if (!glyph) continue;
 
             if (!charHasUprightVerticalOrientation(codePoint) || writingMode === WritingMode.horizontal) {
-                positionedGlyphs.push({glyph: codePoint, x, y: y + baselineOffset, vertical: false, scale: section.scale, fontStack: section.fontStack});
+                positionedGlyphs.push({glyph: codePoint, x, y: y + baselineOffset, vertical: false, scale: section.scale, fontStack: section.fontStack, sectionIndex});
                 x += glyph.metrics.advance * section.scale + spacing;
             } else {
-                positionedGlyphs.push({glyph: codePoint, x, y: baselineOffset, vertical: true, scale: section.scale, fontStack: section.fontStack});
+                positionedGlyphs.push({glyph: codePoint, x, y: baselineOffset, vertical: true, scale: section.scale, fontStack: section.fontStack, sectionIndex});
                 x += ONE_EM * section.scale + spacing;
             }
         }

--- a/test/expected/text-shaping-default.json
+++ b/test/expected/text-shaping-default.json
@@ -6,7 +6,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 98,
@@ -14,7 +15,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 99,
@@ -22,7 +24,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 100,
@@ -30,7 +33,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 101,
@@ -38,7 +42,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     }
   ],
   "text": "abcde",

--- a/test/expected/text-shaping-linebreak.json
+++ b/test/expected/text-shaping-linebreak.json
@@ -6,7 +6,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 98,
@@ -14,7 +15,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 99,
@@ -22,7 +24,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 100,
@@ -30,7 +33,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 101,
@@ -38,7 +42,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 97,
@@ -46,7 +51,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 98,
@@ -54,7 +60,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 99,
@@ -62,7 +69,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 100,
@@ -70,7 +78,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 101,
@@ -78,7 +87,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     }
   ],
   "text": "abcde abcde",

--- a/test/expected/text-shaping-newline.json
+++ b/test/expected/text-shaping-newline.json
@@ -6,7 +6,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 98,
@@ -14,7 +15,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 99,
@@ -22,7 +24,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 100,
@@ -30,7 +33,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 101,
@@ -38,7 +42,8 @@
       "y": -29,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 97,
@@ -46,7 +51,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 98,
@@ -54,7 +60,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 99,
@@ -62,7 +69,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 100,
@@ -70,7 +78,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 101,
@@ -78,7 +87,8 @@
       "y": -5,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     }
   ],
   "text": "abcde\nabcde",

--- a/test/expected/text-shaping-newlines-in-middle.json
+++ b/test/expected/text-shaping-newlines-in-middle.json
@@ -6,7 +6,8 @@
       "y": -41,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 98,
@@ -14,7 +15,8 @@
       "y": -41,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 99,
@@ -22,7 +24,8 @@
       "y": -41,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 100,
@@ -30,7 +33,8 @@
       "y": -41,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 101,
@@ -38,7 +42,8 @@
       "y": -41,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 97,
@@ -46,7 +51,8 @@
       "y": 7,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 98,
@@ -54,7 +60,8 @@
       "y": 7,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 99,
@@ -62,7 +69,8 @@
       "y": 7,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 100,
@@ -70,7 +78,8 @@
       "y": 7,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 101,
@@ -78,7 +87,8 @@
       "y": 7,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     }
   ],
   "text": "abcde\n\nabcde",

--- a/test/expected/text-shaping-null.json
+++ b/test/expected/text-shaping-null.json
@@ -6,7 +6,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 105,
@@ -14,7 +15,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     }
   ],
   "text": "hi\u0000",

--- a/test/expected/text-shaping-spacing.json
+++ b/test/expected/text-shaping-spacing.json
@@ -6,7 +6,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 98,
@@ -14,7 +15,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 99,
@@ -22,7 +24,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 100,
@@ -30,7 +33,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     },
     {
       "glyph": 101,
@@ -38,7 +42,8 @@
       "y": -17,
       "vertical": false,
       "scale": 1,
-      "fontStack": "Test"
+      "fontStack": "Test",
+      "sectionIndex": 0
     }
   ],
   "text": "abcde",

--- a/test/integration/expression-tests/format/basic/test.json
+++ b/test/integration/expression-tests/format/basic/test.json
@@ -16,6 +16,14 @@
           "b"
         ]
       ]
+    },
+    "d",
+    {
+      "section": "d"
+    },
+    "e",
+    {
+      "section": 42
     }
   ],
   "inputs": [
@@ -37,17 +45,32 @@
           {
             "text": "a",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id":null
           },
           {
             "text": "b",
             "scale": 2,
-            "fontStack": null
+            "fontStack": null,
+            "id":null
           },
           {
             "text": "c",
             "scale": null,
-            "fontStack": "a,b"
+            "fontStack": "a,b",
+            "id":null
+          },
+          {
+            "text": "d",
+            "scale": null,
+            "fontStack": null,
+            "id": "d"
+          },
+          {
+            "text": "e",
+            "scale": null,
+            "fontStack": null,
+            "id": 42
           }
         ]
       }
@@ -69,6 +92,14 @@
             "b"
           ]
         ]
+      },
+      "d",
+      {
+        "section": "d"
+      },
+      "e",
+      {
+        "section": 42
       }
     ]
   }

--- a/test/integration/expression-tests/format/coercion/test.json
+++ b/test/integration/expression-tests/format/coercion/test.json
@@ -22,17 +22,20 @@
           {
             "text": "a",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           },
           {
             "text": "1",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           },
           {
             "text": "true",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       }

--- a/test/integration/expression-tests/format/data-driven-font/test.json
+++ b/test/integration/expression-tests/format/data-driven-font/test.json
@@ -23,7 +23,8 @@
           {
             "text": "a",
             "scale": 1.5,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       },
@@ -32,7 +33,8 @@
           {
             "text": "a",
             "scale": 0.5,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       }

--- a/test/integration/expression-tests/format/implicit-coerce/test.json
+++ b/test/integration/expression-tests/format/implicit-coerce/test.json
@@ -21,7 +21,8 @@
           {
             "text": "",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       },
@@ -30,7 +31,8 @@
           {
             "text": "0",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       },
@@ -39,7 +41,8 @@
           {
             "text": "a",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       }

--- a/test/integration/expression-tests/format/implicit-omit/test.json
+++ b/test/integration/expression-tests/format/implicit-omit/test.json
@@ -21,7 +21,8 @@
           {
             "text": "",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       },
@@ -30,7 +31,8 @@
           {
             "text": "0",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       },
@@ -39,7 +41,8 @@
           {
             "text": "a",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       }

--- a/test/integration/expression-tests/format/implicit/test.json
+++ b/test/integration/expression-tests/format/implicit/test.json
@@ -21,7 +21,8 @@
           {
             "text": "",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       },
@@ -30,7 +31,8 @@
           {
             "text": "0",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       },
@@ -39,7 +41,8 @@
           {
             "text": "a",
             "scale": null,
-            "fontStack": null
+            "fontStack": null,
+            "id": null
           }
         ]
       }

--- a/test/unit/symbol/quads.test.js
+++ b/test/unit/symbol/quads.test.js
@@ -37,7 +37,8 @@ test('getIconQuads', (t) => {
                 br: { x: 9, y: 7 },
                 tex: {  x: 0, y: 0, w: 17, h: 13 },
                 writingMode: null,
-                glyphOffset: [0, 0]
+                glyphOffset: [0, 0],
+                sectionIndex: 0
             }]);
         t.end();
     });
@@ -55,7 +56,8 @@ test('getIconQuads', (t) => {
                 br: { x: 9, y: 7 },
                 tex: { x: 0, y: 0, w: 17, h: 13 },
                 writingMode: null,
-                glyphOffset: [0, 0]
+                glyphOffset: [0, 0],
+                sectionIndex: 0
             }]);
         t.end();
     });


### PR DESCRIPTION
POC for advanced label formatting proposal in https://github.com/mapbox/mapbox-gl-native/pull/13904

This PR adds `["text-section"]` expression that can be used for SymbolLayer paint properties in order to style formatted text sections.

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page