### PR TITLE
Remove out-of-date test run URLs

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -72,11 +72,6 @@ or
 open ./test/integration/query-tests/index.html
 ```
 
-When run via Travis, the test artifacts are uploaded to S3 as a permanent record of results. Near the
-end of the Travis output is a link to the result, for example:
-
-http://mapbox.s3.amazonaws.com/mapbox-gl-native/tests/5952.10/index.html
-
 ## Writing new tests
 
 _Note: Expected results are always generated with the **js** implementation. This is merely for consistency and does not


### PR DESCRIPTION
Removed out-of-date links to travis CI based URLs for test runs. We have switched over to Circle CI, but also no longer upload the results to S3.
