### PR TITLE
Expose mapboxgl.rtlTextPluginRequested boolean

### DIFF
--- a/debug/rtl.html
+++ b/debug/rtl.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
+
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js');
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 16.5,
+    center: [44.355435, 33.258814],
+    style: 'mapbox://styles/mapbox/streets-v11',
+    hash: true
+});
+
+map.on('load', function () {
+    if (!mapboxgl.rtlTextPluginRequested) {
+        mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js');
+    }
+});
+
+</script>
+</body>
+</html>

--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -7,6 +7,7 @@ toc:
   - supported
   - version
   - setRTLTextPlugin
+  - rtlTextPluginRequested
   - clearStorage
   - AnimationOptions
   - CameraOptions

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ import Point from '@mapbox/point-geometry';
 import MercatorCoordinate from './geo/mercator_coordinate';
 import {Evented} from './util/evented';
 import config from './util/config';
-import {setRTLTextPlugin} from './source/rtl_text_plugin';
+import {setRTLTextPlugin, rtlTextPluginRequested} from './source/rtl_text_plugin';
 import WorkerPool from './util/worker_pool';
 import {clearTileCache} from './util/tile_request_cache';
 
@@ -89,6 +89,19 @@ const exported = {
 
     set workerCount(count: number) {
         WorkerPool.workerCount = count;
+    },
+
+    /**
+     * Gets a boolean indicating whether or not the RTL plugin has been previously requested
+     *
+     * @var {string} rtlTextPluginRequested
+     * @example
+     * if (!mapboxgl.rtlTextPluginRequested) {
+     *   mapboxgl.setRTLTextPlugin(pluginUrl);
+     * }
+     */
+    get rtlTextPluginRequested(): boolean {
+        return rtlTextPluginRequested();
     },
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -92,12 +92,12 @@ const exported = {
     },
 
     /**
-     * Gets a boolean indicating whether or not the RTL plugin has been previously requested
+     * Gets a boolean indicating whether or not the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text) has been previously requested
      *
      * @var {string} rtlTextPluginRequested
      * @example
      * if (!mapboxgl.rtlTextPluginRequested) {
-     *   mapboxgl.setRTLTextPlugin(pluginUrl);
+     *   mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js');
      * }
      */
     get rtlTextPluginRequested(): boolean {

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -25,6 +25,10 @@ export const registerForPluginAvailability = function(
     return callback;
 };
 
+export const rtlTextPluginRequested = function () {
+    return pluginRequested;
+};
+
 export const clearRTLTextPlugin = function() {
     pluginRequested = false;
     pluginURL = null;


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

Fixes #7869 

 - [x] briefly describe the changes in this PR
  This PR exposes `mapboxgl.rtlTextPluginRequested` which returns a boolean that is `true` if the RTL plugin has previously been requested. This allows users to avoid requesting the plugin multiple times which causes an error.
 - [x] document any changes to public APIs
 - [x] manually test the debug page
  Added an RTL debug page

I considered exposing the existing [`clearRTLTextPlugin`](https://github.com/mapbox/mapbox-gl-js/blob/ead961f7c6b903bb5bbfbc3f128362bb46d421eb/src/source/rtl_text_plugin.js#L28) method, but ultimately decided that this made more sense code-wise. I'm open to differing opinions though.

```
if (!mapboxgl.rtlTextPluginRequested) {
  mapboxgl.setRTLTextPlugin(url);
}
```