### PR TITLE
Fix perf metrics ingestion

### DIFF
--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -37,10 +37,9 @@ function waitForConsole(page) {
     stats.dt = execSync('git show --no-patch --no-notes --pretty=\'%cI\' HEAD').toString().substring(0, 19);
     stats.commit = execSync('git rev-parse --short HEAD').toString().trim();
     stats.message = execSync('git show -s --format=%s HEAD').toString().trim();
-    const statsStr = JSON.stringify(stats, null, 2);
-    console.log(statsStr);
+    console.log(JSON.stringify(stats, null, 2));
 
-    fs.writeFileSync('data.json.gz', zlib.gzipSync(statsStr));
+    fs.writeFileSync('data.json.gz', zlib.gzipSync(JSON.stringify(stats)));
 
     await page.close();
     await browser.close();


### PR DESCRIPTION
Turned out it failed because the upload JSON was prettified while it expects one-line entries.