### PR TITLE
Compare original styles in setStyle API to minimize changes list (#8298)

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -432,7 +432,7 @@ class Style extends Evented {
         nextState = clone(nextState);
         nextState.layers = deref(nextState.layers);
 
-        const changes = diffStyles(this.serialize(), nextState)
+        const changes = diffStyles(this.stylesheet, nextState)
             .filter(op => !(op.command in ignoredDiffOperations));
 
         if (changes.length === 0) {


### PR DESCRIPTION
Minimize list of changes by comparing original style json with the next style state (#8298)

Pass this.stylesheet into diff-styles in order to detect only real changes not affected by modifications in loadJson + serialize implementation

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
