### PR TITLE
Add `originalEvent` property to NavigationControl events

### DIFF
--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -52,18 +52,18 @@ class NavigationControl {
             bindAll([
                 '_updateZoomButtons'
             ], this);
-            this._zoomInButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-in', 'Zoom in', () => this._map.zoomIn());
-            this._zoomOutButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-out', 'Zoom out', () => this._map.zoomOut());
+            this._zoomInButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-in', 'Zoom in', (e) => this._map.zoomIn({}, { originalEvent: e }));
+            this._zoomOutButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-out', 'Zoom out', (e) => this._map.zoomOut({}, { originalEvent: e }));
         }
         if (this.options.showCompass) {
             bindAll([
                 '_rotateCompassArrow'
             ], this);
-            this._compass = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-compass', 'Reset bearing to north', () => {
+            this._compass = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-compass', 'Reset bearing to north', (e) => {
                 if (this.options.visualizePitch) {
-                    this._map.resetNorthPitch();
+                    this._map.resetNorthPitch({}, { originalEvent: e });
                 } else {
-                    this._map.resetNorth();
+                    this._map.resetNorth({}, { originalEvent: e });
                 }
             });
             this._compassArrow = DOM.create('span', 'mapboxgl-ctrl-compass-arrow', this._compass);

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -52,8 +52,8 @@ class NavigationControl {
             bindAll([
                 '_updateZoomButtons'
             ], this);
-            this._zoomInButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-in', 'Zoom in', (e) => this._map.zoomIn({}, { originalEvent: e }));
-            this._zoomOutButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-out', 'Zoom out', (e) => this._map.zoomOut({}, { originalEvent: e }));
+            this._zoomInButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-in', 'Zoom in', (e) => this._map.zoomIn({}, {originalEvent: e}));
+            this._zoomOutButton = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-zoom-out', 'Zoom out', (e) => this._map.zoomOut({}, {originalEvent: e}));
         }
         if (this.options.showCompass) {
             bindAll([
@@ -61,9 +61,9 @@ class NavigationControl {
             ], this);
             this._compass = this._createButton('mapboxgl-ctrl-icon mapboxgl-ctrl-compass', 'Reset bearing to north', (e) => {
                 if (this.options.visualizePitch) {
-                    this._map.resetNorthPitch({}, { originalEvent: e });
+                    this._map.resetNorthPitch({}, {originalEvent: e});
                 } else {
-                    this._map.resetNorth({}, { originalEvent: e });
+                    this._map.resetNorth({}, {originalEvent: e});
                 }
             });
             this._compassArrow = DOM.create('span', 'mapboxgl-ctrl-compass-arrow', this._compass);

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -214,6 +214,9 @@ export class MapWheelEvent extends Event {
 }
 
 /**
+ * A `MapBoxZoomEvent` is the event type for boxzoom-related map events.
+ * `originalEvent` can be a {@link Map.event:click} when the zoom is triggered by a UI event.
+ *
  * @typedef {Object} MapBoxZoomEvent
  * @property {MouseEvent} originalEvent
  */


### PR DESCRIPTION
This PR adds `originalEvent` property to events initiated using `NavigationControl` (zoom in, zoom out, reset bearing). Relates to https://github.com/mapbox/mapbox-gl-js/issues/6405