### PR TITLE
fix #8481, unbounded memory growth in IE

### DIFF
--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -56,12 +56,16 @@ class Actor {
         }, buffers);
         if (callback) {
             return {
-                cancel: () => this.target.postMessage({
-                    targetMapId,
-                    sourceMapId: this.mapId,
-                    type: '<cancel>',
-                    id: String(id)
-                })
+                cancel: () => {
+                    // Set the callback to null so that it never fires after the request is aborted.
+                    this.callbacks[id] = null;
+                    this.target.postMessage({
+                        targetMapId,
+                        sourceMapId: this.mapId,
+                        type: '<cancel>',
+                        id: String(id)
+                    });
+                }
             };
         }
     }


### PR DESCRIPTION
Cancellable requests to workers should never call back after they have been cancelled.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page