### PR TITLE
prefer breaking lines at a zero width space.

### DIFF
--- a/src/symbol/shaping.js
+++ b/src/symbol/shaping.js
@@ -282,6 +282,11 @@ function calculatePenalty(codePoint: number, nextCodePoint: number) {
     if (codePoint === 0x0a) {
         penalty -= 10000;
     }
+    // Prioritize zero width spaces because the are used by mapbox as a way
+    // to mark ideal break points in Japanese text.
+    if (codePoint === 0x200b) {
+        penalty -= 50;
+    }
     // Penalize open parenthesis at end of line
     if (codePoint === 0x28 || codePoint === 0xff08) {
         penalty += 50;

--- a/test/expected/text-shaping-zero-width-space.json
+++ b/test/expected/text-shaping-zero-width-space.json
@@ -1,195 +1,123 @@
 {
   "positionedGlyphs": [
     {
-      "glyph": 65,
-      "x": -52.5,
+      "glyph": 19977,
+      "x": -63,
       "y": -41,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 32,
-      "x": -37.5,
+      "glyph": 19977,
+      "x": -42,
       "y": -41,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 66,
-      "x": -31.5,
+      "glyph": 19977,
+      "x": -21,
       "y": -41,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 67,
-      "x": -16.5,
+      "glyph": 19977,
+      "x": 0,
       "y": -41,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 32,
-      "x": -1.5,
+      "glyph": 19977,
+      "x": 21,
       "y": -41,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 68,
-      "x": 4.5,
+      "glyph": 19977,
+      "x": 42,
       "y": -41,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 69,
-      "x": 21.5,
-      "y": -41,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 32,
-      "x": 34.5,
-      "y": -41,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 70,
-      "x": 40.5,
-      "y": -41,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 71,
-      "x": -51,
+      "glyph": 19977,
+      "x": -63,
       "y": -17,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 32,
-      "x": -34,
+      "glyph": 19977,
+      "x": -42,
       "y": -17,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 72,
-      "x": -28,
+      "glyph": 19977,
+      "x": -21,
       "y": -17,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 32,
-      "x": -11,
+      "glyph": 19977,
+      "x": 0,
       "y": -17,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 73,
-      "x": -5,
+      "glyph": 19977,
+      "x": 21,
       "y": -17,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 32,
-      "x": 1,
+      "glyph": 19977,
+      "x": 42,
       "y": -17,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 74,
-      "x": 7,
-      "y": -17,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 32,
-      "x": 13,
-      "y": -17,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 75,
-      "x": 19,
-      "y": -17,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 32,
-      "x": 33,
-      "y": -17,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 76,
-      "x": 39,
-      "y": -17,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 77,
-      "x": -22.5,
+      "glyph": 19977,
+      "x": -21,
       "y": 7,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     },
     {
-      "glyph": 32,
-      "x": -1.5,
-      "y": 7,
-      "vertical": false,
-      "scale": 1,
-      "fontStack": "Test"
-    },
-    {
-      "glyph": 78,
-      "x": 4.5,
+      "glyph": 19977,
+      "x": 0,
       "y": 7,
       "vertical": false,
       "scale": 1,
       "fontStack": "Test"
     }
   ],
-  "text": "A B​C D​E F​G H I J K L​M N",
+  "text": "三三​三三​三三​三三三三三三​三三",
   "top": -36,
   "bottom": 36,
-  "left": -52.5,
-  "right": 52.5,
+  "left": -63,
+  "right": 63,
   "writingMode": 1,
   "lineCount": 3
 }

--- a/test/expected/text-shaping-zero-width-space.json
+++ b/test/expected/text-shaping-zero-width-space.json
@@ -1,0 +1,195 @@
+{
+  "positionedGlyphs": [
+    {
+      "glyph": 65,
+      "x": -52.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": -37.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 66,
+      "x": -31.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 67,
+      "x": -16.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": -1.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 68,
+      "x": 4.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 69,
+      "x": 21.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": 34.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 70,
+      "x": 40.5,
+      "y": -41,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 71,
+      "x": -51,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": -34,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 72,
+      "x": -28,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": -11,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 73,
+      "x": -5,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": 1,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 74,
+      "x": 7,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": 13,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 75,
+      "x": 19,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": 33,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 76,
+      "x": 39,
+      "y": -17,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 77,
+      "x": -22.5,
+      "y": 7,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 32,
+      "x": -1.5,
+      "y": 7,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    },
+    {
+      "glyph": 78,
+      "x": 4.5,
+      "y": 7,
+      "vertical": false,
+      "scale": 1,
+      "fontStack": "Test"
+    }
+  ],
+  "text": "A B​C D​E F​G H I J K L​M N",
+  "top": -36,
+  "bottom": 36,
+  "left": -52.5,
+  "right": 52.5,
+  "writingMode": 1,
+  "lineCount": 3
+}

--- a/test/fixtures/fontstack-glyphs.json
+++ b/test/fixtures/fontstack-glyphs.json
@@ -1918,5 +1918,15 @@
       "top": -5,
       "advance": 15
     }
+  },
+  "19977": {
+    "id": 19977,
+    "metrics": {
+      "width": 18,
+      "height": 18,
+      "left": 2,
+      "top": -8,
+      "advance": 21
+    }
   }
 }

--- a/test/unit/symbol/shaping.test.js
+++ b/test/unit/symbol/shaping.test.js
@@ -55,6 +55,15 @@ test('shaping', (t) => {
     if (UPDATE) fs.writeFileSync(path.join(__dirname, '/../../expected/text-shaping-newlines-in-middle.json'), JSON.stringify(shaped, null, 2));
     t.deepEqual(shaped, expectedNewLinesInMiddle);
 
+    // Prefer zero width spaces when breaking lines. Zero width spaces are used by Mapbox data sources as a hint that
+    // a position is ideal for breaking.
+    const expectedZeroWidthSpaceBreak = JSON.parse(fs.readFileSync(path.join(__dirname, '/../../expected/text-shaping-zero-width-space.json')));
+
+    shaped = shaping.shapeText(Formatted.fromString('A B​C D​E F​G H I J K L​M N'), glyphs, fontStack, 5 * oneEm, oneEm, 'center', 'center', 0, [0, 0], WritingMode.horizontal);
+    if (UPDATE) fs.writeFileSync(path.join(__dirname, '/../../expected/text-shaping-zero-width-space.json'), JSON.stringify(shaped, null, 2));
+    t.deepEqual(shaped, expectedZeroWidthSpaceBreak);
+
+
     // Null shaping.
     shaped = shaping.shapeText(Formatted.fromString(''), glyphs, fontStack, 15 * oneEm, oneEm, 'center', 'center', 0 * oneEm, [0, 0], WritingMode.horizontal);
     t.equal(false, shaped);

--- a/test/unit/symbol/shaping.test.js
+++ b/test/unit/symbol/shaping.test.js
@@ -59,7 +59,7 @@ test('shaping', (t) => {
     // a position is ideal for breaking.
     const expectedZeroWidthSpaceBreak = JSON.parse(fs.readFileSync(path.join(__dirname, '/../../expected/text-shaping-zero-width-space.json')));
 
-    shaped = shaping.shapeText(Formatted.fromString('A B​C D​E F​G H I J K L​M N'), glyphs, fontStack, 5 * oneEm, oneEm, 'center', 'center', 0, [0, 0], WritingMode.horizontal);
+    shaped = shaping.shapeText(Formatted.fromString('三三\u200b三三\u200b三三\u200b三三三三三三\u200b三三'), glyphs, fontStack, 5 * oneEm, oneEm, 'center', 'center', 0, [0, 0], WritingMode.horizontal);
     if (UPDATE) fs.writeFileSync(path.join(__dirname, '/../../expected/text-shaping-zero-width-space.json'), JSON.stringify(shaped, null, 2));
     t.deepEqual(shaped, expectedZeroWidthSpaceBreak);
 


### PR DESCRIPTION
Mapbox data sources use zero width spaces to suggest better break points for Japanese labels. This somewhat hacky approach avoids adding more complex line breaking logic to -gl-js.

@asheemmamoowala @lily-chai 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] tagged @mapbox/gl-native if this PR includes shader changes or needs a native port
