### PR TITLE
Fix flaky turnstile event tests

### DIFF
--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -532,7 +532,7 @@ test("mapbox", (t) => {
                 const req = window.server.requests[0];
                 req.respond(200);
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.equal(reqBody.created, new Date(now).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), now, 100);
                 t.equal(reqBody.skuId, SKU_ID);
 
                 t.end();
@@ -553,7 +553,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.equal(reqBody.created, new Date(firstEvent).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), firstEvent, 100);
 
                 t.end();
             });
@@ -573,7 +573,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.equal(reqBody.created, new Date(firstEvent).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), firstEvent, 100);
 
                 t.end();
             });
@@ -627,7 +627,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.equal(reqBody.created, new Date(firstEvent).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), firstEvent, 100);
 
                 t.end();
             });
@@ -647,7 +647,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.equal(reqBody.created, new Date(firstEvent).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), firstEvent, 100);
 
                 t.end();
             });
@@ -690,7 +690,7 @@ test("mapbox", (t) => {
                 t.equal(reqBody.sdkVersion, version);
                 t.equal(reqBody.skuId, SKU_ID);
                 t.ok(reqBody.userId);
-                t.equal(reqBody.created, new Date(tomorrow).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), tomorrow, 100);
 
                 t.end();
             });
@@ -711,12 +711,12 @@ test("mapbox", (t) => {
                 const reqToday = window.server.requests[0];
                 reqToday.respond(200);
                 let reqBody = JSON.parse(reqToday.requestBody)[0];
-                t.equal(reqBody.created, new Date(today).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), today, 100);
 
                 const reqTomorrow = window.server.requests[1];
                 reqTomorrow.respond(200);
                 reqBody = JSON.parse(reqTomorrow.requestBody)[0];
-                t.equal(reqBody.created, new Date(tomorrow).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), tomorrow, 100);
 
                 t.end();
             });
@@ -852,7 +852,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.equal(reqBody.created, new Date(firstEvent).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), firstEvent, 100);
 
                 t.end();
             });
@@ -872,7 +872,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.equal(reqBody.created, new Date(firstEvent).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), firstEvent, 100);
 
                 t.end();
             });
@@ -942,7 +942,7 @@ test("mapbox", (t) => {
                 t.equal(window.server.requests.length, 1);
 
                 const reqBody = JSON.parse(req.requestBody)[0];
-                t.equal(reqBody.created, new Date(now).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), now, 100);
 
                 t.end();
             });
@@ -981,7 +981,7 @@ test("mapbox", (t) => {
                 t.equal(reqBody.event, 'map.load');
                 t.equal(reqBody.sdkVersion, version);
                 t.ok(reqBody.userId);
-                t.equal(reqBody.created, new Date(now).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), now, 100);
 
                 t.end();
             });
@@ -995,17 +995,17 @@ test("mapbox", (t) => {
                 const reqOne = window.server.requests[0];
                 reqOne.respond(200);
                 let reqBody = JSON.parse(reqOne.requestBody)[0];
-                t.equal(reqBody.created, new Date(now).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), now, 100);
 
                 const reqTwo = window.server.requests[1];
                 reqTwo.respond(200);
                 reqBody = JSON.parse(reqTwo.requestBody)[0];
-                t.equal(reqBody.created, new Date(now).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), now, 100);
 
                 const reqThree = window.server.requests[2];
                 reqThree.respond(200);
                 reqBody = JSON.parse(reqThree.requestBody)[0];
-                t.equal(reqBody.created, new Date(now).toISOString());
+                t.equalWithPrecision(new Date(reqBody.created).valueOf(), now, 100);
 
                 t.end();
             });


### PR DESCRIPTION
The turnstile tests sometime fail because of minor off-by-one-millisecond errors. Examples of failing builds:

- https://circleci.com/gh/mapbox/mapbox-gl-js/43320
- https://circleci.com/gh/mapbox/mapbox-gl-js/43093

This PR makes assertions compare within a 100ms threshold to avoid flakiness.