### PR TITLE
Improve cancellation of tile loads

### DIFF
--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -111,6 +111,7 @@ class CanvasSource extends ImageSource {
      */
 
     load() {
+        this._loaded = true;
         if (!this.canvas) {
             this.canvas = (this.options.canvas instanceof window.HTMLCanvasElement) ?
                 this.options.canvas :

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -100,6 +100,7 @@ class GeoJSONSource extends Evented implements Source {
         this.isTileClipped = true;
         this.reparseOverscaled = true;
         this._removed = false;
+        this._loaded = false;
 
         this.dispatcher = dispatcher;
         this.setEventedParent(eventedParent);
@@ -243,6 +244,7 @@ class GeoJSONSource extends Evented implements Source {
      * using geojson-vt or supercluster as appropriate.
      */
     _updateWorkerData(callback: Callback<void>) {
+        this._loaded = false;
         const options = extend({}, this.workerOptions);
         const data = this._data;
         if (typeof data === 'string') {
@@ -275,6 +277,10 @@ class GeoJSONSource extends Evented implements Source {
             callback(err);
 
         }, this.workerID);
+    }
+
+    loaded(): boolean {
+        return this._loaded;
     }
 
     loadTile(tile: Tile, callback: Callback<void>) {

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -297,7 +297,8 @@ class GeoJSONSource extends Evented implements Source {
             showCollisionBoxes: this.map.showCollisionBoxes
         };
 
-        this.actor.send(message, params, (err, data) => {
+        tile.request = this.actor.send(message, params, (err, data) => {
+            delete tile.request;
             tile.unloadVectorData();
 
             if (tile.aborted) {
@@ -315,6 +316,10 @@ class GeoJSONSource extends Evented implements Source {
     }
 
     abortTile(tile: Tile) {
+        if (tile.request) {
+            tile.request.cancel();
+            delete tile.request;
+        }
         tile.aborted = true;
     }
 

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -83,6 +83,7 @@ class ImageSource extends Evented implements Source {
     _boundsArray: RasterBoundsArray;
     boundsBuffer: VertexBuffer;
     boundsSegments: SegmentVector;
+    _loaded: boolean;
 
     /**
      * @private
@@ -98,6 +99,7 @@ class ImageSource extends Evented implements Source {
         this.maxzoom = 22;
         this.tileSize = 512;
         this.tiles = {};
+        this._loaded = false;
 
         this.setEventedParent(eventedParent);
 
@@ -105,11 +107,13 @@ class ImageSource extends Evented implements Source {
     }
 
     load(newCoordinates?: Coordinates, successCallback?: () => void) {
+        this._loaded = false;
         this.fire(new Event('dataloading', {dataType: 'source'}));
 
         this.url = this.options.url;
 
         getImage(this.map._requestManager.transformRequest(this.url, ResourceType.Image), (err, image) => {
+            this._loaded = true;
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (image) {
@@ -123,6 +127,10 @@ class ImageSource extends Evented implements Source {
                 this._finishLoading();
             }
         });
+    }
+
+    loaded(): boolean {
+        return this._loaded;
     }
 
     /**

--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -64,8 +64,9 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
                     encoding: this.encoding
                 };
 
-                if (!tile.workerID || tile.state === 'expired') {
-                    tile.workerID = this.dispatcher.send('loadDEMTile', params, done.bind(this));
+                if (!tile.actor || tile.state === 'expired') {
+                    tile.actor = this.dispatcher.getActor();
+                    tile.actor.send('loadDEMTile', params, done.bind(this));
                 }
             }
         }
@@ -125,7 +126,9 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
         delete tile.neighboringTiles;
 
         tile.state = 'unloaded';
-        this.dispatcher.send('removeDEMTile', { uid: tile.uid, source: this.id }, undefined, tile.workerID);
+        if (tile.actor) {
+            tile.actor.send('removeDEMTile', { uid: tile.uid, source: this.id });
+        }
     }
 
 }

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -62,9 +62,11 @@ class RasterTileSource extends Evented implements Source {
     }
 
     load() {
+        this._loaded = false;
         this.fire(new Event('dataloading', {dataType: 'source'}));
         this._tileJSONRequest = loadTileJSON(this._options, this.map._requestManager, (err, tileJSON) => {
             this._tileJSONRequest = null;
+            this._loaded = true;
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (tileJSON) {
@@ -81,6 +83,10 @@ class RasterTileSource extends Evented implements Source {
                 this.fire(new Event('data', {dataType: 'source', sourceDataType: 'content'}));
             }
         });
+    }
+
+    loaded(): boolean {
+        return this._loaded;
     }
 
     onAdd(map: Map) {

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -50,6 +50,7 @@ export interface Source {
     vectorLayerIds?: Array<string>,
 
     hasTransition(): boolean;
+    loaded(): boolean;
 
     fire(event: Event): mixed;
 

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -119,6 +119,7 @@ class SourceCache extends Evented {
     loaded(): boolean {
         if (this._sourceErrored) { return true; }
         if (!this._sourceLoaded) { return false; }
+        if (!this._source.loaded()) { return false; }
         for (const t in this._tiles) {
             const tile = this._tiles[t];
             if (tile.state !== 'loaded' && tile.state !== 'errored')

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -22,6 +22,7 @@ const CLOCK_SKEW_RETRY_TIMEOUT = 30000;
 import type {Bucket} from '../data/bucket';
 import type StyleLayer from '../style/style_layer';
 import type {WorkerTileResult} from './worker_source';
+import type Actor from '../util/actor';
 import type DEMData from '../data/dem_data';
 import type {AlphaImage} from '../util/image';
 import type ImageAtlas from '../render/image_atlas';
@@ -73,7 +74,7 @@ class Tile {
     redoWhenDone: boolean;
     showCollisionBoxes: boolean;
     placementSource: any;
-    workerID: number | void;
+    actor: ?Actor;
     vtLayers: {[string]: VectorTileLayer};
     mask: Mask;
 

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -38,6 +38,7 @@ class VectorTileSource extends Evented implements Source {
     reparseOverscaled: boolean;
     isTileClipped: boolean;
     _tileJSONRequest: ?Cancelable;
+    _loaded: boolean;
 
     constructor(id: string, options: VectorSourceSpecification & {collectResourceTiming: boolean}, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
@@ -51,6 +52,7 @@ class VectorTileSource extends Evented implements Source {
         this.tileSize = 512;
         this.reparseOverscaled = true;
         this.isTileClipped = true;
+        this._loaded = false;
 
         extend(this, pick(options, ['url', 'scheme', 'tileSize']));
         this._options = extend({ type: 'vector' }, options);
@@ -65,9 +67,11 @@ class VectorTileSource extends Evented implements Source {
     }
 
     load() {
+        this._loaded = false;
         this.fire(new Event('dataloading', {dataType: 'source'}));
         this._tileJSONRequest = loadTileJSON(this._options, this.map._requestManager, (err, tileJSON) => {
             this._tileJSONRequest = null;
+            this._loaded = true;
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (tileJSON) {
@@ -83,6 +87,10 @@ class VectorTileSource extends Evented implements Source {
                 this.fire(new Event('data', {dataType: 'source', sourceDataType: 'content'}));
             }
         });
+    }
+
+    loaded(): boolean {
+        return this._loaded;
     }
 
     hasTile(tileID: OverscaledTileID) {

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -63,6 +63,7 @@ class VideoSource extends ImageSource {
     }
 
     load() {
+        this._loaded = false;
         const options = this.options;
 
         this.urls = [];
@@ -71,6 +72,7 @@ class VideoSource extends ImageSource {
         }
 
         getVideo(this.urls, (err, video) => {
+            this._loaded = true;
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (video) {

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -57,7 +57,7 @@ export type WorkerDEMTileCallback = (err: ?Error, result: ?DEMData) => void;
  * the WebWorkers. In addition to providing a custom
  * {@link WorkerSource#loadTile}, any other methods attached to a `WorkerSource`
  * implementation may also be targeted by the {@link Source} via
- * `dispatcher.send('source-type.methodname', params, callback)`.
+ * `dispatcher.getActor().send('source-type.methodname', params, callback)`.
  *
  * @see {@link Map#addSourceType}
  * @private

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -20,18 +20,26 @@ import type {Cancelable} from '../types/cancelable';
 class Actor {
     target: any;
     parent: any;
-    mapId: string;
-    callbacks: any;
-    callbackID: number;
+    mapId: ?number;
+    callbacks: { number: any };
     name: string;
+    tasks: { number: any };
+    taskQueue: Array<number>;
+    cancelCallbacks: { number: Cancelable };
+    taskTimeout: ?TimeoutID;
 
-    constructor(target: any, parent: any, mapId: any) {
+    static taskId: number;
+
+    constructor(target: any, parent: any, mapId: ?number) {
         this.target = target;
         this.parent = parent;
         this.mapId = mapId;
         this.callbacks = {};
-        this.callbackID = 0;
-        bindAll(['receive'], this);
+        this.tasks = {};
+        this.taskQueue = [];
+        this.taskTimeout = null;
+        this.cancelCallbacks = {};
+        bindAll(['receive', 'process'], this);
         this.target.addEventListener('message', this.receive, false);
     }
 
@@ -44,78 +52,140 @@ class Actor {
      * @private
      */
     send(type: string, data: mixed, callback: ?Function, targetMapId: ?string): ?Cancelable {
-        const id = callback ? `${this.mapId}:${this.callbackID++}` : null;
-        if (callback) this.callbacks[id] = callback;
+        const id = ++Actor.taskId;
+        if (callback) {
+            this.callbacks[id] = callback;
+        }
         const buffers: Array<Transferable> = [];
         this.target.postMessage({
+            id,
+            type,
+            hasCallback: !!callback,
             targetMapId,
             sourceMapId: this.mapId,
-            type,
-            id: String(id),
             data: serialize(data, buffers)
         }, buffers);
-        if (callback) {
-            return {
-                cancel: () => {
+        return {
+            cancel: () => {
+                if (callback) {
                     // Set the callback to null so that it never fires after the request is aborted.
-                    this.callbacks[id] = null;
-                    this.target.postMessage({
-                        targetMapId,
-                        sourceMapId: this.mapId,
-                        type: '<cancel>',
-                        id: String(id)
-                    });
+                    delete this.callbacks[id];
                 }
-            };
-        }
+                this.target.postMessage({
+                    id,
+                    type: '<cancel>',
+                    targetMapId,
+                    sourceMapId: this.mapId
+                });
+            }
+        };
     }
 
     receive(message: Object) {
         const data = message.data,
             id = data.id;
-        let callback;
 
-        if (data.targetMapId && this.mapId !== data.targetMapId)
+        if (!id) {
             return;
+        }
 
-        const done = (err, data) => {
-            delete this.callbacks[id];
-            const buffers: Array<Transferable> = [];
-            this.target.postMessage({
-                sourceMapId: this.mapId,
-                type: '<response>',
-                id: String(id),
-                error: err ? serialize(err) : null,
-                data: serialize(data, buffers)
-            }, buffers);
-        };
+        if (data.targetMapId && this.mapId !== data.targetMapId) {
+            return;
+        }
 
-        if (data.type === '<response>' || data.type === '<cancel>') {
-            callback = this.callbacks[data.id];
-            delete this.callbacks[data.id];
-            if (callback && data.error) {
-                callback(deserialize(data.error));
-            } else if (callback) {
-                callback(null, deserialize(data.data));
+        if (data.type === '<cancel>') {
+            // Remove the original request from the queue. This is only possible if it
+            // hasn't been kicked off yet. The id will remain in the queue, but because
+            // there is no associated task, it will be dropped once it's time to execute it.
+            delete this.tasks[id];
+            const cancel = this.cancelCallbacks[id];
+            delete this.cancelCallbacks[id];
+            if (cancel) {
+                cancel();
             }
-        } else if (typeof data.id !== 'undefined' && this.parent[data.type]) {
-            // data.type == 'loadTile', 'removeTile', etc.
-            // Add a placeholder so that we can discover when the done callback was called already.
-            this.callbacks[data.id] = null;
-            const cancelable = this.parent[data.type](data.sourceMapId, deserialize(data.data), done);
-            if (cancelable && this.callbacks[data.id] === null) {
-                // Only add the cancelable callback if the done callback wasn't already called.
-                // Otherwise we will never be able to delete it.
-                this.callbacks[data.id] = cancelable.cancel;
-            }
-        } else if (typeof data.id !== 'undefined' && this.parent.getWorkerSource) {
-            // data.type == sourcetype.method
-            const keys = data.type.split('.');
-            const params = (deserialize(data.data): any);
-            const workerSource = (this.parent: any).getWorkerSource(data.sourceMapId, keys[0], params.source);
-            workerSource[keys[1]](params, done);
         } else {
-            this.parent[data.type](deserialize(data.data));
+            // Store the tasks that we need to process before actually processing them. This
+            // is necessary because we want to keep receiving messages, and in particular,
+            // <cancel> messages. Some tasks may take a while in the worker thread, so before
+            // executing the next task in our queue, postMessage preempts this and <cancel>
+            // messages can be processed.
+            this.tasks[id] = data;
+            this.taskQueue.push(id);
+            if (!this.taskTimeout) {
+                this.taskTimeout = setTimeout(this.process, 0);
+            }
+        }
+    }
+
+    process() {
+        // Reset the timeout ID so that we know that no process call is scheduled in the future yet.
+        this.taskTimeout = null;
+        if (!this.taskQueue.length) {
+            return;
+        }
+        const id = this.taskQueue.shift();
+        const task = this.tasks[id];
+        delete this.tasks[id];
+        // Schedule another process call if we know there's more to process _before_ invoking the
+        // current task. This is necessary so that processing continues even if the current task
+        // doesn't execute successfully.
+        if (this.taskQueue.length) {
+            this.taskTimeout = setTimeout(this.process, 0);
+        }
+        if (!task) {
+            // If the task ID doesn't have associated task data anymore, it was canceled.
+            return;
+        }
+
+        if (task.type === '<response>') {
+            // The done() function in the counterpart has been called, and we are now
+            // firing the callback in the originating actor, if there is one.
+            const callback = this.callbacks[id];
+            delete this.callbacks[id];
+            if (callback) {
+                // If we get a response, but don't have a callback, the request was canceled.
+                if (task.error) {
+                    callback(deserialize(task.error));
+                } else {
+                    callback(null, deserialize(task.data));
+                }
+            }
+        } else {
+            let completed = false;
+            const done = task.hasCallback ? (err, data) => {
+                completed = true;
+                delete this.cancelCallbacks[id];
+                const buffers: Array<Transferable> = [];
+                this.target.postMessage({
+                    id,
+                    type: '<response>',
+                    sourceMapId: this.mapId,
+                    error: err ? serialize(err) : null,
+                    data: serialize(data, buffers)
+                }, buffers);
+            } : (_) => {
+                completed = true;
+            };
+
+            let callback = null;
+            const params = (deserialize(task.data): any);
+            if (this.parent[task.type]) {
+                // task.type == 'loadTile', 'removeTile', etc.
+                callback = this.parent[task.type](task.sourceMapId, params, done);
+            } else if (this.parent.getWorkerSource) {
+                // task.type == sourcetype.method
+                const keys = task.type.split('.');
+                const scope = (this.parent: any).getWorkerSource(task.sourceMapId, keys[0], params.source);
+                callback = scope[keys[1]](params, done);
+            } else {
+                // No function was found.
+                done(new Error(`Could not find function ${task.type}`));
+            }
+
+            if (!completed && callback && callback.cancel) {
+                // Allows canceling the task as long as it hasn't been completed yet.
+                this.cancelCallbacks[id] = callback.cancel;
+            }
         }
     }
 
@@ -123,5 +193,7 @@ class Actor {
         this.target.removeEventListener('message', this.receive, false);
     }
 }
+
+Actor.taskId = 0;
 
 export default Actor;

--- a/src/util/dispatcher.js
+++ b/src/util/dispatcher.js
@@ -45,18 +45,12 @@ class Dispatcher {
     }
 
     /**
-     * Send a message to a Worker.
-     * @param targetID The ID of the Worker to which to send this message. Omit to allow the dispatcher to choose.
-     * @returns The ID of the worker to which the message was sent.
+     * Acquires an actor to dispatch messages to. The actors are distributed in round-robin fashion.
+     * @returns An actor object backed by a web worker for processing messages.
      */
-    send(type: string, data: mixed, callback?: ?Function, targetID?: number): number {
-        if (typeof targetID !== 'number' || isNaN(targetID)) {
-            // Use round robin to send requests to web workers.
-            targetID = this.currentActor = (this.currentActor + 1) % this.actors.length;
-        }
-
-        this.actors[targetID].send(type, data, callback);
-        return targetID;
+    getActor(): Actor {
+        this.currentActor = (this.currentActor + 1) % this.actors.length;
+        return this.actors[this.currentActor];
     }
 
     remove() {

--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -115,7 +115,7 @@ let globalEntryCounter = Infinity;
 export function cacheEntryPossiblyAdded(dispatcher: Dispatcher) {
     globalEntryCounter++;
     if (globalEntryCounter > cacheCheckThreshold) {
-        dispatcher.send('enforceCacheSizeLimit', cacheLimit);
+        dispatcher.getActor().send('enforceCacheSizeLimit', cacheLimit);
         globalEntryCounter = 0;
     }
 }

--- a/test/unit/source/query_features.test.js
+++ b/test/unit/source/query_features.test.js
@@ -24,7 +24,11 @@ test('QueryFeatures#source', (t) => {
             type: 'geojson',
             data: { type: 'FeatureCollection', features: [] }
         }, {
-            send (type, params, callback) { return callback(); }
+            getActor() {
+                return {
+                    send(type, params, callback) { return callback(); }
+                };
+            }
         });
         const result = querySourceFeatures(sourceCache, {});
         t.deepEqual(result, []);

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -34,6 +34,9 @@ function MockSourceType(id, sourceOptions, _dispatcher, eventedParent) {
             }
             setTimeout(callback, 0);
         }
+        loaded() {
+            return true;
+        }
         onAdd() {
             if (sourceOptions.noLoad) return;
             if (sourceOptions.error) {

--- a/test/unit/util/actor.test.js
+++ b/test/unit/util/actor.test.js
@@ -14,8 +14,8 @@ test('Actor', (t) => {
 
         const worker = new WebWorker();
 
-        const m1 = new Actor(worker, {}, 'map-1');
-        const m2 = new Actor(worker, {}, 'map-2');
+        const m1 = new Actor(worker, {}, 1);
+        const m2 = new Actor(worker, {}, 2);
 
         t.plan(4);
         m1.send('test', { value: 1729 }, (err, response) => {
@@ -40,15 +40,15 @@ test('Actor', (t) => {
 
         new Actor(worker, {
             test () { t.end(); }
-        }, 'map-1');
+        }, 1);
         new Actor(worker, {
             test () {
                 t.fail();
                 t.end();
             }
-        }, 'map-2');
+        }, 2);
 
-        workerActor.send('test', {}, () => {}, 'map-1');
+        workerActor.send('test', {}, () => {}, 1);
     });
 
     t.test('#remove unbinds event listener', (t) => {


### PR DESCRIPTION
Our `Actor` object is responsible for communicating with other threads, either by sending messages from the main thread to web workers, or vice versa. When calling `Actor#send()`, calls that provided a callback returned a `Cancelable` object that supported calling `.cancel()` for aborting the request. This only worked in a very small number of instances: When the action that was triggered in the corresponding thread was asynchronous, and supported cancellation itself.

This PR changes this to allow cancellation of a much wider array of requests. During high pressure workload phases, e.g. while zooming rapidly, tasks could pile up in the worker: in particular `loadTile` messages, that were followed by `abortTile` messages for the same tile uid. This PR now allows canceling messages while the _wait_ in the worker's queue to be processed. This keeps the task from ever starting in the worker thread. When zooming quickly while loading tiles, this means that we now issue fewer HTTP requests that get cancelled immediately. Similarly, canceling HTTP requests on the worker were delayed by computing tasks on the worker.

Before this PR, the Actor processed messages sent from the counterpart via `postMessage` synchronously. This means that starting a task, followed immediately by a cancellation never actually canceled the task, because the worker first processed the task, then the cancelation. In this PR, I decoupled the message event from processing by putting tasks in a queue, then triggering processing with `setTimeout(..., 0)`. This means that at most 1 task is processed per event loop iteration. This allows message processing run way more frequently, and consequently allows us to process cancel messages more quickly.

I opted for this model instead of a more generic priority queue because we don't have any use cases for a priority queue other than canceling tasks.

This PR also contains the addition of a `loaded` method to `Source` objects. This is necessary to correctly classify the loaded state of a source because we can now no longer rely on all tasks sent to a worker being processed 