### PR TITLE
Fix extent warning and clamp exceeding coords

### DIFF
--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { warnOnce } from '../util/util';
+import { warnOnce, clamp } from '../util/util';
 
 import EXTENT from './extent';
 
@@ -17,7 +17,7 @@ function createBounds(bits) {
     };
 }
 
-const bounds = createBounds(16);
+const bounds = createBounds(15);
 
 /**
  * Loads a geometry from a VectorTileFeature and scales it to the common extent
@@ -39,6 +39,8 @@ export default function loadGeometry(feature: VectorTileFeature): Array<Array<Po
 
             if (point.x < bounds.min || point.x > bounds.max || point.y < bounds.min || point.y > bounds.max) {
                 warnOnce('Geometry exceeds allowed extent, reduce your vector tile buffer size');
+                point.x = clamp(point.x, bounds.min, bounds.max);
+                point.y = clamp(point.y, bounds.min, bounds.max);
             }
         }
     }

--- a/test/unit/data/load_geometry.test.js
+++ b/test/unit/data/load_geometry.test.js
@@ -17,9 +17,9 @@ test('loadGeometry', (t) => {
     t.end();
 });
 
-test('loadGeometry extent error', (t) => {
+test('loadGeometry warns and clamps when exceeding extent', (t) => {
     const feature = vt.layers.road.feature(0);
-    feature.extent = 1024;
+    feature.extent = 2048;
 
     let numWarnings = 0;
 
@@ -31,9 +31,17 @@ test('loadGeometry extent error', (t) => {
         }
     };
 
-    loadGeometry(feature);
+    const lines = loadGeometry(feature);
 
     t.equal(numWarnings, 1);
+
+    let maxValue = -Infinity;
+    for (const line of lines) {
+        for (const {x, y} of line) {
+            maxValue = Math.max(x, y, maxValue);
+        }
+    }
+    t.equal(maxValue, 16383);
 
     // Put it back
     console.warn = warn;


### PR DESCRIPTION
Closes #8477:

- Fixes the extent warning, for which the threshold wasn't updated to reflect #8306 (we only have 15 bits for the coordinates again).
- Clamps the coordinates that exceed allowed extent so that when this does happen, it's unlikely to cause any artifacts.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~ no changes
 - [ ] ~~post benchmark scores~~ not necessary
 - [x] manually test the debug page
