### PR TITLE
swap map-tiles example to use https

### DIFF
--- a/docs/pages/example/map-tiles.html
+++ b/docs/pages/example/map-tiles.html
@@ -7,7 +7,7 @@ var map = new mapboxgl.Map({
         "sources": {
             "raster-tiles": {
                 "type": "raster",
-                "tiles": ["http://tile.stamen.com/watercolor/{z}/{x}/{y}.jpg"],
+                "tiles": ["https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg"],
                 "tileSize": 256,
                 "attribution": 'Map tiles by <a target="_top" rel="noopener" href="http://stamen.com">Stamen Design</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a target="_top" rel="noopener" href="http://openstreetmap.org">OpenStreetMap</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
             }


### PR DESCRIPTION
## Launch Checklist

#8398 reported that https://docs.mapbox.com/mapbox-gl-js/example/map-tiles/ is broken, this PR fixes the mixed content issue by upgrading the tiles to HTTPS.