### PR TITLE
The diff module does not have default export, import all diff exports

### DIFF
--- a/test/integration/lib/expression.js
+++ b/test/integration/lib/expression.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import diff from 'diff';
+import * as diff from 'diff';
 import fs from 'fs';
 import harness from './harness';
 import compactStringify from 'json-stringify-pretty-compact';

--- a/test/integration/lib/query.js
+++ b/test/integration/lib/query.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import diff from 'diff';
+import * as diff from 'diff';
 import {PNG} from 'pngjs';
 import harness from './harness';
 


### PR DESCRIPTION
The new diff module 4.0.1 does not have default exports, comparing to old version that was used. This introduces issues while query and expression tests are executed for gl-native project that uses gl-js testing infrastructure.

This PR introduces change that imports all diff exports under diff scope.