### PR TITLE
Fix usage of String#includes which is es6 but not transformed by buble

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -178,7 +178,7 @@ export class RequestManager {
         if (accessToken[0] === 's')
             throw new Error(`Use a public access token (pk.*) with Mapbox GL, not a secret access token (sk.*). ${help}`);
 
-        urlObject.params = urlObject.params.filter((d) => !d.includes('access_token'));
+        urlObject.params = urlObject.params.filter((d) => d.indexOf('access_token') === -1);
         urlObject.params.push(`access_token=${accessToken}`);
         return formatUrl(urlObject);
     }


### PR DESCRIPTION
Fix a usage of `String#includes` which breaks in any non-es6 browser and is also not handled by buble transformation.

 - [x] briefly describe the changes in this PR