### PR TITLE
Return clone instead of a reference on `map.getCenter()` #3610

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -2,6 +2,7 @@
 
 import {
     bindAll,
+    clone,
     extend,
     deepEqual,
     warnOnce,
@@ -108,7 +109,7 @@ class Camera extends Evented {
      * @memberof Map#
      * @returns The map's geographical centerpoint.
      */
-    getCenter(): LngLat { return this.transform.center; }
+    getCenter(): LngLat { return clone(this.transform.center); }
 
     /**
      * Sets the map's geographical centerpoint. Equivalent to `jumpTo({center: center})`.

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -2,7 +2,6 @@
 
 import {
     bindAll,
-    clone,
     extend,
     deepEqual,
     warnOnce,
@@ -109,7 +108,7 @@ class Camera extends Evented {
      * @memberof Map#
      * @returns The map's geographical centerpoint.
      */
-    getCenter(): LngLat { return clone(this.transform.center); }
+    getCenter(): LngLat { return new LngLat(this.transform.center.lng, this.transform.center.lat); }
 
     /**
      * Sets the map's geographical centerpoint. Equivalent to `jumpTo({center: center})`.


### PR DESCRIPTION
Return clone instead of a reference on `map.getCenter()` according to #3610
Is it correct to use `util.clone` in this case?

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
