### PR TITLE
Fix rotation bug for non-pitched compasses

### DIFF
--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -25,7 +25,7 @@ const defaultOptions: Options = {
  * @param {Object} [options]
  * @param {Boolean} [options.showCompass=true] If `true` the compass button is included.
  * @param {Boolean} [options.showZoom=true] If `true` the zoom-in and zoom-out buttons are included.
- * @param {Boolean} [options.visualizePitch=false] If `true` the pitch is visualized by rotating Y-axis of compass.
+ * @param {Boolean} [options.visualizePitch=false] If `true` the pitch is visualized by rotating X-axis of compass.
  * @example
  * var nav = new mapboxgl.NavigationControl();
  * map.addControl(nav, 'top-left');

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -86,7 +86,7 @@ class NavigationControl {
 
     _rotateCompassArrow() {
         const rotate = this.options.visualizePitch ?
-            `rotateX(${this._map.transform.pitch}deg) rotateZ(${this._map.transform.angle * (180 / Math.PI)}deg)` :
+            `scale(${1/Math.pow(Math.cos(this._map.transform.pitch * (Math.PI / 180)),0.5)}) rotateX(${this._map.transform.pitch}deg) rotateZ(${this._map.transform.angle * (180 / Math.PI)}deg)` :
             `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
 
         this._compassArrow.style.transform = rotate;

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -87,7 +87,7 @@ class NavigationControl {
     _rotateCompassArrow() {
         const rotate = this.options.visualizePitch ?
             `rotateX(${this._map.transform.pitch}deg) rotateZ(${this._map.transform.angle * (180 / Math.PI)}deg)` :
-            `rotate(${this._map.transform.angle}deg)`;
+            `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
 
         this._compassArrow.style.transform = rotate;
     }

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -86,7 +86,7 @@ class NavigationControl {
 
     _rotateCompassArrow() {
         const rotate = this.options.visualizePitch ?
-            `scale(${1/Math.pow(Math.cos(this._map.transform.pitch * (Math.PI / 180)),0.5)}) rotateX(${this._map.transform.pitch}deg) rotateZ(${this._map.transform.angle * (180 / Math.PI)}deg)` :
+            `scale(${1 / Math.pow(Math.cos(this._map.transform.pitch * (Math.PI / 180)), 0.5)}) rotateX(${this._map.transform.pitch}deg) rotateZ(${this._map.transform.angle * (180 / Math.PI)}deg)` :
             `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
 
         this._compassArrow.style.transform = rotate;


### PR DESCRIPTION
## Launch Checklist

Solves https://github.com/mapbox/mapbox-gl-js/issues/8579. Additionally applies a subtle scaling function to pitched compasses, to enhance legibility at high pitches

before and after:

![Screen Shot 2019-08-06 at 12 26 07 PM](https://user-images.githubusercontent.com/4551508/62573103-17ecdb00-b84a-11e9-900e-61065b452b0f.png)

![Screen Shot 2019-08-06 at 12 59 17 PM](https://user-images.githubusercontent.com/4551508/62573112-1d4a2580-b84a-11e9-800f-22fa95196fac.png)

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
