### PR TITLE
Avoid expensive expression parsing when drawing symbols

### DIFF
--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -221,12 +221,12 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         let uniformValues;
         if (isSDF) {
-            uniformValues = symbolSDFUniformValues(sizeData.functionType,
+            uniformValues = symbolSDFUniformValues(sizeData.kind,
                 size, rotateInShader, pitchWithMap, painter, matrix,
                 uLabelPlaneMatrix, uglCoordMatrix, isText, texSize, true);
 
         } else {
-            uniformValues = symbolIconUniformValues(sizeData.functionType,
+            uniformValues = symbolIconUniformValues(sizeData.kind,
                 size, rotateInShader, pitchWithMap, painter, matrix,
                 uLabelPlaneMatrix, uglCoordMatrix, isText, texSize);
         }

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -9,8 +9,6 @@ import * as symbolProjection from '../symbol/projection';
 import * as symbolSize from '../symbol/symbol_size';
 import { mat4 } from 'gl-matrix';
 const identityMat4 = mat4.identity(new Float32Array(16));
-import properties from '../style/style_layer/symbol_style_layer_properties';
-const symbolLayoutProperties = properties.layout;
 import StencilMode from '../gl/stencil_mode';
 import DepthMode from '../gl/depth_mode';
 import CullFaceMode from '../gl/cull_face_mode';
@@ -179,7 +177,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         if (!program) {
             program = painter.useProgram(isSDF ? 'symbolSDF' : 'symbolIcon', programConfiguration);
-            size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom, symbolLayoutProperties.properties[isText ? 'text-size' : 'icon-size']);
+            size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
         }
 
         context.activeTexture.set(gl.TEXTURE0);

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -147,7 +147,7 @@ export class ZoomDependentExpression<Kind: EvaluationKind> {
     isStateDependent: boolean;
 
     _styleExpression: StyleExpression;
-    _interpolationType: ?InterpolationType;
+    interpolationType: ?InterpolationType;
 
     constructor(kind: Kind, expression: StyleExpression, zoomCurve: Step | Interpolate) {
         this.kind = kind;
@@ -155,7 +155,7 @@ export class ZoomDependentExpression<Kind: EvaluationKind> {
         this._styleExpression = expression;
         this.isStateDependent = kind !== ('camera': EvaluationKind) && !isConstant.isStateConstant(expression.expression);
         if (zoomCurve instanceof Interpolate) {
-            this._interpolationType = zoomCurve.interpolation;
+            this.interpolationType = zoomCurve.interpolation;
         }
     }
 
@@ -168,8 +168,8 @@ export class ZoomDependentExpression<Kind: EvaluationKind> {
     }
 
     interpolationFactor(input: number, lower: number, upper: number): number {
-        if (this._interpolationType) {
-            return Interpolate.interpolationFactor(this._interpolationType, input, lower, upper);
+        if (this.interpolationType) {
+            return Interpolate.interpolationFactor(this.interpolationType, input, lower, upper);
         } else {
             return 0;
         }
@@ -191,7 +191,8 @@ export type CameraExpression = {
     kind: 'camera',
     +evaluate: (globals: GlobalProperties, feature?: Feature, featureState?: FeatureState) => any,
     +interpolationFactor: (input: number, lower: number, upper: number) => number,
-    zoomStops: Array<number>
+    zoomStops: Array<number>,
+    interpolationType: ?InterpolationType
 };
 
 export type CompositeExpression = {
@@ -199,7 +200,8 @@ export type CompositeExpression = {
     isStateDependent: boolean,
     +evaluate: (globals: GlobalProperties, feature?: Feature, featureState?: FeatureState) => any,
     +interpolationFactor: (input: number, lower: number, upper: number) => number,
-    zoomStops: Array<number>
+    zoomStops: Array<number>,
+    interpolationType: ?InterpolationType
 };
 
 export type StylePropertyExpression =

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -93,9 +93,11 @@ export function createFunction(parameters, propertySpec) {
             featureFunctionStops.push([featureFunctions[z].zoom, createFunction(featureFunctions[z], propertySpec)]);
         }
 
+        const interpolationType = {name: 'linear'};
         return {
             kind: 'composite',
-            interpolationFactor: Interpolate.interpolationFactor.bind(undefined, {name: 'linear'}),
+            interpolationType,
+            interpolationFactor: Interpolate.interpolationFactor.bind(undefined, interpolationType),
             zoomStops: featureFunctionStops.map(s => s[0]),
             evaluate({zoom}, properties) {
                 return evaluateExponentialFunction({
@@ -105,10 +107,12 @@ export function createFunction(parameters, propertySpec) {
             }
         };
     } else if (zoomDependent) {
+        const interpolationType = {name: 'exponential', base: parameters.base !== undefined ? parameters.base : 1};
         return {
             kind: 'camera',
+            interpolationType,
             interpolationFactor: type === 'exponential' ?
-                Interpolate.interpolationFactor.bind(undefined, {name: 'exponential', base: parameters.base !== undefined ? parameters.base : 1}) :
+                Interpolate.interpolationFactor.bind(undefined, interpolationType) :
                 () => 0,
             zoomStops: parameters.stops.map(s => s[0]),
             evaluate: ({zoom}) => innerFun(parameters, propertySpec, zoom, hashedStops, categoricalKeyType)

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -107,13 +107,12 @@ export function createFunction(parameters, propertySpec) {
             }
         };
     } else if (zoomDependent) {
-        const interpolationType = {name: 'exponential', base: parameters.base !== undefined ? parameters.base : 1};
+        const interpolationType = type === 'exponential' ?
+            {name: 'exponential', base: parameters.base !== undefined ? parameters.base : 1} : null;
         return {
             kind: 'camera',
             interpolationType,
-            interpolationFactor: type === 'exponential' ?
-                Interpolate.interpolationFactor.bind(undefined, interpolationType) :
-                () => 0,
+            interpolationFactor: Interpolate.interpolationFactor.bind(undefined, interpolationType),
             zoomStops: parameters.stops.map(s => s[0]),
             evaluate: ({zoom}) => innerFun(parameters, propertySpec, zoom, hashedStops, categoricalKeyType)
         };

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -6,7 +6,6 @@ import * as symbolSize from './symbol_size';
 import * as projection from './projection';
 import { getAnchorJustification, evaluateRadialOffset } from './symbol_layout';
 import { getAnchorAlignment } from './shaping';
-import symbolLayerProperties from '../style/style_layer/symbol_style_layer_properties';
 import assert from 'assert';
 import pixelsToTileUnits from '../source/pixels_to_tile_units';
 import Point from '@mapbox/point-geometry';
@@ -274,7 +273,7 @@ export class Placement {
             scale: number, textPixelRatio: number, showCollisionBoxes: boolean, holdingForFade: boolean, seenCrossTileIDs: { [string | number]: boolean },
             collisionBoxArray: ?CollisionBoxArray) {
         const layout = bucket.layers[0].layout;
-        const partiallyEvaluatedTextSize = symbolSize.evaluateSizeForZoom(bucket.textSizeData, this.transform.zoom, symbolLayerProperties.layout.properties['text-size']);
+        const partiallyEvaluatedTextSize = symbolSize.evaluateSizeForZoom(bucket.textSizeData, this.transform.zoom);
         const textOptional = layout.get('text-optional');
         const iconOptional = layout.get('icon-optional');
         const textAllowOverlap = layout.get('text-allow-overlap');

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -5,8 +5,6 @@ import Point from '@mapbox/point-geometry';
 import { mat4, vec4 } from 'gl-matrix';
 import * as symbolSize from './symbol_size';
 import { addDynamicAttributes } from '../data/bucket/symbol_bucket';
-import properties from '../style/style_layer/symbol_style_layer_properties';
-const symbolLayoutProperties = properties.layout;
 
 import type Painter from '../render/painter';
 import type Transform from '../geo/transform';
@@ -141,8 +139,7 @@ function updateLineLabels(bucket: SymbolBucket,
                           keepUpright: boolean) {
 
     const sizeData = isText ? bucket.textSizeData : bucket.iconSizeData;
-    const partiallyEvaluatedSize = symbolSize.evaluateSizeForZoom(sizeData, painter.transform.zoom,
-        symbolLayoutProperties.properties[isText ? 'text-size' : 'icon-size']);
+    const partiallyEvaluatedSize = symbolSize.evaluateSizeForZoom(sizeData, painter.transform.zoom);
 
     const clippingBuffer = [256 / painter.width * 2 + 1, 256 / painter.height * 2 + 1];
 

--- a/src/symbol/symbol_layout.js
+++ b/src/symbol/symbol_layout.js
@@ -124,19 +124,19 @@ export function performSymbolLayout(bucket: SymbolBucket,
 
     const sizes = {};
 
-    if (bucket.textSizeData.functionType === 'composite') {
-        const {min, max} = bucket.textSizeData.zoomRange;
+    if (bucket.textSizeData.kind === 'composite') {
+        const {minZoom, maxZoom} = bucket.textSizeData;
         sizes.compositeTextSizes = [
-            unevaluatedLayoutValues['text-size'].possiblyEvaluate(new EvaluationParameters(min)),
-            unevaluatedLayoutValues['text-size'].possiblyEvaluate(new EvaluationParameters(max))
+            unevaluatedLayoutValues['text-size'].possiblyEvaluate(new EvaluationParameters(minZoom)),
+            unevaluatedLayoutValues['text-size'].possiblyEvaluate(new EvaluationParameters(maxZoom))
         ];
     }
 
-    if (bucket.iconSizeData.functionType === 'composite') {
-        const {min, max} = bucket.iconSizeData.zoomRange;
+    if (bucket.iconSizeData.kind === 'composite') {
+        const {minZoom, maxZoom} = bucket.iconSizeData;
         sizes.compositeIconSizes = [
-            unevaluatedLayoutValues['icon-size'].possiblyEvaluate(new EvaluationParameters(min)),
-            unevaluatedLayoutValues['icon-size'].possiblyEvaluate(new EvaluationParameters(max))
+            unevaluatedLayoutValues['icon-size'].possiblyEvaluate(new EvaluationParameters(minZoom)),
+            unevaluatedLayoutValues['icon-size'].possiblyEvaluate(new EvaluationParameters(maxZoom))
         ];
     }
 
@@ -411,14 +411,14 @@ function addTextVertices(bucket: SymbolBucket,
     const sizeData = bucket.textSizeData;
     let textSizeData = null;
 
-    if (sizeData.functionType === 'source') {
+    if (sizeData.kind === 'source') {
         textSizeData = [
             SIZE_PACK_FACTOR * layer.layout.get('text-size').evaluate(feature, {})
         ];
         if (textSizeData[0] > MAX_PACKED_SIZE) {
             warnOnce(`${bucket.layerIds[0]}: Value for "text-size" is >= 256. Reduce your "text-size".`);
         }
-    } else if (sizeData.functionType === 'composite') {
+    } else if (sizeData.kind === 'composite') {
         textSizeData = [
             SIZE_PACK_FACTOR * sizes.compositeTextSizes[0].evaluate(feature, {}),
             SIZE_PACK_FACTOR * sizes.compositeTextSizes[1].evaluate(feature, {})
@@ -540,14 +540,14 @@ function addSymbol(bucket: SymbolBucket,
         const sizeData = bucket.iconSizeData;
         let iconSizeData = null;
 
-        if (sizeData.functionType === 'source') {
+        if (sizeData.kind === 'source') {
             iconSizeData = [
                 SIZE_PACK_FACTOR * layer.layout.get('icon-size').evaluate(feature, {})
             ];
             if (iconSizeData[0] > MAX_PACKED_SIZE) {
                 warnOnce(`${bucket.layerIds[0]}: Value for "icon-size" is >= 256. Reduce your "icon-size".`);
             }
-        } else if (sizeData.functionType === 'composite') {
+        } else if (sizeData.kind === 'composite') {
             iconSizeData = [
                 SIZE_PACK_FACTOR * sizes.compositeIconSizes[0].evaluate(feature, {}),
                 SIZE_PACK_FACTOR * sizes.compositeIconSizes[1].evaluate(feature, {})

--- a/src/symbol/symbol_size.js
+++ b/src/symbol/symbol_size.js
@@ -13,19 +13,21 @@ const SIZE_PACK_FACTOR = 256;
 export { getSizeData, evaluateSizeForFeature, evaluateSizeForZoom, SIZE_PACK_FACTOR };
 
 export type SizeData = {
-    functionType: 'constant',
+    kind: 'constant',
     layoutSize: number
 } | {
-    functionType: 'source'
+    kind: 'source'
 } | {
-    functionType: 'camera',
-    layoutSize: number,
-    zoomRange: {min: number, max: number},
-    sizeRange: {min: number, max: number},
+    kind: 'camera',
+    minZoom: number,
+    maxZoom: number,
+    minSize: number,
+    maxSize: number,
     interpolationType: ?InterpolationType
 } | {
-    functionType: 'composite',
-    zoomRange: {min: number, max: number},
+    kind: 'composite',
+    minZoom: number,
+    maxZoom: number,
     interpolationType: ?InterpolationType
 };
 
@@ -33,86 +35,64 @@ export type SizeData = {
 // the painter to set symbol-size-related uniforms
 function getSizeData(tileZoom: number, value: PropertyValue<number, PossiblyEvaluatedPropertyValue<number>>): SizeData {
     const {expression} = value;
-    if (expression.kind === 'constant') {
-        return {
-            functionType: 'constant',
-            layoutSize: expression.evaluate(new EvaluationParameters(tileZoom + 1))
-        };
-    } else if (expression.kind === 'source') {
-        return {
-            functionType: 'source'
-        };
-    } else {
-        // calculate covering zoom stops for zoom-dependent values
-        const levels = expression.zoomStops;
 
+    if (expression.kind === 'constant') {
+        const layoutSize = expression.evaluate(new EvaluationParameters(tileZoom + 1));
+        return {kind: 'constant', layoutSize};
+
+    } else if (expression.kind === 'source') {
+        return {kind: 'source'};
+
+    } else {
+        const {zoomStops, interpolationType} = expression;
+
+        // calculate covering zoom stops for zoom-dependent values
         let lower = 0;
-        while (lower < levels.length && levels[lower] <= tileZoom) lower++;
+        while (lower < zoomStops.length && zoomStops[lower] <= tileZoom) lower++;
         lower = Math.max(0, lower - 1);
         let upper = lower;
-        while (upper < levels.length && levels[upper] < tileZoom + 1) upper++;
-        upper = Math.min(levels.length - 1, upper);
+        while (upper < zoomStops.length && zoomStops[upper] < tileZoom + 1) upper++;
+        upper = Math.min(zoomStops.length - 1, upper);
 
-        const zoomRange = {
-            min: levels[lower],
-            max: levels[upper]
-        };
-
-        const {interpolationType} = expression;
+        const minZoom = zoomStops[lower];
+        const maxZoom = zoomStops[upper];
 
         // We'd like to be able to use CameraExpression or CompositeExpression in these
         // return types rather than ExpressionSpecification, but the former are not
         // transferrable across Web Worker boundaries.
         if (expression.kind === 'composite') {
-            return {
-                functionType: 'composite',
-                zoomRange,
-                interpolationType
-            };
-        } else {
-            // for camera functions, also save off the function values
-            // evaluated at the covering zoom levels
-            return {
-                functionType: 'camera',
-                layoutSize: expression.evaluate(new EvaluationParameters(tileZoom + 1)),
-                zoomRange,
-                sizeRange: {
-                    min: expression.evaluate(new EvaluationParameters(zoomRange.min)),
-                    max: expression.evaluate(new EvaluationParameters(zoomRange.max))
-                },
-                interpolationType
-            };
+            return {kind: 'composite', minZoom, maxZoom, interpolationType};
         }
+
+        // for camera functions, also save off the function values
+        // evaluated at the covering zoom levels
+        const minSize = expression.evaluate(new EvaluationParameters(minZoom));
+        const maxSize = expression.evaluate(new EvaluationParameters(maxZoom));
+
+        return {kind: 'camera', minZoom, maxZoom, minSize, maxSize, interpolationType};
     }
 }
 
 function evaluateSizeForFeature(sizeData: SizeData,
-                                partiallyEvaluatedSize: { uSize: number, uSizeT: number },
-                                symbol: { lowerSize: number, upperSize: number}) {
-    const part = partiallyEvaluatedSize;
-    if (sizeData.functionType === 'source') {
-        return symbol.lowerSize / SIZE_PACK_FACTOR;
-    } else if (sizeData.functionType === 'composite') {
-        return interpolate(symbol.lowerSize / SIZE_PACK_FACTOR, symbol.upperSize / SIZE_PACK_FACTOR, part.uSizeT);
-    } else {
-        return part.uSize;
+                                {uSize, uSizeT}: { uSize: number, uSizeT: number },
+                                {lowerSize, upperSize}: { lowerSize: number, upperSize: number}) {
+    if (sizeData.kind === 'source') {
+        return lowerSize / SIZE_PACK_FACTOR;
+    } else if (sizeData.kind === 'composite') {
+        return interpolate(lowerSize / SIZE_PACK_FACTOR, upperSize / SIZE_PACK_FACTOR, uSizeT);
     }
+    return uSize;
 }
 
 function evaluateSizeForZoom(sizeData: SizeData, zoom: number) {
-    if (sizeData.functionType === 'constant') {
-        return {
-            uSizeT: 0,
-            uSize: sizeData.layoutSize
-        };
-    } else if (sizeData.functionType === 'source') {
-        return {
-            uSizeT: 0,
-            uSize: 0
-        };
-    } else {
+    let uSizeT = 0;
+    let uSize = 0;
 
-        const {interpolationType, zoomRange} = sizeData;
+    if (sizeData.kind === 'constant') {
+        uSize = sizeData.layoutSize;
+
+    } else if (sizeData.kind !== 'source') {
+        const {interpolationType, minZoom, maxZoom} = sizeData;
 
         // Even though we could get the exact value of the camera function
         // at z = tr.zoom, we intentionally do not: instead, we interpolate
@@ -120,19 +100,14 @@ function evaluateSizeForZoom(sizeData: SizeData, zoom: number) {
         // [tileZoom, tileZoom + 1] in order to be consistent with this
         // restriction on composite functions
         const t = !interpolationType ? 0 : clamp(
-            Interpolate.interpolationFactor(interpolationType, zoom, zoomRange.min, zoomRange.max), 0, 1);
+            Interpolate.interpolationFactor(interpolationType, zoom, minZoom, maxZoom), 0, 1);
 
-        if (sizeData.functionType === 'camera') {
-            const {sizeRange} = sizeData;
-            return {
-                uSizeT: 0,
-                uSize: sizeRange.min + t * (sizeRange.max - sizeRange.min)
-            };
+        if (sizeData.kind === 'camera') {
+            uSize = interpolate(sizeData.minSize, sizeData.maxSize, t);
+        } else {
+            uSizeT = t;
         }
-
-        return {
-            uSizeT: t,
-            uSize: 0
-        };
     }
+
+    return {uSizeT, uSize};
 }


### PR DESCRIPTION
Prior to this PR, the `drawSymbols` routine had to reparse any icon/text-size property expressions when performing `evaluateSizeForZoom` routine. This led to it taking a noticeable time on the main thread.

The main goal of the PR (first 3 commits) is to simplify the `sizeData` structure used for it so that it only retains the interpolation factor rather than the whole expression property, making it leaner and completely avoiding the need to parse expressions. On a sample profiling of a Streers-v11 style, it shows roughly 5-10% less time for `drawSymbols`.

The last commit just simplifies the code to make it easier to read.

The Paint/LayerSymbol benchmarks don't show any difference because the overhead only appear when using expression-heavy styles such as Streets-v11. We should update our benchmark to reflect the current style spec usage in a separate PR.