### PR TITLE
Collect GL performance stats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,9 @@ workflows:
             - build
           filters:
             tags:
-              only: /.*/
+              ignore: /.*/
+            branches:
+              only: master
       - test-flow:
           requires:
             - prepare
@@ -170,7 +172,7 @@ jobs:
       - aws-cli/install
       - run:
           name: Upload performance stats
-          command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_metrics_dev/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz
+          command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_metrics_staging/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz
 
   test-flow:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ jobs:
       - run:
           name: Collect performance stats
           command: node bench/gl-stats.js
+      - aws-cli/install
       - run:
           name: Upload performance stats
           command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_stats_dev/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,10 +105,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-yarn-{{ checksum "yarn.lock" }}
+            - v3-yarn-{{ checksum "yarn.lock" }}
       - run: yarn
       - save_cache:
-          key: v2-yarn-{{ checksum "yarn.lock" }}
+          key: v3-yarn-{{ checksum "yarn.lock" }}
           paths:
             - '~/.yarn'
             - 'node_modules'
@@ -124,13 +124,13 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - v1-lint-{{ .Branch }}
-            - v1-lint
+            - v2-lint-{{ .Branch }}
+            - v2-lint
       - run: yarn run lint
       - run: yarn run lint-docs
       - run: yarn run lint-css
       - save_cache:
-          key: v1-lint-{{ .Branch }}-{{ .Revision }}
+          key: v2-lint-{{ .Branch }}-{{ .Revision }}
           paths:
             - '.eslintcache'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ workflows:
 
 defaults: &defaults
   docker:
-    - image: mbgl/80dbb7f452:linux
+    - image: circleci/node:10.16-browsers
   working_directory: ~/mapbox-gl-js
 
 jobs:
@@ -162,7 +162,6 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: apt-get update -yq && apt-get install -yq libxcomposite1 libxtst6 libnss3 libcups2 libxss1 libasound2 libatk1.0-0 libatk-bridge2.0-0 libpangocairo-1.0-0 libgtk-3-0
       - run: node bench/gl-stats.js
 
   test-flow:
@@ -177,14 +176,14 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: xvfb-run --server-args="-screen 0 1024x768x24" npm run test-unit
+      - run: npm run test-unit
 
   test-render:
     <<: *defaults
     steps:
       - attach_workspace:
           at: .
-      - run: xvfb-run --server-args="-screen 0 1024x768x24" npm run test-render
+      - run: npm run test-render
       - store_artifacts:
           path: "test/integration/render-tests/index.html"
 
@@ -193,7 +192,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: xvfb-run --server-args="-screen 0 1024x768x24" npm run test-query
+      - run: npm run test-query
       - store_artifacts:
           path: "test/integration/query-tests/index.html"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  aws-cli: circleci/aws-cli@0.1.16
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,12 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: node bench/gl-stats.js
+      - run:
+          name: Collect performance stats
+          command: node bench/gl-stats.js
+      - run:
+          name: Upload performance stats
+          command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_stats_dev/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz
 
   test-flow:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - aws-cli/install
       - run:
           name: Upload performance stats
-          command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_stats_dev/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz
+          command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_metrics_dev/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz
 
   test-flow:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - collect-stats:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
       - test-flow:
           requires:
             - prepare
@@ -150,6 +156,14 @@ jobs:
       - attach_workspace:
           at: .
       - run: node build/check-bundle-size.js "dist/mapbox-gl.js" "GL JS - Minified"
+
+  collect-stats:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run: apt-get update -yq && apt-get install -yq libxcomposite1 libxtst6 libnss3 libcups2 libxss1 libasound2 libatk1.0-0 libatk-bridge2.0-0 libpangocairo-1.0-0 libgtk-3-0
+      - run: node bench/gl-stats.js
 
   test-flow:
     <<: *defaults

--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -14,54 +14,59 @@ var map = new mapboxgl.Map({
     container: document.getElementById('map'),
     style: 'mapbox://styles/mapbox/streets-v11',
     center: [-77.07842066675323, 38.890315130853566],
-    zoom: 11.1,
-    fadeDuration: 0
+    zoom: 11
 });
 
 const gl = map.painter.context && map.painter.context.gl || map.painter.gl;
 const vao = map.painter.context && map.painter.context.extVertexArrayObject || map.painter.extVertexArrayObject;
 
-const stats = {
-    'buffer-data-bytes': 0,
-    'tex-image-2d-bytes': 0,
-    'draw-calls': 0,
-    'bind-vao-calls': 0,
-    'use-program-calls': 0
-};
+const tileStats = {};
+const frameStats = {};
+let numFrames = 0;
 
-const {bufferData, texImage2D, drawElements, drawArrays, useProgram} = gl;
-const {bindVertexArrayOES} = vao;
+function hookStats(stats, obj, methodName, statName = methodName, getStat) {
+    const originalFn = obj[methodName];
+    stats[statName] = 0;
+    obj[methodName] = (...args) => {
+        stats[statName] += getStat ? getStat(args) : 1;
+        originalFn.call(obj, ...args);
+    };
+}
 
-gl.bufferData = (...args) => {
-    stats['buffer-data-bytes'] += args[1].byteLength;
-    bufferData.call(gl, ...args);
-};
-gl.texImage2D = (...args) => {
-    stats['tex-image-2d-bytes'] += args[5] ? args[5].width * args[5].height : args[3] * args[4];
-    texImage2D.call(gl, ...args);
-};
-gl.drawElements = (...args) => {
-    stats['draw-calls']++;
-    drawElements.call(gl, ...args);
-};
-gl.drawArrays = (...args) => {
-    stats['draw-calls']++;
-    drawArrays.call(gl, ...args);
-};
-gl.useProgram = (...args) => {
-    stats['use-program-calls']++;
-    useProgram.call(gl, ...args);
-};
-vao.bindVertexArrayOES  = (...args) => {
-    stats['bind-vao-calls']++;
-    bindVertexArrayOES.call(vao, ...args);
-};
+map.on('data', function onData(e) {
+    if (!e.coord) return;
+    // wait for the tile to load before collecting metrics
 
-map.on('render', function logStats() {
-    if (!map._sourcesDirty && !map._repaint && !map._styleDirty && !map._placementDirty && map.loaded()) {
-        console.log(JSON.stringify(stats, null, 2));
-        map.off('render', logStats);
-    }
+    map.off('data', onData);
+
+    hookStats(tileStats, gl, 'bufferData');
+    hookStats(tileStats, gl, 'bufferData', 'bufferData_bytes', (args) => args[1].byteLength);
+
+    hookStats(frameStats, gl, 'bufferSubData');
+    hookStats(frameStats, gl, 'bufferSubData', 'bufferSubData_bytes', (args) => args[2].byteLength);
+
+    hookStats(tileStats, gl, 'texImage2D');
+    hookStats(tileStats, gl, 'texImage2D', 'texImage2D_bytes',
+        (args) => args[5] ? args[5].width * args[5].height : args[3] * args[4]);
+
+    hookStats(tileStats, gl, 'texSubImage2D');
+    hookStats(tileStats, gl, 'texSubImage2D', 'texSubImage2D_bytes',
+        (args) => args[6] && args[6].width ? args[6].width * args[6].height : args[4] * args[5]);
+
+    hookStats(frameStats, gl, 'drawElements', 'draw');
+    hookStats(frameStats, gl, 'drawArrays', 'draw');
+    hookStats(frameStats, gl, 'useProgram');
+    hookStats(frameStats, vao, 'bindVertexArrayOES', 'bindVAO');
+
+    map.on('render', () => numFrames++);
+    map.once('moveend', () => {
+        for (const id in frameStats) {
+            frameStats[id] = Math.round(10 * frameStats[id] / numFrames) / 10;
+        }
+        console.log(JSON.stringify({tileStats, frameStats}, null, 2));
+    });
+
+    setTimeout(() => map.zoomTo(11.99, {duration: 5000, easing: (t) => t}), 1000);
 });
 </script>
 </html>

--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../dist/mapbox-gl.js"></script>
+<style>.mapboxgl-canary { background-color: salmon; }</style>
+</head>
+<body style="margin: 0; padding: 0"><div id="map" style="width: 500px; height: 500px"></div></body>
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoibW91cm5lciIsImEiOiJWWnRiWG1VIn0.j6eccFHpE3Q04XPLI7JxbA';
+mapboxgl.workerCount = 1;
+
+var map = new mapboxgl.Map({
+    container: document.getElementById('map'),
+    style: 'mapbox://styles/mapbox/streets-v11',
+    center: [-77.07842066675323, 38.890315130853566],
+    zoom: 11.1,
+    fadeDuration: 0
+});
+
+const gl = map.painter.context && map.painter.context.gl || map.painter.gl;
+const vao = map.painter.context && map.painter.context.extVertexArrayObject || map.painter.extVertexArrayObject;
+
+const stats = {
+    'buffer-data-bytes': 0,
+    'tex-image-2d-bytes': 0,
+    'draw-calls': 0,
+    'bind-vao-calls': 0,
+    'use-program-calls': 0
+};
+
+const {bufferData, texImage2D, drawElements, drawArrays, useProgram} = gl;
+const {bindVertexArrayOES} = vao;
+
+gl.bufferData = (...args) => {
+    stats['buffer-data-bytes'] += args[1].byteLength;
+    bufferData.call(gl, ...args);
+};
+gl.texImage2D = (...args) => {
+    stats['tex-image-2d-bytes'] += args[5] ? args[5].width * args[5].height : args[3] * args[4];
+    texImage2D.call(gl, ...args);
+};
+gl.drawElements = (...args) => {
+    stats['draw-calls']++;
+    drawElements.call(gl, ...args);
+};
+gl.drawArrays = (...args) => {
+    stats['draw-calls']++;
+    drawArrays.call(gl, ...args);
+};
+gl.useProgram = (...args) => {
+    stats['use-program-calls']++;
+    useProgram.call(gl, ...args);
+};
+vao.bindVertexArrayOES  = (...args) => {
+    stats['bind-vao-calls']++;
+    bindVertexArrayOES.call(vao, ...args);
+};
+
+map.on('render', function logStats() {
+    if (!map._sourcesDirty && !map._repaint && !map._styleDirty && !map._placementDirty && map.loaded()) {
+        console.log(JSON.stringify(stats, null, 2));
+        map.off('render', logStats);
+    }
+});
+</script>
+</html>

--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -2,6 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
+<script>
+let now = performance.now();
+window.performance.now = () => now;
+</script>
 <script src="../dist/mapbox-gl.js"></script>
 <style>.mapboxgl-canary { background-color: salmon; }</style>
 </head>
@@ -64,15 +68,26 @@ map.on('data', function onData(e) {
     hookStats(frameStats, gl, 'bufferSubData', 'bufferSubData');
     hookStats(frameStats, gl, 'bufferSubData', 'bufferSubData_bytes', (args) => args[2].byteLength);
 
-    map.on('render', () => numFrames++);
+    map.on('render', () => {
+        numFrames++;
+        now += 16;
+    });
     map.once('moveend', () => {
         for (const id in frameStats) {
             frameStats[id] = Math.round(10 * frameStats[id] / numFrames) / 10;
         }
-        console.log(JSON.stringify({tileStats, frameStats}, null, 2));
+        const stats = {};
+        for (const id in tileStats) stats[`tile_${id}`] = tileStats[id];
+        for (const id in frameStats) stats[`frame_${id}`] = frameStats[id];
+        console.log(JSON.stringify(stats, null, 2));
     });
 
-    setTimeout(() => map.zoomTo(11.99, {duration: 5000, easing: (t) => t}), 1000);
+    map.on('render', function onIdle() {
+        if (!map._sourcesDirty && !map._repaint && !map._styleDirty && !map._placementDirty && map.loaded()) {
+            map.off('render', onIdle);
+            map.zoomTo(11.99, {duration: 1000, easing: (t) => t});
+        }
+    });
 });
 </script>
 </html>

--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -39,11 +39,14 @@ map.on('data', function onData(e) {
 
     map.off('data', onData);
 
-    hookStats(tileStats, gl, 'bufferData');
-    hookStats(tileStats, gl, 'bufferData', 'bufferData_bytes', (args) => args[1].byteLength);
+    const ifIndex = (args, value = 1) => args[0] === gl.ELEMENT_ARRAY_BUFFER ? value : 0;
+    const ifVertex = (args, value = 1) => args[0] === gl.ARRAY_BUFFER ? value : 0;
 
-    hookStats(frameStats, gl, 'bufferSubData');
-    hookStats(frameStats, gl, 'bufferSubData', 'bufferSubData_bytes', (args) => args[2].byteLength);
+    hookStats(tileStats, gl, 'bufferData', 'bufferData_index', ifIndex);
+    hookStats(tileStats, gl, 'bufferData', 'bufferData_vertex', ifVertex);
+
+    hookStats(tileStats, gl, 'bufferData', 'bufferData_index_bytes', (args) => ifIndex(args, args[1].byteLength));
+    hookStats(tileStats, gl, 'bufferData', 'bufferData_vertex_bytes', (args) => ifVertex(args, args[1].byteLength));
 
     hookStats(tileStats, gl, 'texImage2D');
     hookStats(tileStats, gl, 'texImage2D', 'texImage2D_bytes',
@@ -57,6 +60,9 @@ map.on('data', function onData(e) {
     hookStats(frameStats, gl, 'drawArrays', 'draw');
     hookStats(frameStats, gl, 'useProgram');
     hookStats(frameStats, vao, 'bindVertexArrayOES', 'bindVAO');
+
+    hookStats(frameStats, gl, 'bufferSubData', 'bufferSubData');
+    hookStats(frameStats, gl, 'bufferSubData', 'bufferSubData_bytes', (args) => args[2].byteLength);
 
     map.on('render', () => numFrames++);
     map.once('moveend', () => {

--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="utf-8">
 <script>
+// stub performance.now for deterministic rendering per-frame;
+// we'll later increment the value by 16 on every frame (16ms per frame for 60fps)
 let now = performance.now();
 window.performance.now = () => now;
 </script>

--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -11,7 +11,7 @@ window.performance.now = () => now;
 </head>
 <body style="margin: 0; padding: 0"><div id="map" style="width: 500px; height: 500px"></div></body>
 <script>
-mapboxgl.accessToken = 'pk.eyJ1IjoibW91cm5lciIsImEiOiJWWnRiWG1VIn0.j6eccFHpE3Q04XPLI7JxbA';
+mapboxgl.accessToken = 'MAPBOX_ACCESS_TOKEN';
 mapboxgl.workerCount = 1;
 
 var map = new mapboxgl.Map({

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -3,43 +3,9 @@
 const puppeteer = require('puppeteer');
 const fs = require('fs');
 const mapboxGlSrc = fs.readFileSync('dist/mapbox-gl.js', 'utf8');
+const benchSrc = fs.readFileSync('bench/gl-stats.html', 'utf8');
 
-const benchHTML = `<!doctype html>
-<html>
-<head>
-<meta charset="utf-8">
-<script>${mapboxGlSrc}</script>
-<link rel="stylesheet" href="dist/mapbox-gl.css">
-</head>
-<body style="margin: 0; padding: 0"><div id="map" style="width: 500px; height: 500px"></div></body>
-<script>
-mapboxgl.accessToken = 'pk.eyJ1IjoibW91cm5lciIsImEiOiJWWnRiWG1VIn0.j6eccFHpE3Q04XPLI7JxbA';
-mapboxgl.workerCount = 1;
-
-var map = new mapboxgl.Map({
-    container: document.getElementById('map'),
-    style: 'mapbox://styles/mapbox/streets-v11',
-    center: [-77.07842066675323, 38.890315130853566],
-    zoom: 11.1
-});
-
-const gl = map.painter.context && map.painter.context.gl || map.painter.gl;
-
-let bufferDataTotal = 0;
-
-const originalBufferData = gl.bufferData;
-gl.bufferData = function (target, data, usage) {
-    bufferDataTotal += data.byteLength;
-    originalBufferData.call(gl, target, data, usage);
-};
-
-map.on('render', () => {
-    if (!map._sourcesDirty && !map._repaint && !map._styleDirty && !map._placementDirty && map.loaded()) {
-        console.log(JSON.stringify({'buffer-data': bufferDataTotal}));
-    }
-});
-</script>
-</html>`;
+const benchHTML = benchSrc.replace(/<script src="..\/dist\/mapbox-gl.js"><\/script>/, `<script>${mapboxGlSrc}</script>`);
 
 function waitForConsole(page) {
     return new Promise((resolve) => {

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -2,6 +2,7 @@
 
 const puppeteer = require('puppeteer');
 const fs = require('fs');
+const zlib = require('zlib');
 const mapboxGlSrc = fs.readFileSync('dist/mapbox-gl.js', 'utf8');
 const benchSrc = fs.readFileSync('bench/gl-stats.html', 'utf8');
 
@@ -28,6 +29,10 @@ function waitForConsole(page) {
     await page.setContent(benchHTML);
 
     const stats = JSON.parse(await waitForConsole(page));
+    stats.bundleStats = {
+        size: mapboxGlSrc.length,
+        "size_gz": zlib.gzipSync(mapboxGlSrc).length
+    };
     console.log(JSON.stringify(stats, null, 2));
 
     await page.close();

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const zlib = require('zlib');
 const mapboxGlSrc = fs.readFileSync('dist/mapbox-gl.js', 'utf8');
 const benchSrc = fs.readFileSync('bench/gl-stats.html', 'utf8');
+const {execSync} = require('child_process');
 
 const benchHTML = benchSrc.replace(/<script src="..\/dist\/mapbox-gl.js"><\/script>/, `<script>${mapboxGlSrc}</script>`);
 
@@ -33,6 +34,8 @@ function waitForConsole(page) {
         size: mapboxGlSrc.length,
         "size_gz": zlib.gzipSync(mapboxGlSrc).length
     };
+    stats.dt = new Date().toISOString().substring(0, 16);
+    stats.commit = execSync('git rev-parse --short=7 HEAD').toString().trim();
     console.log(JSON.stringify(stats, null, 2));
 
     await page.close();

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -7,7 +7,9 @@ const mapboxGlSrc = fs.readFileSync('dist/mapbox-gl.js', 'utf8');
 const benchSrc = fs.readFileSync('bench/gl-stats.html', 'utf8');
 const {execSync} = require('child_process');
 
-const benchHTML = benchSrc.replace(/<script src="..\/dist\/mapbox-gl.js"><\/script>/, `<script>${mapboxGlSrc}</script>`);
+const benchHTML = benchSrc
+    .replace(/<script src="..\/dist\/mapbox-gl.js"><\/script>/, `<script>${mapboxGlSrc}</script>`)
+    .replace('MAPBOX_ACCESS_TOKEN', process.env.MAPBOX_ACCESS_TOKEN);
 
 function waitForConsole(page) {
     return new Promise((resolve) => {

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -37,7 +37,10 @@ function waitForConsole(page) {
     stats.dt = execSync('git show --no-patch --no-notes --pretty=\'%cI\' HEAD').toString().substring(0, 19);
     stats.commit = execSync('git rev-parse --short HEAD').toString().trim();
     stats.message = execSync('git show -s --format=%s HEAD').toString().trim();
-    console.log(JSON.stringify(stats, null, 2));
+    const statsStr = JSON.stringify(stats, null, 2);
+    console.log(statsStr);
+
+    fs.writeFileSync('data.json.gz', zlib.gzipSync(statsStr));
 
     await page.close();
     await browser.close();

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -1,0 +1,69 @@
+/* eslint-disable import/no-commonjs */
+
+const puppeteer = require('puppeteer');
+const fs = require('fs');
+const mapboxGlSrc = fs.readFileSync('dist/mapbox-gl.js', 'utf8');
+
+const benchHTML = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script>${mapboxGlSrc}</script>
+<link rel="stylesheet" href="dist/mapbox-gl.css">
+</head>
+<body style="margin: 0; padding: 0"><div id="map" style="width: 500px; height: 500px"></div></body>
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoibW91cm5lciIsImEiOiJWWnRiWG1VIn0.j6eccFHpE3Q04XPLI7JxbA';
+mapboxgl.workerCount = 1;
+
+var map = new mapboxgl.Map({
+    container: document.getElementById('map'),
+    style: 'mapbox://styles/mapbox/streets-v11',
+    center: [-77.07842066675323, 38.890315130853566],
+    zoom: 11.1
+});
+
+const gl = map.painter.context && map.painter.context.gl || map.painter.gl;
+
+let bufferDataTotal = 0;
+
+const originalBufferData = gl.bufferData;
+gl.bufferData = function (target, data, usage) {
+    bufferDataTotal += data.byteLength;
+    originalBufferData.call(gl, target, data, usage);
+};
+
+map.on('render', () => {
+    if (!map._sourcesDirty && !map._repaint && !map._styleDirty && !map._placementDirty && map.loaded()) {
+        console.log(JSON.stringify({'buffer-data': bufferDataTotal}));
+    }
+});
+</script>
+</html>`;
+
+function waitForConsole(page) {
+    return new Promise((resolve) => {
+        function onConsole(msg) {
+            page.removeListener('console', onConsole);
+            resolve(msg.text());
+        }
+        page.on('console', onConsole);
+    });
+}
+
+(async () => {
+    const browser = await puppeteer.launch({
+        args: ['--no-sandbox', '--disable-setuid-sandbox']
+    });
+    const page = await browser.newPage();
+
+    console.log('collecting stats...');
+    await page.setViewport({width: 600, height: 600, deviceScaleFactor: 2});
+    await page.setContent(benchHTML);
+
+    const stats = JSON.parse(await waitForConsole(page));
+    console.log(JSON.stringify(stats, null, 2));
+
+    await page.close();
+    await browser.close();
+})();

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -30,12 +30,11 @@ function waitForConsole(page) {
     await page.setContent(benchHTML);
 
     const stats = JSON.parse(await waitForConsole(page));
-    stats.bundleStats = {
-        size: mapboxGlSrc.length,
-        "size_gz": zlib.gzipSync(mapboxGlSrc).length
-    };
-    stats.dt = new Date().toISOString().substring(0, 16);
-    stats.commit = execSync('git rev-parse --short=7 HEAD').toString().trim();
+    stats["bundle_size"] = mapboxGlSrc.length;
+    stats["bundle_size_gz"] = zlib.gzipSync(mapboxGlSrc).length;
+    stats.dt = execSync('git show --no-patch --no-notes --pretty=\'%cI\' HEAD').toString().substring(0, 19);
+    stats.commit = execSync('git rev-parse --short HEAD').toString().trim();
+    stats.message = execSync('git show -s --format=%s HEAD').toString().trim();
     console.log(JSON.stringify(stats, null, 2));
 
     await page.close();

--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -36,7 +36,7 @@
                                     "Effect": "Allow",
                                     "Resource": [
                                         "arn:aws:s3:::mapbox-gl-js/*",
-                                        "arn:aws:s3:::loading-dock/raw/gl_js.perf_metrics*/*"
+                                        "arn:aws:s3:::mapbox-loading-dock/raw/gl_js.perf_metrics*/*"
                                     ]
                                 }
                             ]

--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -35,7 +35,8 @@
                                     ],
                                     "Effect": "Allow",
                                     "Resource": [
-                                        "arn:aws:s3:::mapbox-gl-js/*"
+                                        "arn:aws:s3:::mapbox-gl-js/*",
+                                        "arn:aws:s3:::loading-dock/raw/gl_js.perf_metrics*/*"
                                     ]
                                 }
                             ]

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "pretty-bytes": "^5.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "puppeteer": "^1.18.0",
     "request": "^2.88.0",
     "rollup": "^1.16.4",
     "rollup-plugin-buble": "^0.19.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,7 +2212,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.6.0, concat-stream@^1.6.1, concat-stream@~1.6.0:
+concat-stream@1.6.2, concat-stream@^1.6.0, concat-stream@^1.6.1, concat-stream@~1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -2791,17 +2791,17 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
@@ -3624,6 +3624,16 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-zip@^1.6.6:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
+  integrity sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=
+  dependencies:
+    concat-stream "1.6.2"
+    debug "2.6.9"
+    mkdirp "0.5.1"
+    yauzl "2.4.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -3667,6 +3677,13 @@ faye-websocket@~0.10.0:
   integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
   dependencies:
     websocket-driver ">=0.5.1"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
+  dependencies:
+    pend "~1.2.0"
 
 fd@~0.0.2:
   version "0.0.3"
@@ -4313,7 +4330,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^2.2.0:
+https-proxy-agent@^2.2.0, https-proxy-agent@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
   integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
@@ -5535,7 +5552,7 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.40.0"
 
-mime@^2.2.0:
+mime@^2.0.3, mime@^2.2.0:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
@@ -5628,7 +5645,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -6429,6 +6446,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -6721,7 +6743,7 @@ process@~0.11.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -6751,6 +6773,11 @@ protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.7.tgz#95f788a4f0e979b291ffefcf5636ad113d037d32"
   integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
+
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -6821,6 +6848,20 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+puppeteer@^1.18.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.19.0.tgz#e3b7b448c2c97933517078d7a2c53687361bebea"
+  integrity sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==
+  dependencies:
+    debug "^4.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
+    mime "^2.0.3"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^6.1.0"
 
 qs@^6.4.0:
   version "6.7.0"
@@ -9171,7 +9212,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^6.1.2:
+ws@^6.1.0, ws@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
@@ -9255,6 +9296,13 @@ yargs@^12.0.1, yargs@^12.0.2, yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  integrity sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=
+  dependencies:
+    fd-slicer "~1.0.1"
 
 yn@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
Runs a slow 5-second zoom over a single dense Mapbox Streets tile with Puppeteer on Circle CI and collects various performance-related stats:

```json
{
  "tileStats": {
    "bufferData_index": 48,
    "bufferData_vertex": 105,
    "bufferData_index_bytes": 557324,
    "bufferData_vertex_bytes": 1847176,
    "texImage2D": 3,
    "texImage2D_bytes": 211329,
    "texSubImage2D": 2,
    "texSubImage2D_bytes": 262144
  },
  "frameStats": {
    "draw": 44,
    "useProgram": 28.4,
    "bindVAO": 40,
    "bufferSubData": 2.7,
    "bufferSubData_bytes": 6508.4
  },
  "bundleStats": {
    "size": 691107,
    "size_gz": 175623
  },
  "dt": "2019-08-16T12:37",
  "commit": "8533a3b"
}
```

You can run the same stats locally by opening `bench/gl-stats.html` (and making sure you have `dist/mapbox-gl.js` built).

## To do

- [ ] Set this up for upload to S3 (only on master commits)
- [ ] Possibly cache dependencies that have to be installed with `apt-get` on every run to get Puppeteer to work
- [ ] See if any other suggestions for useful GL stats to collect.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - ~~write tests for all new functionality~~
 - ~~document any changes to public APIs~~
 - ~~post benchmark scores~~
 - [x] manually test the debug page
