### PR TITLE
Optimize and simplify line tessellation code

### DIFF
--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -252,13 +252,9 @@ class LineBucket implements Bucket {
 
         const sharpCornerOffset = SHARP_CORNER_OFFSET * (EXTENT / (512 * this.overscaling));
 
-        const firstVertex = vertices[first];
-
         // we could be more precise, but it would only save a negligible amount of space
         const segment = this.segments.prepareSegment(len * 10, this.layoutVertexArray, this.indexArray);
 
-        const beginCap = cap,
-            endCap = isPolygon ? 'butt' : cap;
         let currentVertex;
         let prevVertex = ((undefined: any): Point);
         let nextVertex = ((undefined: any): Point);
@@ -270,7 +266,7 @@ class LineBucket implements Bucket {
 
         if (isPolygon) {
             currentVertex = vertices[len - 2];
-            nextNormal = firstVertex.sub(currentVertex)._unit()._perp();
+            nextNormal = vertices[first].sub(currentVertex)._unit()._perp();
         }
 
         for (let i = first; i < len; i++) {
@@ -342,7 +338,7 @@ class LineBucket implements Bucket {
 
             // The join if a middle vertex, otherwise the cap.
             const middleVertex = prevVertex && nextVertex;
-            let currentJoin = middleVertex ? join : nextVertex ? beginCap : endCap;
+            let currentJoin = middleVertex ? join : isPolygon ? 'butt' : cap;
 
             if (middleVertex && currentJoin === 'round') {
                 if (miterLength < roundLimit) {

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -503,11 +503,12 @@ class LineBucket implements Bucket {
     /**
      * Add two vertices to the buffers.
      *
-     * @param {Object} currentVertex the line vertex to add buffer vertices for
-     * @param {number} distance the distance from the beginning of the line to the vertex
-     * @param {number} endLeft extrude to shift the left vertex along the line
-     * @param {number} endRight extrude to shift the left vertex along the line
-     * @param {boolean} round whether this is a round cap
+     * @param currentVertex the line vertex to add buffer vertices for
+     * @param normal vertex normal
+     * @param endLeft extrude to shift the left vertex along the line
+     * @param endRight extrude to shift the left vertex along the line
+     * @param segment the segment object to add the vertex to
+     * @param round whether this is a round cap
      * @private
      */
     addCurrentVertex(p: Point, normal: Point, endLeft: number, endRight: number, segment: Segment, round: boolean = false) {

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -357,7 +357,7 @@ class LineBucket implements Bucket {
                 if (prevSegmentLength > 2 * sharpCornerOffset) {
                     const newPrevVertex = currentVertex.sub(currentVertex.sub(prevVertex)._mult(sharpCornerOffset / prevSegmentLength)._round());
                     this.distance += newPrevVertex.dist(prevVertex);
-                    this.addCurrentVertex(newPrevVertex, prevNormal.mult(1), 0, 0, false, segment);
+                    this.addCurrentVertex(newPrevVertex, prevNormal.mult(1), 0, 0, segment);
                     prevVertex = newPrevVertex;
                 }
             }
@@ -394,7 +394,7 @@ class LineBucket implements Bucket {
             if (currentJoin === 'miter') {
 
                 joinNormal._mult(miterLength);
-                this.addCurrentVertex(currentVertex, joinNormal, 0, 0, false, segment);
+                this.addCurrentVertex(currentVertex, joinNormal, 0, 0, segment);
 
             } else if (currentJoin === 'flipbevel') {
                 // miter is too big, flip the direction to make a beveled join
@@ -408,8 +408,8 @@ class LineBucket implements Bucket {
                     const bevelLength = miterLength * prevNormal.add(nextNormal).mag() / prevNormal.sub(nextNormal).mag();
                     joinNormal._perp()._mult(bevelLength * direction);
                 }
-                this.addCurrentVertex(currentVertex, joinNormal, 0, 0, false, segment);
-                this.addCurrentVertex(currentVertex, joinNormal.mult(-1), 0, 0, false, segment);
+                this.addCurrentVertex(currentVertex, joinNormal, 0, 0, segment);
+                this.addCurrentVertex(currentVertex, joinNormal.mult(-1), 0, 0, segment);
 
             } else if (currentJoin === 'bevel' || currentJoin === 'fakeround') {
                 const lineTurnsLeft = (prevNormal.x * nextNormal.y - prevNormal.y * nextNormal.x) > 0;
@@ -424,7 +424,7 @@ class LineBucket implements Bucket {
 
                 // Close previous segment with a bevel
                 if (!startOfLine) {
-                    this.addCurrentVertex(currentVertex, prevNormal, offsetA, offsetB, false, segment);
+                    this.addCurrentVertex(currentVertex, prevNormal, offsetA, offsetB, segment);
                 }
 
                 if (currentJoin === 'fakeround') {
@@ -452,25 +452,25 @@ class LineBucket implements Bucket {
 
                 // Start next segment
                 if (nextVertex) {
-                    this.addCurrentVertex(currentVertex, nextNormal, -offsetA, -offsetB, false, segment);
+                    this.addCurrentVertex(currentVertex, nextNormal, -offsetA, -offsetB, segment);
                 }
 
             } else if (currentJoin === 'butt') {
                 if (!startOfLine) {
                     // Close previous segment with a butt
-                    this.addCurrentVertex(currentVertex, prevNormal, 0, 0, false, segment);
+                    this.addCurrentVertex(currentVertex, prevNormal, 0, 0, segment);
                 }
 
                 // Start next segment with a butt
                 if (nextVertex) {
-                    this.addCurrentVertex(currentVertex, nextNormal, 0, 0, false, segment);
+                    this.addCurrentVertex(currentVertex, nextNormal, 0, 0, segment);
                 }
 
             } else if (currentJoin === 'square') {
 
                 if (!startOfLine) {
                     // Close previous segment with a square cap
-                    this.addCurrentVertex(currentVertex, prevNormal, 1, 1, false, segment);
+                    this.addCurrentVertex(currentVertex, prevNormal, 1, 1, segment);
 
                     // The segment is done. Unset vertices to disconnect segments.
                     this.e1 = this.e2 = -1;
@@ -478,17 +478,17 @@ class LineBucket implements Bucket {
 
                 // Start next segment
                 if (nextVertex) {
-                    this.addCurrentVertex(currentVertex, nextNormal, -1, -1, false, segment);
+                    this.addCurrentVertex(currentVertex, nextNormal, -1, -1, segment);
                 }
 
             } else if (currentJoin === 'round') {
 
                 if (!startOfLine) {
                     // Close previous segment with butt
-                    this.addCurrentVertex(currentVertex, prevNormal, 0, 0, false, segment);
+                    this.addCurrentVertex(currentVertex, prevNormal, 0, 0, segment);
 
                     // Add round cap or linejoin at end of segment
-                    this.addCurrentVertex(currentVertex, prevNormal, 1, 1, true, segment);
+                    this.addCurrentVertex(currentVertex, prevNormal, 1, 1, segment, true);
 
                     // The segment is done. Unset vertices to disconnect segments.
                     this.e1 = this.e2 = -1;
@@ -497,9 +497,9 @@ class LineBucket implements Bucket {
                 // Start next segment with a butt
                 if (nextVertex) {
                     // Add round cap before first segment
-                    this.addCurrentVertex(currentVertex, nextNormal, -1, -1, true, segment);
+                    this.addCurrentVertex(currentVertex, nextNormal, -1, -1, segment, true);
 
-                    this.addCurrentVertex(currentVertex, nextNormal, 0, 0, false, segment);
+                    this.addCurrentVertex(currentVertex, nextNormal, 0, 0, segment);
                 }
             }
 
@@ -508,7 +508,7 @@ class LineBucket implements Bucket {
                 if (nextSegmentLength > 2 * sharpCornerOffset) {
                     const newCurrentVertex = currentVertex.add(nextVertex.sub(currentVertex)._mult(sharpCornerOffset / nextSegmentLength)._round());
                     this.distance += newCurrentVertex.dist(currentVertex);
-                    this.addCurrentVertex(newCurrentVertex, nextNormal.mult(1), 0, 0, false, segment);
+                    this.addCurrentVertex(newCurrentVertex, nextNormal.mult(1), 0, 0, segment);
                     currentVertex = newCurrentVertex;
                 }
             }
@@ -529,12 +529,7 @@ class LineBucket implements Bucket {
      * @param {boolean} round whether this is a round cap
      * @private
      */
-    addCurrentVertex(currentVertex: Point,
-                     normal: Point,
-                     endLeft: number,
-                     endRight: number,
-                     round: boolean,
-                     segment: Segment) {
+    addCurrentVertex(currentVertex: Point, normal: Point, endLeft: number, endRight: number, segment: Segment, round: boolean = false) {
         let extrude;
         const layoutVertexArray = this.layoutVertexArray;
         const indexArray = this.indexArray;
@@ -569,7 +564,7 @@ class LineBucket implements Bucket {
         // to `linesofar`.
         if (this.distance > MAX_LINE_DISTANCE / 2 && this.totalDistance === 0) {
             this.distance = 0;
-            this.addCurrentVertex(currentVertex, normal, endLeft, endRight, round, segment);
+            this.addCurrentVertex(currentVertex, normal, endLeft, endRight, segment, round);
         }
     }
 

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -352,7 +352,7 @@ class LineBucket implements Bucket {
                 if (prevSegmentLength > 2 * sharpCornerOffset) {
                     const newPrevVertex = currentVertex.sub(currentVertex.sub(prevVertex)._mult(sharpCornerOffset / prevSegmentLength)._round());
                     this.distance += newPrevVertex.dist(prevVertex);
-                    this.addCurrentVertex(newPrevVertex, this.distance, prevNormal.mult(1), 0, 0, false, segment, lineDistances);
+                    this.addCurrentVertex(newPrevVertex, prevNormal.mult(1), 0, 0, false, segment, lineDistances);
                     prevVertex = newPrevVertex;
                 }
             }
@@ -389,7 +389,7 @@ class LineBucket implements Bucket {
             if (currentJoin === 'miter') {
 
                 joinNormal._mult(miterLength);
-                this.addCurrentVertex(currentVertex, this.distance, joinNormal, 0, 0, false, segment, lineDistances);
+                this.addCurrentVertex(currentVertex, joinNormal, 0, 0, false, segment, lineDistances);
 
             } else if (currentJoin === 'flipbevel') {
                 // miter is too big, flip the direction to make a beveled join
@@ -403,8 +403,8 @@ class LineBucket implements Bucket {
                     const bevelLength = miterLength * prevNormal.add(nextNormal).mag() / prevNormal.sub(nextNormal).mag();
                     joinNormal._perp()._mult(bevelLength * direction);
                 }
-                this.addCurrentVertex(currentVertex, this.distance, joinNormal, 0, 0, false, segment, lineDistances);
-                this.addCurrentVertex(currentVertex, this.distance, joinNormal.mult(-1), 0, 0, false, segment, lineDistances);
+                this.addCurrentVertex(currentVertex, joinNormal, 0, 0, false, segment, lineDistances);
+                this.addCurrentVertex(currentVertex, joinNormal.mult(-1), 0, 0, false, segment, lineDistances);
 
             } else if (currentJoin === 'bevel' || currentJoin === 'fakeround') {
                 const lineTurnsLeft = (prevNormal.x * nextNormal.y - prevNormal.y * nextNormal.x) > 0;
@@ -419,7 +419,7 @@ class LineBucket implements Bucket {
 
                 // Close previous segment with a bevel
                 if (!startOfLine) {
-                    this.addCurrentVertex(currentVertex, this.distance, prevNormal, offsetA, offsetB, false, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, prevNormal, offsetA, offsetB, false, segment, lineDistances);
                 }
 
                 if (currentJoin === 'fakeround') {
@@ -441,31 +441,31 @@ class LineBucket implements Bucket {
                             t = t + t * t2 * (t - 1) * (A * t2 * t2 + B);
                         }
                         const approxFractionalNormal = prevNormal.mult(1 - t)._add(nextNormal.mult(t))._unit();
-                        this.addPieSliceVertex(currentVertex, this.distance, approxFractionalNormal, lineTurnsLeft, segment, lineDistances);
+                        this.addPieSliceVertex(currentVertex, approxFractionalNormal, lineTurnsLeft, segment, lineDistances);
                     }
                 }
 
                 // Start next segment
                 if (nextVertex) {
-                    this.addCurrentVertex(currentVertex, this.distance, nextNormal, -offsetA, -offsetB, false, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, nextNormal, -offsetA, -offsetB, false, segment, lineDistances);
                 }
 
             } else if (currentJoin === 'butt') {
                 if (!startOfLine) {
                     // Close previous segment with a butt
-                    this.addCurrentVertex(currentVertex, this.distance, prevNormal, 0, 0, false, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, prevNormal, 0, 0, false, segment, lineDistances);
                 }
 
                 // Start next segment with a butt
                 if (nextVertex) {
-                    this.addCurrentVertex(currentVertex, this.distance, nextNormal, 0, 0, false, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, nextNormal, 0, 0, false, segment, lineDistances);
                 }
 
             } else if (currentJoin === 'square') {
 
                 if (!startOfLine) {
                     // Close previous segment with a square cap
-                    this.addCurrentVertex(currentVertex, this.distance, prevNormal, 1, 1, false, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, prevNormal, 1, 1, false, segment, lineDistances);
 
                     // The segment is done. Unset vertices to disconnect segments.
                     this.e1 = this.e2 = -1;
@@ -473,17 +473,17 @@ class LineBucket implements Bucket {
 
                 // Start next segment
                 if (nextVertex) {
-                    this.addCurrentVertex(currentVertex, this.distance, nextNormal, -1, -1, false, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, nextNormal, -1, -1, false, segment, lineDistances);
                 }
 
             } else if (currentJoin === 'round') {
 
                 if (!startOfLine) {
                     // Close previous segment with butt
-                    this.addCurrentVertex(currentVertex, this.distance, prevNormal, 0, 0, false, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, prevNormal, 0, 0, false, segment, lineDistances);
 
                     // Add round cap or linejoin at end of segment
-                    this.addCurrentVertex(currentVertex, this.distance, prevNormal, 1, 1, true, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, prevNormal, 1, 1, true, segment, lineDistances);
 
                     // The segment is done. Unset vertices to disconnect segments.
                     this.e1 = this.e2 = -1;
@@ -492,9 +492,9 @@ class LineBucket implements Bucket {
                 // Start next segment with a butt
                 if (nextVertex) {
                     // Add round cap before first segment
-                    this.addCurrentVertex(currentVertex, this.distance, nextNormal, -1, -1, true, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, nextNormal, -1, -1, true, segment, lineDistances);
 
-                    this.addCurrentVertex(currentVertex, this.distance, nextNormal, 0, 0, false, segment, lineDistances);
+                    this.addCurrentVertex(currentVertex, nextNormal, 0, 0, false, segment, lineDistances);
                 }
             }
 
@@ -503,7 +503,7 @@ class LineBucket implements Bucket {
                 if (nextSegmentLength > 2 * sharpCornerOffset) {
                     const newCurrentVertex = currentVertex.add(nextVertex.sub(currentVertex)._mult(sharpCornerOffset / nextSegmentLength)._round());
                     this.distance += newCurrentVertex.dist(currentVertex);
-                    this.addCurrentVertex(newCurrentVertex, this.distance, nextNormal.mult(1), 0, 0, false, segment, lineDistances);
+                    this.addCurrentVertex(newCurrentVertex, nextNormal.mult(1), 0, 0, false, segment, lineDistances);
                     currentVertex = newCurrentVertex;
                 }
             }
@@ -525,7 +525,6 @@ class LineBucket implements Bucket {
      * @private
      */
     addCurrentVertex(currentVertex: Point,
-                     distance: number,
                      normal: Point,
                      endLeft: number,
                      endRight: number,
@@ -536,10 +535,8 @@ class LineBucket implements Bucket {
         const layoutVertexArray = this.layoutVertexArray;
         const indexArray = this.indexArray;
 
-        if (distancesForScaling) {
-            // For gradient lines, scale distance from tile units to [0, 2^15)
-            distance = scaleDistance(distance, distancesForScaling);
-        }
+        // scale the distance for gradient lines
+        const distance = distancesForScaling ? scaleDistance(distance, distancesForScaling) : this.distance;
 
         extrude = normal.clone();
         if (endLeft) extrude._sub(normal.perp()._mult(endLeft));
@@ -569,7 +566,7 @@ class LineBucket implements Bucket {
         // to `linesofar`.
         if (distance > MAX_LINE_DISTANCE / 2 && !distancesForScaling) {
             this.distance = 0;
-            this.addCurrentVertex(currentVertex, this.distance, normal, endLeft, endRight, round, segment);
+            this.addCurrentVertex(currentVertex, normal, endLeft, endRight, round, segment);
         }
     }
 
@@ -578,13 +575,11 @@ class LineBucket implements Bucket {
      * This adds a pie slice triangle near a join to simulate round joins
      *
      * @param currentVertex the line vertex to add buffer vertices for
-     * @param distance the distance from the beginning of the line to the vertex
      * @param extrude the offset of the new vertex from the currentVertex
      * @param lineTurnsLeft whether the line is turning left or right at this angle
      * @private
      */
     addPieSliceVertex(currentVertex: Point,
-                      distance: number,
                       extrude: Point,
                       lineTurnsLeft: boolean,
                       segment: Segment,
@@ -593,7 +588,7 @@ class LineBucket implements Bucket {
         const layoutVertexArray = this.layoutVertexArray;
         const indexArray = this.indexArray;
 
-        if (distancesForScaling) distance = scaleDistance(distance, distancesForScaling);
+        const distance = distancesForScaling ? scaleDistance(distance, distancesForScaling) : this.distance;
 
         addLineVertex(layoutVertexArray, currentVertex, extrude, false, lineTurnsLeft, 0, distance);
         this.e3 = segment.vertexLength++;

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -332,6 +332,7 @@ class LineBucket implements Bucket {
             const approxAngle = 2 * Math.sqrt(2 - 2 * cosHalfAngle);
 
             const isSharpCorner = cosHalfAngle < COS_HALF_SHARP_CORNER && prevVertex && nextVertex;
+            const lineTurnsLeft = prevNormal.x * nextNormal.y - prevNormal.y * nextNormal.x > 0;
 
             if (isSharpCorner && i > first) {
                 const prevSegmentLength = currentVertex.dist(prevVertex);
@@ -385,15 +386,13 @@ class LineBucket implements Bucket {
                     joinNormal = nextNormal.mult(-1);
 
                 } else {
-                    const direction = prevNormal.x * nextNormal.y - prevNormal.y * nextNormal.x > 0 ? -1 : 1;
                     const bevelLength = miterLength * prevNormal.add(nextNormal).mag() / prevNormal.sub(nextNormal).mag();
-                    joinNormal._perp()._mult(bevelLength * direction);
+                    joinNormal._perp()._mult(bevelLength * (lineTurnsLeft ? -1 : 1));
                 }
                 this.addCurrentVertex(currentVertex, joinNormal, 0, 0, segment);
                 this.addCurrentVertex(currentVertex, joinNormal.mult(-1), 0, 0, segment);
 
             } else if (currentJoin === 'bevel' || currentJoin === 'fakeround') {
-                const lineTurnsLeft = (prevNormal.x * nextNormal.y - prevNormal.y * nextNormal.x) > 0;
                 const offset = -Math.sqrt(miterLength * miterLength - 1);
                 if (lineTurnsLeft) {
                     offsetB = 0;
@@ -431,8 +430,8 @@ class LineBucket implements Bucket {
                     }
                 }
 
-                // Start next segment
                 if (nextVertex) {
+                    // Start next segment
                     this.addCurrentVertex(currentVertex, nextNormal, -offsetA, -offsetB, segment);
                 }
 
@@ -441,9 +440,8 @@ class LineBucket implements Bucket {
                     // Close previous segment with a butt
                     this.addCurrentVertex(currentVertex, prevNormal, 0, 0, segment);
                 }
-
-                // Start next segment with a butt
                 if (nextVertex) {
+                    // Start next segment with a butt
                     this.addCurrentVertex(currentVertex, nextNormal, 0, 0, segment);
                 }
 
@@ -452,13 +450,9 @@ class LineBucket implements Bucket {
                 if (!startOfLine) {
                     // Close previous segment with a square cap
                     this.addCurrentVertex(currentVertex, prevNormal, 1, 1, segment);
-
-                    // The segment is done. Unset vertices to disconnect segments.
-                    this.e1 = this.e2 = -1;
                 }
-
-                // Start next segment
                 if (nextVertex) {
+                    // Start next segment
                     this.addCurrentVertex(currentVertex, nextNormal, -1, -1, segment);
                 }
 
@@ -470,16 +464,12 @@ class LineBucket implements Bucket {
 
                     // Add round cap or linejoin at end of segment
                     this.addCurrentVertex(currentVertex, prevNormal, 1, 1, segment, true);
-
-                    // The segment is done. Unset vertices to disconnect segments.
-                    this.e1 = this.e2 = -1;
                 }
-
-                // Start next segment with a butt
                 if (nextVertex) {
                     // Add round cap before first segment
                     this.addCurrentVertex(currentVertex, nextNormal, -1, -1, segment, true);
 
+                    // Start next segment with a butt
                     this.addCurrentVertex(currentVertex, nextNormal, 0, 0, segment);
                 }
             }


### PR DESCRIPTION
This PR refactors the line tessellation code, removing code repetition and some unnecessary logic, making it both faster and easier to follow.

The potential performance improvement comes from reducing the amount of temporary `Point` object allocations by ~2 times, which theoretically reduces the amount of subsequent GC pauses. I'll try to find a way to measure real-world performance impact, but roughly it should be 5-10% less time spent tessellating lines on the worker side.

It brings some ideas from #7085 but in a less intrusive way.

The PR is made on top of #8275 so needs to be applied after it lands.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] ~~write tests for all new functionality~~ already covered
 - [x] ~~document any changes to public APIs~~ no changes
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged @mapbox/gl-native — might need a port to native to make the code between platforms more similar.