### PR TITLE
link to integration tests README from test README

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -12,9 +12,13 @@ There are two test suites associated with Mapbox GL JS
 
  To run individual tests:
 
- - Unit tests: `yarn test-unit path/to/file.test.js` where path *does not include* `test/unit/` 
+ - Unit tests: `yarn test-unit path/to/file.test.js` where path *does not include* `test/unit/`
    - e.g. `yarn test-unit ui/handler/scroll_zoom.test.js`
  - Render tests: `yarn test-render render-test-name` (e.g. `yarn test-render background-color/default`)
+
+## Integration Tests
+
+See [`test/integration/README.md`](https://github.com/mapbox/mapbox-gl-js/blob/master/test/integration/README.md).
 
 ## Writing Unit Tests
 


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

There is a very helpful documentation on the integration tests at https://github.com/mapbox/mapbox-gl-js/blob/master/test/integration/README.md but since it's not linked to from anywhere it makes it harder for new contributors to find.

This PR, add's a link to it from the higher level test README, so that it can be discovered more easily.
