### PR TITLE
Add base-62 test for sku tokens

### DIFF
--- a/test/unit/util/sku_token.test.js
+++ b/test/unit/util/sku_token.test.js
@@ -19,6 +19,12 @@ test('sku token generation', (t) => {
         t.end();
     });
 
+    t.test('token only contains base-62 characters', (t) => {
+        const regex = /^[0-9a-zA-Z]+$/;
+        t.ok(regex.exec(skuToken));
+        t.end();
+    });
+
     t.test('createSkuToken generates a unique token each time it\'s called', (t) => {
         const secondSkuToken = createSkuToken().token;
         const thirdSkuToken = createSkuToken().token;


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - adds a test that sku tokens are composed of base-62 characters
 - [x] write tests for all new functionality
