### PR TITLE
Return 3d features first from queryRenderedFeatures

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -941,6 +941,7 @@ class Style extends Evented {
     }
 
     _flattenAndSortRenderedFeatures(sourceResults: Array<any>) {
+        const result = [];
         const features = [];
         const features3D = [];
         for (let l = this._order.length - 1; l >= 0; l--) {
@@ -966,10 +967,14 @@ class Style extends Evented {
         });
 
         for (const featureWrapper of features3D) {
-            features.push(featureWrapper.feature);
+            result.push(featureWrapper.feature);
         }
 
-        return features;
+        for (const feature of features) {
+            result.push(feature);
+        }
+
+        return result;
     }
 
     queryRenderedFeatures(queryGeometry: any, params: any, transform: Transform) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -825,8 +825,8 @@ class Map extends Camera {
      * contribution to the rendered result; for example, because the layer's opacity or color alpha component is set to
      * 0.
      *
-     * The topmost rendered feature appears first in the returned array, and subsequent features are sorted by
-     * descending z-order. Features that are rendered multiple times (due to wrapping across the antimeridian at low
+     * `fill-extrusion` features will appear first in the returned array, sorted by depth. Subsequent features are sorted by
+     * descending layer order. Features that are rendered multiple times (due to wrapping across the antimeridian at low
      * zoom levels) are returned only once (though subject to the following caveat).
      *
      * Because features come from tiled vector data or GeoJSON data that is converted to tiles internally, feature


### PR DESCRIPTION
Fixes #7883 by returning `fill-extrusions` first. `fill-extrusions` don't obey the layer order because they're sorted by depth, and it makes more sense to return them first rather than last.

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores (no measurable change)
 - [x] manually test the debug page

Does this need a unit or integration test? I'd be grateful for some guidance here.
