### PR TITLE
Fixes #8256

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -215,9 +215,12 @@ class ScrollZoomHandler {
         }
 
         this._active = true;
-        this._zooming = true;
-        this._map.fire(new Event('movestart', {originalEvent: e}));
-        this._map.fire(new Event('zoomstart', {originalEvent: e}));
+        if (!this.isZooming()) {
+            this._zooming = true;
+            this._map.fire(new Event('movestart', {originalEvent: e}));
+            this._map.fire(new Event('zoomstart', {originalEvent: e}));
+        }
+
         if (this._finishTimeout) {
             clearTimeout(this._finishTimeout);
         }

--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,8 @@ There are two test suites associated with Mapbox GL JS
 
  To run individual tests:
 
- - Unit tests: `yarn test-unit path/to/file.test.js` where the path begins within the `/test/unit/` directory
+ - Unit tests: `yarn test-unit path/to/file.test.js` where path *does not include* `test/unit/` 
+   - e.g. `yarn test-unit ui/handler/scroll_zoom.test.js`
  - Render tests: `yarn test-render render-test-name` (e.g. `yarn test-render background-color/default`)
 
 ## Writing Unit Tests


### PR DESCRIPTION
## Launch Checklist

This PR is to fix #8256. By wrapping the movestart event emitter in a check to see if `_zooming` has already started, it will only fire once. 

This affects both movestart and zoomstart, both of which suffered from the problem outlined in the issue. 

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] ~document any changes to public APIs~
 - [x] ~post benchmark scores~ <-- couldn't get these to run
 - [x] manually test the debug page
 - [x] ~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~
 - [x] ~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~

