### PR TITLE
fix #8705 actor error after map is removed

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -708,7 +708,7 @@ class SourceCache extends Evented {
         if (tile.uses > 0)
             return;
 
-        if (tile.hasData()) {
+        if (tile.hasData() && tile.state !== 'reloading') {
             this._cache.add(tile.tileID, tile, tile.getExpiryTimeout());
         } else {
             tile.aborted = true;

--- a/src/util/dispatcher.js
+++ b/src/util/dispatcher.js
@@ -2,6 +2,7 @@
 
 import {uniqueId, asyncAll} from './util';
 import Actor from './actor';
+import assert from 'assert';
 
 import type WorkerPool from './worker_pool';
 
@@ -32,12 +33,14 @@ class Dispatcher {
             actor.name = `Worker ${i}`;
             this.actors.push(actor);
         }
+        assert(this.actors.length);
     }
 
     /**
      * Broadcast a message to all Workers.
      */
     broadcast(type: string, data: mixed, cb?: Function) {
+        assert(this.actors.length);
         cb = cb || function () {};
         asyncAll(this.actors, (actor, done) => {
             actor.send(type, data, done);
@@ -49,6 +52,7 @@ class Dispatcher {
      * @returns An actor object backed by a web worker for processing messages.
      */
     getActor(): Actor {
+        assert(this.actors.length);
         this.currentActor = (this.currentActor + 1) % this.actors.length;
         return this.actors[this.currentActor];
     }


### PR DESCRIPTION
This attempts to fix https://github.com/mapbox/mapbox-gl-js/issues/8705. I was able to reproduce that error only with `map.style._reloadSource('mapbox'); map.remove();` on `debug/satellite.html`

If a tile was reloaded shortly before a `map.remove()`, raster tiles that were in the middle of being loaded would not be aborted leading to an error when the tried to work with the removed map.

The broader problem happens whenever a tile is removed while it is being reloaded.

Overall all the code that deals with tile state and map removing seems very brittle and something worth looking at for a refactor.

I'm not sure how to test this.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page