### PR TITLE
fix imagery endpoint for WMS example

### DIFF
--- a/debug/wms.html
+++ b/debug/wms.html
@@ -31,7 +31,7 @@ map.addControl(new mapboxgl.NavigationControl());
 map.on('load', function() {
     map.addSource('wms-test', {
         "type": "raster",
-        "tiles": ['https://geodata.state.nj.us/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&layers=Natural2015'
+        "tiles": ['https://img.nj.gov/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&layers=Natural2015'
         ],
         "tileSize": 256
     });

--- a/docs/pages/example/wms.html
+++ b/docs/pages/example/wms.html
@@ -15,7 +15,7 @@ map.on('load', function() {
         'source': {
             'type': 'raster',
             'tiles': [
-                'https://geodata.state.nj.us/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&layers=Natural2015'
+                'https://img.nj.gov/imagerywms/Natural2015?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&layers=Natural2015'
             ],
             'tileSize': 256
         },


### PR DESCRIPTION
## Launch Checklist


 - [x] briefly describe the changes in this PR

The external endpoint for imagery on https://docs.mapbox.com/mapbox-gl-js/example/wms/ changed. This PR updates the endpoint so the example will display the imagery layer.

![image](https://user-images.githubusercontent.com/2180540/56830295-fb490c00-6833-11e9-8638-8baab9cb2b43.png)


cc @hjudge 