### PR TITLE
cosmetic update to draggable Marker/point examples to prevent coordinates overlapping Mapbox logo

### DIFF
--- a/docs/pages/example/drag-a-marker.html
+++ b/docs/pages/example/drag-a-marker.html
@@ -4,7 +4,7 @@
     background: rgba(0,0,0,0.5);
     color: #fff;
     position: absolute;
-    bottom: 10px;
+    bottom: 40px;
     left: 10px;
     padding:5px 10px;
     margin: 0;

--- a/docs/pages/example/drag-a-point.html
+++ b/docs/pages/example/drag-a-point.html
@@ -4,7 +4,7 @@
     background: rgba(0,0,0,0.5);
     color: #fff;
     position: absolute;
-    bottom: 10px;
+    bottom: 40px;
     left: 10px;
     padding:5px 10px;
     margin: 0;


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

cosmetic update to draggable Marker/point examples to prevent coordinates overlapping Mapbox logo

before:
![Screenshot from 2019-03-20 22-51-44](https://user-images.githubusercontent.com/117278/54682459-1785c900-4b63-11e9-95ca-9a98d0f0ba0e.png)

after:
![Screenshot from 2019-03-20 22-50-44](https://user-images.githubusercontent.com/117278/54682460-1785c900-4b63-11e9-90b1-a5277f7ffa9a.png)

I think this occurred because the Mapbox logo didn't used to show up on examples.