### PR TITLE
Upgrade pbf to v3.2.1 to fix memory leak with long strings in VT

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grid-index": "^1.1.0",
     "minimist": "0.0.8",
     "murmurhash-js": "^1.0.0",
-    "pbf": "^3.0.5",
+    "pbf": "^3.2.1",
     "potpack": "^1.0.1",
     "quickselect": "^2.0.0",
     "rw": "^1.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7153,6 +7153,14 @@ pbf@^3.0.5:
     ieee754 "^1.1.12"
     resolve-protobuf-schema "^2.1.0"
 
+pbf@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.2.1.tgz#b4c1b9e72af966cd82c6531691115cc0409ffe2a"
+  integrity sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==
+  dependencies:
+    ieee754 "^1.1.12"
+    resolve-protobuf-schema "^2.1.0"
+
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"


### PR DESCRIPTION
Closes #8471. Fixes a huge memory leak with large vector tiles that contain long strings in feature properties. The actual change is in https://github.com/mapbox/pbf/pull/109.

Without this PR, when you zoom and hover over features in [this JSBin test case](https://jsbin.com/denavet/edit?html,output), memory quickly grows to **gigabytes** for each thread in both Chrome and Firefox. After the patch, memory stays neatly below 20MB per thread.