### PR TITLE
add support for dynamic vector tiles rendering #3709

### DIFF
--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -66,8 +66,6 @@ class VectorTileSource extends Evented implements Source {
             throw new Error('vector tile sources must have a tileSize of 512');
         }
 
-        // this._updateOptions(options);
-
         this.setEventedParent(eventedParent);
     }
 
@@ -107,28 +105,29 @@ class VectorTileSource extends Evented implements Source {
         this.load();
     }
 
-    _updateOptions(options: VectorTileSourceOptions) {
-        extend(this, pick(options, ['url', 'scheme', 'tileSize']));
-        this._options = extend({ type: 'vector' }, options);
-
-        this._collectResourceTiming = !!options.collectResourceTiming;
-
-        if (this.tileSize !== 512) {
-            throw new Error('vector tile sources must have a tileSize of 512');
-        }
-    }
-
-    setSourceProperty(name: string, value: mixed) {
+    setSourceProperty(callback: Function) {
         if (this._tileJSONRequest) {
             this._tileJSONRequest.cancel();
         }
 
-        const options = { [name]: value};
-        this._updateOptions(options);
+        callback();
 
         const sourceCache = this.map.style.sourceCaches[this.id];
         sourceCache.clearTiles();
         this.load();
+    }
+
+    setTiles(tiles: Array<string>) {
+        this.setSourceProperty(() => {
+            this._options.tiles = tiles;
+        });
+    }
+
+    setUrl(url: string) {
+        this.setSourceProperty(() => {
+            this.url = url;
+            this._options.url = url;
+        });
     }
 
     onRemove() {

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -121,7 +121,7 @@ class VectorTileSource extends Evented implements Source {
         });
     }
 
-    setURL(url: string) {
+    setUrl(url: string) {
         this.setSourceProperty(() => {
             this.url = url;
             this._options.url = url;

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -116,6 +116,8 @@ class VectorTileSource extends Evented implements Source {
             throw new Error('vector tile sources must have a tileSize of 512');
         }
 
+        const sourceCache = this.map.style.sourceCaches[this.id];
+        sourceCache.clearTiles();
         this.load();
     }
 

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -19,6 +19,32 @@ import type {Callback} from '../types/callback';
 import type {Cancelable} from '../types/cancelable';
 import type {VectorSourceSpecification, PromoteIdSpecification} from '../style-spec/types';
 
+/**
+ * A source containing vector tiles in [Mapbox Vector Tile format](https://docs.mapbox.com/vector-tiles/reference/).
+ * (See the [Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector) for detailed documentation of options.)
+ *
+ * @example
+ * map.addSource('some id', {
+ *     type: 'vector',
+ *     url: 'mapbox://mapbox.mapbox-streets-v6'
+ * });
+ *
+ * @example
+ * map.addSource('some id', {
+ *     type: 'vector',
+ *     tiles: ['https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt'],
+ *     minzoom: 6,
+ *     maxzoom: 14
+ * });
+ *
+ * @example
+ * map.getSource('some id').setUrl("mapbox://mapbox.mapbox-streets-v6");
+ *
+ * @example
+ * map.getSource('some id').setTiles(['https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt']);
+ * @see [Add a vector tile source](https://docs.mapbox.com/mapbox-gl-js/example/vector-source/)
+ * @see [Add a third party vector tile source](https://docs.mapbox.com/mapbox-gl-js/example/third-party/)
+ */
 class VectorTileSource extends Evented implements Source {
     type: 'vector';
     id: string;
@@ -115,17 +141,33 @@ class VectorTileSource extends Evented implements Source {
         this.load();
     }
 
+    /**
+     * Sets the source `tiles` property and re-renders the map.
+     *
+     * @param {string[]} tiles An array of one or more tile source URLs, as in the TileJSON spec.
+     * @returns {VectorTileSource} this
+     */
     setTiles(tiles: Array<string>) {
         this.setSourceProperty(() => {
             this._options.tiles = tiles;
         });
+
+        return this;
     }
 
+    /**
+     * Sets the source `url` property and re-renders the map.
+     *
+     * @param {string} url A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
+     * @returns {VectorTileSource} this
+     */
     setUrl(url: string) {
         this.setSourceProperty(() => {
             this.url = url;
             this._options.url = url;
         });
+
+        return this;
     }
 
     onRemove() {

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -19,8 +19,6 @@ import type {Callback} from '../types/callback';
 import type {Cancelable} from '../types/cancelable';
 import type {VectorSourceSpecification, PromoteIdSpecification} from '../style-spec/types';
 
-export type VectorTileSourceOptions = {...VectorSourceSpecification, collectResourceTiming?: boolean};
-
 class VectorTileSource extends Evented implements Source {
     type: 'vector';
     id: string;
@@ -43,7 +41,7 @@ class VectorTileSource extends Evented implements Source {
     _tileJSONRequest: ?Cancelable;
     _loaded: boolean;
 
-    constructor(id: string, options: VectorTileSourceOptions, dispatcher: Dispatcher, eventedParent: Evented) {
+    constructor(id: string, options: {...VectorSourceSpecification, collectResourceTiming?: boolean}, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
         this.id = id;
         this.dispatcher = dispatcher;
@@ -60,7 +58,7 @@ class VectorTileSource extends Evented implements Source {
         extend(this, pick(options, ['url', 'scheme', 'tileSize', 'promoteId']));
         this._options = extend({type: 'vector'}, options);
 
-        this._collectResourceTiming = options.collectResourceTiming;
+        this._collectResourceTiming = !!options.collectResourceTiming;
 
         if (this.tileSize !== 512) {
             throw new Error('vector tile sources must have a tileSize of 512');

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -103,6 +103,23 @@ class VectorTileSource extends Evented implements Source {
         this.load();
     }
 
+    setData(options: VectorSourceSpecification & {collectResourceTiming: boolean}) {
+        if (this._tileJSONRequest) {
+            this._tileJSONRequest.cancel();
+        }
+
+        extend(this, pick(options, ['url', 'scheme', 'tileSize']));
+        this._options = extend({ type: 'vector' }, options);
+
+        this._collectResourceTiming = options.collectResourceTiming;
+
+        if (this.tileSize !== 512) {
+            throw new Error('vector tile sources must have a tileSize of 512');
+        }
+
+        this.load();
+    }
+
     onRemove() {
         if (this._tileJSONRequest) {
             this._tileJSONRequest.cancel();

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -103,15 +103,14 @@ class VectorTileSource extends Evented implements Source {
         this.load();
     }
 
-    setData(options: VectorSourceSpecification & {collectResourceTiming: boolean}) {
+    setSourceProperty(name: string, value: mixed) {
         if (this._tileJSONRequest) {
             this._tileJSONRequest.cancel();
         }
 
+        const options = { [name]: value};
         extend(this, pick(options, ['url', 'scheme', 'tileSize']));
         this._options = extend({ type: 'vector' }, options);
-
-        this._collectResourceTiming = options.collectResourceTiming;
 
         if (this.tileSize !== 512) {
             throw new Error('vector tile sources must have a tileSize of 512');

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -41,7 +41,7 @@ class VectorTileSource extends Evented implements Source {
     _tileJSONRequest: ?Cancelable;
     _loaded: boolean;
 
-    constructor(id: string, options: {...VectorSourceSpecification, collectResourceTiming?: boolean}, dispatcher: Dispatcher, eventedParent: Evented) {
+    constructor(id: string, options: VectorSourceSpecification & {collectResourceTiming: boolean}, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
         this.id = id;
         this.dispatcher = dispatcher;
@@ -58,7 +58,7 @@ class VectorTileSource extends Evented implements Source {
         extend(this, pick(options, ['url', 'scheme', 'tileSize', 'promoteId']));
         this._options = extend({type: 'vector'}, options);
 
-        this._collectResourceTiming = !!options.collectResourceTiming;
+        this._collectResourceTiming = options.collectResourceTiming;
 
         if (this.tileSize !== 512) {
             throw new Error('vector tile sources must have a tileSize of 512');

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -121,7 +121,7 @@ class VectorTileSource extends Evented implements Source {
         });
     }
 
-    setUrl(url: string) {
+    setURL(url: string) {
         this.setSourceProperty(() => {
             this.url = url;
             this._options.url = url;

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -22,7 +22,8 @@ function createSource(options, transformCallback) {
     source.onAdd({
         transform: {showCollisionBoxes: false},
         _getMapId: () => 1,
-        _requestManager: new RequestManager(transformCallback)
+        _requestManager: new RequestManager(transformCallback),
+        style: {sourceCaches: {id: {clearTiles: () => {}}}}
     });
 
     source.on('error', (e) => {
@@ -323,6 +324,36 @@ test('VectorTileSource', (t) => {
         const source = createSource({url: "/source.json"});
         source.onRemove();
         t.equal(window.server.lastRequest.aborted, true);
+        t.end();
+    });
+
+    t.test('supports url property updates', (t) => {
+        const source = createSource({
+            url: "http://localhost:2900/source.json"
+        });
+        source.setUrl("http://localhost:2900/source2.json");
+        t.deepEqual(source.serialize(), {
+            type: 'vector',
+            url: "http://localhost:2900/source2.json"
+        });
+        t.end();
+    });
+
+    t.test('supports tiles property updates', (t) => {
+        const source = createSource({
+            minzoom: 1,
+            maxzoom: 10,
+            attribution: "Mapbox",
+            tiles: ["http://example.com/{z}/{x}/{y}.png"]
+        });
+        source.setTiles(["http://example2.com/{z}/{x}/{y}.png"]);
+        t.deepEqual(source.serialize(), {
+            type: 'vector',
+            minzoom: 1,
+            maxzoom: 10,
+            attribution: "Mapbox",
+            tiles: ["http://example2.com/{z}/{x}/{y}.png"]
+        });
         t.end();
     });
 


### PR DESCRIPTION
Hey everyone! This PR adds the equivalent of GeoJSON Source `setData` to the Vector Sources, so a user can change sources without updating the whole map style.

Usage:

```js
map.addSource('example', {
  type: 'vector',
  url: 'mapbox://stepankuzmin.cjtd6d7i8107f3vqtku9o5jqn-7xl1l'
});

const source = map.getSource('example');
source.setSourceProperty('url', 'mapbox://stepankuzmin.cjtd6f5jh2eyk2xqtsyuo1kbz-3w7xz');
```

What do you think about it?

I'm not sure how to properly reload cached tiles, maybe someone can point me a direction for this?

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
