### PR TITLE
[docs] fix errors on IE11 caused by dr-ui dependencies

### DIFF
--- a/batfish.config.js
+++ b/batfish.config.js
@@ -71,7 +71,11 @@ module.exports = () => {
             }
         },
         devBrowserslist: false,
-        babelInclude: ['documentation']
+        babelInclude: [
+          'documentation',
+          'debounce-fn',
+          'mimic-fn'
+        ]
     };
 
     // Local builds treat the `dist` directory as static assets, allowing you to test examples against the

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@mapbox/appropriate-images": "^2.0.0",
     "@mapbox/appropriate-images-react": "^1.0.0",
     "@mapbox/batfish": "1.9.8",
-    "@mapbox/dr-ui": "0.19.0",
+    "@mapbox/dr-ui": "0.19.1",
     "@mapbox/flow-remove-types": "^1.3.0-await.upstream.2",
     "@mapbox/gazetteer": "^3.1.2",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1241,10 +1241,10 @@
     webpack-merge "^4.1.2"
     worker-farm "^1.6.0"
 
-"@mapbox/dr-ui@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/dr-ui/-/dr-ui-0.19.0.tgz#cd5a89f91370633e1eda697b9f6147d8991b1141"
-  integrity sha512-bRA6dQUtJ582Eja9cfJ10oM4C+Kb9rT7KYYcT2yku/QsqchSMceW7eJekzG4fffU7PL49+7Iwnzxa0QiMLmxKQ==
+"@mapbox/dr-ui@0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/dr-ui/-/dr-ui-0.19.1.tgz#97806b96d7eae5458ec7a03b750a312ae4d47c82"
+  integrity sha512-B7+W4mNogqIF2WWR3oHD0y6aHELl6TVltNcbuXuTpGkuqQFFovqEbS/QytIx3yujgar+RdJTSMOvmZJbe402aQ==
   dependencies:
     "@elastic/react-search-ui" "^1.0.0"
     "@elastic/react-search-ui-views" "^1.0.0"


### PR DESCRIPTION
Earlier this week the docs team received a report from the GL JS team that they were unable to test the local site on IE11. In addition, IE11 would not load maps on IE11 and showed the webgl is unsupported note despite webgl being enabled.

The bug is directly related to dependencies of dr-ui's Search component which use es2015 features and were not properly polyfilled.

This PR treats the symptoms of this bug in two ways:
1. Adds `mimic-fn` and `debounce-fn` to batfish config's `babelInclude` to polyfill those dependencies which caused the initial error.
2. Updates dr-ui with a patch that will prevent IE11 from loading the search component. Since IE users account for less than 1% of traffic and the search framework we are using is not optimized for IE, we decided that graceful degradation is the best option. 

![image](https://user-images.githubusercontent.com/2180540/61798783-edd1fc80-adf7-11e9-8608-46231c4d8680.png)
_website now loading properly in IE11_

## Launch Checklist

 - [x] briefly describe the changes in this PR

