### PR TITLE
Update PULL_REQUEST_TEMPLATE.md with new docs workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,6 @@
 
 <!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 
-<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->
-
  - [ ] briefly describe the changes in this PR
  - [ ] write tests for all new functionality
  - [ ] document any changes to public APIs


### PR DESCRIPTION
## Launch Checklist
This removes from the GitHub PR template the following:

> If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation

Since the docs are now external to mapbox-gl-js, this no longer applies.