### PR TITLE
Revert "Allowance for regressions/mapbox-gl-js#7066 render test (#8318)"

### DIFF
--- a/test/integration/render-tests/regressions/mapbox-gl-js#7066/style.json
+++ b/test/integration/render-tests/regressions/mapbox-gl-js#7066/style.json
@@ -4,8 +4,7 @@
     "test": {
       "pixelRatio": 10,
       "width": 24,
-      "height": 24,
-      "allowed": 0.00025
+      "height": 24 
     }
   },
   "sources": {


### PR DESCRIPTION
Fixed an issue in the GL Native upcoming test runner that was causing pixelmatch results to be erroneous. The problem wasn't on pixelmatch itself, the root cause was not considering the precision loss when storing a `uint64_t` value in a `double`.

Apologies @mourner for the noise :-)