### PR TITLE
ensure fetch/ajax image requests accept webp when supported

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -6,6 +6,7 @@ import {isMapboxHTTPURL, hasCacheDefeatingSku} from './mapbox';
 import config from './config';
 import assert from 'assert';
 import {cacheGet, cachePut} from './tile_request_cache';
+import webpSupported from './webp_supported';
 
 import type {Callback} from '../types/callback';
 import type {Cancelable} from '../types/cancelable';
@@ -266,6 +267,13 @@ export const resetImageRequestQueue = () => {
 resetImageRequestQueue();
 
 export const getImage = function(requestParameters: RequestParameters, callback: Callback<HTMLImageElement>): Cancelable {
+    if (webpSupported.supported) {
+        if (!requestParameters.headers) {
+            requestParameters.headers = {};
+        }
+        requestParameters.headers.accept = 'image/webp,*/*';
+    }
+
     // limit concurrent image loads to help with raster sources performance on big screens
     if (numImageRequests >= config.MAX_PARALLEL_IMAGE_REQUESTS) {
         const queued = {

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -195,24 +195,16 @@ test('ajax', (t) => {
         });
 
         // mock webp support
-        webpSupported.supported = true
+        webpSupported.supported = true;
 
         // jsdom doesn't call image onload; fake it https://github.com/jsdom/jsdom/issues/1816
-        const jsdomImage = window.Image;
         window.Image = class {
             set src(src) {
                 setTimeout(() => this.onload());
             }
         };
 
-        function callback(err) {
-            if (err) return;
-
-            window.Image = jsdomImage;
-            t.end();
-        }
-
-        getImage({url: ''}, callback);
+        getImage({url: ''}, () => { t.end() });
 
         window.server.respond();
     });

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -204,7 +204,7 @@ test('ajax', (t) => {
             }
         };
 
-        getImage({url: ''}, () => { t.end() });
+        getImage({url: ''}, () => { t.end(); });
 
         window.server.respond();
     });

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -8,6 +8,7 @@ import {
 } from '../../../src/util/ajax';
 import window from '../../../src/util/window';
 import config from '../../../src/util/config';
+import webpSupported from '../../../src/util/webp_supported';
 
 test('ajax', (t) => {
     t.beforeEach(callback => {
@@ -181,6 +182,21 @@ test('ajax', (t) => {
         t.equals(queuedRequest.aborted, undefined);
         queued.cancel();
         t.equals(queuedRequest.aborted, true);
+
+        t.end();
+    });
+
+    t.test('getImage sends accept/webp when supported', (t) => {
+        resetImageRequestQueue();
+
+        window.server.respondWith((request) => {
+            t.ok(request.requestHeaders.accept.includes('image/webp'), 'accepts header contains image/webp')
+        });
+
+        // mock webp support
+        webpSupported.supported = true
+
+        getImage({url: ''}, () => t.fail);
 
         t.end();
     });


### PR DESCRIPTION
## Launch Checklist

fixes #8261

 - [x] briefly describe the changes in this PR
See further detail at #8261 , but in essence this PR ensures image requests from GL JS to servers, include accepts image/webp where supported, so the server knows if it can respond with a webp image or not
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] post benchmark scores
 - [x] ~~check this webp support test is only run once, instead of at each tile request, and what impact it has on performance~~ tested, only run once
 - [x] manually test the debug page
tested