### PR TITLE
Fix #8154: Add a WebGLRenderingContext argument to CustomLayerInterface

### DIFF
--- a/src/style/style_layer/custom_style_layer.js
+++ b/src/style/style_layer/custom_style_layer.js
@@ -97,6 +97,7 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => 
  * @instance
  * @name onRemove
  * @param {Map} map The Map this custom layer was just added to.
+ * @param {WebGLRenderingContext} gl The gl context for the map.
  */
 
 /**
@@ -152,7 +153,7 @@ export type CustomLayerInterface = {
     render: CustomRenderMethod,
     prerender: ?CustomRenderMethod,
     onAdd: ?(map: Map, gl: WebGLRenderingContext) => void,
-    onRemove: ?(map: Map) => void
+    onRemove: ?(map: Map, gl: WebGLRenderingContext) => void
 }
 
 export function validateCustomStyleLayer(layerObject: CustomLayerInterface) {
@@ -215,7 +216,7 @@ class CustomStyleLayer extends StyleLayer {
 
     onRemove(map: Map) {
         if (this.implementation.onRemove) {
-            this.implementation.onRemove(map);
+            this.implementation.onRemove(map, map.painter.context.gl);
         }
     }
 }


### PR DESCRIPTION
## Launch Checklist

Implement proposal in #8154, i.e. to add a gl argument to the onRemove function of the CustomLayerInterface. This allows to clean up the related context directly. Update the documentation to reflect the change.


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
