### PR TITLE
Add third parameter to once event handler

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -439,7 +439,6 @@ class Map extends Camera {
         return this._mapId;
     }
 
-
     _createDelegatedListener(type: MapEvent, layerId: any, listener: any) {
         if (type === 'mouseenter' || type === 'mouseover') {
             let mousein = false;
@@ -486,7 +485,7 @@ class Map extends Camera {
             };
             return {layer: layerId, listener, delegates: {[type]: delegate}};
         }
-    };
+    }
 
     /**
      * Adds a {@link IControl} to the map, calling `control.onAdd(this)`.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -880,8 +880,9 @@ class Map extends Camera {
     }
 
     once(type: MapEvent, layerId: any, listener: any) {
+
         if (listener === undefined) {
-            return super.on(type, layerId);
+            return super.once(type, layerId);
         }
 
         const delegatedListener = this._createDelegatedListener(type, layerId, listener);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -838,13 +838,13 @@ class Map extends Camera {
     }
 
     /**
-     * Adds a listener for events of a specified type.
+     * Adds a listener that will be called only once to a specified event type.
      *
      * @method
      * @name once
      * @memberof Map
      * @instance
-     * @param {string} type The event type to add a listen for.
+     * @param {string} type The event type to add a listener for.
      * @param {Function} listener The function to be called when the event is fired.
      *   The listener function is called with the data object passed to `fire`,
      *   extended with `target` and `type` properties.
@@ -852,7 +852,7 @@ class Map extends Camera {
      */
 
     /**
-     * Adds a listener for events of a specified type occurring on features in a specified style layer.
+     * Adds a listener that will be called only once to a specified event type occurring on features in a specified style layer.
      *
      * @param {string} type The event type to listen for; one of `'mousedown'`, `'mouseup'`, `'click'`, `'dblclick'`,
      * `'mousemove'`, `'mouseenter'`, `'mouseleave'`, `'mouseover'`, `'mouseout'`, `'contextmenu'`, `'touchstart'`,

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1,5 +1,9 @@
 // @flow
 
+// map.fire(event, options)
+// remove the delegatedoneTimeListener
+// super.fire(event, options)
+
 import {version} from '../../package.json';
 import {extend, bindAll, warnOnce, uniqueId} from '../util/util';
 import browser from '../util/browser';
@@ -269,6 +273,7 @@ class Map extends Camera {
     _refreshExpiredTiles: boolean;
     _hash: Hash;
     _delegatedListeners: any;
+    _delegatedOneTimeListeners: any;
     _fadeDuration: number;
     _crossSourceCollisions: boolean;
     _crossFadingFactor: number;
@@ -862,8 +867,8 @@ class Map extends Camera {
             return super.off(type, layerId);
         }
 
-        if (this._delegatedListeners && this._delegatedListeners[type]) {
-            const listeners = this._delegatedListeners[type];
+        const removeDelegatedListener = (delegatedListeners) => {
+            const listeners = delegatedListeners[type];
             for (let i = 0; i < listeners.length; i++) {
                 const delegatedListener = listeners[i];
                 if (delegatedListener.layer === layerId && delegatedListener.listener === listener) {
@@ -874,6 +879,14 @@ class Map extends Camera {
                     return this;
                 }
             }
+        };
+
+        if (this._delegatedListeners && this._delegatedListeners[type]) {
+            removeDelegatedListener(this._delegatedListeners);
+        }
+
+        if (this._delegatedOneTimeListeners && this._delegatedOneTimeListeners[type]) {
+            removeDelegatedListener(this._delegatedOneTimeListeners);
         }
 
         return this;
@@ -887,9 +900,9 @@ class Map extends Camera {
 
         const delegatedListener = this._createDelegatedListener(type, layerId, listener);
 
-        this._delegatedListeners = this._delegatedListeners || {};
-        this._delegatedListeners[type] = this._delegatedListeners[type] || [];
-        this._delegatedListeners[type].push(delegatedListener);
+        this._delegatedOneTimeListeners = this._delegatedOneTimeListeners || {};
+        this._delegatedOneTimeListeners[type] = this._delegatedOneTimeListeners[type] || [];
+        this.delegatedOneTimeListeners[type].push(delegatedListener);
 
         for (const event in delegatedListener.delegates) {
             this.once((event: any), delegatedListener.delegates[event]);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -269,7 +269,6 @@ class Map extends Camera {
     _refreshExpiredTiles: boolean;
     _hash: Hash;
     _delegatedListeners: any;
-    _delegatedOneTimeListeners: any;
     _fadeDuration: number;
     _crossSourceCollisions: boolean;
     _crossFadingFactor: number;
@@ -876,10 +875,6 @@ class Map extends Camera {
 
         const delegatedListener = this._createDelegatedListener(type, layerId, listener);
 
-        this._delegatedOneTimeListeners = this._delegatedOneTimeListeners || {};
-        this._delegatedOneTimeListeners[type] = this._delegatedOneTimeListeners[type] || [];
-        this.delegatedOneTimeListeners[type].push(delegatedListener);
-
         for (const event in delegatedListener.delegates) {
             this.once((event: any), delegatedListener.delegates[event]);
         }
@@ -928,10 +923,6 @@ class Map extends Camera {
 
         if (this._delegatedListeners && this._delegatedListeners[type]) {
             removeDelegatedListener(this._delegatedListeners);
-        }
-
-        if (this._delegatedOneTimeListeners && this._delegatedOneTimeListeners[type]) {
-            removeDelegatedListener(this._delegatedOneTimeListeners);
         }
 
         return this;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -838,6 +838,36 @@ class Map extends Camera {
         return this;
     }
 
+    /**
+     * Adds a listener for events of a specified type.
+     *
+     * @method
+     * @name once
+     * @memberof Map
+     * @instance
+     * @param {string} type The event type to add a listen for.
+     * @param {Function} listener The function to be called when the event is fired.
+     *   The listener function is called with the data object passed to `fire`,
+     *   extended with `target` and `type` properties.
+     * @returns {Map} `this`
+     */
+
+    /**
+     * Adds a listener for events of a specified type occurring on features in a specified style layer.
+     *
+     * @param {string} type The event type to listen for; one of `'mousedown'`, `'mouseup'`, `'click'`, `'dblclick'`,
+     * `'mousemove'`, `'mouseenter'`, `'mouseleave'`, `'mouseover'`, `'mouseout'`, `'contextmenu'`, `'touchstart'`,
+     * `'touchend'`, or `'touchcancel'`. `mouseenter` and `mouseover` events are triggered when the cursor enters
+     * a visible portion of the specified layer from outside that layer or outside the map canvas. `mouseleave`
+     * and `mouseout` events are triggered when the cursor leaves a visible portion of the specified layer, or leaves
+     * the map canvas.
+     * @param {string} layerId The ID of a style layer. Only events whose location is within a visible
+     * feature in this layer will trigger the listener. The event will have a `features` property containing
+     * an array of the matching features.
+     * @param {Function} listener The function to be called when the event is fired.
+     * @returns {Map} `this`
+     */
+
     once(type: MapEvent, layerId: any, listener: any) {
 
         if (listener === undefined) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -877,6 +877,69 @@ class Map extends Camera {
         return this;
     }
 
+    once(type: MapEvent, layerId: any, listener: any) {
+        if (listener === undefined) {
+            return super.on(type, layerId);
+        }
+        const delegatedListener = (() => {
+            if (type === 'mouseenter' || type === 'mouseover') {
+                let mousein = false;
+                const mousemove = (e) => {
+                    const features = this.getLayer(layerId) ? this.queryRenderedFeatures(e.point, {layers: [layerId]}) : [];
+                    if (!features.length) {
+                        mousein = false;
+                    } else if (!mousein) {
+                        mousein = true;
+                        listener.call(this, new MapMouseEvent(type, this, e.originalEvent, {features}));
+                    }
+                };
+                const mouseout = () => {
+                    mousein = false;
+                };
+                return {layer: layerId, listener, delegates: {mousemove, mouseout}};
+            } else if (type === 'mouseleave' || type === 'mouseout') {
+                let mousein = false;
+                const mousemove = (e) => {
+                    const features = this.getLayer(layerId) ? this.queryRenderedFeatures(e.point, {layers: [layerId]}) : [];
+                    if (features.length) {
+                        mousein = true;
+                    } else if (mousein) {
+                        mousein = false;
+                        listener.call(this, new MapMouseEvent(type, this, e.originalEvent));
+                    }
+                };
+                const mouseout = (e) => {
+                    if (mousein) {
+                        mousein = false;
+                        listener.call(this, new MapMouseEvent(type, this, e.originalEvent));
+                    }
+                };
+                return {layer: layerId, listener, delegates: {mousemove, mouseout}};
+            } else {
+                const delegate = (e) => {
+                    const features = this.getLayer(layerId) ? this.queryRenderedFeatures(e.point, {layers: [layerId]}) : [];
+                    if (features.length) {
+                        // Here we need to mutate the original event, so that preventDefault works as expected.
+                        e.features = features;
+                        listener.call(this, e);
+                        delete e.features;
+                    }
+                };
+                return {layer: layerId, listener, delegates: {[type]: delegate}};
+            }
+        })();
+
+        this._delegatedListeners = this._delegatedListeners || {};
+        this._delegatedListeners[type] = this._delegatedListeners[type] || [];
+        this._delegatedListeners[type].push(delegatedListener);
+
+        for (const event in delegatedListener.delegates) {
+            this.once((event: any), delegatedListener.delegates[event]);
+        }
+
+        return this;
+    }
+
     /**
      * Returns an array of [GeoJSON](http://geojson.org/)
      * [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2)

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -1,7 +1,6 @@
 // @flow
 
 import {extend} from './util';
-import type {MapEvent} from '../ui/events';
 
 type Listener = (Object) => any;
 type Listeners = { [string]: Array<Listener> };
@@ -90,7 +89,7 @@ export class Evented {
      * @param {Function} listener The function to be called when the event is fired the first time.
      * @returns {Object} `this`
      */
-    once(type: MapEvent | string, listener: Listener) {
+    once(type: *, listener: Listener) {
         this._oneTimeListeners = this._oneTimeListeners || {};
         _addEventListener(type, listener, this._oneTimeListeners);
 

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {extend} from './util';
+import type {MapEvent} from '../ui/events';
 
 type Listener = (Object) => any;
 type Listeners = { [string]: Array<Listener> };
@@ -89,7 +90,7 @@ export class Evented {
      * @param {Function} listener The function to be called when the event is fired the first time.
      * @returns {Object} `this`
      */
-    once(type: *, listener: Listener) {
+    once(type: MapEvent | string, listener: Listener) {
         this._oneTimeListeners = this._oneTimeListeners || {};
         _addEventListener(type, listener, this._oneTimeListeners);
 

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -89,7 +89,7 @@ export class Evented {
      * @param {Function} listener The function to be called when the event is fired the first time.
      * @returns {Object} `this`
      */
-    once(type: string, listener: Listener) {
+    once(type: *, listener: Listener) {
         this._oneTimeListeners = this._oneTimeListeners || {};
         _addEventListener(type, listener, this._oneTimeListeners);
 


### PR DESCRIPTION
## Launch Checklist

Fixes https://github.com/mapbox/mapbox-gl-js/issues/7975 by allowing the use of a layer ID argument with the once event.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
