### PR TITLE
add example for accessibility plugin (not ready)

### DIFF
--- a/docs/pages/example/accessibility.html
+++ b/docs/pages/example/accessibility.html
@@ -1,0 +1,36 @@
+<div id='map'></div>
+<script src='<js lib here>' charset='utf-8'></script>
+
+<script>
+
+	var map = new mapboxgl.Map({
+	    container: 'map', // container id
+	    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
+	    center: [-74.50, 40], // starting position [lng, lat]
+	    zoom: 9 // starting zoom
+	});
+
+	// Should be run after the map has been initialized
+
+	map.on('load', () => {
+		map.addControl(new MapboxAccessibility({
+
+			// A string value representing a property key in the data. This 
+			// will be used as the text in voiceover.
+			accessibleLabelProperty: 'name',
+
+			// The layers within the style that
+			// 1. Contain the `accessibleLabelProperty` value as a key
+			// 2. Should be used for voiceover.
+			layers: [
+				'poi-scalerank4-l15',
+				'poi-scalerank4-l1',
+				'poi-scalerank3',
+				'poi-scalerank2',
+				'poi-scalerank1',
+				'poi-parks_scalerank4',
+				'rail-label'
+			]
+		}));
+	});
+</script>

--- a/docs/pages/example/accessibility.js
+++ b/docs/pages/example/accessibility.js
@@ -1,0 +1,10 @@
+/*---
+title: Accessibility plugin
+description: Add accessibility controls.
+tags:
+  - styles
+pathname: /mapbox-gl-js/example/accessibility/
+---*/
+import Example from '../../components/example';
+import html from './accessibility.html';
+export default Example(html);


### PR DESCRIPTION
Adding example now that the link in https://github.com/mapbox/mapbox-gl-accessibility is stale. Currently blocked by having a hosted library to link to.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
