### PR TITLE
fix cache support check when enforcing size limit

### DIFF
--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -101,6 +101,7 @@ export function cacheEntryPossiblyAdded(dispatcher: Dispatcher) {
 
 // runs on worker, see above comment
 export function enforceCacheSizeLimit(limit: number) {
+    if (!window.caches) return;
     window.caches.open(CACHE_NAME)
         .then(cache => {
             cache.keys().then(keys => {


### PR DESCRIPTION
This was throwing errors in browsers that don't support the cache api but wasn't previously noticed because it was not breaking anything.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page