### PR TITLE
Fix accidental reversion of text-radial-offset style-spec

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1867,10 +1867,7 @@
         }
       },
       "requires": [
-        "text-field",
-        {
-          "!" : "text-offset"
-        }
+        "text-field"
       ],
       "property-type": "data-driven",
       "expression": {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
This was reverted accidentally via an incorrect merge conflict resolution

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
