### PR TITLE
add support for animated images

### DIFF
--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -9,6 +9,7 @@ toc:
   - CameraOptions
   - PaddingOptions
   - RequestParameters
+  - StyleImageInterface
   - CustomLayerInterface
   - name: Geography & Geometry
     description: |

--- a/docs/pages/example/add-image-animated.html
+++ b/docs/pages/example/add-image-animated.html
@@ -1,0 +1,85 @@
+<div id='map'></div>
+
+<script>
+
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v9'
+});
+
+var size = 200;
+
+var pulsingDot = {
+    width: size,
+    height: size,
+    data: new Uint8Array(size * size * 4),
+
+    onAdd: function() {
+        var canvas = document.createElement('canvas');
+        canvas.width = this.width;
+        canvas.height = this.height;
+        this.context = canvas.getContext('2d');
+    },
+
+    render: function() {
+        var duration = 1000;
+        var t = (performance.now() % duration) / duration;
+
+        var radius = size / 2 * 0.3;
+        var outerRadius = size / 2 * 0.7 * t + radius;
+        var context = this.context;
+
+        // draw outer circle
+        context.clearRect(0, 0, this.width, this.height);
+        context.beginPath();
+        context.arc(this.width / 2, this.height / 2, outerRadius, 0, Math.PI * 2);
+        context.fillStyle = 'rgba(255, 200, 200,' + (1 - t) + ')';
+        context.fill();
+
+        // draw inner circle
+        context.beginPath();
+        context.arc(this.width / 2, this.height / 2, radius, 0, Math.PI * 2);
+        context.fillStyle = 'rgba(255, 100, 100, 1)';
+        context.strokeStyle = 'white';
+        context.lineWidth = 2 + 4 * (1 - t);
+        context.fill();
+        context.stroke();
+
+        // update this image's data with data from the canvas
+        this.data = context.getImageData(0, 0, this.width, this.height).data;
+
+        // keep the map repainting
+        map.triggerRepaint();
+
+        // return `true` to let the map know that the image was updated
+        return true;
+    }
+};
+
+map.on('load', function () {
+
+    map.addImage('pulsing-dot', pulsingDot, { pixelRatio: 2 });
+
+    map.addLayer({
+        "id": "points",
+        "type": "symbol",
+        "source": {
+            "type": "geojson",
+            "data": {
+                "type": "FeatureCollection",
+                "features": [{
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [0, 0]
+                    }
+                }]
+            }
+        },
+        "layout": {
+            "icon-image": "pulsing-dot"
+        }
+    });
+});
+
+</script>

--- a/docs/pages/example/add-image-animated.js
+++ b/docs/pages/example/add-image-animated.js
@@ -1,0 +1,11 @@
+/*---
+title: Add an animated icon to the map
+description: Add an animated icon to the map that was generated at runtime with a Canvas.
+tags:
+  - styles
+  - layers
+pathname: /mapbox-gl-js/example/add-image-animated/
+---*/
+import Example from '../../components/example';
+import html from './add-image-animated.html';
+export default Example(html);

--- a/src/render/image_atlas.js
+++ b/src/render/image_atlas.js
@@ -63,40 +63,13 @@ export default class ImageAtlas {
     uploaded: ?boolean;
 
     constructor(icons: {[string]: StyleImage}, patterns: {[string]: StyleImage}) {
-        const iconPositions = {}, patternPositions = {}, haveRenderCallbacks = [];
+        const iconPositions = {}, patternPositions = {};
+        this.haveRenderCallbacks = [];
 
         const bins = [];
-        for (const id in icons) {
-            const src = icons[id];
-            const bin = {
-                x: 0,
-                y: 0,
-                w: src.data.width + 2 * padding,
-                h: src.data.height + 2 * padding,
-            };
-            bins.push(bin);
-            iconPositions[id] = new ImagePosition(bin, src);
 
-            if (src.hasRenderCallback) {
-                haveRenderCallbacks.push(id);
-            }
-        }
-
-        for (const id in patterns) {
-            const src = patterns[id];
-            const bin = {
-                x: 0,
-                y: 0,
-                w: src.data.width + 2 * padding,
-                h: src.data.height + 2 * padding,
-            };
-            bins.push(bin);
-            patternPositions[id] = new ImagePosition(bin, src);
-
-            if (src.hasRenderCallback) {
-                haveRenderCallbacks.push(id);
-            }
-        }
+        this.addImages(icons, iconPositions, bins);
+        this.addImages(patterns, patternPositions, bins);
 
         const {w, h} = potpack(bins);
         const image = new RGBAImage({width: w || 1, height: h || 1});
@@ -126,7 +99,24 @@ export default class ImageAtlas {
         this.image = image;
         this.iconPositions = iconPositions;
         this.patternPositions = patternPositions;
-        this.haveRenderCallbacks = haveRenderCallbacks;
+    }
+
+    addImages(images: {[string]: StyleImage}, positions: {[string]: ImagePosition}, bins: Array<Rect>) {
+        for (const id in images) {
+            const src = images[id];
+            const bin = {
+                x: 0,
+                y: 0,
+                w: src.data.width + 2 * padding,
+                h: src.data.height + 2 * padding,
+            };
+            bins.push(bin);
+            positions[id] = new ImagePosition(bin, src);
+
+            if (src.hasRenderCallback) {
+                this.haveRenderCallbacks.push(id);
+            }
+        }
     }
 
     patchUpdatedImages(imageManager: ImageManager, texture: Texture) {

--- a/src/render/image_atlas.js
+++ b/src/render/image_atlas.js
@@ -143,8 +143,8 @@ export default class ImageAtlas {
         if (position.version === image.version) return;
 
         position.version = image.version;
-        const tl = position.tl;
-        texture.update(image.data, undefined, { x: tl[0], y: tl[1] });
+        const [x, y] = position.tl;
+        texture.update(image.data, undefined, {x, y});
     }
 
 }

--- a/src/render/image_manager.js
+++ b/src/render/image_manager.js
@@ -30,6 +30,7 @@ const padding = 1;
 
         1. Tracks requests for icon images from tile workers and sends responses when the requests are fulfilled.
         2. Builds a texture atlas for pattern images.
+        3. Rerenders renderable images once per frame
 
     These are disparate responsibilities and should eventually be handled by different classes. When we implement
     data-driven support for `*-pattern`, we'll likely use per-bucket pattern atlases, and that would be a good time

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -329,6 +329,8 @@ class Painter {
 
         this.symbolFadeChange = style.placement.symbolFadeChange(browser.now());
 
+        this.imageManager.beginFrame();
+
         const layerIds = this.style._order;
         const sourceCaches = this.style.sourceCaches;
 

--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -49,9 +49,9 @@ class Texture {
         this.update(image, options);
     }
 
-    update(image: TextureImage, options: ?{premultiply?: boolean, useMipmap?: boolean}) {
+    update(image: TextureImage, options: ?{premultiply?: boolean, useMipmap?: boolean}, position?: { x: number, y: number }) {
         const {width, height} = image;
-        const resize = !this.size || this.size[0] !== width || this.size[1] !== height;
+        const resize = (!this.size || this.size[0] !== width || this.size[1] !== height) && !position;
         const {context} = this;
         const {gl} = context;
 
@@ -72,10 +72,11 @@ class Texture {
             }
 
         } else {
+            const {x, y} = position || { x: 0, y: 0};
             if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData) {
-                gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, image);
+                gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, gl.RGBA, gl.UNSIGNED_BYTE, image);
             } else {
-                gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, image.data);
+                gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, image.data);
             }
         }
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -169,7 +169,9 @@ class SourceCache extends Evented {
 
         this._state.coalesceChanges(this._tiles, this.map ? this.map.painter : null);
         for (const i in this._tiles) {
-            this._tiles[i].upload(context);
+            const tile = this._tiles[i];
+            tile.upload(context);
+            tile.prepare(this.map.style.imageManager);
         }
     }
 

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -25,6 +25,7 @@ import type {WorkerTileResult} from './worker_source';
 import type DEMData from '../data/dem_data';
 import type {AlphaImage} from '../util/image';
 import type ImageAtlas from '../render/image_atlas';
+import type ImageManager from '../render/image_manager';
 import type Mask from '../render/tile_mask';
 import type Context from '../gl/context';
 import type IndexBuffer from '../gl/index_buffer';
@@ -251,6 +252,12 @@ class Tile {
         if (this.glyphAtlasImage) {
             this.glyphAtlasTexture = new Texture(context, this.glyphAtlasImage, gl.ALPHA);
             this.glyphAtlasImage = null;
+        }
+    }
+
+    prepare(imageManager: ImageManager) {
+        if (this.imageAtlas) {
+            this.imageAtlas.patchUpdatedImages(imageManager, this.imageAtlasTexture);
         }
     }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -466,6 +466,10 @@ class Style extends Evented {
         this.fire(new Event('data', {dataType: 'style'}));
     }
 
+    updateImage(id: string, image: StyleImage) {
+        this.imageManager.updateImage(id, image);
+    }
+
     getImage(id: string): ?StyleImage {
         return this.imageManager.getImage(id);
     }

--- a/src/style/style_image.js
+++ b/src/style/style_image.js
@@ -98,6 +98,9 @@ export function renderStyleImage(image: StyleImage) {
  * If the method updates the image it must return `true` to commit the change.
  * If the method returns `false` or nothing the image is assumed to not have changed.
  *
+ * If updates are infrequent it maybe easier to use {@link Map#updateImage} to update
+ * the image instead of implementing this method.
+ *
  * @function
  * @memberof StyleImageInterface
  * @instance

--- a/src/style/style_image.js
+++ b/src/style/style_image.js
@@ -1,9 +1,126 @@
 // @flow
 
-import type {RGBAImage} from '../util/image';
+import {RGBAImage} from '../util/image';
+
+import type Map from '../ui/map';
 
 export type StyleImage = {
     data: RGBAImage,
     pixelRatio: number,
-    sdf: boolean
+    sdf: boolean,
+    version: number,
+    hasRenderCallback?: boolean,
+    userImage?: StyleImageInterface
 };
+
+export type StyleImageInterface = {
+    width: number,
+    height: number,
+    data: Uint8Array | Uint8ClampedArray,
+    render?: () => void,
+    onAdd?: (map: Map, id: string) => void,
+    onRemove?: () => void
+};
+
+export function renderStyleImage(image: StyleImage) {
+    const {userImage} = image;
+    if (userImage && userImage.render) {
+        const updated = userImage.render();
+        if (updated) {
+            image.data.replace(new Uint8Array(userImage.data.buffer));
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Interface for dynamically generated style images. This is a specification for
+ * implementers to model: it is not an exported method or class.
+ *
+ * Images implementing this interface can be redrawn for every frame. They can be used to animate
+ * icons and patterns or make them respond to user input. Style images can implement a
+ * {@link StyleImageInterface#render} method. The method is called every frame and
+ * can be used to update the image.
+ *
+ * @interface StyleImageInterface
+ * @property {number} width
+ * @property {number} height
+ * @property {Uint8Array | Uint8ClampedArray} data
+ *
+ * @see [Add an animated icon to the map.](https://docs.mapbox.com/mapbox-gl-js/example/add-image-animated/)
+ *
+ * @example
+ * var flashingSquare = {
+ *     width: 64,
+ *     height: 64,
+ *     data: new Uint8Array(64 * 64 * 4),
+ *
+ *     onAdd: function(map) {
+ *         this.map = map;
+ *     },
+ *
+ *     render: function() {
+ *         // keep repainting while the icon is on the map
+ *         this.map.triggerRepaint();
+ *
+ *         // alternate between black and white based on the time
+ *         var value = Math.round(Date.now() / 1000) % 2 === 0  ? 255 : 0;
+ *
+ *         // check if image needs to be changed
+ *         if (value !== this.previousValue) {
+ *             this.previousValue = value;
+ *
+ *             var bytesPerPixel = 4;
+ *             for (var x = 0; x < this.width; x++) {
+ *                 for (var y = 0; y < this.height; y++) {
+ *                     var offset = (y * this.width + x) * bytesPerPixel;
+ *                     this.data[offset + 0] = value;
+ *                     this.data[offset + 1] = value;
+ *                     this.data[offset + 2] = value;
+ *                     this.data[offset + 3] = 255;
+ *                 }
+ *             }
+ *
+ *             // return true to indicate that the image changed
+ *             return true;
+ *         }
+ *     }
+ *  }
+ *
+ *  map.addImage('flashing_square', flashingSquare);
+ */
+
+/**
+ * This method is called once before every frame where the icon will be used.
+ * The method can optionally update the image's `data` member with a new image.
+ *
+ * If the method updates the image it must return `true` to commit the change.
+ * If the method returns `false` or nothing the image is assumed to not have changed.
+ *
+ * @function
+ * @memberof StyleImageInterface
+ * @instance
+ * @name render
+ * @return {boolean} `true` if this method updated the image. `false` if the image was not changed.
+ */
+
+/**
+ * Optional method called when the layer has been added to the Map with {@link Map#addImage}.
+ *
+ * @function
+ * @memberof StyleImageInterface
+ * @instance
+ * @name onAdd
+ * @param {Map} map The Map this custom layer was just added to.
+ */
+
+/**
+ * Optional method called when the icon is removed from the map with {@link Map#removeImage}.
+ * This gives the image a chance to clean up resources and event listeners.
+ *
+ * @function
+ * @memberof StyleImageInterface
+ * @instance
+ * @name onRemove
+ */

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -115,6 +115,14 @@ export class RGBAImage {
         resizeImage(this, size, 4);
     }
 
+    replace(data: Uint8Array | Uint8ClampedArray, copy?: boolean) {
+        if (copy) {
+            this.data.set(data);
+        } else {
+            this.data = data;
+        }
+    }
+
     clone() {
         return new RGBAImage({width: this.width, height: this.height}, new Uint8Array(this.data));
     }


### PR DESCRIPTION
This adds support for updating and animating images. fixes #7588 and fixes #4804

There are two parts to this:

### StyleImageInterface

```js
export type StyleImageInterface = {
    width: number,
    height: number,
    data: Uint8Array | Uint8ClampedArray,
    render?: () => void,
    onAdd?: (map: Map, id: string) => void,
    onRemove?: () => void
};
```
`map.addImage(...)` now accepts images that implement the `StyleImageInterface`. This interface adds three new and optional methods:
- `render` gets called once for every map frame that the icon is used in the visible map. The user can update the icon in this method to animate the icon.
- `onAdd` gets called when the icon gets added to the map to allow for resource initialization, etc.
- `onRemove` mirrors onAdd and will be useful if/when we add image eviction


This pull-based approach to image updating allows the user to only rerender the image when it is necessary. The image is not rerendered for cached tiles. Image renders are synchronized with map renders.

### map.updateImage(id, image)

This updates and image and immediately updates map. This is a lighter alternative to the above `render` approach and should be useful for instant, infrequent updates. For example, changing an icon on click. Or changing an icon when a resource has loaded.

Both approaches use the same underlying implementation.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page