### PR TITLE
Install AWS cli earlier to fix bench/release deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
       - restore_cache:
           keys:
             - v3-yarn-{{ checksum "yarn.lock" }}
+      - aws-cli/install
       - run: yarn
       - save_cache:
           key: v3-yarn-{{ checksum "yarn.lock" }}
@@ -171,7 +172,6 @@ jobs:
       - run:
           name: Collect performance stats
           command: node bench/gl-stats.js
-      - aws-cli/install
       - run:
           name: Upload performance stats
           command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_metrics_staging/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz


### PR DESCRIPTION
Follow-up to #8645. We need to install AWS Cli earlier in the workflow so that it's available in `deploy-benchmarks` and `deploy-release` jobs.