### PR TITLE
Include Hiragana and Katakana code blocks for local glyph generation

### DIFF
--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -123,8 +123,12 @@ class GlyphManager {
         if (!family) {
             return;
         }
-
-        if (!isChar['CJK Unified Ideographs'](id) && !isChar['Hangul Syllables'](id)) { // eslint-disable-line new-cap
+        /* eslint-disable new-cap */
+        if (!isChar['CJK Unified Ideographs'](id) &&
+            !isChar['Hangul Syllables'](id) &&
+            !isChar['Hiragana'](id) &&
+            !isChar['Katakana'](id)
+        ) { /* eslint-enable new-cap */
             return;
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -202,7 +202,7 @@ const defaultOptions = {
  * @param {boolean} [options.renderWorldCopies=true]  If `true`, multiple copies of the world will be rendered, when zoomed out.
  * @param {number} [options.maxTileCacheSize=null]  The maximum number of tiles stored in the tile cache for a given source. If omitted, the cache will be dynamically sized based on the current viewport.
  * @param {string} [options.localIdeographFontFamily='sans-serif'] Defines a CSS
- *   font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs' and 'Hangul Syllables' ranges.
+ *   font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs', 'Hiragana', 'Katakana' and 'Hangul Syllables' ranges.
  *   In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
  *   Set to `false`, to enable font settings from the map's style for these glyph ranges.
  *   The purpose of this option is to avoid bandwidth-intensive glyph server requests. (see [Use locally generated ideographs](https://www.mapbox.com/mapbox-gl-js/example/local-ideographs))
@@ -950,7 +950,7 @@ class Map extends Camera {
      * @param {boolean} [options.diff=true] If false, force a 'full' update, removing the current style
      *   and building the given one instead of attempting a diff-based update.
      * @param {string} [options.localIdeographFontFamily='sans-serif'] Defines a CSS
-     *   font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs' and 'Hangul Syllables' ranges.
+     *   font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs', 'Hiragana', 'Katakana' and 'Hangul Syllables' ranges.
      *   In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
      *   Set to `false`, to enable font settings from the map's style for these glyph ranges.
      *   Forces a full update.

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -60,3 +60,41 @@ test('GlyphManager generates CJK PBF locally', (t) => {
         t.end();
     });
 });
+
+test('GlyphManager generates Katakana PBF locally', (t) => {
+    t.stub(GlyphManager, 'TinySDF').value(class {
+        // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
+        draw() {
+            return new Uint8ClampedArray(900);
+        }
+    });
+
+    const manager = new GlyphManager((url) => ({url}), 'sans-serif');
+    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+
+    // Katakana letter te
+    manager.getGlyphs({'Arial Unicode MS': [0x30c6]}, (err, glyphs) => {
+        t.ifError(err);
+        t.equal(glyphs['Arial Unicode MS'][0x30c6].metrics.advance, 24);
+        t.end();
+    });
+});
+
+test('GlyphManager generates Hiragana PBF locally', (t) => {
+    t.stub(GlyphManager, 'TinySDF').value(class {
+        // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
+        draw() {
+            return new Uint8ClampedArray(900);
+        }
+    });
+
+    const manager = new GlyphManager((url) => ({url}), 'sans-serif');
+    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+
+    //Hiragana letter te
+    manager.getGlyphs({'Arial Unicode MS': [0x3066]}, (err, glyphs) => {
+        t.ifError(err);
+        t.equal(glyphs['Arial Unicode MS'][0x3066].metrics.advance, 24);
+        t.end();
+    });
+});


### PR DESCRIPTION
This PR adds support for locally generating glyphs in the Hiragana and Katakana code blocks. This allows layers with mixed japaense syllabary to be able to use a single font. Without this change - kanji would use the locally generated glyphs but hiragana and katakana would use glyphs based on the style. 

The `localIdeographFontFamily` map option that is used to control this behavior is now not the best name given that Hiragana and Katakana are not ideographic. The name should be changed in a future API breaking release.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - ~[ ] post benchmark scores~
 - [x] manually test the debug page
 - [x] tagged @mapbox/studio and/or @mapbox/maps-design if this PR includes style spec changes
 - [x] tagged @mapbox/gl-native  if this PR includes shader changes or needs a native port

cc @1ec5 @chloekraw @tristen 