### PR TITLE
Fixes shifted mouse events when CSS transform-scale applied

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -3,7 +3,7 @@
 import assert from 'assert';
 import DOM from '../../util/dom';
 
-import { ease as _ease, bindAll, bezier } from '../../util/util';
+import { ease as _ease, bindAll, bezier, cssTransformPoint } from '../../util/util';
 import browser from '../../util/browser';
 import window from '../../util/window';
 import { number as interpolate } from '../../style-spec/util/interpolate';
@@ -226,8 +226,9 @@ class ScrollZoomHandler {
         }
 
         const pos = DOM.mousePos(this._el, e);
+        const transformedPos = cssTransformPoint(pos, this._map._cssTransforms);
 
-        this._around = LngLat.convert(this._aroundCenter ? this._map.getCenter() : this._map.unproject(pos));
+        this._around = LngLat.convert(this._aroundCenter ? this._map.getCenter() : this._map.unproject(transformedPos));
         this._aroundPoint = this._map.transform.locationPoint(this._around);
         if (!this._frameId) {
             this._frameId = this._map._requestRenderFrame(this._onScrollFrame);

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -1,7 +1,7 @@
 // @flow
 
 import DOM from '../../util/dom';
-import { bezier, bindAll } from '../../util/util';
+import { bezier, bindAll, cssTransformPoint } from '../../util/util';
 import window from '../../util/window';
 import browser from '../../util/browser';
 import { Event } from '../../util/evented';
@@ -116,8 +116,9 @@ class TouchZoomRotateHandler {
         if (!this.isEnabled()) return;
         if (e.touches.length !== 2) return;
 
-        const p0 = DOM.mousePos(this._el, e.touches[0]),
-            p1 = DOM.mousePos(this._el, e.touches[1]),
+        const cssTransforms = this._map._cssTransforms;
+        const p0 = cssTransformPoint(DOM.mousePos(this._el, e.touches[0]), cssTransforms),
+            p1 = cssTransformPoint(DOM.mousePos(this._el, e.touches[1]), cssTransforms),
             center = p0.add(p1).div(2);
 
         this._startVec = p0.sub(p1);
@@ -130,8 +131,9 @@ class TouchZoomRotateHandler {
     }
 
     _getTouchEventData(e: TouchEvent) {
-        const p0 = DOM.mousePos(this._el, e.touches[0]),
-            p1 = DOM.mousePos(this._el, e.touches[1]);
+        const cssTransforms = this._map._cssTransforms;
+        const p0 = cssTransformPoint(DOM.mousePos(this._el, e.touches[0]), cssTransforms),
+            p1 = cssTransformPoint(DOM.mousePos(this._el, e.touches[1]), cssTransforms);
 
         const vec = p0.sub(p1);
         return {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -467,3 +467,24 @@ export function b64DecodeUnicode(str: string) {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2); //eslint-disable-line
     }).join(''));
 }
+
+
+export type CssTransforms = {
+    scale?: string | number;
+}
+
+/**
+ * Takes a Mapbox Point and an object of CSS transforms from the Mapbox
+ * constructor options and returns a new Point with those transforms applied.
+ * @param {Point} pos
+ * @param {Object} cssTransforms
+ * @param {string|number} cssTransforms.scale
+ */
+export function cssTransformPoint(pos: Point, cssTransforms: ?CssTransforms): Point {
+    // Eventually we can apply css rotations, etc. For now
+    // only scale is supported
+    const scale = (cssTransforms && cssTransforms.scale) ? cssTransforms.scale : 1;
+    let posCloned = pos.clone();
+    if (scale !== 1) posCloned = pos.div(scale);
+    return posCloned;
+}

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -2003,6 +2003,14 @@ test('Map', (t) => {
         });
     });
 
+    t.test('should accept and apply new cssTransforms when setCssTransforms is called', (t) => {
+        const map = createMap(t);
+        t.deepEqual(map._cssTransforms, { scale: 1 });
+        map.setCssTransforms({ scale: 2 });
+        t.deepEqual(map._cssTransforms, { scale: 2 });
+        t.end();
+    });
+
     t.end();
 });
 

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -2,7 +2,7 @@
 
 import { test } from '../../util/test';
 
-import { easeCubicInOut, keysDifference, extend, pick, uniqueId, bindAll, asyncAll, clamp, wrap, bezier, endsWith, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl, uuid, validateUuid } from '../../../src/util/util';
+import { easeCubicInOut, keysDifference, extend, pick, uniqueId, bindAll, asyncAll, clamp, wrap, bezier, endsWith, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl, uuid, validateUuid, cssTransformPoint } from '../../../src/util/util';
 import Point from '@mapbox/point-geometry';
 
 test('util', (t) => {
@@ -296,6 +296,26 @@ test('util', (t) => {
         t.false(validateUuid(uuid().substr(0, 10)));
         t.false(validateUuid('foobar'));
         t.false(validateUuid(null));
+        t.end();
+    });
+
+    t.test('cssTransformPoint', (t) => {
+        t.deepEqual(cssTransformPoint(new Point(10, 10)), {
+            x: 10,
+            y: 10,
+        });
+        t.deepEqual(cssTransformPoint(new Point(10, 10), { scale: 1 }), {
+            x: 10,
+            y: 10,
+        });
+        t.deepEqual(cssTransformPoint(new Point(10, 10), { scale: 0.5 }), {
+            x: 20,
+            y: 20,
+        });
+        t.deepEqual(cssTransformPoint(new Point(10, 10), { scale: '0.25' }), {
+            x: 40,
+            y: 40,
+        });
         t.end();
     });
 


### PR DESCRIPTION
This fixes [6079](https://github.com/mapbox/mapbox-gl-js/issues/6079) and part of [7701](https://github.com/mapbox/mapbox-gl-js/issues/7701) where mouse and touch events are incorrect when CSS transforms are applied to the map or any parent element wrapping it.

**NOTE: The PR is a draft until someone can confirm this could be a sensible fix.**

 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
