### PR TITLE
Bugfix - removeFeatureState fails with target.id === 0

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -878,12 +878,12 @@ class Style extends Evented {
             return;
         }
 
-        if (target.id && isNaN(featureId) || featureId < 0) {
+        if (target.id !== undefined && isNaN(featureId) || featureId < 0) {
             this.fire(new ErrorEvent(new Error(`The feature id parameter must be non-negative.`)));
             return;
         }
 
-        if (key && !target.id) {
+        if (key && typeof target.id !== 'number') {
             this.fire(new ErrorEvent(new Error(`A feature id is requred to remove its specific state property.`)));
             return;
         }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -883,7 +883,7 @@ class Style extends Evented {
             return;
         }
 
-        if (key && typeof target.id !== 'number') {
+        if (key && (typeof target.id !== 'string' || typeof target.id !== 'number')) {
             this.fire(new ErrorEvent(new Error(`A feature id is requred to remove its specific state property.`)));
             return;
         }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -883,7 +883,7 @@ class Style extends Evented {
             return;
         }
 
-        if (key && (typeof target.id !== 'string' || typeof target.id !== 'number')) {
+        if (key && (typeof target.id !== 'string' && typeof target.id !== 'number')) {
             this.fire(new ErrorEvent(new Error(`A feature id is requred to remove its specific state property.`)));
             return;
         }

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1524,6 +1524,27 @@ test('Map', (t) => {
                 t.end();
             });
         });
+        t.test('remove properties for zero-based feature IDs.', (t) => {
+            const map = createMap(t, {
+                style: {
+                    "version": 8,
+                    "sources": {
+                        "geojson": createStyleSource()
+                    },
+                    "layers": []
+                }
+            });
+            map.on('load', () => {
+                map.setFeatureState({ source: 'geojson', id: 0}, {'hover': true, 'foo': true});
+                map.removeFeatureState({ source: 'geojson', id: 0});
+
+                const fState = map.getFeatureState({ source: 'geojson', id: 0});
+                t.equal(fState.hover, undefined);
+                t.equal(fState.foo, undefined);
+
+                t.end();
+            });
+        });
         t.test('other properties persist when removing specific property', (t) => {
             const map = createMap(t, {
                 style: {


### PR DESCRIPTION
## The issue

If one tries to remove feature state for feature with `0` as it's ID (commonly created by using `generateId: true` for GeoJSON source), removing the feature state would fail, throwing:

```
A feature id is requred to remove its specific state property.
```

## The fix

To address the issue, we need to make sure to check that the `.id` is not `undefined`, vs just a falsy check. After this, the removal of the feature state happens as it should.