### PR TITLE
[wip] Support node engine v8+. Deprecate support for node engine 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git://github.com/mapbox/mapbox-gl-js.git"
   },
   "engines": {
-    "node": ">=6.4.0"
+    "node": ">=8.16.0"
   },
   "dependencies": {
     "@mapbox/geojson-rewind": "^0.4.0",


### PR DESCRIPTION
Addresses #8528 

Update `package.json`s `engine` field to v8.

**Note:** When switching (upgrade or downgrade) node versions, native node modules need to be re-compiled. With yarn <1.17.3 use `yarn --force` to force re-install and rebuild all the packages. With yarn v1.17.3+ a `>yarn install` will rebuild automatically.


## TODO
- [x] Wait for https://github.com/mapbox/mapbox-gl-js/pull/8538 to land
- [ ] Upgrade CI container to node v10