### PR TITLE
Fix lint failure no-multiple-empty-lines in video_source.test.js

### DIFF
--- a/test/unit/source/video_source.test.js
+++ b/test/unit/source/video_source.test.js
@@ -15,7 +15,6 @@ function createSource(options) {
     return source;
 }
 
-
 test('VideoSource', (t) => {
 
     const source = createSource({


### PR DESCRIPTION
Fixes a lint rule failure that somehow escaped CI on PR.

 - [x] briefly describe the changes in this PR