### PR TITLE
Instantiate popup element before modifying its classList

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -203,6 +203,10 @@ export default class Popup extends Evented {
         this._lngLat = LngLat.convert(lnglat);
         this._pos = null;
 
+        this._trackPointer = false;
+
+        this._update();
+
         if (this._map) {
             this._map.on('move', this._update);
             this._map.off('mousemove');
@@ -210,9 +214,6 @@ export default class Popup extends Evented {
             this._map._canvasContainer.classList.remove('mapboxgl-track-pointer');
         }
 
-        this._trackPointer = false;
-
-        this._update();
         return this;
     }
 


### PR DESCRIPTION
Addresses https://github.com/mapbox/mapbox-gl-js/issues/8535

This bug occurs when attempting to reposition a marker that has been added to the map, but _without_ a lnglat set. 

Because `setLngLat` doesn't create a DOM element for `popup` until near the end of its run,  the operation first tries to edit a classList of a nonexistent `this._container` element.

This PR modifies `setLngLat` so that it instantiates the DOM element, _before_ modifying its classList.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page

