### PR TITLE
never use Uint8ClampedArray with texSubImage2D

### DIFF
--- a/src/util/image.js
+++ b/src/util/image.js
@@ -17,6 +17,8 @@ type Point = {
 function createImage(image: *, {width, height}: Size, channels: number, data?: Uint8Array | Uint8ClampedArray) {
     if (!data) {
         data = new Uint8Array(width * height * channels);
+    } else if (data instanceof Uint8ClampedArray) {
+        data = new Uint8Array(data.buffer);
     } else if (data.length !== width * height * channels) {
         throw new RangeError('mismatched image size');
     }
@@ -81,7 +83,7 @@ function copyImage(srcImg: *, dstImg: *, srcPt: Point, dstPt: Point, size: Size,
 export class AlphaImage {
     width: number;
     height: number;
-    data: Uint8Array | Uint8ClampedArray;
+    data: Uint8Array;
 
     constructor(size: Size, data?: Uint8Array | Uint8ClampedArray) {
         createImage(this, size, 1, data);
@@ -105,7 +107,10 @@ export class AlphaImage {
 export class RGBAImage {
     width: number;
     height: number;
-    data: Uint8Array | Uint8ClampedArray;
+
+    // data must be a Uint8Array instead of Uint8ClampedArray because texImage2D does not
+    // support Uint8ClampedArray in all browsers
+    data: Uint8Array;
 
     constructor(size: Size, data?: Uint8Array | Uint8ClampedArray) {
         createImage(this, size, 4, data);
@@ -118,6 +123,8 @@ export class RGBAImage {
     replace(data: Uint8Array | Uint8ClampedArray, copy?: boolean) {
         if (copy) {
             this.data.set(data);
+        } else if (data instanceof Uint8ClampedArray) {
+            this.data = new Uint8Array(data.buffer);
         } else {
             this.data = data;
         }


### PR DESCRIPTION
fix #8190

Chrome doesn't support using Uint8ClampedArray with texSubImage2D. Work around that.

I'm not sure how to test this given that it is a environment specific bug. Any ideas?

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page