### PR TITLE
Eliminate tile lookups in drawing code

### DIFF
--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -9,11 +9,11 @@ import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
 import type CircleStyleLayer from '../style/style_layer/circle_style_layer';
 import type CircleBucket from '../data/bucket/circle_bucket';
-import type {OverscaledTileID} from '../source/tile_id';
+import type Tile from '../source/tile';
 
 export default drawCircles;
 
-function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>) {
+function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, tiles: Array<Tile>) {
     if (painter.renderPass !== 'translucent') return;
 
     const opacity = layer.paint.get('circle-opacity');
@@ -33,10 +33,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
     const stencilMode = StencilMode.disabled;
     const colorMode = painter.colorModeForRenderPass();
 
-    for (let i = 0; i < coords.length; i++) {
-        const coord = coords[i];
-
-        const tile = sourceCache.getTile(coord);
+    for (const tile of tiles) {
         const bucket: ?CircleBucket<*> = (tile.getBucket(layer): any);
         if (!bucket) continue;
 
@@ -44,7 +41,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
         const program = painter.useProgram('circle', programConfiguration);
 
         program.draw(context, gl.TRIANGLES, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
-            circleUniformValues(painter, coord, tile, layer), layer.id,
+            circleUniformValues(painter, tile, layer), layer.id,
             bucket.layoutVertexBuffer, bucket.indexBuffer, bucket.segments,
             layer.paint, painter.transform.zoom, programConfiguration);
     }

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -3,7 +3,7 @@
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
 import type StyleLayer from '../style/style_layer';
-import type {OverscaledTileID} from '../source/tile_id';
+import type Tile from '../source/tile';
 import type SymbolBucket from '../data/bucket/symbol_bucket';
 import DepthMode from '../gl/depth_mode';
 import StencilMode from '../gl/stencil_mode';
@@ -12,14 +12,12 @@ import { collisionUniformValues } from './program/collision_program';
 
 export default drawCollisionDebug;
 
-function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, coords: Array<OverscaledTileID>, drawCircles: boolean) {
+function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, tiles: Array<Tile>, drawCircles: boolean) {
     const context = painter.context;
     const gl = context.gl;
     const program = drawCircles ? painter.useProgram('collisionCircle') : painter.useProgram('collisionBox');
 
-    for (let i = 0; i < coords.length; i++) {
-        const coord = coords[i];
-        const tile = sourceCache.getTile(coord);
+    for (const tile of tiles) {
         const bucket: ?SymbolBucket = (tile.getBucket(layer): any);
         if (!bucket) continue;
         const buffers = drawCircles ? bucket.collisionCircle : bucket.collisionBox;
@@ -30,7 +28,7 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
             painter.colorModeForRenderPass(),
             CullFaceMode.disabled,
             collisionUniformValues(
-                coord.posMatrix,
+                tile.posMatrix,
                 painter.transform,
                 tile),
             layer.id, buffers.layoutVertexBuffer, buffers.indexBuffer,
@@ -39,7 +37,7 @@ function drawCollisionDebugGeometry(painter: Painter, sourceCache: SourceCache, 
     }
 }
 
-function drawCollisionDebug(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, coords: Array<OverscaledTileID>) {
-    drawCollisionDebugGeometry(painter, sourceCache, layer, coords, false);
-    drawCollisionDebugGeometry(painter, sourceCache, layer, coords, true);
+function drawCollisionDebug(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, tiles: Array<Tile>) {
+    drawCollisionDebugGeometry(painter, sourceCache, layer, tiles, false);
+    drawCollisionDebugGeometry(painter, sourceCache, layer, tiles, true);
 }

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -14,21 +14,21 @@ import Color from '../style-spec/util/color';
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
-import type {OverscaledTileID} from '../source/tile_id';
+import type Tile from '../source/tile';
 
 export default drawDebug;
 
-function drawDebug(painter: Painter, sourceCache: SourceCache, coords: Array<OverscaledTileID>) {
-    for (let i = 0; i < coords.length; i++) {
-        drawDebugTile(painter, sourceCache, coords[i]);
+function drawDebug(painter: Painter, sourceCache: SourceCache, tiles: Array<Tile>) {
+    for (const tile of tiles) {
+        drawDebugTile(painter, sourceCache, tile);
     }
 }
 
-function drawDebugTile(painter, sourceCache, coord) {
+function drawDebugTile(painter, sourceCache, tile) {
     const context = painter.context;
     const gl = context.gl;
 
-    const posMatrix = coord.posMatrix;
+    const posMatrix = tile.posMatrix;
     const program = painter.useProgram('debug');
 
     const depthMode = DepthMode.disabled;
@@ -40,7 +40,7 @@ function drawDebugTile(painter, sourceCache, coord) {
         debugUniformValues(posMatrix, Color.red), id,
         painter.debugBuffer, painter.tileBorderIndexBuffer, painter.debugSegments);
 
-    const vertices = createTextVertices(coord.toString(), 50, 200, 5);
+    const vertices = createTextVertices(tile.tileID.toString(), 50, 200, 5);
     const debugTextArray = new PosArray();
     const debugTextIndices = new LineIndexArray();
     for (let v = 0; v < vertices.length; v += 2) {
@@ -53,8 +53,8 @@ function drawDebugTile(painter, sourceCache, coord) {
 
     // Draw the halo with multiple 1px lines instead of one wider line because
     // the gl spec doesn't guarantee support for lines with width > 1.
-    const tileSize = sourceCache.getTile(coord).tileSize;
-    const onePixel = EXTENT / (Math.pow(2, painter.transform.zoom - coord.overscaledZ) * tileSize);
+    const tileSize = tile.tileSize;
+    const onePixel = EXTENT / (Math.pow(2, painter.transform.zoom - tile.tileID.overscaledZ) * tileSize);
     const translations = [[-1, -1], [-1, 1], [1, -1], [1, 1]];
     for (let i = 0; i < translations.length; i++) {
         const translation = translations[i];

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -12,11 +12,11 @@ import {
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
 import type HillshadeStyleLayer from '../style/style_layer/hillshade_style_layer';
-import type {OverscaledTileID} from '../source/tile_id';
+import type Tile from '../source/tile';
 
 export default drawHillshade;
 
-function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>) {
+function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tiles: Array<Tile>) {
     if (painter.renderPass !== 'offscreen' && painter.renderPass !== 'translucent') return;
 
     const context = painter.context;
@@ -26,8 +26,7 @@ function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: Hillsh
     const stencilMode = StencilMode.disabled;
     const colorMode = painter.colorModeForRenderPass();
 
-    for (const tileID of tileIDs) {
-        const tile = sourceCache.getTile(tileID);
+    for (const tile of tiles) {
         if (tile.needsHillshadePrepare && painter.renderPass === 'offscreen') {
             prepareHillshade(painter, tile, layer, sourceMaxZoom, depthMode, stencilMode, colorMode);
             continue;

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -14,9 +14,9 @@ import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
 import type LineStyleLayer from '../style/style_layer/line_style_layer';
 import type LineBucket from '../data/bucket/line_bucket';
-import type {OverscaledTileID} from '../source/tile_id';
+import type Tile from '../source/tile';
 
-export default function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>) {
+export default function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, tiles: Array<Tile>) {
     if (painter.renderPass !== 'translucent') return;
 
     const opacity = layer.paint.get('line-opacity');
@@ -52,9 +52,7 @@ export default function drawLine(painter: Painter, sourceCache: SourceCache, lay
         gradientTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
     }
 
-    for (const coord of coords) {
-        const tile = sourceCache.getTile(coord);
-
+    for (const tile of tiles) {
         if (image && !tile.patternsLoaded()) continue;
 
         const bucket: ?LineBucket = (tile.getBucket(layer): any);
@@ -87,7 +85,7 @@ export default function drawLine(painter: Painter, sourceCache: SourceCache, lay
         }
 
         program.draw(context, gl.TRIANGLES, depthMode,
-            painter.stencilModeForClipping(coord), colorMode, CullFaceMode.disabled, uniformValues,
+            painter.stencilModeForClipping(tile), colorMode, CullFaceMode.disabled, uniformValues,
             layer.id, bucket.layoutVertexBuffer, bucket.indexBuffer, bucket.segments,
             layer.paint, painter.transform.zoom, programConfiguration);
 

--- a/src/render/program/circle_program.js
+++ b/src/render/program/circle_program.js
@@ -10,7 +10,6 @@ import pixelsToTileUnits from '../../source/pixels_to_tile_units';
 
 import type Context from '../../gl/context';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
-import type {OverscaledTileID} from '../../source/tile_id';
 import type Tile from '../../source/tile';
 import type CircleStyleLayer from '../../style/style_layer/circle_style_layer';
 import type Painter from '../painter';
@@ -33,7 +32,6 @@ const circleUniforms = (context: Context, locations: UniformLocations): CircleUn
 
 const circleUniformValues = (
     painter: Painter,
-    coord: OverscaledTileID,
     tile: Tile,
     layer: CircleStyleLayer
 ): UniformValues<CircleUniformsType> => {
@@ -53,7 +51,7 @@ const circleUniformValues = (
         'u_camera_to_center_distance': transform.cameraToCenterDistance,
         'u_scale_with_map': +(layer.paint.get('circle-pitch-scale') === 'map'),
         'u_matrix': painter.translatePosMatrix(
-            coord.posMatrix,
+            tile.posMatrix,
             tile,
             layer.paint.get('circle-translate'),
             layer.paint.get('circle-translate-anchor')),

--- a/src/render/program/fill_extrusion_program.js
+++ b/src/render/program/fill_extrusion_program.js
@@ -15,7 +15,6 @@ import { extend } from '../../util/util';
 
 import type Context from '../../gl/context';
 import type Painter from '../painter';
-import type {OverscaledTileID} from '../../source/tile_id';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
 import type {CrossfadeParameters} from '../../style/evaluation_parameters';
 import type Tile from '../../source/tile';
@@ -104,14 +103,13 @@ const fillExtrusionPatternUniformValues = (
     painter: Painter,
     shouldUseVerticalGradient: boolean,
     opacity: number,
-    coord: OverscaledTileID,
-    crossfade: CrossfadeParameters,
-    tile: Tile
+    tile: Tile,
+    crossfade: CrossfadeParameters
 ): UniformValues<FillExtrusionPatternUniformsType> => {
     return extend(fillExtrusionUniformValues(matrix, painter, shouldUseVerticalGradient, opacity),
         patternUniformValues(crossfade, painter, tile),
         {
-            'u_height_factor': -Math.pow(2, coord.overscaledZ) / tile.tileSize / 8
+            'u_height_factor': -Math.pow(2, tile.tileID.overscaledZ) / tile.tileSize / 8
         });
 };
 

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -179,7 +179,7 @@ function calculateTileRatio(tile: Tile, transform: Transform) {
 
 function calculateMatrix(painter, tile, layer) {
     return painter.translatePosMatrix(
-        tile.tileID.posMatrix,
+        tile.posMatrix,
         tile,
         layer.paint.get('line-translate'),
         layer.paint.get('line-translate-anchor')

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -796,12 +796,14 @@ class SourceCache extends Evented {
         return tileResults;
     }
 
-    getVisibleCoordinates(symbolLayer?: boolean): Array<OverscaledTileID> {
-        const coords = this.getRenderableIds(symbolLayer).map((id) => this._tiles[id].tileID);
-        for (const coord of coords) {
-            coord.posMatrix = this.transform.calculatePosMatrix(coord.toUnwrapped());
+    getVisibleTiles(symbolLayer?: boolean): Array<Tile> {
+        const tiles = [];
+        for (const id of this.getRenderableIds(symbolLayer)) {
+            const tile = this._tiles[id];
+            tile.posMatrix = this.transform.calculatePosMatrix(tile.tileID.toUnwrapped());
+            tiles.push(tile);
         }
-        return coords;
+        return tiles;
     }
 
     hasTransition() {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -76,6 +76,7 @@ class Tile {
     workerID: number | void;
     vtLayers: {[string]: VectorTileLayer};
     mask: Mask;
+    posMatrix: Float32Array;
 
     neighboringTiles: ?Object;
     dem: ?DEMData;

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -67,7 +67,6 @@ export class OverscaledTileID {
     wrap: number;
     canonical: CanonicalTileID;
     key: number;
-    posMatrix: Float32Array;
 
     constructor(overscaledZ: number, wrap: number, z: number, x: number, y: number) {
         assert(overscaledZ >= z);
@@ -178,4 +177,4 @@ function getQuadkey(z, x, y) {
 }
 
 register('CanonicalTileID', CanonicalTileID);
-register('OverscaledTileID', OverscaledTileID, {omit: ['posMatrix']});
+register('OverscaledTileID', OverscaledTileID);


### PR DESCRIPTION
Initially I pursuit this due to a glitch in DevTools that attributed a lot of time (10%) to `getTile` (this later went away), but although in practice it doesn't change performance, it seems like it's making the code slightly simpler so maybe worth merging?

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [x] post benchmark scores
 - [x] manually test the debug page
