### PR TITLE
Add CSP/unminified builds to CDN release uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,3 +225,10 @@ jobs:
             upload mapbox-gl.js.map application/octet-stream
             upload mapbox-gl-dev.js application/javascript
             upload mapbox-gl.css    text/css
+
+            upload mapbox-gl-unminified.js     application/javascript
+            upload mapbox-gl-unminified.js.map application/octet-stream
+            upload mapbox-gl-csp.js            application/javascript
+            upload mapbox-gl-csp.js.map        application/octet-stream
+            upload mapbox-gl-csp-worker.js     application/javascript
+            upload mapbox-gl-csp-worker.js.map application/octet-stream


### PR DESCRIPTION
The [CSP section of the GL JS docs](https://docs.mapbox.com/mapbox-gl-js/overview/#csp-directives) has example code with CDN links to the CSP version of the build, but we actually never upload those builds to CDN, so the links don't work.

The PR adds uploading CSP + Unminified builds (js + map) to the `deploy-release` CI job.

Will have to be cherry-picked to `release-queso` for the next release to have those builds on CDN.