### PR TITLE
Cache temporary link for url resolution

### DIFF
--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -17,6 +17,8 @@ const cancel = window.cancelAnimationFrame ||
     window.webkitCancelAnimationFrame ||
     window.msCancelAnimationFrame;
 
+let linkEl;
+
 /**
  * @private
  */
@@ -45,9 +47,9 @@ const exported = {
     },
 
     resolveURL(path: string) {
-        const a = window.document.createElement('a');
-        a.href = path;
-        return a.href;
+        if (!linkEl) linkEl = window.document.createElement('a');
+        linkEl.href = path;
+        return linkEl.href;
     },
 
     hardwareConcurrency: window.navigator.hardwareConcurrency || 4,


### PR DESCRIPTION
Closes #8032. Avoids unnecessary GC freezes when collecting unattached DOM objects by caching the link element for URL resolution. @poletani can you check if this fixes your issue?

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] ~~write tests for all new functionality~~ we don't test browser-dependent methods
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
