### PR TITLE
[style-spec] export validateExpression globally

### DIFF
--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -75,6 +75,7 @@ import convertFunction from './function/convert';
 import { eachSource, eachLayer, eachProperty } from './visit';
 
 import validate from './validate_style';
+import validateExpression from './validate/validate_expression';
 
 const expression = {
     StyleExpression,
@@ -110,6 +111,7 @@ export {
     Color,
     styleFunction as function,
     validate,
+    validateExpression,
     visit
 };
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

Expressions are hard and it would be nice to validate an expression without validating an entire style.json. This PR globally exports `validateExpression`, so it can be used in projects like:

```js
const { validateExpression } = require('@mapbox/mapbox-gl-style-spec')

validateExpression({'value': ["==", "some", "expression" ]})
```


cc @mapbox/map-design-team @mapbox/api-gl @mapsam 


 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality 
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
