### PR TITLE
Fix Flow Circle CI failures, upgrade to v0.95.1

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,4 +17,7 @@
 .*/_site/.*
 
 [version]
-0.91.0
+0.95.1
+
+[options]
+server.max_workers=4

--- a/bench/benchmarks/worker_transfer.js
+++ b/bench/benchmarks/worker_transfer.js
@@ -84,5 +84,5 @@ export default class WorkerTransfer extends Benchmark {
 function barePayload(obj) {
     // strip all transferables from a worker payload, because we can't transfer them repeatedly in the bench:
     // as soon as it's transfered once, it's no longer available on the main thread
-    return JSON.parse(JSON.stringify(obj, (key, value) => ArrayBuffer.isView(value) ? {} : value));
+    return JSON.parse(JSON.stringify(obj, (key, value) => ArrayBuffer.isView(value) ? {} : value) || '{}');
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.11.1",
     "execcommand-copy": "^1.1.0",
-    "flow-bin": "^0.91.0",
+    "flow-bin": "^0.95.1",
     "github-slugger": "^1.1.1",
     "gl": "^4.1.1",
     "glob": "^7.0.3",

--- a/src/style-spec/expression/definitions/coercion.js
+++ b/src/style-spec/expression/definitions/coercion.js
@@ -84,7 +84,7 @@ class Coercion implements Expression {
                     }
                 }
             }
-            throw new RuntimeError(error || `Could not parse color from value '${typeof input === 'string' ? input : JSON.stringify(input)}'`);
+            throw new RuntimeError(error || `Could not parse color from value '${typeof input === 'string' ? input : String(JSON.stringify(input))}'`);
         } else if (this.type.kind === 'number') {
             let value = null;
             for (const arg of this.args) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,10 +4934,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.91.0:
-  version "0.91.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.91.0.tgz#f5c89729f74b2ccbd47df6fbfadbdcc89cc1e478"
-  integrity sha512-j+L+xNiUYnZZ27MjVI0y2c9474ZHOvdSQq0Tjwh56mEA7tfxYqp5Dcb6aZSwvs3tGMTjCrZow9aUlZf3OoRyDQ==
+flow-bin@^0.95.1:
+  version "0.95.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.95.1.tgz#633113831ccff4b7ee70a2730f63fc43b69ba85f"
+  integrity sha512-06IOC/pqPMNRYtC6AMZEWYR9Fi6UdBC7gImGinPuNUpPZFnP5E9/0cBCl3DWrH4zz/gSM2HdDilU7vPGpYIr2w==
 
 flush-write-stream@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
- Closes #8060 by setting `max_workers=4` for Flow (thanks to [this tip](https://github.com/flowtype/flow-bin/issues/138#issuecomment-448416874))
- Upgrade Flow from v0.91.0 to v0.95.1. Should have some perf improvements too.