### PR TITLE
Update mapbox-gl.css

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -3,6 +3,7 @@
     overflow: hidden;
     position: relative;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    text-align: left;
 }
 
 .mapboxgl-map:-webkit-full-screen {


### PR DESCRIPTION
When the map is inside a tag with `text-align: center` (or `right`), the map is not displayed properly. An easy fix is to add `text-align: left`.

Screenshot with `text-align: center`: https://i.imgur.com/t1XU5uw.png
