### PR TITLE
fix class toggling on control for IE

### DIFF
--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -72,12 +72,16 @@ class NavigationControl {
 
     _updateZoomButtons() {
         const zoom = this._map.getZoom();
-        zoom === this._map.getMaxZoom() ?
-            this._zoomInButton.classList.add('mapboxgl-ctrl-icon-disabled') :
+        if (zoom === this._map.getMaxZoom()) {
+            this._zoomInButton.classList.add('mapboxgl-ctrl-icon-disabled');
+        } else {
             this._zoomInButton.classList.remove('mapboxgl-ctrl-icon-disabled');
-        zoom === this._map.getMinZoom() ?
-            this._zoomOutButton.classList.add('mapboxgl-ctrl-icon-disabled') :
+        }
+        if (zoom === this._map.getMinZoom()) {
+            this._zoomOutButton.classList.add('mapboxgl-ctrl-icon-disabled');
+        } else {
             this._zoomOutButton.classList.remove('mapboxgl-ctrl-icon-disabled');
+        }
     }
 
     _rotateCompassArrow() {

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -72,8 +72,12 @@ class NavigationControl {
 
     _updateZoomButtons() {
         const zoom = this._map.getZoom();
-        this._zoomInButton.classList.toggle('mapboxgl-ctrl-icon-disabled', zoom === this._map.getMaxZoom());
-        this._zoomOutButton.classList.toggle('mapboxgl-ctrl-icon-disabled', zoom === this._map.getMinZoom());
+        zoom === this._map.getMaxZoom() ?
+            this._zoomInButton.classList.add('mapboxgl-ctrl-icon-disabled') :
+            this._zoomInButton.classList.remove('mapboxgl-ctrl-icon-disabled');
+        zoom === this._map.getMinZoom() ?
+            this._zoomOutButton.classList.add('mapboxgl-ctrl-icon-disabled') :
+            this._zoomOutButton.classList.remove('mapboxgl-ctrl-icon-disabled');
     }
 
     _rotateCompassArrow() {


### PR DESCRIPTION
The second argument of `classList.toggle` is not supported in IE.
So, the control displays as disabled in IE at default.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11865865/

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR