### PR TITLE
8504 duplicate match exp

### DIFF
--- a/src/style-spec/feature_filter/convert.js
+++ b/src/style-spec/feature_filter/convert.js
@@ -188,13 +188,8 @@ function convertInOp(property: string, values: Array<any>, negate = false) {
 
     if (uniformTypes && (type === 'string' || type === 'number')) {
         // Match expressions must have unique values.
-        const seen = [];
-        const uniqueValues = values.filter(v => {
-            if (seen.indexOf(v) === -1) {
-                seen.push(v);
-                return true;
-            }
-            return false;
+        const uniqueValues = values.sort().filter((value, i) => {
+            return i === 0 || values[i - 1] !== value;
         });
         return ['match', get, uniqueValues, !negate, negate];
     }

--- a/src/style-spec/feature_filter/convert.js
+++ b/src/style-spec/feature_filter/convert.js
@@ -188,9 +188,7 @@ function convertInOp(property: string, values: Array<any>, negate = false) {
 
     if (uniformTypes && (type === 'string' || type === 'number')) {
         // Match expressions must have unique values.
-        const uniqueValues = values.sort().filter((value, i) => {
-            return i === 0 || values[i - 1] !== value;
-        });
+        const uniqueValues = values.sort().filter((v, i) => i === 0 || values[i - 1] !== v);
         return ['match', get, uniqueValues, !negate, negate];
     }
 

--- a/src/style-spec/feature_filter/convert.js
+++ b/src/style-spec/feature_filter/convert.js
@@ -187,7 +187,16 @@ function convertInOp(property: string, values: Array<any>, negate = false) {
     }
 
     if (uniformTypes && (type === 'string' || type === 'number')) {
-        return ['match', get, values, !negate, negate];
+        // Match expressions must have unique values.
+        const seen = [];
+        const uniqueValues = values.filter(v => {
+            if (seen.indexOf(v) === -1) {
+                seen.push(v);
+                return true;
+            }
+            return false;
+        });
+        return ['match', get, uniqueValues, !negate, negate];
     }
 
     return [ negate ? 'all' : 'any' ].concat(

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -139,6 +139,29 @@ test('convert legacy filters to expressions', t => {
         t.end();
     });
 
+    t.test('removes duplicates when outputting match expressions', (t) => {
+        const filter = [
+            "in",
+            "$id",
+            1,
+            1,
+            2,
+            3
+        ];
+
+        const expected = [
+            "match",
+            ["id"],
+            [1, 2, 3],
+            true,
+            false
+        ];
+
+        const converted = convertFilter(filter);
+        t.same(converted, expected);
+        t.end();
+    });
+
     t.end();
 });
 

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -121,7 +121,7 @@ test('convert legacy filters to expressions', t => {
             [
                 "match",
                 ["geometry-type"],
-                ["Polygon", "LineString", "Point"],
+                ["LineString", "Point", "Polygon"],
                 true,
                 false
             ],
@@ -144,9 +144,10 @@ test('convert legacy filters to expressions', t => {
             "in",
             "$id",
             1,
-            1,
             2,
-            3
+            3,
+            2,
+            1
         ];
 
         const expected = [


### PR DESCRIPTION
Closes #8504 

The utility to convert legacy filters to expressions currently outputs a `match` expression as an optimization for certain legacy `in, !in` operators. This PR removes duplicate values from the result to ensure that the expression is valid.