### PR TITLE
Fix location dot shadow

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -9,7 +9,7 @@
     width: 100%;
     height: 100%;
 }
-
+.mapboxgl-user-location-dot::after
 .mapboxgl-canary {
     background-color: salmon;
 }
@@ -466,7 +466,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     width: 15px;
     height: 15px;
     border-radius: 50%;
-    box-shadow: 0 0 2px rgba(0, 0, 0, 0.25);
 }
 
 .mapboxgl-user-location-dot::before {
@@ -492,6 +491,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     top: -2px;
     width: 19px;
     box-sizing: border-box;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.25);
 }
 
 @-webkit-keyframes mapboxgl-user-location-dot-pulse {

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -491,7 +491,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     top: -2px;
     width: 19px;
     box-sizing: border-box;
-    box-shadow: 0 0 2px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.35);
 }
 
 @-webkit-keyframes mapboxgl-user-location-dot-pulse {

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -9,7 +9,7 @@
     width: 100%;
     height: 100%;
 }
-.mapboxgl-user-location-dot::after
+
 .mapboxgl-canary {
     background-color: salmon;
 }


### PR DESCRIPTION
Location dot shadow was applied to blue `div` with 2px width. It was covered by 2px width `::after` pseudo element.

Before:

![image](https://user-images.githubusercontent.com/988471/55555621-5d5b9900-56ee-11e9-8ac2-e3343467c6a5.png)

After:

![image](https://user-images.githubusercontent.com/988471/55555688-8845ed00-56ee-11e9-8350-a4922f464008.png)
