### PR TITLE
Allow setStyle diff by default with localIdeographFontFamily on

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -397,6 +397,7 @@ class Map extends Camera {
 
         this.resize();
 
+        this._localIdeographFontFamily = options.localIdeographFontFamily;
         if (options.style) this.setStyle(options.style, { localIdeographFontFamily: options.localIdeographFontFamily });
 
         if (options.attributionControl)
@@ -964,10 +965,11 @@ class Map extends Camera {
     setStyle(style: StyleSpecification | string | null, options?: {diff?: boolean} & StyleOptions) {
         options = extend({}, { localIdeographFontFamily: defaultOptions.localIdeographFontFamily}, options);
 
-        if ((options.diff !== false && !options.localIdeographFontFamily) && this.style && style) {
+        if ((options.diff !== false && options.localIdeographFontFamily === this._localIdeographFontFamily) && this.style && style) {
             this._diffStyle(style, options);
             return this;
         } else {
+            this._localIdeographFontFamily = options.localIdeographFontFamily;
             return this._updateStyle(style, options);
         }
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -271,6 +271,7 @@ class Map extends Camera {
     _renderTaskQueue: TaskQueue;
     _controls: Array<IControl>;
     _mapId: number;
+    _localIdeographFontFamily: string;
 
     /**
      * The map's {@link ScrollZoomHandler}, which implements zooming in and out with a scroll wheel or trackpad.


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - I noticed during testing that calling `map.setStyle()` does not use the style diffing pathway by default since https://github.com/mapbox/mapbox-gl-js/pull/8008. This PR fixes that by only short-circuiting the diff pathway if `map.setStyle` sets a new `localIdeographFontFamily` on the map.
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
