### PR TITLE
fix race condition between caching and aborting

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -102,6 +102,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
         signal: controller.signal
     });
     let complete = false;
+    let aborted = false;
 
     const cacheIgnoringSearch = hasCacheDefeatingSku(request.url);
 
@@ -110,6 +111,8 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
     }
 
     const validateOrFetch = (err, cachedResponse, responseIsFresh) => {
+        if (aborted) return;
+
         if (err) {
             // Do fetch in case of cache error.
             // HTTP pages in Edge trigger a security error that can be ignored.
@@ -152,6 +155,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
             requestParameters.type === 'json' ? response.json() :
             response.text()
         ).then(result => {
+            if (aborted) return;
             if (cacheableResponse && requestTime) {
                 // The response needs to be inserted into the cache after it has completely loaded.
                 // Until it is fully loaded there is a chance it will be aborted. Aborting while
@@ -172,6 +176,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
     }
 
     return { cancel: () => {
+        aborted = true;
         if (!complete) controller.abort();
     }};
 }


### PR DESCRIPTION
If a request was aborted while it was checking the cache the request would still complete leading to a parsed tile that would never get cleared. The fix is to not call back when the request is aborted.

fix #8470

Any idea if I should / how I could add a test for this?

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page