### PR TITLE
[docs] add trailing slash to `pathname` so resolved URL matches the canonical

### DIFF
--- a/docs/pages/api.js
+++ b/docs/pages/api.js
@@ -11,7 +11,7 @@ import ApiItem from '../components/api-item';
 const meta = {
     title: 'API Reference',
     description: 'The Mapbox GL JS API documentation to render interactive maps from vector tiles and Mapbox styles.',
-    pathname: '/mapbox-gl-js/api',
+    pathname: '/mapbox-gl-js/api/',
     contentType: 'API',
     lanaguage: ['JavaScript']
 };

--- a/docs/pages/examples.js
+++ b/docs/pages/examples.js
@@ -19,7 +19,7 @@ import imageConfig from '../img/dist/image.config.json'; // eslint-disable-line
 const meta = {
     title: 'Examples',
     description: 'Code examples for Mapbox GL JS.',
-    pathname: '/examples',
+    pathname: '/examples/',
     lanaguage: ['JavaScript']
 };
 

--- a/docs/pages/plugins.js
+++ b/docs/pages/plugins.js
@@ -9,7 +9,7 @@ import IconText from '@mapbox/mr-ui/icon-text';
 const meta = {
     title: 'Plugins',
     description: 'Extend your Mapbox GL JS map with plugins.',
-    pathname: '/mapbox-gl-js/plugins'
+    pathname: '/mapbox-gl-js/plugins/'
 };
 
 const plugins = {

--- a/docs/pages/style-spec.js
+++ b/docs/pages/style-spec.js
@@ -12,7 +12,7 @@ import Icon from '@mapbox/mr-ui/icon';
 const meta = {
     title: 'Style Specification',
     description: 'This specification defines and describes the visual appearance of a map: what data to draw, the order to draw it in, and how to style the data when drawing it.',
-    pathname: '/mapbox-gl-js/style-spec',
+    pathname: '/mapbox-gl-js/style-spec/',
     contentType: 'specification'
 };
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR

This PR updates the metadata `pathname` on several pages to have a trailing slash. 

To illustrate:

* `https://docs.mapbox.com/mapbox-gl-js/api` redirects to `https://docs.mapbox.com/mapbox-gl-js/api/`
* the `canonical` URL (which is set by `pathname`) must match the resolved URL which has a trailing slash.

This will fix an issue with Mapbox GL JS pages that are not being indexed by our search provider.

You can test this PR by making sure the pages updated in this PR have a trailing slash in the `canonical` tag:

![image](https://user-images.githubusercontent.com/2180540/57394040-6e3a7700-7192-11e9-959e-4e697bf857b6.png)


