### PR TITLE
Ensure tile mask geometry buffers are cleared when tile is unloaded

### DIFF
--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -88,6 +88,10 @@ function drawDebugTile(painter, sourceCache, coord) {
     program.draw(context, gl.LINES, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
         debugUniformValues(posMatrix, Color.black), id,
         debugTextBuffer, debugTextIndexBuffer, debugTextSegment);
+
+    debugTextBuffer.destroy();
+    debugTextIndexBuffer.destroy();
+    debugTextSegment.destroy();
 }
 
 // Font data From Hershey Simplex Font

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -325,6 +325,7 @@ class GeoJSONSource extends Evented implements Source {
 
     unloadTile(tile: Tile) {
         tile.unloadVectorData();
+        tile.clearMask();
         this.actor.send('removeTile', {uid: tile.uid, type: this.type, source: this.id});
     }
 

--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -123,6 +123,7 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
         }
         if (tile.dem) delete tile.dem;
         delete tile.neighboringTiles;
+        tile.clearMask();
 
         tile.state = 'unloaded';
         if (tile.actor) {

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -158,6 +158,7 @@ class RasterTileSource extends Evented implements Source {
 
     unloadTile(tile: Tile, callback: Callback<void>) {
         if (tile.texture) this.map.painter.saveTileTexture(tile.texture);
+        tile.clearMask();
         callback();
     }
 

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -225,12 +225,6 @@ class Tile {
         this.state = 'unloaded';
     }
 
-    unloadDEMData() {
-        this.dem = null;
-        this.neighboringTiles = null;
-        this.state = 'unloaded';
-    }
-
     getBucket(layer: StyleLayer) {
         return this.buckets[layer.id];
     }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -331,8 +331,8 @@ class Tile {
         // don't redo buffer work if the mask is the same;
         if (deepEqual(this.mask, mask)) return;
 
-        this.mask = mask;
         this.clearMask();
+        this.mask = mask;
 
         // We want to render the full tile, and keeping the segments/vertices/indices empty means
         // using the global shared buffers for covering the entire tile.

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -318,6 +318,8 @@ class Tile {
             this.maskedIndexBuffer.destroy();
             delete this.maskedIndexBuffer;
         }
+
+        delete this.mask;
     }
 
     setMask(mask: Mask, context: Context) {

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -177,6 +177,7 @@ class VectorTileSource extends Evented implements Source {
 
     unloadTile(tile: Tile) {
         tile.unloadVectorData();
+        tile.clearMask();
         if (tile.actor) {
             tile.actor.send('removeTile', {uid: tile.uid, type: this.type, source: this.id}, undefined);
         }


### PR DESCRIPTION
Clear tile mask buffers when tiles are unloaded.
Cherrypick of the fix for the memory leak from #8814 . 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] ~include before/after visuals or gifs if this PR includes visual changes~
 - [ ] ~write tests for all new functionality~
 - [ ] ~document any changes to public APIs~
 - [ ] ~post benchmark scores~
 - [ ] ~manually test the debug page~
 - [ ] ~tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec or visual changes~
 - [ ] ~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~
