### PR TITLE
Ensure controls respect padding

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -45,6 +45,7 @@ class Transform {
     _pitch: number;
     _zoom: number;
     _unmodified: boolean;
+    _paddingDirty: boolean;
     _renderWorldCopies: boolean;
     _minZoom: number;
     _maxZoom: number;
@@ -77,6 +78,7 @@ class Transform {
         this._fov = 0.6435011087932844;
         this._pitch = 0;
         this._unmodified = true;
+        this._paddingDirty = false;
         this._edgeInsets = new EdgeInsets();
         this._posMatrixCache = {};
         this._alignedPosMatrixCache = {};
@@ -94,6 +96,7 @@ class Transform {
         clone._fov = this._fov;
         clone._pitch = this._pitch;
         clone._unmodified = this._unmodified;
+        clone._paddingDirty = this._paddingDirty;
         clone._edgeInsets = this._edgeInsets.clone();
         clone._calcMatrices();
         return clone;
@@ -213,6 +216,7 @@ class Transform {
     set padding(padding: PaddingOptions) {
         if (this._edgeInsets.equals(padding)) return;
         this._unmodified = false;
+        this._paddingDirty = true;
         //Update edge-insets inplace
         this._edgeInsets.interpolate(this._edgeInsets, padding, 1);
         this._calcMatrices();
@@ -250,6 +254,7 @@ class Transform {
      */
     interpolatePadding(start: PaddingOptions, target: PaddingOptions, t: number) {
         this._unmodified = false;
+        this._paddingDirty = true;
         this._edgeInsets.interpolate(start, target, t);
         this._constrain();
         this._calcMatrices();
@@ -426,6 +431,10 @@ class Transform {
     }
 
     get unmodified(): boolean { return this._unmodified; }
+
+    get isPaddingDirty(): boolean { return this._paddingDirty; }
+
+    markPaddingClean() { this._paddingDirty = false; }
 
     zoomScale(zoom: number) { return Math.pow(2, zoom); }
     scaleZoom(scale: number) { return Math.log(scale) / Math.LN2; }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -177,7 +177,7 @@ class AttributionControl {
     }
 
     _updateCompact() {
-        if (this._map.getCanvasContainer().offsetWidth <= 640) {
+        if (this._map.getEffectiveWidth() <= 640) {
             this._container.classList.add('mapboxgl-compact');
         } else {
             this._container.classList.remove('mapboxgl-compact');

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -79,7 +79,8 @@ class LogoControl {
         const containerChildren = this._container.children;
         if (containerChildren.length) {
             const anchor = containerChildren[0];
-            if (this._map.getCanvasContainer().offsetWidth < 250) {
+
+            if (this._map.getEffectiveWidth() < 250) {
                 anchor.classList.add('mapboxgl-compact');
             } else {
                 anchor.classList.remove('mapboxgl-compact');

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -63,6 +63,7 @@ type IControl = {
     onAdd(map: Map): HTMLElement;
     onRemove(map: Map): void;
 
+    +_updateCompact?: () => void;
     +getDefaultPosition?: () => ControlPosition;
 }
 /* eslint-enable no-use-before-define */
@@ -1990,7 +1991,9 @@ class Map extends Camera {
      */
     getEffectiveWidth(): number {
         const padding = this.getPadding();
-        return Math.max(this.getCanvasContainer().offsetWidth - padding.left - padding.right, 0);
+        const left = padding.left || 0;
+        const right = padding.right || 0;
+        return Math.max(this.getCanvasContainer().offsetWidth - left - right, 0);
     }
 
     _containerDimensions() {
@@ -2297,8 +2300,8 @@ class Map extends Camera {
             }
         }
 
-        for(const control of this._controls){
-            if(control._updateCompact) {
+        for (const control of this._controls) {
+            if (control._updateCompact) {
                 control._updateCompact();
             }
         }

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -37,7 +37,7 @@ test('AttributionControl appears in the position specified by the position optio
 
 test('AttributionControl appears in compact mode if compact option is used', (t) => {
     const map = createMap(t);
-    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 700, configurable: true});
+    const stub = t.stub(map, 'getEffectiveWidth').returns(700);
 
     let attributionControl = new AttributionControl({
         compact: true
@@ -49,7 +49,7 @@ test('AttributionControl appears in compact mode if compact option is used', (t)
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib.mapboxgl-compact').length, 1);
     map.removeControl(attributionControl);
 
-    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 600, configurable: true});
+    stub.returns(600);
     attributionControl = new AttributionControl({
         compact: false
     });
@@ -61,14 +61,14 @@ test('AttributionControl appears in compact mode if compact option is used', (t)
 
 test('AttributionControl appears in compact mode if container is less then 640 pixel wide', (t) => {
     const map = createMap(t);
-    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 700, configurable: true});
+    const stub = t.stub(map, 'getEffectiveWidth').returns(700);
     map.addControl(new AttributionControl());
 
     const container = map.getContainer();
 
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib:not(.mapboxgl-compact)').length, 1);
 
-    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 600, configurable: true});
+    stub.returns(600);
     map.resize();
 
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib.mapboxgl-compact').length, 1);

--- a/test/unit/ui/control/logo.test.js
+++ b/test/unit/ui/control/logo.test.js
@@ -92,11 +92,11 @@ test('LogoControl appears in compact mode if container is less then 250 pixel wi
     const map = createMap(t);
     const container = map.getContainer();
 
-    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 255, configurable: true});
+    const stub = t.stub(map, 'getEffectiveWidth').returns(255);
     map.resize();
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-logo:not(.mapboxgl-compact)').length, 1);
 
-    Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 245, configurable: true});
+    stub.returns(245);
     map.resize();
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-logo.mapboxgl-compact').length, 1);
 


### PR DESCRIPTION
This is follow-up to https://github.com/mapbox/mapbox-gl-js/pull/8638, and updates the styling of `Map#_controlPositions` DOM elements to respect the current state of `padding`.

I'm not completely sure if this should be default behavior, or a option that defaults to true.


Demo:
![2020-02-14 18 55 14](https://user-images.githubusercontent.com/1449257/74580677-9f36ac00-4f5b-11ea-9f7f-f4c5187eed43.gif)



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] ~post benchmark scores~ 
 - [x] manually test the debug page
 - [ ] ~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes~
 - [ ] ~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~