### PR TITLE
get/set cameraPosition with altitude

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -381,8 +381,7 @@ class Transform {
         const pitch = this._pitch;
         const altitude = Math.cos(pitch) * this.cameraToCenterDistance;
         const latOffset = Math.tan(pitch) * this.cameraToCenterDistance;
-        const latPosPointInPixels = this.centerPoint.add(new Point(0, latOffset));
-        const lngLat = this.pointLocation(latPosPointInPixels);
+        const lngLat = this.pointLocation(this.centerPoint.add(new Point(0, latOffset)));
         const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(lngLat.lat * (Math.PI / 180))));
         const altitudeInMeters = altitude / verticalScaleConstant;
         const pitchInDegrees = pitch * (180 / Math.PI);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -382,12 +382,12 @@ class Transform {
         const altitude = Math.cos(pitch) * this.cameraToCenterDistance;
         const latOffset = Math.tan(pitch) * this.cameraToCenterDistance;
         const latPosPointInPixels = this.centerPoint.add(new Point(0, latOffset));
-        const latLong = this.pointLocation(latPosPointInPixels);
-        const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(latLong.lat * (Math.PI / 180))));
+        const lngLat = this.pointLocation(latPosPointInPixels);
+        const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(lngLat.lat * (Math.PI / 180))));
         const altitudeInMeters = altitude / verticalScaleConstant;
         const pitchInDegrees = pitch * (180 / Math.PI);
 
-        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch: pitchInDegrees, bearing: this.bearing };
+        return { lng: lngLat.lng, lat: lngLat.lat, altitude: altitudeInMeters, pitch: pitchInDegrees, bearing: this.bearing };
     }
 
     /**
@@ -402,16 +402,15 @@ class Transform {
         const pixelAltitude = Math.abs(Math.cos(pitchInRadians) * cameraToCenterDistance);
         const metersInWorldAtLat = (2 * Math.PI * 6378137 * Math.abs(Math.cos(lat * (Math.PI / 180))));
         const worldsize = pixelAltitude / altitude * metersInWorldAtLat;
-        const zoom = Math.log(worldsize / this.tileSize) / Math.LN2;
 
         const latOffset = Math.tan(pitchInRadians) * cameraToCenterDistance;
         const newPixelPoint = new Point(this.width / 2, this.height / 2 + latOffset);
-        const newLongLat = new LngLat(lng, lat);
+        const newLngLat = new LngLat(lng, lat);
 
-        this.zoom = zoom;
+        this.zoom = Math.log(worldsize / this.tileSize) / Math.LN2;
         this.pitch = pitch;
         this.bearing = bearing;
-        this.setLocationAtPoint(newLongLat, newPixelPoint);
+        this.setLocationAtPoint(newLngLat, newPixelPoint);
     }
 
     /**

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -375,7 +375,7 @@ class Transform {
 
     /**
      * Get the latitude and longitude under the camera, the altitude of the camera in meters, bearing & pitch
-     * @returns {Object} containing longitude, latitude, altitude and pitch(in degrees)
+     * @returns {Object} containing longitude, latitude, altitude and pitch (in degrees)
      */
     getCameraPosition(): { lng: number, lat: number, altitude: number, pitch: number, bearing: number } {
         const pitch = this._pitch;
@@ -395,9 +395,14 @@ class Transform {
 
     /**
      * Set camera position to desired latitude, longitude, altitude, pitch (in degrees) and bearing
-     * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, bearing & pitch
+     * @param {Object} cameraPosition Object containing the latitude and longitude under the camera, the altitude in meters, bearing & pitch
+     * @param {number} [cameraPosition.lng] Camera longitude
+     * @param {number} [cameraPosition.lat] Camera latitude
+     * @param {number} [cameraPosition.altitude] Camera altitude in meters
+     * @param {number} [cameraPosition.pitch] Camera pitch in degrees away from the plane of the screen
+     * @param {number} [cameraPosition.bearing] Camera bearing in degrees counter-clockwise from north
      */
-    setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number, bearing: number }) {
+    setCameraPosition(cameraPosition: { lng: number, lat: number, altitude: number, pitch: number, bearing: number }) {
         const {lng, lat, altitude, pitch, bearing} = camPos;
 
         const pitchInRadians = pitch * (Math.PI / 180);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -390,7 +390,7 @@ class Transform {
         const altitudeInMeters = altitude / verticalScaleConstant;
         const pitchInDegrees = pitch * (180 / Math.PI);
 
-        return { lng: lngLat.lng, lat: lngLat.lat, altitude: altitudeInMeters, pitch: pitchInDegrees, bearing: this.bearing };
+        return {lng: lngLat.lng, lat: lngLat.lat, altitude: altitudeInMeters, pitch: pitchInDegrees, bearing: this.bearing};
     }
 
     /**
@@ -398,7 +398,7 @@ class Transform {
      * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, bearing & pitch
      */
     setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number, bearing: number }) {
-        const { lng, lat, altitude, pitch, bearing } = camPos;
+        const {lng, lat, altitude, pitch, bearing} = camPos;
 
         const pitchInRadians = pitch * (Math.PI / 180);
         const cameraToCenterDistance = 0.5 / Math.tan(this._fov / 2) * this.height;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -403,7 +403,9 @@ class Transform {
         const pitchInRadians = pitch * (Math.PI / 180);
         const cameraToCenterDistance = 0.5 / Math.tan(this._fov / 2) * this.height;
         const pixelAltitude = Math.abs(Math.cos(pitchInRadians) * cameraToCenterDistance);
-        const metersInWorldAtLat = (2 * Math.PI * 6378137 * Math.abs(Math.cos(lat * (Math.PI / 180))));
+        // mercator circumference of the world in meters at the equator
+        const circumferenceAtEquator = 2 * Math.PI * 6378137;
+        const metersInWorldAtLat = (circumferenceAtEquator * Math.abs(Math.cos(lat * (Math.PI / 180))));
         const worldsize = pixelAltitude / altitude * metersInWorldAtLat;
 
         const latOffset = Math.tan(pitchInRadians) * cameraToCenterDistance;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -403,7 +403,7 @@ class Transform {
      * @param {number} [cameraPosition.bearing] Camera bearing in degrees counter-clockwise from north
      */
     setCameraPosition(cameraPosition: { lng: number, lat: number, altitude: number, pitch: number, bearing: number }) {
-        const {lng, lat, altitude, pitch, bearing} = camPos;
+        const {lng, lat, altitude, pitch, bearing} = cameraPosition;
 
         const pitchInRadians = pitch * (Math.PI / 180);
         const cameraToCenterDistance = 0.5 / Math.tan(this._fov / 2) * this.height;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -382,7 +382,11 @@ class Transform {
         const altitude = Math.cos(pitch) * this.cameraToCenterDistance;
         const latOffset = Math.tan(pitch) * this.cameraToCenterDistance;
         const lngLat = this.pointLocation(this.centerPoint.add(new Point(0, latOffset)));
-        const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(lngLat.lat * (Math.PI / 180))));
+
+        // mercator circumference of the world in meters at the equator
+        const circumferenceAtEquator = 2 * Math.PI * 6378137;
+
+        const verticalScaleConstant = this.worldSize / (circumferenceAtEquator * Math.abs(Math.cos(lngLat.lat * (Math.PI / 180))));
         const altitudeInMeters = altitude / verticalScaleConstant;
         const pitchInDegrees = pitch * (180 / Math.PI);
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -375,7 +375,7 @@ class Transform {
 
     /**
      * Get the latitude and longitude under the camera, the altitude of the camera in meters, bearing & pitch
-     * @returns {Object} containing longitude, latitude, altitude and pitch
+     * @returns {Object} containing longitude, latitude, altitude and pitch(in degrees)
      */
     getCameraPosition(): { lng: number, lat: number, altitude: number, pitch: number, bearing: number } {
         const pitch = this._pitch;
@@ -385,24 +385,26 @@ class Transform {
         const latLong = this.pointLocation(latPosPointInPixels);
         const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(latLong.lat * (Math.PI / 180))));
         const altitudeInMeters = altitude / verticalScaleConstant;
+        const pitchInDegrees = pitch * (180 / Math.PI);
 
-        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch, bearing: this.bearing };
+        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch: pitchInDegrees, bearing: this.bearing };
     }
 
     /**
-     * Set camera position to desired latitude, longitude, altitude, pitch and bearing
+     * Set camera position to desired latitude, longitude, altitude, pitch (in degrees) and bearing
      * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, bearing & pitch
      */
     setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number, bearing: number }) {
         const { lng, lat, altitude, pitch, bearing } = camPos;
 
+        const pitchInRadians = pitch * (Math.PI / 180);
         const cameraToCenterDistance = 0.5 / Math.tan(this._fov / 2) * this.height;
-        const pixelAltitude = Math.abs(Math.cos(pitch) * cameraToCenterDistance);
+        const pixelAltitude = Math.abs(Math.cos(pitchInRadians) * cameraToCenterDistance);
         const metersInWorldAtLat = (2 * Math.PI * 6378137 * Math.abs(Math.cos(lat * (Math.PI / 180))));
         const worldsize = pixelAltitude / altitude * metersInWorldAtLat;
         const zoom = Math.log(worldsize / this.tileSize) / Math.LN2;
 
-        const latOffset = Math.tan(pitch) * cameraToCenterDistance;
+        const latOffset = Math.tan(pitchInRadians) * cameraToCenterDistance;
         const newPixelPoint = new Point(this.width / 2, this.height / 2 + latOffset);
         const newLongLat = new LngLat(lng, lat);
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -374,10 +374,10 @@ class Transform {
     }
 
     /**
-     * Get the latitude and longitude under the camera, the altitude of the camera in meters, and the pitch
+     * Get the latitude and longitude under the camera, the altitude of the camera in meters, bearing & pitch
      * @returns {Object} containing longitude, latitude, altitude and pitch
      */
-    getCameraPosition(): { lng: number, lat: number, altitude: number, pitch: number } {
+    getCameraPosition(): { lng: number, lat: number, altitude: number, pitch: number, bearing: number } {
         const pitch = this._pitch;
         const altitude = Math.cos(pitch) * this.cameraToCenterDistance;
         const latOffset = Math.tan(pitch) * this.cameraToCenterDistance;
@@ -386,15 +386,15 @@ class Transform {
         const verticalScaleConstant = this.worldSize / (2 * Math.PI * 6378137 * Math.abs(Math.cos(latLong.lat * (Math.PI / 180))));
         const altitudeInMeters = altitude / verticalScaleConstant;
 
-        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch };
+        return { lng: latLong.lng, lat: latLong.lat, altitude: altitudeInMeters, pitch, bearing: this.bearing };
     }
 
     /**
-     * Set camera position to desired latitude, longitude, altitude and pitch
-     * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, and pitch
+     * Set camera position to desired latitude, longitude, altitude, pitch and bearing
+     * @param {Object} camPos Object containing the latitude and longitude under the camera, the altitude in meters, bearing & pitch
      */
-    setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number }) {
-        const { lng, lat, altitude, pitch } = camPos;
+    setCameraPosition(camPos: { lng: number, lat: number, altitude: number, pitch: number, bearing: number }) {
+        const { lng, lat, altitude, pitch, bearing } = camPos;
 
         const cameraToCenterDistance = 0.5 / Math.tan(this._fov / 2) * this.height;
         const pixelAltitude = Math.abs(Math.cos(pitch) * cameraToCenterDistance);
@@ -408,6 +408,7 @@ class Transform {
 
         this.zoom = zoom;
         this.pitch = pitch;
+        this.bearing = bearing;
         this.setLocationAtPoint(newLongLat, newPixelPoint);
     }
 

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -98,7 +98,7 @@ test('transform', (t) => {
             bearing: 0
         });
 
-        t.deepEqual(transform.center, { lng: 20, lat: 20 });
+        t.deepEqual(transform.center, {lng: 20, lat: 20});
         t.equal(transform.zoom, 14.166460609951343);
         t.equal(transform.pitch, 0);
         t.equal(transform.bearing, 0);

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -67,6 +67,44 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test('gets accurate camera position via getCameraPosition', (t) => {
+        const transform = new Transform();
+        transform.resize(500, 500);
+        transform.zoom = 12;
+        transform.pitch = 50;
+        transform.center = new LngLat(10, 10);
+        const cameraPosition = transform.getCameraPosition();
+        t.deepEqual(cameraPosition, {
+            lng: 10.00000000000881,
+            lat: 9.9028586843625,
+            altitude: 9075.137447222842,
+            pitch: 50,
+            bearing: -0
+        });
+        t.end();
+    });
+
+    t.test('sets camera position via setCameraPosition', (t) => {
+        const transform = new Transform();
+        transform.resize(500, 500);
+        transform.zoom = 12;
+        transform.pitch = 50;
+        transform.center = new LngLat(10, 10);
+        transform.setCameraPosition({
+            lng: 20,
+            lat: 20,
+            altitude: 3000,
+            pitch: 0,
+            bearing: 0
+        });
+
+        t.deepEqual(transform.center, { lng: 20, lat: 20 });
+        t.equal(transform.zoom, 14.166460609951343);
+        t.equal(transform.pitch, 0);
+        t.equal(transform.bearing, 0);
+        t.end();
+    });
+
     t.test('has a default zoom', (t) => {
         const transform = new Transform();
         transform.resize(500, 500);


### PR DESCRIPTION
## Launch Checklist

resurrecting #6093 to explore the possibility of exposing getting and setting the camera real world elevation, only a WIP at the moment.

addresses #3552

 - [x] briefly describe the changes in this PR

adds internal transform methods for get/setCameraPosition from a lng, lat, **altitude** (in meters), pitch and bearing as an alternative to setting a zoom.

This is useful for ensuring setting the view to an extrusion or 3D feature is set at the right height (altitude, zoom) that the top is visible.

An alternative would be be a zoomFromAltitude method which would just return the equivalent zoom for an altitude which you could then use for the normal view methods.

 - [ ] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec or visual changes~~
 - [ ] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
