### PR TITLE
Build unminified & CSP builds in build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,8 @@ jobs:
       - attach_workspace:
           at: .
       - run: yarn run build-prod-min
+      - run: yarn run build-prod
+      - run: yarn run build-csp
       - run: yarn run build-dev
       - run: yarn run build-css
       - run: yarn run build-style-spec


### PR DESCRIPTION
Follow-up to #8681. The upload failed because we didn't actually build those in the `build` CI job.