### PR TITLE
[docs] fix data-driven styling support section for symbol-sort-key

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -972,7 +972,12 @@
           "ios": "4.11.0",
           "macos": "0.14.0"
         },
-        "data-driven styling": {}
+        "data-driven styling": {
+          "js": "0.53.0",
+          "android": "7.4.0",
+          "ios": "4.11.0",
+          "macos": "0.14.0"
+        }
       },
       "expression": {
         "interpolated": false,


### PR DESCRIPTION
`symbol-sort-key` supports data-driven styling on all platforms.

cc @tristen @tmpsantos 