### PR TITLE
Allowance for regressions/mapbox-gl-js#7066 render test

### DIFF
--- a/test/integration/render-tests/regressions/mapbox-gl-js#7066/style.json
+++ b/test/integration/render-tests/regressions/mapbox-gl-js#7066/style.json
@@ -4,7 +4,8 @@
     "test": {
       "pixelRatio": 10,
       "width": 24,
-      "height": 24 
+      "height": 24,
+      "allowed": 0.00025
     }
   },
   "sources": {


### PR DESCRIPTION
The upcoming test runner for GL Native accuses a difference that is slightly above the default allowance, but visually irrelevant - the actual result is the same as the one generated with GL native's current render test implementation, so I'd blame the fact that the upcoming test runner uses the C++ pixelmatch instead of the Javascript version, which could explain the difference.
