### PR TITLE
port fix for icon-text-fit combined with variable text placement

### DIFF
--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -422,10 +422,11 @@ register('StructArrayLayout2ub2f12', StructArrayLayout2ub2f12);
  * [28]: Float32[2]
  * [36]: Uint8[3]
  * [40]: Uint32[1]
+ * [44]: Int16[1]
  *
  * @private
  */
-class StructArrayLayout2i2ui3ul3ui2f3ub1ul44 extends StructArray {
+class StructArrayLayout2i2ui3ul3ui2f3ub1ul1i48 extends StructArray {
     uint8: Uint8Array;
     int16: Int16Array;
     uint16: Uint16Array;
@@ -440,16 +441,16 @@ class StructArrayLayout2i2ui3ul3ui2f3ub1ul44 extends StructArray {
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
-    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number) {
+    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number, v16: number) {
         const i = this.length;
         this.resize(i + 1);
-        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16);
     }
 
-    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number) {
-        const o2 = i * 22;
-        const o4 = i * 11;
-        const o1 = i * 44;
+    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number, v16: number) {
+        const o2 = i * 24;
+        const o4 = i * 12;
+        const o1 = i * 48;
         this.int16[o2 + 0] = v0;
         this.int16[o2 + 1] = v1;
         this.uint16[o2 + 2] = v2;
@@ -466,23 +467,24 @@ class StructArrayLayout2i2ui3ul3ui2f3ub1ul44 extends StructArray {
         this.uint8[o1 + 37] = v13;
         this.uint8[o1 + 38] = v14;
         this.uint32[o4 + 10] = v15;
+        this.int16[o2 + 22] = v16;
         return i;
     }
 }
 
-StructArrayLayout2i2ui3ul3ui2f3ub1ul44.prototype.bytesPerElement = 44;
-register('StructArrayLayout2i2ui3ul3ui2f3ub1ul44', StructArrayLayout2i2ui3ul3ui2f3ub1ul44);
+StructArrayLayout2i2ui3ul3ui2f3ub1ul1i48.prototype.bytesPerElement = 48;
+register('StructArrayLayout2i2ui3ul3ui2f3ub1ul1i48', StructArrayLayout2i2ui3ul3ui2f3ub1ul1i48);
 
 /**
  * Implementation of the StructArray layout:
- * [0]: Int16[6]
- * [12]: Uint16[11]
- * [36]: Uint32[1]
- * [40]: Float32[3]
+ * [0]: Int16[8]
+ * [16]: Uint16[14]
+ * [44]: Uint32[1]
+ * [48]: Float32[3]
  *
  * @private
  */
-class StructArrayLayout6i11ui1ul3f52 extends StructArray {
+class StructArrayLayout8i14ui1ul3f60 extends StructArray {
     uint8: Uint8Array;
     int16: Int16Array;
     uint16: Uint16Array;
@@ -497,23 +499,23 @@ class StructArrayLayout6i11ui1ul3f52 extends StructArray {
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
-    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number, v16: number, v17: number, v18: number, v19: number, v20: number) {
+    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number, v16: number, v17: number, v18: number, v19: number, v20: number, v21: number, v22: number, v23: number, v24: number, v25: number) {
         const i = this.length;
         this.resize(i + 1);
-        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20);
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25);
     }
 
-    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number, v16: number, v17: number, v18: number, v19: number, v20: number) {
-        const o2 = i * 26;
-        const o4 = i * 13;
+    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number, v8: number, v9: number, v10: number, v11: number, v12: number, v13: number, v14: number, v15: number, v16: number, v17: number, v18: number, v19: number, v20: number, v21: number, v22: number, v23: number, v24: number, v25: number) {
+        const o2 = i * 30;
+        const o4 = i * 15;
         this.int16[o2 + 0] = v0;
         this.int16[o2 + 1] = v1;
         this.int16[o2 + 2] = v2;
         this.int16[o2 + 3] = v3;
         this.int16[o2 + 4] = v4;
         this.int16[o2 + 5] = v5;
-        this.uint16[o2 + 6] = v6;
-        this.uint16[o2 + 7] = v7;
+        this.int16[o2 + 6] = v6;
+        this.int16[o2 + 7] = v7;
         this.uint16[o2 + 8] = v8;
         this.uint16[o2 + 9] = v9;
         this.uint16[o2 + 10] = v10;
@@ -523,16 +525,21 @@ class StructArrayLayout6i11ui1ul3f52 extends StructArray {
         this.uint16[o2 + 14] = v14;
         this.uint16[o2 + 15] = v15;
         this.uint16[o2 + 16] = v16;
-        this.uint32[o4 + 9] = v17;
-        this.float32[o4 + 10] = v18;
-        this.float32[o4 + 11] = v19;
-        this.float32[o4 + 12] = v20;
+        this.uint16[o2 + 17] = v17;
+        this.uint16[o2 + 18] = v18;
+        this.uint16[o2 + 19] = v19;
+        this.uint16[o2 + 20] = v20;
+        this.uint16[o2 + 21] = v21;
+        this.uint32[o4 + 11] = v22;
+        this.float32[o4 + 12] = v23;
+        this.float32[o4 + 13] = v24;
+        this.float32[o4 + 14] = v25;
         return i;
     }
 }
 
-StructArrayLayout6i11ui1ul3f52.prototype.bytesPerElement = 52;
-register('StructArrayLayout6i11ui1ul3f52', StructArrayLayout6i11ui1ul3f52);
+StructArrayLayout8i14ui1ul3f60.prototype.bytesPerElement = 60;
+register('StructArrayLayout8i14ui1ul3f60', StructArrayLayout8i14ui1ul3f60);
 
 /**
  * Implementation of the StructArray layout:
@@ -874,6 +881,7 @@ class PlacedSymbolStruct extends Struct {
     placedOrientation: number;
     hidden: number;
     crossTileID: number;
+    placedIconSymbolIndex: number;
     get anchorX() { return this._structArray.int16[this._pos2 + 0]; }
     set anchorX(x: number) { this._structArray.int16[this._pos2 + 0] = x; }
     get anchorY() { return this._structArray.int16[this._pos2 + 1]; }
@@ -906,16 +914,18 @@ class PlacedSymbolStruct extends Struct {
     set hidden(x: number) { this._structArray.uint8[this._pos1 + 38] = x; }
     get crossTileID() { return this._structArray.uint32[this._pos4 + 10]; }
     set crossTileID(x: number) { this._structArray.uint32[this._pos4 + 10] = x; }
+    get placedIconSymbolIndex() { return this._structArray.int16[this._pos2 + 22]; }
+    set placedIconSymbolIndex(x: number) { this._structArray.int16[this._pos2 + 22] = x; }
 }
 
-PlacedSymbolStruct.prototype.size = 44;
+PlacedSymbolStruct.prototype.size = 48;
 
 export type PlacedSymbol = PlacedSymbolStruct;
 
 /**
  * @private
  */
-export class PlacedSymbolArray extends StructArrayLayout2i2ui3ul3ui2f3ub1ul44 {
+export class PlacedSymbolArray extends StructArrayLayout2i2ui3ul3ui2f3ub1ul1i48 {
     /**
      * Return the PlacedSymbolStruct at the given location in the array.
      * @param {number} index The index of the element.
@@ -936,6 +946,8 @@ class SymbolInstanceStruct extends Struct {
     centerJustifiedTextSymbolIndex: number;
     leftJustifiedTextSymbolIndex: number;
     verticalPlacedTextSymbolIndex: number;
+    placedIconSymbolIndex: number;
+    verticalPlacedIconSymbolIndex: number;
     key: number;
     textBoxStartIndex: number;
     textBoxEndIndex: number;
@@ -943,10 +955,13 @@ class SymbolInstanceStruct extends Struct {
     verticalTextBoxEndIndex: number;
     iconBoxStartIndex: number;
     iconBoxEndIndex: number;
+    verticalIconBoxStartIndex: number;
+    verticalIconBoxEndIndex: number;
     featureIndex: number;
     numHorizontalGlyphVertices: number;
     numVerticalGlyphVertices: number;
     numIconVertices: number;
+    numVerticalIconVertices: number;
     crossTileID: number;
     textBoxScale: number;
     textOffset0: number;
@@ -963,46 +978,56 @@ class SymbolInstanceStruct extends Struct {
     set leftJustifiedTextSymbolIndex(x: number) { this._structArray.int16[this._pos2 + 4] = x; }
     get verticalPlacedTextSymbolIndex() { return this._structArray.int16[this._pos2 + 5]; }
     set verticalPlacedTextSymbolIndex(x: number) { this._structArray.int16[this._pos2 + 5] = x; }
-    get key() { return this._structArray.uint16[this._pos2 + 6]; }
-    set key(x: number) { this._structArray.uint16[this._pos2 + 6] = x; }
-    get textBoxStartIndex() { return this._structArray.uint16[this._pos2 + 7]; }
-    set textBoxStartIndex(x: number) { this._structArray.uint16[this._pos2 + 7] = x; }
-    get textBoxEndIndex() { return this._structArray.uint16[this._pos2 + 8]; }
-    set textBoxEndIndex(x: number) { this._structArray.uint16[this._pos2 + 8] = x; }
-    get verticalTextBoxStartIndex() { return this._structArray.uint16[this._pos2 + 9]; }
-    set verticalTextBoxStartIndex(x: number) { this._structArray.uint16[this._pos2 + 9] = x; }
-    get verticalTextBoxEndIndex() { return this._structArray.uint16[this._pos2 + 10]; }
-    set verticalTextBoxEndIndex(x: number) { this._structArray.uint16[this._pos2 + 10] = x; }
-    get iconBoxStartIndex() { return this._structArray.uint16[this._pos2 + 11]; }
-    set iconBoxStartIndex(x: number) { this._structArray.uint16[this._pos2 + 11] = x; }
-    get iconBoxEndIndex() { return this._structArray.uint16[this._pos2 + 12]; }
-    set iconBoxEndIndex(x: number) { this._structArray.uint16[this._pos2 + 12] = x; }
-    get featureIndex() { return this._structArray.uint16[this._pos2 + 13]; }
-    set featureIndex(x: number) { this._structArray.uint16[this._pos2 + 13] = x; }
-    get numHorizontalGlyphVertices() { return this._structArray.uint16[this._pos2 + 14]; }
-    set numHorizontalGlyphVertices(x: number) { this._structArray.uint16[this._pos2 + 14] = x; }
-    get numVerticalGlyphVertices() { return this._structArray.uint16[this._pos2 + 15]; }
-    set numVerticalGlyphVertices(x: number) { this._structArray.uint16[this._pos2 + 15] = x; }
-    get numIconVertices() { return this._structArray.uint16[this._pos2 + 16]; }
-    set numIconVertices(x: number) { this._structArray.uint16[this._pos2 + 16] = x; }
-    get crossTileID() { return this._structArray.uint32[this._pos4 + 9]; }
-    set crossTileID(x: number) { this._structArray.uint32[this._pos4 + 9] = x; }
-    get textBoxScale() { return this._structArray.float32[this._pos4 + 10]; }
-    set textBoxScale(x: number) { this._structArray.float32[this._pos4 + 10] = x; }
-    get textOffset0() { return this._structArray.float32[this._pos4 + 11]; }
-    set textOffset0(x: number) { this._structArray.float32[this._pos4 + 11] = x; }
-    get textOffset1() { return this._structArray.float32[this._pos4 + 12]; }
-    set textOffset1(x: number) { this._structArray.float32[this._pos4 + 12] = x; }
+    get placedIconSymbolIndex() { return this._structArray.int16[this._pos2 + 6]; }
+    set placedIconSymbolIndex(x: number) { this._structArray.int16[this._pos2 + 6] = x; }
+    get verticalPlacedIconSymbolIndex() { return this._structArray.int16[this._pos2 + 7]; }
+    set verticalPlacedIconSymbolIndex(x: number) { this._structArray.int16[this._pos2 + 7] = x; }
+    get key() { return this._structArray.uint16[this._pos2 + 8]; }
+    set key(x: number) { this._structArray.uint16[this._pos2 + 8] = x; }
+    get textBoxStartIndex() { return this._structArray.uint16[this._pos2 + 9]; }
+    set textBoxStartIndex(x: number) { this._structArray.uint16[this._pos2 + 9] = x; }
+    get textBoxEndIndex() { return this._structArray.uint16[this._pos2 + 10]; }
+    set textBoxEndIndex(x: number) { this._structArray.uint16[this._pos2 + 10] = x; }
+    get verticalTextBoxStartIndex() { return this._structArray.uint16[this._pos2 + 11]; }
+    set verticalTextBoxStartIndex(x: number) { this._structArray.uint16[this._pos2 + 11] = x; }
+    get verticalTextBoxEndIndex() { return this._structArray.uint16[this._pos2 + 12]; }
+    set verticalTextBoxEndIndex(x: number) { this._structArray.uint16[this._pos2 + 12] = x; }
+    get iconBoxStartIndex() { return this._structArray.uint16[this._pos2 + 13]; }
+    set iconBoxStartIndex(x: number) { this._structArray.uint16[this._pos2 + 13] = x; }
+    get iconBoxEndIndex() { return this._structArray.uint16[this._pos2 + 14]; }
+    set iconBoxEndIndex(x: number) { this._structArray.uint16[this._pos2 + 14] = x; }
+    get verticalIconBoxStartIndex() { return this._structArray.uint16[this._pos2 + 15]; }
+    set verticalIconBoxStartIndex(x: number) { this._structArray.uint16[this._pos2 + 15] = x; }
+    get verticalIconBoxEndIndex() { return this._structArray.uint16[this._pos2 + 16]; }
+    set verticalIconBoxEndIndex(x: number) { this._structArray.uint16[this._pos2 + 16] = x; }
+    get featureIndex() { return this._structArray.uint16[this._pos2 + 17]; }
+    set featureIndex(x: number) { this._structArray.uint16[this._pos2 + 17] = x; }
+    get numHorizontalGlyphVertices() { return this._structArray.uint16[this._pos2 + 18]; }
+    set numHorizontalGlyphVertices(x: number) { this._structArray.uint16[this._pos2 + 18] = x; }
+    get numVerticalGlyphVertices() { return this._structArray.uint16[this._pos2 + 19]; }
+    set numVerticalGlyphVertices(x: number) { this._structArray.uint16[this._pos2 + 19] = x; }
+    get numIconVertices() { return this._structArray.uint16[this._pos2 + 20]; }
+    set numIconVertices(x: number) { this._structArray.uint16[this._pos2 + 20] = x; }
+    get numVerticalIconVertices() { return this._structArray.uint16[this._pos2 + 21]; }
+    set numVerticalIconVertices(x: number) { this._structArray.uint16[this._pos2 + 21] = x; }
+    get crossTileID() { return this._structArray.uint32[this._pos4 + 11]; }
+    set crossTileID(x: number) { this._structArray.uint32[this._pos4 + 11] = x; }
+    get textBoxScale() { return this._structArray.float32[this._pos4 + 12]; }
+    set textBoxScale(x: number) { this._structArray.float32[this._pos4 + 12] = x; }
+    get textOffset0() { return this._structArray.float32[this._pos4 + 13]; }
+    set textOffset0(x: number) { this._structArray.float32[this._pos4 + 13] = x; }
+    get textOffset1() { return this._structArray.float32[this._pos4 + 14]; }
+    set textOffset1(x: number) { this._structArray.float32[this._pos4 + 14] = x; }
 }
 
-SymbolInstanceStruct.prototype.size = 52;
+SymbolInstanceStruct.prototype.size = 60;
 
 export type SymbolInstance = SymbolInstanceStruct;
 
 /**
  * @private
  */
-export class SymbolInstanceArray extends StructArrayLayout6i11ui1ul3f52 {
+export class SymbolInstanceArray extends StructArrayLayout8i14ui1ul3f60 {
     /**
      * Return the SymbolInstanceStruct at the given location in the array.
      * @param {number} index The index of the element.
@@ -1124,8 +1149,8 @@ export {
     StructArrayLayout6i1ul2ui2i24,
     StructArrayLayout2i2i2i12,
     StructArrayLayout2ub2f12,
-    StructArrayLayout2i2ui3ul3ui2f3ub1ul44,
-    StructArrayLayout6i11ui1ul3f52,
+    StructArrayLayout2i2ui3ul3ui2f3ub1ul1i48,
+    StructArrayLayout8i14ui1ul3f60,
     StructArrayLayout1f4,
     StructArrayLayout3i6,
     StructArrayLayout1ul2ui8,

--- a/src/data/bucket/symbol_attributes.js
+++ b/src/data/bucket/symbol_attributes.js
@@ -73,7 +73,8 @@ export const placement = createLayout([
     {type: 'Uint8', name: 'writingMode'},
     {type: 'Uint8', name: 'placedOrientation'},
     {type: 'Uint8', name: 'hidden'},
-    {type: 'Uint32', name: 'crossTileID'}
+    {type: 'Uint32', name: 'crossTileID'},
+    {type: 'Int16', name: 'placedIconSymbolIndex'}
 ]);
 
 export const symbolInstance = createLayout([
@@ -83,6 +84,8 @@ export const symbolInstance = createLayout([
     {type: 'Int16', name: 'centerJustifiedTextSymbolIndex'},
     {type: 'Int16', name: 'leftJustifiedTextSymbolIndex'},
     {type: 'Int16', name: 'verticalPlacedTextSymbolIndex'},
+    {type: 'Int16', name: 'placedIconSymbolIndex'},
+    {type: 'Int16', name: 'verticalPlacedIconSymbolIndex'},
     {type: 'Uint16', name: 'key'},
     {type: 'Uint16', name: 'textBoxStartIndex'},
     {type: 'Uint16', name: 'textBoxEndIndex'},
@@ -90,10 +93,13 @@ export const symbolInstance = createLayout([
     {type: 'Uint16', name: 'verticalTextBoxEndIndex'},
     {type: 'Uint16', name: 'iconBoxStartIndex'},
     {type: 'Uint16', name: 'iconBoxEndIndex'},
+    {type: 'Uint16', name: 'verticalIconBoxStartIndex'},
+    {type: 'Uint16', name: 'verticalIconBoxEndIndex'},
     {type: 'Uint16', name: 'featureIndex'},
     {type: 'Uint16', name: 'numHorizontalGlyphVertices'},
     {type: 'Uint16', name: 'numVerticalGlyphVertices'},
     {type: 'Uint16', name: 'numIconVertices'},
+    {type: 'Uint16', name: 'numVerticalIconVertices'},
     {type: 'Uint32', name: 'crossTileID'},
     {type: 'Float32', name: 'textBoxScale'},
     {type: 'Float32', components: 2, name: 'textOffset'}

--- a/src/symbol/quads.js
+++ b/src/symbol/quads.js
@@ -9,6 +9,7 @@ import type {PositionedIcon, Shaping} from './shaping';
 import type SymbolStyleLayer from '../style/style_layer/symbol_style_layer';
 import type {Feature} from '../style-spec/expression';
 import type {GlyphPosition} from '../render/glyph_atlas';
+import type {WritingModeType} from './shaping';
 import ONE_EM from './one_em';
 
 /**
@@ -44,11 +45,10 @@ export type SymbolQuad = {
  * Create the quads used for rendering an icon.
  * @private
  */
-export function getIconQuads(anchor: Anchor,
+export function getIconQuads(
                       shapedIcon: PositionedIcon,
+                      writingMode: WritingModeType,
                       layer: SymbolStyleLayer,
-                      alongLine: boolean,
-                      shapedText: Shaping | null,
                       feature: Feature): Array<SymbolQuad> {
     const image = shapedIcon.image;
     const layout = layer.layout;
@@ -62,9 +62,8 @@ export function getIconQuads(anchor: Anchor,
     const left = shapedIcon.left - border / image.pixelRatio;
     const bottom = shapedIcon.bottom + border / image.pixelRatio;
     const right = shapedIcon.right + border / image.pixelRatio;
-    let tl, tr, br, bl;
 
-    // text-fit mode
+                          /*
     if (layout.get('icon-text-fit') !== 'none' && shapedText) {
         const iconWidth = (right - left),
             iconHeight = (bottom - top),
@@ -87,13 +86,13 @@ export function getIconQuads(anchor: Anchor,
         tr = new Point(textLeft + offsetX + padR + width, textTop + offsetY - padT);
         br = new Point(textLeft + offsetX + padR + width, textTop + offsetY + padB + height);
         bl = new Point(textLeft + offsetX - padL,         textTop + offsetY + padB + height);
+
+        */
     // Normal icon size mode
-    } else {
-        tl = new Point(left, top);
-        tr = new Point(right, top);
-        br = new Point(right, bottom);
-        bl = new Point(left, bottom);
-    }
+    const tl = new Point(left, top);
+    const tr = new Point(right, top);
+    const br = new Point(right, bottom);
+    const bl = new Point(left, bottom);
 
     const angle = layer.layout.get('icon-rotate').evaluate(feature, {}) * Math.PI / 180;
 
@@ -109,7 +108,7 @@ export function getIconQuads(anchor: Anchor,
     }
 
     // Icon quad is padded, so texture coordinates also need to be padded.
-    return [{tl, tr, bl, br, tex: image.paddedRect, writingMode: undefined, glyphOffset: [0, 0], sectionIndex: 0}];
+    return [{tl, tr, bl, br, tex: image.paddedRect, writingMode, glyphOffset: [0, 0], sectionIndex: 0}];
 }
 
 /**

--- a/src/symbol/symbol_layout.js
+++ b/src/symbol/symbol_layout.js
@@ -4,7 +4,7 @@ import Anchor from './anchor';
 
 import {getAnchors, getCenterAnchor} from './get_anchors';
 import clipLine from './clip_line';
-import {shapeText, shapeIcon, WritingMode} from './shaping';
+import {shapeText, shapeIcon, WritingMode, fitIconToText} from './shaping';
 import {getGlyphQuads, getIconQuads} from './quads';
 import CollisionFeature from './collision_feature';
 import {warnOnce} from '../util/util';
@@ -376,6 +376,19 @@ function addFeature(bucket: SymbolBucket,
         symbolPlacement = layout.get('symbol-placement'),
         textRepeatDistance = symbolMinDistance / 2;
 
+    const hasIconTextFit = layout.get('icon-text-fit') !== 'none';
+    let verticallyShapedIcon;
+    // Adjust shaped icon size when icon-text-fit is used.
+    if (shapedIcon && hasIconTextFit) {
+        // Create vertically shaped icon for vertical writing mode if needed.
+        if (bucket.allowVerticalPlacement && shapedTextOrientations.vertical) {
+            verticallyShapedIcon = fitIconToText(shapedIcon, layout, shapedTextOrientations.vertical, fontScale);
+        }
+        if (defaultHorizontalShaping) {
+            shapedIcon = fitIconToText(shapedIcon, layout, defaultHorizontalShaping, fontScale);
+        }
+    }
+
     const addSymbolAtAnchor = (line, anchor) => {
         if (anchor.x < 0 || anchor.x >= EXTENT || anchor.y < 0 || anchor.y >= EXTENT) {
             // Symbol layers are drawn across tile boundaries, We filter out symbols
@@ -384,7 +397,7 @@ function addFeature(bucket: SymbolBucket,
             return;
         }
 
-        addSymbol(bucket, anchor, line, shapedTextOrientations, shapedIcon, bucket.layers[0],
+        addSymbol(bucket, anchor, line, shapedTextOrientations, shapedIcon, verticallyShapedIcon, bucket.layers[0],
             bucket.collisionBoxArray, feature.index, feature.sourceLayerIndex, bucket.index,
             textBoxScale, textPadding, textAlongLine, textOffset,
             iconBoxScale, iconPadding, iconAlongLine, iconOffset,
@@ -462,7 +475,8 @@ function addTextVertices(bucket: SymbolBucket,
                          placementTypes: Array<'vertical' | 'center' | 'left' | 'right'>,
                          placedTextSymbolIndices: {[string]: number},
                          glyphPositionMap: {[string]: {[number]: GlyphPosition}},
-                         sizes: Sizes) {
+                         sizes: Sizes,
+                         placedIconIndex: number) {
     const glyphQuads = getGlyphQuads(anchor, shapedText, textOffset,
                             layer, textAlongLine, feature, glyphPositionMap, bucket.allowVerticalPlacement);
 
@@ -496,7 +510,8 @@ function addTextVertices(bucket: SymbolBucket,
         writingMode,
         anchor,
         lineArray.lineStartIndex,
-        lineArray.lineLength);
+        lineArray.lineLength,
+        placedIconIndex);
 
     // The placedSymbolArray is used at render time in drawTileSymbols
     // These indices allow access to the array at collision detection time
@@ -526,6 +541,7 @@ function addSymbol(bucket: SymbolBucket,
                    line: Array<Point>,
                    shapedTextOrientations: any,
                    shapedIcon: PositionedIcon | void,
+                   verticallyShapedIcon: PositionedIcon | void,
                    layer: SymbolStyleLayer,
                    collisionBoxArray: CollisionBoxArray,
                    featureIndex: number,
@@ -544,9 +560,10 @@ function addSymbol(bucket: SymbolBucket,
                    sizes: Sizes) {
     const lineArray = bucket.addToLineVertexArray(anchor, line);
 
-    let textCollisionFeature, iconCollisionFeature, verticalTextCollisionFeature;
+    let textCollisionFeature, iconCollisionFeature, verticalTextCollisionFeature, verticalIconCollisionFeature;
 
     let numIconVertices = 0;
+    let numVerticalIconVertices = 0;
     let numHorizontalGlyphVertices = 0;
     let numVerticalGlyphVertices = 0;
     const placedTextSymbolIndices = {};
@@ -566,51 +583,29 @@ function addSymbol(bucket: SymbolBucket,
         const verticalTextRotation = textRotation + 90.0;
         const verticalShaping = shapedTextOrientations.vertical;
         verticalTextCollisionFeature = new CollisionFeature(collisionBoxArray, line, anchor, featureIndex, sourceLayerIndex, bucketIndex, verticalShaping, textBoxScale, textPadding, textAlongLine, bucket.overscaling, verticalTextRotation);
-    }
-
-    for (const justification: any in shapedTextOrientations.horizontal) {
-        const shaping = shapedTextOrientations.horizontal[justification];
-
-        if (!textCollisionFeature) {
-            key = murmur3(shaping.text);
-            const textRotate = layer.layout.get('text-rotate').evaluate(feature, {});
-            // As a collision approximation, we can use either the vertical or any of the horizontal versions of the feature
-            // We're counting on all versions having similar dimensions
-            textCollisionFeature = new CollisionFeature(collisionBoxArray, line, anchor, featureIndex, sourceLayerIndex, bucketIndex, shaping, textBoxScale, textPadding, textAlongLine, bucket.overscaling, textRotate);
-        }
-
-        const singleLine = shaping.lineCount === 1;
-        numHorizontalGlyphVertices += addTextVertices(
-            bucket, anchor, shaping, layer, textAlongLine, feature, textOffset, lineArray,
-            shapedTextOrientations.vertical ? WritingMode.horizontal : WritingMode.horizontalOnly,
-            singleLine ? (Object.keys(shapedTextOrientations.horizontal): any) : [justification],
-            placedTextSymbolIndices, glyphPositionMap, sizes);
-
-        if (singleLine) {
-            break;
+        if (verticallyShapedIcon) {
+            verticalIconCollisionFeature = new CollisionFeature(collisionBoxArray, line, anchor, featureIndex, sourceLayerIndex, bucketIndex, verticallyShapedIcon, iconBoxScale, iconPadding, textAlongLine, bucket.overscaling, verticalTextRotation);
         }
     }
 
-    if (shapedTextOrientations.vertical) {
-        numVerticalGlyphVertices += addTextVertices(
-            bucket, anchor, shapedTextOrientations.vertical, layer, textAlongLine, feature,
-            textOffset, lineArray, WritingMode.vertical, ['vertical'], placedTextSymbolIndices, glyphPositionMap, sizes);
-    }
-
-    const textBoxStartIndex = textCollisionFeature ? textCollisionFeature.boxStartIndex : bucket.collisionBoxArray.length;
-    const textBoxEndIndex = textCollisionFeature ? textCollisionFeature.boxEndIndex : bucket.collisionBoxArray.length;
-
-    const verticalTextBoxStartIndex = verticalTextCollisionFeature ? verticalTextCollisionFeature.boxStartIndex : bucket.collisionBoxArray.length;
-    const verticalTextBoxEndIndex = verticalTextCollisionFeature ? verticalTextCollisionFeature.boxEndIndex : bucket.collisionBoxArray.length;
+    let placedIconSymbolIndex = -1;
+    let verticalPlacedIconSymbolIndex = -1;
 
     if (shapedIcon) {
-        const iconQuads = getIconQuads(anchor, shapedIcon, layer,
-                            iconAlongLine, getDefaultHorizontalShaping(shapedTextOrientations.horizontal),
-                            feature);
+        const iconQuads = getIconQuads(
+            shapedIcon,
+            ((getDefaultHorizontalShaping(shapedTextOrientations.horizontal): any): Shaping).writingMode,
+            layer,
+            feature);
+
+        const verticalIconQuads = verticallyShapedIcon ?
+            getIconQuads(verticallyShapedIcon, shapedTextOrientations.vertical.writingMode, layer, feature) :
+            undefined;
+
         const iconRotate = layer.layout.get('icon-rotate').evaluate(feature, {});
         iconCollisionFeature = new CollisionFeature(collisionBoxArray, line, anchor, featureIndex, sourceLayerIndex, bucketIndex, shapedIcon, iconBoxScale, iconPadding, /*align boxes to line*/false, bucket.overscaling, iconRotate);
 
-        numIconVertices = iconQuads.length * 4;
+        numIconVertices = iconQuads.length * 4; // TODO
 
         const sizeData = bucket.iconSizeData;
         let iconSizeData = null;
@@ -635,6 +630,7 @@ function addSymbol(bucket: SymbolBucket,
         bucket.addSymbols(
             bucket.icon,
             iconQuads,
+            // TODO
             iconSizeData,
             iconOffset,
             iconAlongLine,
@@ -642,12 +638,73 @@ function addSymbol(bucket: SymbolBucket,
             false,
             anchor,
             lineArray.lineStartIndex,
-            lineArray.lineLength);
+            lineArray.lineLength,
+            0);
+
+        placedIconSymbolIndex = bucket.icon.placedSymbolArray.length - 1;
+
+        if (verticalIconQuads) {
+            numVerticalIconVertices = verticalIconQuads.length * 4;
+            // TODO ???
+            bucket.addSymbols(
+                bucket.icon,
+                verticalIconQuads,
+                // TODO
+                iconSizeData,
+                iconOffset,
+                iconAlongLine,
+                feature,
+                false,
+                anchor,
+                lineArray.lineStartIndex,
+                lineArray.lineLength,
+                0);
+
+            verticalPlacedIconSymbolIndex = bucket.icon.placedSymbolArray.length - 1;
+        }
     }
 
     const iconBoxStartIndex = iconCollisionFeature ? iconCollisionFeature.boxStartIndex : bucket.collisionBoxArray.length;
     const iconBoxEndIndex = iconCollisionFeature ? iconCollisionFeature.boxEndIndex : bucket.collisionBoxArray.length;
 
+    const verticalIconBoxStartIndex = verticalIconCollisionFeature ? verticalIconCollisionFeature.boxStartIndex : bucket.collisionBoxArray.length;
+    const verticalIconBoxEndIndex = verticalIconCollisionFeature ? verticalIconCollisionFeature.boxEndIndex : bucket.collisionBoxArray.length;
+
+
+    for (const justification: any in shapedTextOrientations.horizontal) {
+        const shaping = shapedTextOrientations.horizontal[justification];
+
+        if (!textCollisionFeature) {
+            key = murmur3(shaping.text);
+            const textRotate = layer.layout.get('text-rotate').evaluate(feature, {});
+            // As a collision approximation, we can use either the vertical or any of the horizontal versions of the feature
+            // We're counting on all versions having similar dimensions
+            textCollisionFeature = new CollisionFeature(collisionBoxArray, line, anchor, featureIndex, sourceLayerIndex, bucketIndex, shaping, textBoxScale, textPadding, textAlongLine, bucket.overscaling, textRotate);
+        }
+
+        const singleLine = shaping.lineCount === 1;
+        numHorizontalGlyphVertices += addTextVertices(
+            bucket, anchor, shaping, layer, textAlongLine, feature, textOffset, lineArray,
+            shapedTextOrientations.vertical ? WritingMode.horizontal : WritingMode.horizontalOnly,
+            singleLine ? (Object.keys(shapedTextOrientations.horizontal): any) : [justification],
+            placedTextSymbolIndices, glyphPositionMap, sizes, placedIconSymbolIndex);
+
+        if (singleLine) {
+            break;
+        }
+    }
+
+    if (shapedTextOrientations.vertical) {
+        numVerticalGlyphVertices += addTextVertices(
+            bucket, anchor, shapedTextOrientations.vertical, layer, textAlongLine, feature,
+            textOffset, lineArray, WritingMode.vertical, ['vertical'], placedTextSymbolIndices, glyphPositionMap, sizes, verticalPlacedIconSymbolIndex);
+    }
+
+    const textBoxStartIndex = textCollisionFeature ? textCollisionFeature.boxStartIndex : bucket.collisionBoxArray.length;
+    const textBoxEndIndex = textCollisionFeature ? textCollisionFeature.boxEndIndex : bucket.collisionBoxArray.length;
+
+    const verticalTextBoxStartIndex = verticalTextCollisionFeature ? verticalTextCollisionFeature.boxStartIndex : bucket.collisionBoxArray.length;
+    const verticalTextBoxEndIndex = verticalTextCollisionFeature ? verticalTextCollisionFeature.boxEndIndex : bucket.collisionBoxArray.length;
     if (bucket.glyphOffsetArray.length >= SymbolBucket.MAX_GLYPHS) warnOnce(
         "Too many glyphs being rendered in a tile. See https://github.com/mapbox/mapbox-gl-js/issues/2907"
     );
@@ -659,6 +716,8 @@ function addSymbol(bucket: SymbolBucket,
         placedTextSymbolIndices.center >= 0 ? placedTextSymbolIndices.center : -1,
         placedTextSymbolIndices.left >= 0 ? placedTextSymbolIndices.left : -1,
         placedTextSymbolIndices.vertical || -1,
+        placedIconSymbolIndex,
+        verticalPlacedIconSymbolIndex,
         key,
         textBoxStartIndex,
         textBoxEndIndex,
@@ -666,10 +725,13 @@ function addSymbol(bucket: SymbolBucket,
         verticalTextBoxEndIndex,
         iconBoxStartIndex,
         iconBoxEndIndex,
+        verticalIconBoxStartIndex,
+        verticalIconBoxEndIndex,
         featureIndex,
         numHorizontalGlyphVertices,
         numVerticalGlyphVertices,
         numIconVertices,
+        numVerticalIconVertices,
         0,
         textBoxScale,
         textOffset0,


### PR DESCRIPTION
Addresses : #8583 

This is still very much a WIP that doesn't work yet. https://github.com/mapbox/mapbox-gl-native/pull/15367.

When I got to porting the changes in `placement.cpp` I tried adding the all at once because I didn't see a clear way of doing it incrementally. But that may have not been the best plan since it doesn't work and I'm not sure if it's close or if there are many large bugs remaining.

The next steps for working on this could be to try run `yarn run test-render icon-text-fit` and debug the crashes and problems one by one as they appear. But it may actually be better to do a careful readthrough of the original PR and make sure everything is included. Finally, if that doesn't work, it might be easiest to start with a fresh branch and gradually cherry-pick changes from this branch over or use it as a guide.