### PR TITLE
Tweak tolerance in render tests to expose false passing test

### DIFF
--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -135,7 +135,7 @@ export function run(implementation, ignores, render) {
 
                     const diff = pixelmatch(
                         actualImg.data, expectedImg.data, diffImg.data,
-                        width, height, {threshold: 0.13}) / (width * height);
+                        width, height, {threshold: 0.1285}) / (width * height);
 
                     if (diff < minDiff) {
                         minDiff = diff;


### PR DESCRIPTION
fill-extrusion-vertical-gradient/default was [falsely passing - Issue #14784](https://github.com/mapbox/mapbox-gl-native/issues/14784).
This tweak makes the test fail while keeping other tests passing.