### PR TITLE
[DNM] Further experiments with fading adjustments during zoom-out (#8627)

### DIFF
--- a/debug/8627.html
+++ b/debug/8627.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+        #buttons {
+          position: absolute;
+          border-radius: 4px;
+          background: rgba(255,255,255,0.85);
+          top: 10px;
+          left: 10px;
+          padding: 10px;
+        }
+    </style>
+</head>
+
+<body>
+
+<div id='map'></div>
+<div id='buttons'>
+  <button id='zoom' onclick="zoomOut();">zoom out</button>
+  <button id='zoom' onclick="zoomIn();">zoom in</button>
+</div>
+
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
+
+const CENTER = { lng: -74.0009917133583, lat: 40.72092299699548 };
+
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12,
+    center: [CENTER.lng, CENTER.lat],
+    style: 'mapbox://styles/mapbox/streets-v10',
+    fadeDuration: 300,
+    hash: false
+});
+
+
+
+function zoomOut() {
+    map.setCenter(CENTER).setZoom(15);
+    window.setTimeout(() => {
+        map.setCenter(CENTER).zoomTo(12, { duration: 500 });
+    }, 2500);
+}
+
+function zoomIn() {
+    map.setCenter(CENTER).setZoom(12);
+    window.setTimeout(() => {
+        map.setCenter(CENTER).zoomTo(15, { duration: 500 });
+    }, 2500);
+}
+
+
+</script>
+</body>
+</html>

--- a/src/style/pauseable_placement.js
+++ b/src/style/pauseable_placement.js
@@ -95,8 +95,8 @@ class PauseablePlacement {
         this._done = true;
     }
 
-    commit(now: number) {
-        this.placement.commit(now);
+    commit(now: number, zoom: number) {
+        this.placement.commit(now, zoom);
         return this.placement;
     }
 }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1192,6 +1192,8 @@ class Style extends Evented {
         }
         this.crossTileSymbolIndex.pruneUnusedLayers(this._order);
 
+        console.log('map._zooming', this.map._zooming);
+
         // Anything that changes our "in progress" layer and tile indices requires us
         // to start over. When we start over, we do a full placement instead of incremental
         // to prevent starvation.
@@ -1199,6 +1201,15 @@ class Style extends Evented {
         // Also force full placement when fadeDuration === 0 to ensure that newly loaded
         // tiles will fully display symbols in their first frame
         const forceFullPlacement = this._layerOrderChanged || fadeDuration === 0;
+
+        // if (this.pauseablePlacement) {
+        //   console.log('current placement done?', this.pauseablePlacement.isDone());
+        //   if (!this.placement.stillRecent(browser.now(), transform.zoom)) {
+        //     console.log('should update placement', browser.now(), transform.zoom);
+        //   } else {
+        //     console.log('should not update placement', browser.now(), transform.zoom);
+        //   }
+        // }
 
         if (forceFullPlacement || !this.pauseablePlacement || (this.pauseablePlacement.isDone() && !this.placement.stillRecent(browser.now(), transform.zoom))) {
             this.pauseablePlacement = new PauseablePlacement(transform, this._order, forceFullPlacement, showCollisionBoxes, fadeDuration, crossSourceCollisions, this.placement);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1200,7 +1200,8 @@ class Style extends Evented {
         // We need to restart placement to keep layer indices in sync.
         // Also force full placement when fadeDuration === 0 to ensure that newly loaded
         // tiles will fully display symbols in their first frame
-        const forceFullPlacement = this._layerOrderChanged || fadeDuration === 0;
+        const forceFullPlacement = this._layerOrderChanged || fadeDuration === 0 || this.map._zooming ;
+
 
         // if (this.pauseablePlacement) {
         //   console.log('current placement done?', this.pauseablePlacement.isDone());

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1200,7 +1200,7 @@ class Style extends Evented {
         // tiles will fully display symbols in their first frame
         const forceFullPlacement = this._layerOrderChanged || fadeDuration === 0;
 
-        if (forceFullPlacement || !this.pauseablePlacement || (this.pauseablePlacement.isDone() && !this.placement.stillRecent(browser.now()))) {
+        if (forceFullPlacement || !this.pauseablePlacement || (this.pauseablePlacement.isDone() && !this.placement.stillRecent(browser.now(), transform.zoom))) {
             this.pauseablePlacement = new PauseablePlacement(transform, this._order, forceFullPlacement, showCollisionBoxes, fadeDuration, crossSourceCollisions, this.placement);
             this._layerOrderChanged = false;
         }
@@ -1215,7 +1215,7 @@ class Style extends Evented {
             this.pauseablePlacement.continuePlacement(this._order, this._layers, layerTiles);
 
             if (this.pauseablePlacement.isDone()) {
-                this.placement = this.pauseablePlacement.commit(browser.now());
+                this.placement = this.pauseablePlacement.commit(browser.now(), transform.zoom);
                 placementCommitted = true;
             }
 

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -481,6 +481,7 @@ export class Placement {
     }
 
     commit(now: number, zoom: number): void {
+        console.log('committing at', now, zoom);
         this.commitTime = now;
 
         const prevPlacement = this.prevPlacement;
@@ -722,6 +723,7 @@ export class Placement {
     }
 
     stillRecent(now: number, zoom: number) {
+        // if (this.zoomAdjustment(zoom) > 0) return now - this.commitTime <= 100;
         return this.commitTime + this.fadeDuration * (1 - this.zoomAdjustment(zoom))  > now;
     }
 

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -166,6 +166,8 @@ export class Placement {
     opacities: { [CrossTileID]: JointOpacityState };
     variableOffsets: {[CrossTileID]: VariableOffset };
     commitTime: number;
+    commitZoom: number;
+    prevZoomAdjustment: number;
     lastPlacementChangeTime: number;
     stale: boolean;
     fadeDuration: number;
@@ -479,15 +481,15 @@ export class Placement {
         }
     }
 
-    commit(now: number): void {
+    commit(now: number, zoom: number): void {
         this.commitTime = now;
+        this.commitZoom = zoom;
 
         const prevPlacement = this.prevPlacement;
         let placementChanged = false;
 
-        const increment = (prevPlacement && this.fadeDuration !== 0) ?
-            (this.commitTime - prevPlacement.commitTime) / this.fadeDuration :
-            1;
+        this.prevZoomAdjustment = prevPlacement ? prevPlacement.zoomAdjustment(zoom) : 0;
+        const increment = prevPlacement ? prevPlacement.symbolFadeChange(now) : 1;
 
         const prevOpacities = prevPlacement ? prevPlacement.opacities : {};
         const prevOffsets = prevPlacement ? prevPlacement.variableOffsets : {};
@@ -705,7 +707,15 @@ export class Placement {
     symbolFadeChange(now: number) {
         return this.fadeDuration === 0 ?
             1 :
-            (now - this.commitTime) / this.fadeDuration;
+            ((now - this.commitTime) / this.fadeDuration + this.prevZoomAdjustment);
+    }
+
+    zoomAdjustment(zoom: number) {
+        // When zooming out quickly labels can overlap each quickly. This
+        // adjustment is used to reduce the fade duration when zooming out quickly and
+        // to reduce the interval between placement calculations. Discovering the
+        // collisions more quickly and fading them more quickly reduces the unwanted effect.
+        return Math.max(0, 1 - Math.pow(2, zoom - this.commitZoom));
     }
 
     hasTransitions(now: number) {
@@ -713,8 +723,8 @@ export class Placement {
             now - this.lastPlacementChangeTime < this.fadeDuration;
     }
 
-    stillRecent(now: number) {
-        return this.commitTime + this.fadeDuration > now;
+    stillRecent(now: number, zoom: number) {
+        return this.commitTime + this.fadeDuration * (1 - this.zoomAdjustment(zoom))  > now;
     }
 
     setStale() {

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -166,7 +166,6 @@ export class Placement {
     opacities: { [CrossTileID]: JointOpacityState };
     variableOffsets: {[CrossTileID]: VariableOffset };
     commitTime: number;
-    commitZoom: number;
     prevZoomAdjustment: number;
     lastPlacementChangeTime: number;
     stale: boolean;
@@ -483,7 +482,6 @@ export class Placement {
 
     commit(now: number, zoom: number): void {
         this.commitTime = now;
-        this.commitZoom = zoom;
 
         const prevPlacement = this.prevPlacement;
         let placementChanged = false;
@@ -707,7 +705,7 @@ export class Placement {
     symbolFadeChange(now: number) {
         return this.fadeDuration === 0 ?
             1 :
-            ((now - this.commitTime) / this.fadeDuration + this.prevZoomAdjustment);
+            ((now - this.commitTime) / this.fadeDuration + this.prevZoomAdjustment + 1);
     }
 
     zoomAdjustment(zoom: number) {
@@ -715,7 +713,7 @@ export class Placement {
         // adjustment is used to reduce the fade duration when zooming out quickly and
         // to reduce the interval between placement calculations. Discovering the
         // collisions more quickly and fading them more quickly reduces the unwanted effect.
-        return Math.max(0, 1 - Math.pow(2, zoom - this.commitZoom));
+        return Math.max(0, 1 - Math.pow(2, zoom - this.transform.zoom));
     }
 
     hasTransitions(now: number) {


### PR DESCRIPTION
This PR extends #8628 with some debugging & experimentation that @asheemmamoowala and I did today to try to resolve #8627 while still not introducing jank.

Changes from #8628:
- [dnm] Adds a debug page for easier testing of rapid zoom in/out
- [dnm] Adds some debug logging in `style.js` and `placement.js`
- Attempts to prevent lingering label clusters by forcing a full placement during a zoom instead of waiting for the previous placement to complete

Notes:
  - In manual testing on Ubuntu Firefox & Chrome, this arguably results in a better label experience when zooming out
  - However, it may introduce jank - this was more noticeable in Chrome - and hasn't been tested in all situations (e.g. how does it look in a long flyTo crossing a large area?)
  - This does not solve the label clustering/not fading problem when the zoom is instantaneous, e.g. jumpTo/setCenter

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] manually test the debug page

