### PR TITLE
Optimize setUniforms

### DIFF
--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -36,8 +36,7 @@ import type {FeatureStates} from '../source/source_state';
 export type BinderUniform = {
     name: string,
     property: string,
-    binding: Uniform<any>,
-    binder: Binder<any>
+    binding: Uniform<any>
 };
 
 function packColor(color: Color): [number, number] {
@@ -670,8 +669,10 @@ export default class ProgramConfiguration {
         for (const property in this.binders) {
             const binder = this.binders[property];
             for (const name of binder.uniformNames) {
-                const binding = binder.getBinding(context, locations[name]);
-                uniforms.push({name, property, binding, binder});
+                if (locations[name]) {
+                    const binding = binder.getBinding(context, locations[name]);
+                    uniforms.push({name, property, binding});
+                }
             }
         }
         return uniforms;
@@ -680,8 +681,8 @@ export default class ProgramConfiguration {
     setUniforms<Properties: Object>(context: Context, binderUniforms: Array<BinderUniform>, properties: PossiblyEvaluated<Properties>, globals: GlobalProperties) {
         // Uniform state bindings are owned by the Program, but we set them
         // from within the ProgramConfiguraton's binder members.
-        for (const {name, property, binding, binder} of binderUniforms) {
-            binder.setUniforms(context, binding, globals, properties.get(property), name);
+        for (const {name, property, binding} of binderUniforms) {
+            this.binders[property].setUniforms(context, binding, globals, properties.get(property), name);
         }
     }
 

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -16,6 +16,7 @@ import type StencilMode from '../gl/stencil_mode';
 import type ColorMode from '../gl/color_mode';
 import type CullFaceMode from '../gl/cull_face_mode';
 import type {UniformBindings, UniformValues, UniformLocations} from './uniform_binding';
+import type {BinderUniform} from '../data/program_configuration';
 
 export type DrawMode =
     | $PropertyType<WebGLRenderingContext, 'LINES'>
@@ -27,7 +28,7 @@ class Program<Us: UniformBindings> {
     attributes: {[string]: number};
     numAttributes: number;
     fixedUniforms: Us;
-    binderUniforms: UniformBindings;
+    binderUniforms: Array<BinderUniform>;
 
     constructor(context: Context,
                 source: {fragmentSource: string, vertexSource: string},


### PR DESCRIPTION
Eliminates unnecessary loops and object lookups in a performance-critical method (`setUniforms`). Measuring this with DevTools profiler, the method seems to get 2.5x faster — from taking 9.1% of CPU time to 3.7%.

Before:
![image](https://user-images.githubusercontent.com/25395/53577743-e5460480-3b7e-11e9-9f59-79d85716bde2.png)

After:
![image](https://user-images.githubusercontent.com/25395/53585207-0eba5c80-3b8e-11e9-808f-603e05d39035.png)

However, the Paint benchmark doesn't show this improvement — once again implying that it's not representative of real world performance (which needs to be investigated separately).

![image](https://user-images.githubusercontent.com/25395/53577667-bc257400-3b7e-11e9-9c99-e6a3144cb168.png)

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
