### PR TITLE
[DOCS] Update Popup maxWidth description

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -54,8 +54,8 @@ export type PopupOptions = {
  * @param {string} [options.className] Space-separated CSS class names to add to popup container
  * @param {string} [options.maxWidth='240px'] -
  *  A string that sets the CSS property of the popup's maximum width, eg `'300px'`.
- *  If you want a fluid container which sizes to the inner size, you can set this property to `'none'`.
- *  All available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
+ *  To ensure the popup resizes to fit its content, set this property to `'none'`.
+ *  Available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
  * @example
  * var markerHeight = 50, markerRadius = 10, linearOffset = 25;
  * var popupOffsets = {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -52,7 +52,10 @@ export type PopupOptions = {
  *   - an object of {@link Point}s specifing an offset for each anchor position
  *  Negative offsets indicate left and up.
  * @param {string} [options.className] Space-separated CSS class names to add to popup container
- * @param {string} [options.maxWidth] A string that sets the CSS property of the popup's maxWidth in pixels, eg "300px"
+ * @param {string} [options.maxWidth='240px'] -
+ *  A string that sets the CSS property of the popup's maximum width, eg `'300px'`.
+ *  If you want a fluid container which sizes to the inner size, you can set this property to `'none'`.
+ *  All available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
  * @example
  * var markerHeight = 50, markerRadius = 10, linearOffset = 25;
  * var popupOffsets = {
@@ -236,18 +239,19 @@ export default class Popup extends Evented {
     }
 
     /**
-     * Returns the popup's max width.
+     * Returns the popup's maximum width.
      *
-     * @returns {string} The max width of the popup.
+     * @returns {string} The maximum width of the popup.
      */
     getMaxWidth() {
         return this._container.style.maxWidth;
     }
 
     /**
-     * Sets the popup's max width. This is setting the CSS property maxWidth. It expects a string in "Npx" format, where N is some number.
+     * Sets the popup's maximum width. This is setting the CSS property `max-width`.
+     * Available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
      *
-     * @param maxWidth A string representing the pixel value for the maximum width.
+     * @param maxWidth A string representing the value for the maximum width.
      * @returns {Popup} `this`
      */
     setMaxWidth(maxWidth: string) {


### PR DESCRIPTION
It updates the `maxWidth` property description as it accepts not only pixel values but all available `max-width` CSS values. I've also added the default value to the documentation which was missing.
Also added some small info as a tip to users that want to have a fluid container size.
