### PR TITLE
Enable combinations/fill-extrusion-translucent--background-opaque

### DIFF
--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -27,7 +27,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
     const image = layer.paint.get('background-pattern');
     if (painter.isPatternMissing(image)) return;
 
-    const pass = (!image && color.a === 1 && opacity === 1) ? 'opaque' : 'translucent';
+    const pass = (!image && color.a === 1 && opacity === 1 && painter.opaquePassEnabledForLayer()) ? 'opaque' : 'translucent';
     if (painter.renderPass !== pass) return;
 
     const stencilMode = StencilMode.disabled;

--- a/test/ignores.json
+++ b/test/ignores.json
@@ -1,7 +1,5 @@
 {
   "query-tests/regressions/mapbox-gl-js#4494": "https://github.com/mapbox/mapbox-gl-js/issues/2716",
-  "render-tests/combinations/fill-extrusion-translucent--background-opaque": "https://github.com/mapbox/mapbox-gl-js/issues/5831",
-  "render-tests/combinations/fill-extrusion-translucent--fill-opaque": "https://github.com/mapbox/mapbox-gl-js/issues/5831",
   "render-tests/geojson/inline-linestring-fill": "current behavior is arbitrary",
   "render-tests/map-mode/static": "https://github.com/mapbox/mapbox-gl-js/issues/5649",
   "render-tests/map-mode/tile": "skip - mapbox-gl-js does not need to render tiles",


### PR DESCRIPTION
and combinations/fill-extrusion-translucent--fill-opaque tests.

combinations/fill-extrusion-translucent--fill-opaque was already passing, but ignored.
Copied the approach from fill-opaque rendering to background.

Related to #5831