### PR TITLE
Optimize matrix calculation for labels

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -37,6 +37,8 @@ class Transform {
     alignedProjMatrix: Float64Array;
     pixelMatrix: Float64Array;
     pixelMatrixInverse: Float64Array;
+    glCoordMatrix: Float32Array;
+    labelPlaneMatrix: Float32Array;
     _fov: number;
     _pitch: number;
     _zoom: number;
@@ -568,11 +570,19 @@ class Transform {
         mat4.translate(alignedM, alignedM, [ dx > 0.5 ? dx - 1 : dx, dy > 0.5 ? dy - 1 : dy, 0 ]);
         this.alignedProjMatrix = alignedM;
 
-        // matrix for conversion from location to screen coordinates
         m = mat4.create();
         mat4.scale(m, m, [this.width / 2, -this.height / 2, 1]);
         mat4.translate(m, m, [1, -1, 0]);
-        this.pixelMatrix = mat4.multiply(new Float64Array(16), m, this.projMatrix);
+        this.labelPlaneMatrix = m;
+
+        m = mat4.create();
+        mat4.scale(m, m, [1, -1, 1]);
+        mat4.translate(m, m, [-1, -1, 0]);
+        mat4.scale(m, m, [2 / this.width, 2 / this.height, 1]);
+        this.glCoordMatrix = m;
+
+        // matrix for conversion from location to screen coordinates
+        this.pixelMatrix = mat4.multiply(new Float64Array(16), this.labelPlaneMatrix, this.projMatrix);
 
         // inverse matrix for conversion from screen coordinaes to location
         m = mat4.invert(new Float64Array(16), this.pixelMatrix);

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -73,17 +73,14 @@ function getLabelPlaneMatrix(posMatrix: mat4,
                              rotateWithMap: boolean,
                              transform: Transform,
                              pixelsToTileUnits: number) {
-    const m = mat4.identity(new Float32Array(16));
+    const m = mat4.create();
     if (pitchWithMap) {
-        mat4.identity(m);
         mat4.scale(m, m, [1 / pixelsToTileUnits, 1 / pixelsToTileUnits, 1]);
         if (!rotateWithMap) {
             mat4.rotateZ(m, m, transform.angle);
         }
     } else {
-        mat4.scale(m, m, [transform.width / 2, -transform.height / 2, 1]);
-        mat4.translate(m, m, [1, -1, 0]);
-        mat4.multiply(m, m, posMatrix);
+        mat4.multiply(m, transform.labelPlaneMatrix, posMatrix);
     }
     return m;
 }
@@ -96,19 +93,16 @@ function getGlCoordMatrix(posMatrix: mat4,
                           rotateWithMap: boolean,
                           transform: Transform,
                           pixelsToTileUnits: number) {
-    const m = mat4.identity(new Float32Array(16));
     if (pitchWithMap) {
-        mat4.multiply(m, m, posMatrix);
+        const m = mat4.clone(posMatrix);
         mat4.scale(m, m, [pixelsToTileUnits, pixelsToTileUnits, 1]);
         if (!rotateWithMap) {
             mat4.rotateZ(m, m, -transform.angle);
         }
+        return m;
     } else {
-        mat4.scale(m, m, [1, -1, 1]);
-        mat4.translate(m, m, [-1, -1, 0]);
-        mat4.scale(m, m, [2 / transform.width, 2 / transform.height, 1]);
+        return transform.glCoordMatrix;
     }
-    return m;
 }
 
 function project(point: Point, matrix: mat4) {


### PR DESCRIPTION
I noticed that `getLabelPlaneMatrix` and `getGlCoordMatrix` functions were taking considerable time on the main thread, and made matrix caching more aggressive to avoid a lot of this work, at least for screen-aligned labels which dominate the map. After the changes they take 10x less time.

We could cache even more (and I might follow up on this), but this PR gets us most of the way there with minimal changes.

Before:
![image](https://user-images.githubusercontent.com/25395/53573353-f5a5b180-3b75-11e9-9df5-3eae5a4536c6.png)

After:
![image](https://user-images.githubusercontent.com/25395/53573318-e4f53b80-3b75-11e9-8e1b-caeb0e496a58.png)

Bench:
![image](https://user-images.githubusercontent.com/25395/53572808-c5114800-3b74-11e9-98a2-13feddc6fc01.png)

Curiously, paint benchmark is nearly unaffected.

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
