### PR TITLE
[docs] dr-ui 0.6.0

### DIFF
--- a/docs/components/page_shell.js
+++ b/docs/components/page_shell.js
@@ -79,6 +79,7 @@ class PageShell extends React.Component {
                     .filter(item => item.tags[0] === topic)
                     .map(item => ({
                         text: item.title,
+                        description: item.description,
                         url: item.path,
                         active: this.props.location.pathname === item.path
                     }));
@@ -91,11 +92,33 @@ class PageShell extends React.Component {
         );
     }
 
+    innerJsxText(jsx) {
+        // compliments of https://github.com/CharlesStover/react-innertext
+        if (typeof jsx === 'string') {
+            return jsx;
+        }
+        if (Array.isArray(jsx)) {
+            return jsx.reduce(
+            (previous, current) =>
+                previous + this.innerJsxText(current),
+            ''
+            );
+        }
+        if (
+            Object.prototype.hasOwnProperty.call(jsx, 'props') &&
+          Object.prototype.hasOwnProperty.call(jsx.props, 'children')
+        ) {
+            return this.innerJsxText(jsx.props.children);
+        }
+        return '';
+    }
+
     getPluginSections(data) {
         return (
             Object.keys(data).map((section) => {
                 const subNavItems = Object.keys(data[section]).map(item => ({
                     text: item,
+                    description: this.innerJsxText(data[section][item].description),
                     url: data[section][item].website
                 }));
                 return {

--- a/docs/components/prism_highlight.js
+++ b/docs/components/prism_highlight.js
@@ -13,7 +13,7 @@ export default function prismHighlight(code, language) {
     if (dedentSize) {
         code = code.replace(new RegExp(`^ {0,${dedentSize}}`, 'mg'), '');
     }
-    return <pre><code className={`language-${language}`} dangerouslySetInnerHTML={highlight(code.trim(), language)}/></pre>;
+    return <pre className={`language-${language}`}><code className={`language-${language}`} dangerouslySetInnerHTML={highlight(code.trim(), language)}/></pre>;
 }
 
 export function highlightMarkup(code) {
@@ -29,5 +29,5 @@ export function highlightJSON(code) {
 }
 
 export function highlightShell(code) {
-    return <pre><code className={`language-shell`}/>{code}</pre>;
+    return <pre className={`language-shell`}><code className={`language-shell`}/>{code}</pre>;
 }

--- a/docs/components/site.css
+++ b/docs/components/site.css
@@ -6,10 +6,6 @@
   padding-top: 0 !important;
 }
 
-.examples-page .prose pre {
-  max-height: none;
-}
-
 .prose pre {
   margin-bottom: 18px !important;
 }

--- a/docs/pages/api.js
+++ b/docs/pages/api.js
@@ -55,7 +55,7 @@ export default class extends React.Component {
     render() {
         return (
             <PageShell meta={meta} onUser={(_, token) => this.setState({token})}>
-                <div class="prose">
+                <div className="prose">
                     <h1 className='mt24 mt0-mm txt-fancy'>Mapbox GL JS</h1>
                     <div className='py6 color-gray txt-s mt-neg24 mb12'>
                     Current version:{' '}<span className='round bg-gray-faint py3 px6'><a href='https://github.com/mapbox/mapbox-gl-js/releases'>mapbox-gl.js v{version}</a></span>

--- a/docs/pages/overview/index.md
+++ b/docs/pages/overview/index.md
@@ -9,7 +9,6 @@ pathname: /mapbox-gl-js/overview/
 ---
 
 {{
-<div className="mb24">
     <OverviewHeader
     features={[
         "Custom map styles",
@@ -23,7 +22,6 @@ pathname: /mapbox-gl-js/overview/
     installLink="https://www.mapbox.com/install/js/"
     image={<div />}
     />
-</div>
 }}
 
 Mapbox GL JS is a JavaScript library that uses WebGL to render interactive maps from [vector tiles](https://docs.mapbox.com/help/glossary/vector-tiles/) and [Mapbox styles]({{prefixUrl('/style-spec')}}). It is part of the Mapbox GL ecosystem, which includes [Mapbox Mobile](https://www.mapbox.com/mobile/), a compatible renderer written in C++ with bindings for desktop and mobile platforms.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "node": ">=6.4.0"
   },
   "dependencies": {
+    "@mapbox/dr-ui": "0.6.0",
     "@mapbox/geojson-rewind": "^0.4.0",
-    "@mapbox/dr-ui": "0.5.0",
     "@mapbox/geojson-types": "^1.0.2",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^1.4.0",
@@ -42,7 +42,7 @@
     "vt-pbf": "^3.1.1"
   },
   "devDependencies": {
-    "@mapbox/batfish": "^1.9.7",
+    "@mapbox/batfish": "1.9.8",
     "@mapbox/flow-remove-types": "^1.3.0-await.upstream.2",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.0",
     "@mapbox/mapbox-gl-test-suite": "file:test/integration",

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,9 +960,10 @@
     "@mapbox/jsxtreme-markdown" "^0.9.3"
     babylon "^6.18.0"
 
-"@mapbox/batfish@^1.9.7":
-  version "1.9.7"
-  resolved "https://registry.yarnpkg.com/@mapbox/batfish/-/batfish-1.9.7.tgz#35d901b976684a1a7b49a4869925a3702cb31d8a"
+"@mapbox/batfish@1.9.8":
+  version "1.9.8"
+  resolved "https://registry.yarnpkg.com/@mapbox/batfish/-/batfish-1.9.8.tgz#8bdc549ee5dbbfefbe908233e3b1513ac0d53cec"
+  integrity sha512-d7/8gxdT7yq6QnwwQVzkSZQe4Jg0g2mxY/i5uiUXPj1pnyXIp+Tb6LMlOOkBgYYRqFhBrqQOY5aIUjRLxefKxg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@mapbox/babel-plugin-transform-jsxtreme-markdown" "^0.5.3"
@@ -1036,10 +1037,10 @@
     webpack-merge "^4.1.2"
     worker-farm "^1.6.0"
 
-"@mapbox/dr-ui@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/dr-ui/-/dr-ui-0.5.0.tgz#9d066e10cf96cc719fe09dc6796b6ceab6106af5"
-  integrity sha512-XrigpT+Y5DuaX2PO865Xka6PzlJ/+j2iwv+pzjNxJ+9z+Cmrg+QEQmFVom/JpFeCqowNcCmCfeK2DtyAMgPgVA==
+"@mapbox/dr-ui@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/dr-ui/-/dr-ui-0.6.0.tgz#3b7134dc39c5bc84581a756054f9bcc3e212ef91"
+  integrity sha512-IghUwbHqtoxhASCMWoqtR1Sqf8gnziBAIxrHp4hvxLzHDtIDzipACY4DA+OsJJ3DbkUveTB+keN1AG2901lunA==
   dependencies:
     "@mapbox/mr-ui" "^0.5.0"
     classnames "^2.2.6"


### PR DESCRIPTION
* [x] npm install @mapbox/dr-ui@0.6.0 @mapbox/batfish@1.9.8
* [x] check code blocks in markdown files and example pages. Expected behavior:
  - markdown files: code blocks will have max-height of 300px
  - examples pages: no max-height, unless specified in the code
* [x] check css file and clean out any code related to max-height on code blocks
* [x] remove any bottom-spacing given to `OverviewHeader`
* [x] for sites using `SectionedNavigation` with filtering turned on, considering updating data source to include `description`. Test to make sure you can filter results based on a string in a description. 

ref https://github.com/mapbox/documentation/issues/131

fixes #7888 - in dr-ui 0.6.0 we added the ability to filter descriptions if the data is passed to the prop. This PR passes the descriptions for examples and also plugins to the filter on their respective pages.