### PR TITLE
A more accurate algorithm for approximating round line joins

### DIFF
--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -52,6 +52,9 @@ const EXTRUDE_SCALE = 63;
 const COS_HALF_SHARP_CORNER = Math.cos(75 / 2 * (Math.PI / 180));
 const SHARP_CORNER_OFFSET = 15;
 
+// Angle per triangle for approximating round line joins.
+const DEG_PER_TRIANGLE = 30;
+
 // The number of bits that is used to store the line distance in the buffer.
 const LINE_DISTANCE_BUFFER_BITS = 15;
 
@@ -331,11 +334,16 @@ class LineBucket implements Bucket {
              *
              */
 
-            // Calculate the length of the miter (the ratio of the miter to the width).
-            // Find the cosine of the angle between the next and join normals
-            // using dot product. The inverse of that is the miter length.
+            // calculate cosines of the angle (and its half) using dot product
+            const cosAngle = prevNormal.x * nextNormal.x + prevNormal.y * nextNormal.y;
             const cosHalfAngle = joinNormal.x * nextNormal.x + joinNormal.y * nextNormal.y;
+
+            // Calculate the length of the miter (the ratio of the miter to the width)
+            // as the inverse of cosine of the angle between next and join normals
             const miterLength = cosHalfAngle !== 0 ? 1 / cosHalfAngle : Infinity;
+
+            // approximate angle from cosine
+            const approxAngle = 2 * Math.sqrt(2 - 2 * cosHalfAngle);
 
             const isSharpCorner = cosHalfAngle < COS_HALF_SHARP_CORNER && prevVertex && nextVertex;
 
@@ -420,21 +428,18 @@ class LineBucket implements Bucket {
                     // Create a round join by adding multiple pie slices. The join isn't actually round, but
                     // it looks like it is at the sizes we render lines at.
 
-                    // Add more triangles for sharper angles.
-                    // This math is just a good enough approximation. It isn't "correct".
-                    const n = Math.floor((0.5 - (cosHalfAngle - 0.5)) * 8);
-                    let approxFractionalJoinNormal;
+                    // pick the number of triangles for approximating round join by based on the angle between normals
+                    const n = Math.round((approxAngle * 180 / Math.PI) / DEG_PER_TRIANGLE);
 
-                    for (let m = 0; m < n; m++) {
-                        approxFractionalJoinNormal = nextNormal.mult((m + 1) / (n + 1))._add(prevNormal)._unit();
-                        this.addPieSliceVertex(currentVertex, this.distance, approxFractionalJoinNormal, lineTurnsLeft, segment, lineDistances);
-                    }
-
-                    this.addPieSliceVertex(currentVertex, this.distance, joinNormal, lineTurnsLeft, segment, lineDistances);
-
-                    for (let k = n - 1; k >= 0; k--) {
-                        approxFractionalJoinNormal = prevNormal.mult((k + 1) / (n + 1))._add(nextNormal)._unit();
-                        this.addPieSliceVertex(currentVertex, this.distance, approxFractionalJoinNormal, lineTurnsLeft, segment, lineDistances);
+                    for (let m = 1; m < n; m++) {
+                        const t = m / n;
+                        // approximate spherical interpolation https://observablehq.com/@mourner/approximating-geometric-slerp
+                        const t2 = t - 0.5;
+                        const A = 1.0904 + cosAngle * (-3.2452 + cosAngle * (3.55645 - cosAngle * 1.43519));
+                        const B = 0.848013 + cosAngle * (-1.06021 + cosAngle * 0.215638);
+                        const ot = t + t * t2 * (t - 1) * (A * t2 * t2 + B);
+                        const approxFractionalNormal = prevNormal.mult(1 - ot)._add(nextNormal.mult(ot))._unit();
+                        this.addPieSliceVertex(currentVertex, this.distance, approxFractionalNormal, lineTurnsLeft, segment, lineDistances);
                     }
                 }
 

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -53,7 +53,7 @@ const COS_HALF_SHARP_CORNER = Math.cos(75 / 2 * (Math.PI / 180));
 const SHARP_CORNER_OFFSET = 15;
 
 // Angle per triangle for approximating round line joins.
-const DEG_PER_TRIANGLE = 30;
+const DEG_PER_TRIANGLE = 20;
 
 // The number of bits that is used to store the line distance in the buffer.
 const LINE_DISTANCE_BUFFER_BITS = 15;

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -432,13 +432,15 @@ class LineBucket implements Bucket {
                     const n = Math.round((approxAngle * 180 / Math.PI) / DEG_PER_TRIANGLE);
 
                     for (let m = 1; m < n; m++) {
-                        const t = m / n;
-                        // approximate spherical interpolation https://observablehq.com/@mourner/approximating-geometric-slerp
-                        const t2 = t - 0.5;
-                        const A = 1.0904 + cosAngle * (-3.2452 + cosAngle * (3.55645 - cosAngle * 1.43519));
-                        const B = 0.848013 + cosAngle * (-1.06021 + cosAngle * 0.215638);
-                        const ot = t + t * t2 * (t - 1) * (A * t2 * t2 + B);
-                        const approxFractionalNormal = prevNormal.mult(1 - ot)._add(nextNormal.mult(ot))._unit();
+                        let t = m / n;
+                        if (t !== 0.5) {
+                            // approximate spherical interpolation https://observablehq.com/@mourner/approximating-geometric-slerp
+                            const t2 = t - 0.5;
+                            const A = 1.0904 + cosAngle * (-3.2452 + cosAngle * (3.55645 - cosAngle * 1.43519));
+                            const B = 0.848013 + cosAngle * (-1.06021 + cosAngle * 0.215638);
+                            t = t + t * t2 * (t - 1) * (A * t2 * t2 + B);
+                        }
+                        const approxFractionalNormal = prevNormal.mult(1 - t)._add(nextNormal.mult(t))._unit();
                         this.addPieSliceVertex(currentVertex, this.distance, approxFractionalNormal, lineTurnsLeft, segment, lineDistances);
                     }
                 }


### PR DESCRIPTION
The algorithm we used for approximating round joins with triangles had several issues:

1. Since the number of slices was linearly based on cosine of half angle between normals (rather than the angle itself), it led to wildly inconsistent approximation — sharper corners were over-approximated while flatter corners were under-approximated. Here, the left turn uses 2 triangles while the right one 6 (!):

![image](https://user-images.githubusercontent.com/25395/58181730-fea9a900-7cb4-11e9-86d2-fe04267958c7.png)

2. We used linear (rather than angular) interpolation between normals to generate triangles, which meant that triangles were inconsistent in size — those closer to the join normal were bigger and those closer to prev/next normals smaller:

![Fig. 4: uneven slices](https://paper-attachments.dropbox.com/s_58F2963EF67FACAE9A046003D9D8A38AFE18142FD966539CEF5D80DD9BCAF01B_1558456697669_image.png)

3. Since we always generated a pie slice vertex in the middle, the number of approximating triangles could only be even, which lead to sometimes missing an opportunity for better approximation (e.g. using 2 where 3 would be better or using 6 when 5 would suffice).

These issues combined meant that we 1) generated more triangles than needed overall, 2) had inconsistent quality of approximation.

This PR changes the algorithm to use a more mathematically correct spherical interpolation, solving both issues. To avoid trigonometric calculations in this perf-sensitive section of the code, I adopted polynomial curve fitting approximation [demonstrated here](https://observablehq.com/@mourner/approximating-geometric-slerp). The quality of approximation is now controlled by the constant `DEG_PER_TRIANGLE`, which is 30 degrees by default — this seems to be an OK value quality-wise, and reduces the number of GPU buffer size on a typical streets z11 view by ~4-5% (#8243). We could definitely tweak this though. Here's how this looks for oversized lines at the moment (3 triangles on the left, 2 on the right):

![image](https://user-images.githubusercontent.com/25395/58183997-f5bad680-7cb8-11e9-9994-1676f144d557.png)

Pending benchmark results, review and a discussion of the constant.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~ covered by render tests
 - [x] ~~document any changes to public APIs~~ no changes
 - [x] post benchmark scores
 - [x] manually test the debug page
