### PR TITLE
Fix disappearing controls in Safari 12+

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -56,7 +56,12 @@
 .mapboxgl-ctrl-bottom-left  { bottom: 0; left: 0; }
 .mapboxgl-ctrl-bottom-right { right: 0; bottom: 0; }
 
-.mapboxgl-ctrl { clear: both; pointer-events: auto; }
+.mapboxgl-ctrl {
+    clear: both;
+    pointer-events: auto;
+    /* workaround for a Safari bug https://github.com/mapbox/mapbox-gl-js/issues/8185 */
+    transform: translate(0, 0);
+}
 .mapboxgl-ctrl-top-left .mapboxgl-ctrl     { margin: 10px 0 0 10px; float: left; }
 .mapboxgl-ctrl-top-right .mapboxgl-ctrl    { margin: 10px 10px 0 0; float: right; }
 .mapboxgl-ctrl-bottom-left .mapboxgl-ctrl  { margin: 0 0 10px 10px; float: left; }

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -59,6 +59,7 @@
 .mapboxgl-ctrl {
     clear: both;
     pointer-events: auto;
+
     /* workaround for a Safari bug https://github.com/mapbox/mapbox-gl-js/issues/8185 */
     transform: translate(0, 0);
 }


### PR DESCRIPTION
Closes #8185. This is apparently a regression in Safari 12. Not sure if it's reproducible for everyone (might be GPU-specific). This accidentally discovered fix makes the controls appear for me.