### PR TITLE
Check map maxBounds in Geolocate control

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -156,6 +156,7 @@ class GeolocateControl extends Evented {
             this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-active-error');
 
             this.fire(new Event('outofmaxbounds', position));
+            this._updateMarker()
             this._finish();
             
             return;

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -137,7 +137,30 @@ class GeolocateControl extends Evented {
         this._map = (undefined: any);
     }
 
+    _isOutOfMapMaxBounds(position: Position) {
+        const bounds = this._map.getMaxBounds();
+        const coordinates = position.coords;
+
+        return bounds && (
+            coordinates.longitude < bounds.getWest() ||
+            coordinates.longitude > bounds.getEast() ||
+            coordinates.latitude < bounds.getSouth() ||
+            coordinates.latitude > bounds.getNorth()
+        )
+    }
+
     _onSuccess(position: Position) {
+        if (this._isOutOfMapMaxBounds(position)) {
+            this._watchState = 'ACTIVE_ERROR';
+            this._geolocateButton.classList.remove('mapboxgl-ctrl-geolocate-active');
+            this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-active-error');
+
+            this.fire(new Event('outofmaxbounds', position));
+            this._finish();
+            
+            return;
+        }
+
         if (this.options.trackUserLocation) {
             // keep a record of the position so that if the state is BACKGROUND and the user
             // clicks the button, we can move to ACTIVE_LOCK immediately without waiting for
@@ -453,6 +476,16 @@ export default GeolocateControl;
  * @memberof GeolocateControl
  * @instance
  * @property {PositionError} data The returned [PositionError](https://developer.mozilla.org/en-US/docs/Web/API/PositionError) object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or [Geolocation.watchPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
+ *
+ */
+
+/**
+ * Fired on each Geolocation API position update which returned as success but user position is out of map maxBounds.
+ *
+ * @event outofmaxbounds
+ * @memberof GeolocateControl
+ * @instance
+ * @property {Position} data The returned [Position](https://developer.mozilla.org/en-US/docs/Web/API/Position) object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or [Geolocation.watchPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
  *
  */
 

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -149,11 +149,37 @@ class GeolocateControl extends Evented {
         );
     }
 
-    _onSuccess(position: Position) {
-        if (this._isOutOfMapMaxBounds(position)) {
+    _goToErrorState() {
+        switch (this._watchState) {
+        case 'WAITING_ACTIVE':
             this._watchState = 'ACTIVE_ERROR';
             this._geolocateButton.classList.remove('mapboxgl-ctrl-geolocate-active');
             this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-active-error');
+            break;
+        case 'ACTIVE_LOCK':
+            this._watchState = 'ACTIVE_ERROR';
+            this._geolocateButton.classList.remove('mapboxgl-ctrl-geolocate-active');
+            this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-active-error');
+            this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-waiting');
+            // turn marker grey
+            break;
+        case 'BACKGROUND':
+            this._watchState = 'BACKGROUND_ERROR';
+            this._geolocateButton.classList.remove('mapboxgl-ctrl-geolocate-background');
+            this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-background-error');
+            this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-waiting');
+            // turn marker grey
+            break;
+        case 'ACTIVE_ERROR':
+            break;
+        default:
+            assert(false, `Unexpected watchState ${this._watchState}`);
+        }
+    }
+
+    _onSuccess(position: Position) {
+        if (this._isOutOfMapMaxBounds(position)) {
+            this._goToErrorState();
 
             this.fire(new Event('outofmaxbounds', position));
             this._updateMarker();
@@ -242,31 +268,7 @@ class GeolocateControl extends Evented {
                     this._clearWatch();
                 }
             } else {
-                switch (this._watchState) {
-                case 'WAITING_ACTIVE':
-                    this._watchState = 'ACTIVE_ERROR';
-                    this._geolocateButton.classList.remove('mapboxgl-ctrl-geolocate-active');
-                    this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-active-error');
-                    break;
-                case 'ACTIVE_LOCK':
-                    this._watchState = 'ACTIVE_ERROR';
-                    this._geolocateButton.classList.remove('mapboxgl-ctrl-geolocate-active');
-                    this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-active-error');
-                    this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-waiting');
-                    // turn marker grey
-                    break;
-                case 'BACKGROUND':
-                    this._watchState = 'BACKGROUND_ERROR';
-                    this._geolocateButton.classList.remove('mapboxgl-ctrl-geolocate-background');
-                    this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-background-error');
-                    this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-waiting');
-                    // turn marker grey
-                    break;
-                case 'ACTIVE_ERROR':
-                    break;
-                default:
-                    assert(false, `Unexpected watchState ${this._watchState}`);
-                }
+                this._goToErrorState();
             }
         }
 

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -146,7 +146,7 @@ class GeolocateControl extends Evented {
             coordinates.longitude > bounds.getEast() ||
             coordinates.latitude < bounds.getSouth() ||
             coordinates.latitude > bounds.getNorth()
-        )
+        );
     }
 
     _onSuccess(position: Position) {
@@ -156,9 +156,9 @@ class GeolocateControl extends Evented {
             this._geolocateButton.classList.add('mapboxgl-ctrl-geolocate-active-error');
 
             this.fire(new Event('outofmaxbounds', position));
-            this._updateMarker()
+            this._updateMarker();
             this._finish();
-            
+
             return;
         }
 

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -149,7 +149,7 @@ class GeolocateControl extends Evented {
         );
     }
 
-    _goToErrorState() {
+    _setErrorState() {
         switch (this._watchState) {
         case 'WAITING_ACTIVE':
             this._watchState = 'ACTIVE_ERROR';
@@ -179,7 +179,7 @@ class GeolocateControl extends Evented {
 
     _onSuccess(position: Position) {
         if (this._isOutOfMapMaxBounds(position)) {
-            this._goToErrorState();
+            this._setErrorState();
 
             this.fire(new Event('outofmaxbounds', position));
             this._updateMarker();
@@ -268,7 +268,7 @@ class GeolocateControl extends Evented {
                     this._clearWatch();
                 }
             } else {
-                this._goToErrorState();
+                this._setErrorState();
             }
         }
 

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -49,16 +49,18 @@ test('GeolocateControl error event', (t) => {
 });
 
 test('GeolocateControl outofmaxbounds event', (t) => {
-    t.plan(4);
+    t.plan(5);
 
     const map = createMap(t);
     const geolocate = new GeolocateControl();
     map.addControl(geolocate);
     map.setMaxBounds([[0, 0], [10, 10]]);
+    geolocate._watchState = 'ACTIVE_LOCK';
 
     const click = new window.Event('click');
 
     geolocate.on('outofmaxbounds', (position) => {
+        t.equal(geolocate._watchState, 'ACTIVE_ERROR', 'geolocate state');
         t.equal(position.coords.latitude, 10, 'geolocate position latitude');
         t.equal(position.coords.longitude, 20, 'geolocate position longitude');
         t.equal(position.coords.accuracy, 3, 'geolocate position accuracy');

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -48,7 +48,7 @@ test('GeolocateControl error event', (t) => {
     geolocation.sendError({code: 2, message: 'error message'});
 });
 
-test('GeolocateControl outofmaxbounds event', (t) => {
+test('GeolocateControl outofmaxbounds event in active lock state', (t) => {
     t.plan(5);
 
     const map = createMap(t);
@@ -61,6 +61,29 @@ test('GeolocateControl outofmaxbounds event', (t) => {
 
     geolocate.on('outofmaxbounds', (position) => {
         t.equal(geolocate._watchState, 'ACTIVE_ERROR', 'geolocate state');
+        t.equal(position.coords.latitude, 10, 'geolocate position latitude');
+        t.equal(position.coords.longitude, 20, 'geolocate position longitude');
+        t.equal(position.coords.accuracy, 3, 'geolocate position accuracy');
+        t.equal(position.timestamp, 4, 'geolocate timestamp');
+        t.end();
+    });
+    geolocate._geolocateButton.dispatchEvent(click);
+    geolocation.send({latitude: 10, longitude: 20, accuracy: 3, timestamp: 4});
+});
+
+test('GeolocateControl outofmaxbounds event in background state', (t) => {
+    t.plan(5);
+
+    const map = createMap(t);
+    const geolocate = new GeolocateControl();
+    map.addControl(geolocate);
+    map.setMaxBounds([[0, 0], [10, 10]]);
+    geolocate._watchState = 'BACKGROUND';
+
+    const click = new window.Event('click');
+
+    geolocate.on('outofmaxbounds', (position) => {
+        t.equal(geolocate._watchState, 'BACKGROUND_ERROR', 'geolocate state');
         t.equal(position.coords.latitude, 10, 'geolocate position latitude');
         t.equal(position.coords.longitude, 20, 'geolocate position longitude');
         t.equal(position.coords.accuracy, 3, 'geolocate position accuracy');

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -48,6 +48,27 @@ test('GeolocateControl error event', (t) => {
     geolocation.sendError({code: 2, message: 'error message'});
 });
 
+test('GeolocateControl outofmaxbounds event', (t) => {
+    t.plan(4);
+
+    const map = createMap(t);
+    const geolocate = new GeolocateControl();
+    map.addControl(geolocate);
+    map.setMaxBounds([[0, 0], [10, 10]]);
+
+    const click = new window.Event('click');
+
+    geolocate.on('outofmaxbounds', (position) => {
+        t.equal(position.coords.latitude, 10, 'geolocate position latitude');
+        t.equal(position.coords.longitude, 20, 'geolocate position longitude');
+        t.equal(position.coords.accuracy, 3, 'geolocate position accuracy');
+        t.equal(position.timestamp, 4, 'geolocate timestamp');
+        t.end();
+    });
+    geolocate._geolocateButton.dispatchEvent(click);
+    geolocation.send({latitude: 10, longitude: 20, accuracy: 3, timestamp: 4});
+});
+
 test('GeolocateControl geolocate event', (t) => {
     t.plan(4);
 


### PR DESCRIPTION
## Launch Checklist
Changes:
The GeolocateControl with a `maxBounds` set on the map when a user is located outside of the `maxBounds`, keeps trying to move the camera outside of the `maxBounds` and causes a bad experience for users. In this PR, I checked map `maxBounds` on geolocate success callback and if the located position is out of `maxBounds`, remove location dot marker, update control `classList`, emit an event called `outofmaxbounds` and return to avoid camera update.

Related issue: #4872

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [x] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
