### PR TITLE
Change maximum of function_stop from 22 to 24

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2528,7 +2528,7 @@
   "function_stop": {
     "type": "array",
     "minimum": 0,
-    "maximum": 22,
+    "maximum": 24,
     "value": [
       "number",
       "color"


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

Change the style spec json for function_stop from 22 to 24. I am not sure if mapbox-gl allows anything more than 24 for the maximum zoom but function_stop should allow up to the max-zoom.

fixes #7732
