### PR TITLE
Handle Firefox SecurityError when opening window cache

### DIFF
--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {parseCacheControl} from './util';
+import {warnOnce, parseCacheControl} from './util';
 import window from './window';
 
 import type Dispatcher from './dispatcher';
@@ -61,8 +61,8 @@ export function cachePut(request: Request, response: Response, requestTime: numb
         const clonedResponse = new window.Response(body, options);
 
         window.caches.open(CACHE_NAME)
-          .catch(e => warnOnce(e.message))
-          .then(cache => cache.put(stripQueryParameters(request.url), clonedResponse));
+            .catch(e => warnOnce(e.message))
+            .then(cache => cache.put(stripQueryParameters(request.url), clonedResponse));
     });
 }
 

--- a/src/util/tile_request_cache.js
+++ b/src/util/tile_request_cache.js
@@ -60,7 +60,9 @@ export function cachePut(request: Request, response: Response, requestTime: numb
     prepareBody(response, body => {
         const clonedResponse = new window.Response(body, options);
 
-        window.caches.open(CACHE_NAME).then(cache => cache.put(stripQueryParameters(request.url), clonedResponse));
+        window.caches.open(CACHE_NAME)
+          .catch(e => warnOnce(e.message))
+          .then(cache => cache.put(stripQueryParameters(request.url), clonedResponse));
     });
 }
 


### PR DESCRIPTION
Catch & warn on the SecurityError thrown by Firefox 69+ when the worker tries to access the cache.

cc @asheemmamoowala @mourner @arindam1993 @mapbox/studio @mapbox/map-design-team 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page

