### PR TITLE
Catch errors when createMap is called

### DIFF
--- a/bench/benchmarks/layers.js
+++ b/bench/benchmarks/layers.js
@@ -25,6 +25,8 @@ export class LayerBenchmark extends Benchmark {
             style: this.layerStyle
         }).then(map => {
             this.map = map;
+        }).catch(error => {
+            console.error(error);
         });
     }
 

--- a/bench/benchmarks/map_load.js
+++ b/bench/benchmarks/map_load.js
@@ -10,6 +10,10 @@ export default class MapLoad extends Benchmark {
                 sources: {},
                 layers: []
             }
-        }).then(map => map.remove());
+        })
+            .then(map => map.remove())
+            .catch(error => {
+                console.error(error);
+            });
     }
 }

--- a/bench/benchmarks/paint.js
+++ b/bench/benchmarks/paint.js
@@ -30,6 +30,9 @@ export default class Paint extends Benchmark {
         }))
             .then(maps => {
                 this.maps = maps;
+            })
+            .catch(error => {
+                console.error(error);
             });
     }
 

--- a/bench/benchmarks/paint_states.js
+++ b/bench/benchmarks/paint_states.js
@@ -53,6 +53,8 @@ export default class PaintStates extends Benchmark {
                     style
                 }).then(map => {
                     this.map = map;
+                }).catch(error => {
+                    console.error(error);
                 });
             });
     }

--- a/bench/benchmarks/query_box.js
+++ b/bench/benchmarks/query_box.js
@@ -30,6 +30,9 @@ export default class QueryBox extends Benchmark {
         }))
             .then(maps => {
                 this.maps = maps;
+            })
+            .catch(error => {
+                console.error(error);
             });
     }
 

--- a/bench/benchmarks/query_point.js
+++ b/bench/benchmarks/query_point.js
@@ -41,6 +41,9 @@ export default class QueryPoint extends Benchmark {
         }))
             .then(maps => {
                 this.maps = maps;
+            })
+            .catch(error => {
+                console.error(error);
             });
     }
 

--- a/bench/benchmarks/remove_paint_state.js
+++ b/bench/benchmarks/remove_paint_state.js
@@ -53,7 +53,10 @@ class RemovePaintState extends Benchmark {
                     style
                 }).then(map => {
                     this.map = map;
-                });
+                })
+                    .catch(error => {
+                        console.error(error);
+                    });
             });
     }
 


### PR DESCRIPTION
This commit adds a catch statement to any `createMap` calls in benchmarks so a meaningful error is provided when something goes wrong.
