### PR TITLE
Don't cache server requested glyphs in the local glyph ranges

### DIFF
--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -64,6 +64,7 @@ class GlyphManager {
 
             glyph = this._tinySDF(entry, stack, id);
             if (glyph) {
+                entry.glyphs[id] = glyph;
                 callback(null, {stack, id, glyph});
                 return;
             }

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -82,7 +82,7 @@ class GlyphManager {
                     (err, response: ?{[number]: StyleGlyph | null}) => {
                         if (response) {
                             for (const id in response) {
-                                if (!this._doesCharSupportLocalGlyph(id)) {
+                                if (!this._doesCharSupportLocalGlyph(+id)) {
                                     entry.glyphs[+id] = response[+id];
                                 }
                             }
@@ -121,13 +121,13 @@ class GlyphManager {
         });
     }
 
-    _doesCharSupportLocalGlyph(id: number): Boolean {
+    _doesCharSupportLocalGlyph(id: number):boolean {
         /* eslint-disable new-cap */
-        return this.localIdeographFontFamily && 
+        return !!this.localIdeographFontFamily &&
             (isChar['CJK Unified Ideographs'](id) ||
                 isChar['Hangul Syllables'](id) ||
                 isChar['Hiragana'](id) ||
-                isChar['Katakana'](id)) 
+                isChar['Katakana'](id));
         /* eslint-enable new-cap */
     }
 

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -121,7 +121,7 @@ class GlyphManager {
         });
     }
 
-    _doesCharSupportLocalGlyph(id: number):boolean {
+    _doesCharSupportLocalGlyph(id: number): boolean {
         /* eslint-disable new-cap */
         return !!this.localIdeographFontFamily &&
             (isChar['CJK Unified Ideographs'](id) ||

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -81,7 +81,9 @@ class GlyphManager {
                     (err, response: ?{[number]: StyleGlyph | null}) => {
                         if (response) {
                             for (const id in response) {
-                                entry.glyphs[+id] = response[+id];
+                                if (!this._doesCharSupportLocalGlyph(id)) {
+                                    entry.glyphs[+id] = response[+id];
+                                }
                             }
                         }
                         for (const cb of requests) {
@@ -118,17 +120,23 @@ class GlyphManager {
         });
     }
 
+    _doesCharSupportLocalGlyph(id: number): Boolean {
+        /* eslint-disable new-cap */
+        return this.localIdeographFontFamily && 
+            (isChar['CJK Unified Ideographs'](id) ||
+                isChar['Hangul Syllables'](id) ||
+                isChar['Hiragana'](id) ||
+                isChar['Katakana'](id)) 
+        /* eslint-enable new-cap */
+    }
+
     _tinySDF(entry: Entry, stack: string, id: number): ?StyleGlyph {
         const family = this.localIdeographFontFamily;
         if (!family) {
             return;
         }
-        /* eslint-disable new-cap */
-        if (!isChar['CJK Unified Ideographs'](id) &&
-            !isChar['Hangul Syllables'](id) &&
-            !isChar['Hiragana'](id) &&
-            !isChar['Katakana'](id)
-        ) { /* eslint-enable new-cap */
+
+        if (!this._doesCharSupportLocalGlyph(id)) {
             return;
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -965,7 +965,7 @@ class Map extends Camera {
      * @see [Change a map's style](https://www.mapbox.com/mapbox-gl-js/example/setstyle/)
      */
     setStyle(style: StyleSpecification | string | null, options?: {diff?: boolean} & StyleOptions) {
-        options = extend({}, { localIdeographFontFamily: defaultOptions.localIdeographFontFamily}, options);
+        options = extend({}, { localIdeographFontFamily: this._localIdeographFontFamily}, options);
 
         if ((options.diff !== false && options.localIdeographFontFamily === this._localIdeographFontFamily) && this.style && style) {
             this._diffStyle(style, options);

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -43,6 +43,41 @@ test('GlyphManager requests remote CJK PBF', (t) => {
     });
 });
 
+test('GlyphManager does not cache CJK chars that should be rendered locally', (t) => {
+    t.stub(GlyphManager, 'loadGlyphRange').callsFake((stack, range, urlTemplate, transform, callback) => {
+        const overlappingGlyphs = {};
+        const start = range * 256;
+        const end = start + 256
+        for (let i=start, j = 0; i < end; i++, j++) {
+            overlappingGlyphs[i] = glyphs[j];
+        }
+        setImmediate(() => callback(null, overlappingGlyphs));
+    });
+    t.stub(GlyphManager, 'TinySDF').value(class {
+        // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
+        draw() {
+            return new Uint8ClampedArray(900);
+        }
+    });
+    const manager = new GlyphManager((url) => ({url}), 'sans-serif');
+    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+
+    //Request char that overlaps Katakana range
+    manager.getGlyphs({'Arial Unicode MS': [0x3005]}, (err, glyphs) => {
+        t.ifError(err);
+        t.notEqual(glyphs['Arial Unicode MS'][0x3005], null);
+        //Request char from Katakana range (te)
+        manager.getGlyphs({'Arial Unicode MS': [0x30C6]}, (err, glyphs) => {
+            t.ifError(err);
+            const glyph = glyphs['Arial Unicode MS'][0x30c6];
+            //Ensure that te is locally generated.
+            t.equal(glyph.bitmap.height, 30);
+            t.equal(glyph.bitmap.width, 30);
+            t.end();
+        });
+    });
+});
+
 test('GlyphManager generates CJK PBF locally', (t) => {
     t.stub(GlyphManager, 'TinySDF').value(class {
         // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -47,8 +47,8 @@ test('GlyphManager does not cache CJK chars that should be rendered locally', (t
     t.stub(GlyphManager, 'loadGlyphRange').callsFake((stack, range, urlTemplate, transform, callback) => {
         const overlappingGlyphs = {};
         const start = range * 256;
-        const end = start + 256
-        for (let i=start, j = 0; i < end; i++, j++) {
+        const end = start + 256;
+        for (let i = start, j = 0; i < end; i++, j++) {
             overlappingGlyphs[i] = glyphs[j];
         }
         setImmediate(() => callback(null, overlappingGlyphs));
@@ -136,7 +136,7 @@ test('GlyphManager generates Hiragana PBF locally', (t) => {
 
 test('GlyphManager caches locally generated glyphs', (t) => {
     let drawCallCount = 0;
-    const stub = t.stub(GlyphManager, 'TinySDF').value(class {
+    t.stub(GlyphManager, 'TinySDF').value(class {
         // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
         draw() {
             drawCallCount++;
@@ -151,7 +151,7 @@ test('GlyphManager caches locally generated glyphs', (t) => {
     manager.getGlyphs({'Arial Unicode MS': [0x30c6]}, (err, glyphs) => {
         t.ifError(err);
         t.equal(glyphs['Arial Unicode MS'][0x30c6].metrics.advance, 24);
-        manager.getGlyphs({'Arial Unicode MS': [0x30c6]}, (err, glyphs) => {
+        manager.getGlyphs({'Arial Unicode MS': [0x30c6]}, () => {
             t.equal(drawCallCount, 1);
             t.end();
         });


### PR DESCRIPTION
Fixes #8653.

Font glyphs from the server are requested in packed in ranges of 256 characters. In some rare cases a single range may contain characters that can be locally generated (using tinySDF) and that need to be fetched from the server.

The issue described in #8653 stems from a character from such an overlapping range causing the remote glyphs being cached for even those characters that should be locally generated. This would be a non-issue if both local generation and the server request were resolving to the same font.

The fix is to check each character in the fetched range and skip it if it is should be generated locally. An additional improvement in this PR is to cache the locally generated glyphs so that subsequent tiles don't need to re-generate them.

I also found a bug in `Map#setStyle` while debugging this issue that uses the wrong `default` font family for local glyph generation. It should use the value resolved in the map constructor.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged @mapbox/map-design-team 
 - [x] tagged @mapbox/gl-native for native port


cc @chloekraw @tmpsantos 