### PR TITLE
baseApiUrl w/ path & normalizeTileURL functionality

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -110,6 +110,7 @@ export class RequestManager {
 
         const urlObject = parseUrl(tileURL);
         const imageExtensionRe = /(\.(png|jpg)\d*)(?=$)/;
+        const tileURLAPIPrefixRe = /^.+\/v4\//;
 
         // The v4 mapbox tile API supports 512x512 image tiles only when @2x
         // is appended to the tile URL. If `tileSize: 512` is specified for
@@ -117,6 +118,7 @@ export class RequestManager {
         const suffix = browser.devicePixelRatio >= 2 || tileSize === 512 ? '@2x' : '';
         const extension = webpSupported.supported ? '.webp' : '$1';
         urlObject.path = urlObject.path.replace(imageExtensionRe, `${suffix}${extension}`);
+        urlObject.path = urlObject.path.replace(tileURLAPIPrefixRe, '/');
         urlObject.path = `/v4${urlObject.path}`;
 
         if (config.REQUIRE_ACCESS_TOKEN && (config.ACCESS_TOKEN || this._customAccessToken) && this._skuToken) {
@@ -176,6 +178,7 @@ export class RequestManager {
         if (accessToken[0] === 's')
             throw new Error(`Use a public access token (pk.*) with Mapbox GL, not a secret access token (sk.*). ${help}`);
 
+        urlObject.params = urlObject.params.filter((d) => !d.includes('access_token'));
         urlObject.params.push(`access_token=${accessToken}`);
         return formatUrl(urlObject);
     }

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -357,6 +357,15 @@ test("mapbox", (t) => {
                 t.end();
             });
 
+            t.test('.normalizeTileURL ignores non-mapbox:// sources', (t) => {
+                // Add a path to the config:
+                config.API_URL = 'http://localhost:8080/mbx';
+                const input    = `https://localhost:8080/mbx/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7/10/184/401.vector.pbf?access_token=${config.ACCESS_TOKEN}`;
+                const expected =  `http://localhost:8080/mbx/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7/10/184/401.vector.pbf?sku=${manager._skuToken}&access_token=${config.ACCESS_TOKEN}`;
+                t.equal(manager.normalizeTileURL(input, 'mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7'), expected);
+                t.end();
+            });
+
             t.test('.normalizeTileURL ignores undefined sources', (t) => {
                 t.equal(manager.normalizeTileURL('http://path.png'), 'http://path.png');
                 t.end();

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -357,7 +357,7 @@ test("mapbox", (t) => {
                 t.end();
             });
 
-            t.test('.normalizeTileURL ignores non-mapbox:// sources', (t) => {
+            t.test('.normalizeTileURL accounts for tileURLs w/ paths', (t) => {
                 // Add a path to the config:
                 config.API_URL = 'http://localhost:8080/mbx';
                 const input    = `https://localhost:8080/mbx/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7/10/184/401.vector.pbf?access_token=${config.ACCESS_TOKEN}`;


### PR DESCRIPTION
- adds regex to trim tileURL prefix to /v4/...
- adds filter to makeAPIURL preventing duplication of param 'access_token'
- adds test for edge case

closes #8458

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
