### PR TITLE
[style-spec] expose convertFilter API

### DIFF
--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -68,6 +68,7 @@ import ValidationError from './error/validation_error';
 import ParsingError from './error/parsing_error';
 import { StyleExpression, isExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction } from './expression';
 import featureFilter from './feature_filter';
+import convertFilter from './feature_filter/convert';
 import Color from './util/color';
 import { createFunction, isFunction } from './function';
 import convertFunction from './function/convert';
@@ -105,6 +106,7 @@ export {
     ParsingError,
     expression,
     featureFilter,
+    convertFilter,
     Color,
     styleFunction as function,
     validate,


### PR DESCRIPTION
This PR exposes the `convertFilter` at https://github.com/mapbox/mapbox-gl-js/blob/b5c90201dc2653ca4672ab8ffd06ad62221803f5/src/style-spec/feature_filter/convert.js#L14

I need this exposed to be able to auto-upgrade legacy filters in a downstream module that uses `require('@mapbox/mapbox-gl-style-spec')`

The larger context is that I need to combine multiple filters into one array to pass them to gl-native. However gl-native cannot cope with mixing legacy filters and new style expressions. Previously it crashed and now it throws (https://github.com/mapbox/mapbox-gl-native/pull/12065). But ideally, through auto-upgrading using this newly exposed function, I can avoid gl-native throwing.

Thanks @samanpwbb and `@mapbox/studio` for recommending this fix.
