### PR TITLE
Add `dragInertia` options for custom drag panning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _site
 yarn-error.log
 yarn-debug.log
 npm-debug.log
+.vscode/

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -28,7 +28,7 @@ export function easeCubicInOut(t: number): number {
 }
 
 /**
- * Given given (x, y), (x1, y1) control points for a bezier curve,
+ * Given (x, y), (x1, y1) control points for a bezier curve,
  * return a function that interpolates along that curve.
  *
  * @param p1x control point 1 x coordinate


### PR DESCRIPTION
This PR Adds `dragInertia` options to the base map options.

I don't know if this exposes too many options, and/or if there should be another option for setting `velocity` directly.  I also don't know if I'm following convention as this is my first PR to the codebase. Happy to change what's needed.

I haven't written tests for this yet, but can once the idea & options format is considered acceptable. Likewise for public API documentation & benchmarks.

Fixes #4851

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
