### PR TITLE
Avoid throwing styleimagemissing event for empty strings

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -382,7 +382,7 @@ class SymbolBucket implements Bucket {
         // this allows us to fire the styleimagemissing event if image evaluation returns null
         // the only way to distinguish between null returned from a coalesce statement with no valid images
         // and null returned because icon-image wasn't defined is to check whether or not iconImage.parameters is an empty object
-        const hasIcon = iconImage.value.kind !== 'constant' || !!iconImage.value.value || Object.keys(iconImage.parameters).length > 0;
+        const hasIcon = (iconImage.value.kind !== 'constant' || !!iconImage.value.value) && Object.keys(iconImage.parameters).length > 0;
         const symbolSortKey = layout.get('symbol-sort-key');
 
         this.features = [];


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Fixes https://github.com/mapbox/mapbox-gl-js/issues/8800

 - [x] briefly describe the changes in this PR
    - The `image` operator treated empty strings the same as any other string so the `styleimagemissing` operator was fired with `icon-image: ""`. This PR filters out the empty string and treats it as if `icon-image` was not defined.
 - [x] manually test the debug page
