### PR TITLE
[] add a cache to style-layer-index so we don't recalculate keys

### DIFF
--- a/src/style-spec/group_by_layout.js
+++ b/src/style-spec/group_by_layout.js
@@ -53,11 +53,11 @@ function groupByLayout(layers, cachedKeys) {
 
     for (let i = 0; i < layers.length; i++) {
 
-        const k = (cachedKeys && cachedKeys[layers[i].id] ) || getKey(layers[i]);
+        const k = (cachedKeys && cachedKeys[layers[i].id]) || getKey(layers[i]);
         // update the cache if there is one
-        if ( cachedKeys )
+        if (cachedKeys)
             cachedKeys[layers[i].id] = k;
-            
+
         let group = groups[k];
         if (!group) {
             group = groups[k] = [];

--- a/src/style-spec/group_by_layout.js
+++ b/src/style-spec/group_by_layout.js
@@ -45,13 +45,19 @@ export default groupByLayout;
  *
  * @private
  * @param {Array<Layer>} layers
+ * @param {Object} cachedKeys
  * @returns {Array<Array<Layer>>}
  */
-function groupByLayout(layers) {
+function groupByLayout(layers, cachedKeys) {
     const groups = {};
 
     for (let i = 0; i < layers.length; i++) {
-        const k = getKey(layers[i]);
+        // if the key isn't in the cache - add it
+        if (!cachedKeys[layers[i].id])
+            cachedKeys[layers[i].id] = getKey(layers[i]);
+        // get the key from the cache
+        const k = cachedKeys[layers[i].id];
+
         let group = groups[k];
         if (!group) {
             group = groups[k] = [];

--- a/src/style-spec/group_by_layout.js
+++ b/src/style-spec/group_by_layout.js
@@ -45,19 +45,19 @@ export default groupByLayout;
  *
  * @private
  * @param {Array<Layer>} layers
- * @param {Object} cachedKeys
+ * @param {Object} [cachedKeys] - an object to keep already calculated keys.
  * @returns {Array<Array<Layer>>}
  */
 function groupByLayout(layers, cachedKeys) {
     const groups = {};
 
     for (let i = 0; i < layers.length; i++) {
-        // if the key isn't in the cache - add it
-        if (!cachedKeys[layers[i].id])
-            cachedKeys[layers[i].id] = getKey(layers[i]);
-        // get the key from the cache
-        const k = cachedKeys[layers[i].id];
 
+        const k = (cachedKeys && cachedKeys[layers[i].id] ) || getKey(layers[i]);
+        // update the cache if there is one
+        if ( cachedKeys )
+            cachedKeys[layers[i].id] = k;
+            
         let group = groups[k];
         if (!group) {
             group = groups[k] = [];

--- a/src/style/style_layer_index.js
+++ b/src/style/style_layer_index.js
@@ -15,11 +15,13 @@ export type Family<Layer: TypedStyleLayer> = Array<Layer>;
 
 class StyleLayerIndex {
     familiesBySource: { [source: string]: { [sourceLayer: string]: Array<Family<*>> } };
+    keyCache: { [source: string]: string };
 
     _layerConfigs: LayerConfigs;
     _layers: { [string]: StyleLayer };
 
     constructor(layerConfigs: ?Array<LayerSpecification>) {
+        this.keyCache = {};
         if (layerConfigs) {
             this.replace(layerConfigs);
         }
@@ -37,15 +39,18 @@ class StyleLayerIndex {
 
             const layer = this._layers[layerConfig.id] = createStyleLayer(layerConfig);
             layer._featureFilter = featureFilter(layer.filter);
+            if (this.keyCache[layerConfig.id])
+                delete this.keyCache[layerConfig.id];
         }
         for (const id of removedIds) {
+            delete this.keyCache[id];
             delete this._layerConfigs[id];
             delete this._layers[id];
         }
 
         this.familiesBySource = {};
 
-        const groups = groupByLayout(values(this._layerConfigs));
+        const groups = groupByLayout(values(this._layerConfigs), this.keyCache);
 
         for (const layerConfigs of groups) {
             const layers = layerConfigs.map((layerConfig) => this._layers[layerConfig.id]);

--- a/test/unit/style-spec/group_by_layout.test.js
+++ b/test/unit/style-spec/group_by_layout.test.js
@@ -10,9 +10,9 @@ t('group layers whose ref properties are identical', (t) => {
         'id': 'child',
         'type': 'line'
     };
-    t.deepEqual(group([a, b]), [[a, b]]);
-    t.equal(group([a, b])[0][0], a);
-    t.equal(group([a, b])[0][1], b);
+    t.deepEqual(group([a, b], {}), [[a, b]]);
+    t.equal(group([a, b], {})[0][0], a);
+    t.equal(group([a, b], {})[0][1], b);
     t.end();
 });
 
@@ -26,7 +26,7 @@ t('group does not group unrelated layers', (t) => {
             'id': 'child',
             'type': 'fill'
         }
-    ]), [
+    ], {}), [
         [{
             'id': 'parent',
             'type': 'line'
@@ -50,7 +50,7 @@ t('group works even for differing layout key orders', (t) => {
             'type': 'line',
             'layout': {'b': 2, 'a': 1}
         }
-    ]), [[
+    ], {}), [[
         {
             'id': 'parent',
             'type': 'line',


### PR DESCRIPTION
## Launch Checklist

Test case: 33000 post codes are displayed on a map in a single fill layer. The tileset that its based upon contains postcodes for other countries so to reduce memory usage - a filter is applied on the layer so that only the 33000 postcodes that we're interested in are displayed. 
Next we add a second layer for region outlines. When we mouseover a region - we set this "highlight" layer to show the single item. 
Issue is that the speed of updating the "highlight" layer is slow. Profiling has shown this is due to the filter applied on the original region layer. When the "highlight" layer is changed - a broadcast event is sent to each tileworker - with the updated style. The tileworker then updates its styles based on the broadcast - and calculates a key for each layer. The key includes the filter - so to make the key it requires iterating over the 33000 items.

However this layer isn't one which is changing. In this case it seem a waste to have to regenerate the key.So add a key cache to the style_layer_index. When the key is calculated - save it in the cache. For updated layers - remove the key from the cache so we get a new key generated. For layers which stay the same - just use the existing key from the cache. 

With this change - the testcase average time to display a hightlight was 381.03ms - whereas without the change the average highlight time is 830.58

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [x] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
