### PR TITLE
Provide an es modules build in dist/ for mapbox-gl-style-spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist/
 /docs/pages/dist/
 /docs/img/dist/
+*.es.js
 *.js.map
 node_modules
 package-lock.json

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -10,9 +10,10 @@
   ],
   "license": "ISC",
   "main": "./dist/index.js",
+  "module": "./dist/index.es.js",
   "scripts": {
     "copy-flow-typed": "cp -R ../../flow-typed .",
-    "build": "../../node_modules/.bin/rollup -c",
+    "build": "../../node_modules/.bin/rollup -c && ../../node_modules/.bin/rollup -c --environment esm",
     "prepublish": "yarn copy-flow-typed && yarn build",
     "postpublish": "rm -r flow-typed dist/index.js"
   },
@@ -34,5 +35,6 @@
     "minimist": "0.0.8",
     "rw": "^1.3.3",
     "sort-object": "^0.3.2"
-  }
+  },
+  "sideEffects": false
 }

--- a/src/style-spec/rollup.config.js
+++ b/src/style-spec/rollup.config.js
@@ -6,12 +6,20 @@ import unassert from 'rollup-plugin-unassert';
 import json from 'rollup-plugin-json';
 import {flow} from '../../build/rollup_plugins';
 
+// Build es modules?
+const esm = 'esm' in process.env;
+
+const transforms = {
+    dangerousForOf: true,
+    modules: esm ? false : undefined
+};
+
 const config = [{
     input: `${__dirname}/style-spec.js`,
     output: {
         name: 'mapboxGlStyleSpecification',
-        file: `${__dirname}/dist/index.js`,
-        format: 'umd',
+        file: `${__dirname}/dist/${esm ? 'index.es.js' : 'index.js'}`,
+        format: esm ? 'esm' : 'umd',
         sourcemap: true
     },
     plugins: [
@@ -25,7 +33,7 @@ const config = [{
         }),
         flow(),
         json(),
-        buble({transforms: {dangerousForOf: true}, objectAssign: "Object.assign"}),
+        buble({transforms, objectAssign: "Object.assign"}),
         unassert(),
         resolve({
             browser: true,


### PR DESCRIPTION
This pull request adds an es modules bundle to the `@mapbox/mapbox-gl-style-spec` package. With the accompanying changes in `package.json`, es module capable bundlers like webpack will automatically pick up the es module instead of the umd one. The result will be a smaller application bundle thanks to tree shaking.