### PR TITLE
Fix SDK support section of symbol-sort-key docs

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -966,7 +966,13 @@
       "type": "number",
       "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key when they overlap. Features with a lower sort key will have priority over other features when doing placement.",
       "sdk-support": {
-          "js": "0.53.0"
+        "basic functionality": {
+          "js": "0.53.0",
+          "android": "7.4.0",
+          "ios": "5.1.0",
+          "macos": "0.14.0"
+        },
+        "data-driven styling": {}
       },
       "expression": {
         "interpolated": false,

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -969,7 +969,7 @@
         "basic functionality": {
           "js": "0.53.0",
           "android": "7.4.0",
-          "ios": "5.1.0",
+          "ios": "4.11.0",
           "macos": "0.14.0"
         },
         "data-driven styling": {}


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js/issues/8488

This PR adds the SDK support section docs for the `symbol-sort-key` property. 

- JS: https://github.com/mapbox/mapbox-gl-js/commits/v0.53.0
  - This was added in JS in https://github.com/mapbox/mapbox-gl-js/pull/7678, merged on Dec. 12. It was the same day as the 0.52-beta but it must've missed branch cut: https://github.com/mapbox/mapbox-gl-js/commits/v0.52.0
- iOS 4.11: https://github.com/mapbox/mapbox-gl-native/commits/ios-v4.11.0
- Android 7.4: https://github.com/mapbox/mapbox-gl-native/commits/android-v7.4.0
  - This was added in core in https://github.com/mapbox/mapbox-gl-native/pull/14386, merged on April 17, so it was released in `mojito`.

I couldn't get past the `@mapbox/appropriate-images` error to run the docs server locally 😢

Merging into master because these properties are already released.
