### PR TITLE
Fix double-tap zoom (#6217)

### DIFF
--- a/src/ui/handler/dblclick_zoom.js
+++ b/src/ui/handler/dblclick_zoom.js
@@ -14,6 +14,7 @@ class DoubleClickZoomHandler {
     _enabled: boolean;
     _active: boolean;
     _tapped: ?TimeoutID;
+    _tappedPoint: ?{x: number, y: number};
 
     /**
      * @private
@@ -71,12 +72,22 @@ class DoubleClickZoomHandler {
         if (!this.isEnabled()) return;
         if (e.points.length > 1) return;
 
+        const maxDelta = 0;
+
         if (!this._tapped) {
-            this._tapped = setTimeout(() => { this._tapped = null; }, 300);
+            this._tappedPoint = e.points[0];
+            this._tapped = setTimeout(() => { this._tapped = null; this._tappedPoint = null; }, 300);
         } else {
+            const newTap = e.points[0];
+            const firstTap = this._tappedPoint;
+
             clearTimeout(this._tapped);
             this._tapped = null;
-            this._zoom(e);
+            this._tappedPoint = null;
+
+            if (firstTap && Math.abs(firstTap.x - newTap.x) <= maxDelta && Math.abs(firstTap.y - newTap.y) <= maxDelta) {
+                this._zoom(e);
+            }
         }
     }
 

--- a/src/ui/handler/dblclick_zoom.js
+++ b/src/ui/handler/dblclick_zoom.js
@@ -72,7 +72,7 @@ class DoubleClickZoomHandler {
         if (!this.isEnabled()) return;
         if (e.points.length > 1) return;
 
-        const maxDelta = 0;
+        const maxDelta = 30;
 
         if (!this._tapped) {
             this._tappedPoint = e.points[0];

--- a/src/ui/handler/dblclick_zoom.js
+++ b/src/ui/handler/dblclick_zoom.js
@@ -82,6 +82,8 @@ class DoubleClickZoomHandler {
             const firstTap = this._tappedPoint;
 
             if (firstTap && Math.abs(firstTap.x - newTap.x) <= maxDelta && Math.abs(firstTap.y - newTap.y) <= maxDelta) {
+                e.originalEvent.preventDefault(); // prevent duplicate zoom on dblclick
+
                 const onTouchEnd = () => {
                     if (this._tapped) { // make sure we are still within the timeout window
                         this._zoom(e); // pass this touchstart event, as touchend events have no points

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -9,6 +9,21 @@ function createMap(t) {
     return new Map({ container: DOM.create('div', '', window.document.body) });
 }
 
+test('DoubleClickZoomHandler zooms on dblclick event', (t) => {
+    const map = createMap(t);
+
+    const zoom = t.spy();
+    map.on('zoom', zoom);
+
+    simulate.dblclick(map.getCanvas());
+    map._renderTaskQueue.run();
+
+    t.ok(zoom.called);
+
+    map.remove();
+    t.end();
+});
+
 test('DoubleClickZoomHandler does not zoom if preventDefault is called on the dblclick event', (t) => {
     const map = createMap(t);
 
@@ -18,6 +33,7 @@ test('DoubleClickZoomHandler does not zoom if preventDefault is called on the db
     map.on('zoom', zoom);
 
     simulate.dblclick(map.getCanvas());
+    map._renderTaskQueue.run();
 
     t.equal(zoom.callCount, 0);
 

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -40,3 +40,59 @@ test('DoubleClickZoomHandler does not zoom if preventDefault is called on the db
     map.remove();
     t.end();
 });
+
+test('DoubleClickZoomHandler zooms on double tap if touchstart events are < 300ms apart', (t) => {
+    const map = createMap(t);
+
+    const zoom = t.spy();
+    map.on('zoom', zoom);
+
+    const simulateDoubleTap = () => {
+        return new Promise(resolve => {
+            simulate.touchstart(map.getCanvas());
+            simulate.touchend(map.getCanvas());
+            setTimeout(() => {
+                simulate.touchstart(map.getCanvas());
+                simulate.touchend(map.getCanvas());
+                map._renderTaskQueue.run();
+                resolve();
+            }, 100);
+        });
+    };
+
+    simulateDoubleTap(map, 100).then(() => {
+        t.ok(zoom.called);
+
+        map.remove();
+        t.end();
+    });
+
+});
+
+test('DoubleClickZoomHandler does not zoom on double tap if touchstart events are > 300ms apart', (t) => {
+    const map = createMap(t);
+
+    const zoom = t.spy();
+    map.on('zoom', zoom);
+
+    const simulateDelayedDoubleTap = () => {
+        return new Promise(resolve => {
+            simulate.touchstart(map.getCanvas());
+            simulate.touchend(map.getCanvas());
+            setTimeout(() => {
+                simulate.touchstart(map.getCanvas());
+                simulate.touchend(map.getCanvas());
+                map._renderTaskQueue.run();
+                resolve();
+            }, 300);
+        });
+    };
+
+    simulateDelayedDoubleTap().then(() => {
+        t.equal(zoom.callCount, 0);
+
+        map.remove();
+        t.end();
+    });
+
+});

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -96,3 +96,31 @@ test('DoubleClickZoomHandler does not zoom on double tap if touchstart events ar
     });
 
 });
+
+test('DoubleClickZoomHandler does not zoom on double tap if touchstart events are in different locations', (t) => {
+    const map = createMap(t);
+
+    const zoom = t.spy();
+    map.on('zoom', zoom);
+
+    const simulateTwoDifferentTaps = () => {
+        return new Promise(resolve => {
+            simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}]});
+            simulate.touchend(map.getCanvas());
+            setTimeout(() => {
+                simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0.5, clientY: 0.5}]});
+                simulate.touchend(map.getCanvas());
+                map._renderTaskQueue.run();
+                resolve();
+            }, 100);
+        });
+    };
+
+    simulateTwoDifferentTaps().then(() => {
+        t.equal(zoom.callCount, 0);
+
+        map.remove();
+        t.end();
+    });
+
+});

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -108,7 +108,7 @@ test('DoubleClickZoomHandler does not zoom on double tap if touchstart events ar
             simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}]});
             simulate.touchend(map.getCanvas());
             setTimeout(() => {
-                simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0.5, clientY: 0.5}]});
+                simulate.touchstart(map.getCanvas(), {touches: [{clientX: 30.5, clientY: 30.5}]});
                 simulate.touchend(map.getCanvas());
                 map._renderTaskQueue.run();
                 resolve();


### PR DESCRIPTION
Hi folks! Per chat with @asheemmamoowala I'm jumping in on a `good first issue`, trying to fix the double-tap zoom issues described in #6217. Thanks in advance for the feedback :pray: 

### Changes:
- Add tests for existing double-click zoom functionality & fix up existing spuriously-passing test
- Prevent zooming when two taps are within 300ms but in different locations (based on best-guess threshold; see below), & add tests
- Zoom on the second `touchend` event (not `touchstart`) of double-tap within the time threshold, & add tests

### Known issues/questions:
- I've set the `maxDelta` between tap locations (in both x & y) to 30, rather arbitrarily based on my manual tests - happy to use a different value if there is some standard for this. 
- On the Android device I manually tested with, in addition to touch events being fired a dblclick event is also fired when the double-tap points are within a distance threshold, which is somewhat higher than the threshold I set :point_up: - this means it's possible for two slightly-farther-apart touch events to trigger zoom via the dblclick handler, rather than the double-tap handler. That behavior seems OK to me, but just wanted to flag it. 
- The "Size" check shows this as adding +483 B - Is that normal/OK for such a small fix? If there are ways I can improve this I'm all ears


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - ~document any changes to public APIs~ N/A afaict
 - [x] post benchmark scores :point_right: [screenshot](https://user-images.githubusercontent.com/5424927/55045363-c65e5500-4ffa-11e9-8013-af528a2c77f0.png)  (charts seem broken in Firefox :cry: )
 - [x] manually test the debug page - didn't notice any breakage on debug or events pages on desktop (Chrome & Firefox on Linux) or mobile (Chrome on Android)
