### PR TITLE
derive scale in 3d model example

### DIFF
--- a/docs/pages/example/add-3d-model.html
+++ b/docs/pages/example/add-3d-model.html
@@ -15,7 +15,10 @@ var map = window.map = new mapboxgl.Map({
 var modelOrigin = [148.98190, -35.39847];
 var modelAltitude = 0;
 var modelRotate = [Math.PI / 2, 0, 0];
-var modelScale = 5.41843220338983e-8;
+
+var scaleFactor = 1 / Math.cos(modelOrigin[1] * Math.PI / 180);
+var mercatorExtent = 2 * Math.PI * 6378137;
+var modelScale = 1 / mercatorExtent * scaleFactor;
 
 // transformation parameters to position, rotate and scale the 3D model onto the map
 var modelTransform = {


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

closes #8508. the [custom layers with three.js example](https://docs.mapbox.com/mapbox-gl-js/example/add-3d-model/
) uses a magic number for the model scale, in this PR we try to show for a model with units in meters, how to determine the scale.

This PR is one option. another option is move most of this code to src/geo/mercator_coordinates.js, so the user can just ask for MercatorScale(lat), I'd probably prefer the latter, thoughts?