### PR TITLE
Add contains method to LngLatBounds

### DIFF
--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -1,8 +1,6 @@
 // @flow
 
 import LngLat from './lng_lat';
-import Point from '@mapbox/point-geometry';
-import Transform from './transform';
 
 import type {LngLatLike} from './lng_lat';
 
@@ -214,37 +212,21 @@ class LngLatBounds {
     /**
     * Check if the point is within the bounding box.
     *
-    * @returns {boolean} True is the point is within the bounding box.
+    * @returns {boolean} True if the point is within the bounding box.
     */
     contains(lnglat: LngLatLike) {
-      lnglat = lnglat instanceof LngLat ? new LngLat(lnglat.lng, lnglat.lat) : LngLat.convert(lnglat);
+        lnglat = lnglat instanceof LngLat ? new LngLat(lnglat.lng, lnglat.lat) : LngLat.convert(lnglat);
 
-      const containsLatitude = this._sw.lat <= lnglat.lat && lnglat.lat <= this._ne.lat;
-      let containsLongitude = this._sw.lng <= lnglat.lng && lnglat.lng <= this._ne.lng;
+        const containsLatitude = this._sw.lat <= lnglat.lat && lnglat.lat <= this._ne.lat;
+        let containsLongitude = this._sw.lng <= lnglat.lng && lnglat.lng <= this._ne.lng;
 
-      if (this._sw.lng > this._ne.lng) {
-        // wrapped coordinate
-        containsLongitude = this._sw.lng >= lnglat.lng && lnglat.lng >= this._ne.lng;
-      }
+        if (this._sw.lng > this._ne.lng) {
+        // wrapped coordinates
+            containsLongitude = this._sw.lng >= lnglat.lng && lnglat.lng >= this._ne.lng;
+        }
 
-      return containsLatitude && containsLongitude;
+        return containsLatitude && containsLongitude;
     }
-
-    /**
-    * Check if the polygon is within the bounding box.
-    *
-    * @returns {boolean} True is the polygon is within the bounding box.
-
-    contains(): Polygon {
-      // var corners = get all verticies of polygon
-      Polygon.forEach(function(corner){
-        return (this._sw.lng =< p.lng =< this._ne.lng && this._sw.lat =< p.lat =< this._ne.lat ||
-          this._sw.lat =< p.lat && this._ne.lat =< p.lat ||
-          this._sw.lng >= p.lng >= this._ne.lng && this._sw =< p.lat =< this._ne.lat)
-      });
-
-    }
-    */
 
     /**
      * Converts an array to a `LngLatBounds` object.

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -1,6 +1,8 @@
 // @flow
 
 import LngLat from './lng_lat';
+import Point from '@mapbox/point-geometry';
+import Transform from './transform';
 
 import type {LngLatLike} from './lng_lat';
 
@@ -208,6 +210,41 @@ class LngLatBounds {
     isEmpty() {
         return !(this._sw && this._ne);
     }
+
+    /**
+    * Check if the point is within the bounding box.
+    *
+    * @returns {boolean} True is the point is within the bounding box.
+    */
+    contains(lnglat: LngLatLike) {
+      lnglat = lnglat instanceof LngLat ? new LngLat(lnglat.lng, lnglat.lat) : LngLat.convert(lnglat);
+
+      const containsLatitude = this._sw.lat <= lnglat.lat && lnglat.lat <= this._ne.lat;
+      let containsLongitude = this._sw.lng <= lnglat.lng && lnglat.lng <= this._ne.lng;
+
+      if (this._sw.lng > this._ne.lng) {
+        // wrapped coordinate
+        containsLongitude = this._sw.lng >= lnglat.lng && lnglat.lng >= this._ne.lng;
+      }
+
+      return containsLatitude && containsLongitude;
+    }
+
+    /**
+    * Check if the polygon is within the bounding box.
+    *
+    * @returns {boolean} True is the polygon is within the bounding box.
+
+    contains(): Polygon {
+      // var corners = get all verticies of polygon
+      Polygon.forEach(function(corner){
+        return (this._sw.lng =< p.lng =< this._ne.lng && this._sw.lat =< p.lat =< this._ne.lat ||
+          this._sw.lat =< p.lat && this._ne.lat =< p.lat ||
+          this._sw.lng >= p.lng >= this._ne.lng && this._sw =< p.lat =< this._ne.lat)
+      });
+
+    }
+    */
 
     /**
      * Converts an array to a `LngLatBounds` object.

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -212,7 +212,7 @@ class LngLatBounds {
     /**
     * Check if the point is within the bounding box.
     *
-    * @param {LngLatLike} geographic point to check against.
+    * @param {LngLatLike} lnglat geographic point to check against.
     * @returns {boolean} True if the point is within the bounding box.
     */
     contains(lnglat: LngLatLike) {

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -215,7 +215,7 @@ class LngLatBounds {
     * @returns {boolean} True if the point is within the bounding box.
     */
     contains(lnglat: LngLatLike) {
-        lnglat = lnglat instanceof LngLat ? new LngLat(lnglat.lng, lnglat.lat) : LngLat.convert(lnglat);
+        lnglat = LngLat.convert(lnglat);
 
         const containsLatitude = this._sw.lat <= lnglat.lat && lnglat.lat <= this._ne.lat;
         let containsLongitude = this._sw.lng <= lnglat.lng && lnglat.lng <= this._ne.lng;

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -212,17 +212,16 @@ class LngLatBounds {
     /**
     * Check if the point is within the bounding box.
     *
+    * @param {LngLatLike} geographic point to check against.
     * @returns {boolean} True if the point is within the bounding box.
     */
     contains(lnglat: LngLatLike) {
-        lnglat = LngLat.convert(lnglat);
+        const {lng, lat} = LngLat.convert(lnglat);
 
-        const containsLatitude = this._sw.lat <= lnglat.lat && lnglat.lat <= this._ne.lat;
-        let containsLongitude = this._sw.lng <= lnglat.lng && lnglat.lng <= this._ne.lng;
-
-        if (this._sw.lng > this._ne.lng) {
-        // wrapped coordinates
-            containsLongitude = this._sw.lng >= lnglat.lng && lnglat.lng >= this._ne.lng;
+        const containsLatitude = this._sw.lat <= lat && lat <= this._ne.lat;
+        let containsLongitude = this._sw.lng <= lng && lng <= this._ne.lng;
+        if (this._sw.lng > this._ne.lng) { // wrapped coordinates
+            containsLongitude = this._sw.lng >= lng && lng >= this._ne.lng;
         }
 
         return containsLatitude && containsLongitude;

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -172,5 +172,55 @@ test('LngLatBounds', (t) => {
         t.end();
     });
 
+    t.test('contains', (t) => {
+      t.test('point', (t) => {
+        t.test('point is in bounds', (t) => {
+          const llb = new LngLatBounds([-1, -1], [1, 1]);
+          const ll = { lng:0, lat: 0 };
+          t.ok(llb.contains(ll));
+          t.end();
+        });
+
+        t.test('point is not in bounds', (t) => {
+          const llb = new LngLatBounds([-1, -1], [1, 1]);
+          const ll = { lng:3, lat: 3 };
+          t.notOk(llb.contains(ll));
+          t.end();
+        })
+
+        t.test('point is in bounds that spans dateline', (t) => {
+          const llb = new LngLatBounds([190, -10], [170, 10]);
+          const ll = { lng: 180, lat: 0 };
+          t.ok(llb.contains(ll));
+          t.end();
+        });
+
+        t.test('point is not in bounds that spans dateline', (t) => {
+          const llb = new LngLatBounds([190, -10], [170, 10]);
+          const ll = { lng: 0, lat: 0 };
+          t.notOk(llb.contains(ll));
+          t.end();
+        });
+
+        /*
+        t.test('handles wrapped coordinates', (t) => {
+          const llb = new LngLatBounds([-1, -1], [1, 1]);
+          const ll = { lng:360, lat: 0 };
+          t.ok(llb.contains(ll));
+          t.end();
+        })
+        */
+
+        t.end();
+      });
+
+      /*
+      t.test('contains bounds', (t) => {
+
+      });
+      */
+      t.end();
+    })
+
     t.end();
 });

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -207,5 +207,3 @@ test('LngLatBounds', (t) => {
     });
     t.end();
 });
-
-// pint in gl-js for wrapped & other feedback

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -173,54 +173,39 @@ test('LngLatBounds', (t) => {
     });
 
     t.test('contains', (t) => {
-      t.test('point', (t) => {
-        t.test('point is in bounds', (t) => {
-          const llb = new LngLatBounds([-1, -1], [1, 1]);
-          const ll = { lng:0, lat: 0 };
-          t.ok(llb.contains(ll));
-          t.end();
+        t.test('point', (t) => {
+            t.test('point is in bounds', (t) => {
+                const llb = new LngLatBounds([-1, -1], [1, 1]);
+                const ll = { lng: 0, lat: 0 };
+                t.ok(llb.contains(ll));
+                t.end();
+            });
+
+            t.test('point is not in bounds', (t) => {
+                const llb = new LngLatBounds([-1, -1], [1, 1]);
+                const ll = { lng: 3, lat: 3 };
+                t.notOk(llb.contains(ll));
+                t.end();
+            });
+
+            t.test('point is in bounds that spans dateline', (t) => {
+                const llb = new LngLatBounds([190, -10], [170, 10]);
+                const ll = { lng: 180, lat: 0 };
+                t.ok(llb.contains(ll));
+                t.end();
+            });
+
+            t.test('point is not in bounds that spans dateline', (t) => {
+                const llb = new LngLatBounds([190, -10], [170, 10]);
+                const ll = { lng: 0, lat: 0 };
+                t.notOk(llb.contains(ll));
+                t.end();
+            });
+            t.end();
         });
-
-        t.test('point is not in bounds', (t) => {
-          const llb = new LngLatBounds([-1, -1], [1, 1]);
-          const ll = { lng:3, lat: 3 };
-          t.notOk(llb.contains(ll));
-          t.end();
-        })
-
-        t.test('point is in bounds that spans dateline', (t) => {
-          const llb = new LngLatBounds([190, -10], [170, 10]);
-          const ll = { lng: 180, lat: 0 };
-          t.ok(llb.contains(ll));
-          t.end();
-        });
-
-        t.test('point is not in bounds that spans dateline', (t) => {
-          const llb = new LngLatBounds([190, -10], [170, 10]);
-          const ll = { lng: 0, lat: 0 };
-          t.notOk(llb.contains(ll));
-          t.end();
-        });
-
-        /*
-        t.test('handles wrapped coordinates', (t) => {
-          const llb = new LngLatBounds([-1, -1], [1, 1]);
-          const ll = { lng:360, lat: 0 };
-          t.ok(llb.contains(ll));
-          t.end();
-        })
-        */
-
         t.end();
-      });
-
-      /*
-      t.test('contains bounds', (t) => {
-
-      });
-      */
-      t.end();
-    })
-
+    });
     t.end();
 });
+
+// pint in gl-js for wrapped & other feedback

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -176,28 +176,28 @@ test('LngLatBounds', (t) => {
         t.test('point', (t) => {
             t.test('point is in bounds', (t) => {
                 const llb = new LngLatBounds([-1, -1], [1, 1]);
-                const ll = { lng: 0, lat: 0 };
+                const ll = {lng: 0, lat: 0};
                 t.ok(llb.contains(ll));
                 t.end();
             });
 
             t.test('point is not in bounds', (t) => {
                 const llb = new LngLatBounds([-1, -1], [1, 1]);
-                const ll = { lng: 3, lat: 3 };
+                const ll = {lng: 3, lat: 3};
                 t.notOk(llb.contains(ll));
                 t.end();
             });
 
             t.test('point is in bounds that spans dateline', (t) => {
                 const llb = new LngLatBounds([190, -10], [170, 10]);
-                const ll = { lng: 180, lat: 0 };
+                const ll = {lng: 180, lat: 0};
                 t.ok(llb.contains(ll));
                 t.end();
             });
 
             t.test('point is not in bounds that spans dateline', (t) => {
                 const llb = new LngLatBounds([190, -10], [170, 10]);
-                const ll = { lng: 0, lat: 0 };
+                const ll = {lng: 0, lat: 0};
                 t.notOk(llb.contains(ll));
                 t.end();
             });


### PR DESCRIPTION
I've been working with @ryanhamley to add a `contains` method on `LngLatBounds` that checks to see if a point is within a bounding box. Would love some eyes on how we're handling wrapped coordinates.

For a quickstart, you can add the following to a debug page to test it locally.

```js
var bounds = [[190, -10], [170, 10]];
var bounds = [[190, -10], [170, 10]];
var llb = new mapboxgl.LngLatBounds(bounds[0], bounds[1]);
map.fitBounds(bounds);
var containsPoint = llb.contains([180, 0]); // true
```

Closes #7512.