### PR TITLE
Exclude current Safari from using Fetch API

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -165,10 +165,12 @@ export const makeRequest = function(requestParameters: RequestParameters, callba
     // We're trying to use the Fetch API if possible. However, in some situations we can't use it:
     // - IE11 doesn't support it at all. In this case, we dispatch the request to the main thread so
     //   that we can get an accruate referrer header.
+    // - Safari exposes window.AbortController, but it doesn't work actually abort any requests in
+    //   some versions (see https://bugs.webkit.org/show_bug.cgi?id=174980#c2)
     // - Requests for resources with the file:// URI scheme don't work with the Fetch API either. In
     //   this case we unconditionally use XHR on the current thread since referrers don't matter.
     if (!/^file:/.test(requestParameters.url)) {
-        if (window.fetch && window.Request && window.AbortController) {
+        if (window.fetch && window.Request && window.AbortController && window.Request.prototype.hasOwnProperty('signal')) {
             return makeFetchRequest(requestParameters, callback);
         }
         if (isWorker() && self.worker && self.worker.actor) {


### PR DESCRIPTION
According to https://bugs.webkit.org/show_bug.cgi?id=174980#c2, Safari <= 12 exposes `AbortController`, but it doesn't actually work. This adds a check for `Request.signal`, which indicates that a Request can actually send out signals as a prerequisite for using the Fetch API.