### PR TITLE
Include source name in invalid GeoJSON error

### DIFF
--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -167,7 +167,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
             if (err || !data) {
                 return callback(err);
             } else if (typeof data !== 'object') {
-                return callback(new Error("Input data is not a valid GeoJSON object."));
+                return callback(new Error(`Input data given to '${params.source}' is not a valid GeoJSON object.`));
             } else {
                 rewind(data, true);
 
@@ -267,10 +267,10 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
             try {
                 return callback(null, JSON.parse(params.data));
             } catch (e) {
-                return callback(new Error("Input data is not a valid GeoJSON object."));
+                return callback(new Error(`Input data given to '${params.source}' is not a valid GeoJSON object.`));
             }
         } else {
-            return callback(new Error("Input data is not a valid GeoJSON object."));
+            return callback(new Error(`Input data given to '${params.source}' is not a valid GeoJSON object.`));
         }
     }
 


### PR DESCRIPTION
When supplying invalid data to a GeoJSON source, include the source name in the
error message for easier debugging.

Before PR:
![Error and stack trace without a source name, before the PR](https://user-images.githubusercontent.com/1144615/55464116-117ff580-5603-11e9-9e61-fcd7a7841d96.png)
As the stacktrace is heavily async, we don't get an immediate indication of where in userland code the error originated. It can be any one of the user-defined sources. The only way to figure which source is the erroneous one, one needs to put a breakpoint on the line logging the error (as it's not an exception), and search up the async stack trace. A bit cumerbose for a bug that's usually "whoops I gave the wrong object".

After PR:
![Error and stack trace showing the source name, after the PR](https://user-images.githubusercontent.com/1144615/55464266-64f24380-5603-11e9-86dd-afc9b2b07ece.png)
Nothing but sunshine and kittens, as we can see the source name being supplied invalid GeoJSON we can search our code, and only if needed debug up the stack trace.

This PR unfortunately only covers *some* of the invalid GeoJSON errors, there is another one in a mapbox dependency ([geojson-vt](https://github.com/mapbox/geojson-vt)), which of course does not know about sources and layers and all that fun. So the following call:

```js
map.addSource('awesomesauce', { type: 'bazinga' });
```

Will still show the less fun errors. As there are many ways to solve that error (daisy-chaning an error message defined in the caller with the original error, change the error to a null return value and check that, ...), how would you think it best be done?

Thanks.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality (n/a? no existing tests for this error AFAICT)
 - [x] manually test the debug page