### PR TITLE
Use rel=noopener for _blank anchors

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -104,6 +104,7 @@ class AttributionControl {
                 return acc;
             }, `?`);
             editLink.href = `${config.FEEDBACK_URL}/${paramString}${this._map._hash ? this._map._hash.getHashString(true) : ''}`;
+            editLink.rel = "noopener";
         }
     }
 

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -29,6 +29,7 @@ class LogoControl {
         this._container = DOM.create('div', 'mapboxgl-ctrl');
         const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
         anchor.target = "_blank";
+        anchor.rel = "noopener";
         anchor.href = "https://www.mapbox.com/";
         anchor.setAttribute("aria-label", "Mapbox logo");
         anchor.setAttribute("rel", "noopener");


### PR DESCRIPTION
Using lighthouse to audit our site, we kept getting marked down for ["unsafe" cross-origin links](https://developers.google.com/web/tools/lighthouse/audits/noopener). This PR adds `rel="noopener"` to both hard-coded links.

However, I did notice that the attribution links are not constructed on the client side but [injected directly using innerHTML](https://github.com/mapbox/mapbox-gl-js/blob/6d529c74ac3524749bfb50a4e6f5c991f4d058c7/src/ui/control/attribution_control.js#L160). I think this is a separate issue (which I'll open momentarily), so this PR is an incomplete fix for the lighthouse recommendation.