### PR TITLE
Add check for startPos to fix #7864

### DIFF
--- a/src/ui/bind_handlers.js
+++ b/src/ui/bind_handlers.js
@@ -152,7 +152,7 @@ export default function bindHandlers(map: Map, options: {interactive: boolean, c
 
     function onClick(e: MouseEvent) {
         const pos = DOM.mousePos(el, e);
-        if (pos.equals(startPos) || pos.dist(startPos) < options.clickTolerance) {
+        if (!startPos || pos.equals(startPos) || pos.dist(startPos) < options.clickTolerance) {
             map.fire(new MapMouseEvent('click', map, e));
         }
     }

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -1,6 +1,6 @@
 import { test } from '../../util/test';
 import { createMap } from '../../util';
-import simulate from '../../util/simulate_interaction';
+import simulate, { window } from '../../util/simulate_interaction';
 
 test('Map#on adds a non-delegated event listener', (t) => {
     const map = createMap(t);
@@ -581,6 +581,22 @@ test(`Map#on mousedown does not fire subsequent click event if mouse position ch
 
     simulate.drag(canvas, {clientX: 100, clientY: 100}, {clientX: 100, clientY: 104});
     t.ok(click.notCalled);
+
+    map.remove();
+    t.end();
+});
+
+test(`Map#on click fires subsequent click event if there is no corresponding mousedown/mouseup event`, (t) => {
+    const map = createMap(t, { clickTolerance: 4 });
+
+    const click = t.spy();
+    map.on('click', click);
+    const canvas = map.getCanvas();
+
+    const MouseEvent = window(canvas).MouseEvent;
+    const event = new MouseEvent('click', {bubbles: true, clientX: 100, clientY: 100});
+    canvas.dispatchEvent(event);
+    t.ok(click.called);
 
     map.remove();
     t.end();

--- a/test/util/simulate_interaction.js
+++ b/test/util/simulate_interaction.js
@@ -1,5 +1,5 @@
 
-function window(target) {
+export function window(target) {
     if (target.ownerDocument) {
         return target.ownerDocument.defaultView;
     } else if (target.defaultView) {


### PR DESCRIPTION
Add check for `startPos` to fix #7864.

This falls back to ignoring click tolerance and just firing the click event in the case where startPos is not defined. I've been running with it in production for a few months and have not seen the error since then.