### PR TITLE
[F] rel `nofollow` links

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -105,7 +105,7 @@ class AttributionControl {
                 return acc;
             }, `?`);
             editLink.href = `${config.FEEDBACK_URL}/${paramString}${this._map._hash ? this._map._hash.getHashString(true) : ''}`;
-            editLink.rel = "noopener";
+            editLink.rel = "noopener nofollow";
         }
     }
 

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -29,10 +29,10 @@ class LogoControl {
         this._container = DOM.create('div', 'mapboxgl-ctrl');
         const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
         anchor.target = "_blank";
-        anchor.rel = "noopener";
+        anchor.rel = "noopener nofollow";
         anchor.href = "https://www.mapbox.com/";
         anchor.setAttribute("aria-label", "Mapbox logo");
-        anchor.setAttribute("rel", "noopener");
+        anchor.setAttribute("rel", "noopener nofollow");
         this._container.appendChild(anchor);
         this._container.style.display = 'none';
 

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -118,6 +118,7 @@ test('AttributionControl has the correct edit map link', (t) => {
         map.addLayer({ id: '1', type: 'fill', source: '1' });
         map.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+                t.equal(attribution._editLink.rel, 'noopener nofollow');
                 t.equal(attribution._editLink.href, 'https://feedback.com/?owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/0', 'edit link contains map location data');
                 map.setZoom(2);
                 t.equal(attribution._editLink.href, 'https://feedback.com/?owner=mapbox&id=streets-v10&access_token=pk.123#/0/0/2', 'edit link updates on mapmove');

--- a/test/unit/ui/control/logo.test.js
+++ b/test/unit/ui/control/logo.test.js
@@ -100,7 +100,6 @@ test('LogoControl appears in compact mode if container is less then 250 pixel wi
 });
 
 test('LogoControl has `rel` nooper and nofollow', (t) => {
-    console.log('MyTest');
     const map = createMap(t);
 
     map.on('load', () => {

--- a/test/unit/ui/control/logo.test.js
+++ b/test/unit/ui/control/logo.test.js
@@ -98,3 +98,17 @@ test('LogoControl appears in compact mode if container is less then 250 pixel wi
 
     t.end();
 });
+
+test('LogoControl has `rel` nooper and nofollow', (t) => {
+    console.log('MyTest');
+    const map = createMap(t);
+
+    map.on('load', () => {
+        const container = map.getContainer();
+        const logo = container.querySelector('.mapboxgl-ctrl-logo');
+
+        t.equal(logo.rel, 'noopener nofollow');
+
+        t.end();
+    });
+});


### PR DESCRIPTION
Adds `nofollow` to Mapbox logo link and also to edit (Improve this map) link.

It avoids crawling issues with external crawlers as Google bot.