### PR TITLE
Display outline on control buttons when focused

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -75,7 +75,6 @@
 
 .mapboxgl-ctrl-group {
     border-radius: 4px;
-    overflow: hidden;
     background: #fff;
 }
 
@@ -95,6 +94,22 @@
     box-sizing: border-box;
     background-color: transparent;
     cursor: pointer;
+}
+
+.mapboxgl-ctrl-group > button:focus {
+    box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
+}
+
+.mapboxgl-ctrl-group > button:focus:first-child {
+    border-radius: 4px 4px 0 0;
+}
+
+.mapboxgl-ctrl-group > button:focus:last-child {
+    border-radius: 0 0 4px 4px;
+}
+
+.mapboxgl-ctrl-group > button:focus:only-child {
+    border-radius: inherit;
 }
 
 .mapboxgl-ctrl-group > button + button {

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -114,7 +114,7 @@
     box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
 }
 
-.mapboxgl-ctrl-group > button:focus-visible {
+.mapboxgl-ctrl-group > button:focus:focus-visible {
     box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
 }
 

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -114,6 +114,14 @@
     box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
 }
 
+.mapboxgl-ctrl-group > button:focus-visible {
+    box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
+}
+
+.mapboxgl-ctrl-group > button:focus:not(:focus-visible) {
+    box-shadow: none;
+}
+
 .mapboxgl-ctrl-group > button:focus:first-child {
     border-radius: 4px 4px 0 0;
 }

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -96,6 +96,20 @@
     cursor: pointer;
 }
 
+.mapboxgl-ctrl-group > button + button {
+    border-top: 1px solid #ddd;
+}
+
+/* https://bugzilla.mozilla.org/show_bug.cgi?id=140562 */
+.mapboxgl-ctrl > button::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+}
+
+.mapboxgl-ctrl > button:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
 .mapboxgl-ctrl-group > button:focus {
     box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
 }
@@ -110,20 +124,6 @@
 
 .mapboxgl-ctrl-group > button:focus:only-child {
     border-radius: inherit;
-}
-
-.mapboxgl-ctrl-group > button + button {
-    border-top: 1px solid #ddd;
-}
-
-/* https://bugzilla.mozilla.org/show_bug.cgi?id=140562 */
-.mapboxgl-ctrl > button::-moz-focus-inner {
-    border: 0;
-    padding: 0;
-}
-
-.mapboxgl-ctrl > button:hover {
-    background-color: rgba(0, 0, 0, 0.05);
 }
 
 .mapboxgl-ctrl-icon,


### PR DESCRIPTION
## Launch Checklist

Fixes https://github.com/mapbox/mapbox-gl-js/issues/8246

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - this creates an outline on the control buttons when they are tab focused, which helps with accessibility issues
    - this avoids using the CSS `outline` property because outlines do not follow rounded borders. `box-shadow` does follow rounded borders, leading to a cleaner looking UI while simulating the outline effect (not sure why the GIF is so slow but you get the idea)

![buttons](https://user-images.githubusercontent.com/4523080/61563495-f48ff680-aa28-11e9-8fb9-85fcddaa4d41.gif)
