### PR TITLE
Document type constrain on feature.id for feature state methods.

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2866,7 +2866,7 @@
         }
       },
       "feature-state": {
-        "doc": "Retrieves a property value from the current feature's state. Returns null if the requested property is not present on the feature's state. A feature's state is not part of the GeoJSON or vector tile data, and must be set programmatically on each feature. Note that [\"feature-state\"] can only be used with paint properties that support data-driven styling.",
+        "doc": "Retrieves a property value from the current feature's state. Returns null if the requested property is not present on the feature's state. A feature's state is not part of the GeoJSON or vector tile data, and must be set programmatically on each feature. Features are identified by their `id` attribute, which must be an integer or a string that can be cast to an integer. Note that [\"feature-state\"] can only be used with paint properties that support data-driven styling.",
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1450,13 +1450,13 @@ class Map extends Camera {
     }
 
     /**
-     * Sets the state of a feature. The `state` object is merged in with the existing state of the feature. 
-     * Features are identified by their `id` attribute, which must be an integer or a string that can be 
+     * Sets the state of a feature. The `state` object is merged in with the existing state of the feature.
+     * Features are identified by their `id` attribute, which must be an integer or a string that can be
      * cast to an integer.
      *
      * @param {Object} feature Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
-     * @param {string | number} feature.id Unique id of the feature. 
+     * @param {string | number} feature.id Unique id of the feature.
      * @param {string} feature.source The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
      *  required.*
@@ -1477,7 +1477,7 @@ class Map extends Camera {
      * source is specified, removes all states of that source. If
      * target.id is also specified, removes all keys for that feature's state.
      * If key is also specified, removes that key from that feature's state.
-     * Features are identified by their `id` attribute, which must be an integer or a string that can be 
+     * Features are identified by their `id` attribute, which must be an integer or a string that can be
      * cast to an integer.
      * @param {Object} target Identifier of where to set state: can be a source, a feature, or a specific key of feature.
      * Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
@@ -1494,9 +1494,9 @@ class Map extends Camera {
 
     /**
      * Gets the state of a feature.
-     * Features are identified by their `id` attribute, which must be an integer or a string that can be 
+     * Features are identified by their `id` attribute, which must be an integer or a string that can be
      * cast to an integer.
-     * 
+     *
      * @param {Object} feature Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {string | number} feature.id Unique id of the feature.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1450,11 +1450,13 @@ class Map extends Camera {
     }
 
     /**
-     * Sets the state of a feature. The `state` object is merged in with the existing state of the feature.
+     * Sets the state of a feature. The `state` object is merged in with the existing state of the feature. 
+     * Features are identified by their `id` attribute, which must be an integer or a string that can be 
+     * cast to an integer.
      *
      * @param {Object} feature Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
-     * @param {string | number} feature.id Unique id of the feature.
+     * @param {string | number} feature.id Unique id of the feature. 
      * @param {string} feature.source The Id of the vector source or GeoJSON source for the feature.
      * @param {string} [feature.sourceLayer] (optional)  *For vector tile sources, the sourceLayer is
      *  required.*
@@ -1475,7 +1477,8 @@ class Map extends Camera {
      * source is specified, removes all states of that source. If
      * target.id is also specified, removes all keys for that feature's state.
      * If key is also specified, removes that key from that feature's state.
-     *
+     * Features are identified by their `id` attribute, which must be an integer or a string that can be 
+     * cast to an integer.
      * @param {Object} target Identifier of where to set state: can be a source, a feature, or a specific key of feature.
      * Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {string | number} target.id (optional) Unique id of the feature. Optional if key is not specified.
@@ -1491,7 +1494,9 @@ class Map extends Camera {
 
     /**
      * Gets the state of a feature.
-     *
+     * Features are identified by their `id` attribute, which must be an integer or a string that can be 
+     * cast to an integer.
+     * 
      * @param {Object} feature Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {string | number} feature.id Unique id of the feature.


### PR DESCRIPTION
Closes #7632 

Even though the `feature.id` constraint applies to the data, it is encountered most often in the context of trying to use the `feature state` APIs.