### PR TITLE
Add the default value for the 'text-radial-offset' property

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1798,6 +1798,7 @@
     "text-radial-offset": {
       "type": "number",
       "units": "ems",
+      "default": 0,
       "doc": "Radial offset of text, in the direction of the symbol's anchor. Useful in combination with `text-variable-anchor`, which doesn't support the two-dimensional `text-offset`.",
       "requires": [
         {


### PR DESCRIPTION
Style code generating scripts in gl-native require a default value to be in place.