### PR TITLE
fix #8411, fetch in case of cache error

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -111,7 +111,11 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
 
     const validateOrFetch = (err, cachedResponse, responseIsFresh) => {
         if (err) {
-            return callback(err);
+            // Do fetch in case of cache error.
+            // HTTP pages in Edge trigger a security error that can be ignored.
+            if (err.message !== 'SecurityError') {
+                console.warn(err);
+            }
         }
 
         if (cachedResponse && responseIsFresh) {

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -1,7 +1,7 @@
 // @flow
 
 import window from './window';
-import { extend } from './util';
+import { extend, warnOnce } from './util';
 import { isMapboxHTTPURL, hasCacheDefeatingSku } from './mapbox';
 import config from './config';
 import assert from 'assert';
@@ -114,7 +114,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
             // Do fetch in case of cache error.
             // HTTP pages in Edge trigger a security error that can be ignored.
             if (err.message !== 'SecurityError') {
-                console.warn(err);
+                warnOnce(err);
             }
         }
 


### PR DESCRIPTION
Fixes #8411 . Edge calls back with a cache error in http pages. This silences that error and fetches for all cache error cases.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
