### PR TITLE
convert to resolvedImage type

### DIFF
--- a/build/generate-flow-typed-style-spec.js
+++ b/build/generate-flow-typed-style-spec.js
@@ -120,7 +120,7 @@ export type ColorSpecification = string;
 
 export type FormattedSpecification = string;
 
-export type ImageSpecification = string;
+export type ResolvedImageSpecification = string;
 
 export type FilterSpecification =
     | ['has', string]

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -423,8 +423,6 @@ class SymbolBucket implements Bucket {
                 const resolvedTokens = layer.getValueAndResolveTokens('icon-image', feature, availableImages);
                 if (resolvedTokens instanceof ResolvedImage) {
                     icon = resolvedTokens;
-                } else if (!resolvedTokens || typeof resolvedTokens === 'string') {
-                    icon = ResolvedImage.fromString({name: resolvedTokens, available: false});
                 } else {
                     icon = ResolvedImage.fromString(resolvedTokens);
                 }

--- a/src/style-spec/expression/definitions/coalesce.js
+++ b/src/style-spec/expression/definitions/coalesce.js
@@ -60,7 +60,7 @@ class Coalesce implements Expression {
             result = arg.evaluate(ctx);
             // we need to keep track of the first requested image in a coalesce statement
             // if coalesce can't find a valid image, we return the first image name so styleimagemissing can fire
-            if (arg.type.kind === 'image' && !result.available) {
+            if (arg.type.kind === 'resolvedImage' && !result.available) {
                 if (!requestedImageName) requestedImageName = arg.evaluate(ctx).name;
                 result = null;
                 if (argCount === this.args.length) {

--- a/src/style-spec/expression/definitions/coercion.js
+++ b/src/style-spec/expression/definitions/coercion.js
@@ -101,9 +101,8 @@ class Coercion implements Expression {
             // There is no explicit 'to-formatted' but this coercion can be implicitly
             // created by properties that expect the 'formatted' type.
             return Formatted.fromString(valueToString(this.args[0].evaluate(ctx)));
-        } else if (this.type.kind === 'image') {
-            const name = this.args[0].evaluate(ctx);
-            return typeof name === 'string' ? ResolvedImage.fromString({name, available: false}) : name;
+        } else if (this.type.kind === 'resolvedImage') {
+            return ResolvedImage.fromString(valueToString(this.args[0].evaluate(ctx)));
         } else {
             return valueToString(this.args[0].evaluate(ctx));
         }
@@ -122,7 +121,7 @@ class Coercion implements Expression {
             return new FormatExpression([{text: this.args[0], scale: null, font: null, textColor: null}]).serialize();
         }
 
-        if (this.type.kind === 'image') {
+        if (this.type.kind === 'resolvedImage') {
             return new ImageExpression(this.args[0]).serialize();
         }
 

--- a/src/style-spec/expression/definitions/image.js
+++ b/src/style-spec/expression/definitions/image.js
@@ -1,6 +1,7 @@
 // @flow
 
-import {ImageType, StringType} from '../types';
+import {ResolvedImageType, StringType} from '../types';
+import ResolvedImage from '../types/resolved_image';
 
 import type {Expression} from '../expression';
 import type EvaluationContext from '../evaluation_context';
@@ -12,7 +13,7 @@ export default class ImageExpression implements Expression {
     input: Expression;
 
     constructor(input: Expression) {
-        this.type = ImageType;
+        this.type = ResolvedImageType;
         this.input = input;
     }
 
@@ -35,7 +36,7 @@ export default class ImageExpression implements Expression {
             available = true;
         }
 
-        return {name: evaluatedImageName, available};
+        return new ResolvedImage({name: evaluatedImageName, available});
     }
 
     eachChild(fn: (Expression) => void) {

--- a/src/style-spec/expression/definitions/index.js
+++ b/src/style-spec/expression/definitions/index.js
@@ -39,7 +39,7 @@ import {
 import CollatorExpression from './collator';
 import NumberFormat from './number_format';
 import FormatExpression from './format';
-import Image from './image';
+import ImageExpression from './image';
 import Length from './length';
 
 import type {Varargs} from '../compound_expression';
@@ -60,7 +60,7 @@ const expressions: ExpressionRegistry = {
     'coalesce': Coalesce,
     'collator': CollatorExpression,
     'format': FormatExpression,
-    'image': Image,
+    'image': ImageExpression,
     'interpolate': Interpolate,
     'interpolate-hcl': Interpolate,
     'interpolate-lab': Interpolate,

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -360,7 +360,7 @@ function getExpectedType(spec: StylePropertySpecification): Type {
         enum: StringType,
         boolean: BooleanType,
         formatted: FormattedType,
-        image: ResolvedImageType
+        resolvedImage: ResolvedImageType
     };
 
     if (spec.type === 'array') {

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -350,7 +350,7 @@ function findZoomCurve(expression: Expression): Step | Interpolate | ParsingErro
     return result;
 }
 
-import {ColorType, StringType, NumberType, BooleanType, ValueType, FormattedType, ImageType, array} from './types';
+import {ColorType, StringType, NumberType, BooleanType, ValueType, FormattedType, ResolvedImageType, array} from './types';
 
 function getExpectedType(spec: StylePropertySpecification): Type {
     const types = {
@@ -360,7 +360,7 @@ function getExpectedType(spec: StylePropertySpecification): Type {
         enum: StringType,
         boolean: BooleanType,
         formatted: FormattedType,
-        image: ImageType
+        image: ResolvedImageType
     };
 
     if (spec.type === 'array') {

--- a/src/style-spec/expression/parsing_context.js
+++ b/src/style-spec/expression/parsing_context.js
@@ -112,7 +112,7 @@ class ParsingContext {
                     //
                     if ((expected.kind === 'string' || expected.kind === 'number' || expected.kind === 'boolean' || expected.kind === 'object' || expected.kind === 'array') && actual.kind === 'value') {
                         parsed = annotate(parsed, expected, options.typeAnnotation || 'assert');
-                    } else if ((expected.kind === 'color' || expected.kind === 'formatted' || expected.kind === 'image') && (actual.kind === 'value' || actual.kind === 'string')) {
+                    } else if ((expected.kind === 'color' || expected.kind === 'formatted' || expected.kind === 'resolvedImage') && (actual.kind === 'value' || actual.kind === 'string')) {
                         parsed = annotate(parsed, expected, options.typeAnnotation || 'coerce');
                     } else if (this.checkSubtype(expected, actual)) {
                         return null;
@@ -123,7 +123,7 @@ class ParsingContext {
                 // it immediately and replace it with a literal value in the
                 // parsed/compiled result. Expressions that expect an image should
                 // not be resolved here so we can later get the available images.
-                if (!(parsed instanceof Literal) && (parsed.type.kind !== 'image') && isConstant(parsed)) {
+                if (!(parsed instanceof Literal) && (parsed.type.kind !== 'resolvedImage') && isConstant(parsed)) {
                     const ec = new EvaluationContext();
                     try {
                         parsed = new Literal(parsed.type, parsed.evaluate(ec));

--- a/src/style-spec/expression/types.js
+++ b/src/style-spec/expression/types.js
@@ -10,7 +10,7 @@ export type ValueTypeT = { kind: 'value' };
 export type ErrorTypeT = { kind: 'error' };
 export type CollatorTypeT = { kind: 'collator' };
 export type FormattedTypeT = { kind: 'formatted' };
-export type ImageTypeT = { kind: 'image' };
+export type ResolvedImageTypeT = { kind: 'image' };
 
 export type EvaluationKind = 'constant' | 'source' | 'camera' | 'composite';
 
@@ -26,7 +26,7 @@ export type Type =
     ErrorTypeT |
     CollatorTypeT |
     FormattedTypeT |
-    ImageTypeT
+    ResolvedImageTypeT
 
 export type ArrayType = {
     kind: 'array',
@@ -44,7 +44,7 @@ export const ValueType = {kind: 'value'};
 export const ErrorType = {kind: 'error'};
 export const CollatorType = {kind: 'collator'};
 export const FormattedType = {kind: 'formatted'};
-export const ImageType = {kind: 'image'};
+export const ResolvedImageType = {kind: 'image'};
 
 export function array(itemType: Type, N: ?number): ArrayType {
     return {
@@ -74,7 +74,7 @@ const valueMemberTypes = [
     FormattedType,
     ObjectType,
     array(ValueType),
-    ImageType
+    ResolvedImageType
 ];
 
 /**

--- a/src/style-spec/expression/types.js
+++ b/src/style-spec/expression/types.js
@@ -10,7 +10,7 @@ export type ValueTypeT = { kind: 'value' };
 export type ErrorTypeT = { kind: 'error' };
 export type CollatorTypeT = { kind: 'collator' };
 export type FormattedTypeT = { kind: 'formatted' };
-export type ResolvedImageTypeT = { kind: 'image' };
+export type ResolvedImageTypeT = { kind: 'resolvedImage' };
 
 export type EvaluationKind = 'constant' | 'source' | 'camera' | 'composite';
 
@@ -44,7 +44,7 @@ export const ValueType = {kind: 'value'};
 export const ErrorType = {kind: 'error'};
 export const CollatorType = {kind: 'collator'};
 export const FormattedType = {kind: 'formatted'};
-export const ResolvedImageType = {kind: 'image'};
+export const ResolvedImageType = {kind: 'resolvedImage'};
 
 export function array(itemType: Type, N: ?number): ArrayType {
     return {

--- a/src/style-spec/expression/types/resolved_image.js
+++ b/src/style-spec/expression/types/resolved_image.js
@@ -18,8 +18,8 @@ export default class ResolvedImage {
         return this.name;
     }
 
-    static fromString(options: ResolvedImageOptions): ResolvedImage {
-        return new ResolvedImage(options);
+    static fromString(name: string): ResolvedImage {
+        return new ResolvedImage({name, available: false});
     }
 
     serialize(): Array<mixed> {

--- a/src/style-spec/expression/values.js
+++ b/src/style-spec/expression/values.js
@@ -6,7 +6,7 @@ import Color from '../util/color';
 import Collator from './types/collator';
 import Formatted from './types/formatted';
 import ResolvedImage from './types/resolved_image';
-import {NullType, NumberType, StringType, BooleanType, ColorType, ObjectType, ValueType, CollatorType, FormattedType, ImageType, array} from './types';
+import {NullType, NumberType, StringType, BooleanType, ColorType, ObjectType, ValueType, CollatorType, FormattedType, ResolvedImageType, array} from './types';
 
 import type {Type} from './types';
 
@@ -83,7 +83,7 @@ export function typeOf(value: Value): Type {
     } else if (value instanceof Formatted) {
         return FormattedType;
     } else if (value instanceof ResolvedImage) {
-        return ImageType;
+        return ResolvedImageType;
     } else if (Array.isArray(value)) {
         const length = value.length;
         let itemType: ?Type;

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -202,8 +202,8 @@ function evaluateIdentityFunction(parameters, propertySpec, input) {
         input = Color.parse(input);
     } else if (propertySpec.type === 'formatted') {
         input = Formatted.fromString(input.toString());
-    } else if (propertySpec.type === 'image') {
-        input = ResolvedImage.fromString({name: input.toString(), available: false});
+    } else if (propertySpec.type === 'resolvedImage') {
+        input = ResolvedImage.fromString(input.toString());
     } else if (getType(input) !== propertySpec.type && (propertySpec.type !== 'enum' || !propertySpec.values[input])) {
         input = undefined;
     }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1291,7 +1291,7 @@
       "property-type": "data-constant"
     },
     "icon-image": {
-      "type": "image",
+      "type": "resolvedImage",
       "doc": "Name of image in sprite to use for drawing an image background.",
       "tokens": true,
       "sdk-support": {
@@ -3797,9 +3797,9 @@
       "property-type": "data-constant"
     },
     "fill-pattern": {
-      "type": "image",
+      "type": "resolvedImage",
       "transition": true,
-      "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
+      "doc": "WHY ISNT THIS WORKING",
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
@@ -3943,7 +3943,7 @@
       "property-type": "data-constant"
     },
     "fill-extrusion-pattern": {
-      "type": "image",
+      "type": "resolvedImage",
       "transition": true,
       "doc": "Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
@@ -4332,7 +4332,7 @@
       "property-type": "cross-faded"
     },
     "line-pattern": {
-      "type": "image",
+      "type": "resolvedImage",
       "transition": true,
       "doc": "Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
@@ -5712,7 +5712,7 @@
       "property-type": "data-constant"
     },
     "background-pattern": {
-      "type": "image",
+      "type": "resolvedImage",
       "transition": true,
       "doc": "Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3799,7 +3799,7 @@
     "fill-pattern": {
       "type": "resolvedImage",
       "transition": true,
-      "doc": "WHY ISNT THIS WORKING",
+      "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.",
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",

--- a/src/style-spec/types.js
+++ b/src/style-spec/types.js
@@ -6,7 +6,7 @@ export type ColorSpecification = string;
 
 export type FormattedSpecification = string;
 
-export type ImageSpecification = string;
+export type ResolvedImageSpecification = string;
 
 export type FilterSpecification =
     | ['has', string]
@@ -168,7 +168,7 @@ export type FillLayerSpecification = {|
         "fill-outline-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
         "fill-translate"?: PropertyValueSpecification<[number, number]>,
         "fill-translate-anchor"?: PropertyValueSpecification<"map" | "viewport">,
-        "fill-pattern"?: DataDrivenPropertyValueSpecification<ImageSpecification>
+        "fill-pattern"?: DataDrivenPropertyValueSpecification<ResolvedImageSpecification>
     |}
 |}
 
@@ -199,7 +199,7 @@ export type LineLayerSpecification = {|
         "line-offset"?: DataDrivenPropertyValueSpecification<number>,
         "line-blur"?: DataDrivenPropertyValueSpecification<number>,
         "line-dasharray"?: PropertyValueSpecification<Array<number>>,
-        "line-pattern"?: DataDrivenPropertyValueSpecification<ImageSpecification>,
+        "line-pattern"?: DataDrivenPropertyValueSpecification<ResolvedImageSpecification>,
         "line-gradient"?: ExpressionSpecification
     |}
 |}
@@ -226,7 +226,7 @@ export type SymbolLayerSpecification = {|
         "icon-size"?: DataDrivenPropertyValueSpecification<number>,
         "icon-text-fit"?: PropertyValueSpecification<"none" | "width" | "height" | "both">,
         "icon-text-fit-padding"?: PropertyValueSpecification<[number, number, number, number]>,
-        "icon-image"?: DataDrivenPropertyValueSpecification<ImageSpecification>,
+        "icon-image"?: DataDrivenPropertyValueSpecification<ResolvedImageSpecification>,
         "icon-rotate"?: DataDrivenPropertyValueSpecification<number>,
         "icon-padding"?: PropertyValueSpecification<number>,
         "icon-keep-upright"?: PropertyValueSpecification<boolean>,
@@ -341,7 +341,7 @@ export type FillExtrusionLayerSpecification = {|
         "fill-extrusion-color"?: DataDrivenPropertyValueSpecification<ColorSpecification>,
         "fill-extrusion-translate"?: PropertyValueSpecification<[number, number]>,
         "fill-extrusion-translate-anchor"?: PropertyValueSpecification<"map" | "viewport">,
-        "fill-extrusion-pattern"?: DataDrivenPropertyValueSpecification<ImageSpecification>,
+        "fill-extrusion-pattern"?: DataDrivenPropertyValueSpecification<ResolvedImageSpecification>,
         "fill-extrusion-height"?: DataDrivenPropertyValueSpecification<number>,
         "fill-extrusion-base"?: DataDrivenPropertyValueSpecification<number>,
         "fill-extrusion-vertical-gradient"?: PropertyValueSpecification<boolean>
@@ -405,7 +405,7 @@ export type BackgroundLayerSpecification = {|
     |},
     "paint"?: {|
         "background-color"?: PropertyValueSpecification<ColorSpecification>,
-        "background-pattern"?: PropertyValueSpecification<ImageSpecification>,
+        "background-pattern"?: PropertyValueSpecification<ResolvedImageSpecification>,
         "background-opacity"?: PropertyValueSpecification<number>
     |}
 |}

--- a/src/style-spec/validate/validate.js
+++ b/src/style-spec/validate/validate.js
@@ -39,7 +39,7 @@ const VALIDATORS = {
     'light': validateLight,
     'string': validateString,
     'formatted': validateFormatted,
-    'image': validateImage
+    'resolvedImage': validateImage
 };
 
 // Main recursive validation function. Tracks:

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -600,7 +600,7 @@ export class CrossFadedDataDrivenProperty<T> extends DataDrivenProperty<?CrossFa
             return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: undefined}, parameters);
         } else if (value.expression.kind === 'constant') {
             const evaluatedValue = value.expression.evaluate(parameters, (null: any), {}, availableImages);
-            const isImageExpression = value.property.specification.type === 'image';
+            const isImageExpression = value.property.specification.type === 'resolvedImage';
             const constantValue = isImageExpression && typeof evaluatedValue !== 'string' ? evaluatedValue.name : evaluatedValue;
             const constant = this._calculate(constantValue, constantValue, constantValue, parameters);
             return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: constant}, parameters);

--- a/test/integration/expression-tests/image/basic/test.json
+++ b/test/integration/expression-tests/image/basic/test.json
@@ -14,7 +14,7 @@
       "result": "success",
       "isFeatureConstant": true,
       "isZoomConstant": true,
-      "type": "image"
+      "type": "resolvedImage"
     },
     "outputs": [
       {"name":"monument-15","available":true}

--- a/test/integration/expression-tests/image/coalesce/test.json
+++ b/test/integration/expression-tests/image/coalesce/test.json
@@ -1,7 +1,7 @@
 {
   "expression": ["coalesce", ["image", "foo"], ["image", "bar"], ["image", "monument-15"]],
   "propertySpec": {
-    "type": "image"
+    "type": "resolvedImage"
   },
   "inputs": [
     [{}, {}]
@@ -11,7 +11,7 @@
       "result": "success",
       "isFeatureConstant": true,
       "isZoomConstant": true,
-      "type": "image"
+      "type": "resolvedImage"
     },
     "outputs": [
       {"name":"monument-15","available":true}

--- a/test/integration/expression-tests/image/compound/test.json
+++ b/test/integration/expression-tests/image/compound/test.json
@@ -9,7 +9,7 @@
       "result": "success",
       "isFeatureConstant": false,
       "isZoomConstant": true,
-      "type": "image"
+      "type": "resolvedImage"
     },
     "outputs": [
       {"name":"monument-15","available":true}

--- a/test/integration/expression-tests/image/implicit-assert/test.json
+++ b/test/integration/expression-tests/image/implicit-assert/test.json
@@ -1,13 +1,13 @@
 {
   "expression": ["number", ["get", "icon"]],
   "propertySpec": {
-    "type": "image"
+    "type": "resolvedImage"
   },
   "expected": {
     "compiled": {
         "result": "error",
         "errors": [
-          {"key": "", "error": "Expected image but found number instead."}
+          {"key": "", "error": "Expected resolvedImage but found number instead."}
         ]
     }
   }

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -37,7 +37,7 @@ function validSchema(k, t, obj, ref, version, kind) {
         'visibility-enum',
         'property-type',
         'formatted',
-        'image'
+        'resolvedImage'
     ]);
     const keys = [
         'default',


### PR DESCRIPTION
## Launch Checklist

supersedes #8841 
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - fully converts from `image` Flow and style-spec types to `resolvedImage`
    - this is a prerequisite for allowing the `ResolvedImage` type to be correctly displayed in the docs https://github.com/mapbox/mapbox-gl-js-docs/pull/105
 - [x] document any changes to public APIs
    - public API doesn't change per se but the `image` operator wasn't previously in the docs and the linked PR above adds it
 - [x] manually test the debug page
