### PR TITLE
add `animationFrameProvider` map option

### DIFF
--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -7,6 +7,11 @@ const now = window.performance && window.performance.now ?
     window.performance.now.bind(window.performance) :
     Date.now.bind(Date);
 
+export type AnimationFrameProvider = {
+    requestAnimationFrame: (callback: (time: number) => void) => number,
+    cancelAnimationFrame: (number) => void
+};
+
 const raf = window.requestAnimationFrame ||
     window.mozRequestAnimationFrame ||
     window.webkitRequestAnimationFrame ||
@@ -29,9 +34,18 @@ const exported = {
      */
     now,
 
-    frame(fn: Function): Cancelable {
-        const frame = raf(fn);
-        return { cancel: () => cancel(frame) };
+    frame(fn: Function, provider: ?AnimationFrameProvider): Cancelable {
+        const frame = provider ?
+            provider.requestAnimationFrame(fn) :
+            raf(fn);
+
+        return { cancel: () => {
+            if (provider) {
+                provider.cancelAnimationFrame(frame);
+            } else {
+                cancel(frame);
+            }
+        }};
     },
 
     getImageData(img: CanvasImageSource): ImageData {


### PR DESCRIPTION
This option allows the user to implement `requestAnimationFrame` and `cancelAnimationFrame` in order to synchronize map rendering with their external rendering. While it is generally recommended to let the browser schedule map rendering frames this may be useful for synchronizing with external content in some cases (fix #7893).

This could also be useful for synchronizing multiple maps.

```js

const animationFrameProvider = {
    requestAnimationFrame: fn => { ... },
    cancelAnimationFrame: handle => { ... }
};
const map = new Map({
    animationFrameProvider: animationFrameProvider,
    ...
});
```

### As an alternative to synchronous render frames

https://github.com/mapbox/mapbox-gl-js/issues/7893 explains the reasons why synchronous rendering is necessary in some cases. An `animationFrameProvider` option seemed preferable to implementing a `map.synchronousRepaint()` because:
- it prevents all renders that aren't directly triggered by use (instead of just allowing renders to be triggered by you)
- it could be harder to abuse


```js
class SynchronizedFrameProvider {
    constructor() {
        this._requests = [];
        this._nextHandle = 0;
    }

    requestAnimationFrame(fn) {
        this._requests.push({
            handle: this._nextHandle++,
            fn
        });
    }

    cancelAnimationFrame(handle) {
        this._requests = this._requests.filter(req => req.handle !== handle);
    }

    // called by you to trigger synchronous rendering
    dispatchFrame() {
        // clear array before dispatching to handle case where user calls
        // `requestAnimationFrame` from within the dispatched function.
        const requests = this._requests;
        this._requests = [];

        const now = performance.now();
        for (const req of requests) {
            req.fn(now);
        }
    }
}

const provider = new SynchronizedFrameProvider();

const map = new Map({
    animationFrameProvider: provider
    ...
});

...

provider.dispatchFrame();
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page

@mourner @ryanhamley does this approach seem preferable? Or would it be better just implement a `map.synchronousRender()`?