### PR TITLE
set further near plane to fix depth precision for deckgl

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -537,9 +537,18 @@ class Transform {
         // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
         const farZ = furthestDistance * 1.01;
 
+        // The larger the value of nearZ is
+        // - the more depth precision is available for features (good)
+        // - clipping starts appearing sooner when the camera is close to 3d features (bad)
+        //
+        // Smaller values worked well for mapbox-gl-js but deckgl was encountering precision issues
+        // when rendering it's layers using custom layers. This value was experimentally chosen and
+        // seems to solve z-fighting issues in deckgl while not clipping buildings too close to the camera.
+        const nearZ = this.height / 50;
+
         // matrix for conversion from location to GL coordinates (-1 .. 1)
         let m = new Float64Array(16);
-        mat4.perspective(m, this._fov, this.width / this.height, 1, farZ);
+        mat4.perspective(m, this._fov, this.width / this.height, this.height / 50, farZ);
 
         mat4.scale(m, m, [1, -1, 1]);
         mat4.translate(m, m, [0, 0, -this.cameraToCenterDistance]);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -548,7 +548,7 @@ class Transform {
 
         // matrix for conversion from location to GL coordinates (-1 .. 1)
         let m = new Float64Array(16);
-        mat4.perspective(m, this._fov, this.width / this.height, this.height / 50, farZ);
+        mat4.perspective(m, this._fov, this.width / this.height, nearZ, farZ);
 
         mat4.scale(m, m, [1, -1, 1]);
         mat4.translate(m, m, [0, 0, -this.cameraToCenterDistance]);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1952,6 +1952,8 @@ class Map extends Camera {
      * @memberof Map
      * @var {string} version
      */
+
+     get version(): string { return version; }
 }
 
 export default Map;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { version } from '../../package.json';
 import { extend, bindAll, warnOnce, uniqueId } from '../util/util';
 import browser from '../util/browser';
 import window from '../util/window';
@@ -1942,6 +1943,15 @@ class Map extends Camera {
     _setCacheLimits(limit: number, checkThreshold: number) {
         setCacheLimits(limit, checkThreshold);
     }
+
+    /**
+     * The version of Mapbox GL JS in use as specified in package.json, CHANGELOG.md, and the GitHub release.
+     *
+     * @name version
+     * @instance
+     * @memberof Map
+     * @var {string} version
+     */
 }
 
 export default Map;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1953,7 +1953,7 @@ class Map extends Camera {
      * @var {string} version
      */
 
-     get version(): string { return version; }
+    get version(): string { return version; }
 }
 
 export default Map;

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -424,8 +424,8 @@ test('Marker with draggable:true moves to new position in response to a mouse-tr
     simulate.mouseup(el);
 
     const endPos = map.project(marker.getLngLat());
-    t.equal(Math.floor(endPos.x), startPos.x + 10);
-    t.equal(Math.floor(endPos.y), startPos.y + 10);
+    t.equal(Math.round(endPos.x), startPos.x + 10);
+    t.equal(Math.round(endPos.y), startPos.y + 10);
 
     map.remove();
     t.end();


### PR DESCRIPTION
fix #7573

This fixes precision issues in custom layers that use deckgl. While the old near plane worked well for our fill-extrusion layers it was causing issues in deckgl layers that do more complex projection in the shaders. This moves the near plane further away to a distance that seems to fix both the z-fighting in deckgl while not creating camera-close-to-building clipping issues.

deckgl would have to change `1 / deck.height ` to `1 / 50` here to match our change:
https://github.com/uber/deck.gl/blob/bddc36902a2535fa9430a1b450944f83cf4d9d11/modules/mapbox/src/deck-utils.js#L118

@Pessimistress can you confirm this would work for you?

### Testing
The [debug-z-fighting-deckgl](https://github.com/mapbox/mapbox-gl-js/tree/debug-z-fighting-deckgl) branch contains a debug page that can be used to test this. In the branch I've both patched deckgl and mapbox-gl-js. The third map pane shows both a deckgl layer and a fill-extrusion layer coexisting. To start the example: `yarn run start-debug` and then open http://localhost:9966/debug/

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page