### PR TITLE
Turn off 'move' event listeners when removing a marker

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -228,6 +228,8 @@ export default class Marker extends Evented {
             this._map.off('touchstart', this._addDragHandler);
             this._map.off('mouseup', this._onUp);
             this._map.off('touchend', this._onUp);
+            this._map.off('mousemove', this._onMove);
+            this._map.off('touchmove', this._onMove);
             delete this._map;
         }
         DOM.remove(this._element);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->
fixes #8463 

 - [x] briefly describe the changes in this PR
    - it's currently possible to programmatically remove a marker while dragging it which leads to an error because the `_onMove` event listener is never removed. This fixes that bug.