### PR TITLE
Remove raster flicker on zoom range change

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -939,7 +939,9 @@ class Style extends Evented {
 
     _updateLayer(layer: StyleLayer) {
         this._updatedLayers[layer.id] = true;
-        if (layer.source && !this._updatedSources[layer.source]) {
+        if (layer.source && !this._updatedSources[layer.source] &&
+            //Skip for raster layers (https://github.com/mapbox/mapbox-gl-js/issues/7865)
+            this.sourceCaches[layer.source].getSource().type !== 'raster') {
             this._updatedSources[layer.source] = 'reload';
             this.sourceCaches[layer.source].pause();
         }

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -1768,6 +1768,33 @@ test('Style#setLayerZoomRange', (t) => {
         });
     });
 
+    t.test('does not reload raster source', (t) => {
+        const style = new Style(new StubMap());
+        style.loadJSON({
+            "version": 8,
+            "sources": {
+                "raster": {
+                    type: "raster",
+                    tiles: ['http://tiles.server']
+                }
+            },
+            "layers": [{
+                "id": "raster",
+                "type": "raster",
+                "source": "raster"
+            }]
+        });
+
+        style.on('style.load', () => {
+            t.spy(style, '_reloadSource');
+
+            style.setLayerZoomRange('raster', 5, 12);
+            style.update(0);
+            t.notOk(style._reloadSource.called, '_reloadSource should not be called for raster source');
+            t.end();
+        });
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Closes #7865.

This is an alternative implementation to #7942. It skips source reloading in the `Style` class, since none of the style mutation APIs allow modifying the raster source in a way that requires reloading the tiles.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
