### PR TITLE
Clarify symbol sorting criterion for symbol-z-order: auto value

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -981,7 +981,7 @@
       "type": "enum",
       "values": {
         "auto": {
-          "doc": "If `symbol-sort-key` is set, sort based on that. Otherwise sort symbols by their position relative to the viewport."
+          "doc": "If `symbol-sort-key` is set, sort based on that. Otherwise sort symbols by their y-position relative to the viewport."
         },
         "viewport-y": {
           "doc": "Symbols will be sorted by their y-position relative to the viewport."


### PR DESCRIPTION
Small clarification for `symbol-z-order` style property `auto` value.

## Launch Checklist
 - [x] briefly describe the changes in this PR