### PR TITLE
Reset the Evented parent when removing objects to break GC loop

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1143,9 +1143,16 @@ class Style extends Evented {
             this._spriteRequest = null;
         }
         rtlTextPluginEvented.off('pluginAvailable', this._rtlTextPluginCallback);
+        for (const layerId in this._layers) {
+            const layer: StyleLayer = this._layers[layerId];
+            layer.setEventedParent(null);
+        }
         for (const id in this.sourceCaches) {
             this.sourceCaches[id].clearTiles();
+            this.sourceCaches[id].setEventedParent(null);
         }
+        this.imageManager.setEventedParent(null);
+        this.setEventedParent(null);
         this.dispatcher.remove();
     }
 

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -190,6 +190,7 @@ class Actor {
     }
 
     remove() {
+        this.invoker.remove();
         this.target.removeEventListener('message', this.receive, false);
     }
 }

--- a/src/util/throttled_invoker.js
+++ b/src/util/throttled_invoker.js
@@ -36,6 +36,11 @@ class ThrottledInvoker {
             }
         }
     }
+
+    remove() {
+        delete this._channel;
+        this._callback = () => {};
+    }
 }
 
 export default ThrottledInvoker;


### PR DESCRIPTION
When calling `map.remove()`, we did try to remove things, but due to circular references, most objects were still retained.