### PR TITLE
reduce symbol overlap when zooming out quickly

### DIFF
--- a/src/style/pauseable_placement.js
+++ b/src/style/pauseable_placement.js
@@ -95,8 +95,8 @@ class PauseablePlacement {
         this._done = true;
     }
 
-    commit(now: number) {
-        this.placement.commit(now);
+    commit(now: number, zoom: number) {
+        this.placement.commit(now, zoom);
         return this.placement;
     }
 }

--- a/src/style/pauseable_placement.js
+++ b/src/style/pauseable_placement.js
@@ -95,8 +95,8 @@ class PauseablePlacement {
         this._done = true;
     }
 
-    commit(now: number, zoom: number) {
-        this.placement.commit(now, zoom);
+    commit(now: number) {
+        this.placement.commit(now);
         return this.placement;
     }
 }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1200,7 +1200,7 @@ class Style extends Evented {
         // tiles will fully display symbols in their first frame
         const forceFullPlacement = this._layerOrderChanged || fadeDuration === 0;
 
-        if (forceFullPlacement || !this.pauseablePlacement || (this.pauseablePlacement.isDone() && !this.placement.stillRecent(browser.now()))) {
+        if (forceFullPlacement || !this.pauseablePlacement || (this.pauseablePlacement.isDone() && !this.placement.stillRecent(browser.now(), transform.zoom))) {
             this.pauseablePlacement = new PauseablePlacement(transform, this._order, forceFullPlacement, showCollisionBoxes, fadeDuration, crossSourceCollisions, this.placement);
             this._layerOrderChanged = false;
         }
@@ -1215,7 +1215,7 @@ class Style extends Evented {
             this.pauseablePlacement.continuePlacement(this._order, this._layers, layerTiles);
 
             if (this.pauseablePlacement.isDone()) {
-                this.placement = this.pauseablePlacement.commit(browser.now());
+                this.placement = this.pauseablePlacement.commit(browser.now(), transform.zoom);
                 placementCommitted = true;
             }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1215,7 +1215,7 @@ class Style extends Evented {
             this.pauseablePlacement.continuePlacement(this._order, this._layers, layerTiles);
 
             if (this.pauseablePlacement.isDone()) {
-                this.placement = this.pauseablePlacement.commit(browser.now(), transform.zoom);
+                this.placement = this.pauseablePlacement.commit(browser.now());
                 placementCommitted = true;
             }
 

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -167,7 +167,6 @@ export class Placement {
     variableOffsets: {[CrossTileID]: VariableOffset };
     placedOrientations: {[CrossTileID]: number };
     commitTime: number;
-    commitZoom: number;
     prevZoomAdjustment: number;
     lastPlacementChangeTime: number;
     stale: boolean;
@@ -638,7 +637,6 @@ export class Placement {
 
     commit(now: number, zoom: number): void {
         this.commitTime = now;
-        this.commitZoom = zoom;
 
         const prevPlacement = this.prevPlacement;
         let placementChanged = false;
@@ -895,7 +893,7 @@ export class Placement {
     symbolFadeChange(now: number) {
         return this.fadeDuration === 0 ?
             1 :
-            ((now - this.commitTime) / this.fadeDuration + this.prevZoomAdjustment);
+            ((now - this.commitTime) / this.fadeDuration + this.prevZoomAdjustment + 1);
     }
 
     zoomAdjustment(zoom: number) {
@@ -903,7 +901,7 @@ export class Placement {
         // adjustment is used to reduce the fade duration when zooming out quickly and
         // to reduce the interval between placement calculations. Discovering the
         // collisions more quickly and fading them more quickly reduces the unwanted effect.
-        return Math.max(0, 1 - Math.pow(2, zoom - this.commitZoom));
+        return Math.max(0, 1 - Math.pow(2, zoom - this.transform.zoom));
     }
 
     hasTransitions(now: number) {


### PR DESCRIPTION
fix #8627

When zooming out quickly labels could overlap for a lengthly period of time and produce and unwanted visual effect.

This PR reduces this overlap by:
- reducing the time between collision calculations when zooming out quickly
- reducing the fade duration when zooming out quickly

The collisions are discovered more quickly and eliminated more quickly.

Before:
https://bl.ocks.org/ansis/6d6aa89b8a5dbddb5e2031a29451c767

After:
https://bl.ocks.org/ansis/12665c0c885b6af9ed81c44fa7177078

After without automatic zooming
https://bl.ocks.org/ansis/6ad5fb3402d4ddec926b52af7f3f73fe

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
 - [ ] post benchmark scores
 - [x] manually test the debug page