### PR TITLE
fix: reset map loaded state to false on setStyle #8691

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -965,6 +965,8 @@ class Map extends Camera {
      * @see [Change a map's style](https://www.mapbox.com/mapbox-gl-js/example/setstyle/)
      */
     setStyle(style: StyleSpecification | string | null, options?: {diff?: boolean} & StyleOptions) {
+        this._loaded = false;
+
         options = extend({}, { localIdeographFontFamily: this._localIdeographFontFamily}, options);
 
         if ((options.diff !== false && options.localIdeographFontFamily === this._localIdeographFontFamily) && this.style && style) {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -183,6 +183,23 @@ test('Map', (t) => {
             });
         });
 
+        t.test('fires load event', (t) => {
+            const map = createMap(t);
+
+            const spy1 = t.spy(() => {
+                const spy2 = t.spy(() => {
+                    t.ok(spy1.calledOnce);
+                    t.ok(spy2.calledOnce);
+                    t.end();
+                });
+
+                map.once('load', spy2);
+                map.setStyle(createStyle());
+            });
+
+            map.once('load', spy1);
+        });
+
         t.test('fires *data and *dataloading events', (t) => {
             createMap(t, {}, (error, map) => {
                 t.error(error);


### PR DESCRIPTION
Map loaded state should be reseted to false after style changed with `setStyle`, so `load` event can be emitted.