### PR TITLE
Add mapbox-gl-framerate to plugins list

### DIFF
--- a/docs/pages/plugins.js
+++ b/docs/pages/plugins.js
@@ -155,6 +155,10 @@ const plugins = {
         "mapbox-gl-fps": {
             "website": "https://github.com/MazeMap/mapbox-gl-fps",
             "description": "A frames-per-seconds GUI control and measurer with statistic report output."
+        },
+        "mapbox-gl-framerate": {
+            "website": "https://github.com/mapbox/mapbox-gl-framerate",
+            "description": "A frame rate control to evaluate map rendering performance."
         }
     }
 };


### PR DESCRIPTION
Quick addition that adds [`mapbox-gl-framerate`](https://github.com/mapbox/mapbox-gl-framerate) to the plugins list.