### PR TITLE
hide internal mercatorScale function from api docs

### DIFF
--- a/src/geo/mercator_coordinate.js
+++ b/src/geo/mercator_coordinate.js
@@ -48,6 +48,7 @@ export function altitudeFromMercatorZ(z: number, y: number) {
  *
  * @param {number} lat Latitude
  * @returns {number} scale factor
+ * @private
  */
 export function mercatorScale(lat: number) {
     return 1 / Math.cos(lat * Math.PI / 180);


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

In #8524 we added a [mercatorScale](https://github.com/mapbox/mapbox-gl-js/blob/2dbbf634906dc1b02b48cb740dadb6de16348475/src/geo/mercator_coordinate.js#L43-L54) method, which was only intended to be used internally but it ended up making it into the API docs (also at the bottom of Events in the TOC).

![Screenshot from 2019-10-11 10-14-42](https://user-images.githubusercontent.com/117278/66614774-fb886880-ec15-11e9-9166-5de1875e9c9a.png)

Technically this is probably a breaking change, but to be honest I couldn't work out how to even use this method publicly so I don't think it's an issue to remove this from the public API.

I tested this change does indeed remove it from the API docs.

 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
