### PR TITLE
document the tile size drawn with showTileBoundaries

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1843,7 +1843,11 @@ class Map extends Camera {
 
     /**
      * Gets and sets a Boolean indicating whether the map will render an outline
-     * around each tile. These tile boundaries are useful for debugging.
+     * around each tile and the tile ID. These tile boundaries are useful for
+     * debugging.
+     *
+     * The uncompressed file size of the first vector source is drawn in the top left
+     * corner of each tile, next to the tile ID.
      *
      * @name showTileBoundaries
      * @type {boolean}


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

closes #8376 by documenting the tile size drawn with showTileBoundaries. This is easy to roll out now, and we can change this later if https://github.com/mapbox/mapbox-gl-js/issues/8376#issuecomment-504617066 is implemented.

@tristen would this address your concerns in #8376 ?
