### PR TITLE
Add outline for control buttons while navigating with keyboard

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -75,7 +75,6 @@
 
 .mapboxgl-ctrl-group {
     border-radius: 4px;
-    overflow: hidden;
     background: #fff;
 }
 
@@ -90,7 +89,6 @@
     height: 30px;
     display: block;
     padding: 0;
-    outline: none;
     border: 0;
     box-sizing: border-box;
     background-color: transparent;


### PR DESCRIPTION
This PR solves issue #8246.

If you have some controls on the map (like zoom controls) and you navigate to them with Tab button you couldn't distinguish what button is focused now. This PR adds back an outline for buttons to show what control is focused.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
