### PR TITLE
Make requirements for text offset props more precise

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1815,10 +1815,7 @@
         }
       },
       "requires": [
-        "text-field",
-        {
-          "!" : "text-offset"
-        }
+        "text-field"
       ],
       "property-type": "data-driven",
       "expression": {
@@ -1863,12 +1860,6 @@
       },
       "requires": [
         "text-field",
-        {
-          "!": "text-anchor"
-        },
-        {
-          "!": "text-offset"
-        },
         {
             "symbol-placement": [
                 "point"

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1815,6 +1815,7 @@
         }
       },
       "requires": [
+        "text-field",
         {
           "!" : "text-offset"
         }
@@ -1861,6 +1862,7 @@
         }
       },
       "requires": [
+        "text-field",
         {
           "!": "text-anchor"
         },
@@ -1898,9 +1900,6 @@
     },
     "text-anchor": {
       "type": "enum",
-      "requires": {
-        "!": "text-variable-anchor"
-      },
       "values": {
         "center": {
           "doc": "The center of the text is placed closest to the anchor."
@@ -1933,7 +1932,10 @@
       "default": "center",
       "doc": "Part of the text placed closest to the anchor.",
       "requires": [
-        "text-field"
+        "text-field",
+        {
+          "!": "text-variable-anchor"
+        }
       ],
       "sdk-support": {
         "basic functionality": {
@@ -2135,6 +2137,9 @@
         "text-field",
         {
             "!": "text-radial-offset"
+        },
+        {
+            "!": "text-variable-anchor"
         }
       ],
       "sdk-support": {


### PR DESCRIPTION
This PR partially addresses #8410.

- Adds `text-field` requirement to `text-radial-offset` and `text-variable-anchor`.
- Adds `!: text-variable-anchor` requirement to `text-offset`.
- Merges a duplicate `requires` field on `text-anchor`.

cc @mapbox/studio 