### PR TITLE
Fix an issue with local test failures

### DIFF
--- a/test/stub_loader.js
+++ b/test/stub_loader.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const assert = require('assert');
 const pirates = require('pirates');
 
+process.env["ESM_OPTIONS"] = '{ "cache": "node_modules/.cache/esm-stubbed"}';
+
 pirates.addHook((code, filename) => {
     assert(filename.endsWith('/ajax.js'));
     return fs.readFileSync(`${__dirname}/ajax_stubs.js`, 'utf-8');


### PR DESCRIPTION
I'm surprised there isn't an open ticket for this issue. For many months, multiple developers have complained about integration (render/query) and unit tests failing unpredictably.

Typically many/most of the tests from a suite would fail. 

The issue stems from the `esm` cache being reused between the integration and unit tests.

The unit tests run with locally defined mocks, as needed. The integration tests run with a `stub_loader` that swaps out the `ajax.js` module witjh an alternate implementation that works with node modules (as opposed to browser APIs like `XMLHttpRequest`)

https://github.com/mapbox/mapbox-gl-js/blob/4ffd0e2c6cbdf4f2d96b89f79a816012eba66329/test/render.test.js#L3

Whichever test suite ran first populated the esm cache _(node_modules/.cache/esm)_ with the ajax module in use for it. When the next test suite ran, esm reused the cached ajax module. For example, in the case of render tests, the alternate implementation of `ajax.js` was not being used.

### Solution 
I investigated a few different ways to fix this, but landed on the simple solution to use a different cache when the `stub_loader` is required. This module has to be loaded before `esm` is loaded, so it provides a safe opportunity to set `ESM_OPTIONS` into the environment for setting the alternate path for the cache.

Alternates considered were:
- script deletion of esm cache folder
- change order of stub_loader
- Use stub_loader in unit tests
- User timestamp parameter to bust `ajax.js` cache
- manually delete cache entry on every run

### Example render test failure:
```
* failed basic-v9/z0
Error: Cross origin null forbidden
    at dispatchError (/Users/asheemm/src/mapbox-gl-js/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:60:19)
    at Object.validCORSHeaders (/Users/asheemm/src/mapbox-gl-js/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:72:5)
    at receiveResponse (/Users/asheemm/src/mapbox-gl-js/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:842:21)
    at Request.client.on.res (/Users/asheemm/src/mapbox-gl-js/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:677:38)
    at Request.emit (events.js:198:13)
    at Request.EventEmitter.emit (domain.js:448:20)
    at Request._1e3‍.r.Request.onRequestResponse (/Users/asheemm/src/mapbox-gl-js/node_modules/request/request.js:1066:10)
    at ClientRequest.emit (events.js:198:13)
    at ClientRequest.EventEmitter.emit (domain.js:448:20)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:556:21) undefined
{ [Error] message: '' }
```
