### PR TITLE
Improve diffing of styles containing "visibility": "visible"

### DIFF
--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -39,7 +39,7 @@ class StyleLayer extends Evented {
     minzoom: ?number;
     maxzoom: ?number;
     filter: FilterSpecification | void;
-    visibility: 'visible' | 'none';
+    visibility: 'visible' | 'none' | void;
     _crossfadeParameters: CrossfadeParameters;
 
     _unevaluatedLayout: Layout<any>;
@@ -69,7 +69,6 @@ class StyleLayer extends Evented {
 
         this.id = layer.id;
         this.type = layer.type;
-        this.visibility = 'visible';
         this._featureFilter = () => true;
 
         if (layer.type === 'custom') return;
@@ -116,7 +115,7 @@ class StyleLayer extends Evented {
         return this._unevaluatedLayout.getValue(name);
     }
 
-    setLayoutProperty(name: string, value: mixed, options: StyleSetterOptions = {}) {
+    setLayoutProperty(name: string, value: any, options: StyleSetterOptions = {}) {
         if (value !== null && value !== undefined) {
             const key = `layers.${this.id}.layout.${name}`;
             if (this._validate(validateLayoutProperty, key, name, value, options)) {
@@ -125,7 +124,7 @@ class StyleLayer extends Evented {
         }
 
         if (name === 'visibility') {
-            this.visibility = value === 'none' ? value : 'visible';
+            this.visibility = value;
             return;
         }
 
@@ -173,7 +172,7 @@ class StyleLayer extends Evented {
     isHidden(zoom: number) {
         if (this.minzoom && zoom < this.minzoom) return true;
         if (this.maxzoom && zoom >= this.maxzoom) return true;
-        return this.visibility === 'none';
+        return this.visibility !== 'none';
     }
 
     updateTransitions(parameters: TransitionParameters) {
@@ -210,7 +209,7 @@ class StyleLayer extends Evented {
             'paint': this._transitionablePaint && this._transitionablePaint.serialize()
         };
 
-        if (this.visibility === 'none') {
+        if (this.visibility) {
             output.layout = output.layout || {};
             output.layout.visibility = 'none';
         }
@@ -270,5 +269,3 @@ class StyleLayer extends Evented {
 }
 
 export default StyleLayer;
-
-

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -211,7 +211,7 @@ class StyleLayer extends Evented {
 
         if (this.visibility) {
             output.layout = output.layout || {};
-            output.layout.visibility = 'none';
+            output.layout.visibility = this.visibility;
         }
 
         return filterObject(output, (value, key) => {

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -172,7 +172,7 @@ class StyleLayer extends Evented {
     isHidden(zoom: number) {
         if (this.minzoom && zoom < this.minzoom) return true;
         if (this.maxzoom && zoom >= this.maxzoom) return true;
-        return this.visibility !== 'none';
+        return this.visibility === 'none';
     }
 
     updateTransitions(parameters: TransitionParameters) {

--- a/test/unit/style/style_layer.test.js
+++ b/test/unit/style/style_layer.test.js
@@ -315,6 +315,33 @@ test('StyleLayer#serialize', (t) => {
         t.end();
     });
 
+    t.test('serializes "visibility" of "visible"', (t) => {
+        const layer = createStyleLayer(createSymbolLayer());
+        layer.setLayoutProperty('visibility', 'visible');
+
+        t.equal(layer.serialize().layout['visibility'], 'visible');
+
+        t.end();
+    });
+
+    t.test('serializes "visibility" of "none"', (t) => {
+        const layer = createStyleLayer(createSymbolLayer());
+        layer.setLayoutProperty('visibility', 'none');
+
+        t.equal(layer.serialize().layout['visibility'], 'none');
+
+        t.end();
+    });
+
+    t.test('serializes "visibility" of undefined', (t) => {
+        const layer = createStyleLayer(createSymbolLayer());
+        layer.setLayoutProperty('visibility', undefined);
+
+        t.equal(layer.serialize().layout['visibility'], undefined);
+
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
When I execute this code:

```js
const style = {
    version: 8,
    sources: {},
    layers: [{id: 'background', layout: {visibility: 'visible'}]
}
const map = new Map({style, ...});
map.setStyle(style)
```

I expect `setStyle` to do a diff-based update which reduces to a no-op. 

However what actually happens is that it produces a `['setLayoutProperty', 'visibility', null]` command because we store `visibility: 'visible'` the same way as `visibility: undefined` and always serialize into the latter. `map.getStyle().layers[0].layout.visibility` is `undefined`. 

It is expensive to run a large number of `['setLayoutProperty', 'visibility', null]` commands.

Other properties do not behave like this. Visibility is a special case. 

This PR correctly stores and serializes the state of `visibility` into either `visible` or `undefined`.

This may `fix` https://github.com/mapbox/mapbox-gl-js/issues/7459
This may `fix` https://github.com/mapbox/mapbox-gl-js/issues/7648

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page