### PR TITLE
set custom layers and extrusion examples to use antialias: true

### DIFF
--- a/docs/pages/example/3d-buildings.html
+++ b/docs/pages/example/3d-buildings.html
@@ -6,7 +6,8 @@ var map = new mapboxgl.Map({
     zoom: 15.5,
     pitch: 45,
     bearing: -17.6,
-    container: 'map'
+    container: 'map',
+    antialias: true
 });
 
 // The 'building' layer in the mapbox-streets vector source contains building-height

--- a/docs/pages/example/3d-extrusion-floorplan.html
+++ b/docs/pages/example/3d-extrusion-floorplan.html
@@ -6,7 +6,8 @@ var map = new mapboxgl.Map({
     center: [-87.61694, 41.86625],
     zoom: 15.99,
     pitch: 40,
-    bearing: 20
+    bearing: 20,
+    antialias: true
 });
 
 map.on('load', function() {

--- a/docs/pages/example/add-3d-model.html
+++ b/docs/pages/example/add-3d-model.html
@@ -1,5 +1,5 @@
-<script src='https://unpkg.com/three@0.102.0/build/three.min.js'></script>
-<script src="https://unpkg.com/three@0.102.0/examples/js/loaders/GLTFLoader.js"></script>
+<script src='https://unpkg.com/three@0.106.2/build/three.min.js'></script>
+<script src="https://unpkg.com/three@0.106.2/examples/js/loaders/GLTFLoader.js"></script>
 <div id='map'></div>
 <script>
 var map = window.map = new mapboxgl.Map({
@@ -7,7 +7,8 @@ var map = window.map = new mapboxgl.Map({
     style: 'mapbox://styles/mapbox/light-v10',
     zoom: 17.5,
     center: [148.9819, -35.3981],
-    pitch: 60
+    pitch: 60,
+    antialias: true // create the gl context with MSAA antialiasing, so custom layers are antialiased
 });
 
 // parameters to ensure the model is georeferenced correctly on the map
@@ -57,7 +58,8 @@ var customLayer = {
         // use the Mapbox GL JS map canvas for three.js
         this.renderer = new THREE.WebGLRenderer({
             canvas: map.getCanvas(),
-            context: gl
+            context: gl,
+            antialias: true
         });
 
         this.renderer.autoClear = false;

--- a/docs/pages/example/custom-style-layer.html
+++ b/docs/pages/example/custom-style-layer.html
@@ -4,7 +4,8 @@ var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 3,
     center: [7.5, 58],
-    style: 'mapbox://styles/mapbox/light-v10'
+    style: 'mapbox://styles/mapbox/light-v10',
+    antialias: true // create the gl context with MSAA antialiasing, so custom layers are antialiased
 });
 
 

--- a/docs/pages/example/dancing-buildings.html
+++ b/docs/pages/example/dancing-buildings.html
@@ -12,7 +12,8 @@ var map = new mapboxgl.Map({
     },
     zoom: 15,
     pitch: 55,
-    container: 'map'
+    container: 'map',
+    antialias: true
 });
 
 map.addControl(new mapboxgl.FullscreenControl());


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

#7821 added the antialias option, but since it defaults to false, this PR sets it to true for a few examples which benefit from it, specifically for:

- https://docs.mapbox.com/mapbox-gl-js/example/add-3d-model/
- https://docs.mapbox.com/mapbox-gl-js/example/custom-style-layer/
- https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/
- https://docs.mapbox.com/mapbox-gl-js/example/dancing-buildings/
- https://docs.mapbox.com/mapbox-gl-js/example/3d-extrusion-floorplan/

Although it may have a performance cost, I think on by default is a better choice given how much nicer it looks and that most people copy paste examples without digging into all the options from the API docs.

### before
![Screenshot from 2019-07-13 17-02-48](https://user-images.githubusercontent.com/117278/61168374-b01bdb00-a590-11e9-904f-515ebf4e1874.png)

### after
![Screenshot from 2019-07-13 17-02-40](https://user-images.githubusercontent.com/117278/61168375-b01bdb00-a590-11e9-8aeb-d7466806fb8b.png)

### before
![Screenshot from 2019-07-13 17-02-08](https://user-images.githubusercontent.com/117278/61168377-b0b47180-a590-11e9-8dcb-f7949497f682.png)

### after
![Screenshot from 2019-07-13 17-02-23](https://user-images.githubusercontent.com/117278/61168376-b0b47180-a590-11e9-9297-140eacafec23.png)
