### PR TITLE
Disable compass button mouse/touch handlers when map#interactive is false

### DIFF
--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -104,10 +104,12 @@ class NavigationControl {
             }
             this._map.on('rotate', this._rotateCompassArrow);
             this._rotateCompassArrow();
-            this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass});
-            DOM.addEventListener(this._compass, 'mousedown', this._handler.onMouseDown);
-            DOM.addEventListener(this._compass, 'touchstart', this._handler.onMouseDown, { passive: false });
-            this._handler.enable();
+            if (this._map._interactive) {
+                this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass});
+                DOM.addEventListener(this._compass, 'mousedown', this._handler.onMouseDown);
+                DOM.addEventListener(this._compass, 'touchstart', this._handler.onMouseDown, { passive: false });
+                this._handler.enable();
+            }
         }
         return this._container;
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -174,7 +174,7 @@ const defaultOptions = {
  *
  * @param {boolean} [options.hash=false] If `true`, the map's position (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL.
  *   For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
- * @param {boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners will be attached to the map, so it will not respond to interaction.
+ * @param {boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners will be attached to the map, so it will not respond to user interaction. This option also disables user interaction with the map through the Navigation Control's compass button.
  * @param {number} [options.bearingSnap=7] The threshold, measured in degrees, that determines when the map's
  *   bearing will snap to north. For example, with a `bearingSnap` of 7, if the user rotates
  *   the map within 7 degrees of north, the map will automatically snap to exact north.


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - fixes https://github.com/mapbox/mapbox-gl-js/issues/8618
    - when `map#interactive` is set to `false`, we should disable map interactivity via the Navigation Control's compass button as well
 - [x] document any changes to public APIs
 - [x] manually test the debug page
