### PR TITLE
Avoid reapplying marker anchor class on every frame

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -184,6 +184,8 @@ export default class Marker extends Evented {
         this._element.addEventListener('dragstart', (e: DragEvent) => {
             e.preventDefault();
         });
+        applyAnchorClass(this._element, this._anchor, 'marker');
+
         this._popup = null;
     }
 
@@ -347,7 +349,6 @@ export default class Marker extends Evented {
         }
 
         DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px)`);
-        applyAnchorClass(this._element, this._anchor, 'marker');
     }
 
     /**


### PR DESCRIPTION
`applyAnchorClass` was taking noticeable time when profiling a map with a lot of HTML markers. The PR moves this code to happen once when creating a marker, which should be fine because marker anchors are not mutable.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
