### PR TITLE
clarification of description for step expression

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2646,7 +2646,7 @@
         }
       },
       "step": {
-        "doc": "Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order. Returns the output value of the stop just less than the input, or the first input if the input is less than the first stop.",
+        "doc": "Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order. Returns the output value of the stop just less than the input, or the first output if the input is less than the first stop.",
         "group": "Ramps, scales, curves",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
Style spec:
```
Returns the output value of the stop just less than the input, or the first input if the input is less than the first stop.
```

Should really be

Returns the output value of the stop just less than the input, or the first **_output_** if the input is less than the first stop.