### PR TITLE
add docs for CustomLayerInterface#renderingMode

### DIFF
--- a/src/render/draw_custom.js
+++ b/src/render/draw_custom.js
@@ -19,6 +19,7 @@ function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomSty
         const prerender = implementation.prerender;
         if (prerender) {
             painter.setCustomLayerDefaults();
+            context.setColorMode(painter.colorModeForRenderPass());
 
             prerender.call(implementation, context.gl, painter.transform.customLayerMatrix());
 

--- a/src/style/style_layer/custom_style_layer.js
+++ b/src/style/style_layer/custom_style_layer.js
@@ -20,6 +20,11 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => 
  * and they should appropriately handle {@link Map.event:webglcontextlost} and
  * {@link Map.event:webglcontextrestored}.
  *
+ * The `renderingMode` property controls whether the layer is treated as a `"2d"` or `"3d"` map layer. Use:
+ * - `"renderingMode": "3d"` to use the depth buffer and share it with other layers
+ * - `"renderingMode": "2d"` to add a layer with no depth. If you need to use the depth buffer for a `"2d"` layer you must use an offscreen
+ *   framebuffer and {@link CustomLayerInterface#prerender}
+ *
  * @interface CustomLayerInterface
  * @property {string} id A unique layer id.
  * @property {string} type The layer's type. Must be `"custom"`.
@@ -121,6 +126,12 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => 
  *
  * If the layer needs to render to a texture, it should implement the `prerender` method
  * to do this and only use the `render` method for drawing directly into the main framebuffer.
+ *
+ * The blend function is set to `gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)`. This expects
+ * colors to be provided in premultiplied alpha form where the `r`, `g` and `b` values are already
+ * multiplied by the `a` value. If you are unable to provide colors in premultiplied form you
+ * may want to change the blend function to
+ * `gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA)`.
  *
  * @function
  * @memberof CustomLayerInterface


### PR DESCRIPTION
Add some more documentation for custom layers. Document:
- `renderingMode` and the difference between 2d and 3d
- blending functions