### PR TITLE
Update earcut to v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",
     "csscolorparser": "~1.0.2",
-    "earcut": "^2.1.5",
+    "earcut": "^2.2.0",
     "geojson-vt": "^3.2.1",
     "gl-matrix": "^3.0.0",
     "grid-index": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,10 +3178,10 @@ duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-earcut@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.5.tgz#829280a9a3a0f5fee0529f0a47c3e4eff09b21e4"
-  integrity sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA==
+earcut@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.0.tgz#3996ed8c63c04173761970e9bad590fc2b335e55"
+  integrity sha512-F0Mgm+gO5r8p+II4y9L+6rQ7XfI6qn8ga0mx2vX5xyfWGis8sO+Fpd8IdW0t3pXKPzpEuey9eZNIgBMPAIRtLw==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Closes #8768. Contains a bunch of fixes for difficult, rare cases that previously produced invalid triangulation on valid input. In particular:

- https://github.com/mapbox/earcut/pull/124
- https://github.com/mapbox/earcut/pull/120
- https://github.com/mapbox/earcut/pull/122
- https://github.com/mapbox/earcut/pull/121
- https://github.com/mapbox/earcut/pull/114