### PR TITLE
[WIP] use browser `Cache` interface to cache tiles

### DIFF
--- a/debug/cache_api.html
+++ b/debug/cache_api.html
@@ -269,33 +269,39 @@ const expectedRasterURL = 'https://api.mapbox.com/v4/mapbox.satellite/1/0/0' + r
 let rasterTileExpiry;
 
 function testFirstRaster(done) {
-    cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
-        log(matches.length === 1, 'Caches raster tile.');
-        const match = matches[0];
-        rasterTileExpiry = match && match.headers.get('Expires');
-        done();
+    caches.open(CACHE_NAME).catch(catchError).then(cache => {
+        cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+            const match = matches[0];
+            rasterTileExpiry = match && match.headers.get('Expires');
+            log(matches.length === 1, 'Caches raster tile.' + matches.length + ' ' + rasterTileExpiry);
+            done();
+        });
     });
 }
 
 function testSecondRaster(done) {
-    cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
-        // check that the tile in the cache after the second map load is the same as after the
-        // first one. No new tile was loaded or cached.
-        const match = matches[0];
-        const newExpiry = match && match.headers.get('Expires');
-        log(matches.length === 1 && rasterTileExpiry === newExpiry, 'Reuses cached raster tile without refetching.');
-        done();
+    caches.open(CACHE_NAME).catch(catchError).then(cache => {
+        cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+            // check that the tile in the cache after the second map load is the same as after the
+            // first one. No new tile was loaded or cached.
+            const match = matches[0];
+            const newExpiry = match && match.headers.get('Expires');
+            log(matches.length === 1 && rasterTileExpiry === newExpiry, 'Reuses cached raster tile without refetching.'  + matches.length + ' ' + newExpiry);
+            done();
+        });
     });
 }
 
 function testThirdRaster(done) {
-    cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
-        // check that the tile in the cache after the second map load is the same as after the
-        // first one. No new tile was loaded or cached.
-        const match = matches[0];
-        const newExpiry = match && match.headers.get('Expires');
-        log(matches.length === 1 && rasterTileExpiry !== newExpiry, 'Replaces expired raster tile with new version.');
-        done();
+    caches.open(CACHE_NAME).catch(catchError).then(cache => {
+        cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+            // check that the tile in the cache after the second map load is the same as after the
+            // first one. No new tile was loaded or cached.
+            const match = matches[0];
+            const newExpiry = match && match.headers.get('Expires');
+            log(matches.length === 1 && rasterTileExpiry !== newExpiry, 'Replaces expired raster tile with new version.' + matches.length + ' ' + newExpiry);
+            done();
+        });
     });
 }
 

--- a/debug/cache_api.html
+++ b/debug/cache_api.html
@@ -221,6 +221,7 @@ function testThirdView(done) {
 
     // wait 1 second to give the map a chance to evict from the cache
     setTimeout(() => {
+        caches.open(CACHE_NAME).catch(catchError).then(cache => {
         cache.keys().catch(catchError).then(keys => {
 
             // some tiles were evicted!
@@ -249,6 +250,7 @@ function testThirdView(done) {
 
             done();
         });
+        });
     }, 1000);
 }
 
@@ -264,13 +266,12 @@ function initializeRaster(done) {
 }
 
 
-const ratio = window.devicePixelRatio >= 2 ? '@2x' : '';
-const expectedRasterURL = 'https://api.mapbox.com/v4/mapbox.satellite/1/0/0' + ratio + '.webp';
+const expectedRasterURL = 'https://api.mapbox.com/v4/mapbox.satellite/1/0/0';
 let rasterTileExpiry;
 
 function testFirstRaster(done) {
     caches.open(CACHE_NAME).catch(catchError).then(cache => {
-        cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+        fuzzyMatchAll(cache, expectedRasterURL, matches => {
             const match = matches[0];
             rasterTileExpiry = match && match.headers.get('Expires');
             log(matches.length === 1, 'Caches raster tile.' + matches.length + ' ' + rasterTileExpiry);
@@ -281,7 +282,7 @@ function testFirstRaster(done) {
 
 function testSecondRaster(done) {
     caches.open(CACHE_NAME).catch(catchError).then(cache => {
-        cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+        fuzzyMatchAll(cache, expectedRasterURL, matches => {
             // check that the tile in the cache after the second map load is the same as after the
             // first one. No new tile was loaded or cached.
             const match = matches[0];
@@ -294,7 +295,7 @@ function testSecondRaster(done) {
 
 function testThirdRaster(done) {
     caches.open(CACHE_NAME).catch(catchError).then(cache => {
-        cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+        fuzzyMatchAll(cache, expectedRasterURL, matches => {
             // check that the tile in the cache after the second map load is the same as after the
             // first one. No new tile was loaded or cached.
             const match = matches[0];
@@ -302,6 +303,17 @@ function testThirdRaster(done) {
             log(matches.length === 1 && rasterTileExpiry !== newExpiry, 'Replaces expired raster tile with new version.' + matches.length + ' ' + newExpiry);
             done();
         });
+    });
+}
+
+function fuzzyMatchAll(cache, url, callback) {
+    cache.keys().catch(catchError).then(keys => {
+        for (const key of keys) {
+            if (key.url.indexOf(url) >= 0) {
+                return cache.matchAll(key.url).catch(catchError).then(callback);
+            }
+        }
+        return callback([]);
     });
 }
 

--- a/debug/cache_api.html
+++ b/debug/cache_api.html
@@ -222,34 +222,34 @@ function testThirdView(done) {
     // wait 1 second to give the map a chance to evict from the cache
     setTimeout(() => {
         caches.open(CACHE_NAME).catch(catchError).then(cache => {
-        cache.keys().catch(catchError).then(keys => {
+            cache.keys().catch(catchError).then(keys => {
 
-            // some tiles were evicted!
-            log(keys.length === 6, "Enforces cache size limit: keys.length = 6");
+                // some tiles were evicted!
+                log(keys.length === 6, "Enforces cache size limit: keys.length = 6");
 
-            // check that the cache entries are ordered in order of most least use
+                // check that the cache entries are ordered in order of most least use
 
-            [13, 13, 12, 12, 12, 12].forEach((z, i) => {
-                const correctZoom = keys[i].url.indexOf('/' + z + '/') > 0;
-                log(correctZoom, 'Maintains LRU order: cache entry ' + i + ' has correct zoom level (' + z + ')');
+                [13, 13, 12, 12, 12, 12].forEach((z, i) => {
+                    const correctZoom = keys[i].url.indexOf('/' + z + '/') > 0;
+                    log(correctZoom, 'Maintains LRU order: cache entry ' + i + ' has correct zoom level (' + z + ')');
+                });
+
+                // all the most recent tiles are in the cache
+                const expected = [
+                    "mapbox.mapbox-streets-v7/12/1171/1566.vector.pbf",
+                    "mapbox.mapbox-streets-v7/12/1171/1567.vector.pbf",
+                    "mapbox.mapbox-streets-v7/12/1172/1566.vector.pbf",
+                    "mapbox.mapbox-streets-v7/12/1172/1567.vector.pbf",
+                ];
+
+                for (const expect of expected) {
+                    log(matchURL(keys, expect), "Evicts correct tiles: still has " + expect);
+                }
+
+                checkNotCached(keys);
+
+                done();
             });
-
-            // all the most recent tiles are in the cache
-            const expected = [
-                "mapbox.mapbox-streets-v7/12/1171/1566.vector.pbf",
-                "mapbox.mapbox-streets-v7/12/1171/1567.vector.pbf",
-                "mapbox.mapbox-streets-v7/12/1172/1566.vector.pbf",
-                "mapbox.mapbox-streets-v7/12/1172/1567.vector.pbf",
-            ];
-
-            for (const expect of expected) {
-                log(matchURL(keys, expect), "Evicts correct tiles: still has " + expect);
-            }
-
-            checkNotCached(keys);
-
-            done();
-        });
         });
     }, 1000);
 }

--- a/debug/cache_api.html
+++ b/debug/cache_api.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { width: 500px; height: 500px; }
+    </style>
+</head>
+
+<body>
+<div id='log'>
+    <div id='result' style='background-color:#fec'>Result: running tests...</div>
+</div>
+<div id='map'></div>
+
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
+
+
+const CACHE_NAME = 'mapbox-tiles';
+let map;
+let cache;
+let numFail = 0;
+start(logResult);
+
+function log(pass, message) {
+    if (!pass) numFail++;
+    const div = document.createElement('div');
+    div.innerHTML = (pass ? 'PASS' : 'FAIL') + ' ' + message;
+    const log = document.getElementById('log');
+    log.appendChild(div);
+}
+
+function catchError(err) {
+    log(false, err);
+}
+
+function logResult() {
+    const r = document.getElementById('result');
+    if (numFail === 0) {
+        r.innerHTML = 'Result: SUCCESS. All tests passed';
+        r.style.backgroundColor = '#cfc';
+    } else {
+        r.innerHTML = 'Result: FAIL. ' + numFail + ' tests failed.';
+        r.style.backgroundColor = '#fcc';
+    }
+}
+
+
+
+async function start(done) {
+    cache = await caches.open(CACHE_NAME);
+    storageClearedTest(() => {
+        initialize(12.5, () => {
+            testFirstView(() => {
+                initialize(13, () => {
+                    testSecondView(() => {
+                        initialize(12.5, () => {
+                            testThirdView(() => {
+                                initializeRaster(() => {
+                                    testFirstRaster(() => {
+                                        initializeRaster(() => {
+
+                                            testSecondRaster(() => {
+                                                // move 10 days into the future
+                                                moveToFuture(1000 * 60 * 60 * 24 * 10);
+                                                initializeRaster(() => {
+                                                    testThirdRaster(() => {
+                                                        done();
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+}
+
+
+function storageClearedTest(callback) {
+    mapboxgl.clearStorage(function() {
+        const message = 'Clears cache storage.';
+        caches.open(CACHE_NAME).catch(catchError).then(cache_ => {
+            cache = cache_;
+            cache.keys().then(function(keys) {
+                log(keys.length === 0, message);
+                callback();
+            }).catch(catchError);
+        });
+    });
+}
+
+function initialize(zoom, onLoad) {
+    if (map) map.remove();
+    map = window.map = new mapboxgl.Map({
+        container: 'map',
+        zoom,
+        center: [-77.01866, 38.888],
+        style: 'mapbox://styles/mapbox/streets-v10',
+        interactive: false,
+        hash: false
+    });
+
+    map.on('style.load', function() {
+        // add traffic layer that shouldn't be cached because of short expiry
+        map.addLayer({
+            "id": "traffic",
+            "source": {
+                "url": "mapbox://mapbox.mapbox-traffic-v1",
+                "type": "vector"
+            },
+            "source-layer": "traffic",
+            "type": "line",
+            "paint": {
+                "line-width": 1.5,
+                "line-color": "red"
+            }
+        });
+
+        // add third party source that shouldn't be cached
+        map.addLayer({
+            "id": "mapillary",
+            "type": "line",
+            "source": {
+                "type": "vector",
+                "tiles": ["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"],
+                "minzoom": 6,
+                "maxzoom": 14
+            },
+            "source-layer": "mapillary-sequences",
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-opacity": 0.6,
+                "line-color": "rgb(53, 175, 109)",
+                "line-width": 2
+            }
+        });
+
+        map.on('load', onLoad);
+    });
+}
+
+function checkNotCached(keys) {
+    // check that no resources that shouldn't be cached are cached
+    const dontCache = ['traffic', 'style', 'fonts', 'd25uarhxywzl1j.cloudfront.net'];
+
+    for (const urlSubstring of dontCache) {
+        log(!matchURL(keys, urlSubstring), "Does not cache wrong resource: " + urlSubstring);
+    }
+}
+
+function testFirstView(done) {
+    cache.keys().catch(catchError).then(keys => {
+        log(keys.length === 4, "keys.length = 4");
+
+        // check for expected cache entries
+
+        const expected = [
+            "mapbox.mapbox-streets-v7/12/1171/1566.vector.pbf",
+            "mapbox.mapbox-streets-v7/12/1171/1567.vector.pbf",
+            "mapbox.mapbox-streets-v7/12/1172/1566.vector.pbf",
+            "mapbox.mapbox-streets-v7/12/1172/1567.vector.pbf",
+        ];
+
+        for (const expect of expected) {
+            log(matchURL(keys, expect), "Caches correct resource: " + expect);
+        }
+
+        checkNotCached(keys);
+
+        // lower cache limits so we can more easily test eviction
+        map._setCacheLimits(6, 0);
+
+        done();
+    });
+}
+
+function testSecondView(done) {
+    // wait 1 second to give the map a chance to evict from the cache
+    setTimeout(() => {
+        cache.keys().catch(catchError).then(keys => {
+
+            // some tiles were evicted!
+            log(keys.length === 6, "Enforces cache size limit: keys.length = 6");
+
+            // all the most recent tiles are in the cache
+            const expected = [
+                "mapbox.mapbox-streets-v7/13/2342/3133.vector.pbf",
+                "mapbox.mapbox-streets-v7/13/2342/3134.vector.pbf",
+                "mapbox.mapbox-streets-v7/13/2343/3133.vector.pbf",
+                "mapbox.mapbox-streets-v7/13/2343/3134.vector.pbf",
+            ];
+
+            for (const expect of expected) {
+                log(matchURL(keys, expect), "Evicts correct tiles: still has " + expect);
+            }
+
+            checkNotCached(keys);
+
+            done();
+        });
+    }, 1000);
+}
+
+function testThirdView(done) {
+
+    // wait 1 second to give the map a chance to evict from the cache
+    setTimeout(() => {
+        cache.keys().catch(catchError).then(keys => {
+
+            // some tiles were evicted!
+            log(keys.length === 6, "Enforces cache size limit: keys.length = 6");
+
+            // check that the cache entries are ordered in order of most least use
+
+            [13, 13, 12, 12, 12, 12].forEach((z, i) => {
+                const correctZoom = keys[i].url.indexOf('/' + z + '/') > 0;
+                log(correctZoom, 'Maintains LRU order: cache entry ' + i + ' has correct zoom level (' + z + ')');
+            });
+
+            // all the most recent tiles are in the cache
+            const expected = [
+                "mapbox.mapbox-streets-v7/12/1171/1566.vector.pbf",
+                "mapbox.mapbox-streets-v7/12/1171/1567.vector.pbf",
+                "mapbox.mapbox-streets-v7/12/1172/1566.vector.pbf",
+                "mapbox.mapbox-streets-v7/12/1172/1567.vector.pbf",
+            ];
+
+            for (const expect of expected) {
+                log(matchURL(keys, expect), "Evicts correct tiles: still has " + expect);
+            }
+
+            checkNotCached(keys);
+
+            done();
+        });
+    }, 1000);
+}
+
+function initializeRaster(done) {
+    if (map) map.remove();
+    map = new mapboxgl.Map({
+        container: 'map',
+        zoom: 0,
+        center: [137.9150899566626, 36.25956997955441],
+        style: 'mapbox://styles/mapbox/satellite-v9'
+    });
+    map.on('load', done);
+}
+
+
+const ratio = window.devicePixelRatio >= 2 ? '@2x' : '';
+const expectedRasterURL = 'https://api.mapbox.com/v4/mapbox.satellite/1/0/0' + ratio + '.webp';
+let rasterTileExpiry;
+
+function testFirstRaster(done) {
+    cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+        log(matches.length === 1, 'Caches raster tile.');
+        const match = matches[0];
+        rasterTileExpiry = match && match.headers.get('Expires');
+        done();
+    });
+}
+
+function testSecondRaster(done) {
+    cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+        // check that the tile in the cache after the second map load is the same as after the
+        // first one. No new tile was loaded or cached.
+        const match = matches[0];
+        const newExpiry = match && match.headers.get('Expires');
+        log(matches.length === 1 && rasterTileExpiry === newExpiry, 'Reuses cached raster tile without refetching.');
+        done();
+    });
+}
+
+function testThirdRaster(done) {
+    cache.matchAll(expectedRasterURL, { ignoreSearch: true }).catch(catchError).then(matches => {
+        // check that the tile in the cache after the second map load is the same as after the
+        // first one. No new tile was loaded or cached.
+        const match = matches[0];
+        const newExpiry = match && match.headers.get('Expires');
+        log(matches.length === 1 && rasterTileExpiry !== newExpiry, 'Replaces expired raster tile with new version.');
+        done();
+    });
+}
+
+function moveToFuture(skip) {
+    Date._now = Date.now;
+    Date.now = function () {
+        return this._now() + skip;
+    };
+}
+
+
+function matchURL(keys, s) {
+    for (const key of keys) {
+        if (key.url.indexOf(s) >= 0) return true;
+    }
+    return false;
+}
+
+
+</script>
+</body>
+</html>

--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -7,6 +7,7 @@ toc:
   - supported
   - version
   - setRTLTextPlugin
+  - clearStorage
   - AnimationOptions
   - CameraOptions
   - PaddingOptions

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,9 @@ const exported = {
      * Clears browser storage used by this library. Using this method flushes the tile
      * cache that is managed by this library. Tiles may still be cached by the browser
      * in some cases.
+     *
+     * @function clearStorage
+     * @param {Function} callback Called with an error argument if there is an error.
      */
     clearStorage(callback?: (err: ?Error) => void) {
         clearTileCache(callback);

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import {Evented} from './util/evented';
 import config from './util/config';
 import {setRTLTextPlugin} from './source/rtl_text_plugin';
 import WorkerPool from './util/worker_pool';
+import {clearTileCache} from './util/tile_request_cache';
 
 const exported = {
     version,
@@ -104,6 +105,15 @@ const exported = {
 
     set maxParallelImageRequests(numRequests: number) {
         config.MAX_PARALLEL_IMAGE_REQUESTS = numRequests;
+    },
+
+    /**
+     * Clears browser storage used by this library. Using this method flushes the tile
+     * cache that is managed by this library. Tiles may still be cached by the browser
+     * in some cases.
+     */
+    clearStorage(callback?: (err: ?Error) => void) {
+        clearTileCache(callback);
     },
 
     workerUrl: ''

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -9,6 +9,8 @@ import { postTurnstileEvent, postMapLoadEvent } from '../util/mapbox';
 import TileBounds from './tile_bounds';
 import Texture from '../render/texture';
 
+import { cacheEntryPossiblyAdded } from '../util/tile_request_cache';
+
 import type {Source} from './source';
 import type {OverscaledTileID} from './tile_id';
 import type Map from '../ui/map';
@@ -132,6 +134,8 @@ class RasterTileSource extends Evented implements Source {
                 }
 
                 tile.state = 'loaded';
+
+                cacheEntryPossiblyAdded(this.dispatcher);
 
                 callback(null);
             }

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -8,6 +8,7 @@ import { postTurnstileEvent, postMapLoadEvent } from '../util/mapbox';
 import TileBounds from './tile_bounds';
 import { ResourceType } from '../util/ajax';
 import browser from '../util/browser';
+import { cacheEntryPossiblyAdded } from '../util/tile_request_cache';
 
 import type {Source} from './source';
 import type {OverscaledTileID} from './tile_id';
@@ -142,6 +143,8 @@ class VectorTileSource extends Evented implements Source {
 
             if (this.map._refreshExpiredTiles && data) tile.setExpiryData(data);
             tile.loadVectorData(data, this.map.painter);
+
+            cacheEntryPossiblyAdded(this.dispatcher);
 
             callback(null);
 

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -42,7 +42,7 @@ export type LoadVectorData = (params: WorkerTileParameters, callback: LoadVector
  * @private
  */
 function loadVectorTile(params: WorkerTileParameters, callback: LoadVectorDataCallback) {
-    const request = getArrayBuffer(extend(params.request, { cacheIgnoringSearch: true }), (err: ?Error, data: ?ArrayBuffer, cacheControl: ?string, expires: ?string) => {
+    const request = getArrayBuffer(params.request, (err: ?Error, data: ?ArrayBuffer, cacheControl: ?string, expires: ?string) => {
         if (err) {
             callback(err);
         } else if (data) {

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -42,7 +42,7 @@ export type LoadVectorData = (params: WorkerTileParameters, callback: LoadVector
  * @private
  */
 function loadVectorTile(params: WorkerTileParameters, callback: LoadVectorDataCallback) {
-    const request = getArrayBuffer(params.request, (err: ?Error, data: ?ArrayBuffer, cacheControl: ?string, expires: ?string) => {
+    const request = getArrayBuffer(extend(params.request, { cacheIgnoringSearch: true }), (err: ?Error, data: ?ArrayBuffer, cacheControl: ?string, expires: ?string) => {
         if (err) {
             callback(err);
         } else if (data) {

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -8,6 +8,7 @@ import RasterDEMTileWorkerSource from './raster_dem_tile_worker_source';
 import GeoJSONWorkerSource from './geojson_worker_source';
 import assert from 'assert';
 import { plugin as globalRTLTextPlugin } from './rtl_text_plugin';
+import { enforceCacheSizeLimit } from '../util/tile_request_cache';
 
 import type {
     WorkerSource,
@@ -194,6 +195,10 @@ export default class Worker {
         }
 
         return this.demWorkerSources[mapId][source];
+    }
+
+    enforceCacheSizeLimit() {
+        enforceCacheSizeLimit();
     }
 }
 

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -197,8 +197,8 @@ export default class Worker {
         return this.demWorkerSources[mapId][source];
     }
 
-    enforceCacheSizeLimit() {
-        enforceCacheSizeLimit();
+    enforceCacheSizeLimit(mapId: string, limit: number) {
+        enforceCacheSizeLimit(limit);
     }
 }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -25,6 +25,7 @@ import { Event, ErrorEvent } from '../util/evented';
 import { MapMouseEvent } from './events';
 import TaskQueue from '../util/task_queue';
 import webpSupported from '../util/webp_supported';
+import { setCacheLimits } from '../util/tile_request_cache';
 
 import type {PointLike} from '@mapbox/point-geometry';
 import type { RequestTransformFunction } from '../util/mapbox';
@@ -1922,6 +1923,11 @@ class Map extends Camera {
     // show vertices
     get vertices(): boolean { return !!this._vertices; }
     set vertices(value: boolean) { this._vertices = value; this._update(); }
+
+    // for cache browser tests
+    _setCacheLimits(limit: number, checkThreshold: number) {
+        setCacheLimits(limit, checkThreshold);
+    }
 }
 
 export default Map;

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -130,6 +130,10 @@ function isMapboxHTTPURL(url: string): boolean {
     return mapboxHTTPURLRe.test(url);
 }
 
+function hasCacheDefeatingSku(url: string) {
+    return url.indexOf('sku=') > 0 && isMapboxHTTPURL(url);
+}
+
 const normalizeStyleURL = function(url: string, accessToken?: string): string {
     if (!isMapboxURL(url)) return url;
     const urlObject = parseUrl(url);
@@ -239,7 +243,7 @@ function formatUrl(obj: UrlObject): string {
     return `${obj.protocol}://${obj.authority}${obj.path}${params}`;
 }
 
-export { isMapboxURL, isMapboxHTTPURL };
+export { isMapboxURL, isMapboxHTTPURL, hasCacheDefeatingSku };
 
 const telemEventKey = 'mapbox.eventData';
 

--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -61,7 +61,11 @@ export function cacheGet(request: Request, callback: (error: ?any, response: ?Re
 
                     // Reinsert into cache so that order of keys in the cache is the order of access.
                     // This line makes the cache a LRU instead of a FIFO cache.
-                    if (fresh) cache.put(stripQueryParameters(request.url), response.clone());
+                    const strippedURL = stripQueryParameters(request.url);
+                    cache.delete(strippedURL);
+                    if (fresh) {
+                        cache.put(strippedURL, response.clone());
+                    }
 
                     callback(null, response, fresh);
                 });

--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -1,0 +1,95 @@
+// @flow
+
+import { parseCacheControl } from './util';
+import window from './window';
+
+const CACHE_NAME = 'mapbox-tiles';
+const CACHE_LIMIT = 50;
+
+export type ResponseOptions = {
+    status: number,
+    statusText: string,
+    headers: window.Headers
+};
+
+let numCached = 0;
+if (window.caches) {
+    window.caches.open(CACHE_NAME).then(cache => cache.keys().then(keys => numCached = keys.length));
+}
+
+export function cachePut(request, response, cacheHeaders, requestTime) {
+    if (!window.caches) return;
+    console.log('put');
+
+    const options: ResponseOptions = {
+        status: response.status,
+        statusText: response.statusText,
+        headers: new window.Headers()
+    };
+    response.headers.forEach((v, k) => options.headers.set(k, v));
+
+    const cacheControl = parseCacheControl(response.headers.get('Cache-Control') || '');
+    if (cacheControl['no-store']) {
+        return;
+    }
+    if (cacheControl['max-age']) {
+        options.headers.set('Expires', new Date(requestTime + cacheControl['max-age'] * 1000).toUTCString())
+        console.log(options.headers.get('Expires'));
+    }
+
+    const clonedResponse = new window.Response(response.clone().body, options);
+
+    window.caches.open(CACHE_NAME)
+        .then(cache => {
+            cache.put(request, clonedResponse).then(() => {
+                numCached++;
+                if (numCached > CACHE_LIMIT) trimCache();
+            });
+        });
+}
+
+export function cacheGet(request, callback) {
+    if (!window.caches) return callback(null);
+
+    window.caches.open(CACHE_NAME)
+        .catch(callback)
+        .then(cache => {
+            cache.match(request, { ignoreSearch: true })
+                .catch(callback)
+                .then(response => {
+                    const fresh = isFresh(response);
+
+                    // reinsert into cache so 
+                    if (fresh) cache.put(request, response.clone());
+
+                    callback(null, response, fresh);
+                });
+        });
+}
+
+
+
+function isFresh(response) {
+    if (!response) return false;
+    const expires = new Date(response.headers.get('Expires'));
+    const cacheControl = parseCacheControl(response.headers.get('Cache-Control') || '');
+    return expires > Date.now() && !cacheControl['no-cache'];
+}
+
+function trimCache() {
+    window.caches.open(CACHE_NAME)
+        .then(cache => {
+            cache.keys().then(keys => {
+                for (let i = 0; i < Math.min(numCached - CACHE_LIMIT, keys.length); i++) {
+                    cache.delete(keys[i]);
+                    numCached--;
+                }
+            })
+        });
+}
+
+export function clear(callback) {
+    window.caches.delete(CACHE_NAME)
+        .catch(callback)
+        .then(() => callback());
+}

--- a/test/unit/source/vector_tile_source.test.js
+++ b/test/unit/source/vector_tile_source.test.js
@@ -194,7 +194,7 @@ test('VectorTileSource', (t) => {
         const events = [];
         source.dispatcher.send = function(type, params, cb) {
             events.push(type);
-            setTimeout(cb, 0);
+            if (cb) setTimeout(cb, 0);
             return 1;
         };
 
@@ -212,7 +212,7 @@ test('VectorTileSource', (t) => {
                 source.loadTile(tile, () => {});
                 t.equal(tile.state, 'loading');
                 source.loadTile(tile, () => {
-                    t.same(events, ['loadTile', 'tileLoaded', 'reloadTile', 'tileLoaded']);
+                    t.same(events, ['loadTile', 'tileLoaded', 'enforceCacheSizeLimit', 'reloadTile', 'tileLoaded']);
                     t.end();
                 });
             }
@@ -282,6 +282,10 @@ test('VectorTileSource', (t) => {
             t.true(params.request.collectResourceTiming, 'collectResourceTiming is true on dispatcher message');
             setTimeout(cb, 0);
             t.end();
+
+            // do nothing for cache size check dispatch
+            source.dispatcher.send = function() {};
+
             return 1;
         };
 


### PR DESCRIPTION
The per-session token recently added to each tile request defeats the browser's caching. This adds caching that ignores the token using `Cache` interface.

- [x] push eviction improvements
- [x] write in-browser tests that can be run in all the browsers
- [ ] document challenges encountered and potential future improvements

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page