### PR TITLE
Ignore unfamiliar render tests operations

### DIFF
--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -176,7 +176,9 @@ module.exports = function(style, options, _callback) { // eslint-disable-line im
             map.style.sourceCaches[operation[1]].pause();
             applyOperations(map, operations.slice(1), callback);
         } else {
-            map[operation[0]](...operation.slice(1));
+            if (typeof map[operation[0]] === 'function') {
+                map[operation[0]](...operation.slice(1));
+            }
             applyOperations(map, operations.slice(1), callback);
         }
     }


### PR DESCRIPTION
Before this change, the `suite_implementation` treated any unfamiliar render tests operations as `Map` interface methods and tried to invoke them.

This PR checks if the operations can be invoked on the map object and if not, these operations are ignored.

This change is required because gl-native is extending render-tests operations with the API for collecting various metrics (e.g. https://github.com/mapbox/mapbox-gl-native/pull/15468)

