### PR TITLE
Fix animation performance

### DIFF
--- a/debug/animate.html
+++ b/debug/animate.html
@@ -43,8 +43,8 @@ function crossWithAngle(angle) {
     return {
         "type": "FeatureCollection",
         "features": [
-            line(angle, radius),
-            line(angle, radius + Math.PI / 2)
+            line(angle - Math.PI / 4, radius),
+            line(angle + Math.PI / 4, radius)
         ]
     };
 }
@@ -63,6 +63,16 @@ map.on('load', function () {
         "paint": {
             "line-width": 4,
             "line-color": "#007cbf"
+        }
+    });
+
+    map.addLayer({
+        "id": "dot",
+        "source": "lines",
+        "type": "circle",
+        "paint": {
+            "circle-radius": 10,
+            "circle-color": "#007cbf"
         }
     });
 

--- a/debug/animate.html
+++ b/debug/animate.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='../dist/mapbox-gl.css' />
     <style>
-        #map { width: 764px; height: 400px;  }
+        #map { width: 1200px; height: 800px;  }
     </style>
 </head>
 
@@ -21,42 +21,68 @@ var map = window.map = new mapboxgl.Map({
     container: 'map',
     style: 'mapbox://styles/mapbox/streets-v11',
     center: [0, 0],
-    zoom: 2
+    zoom: 4
 });
 
-var radius = 20;
+var radius = 30;
 
-function pointOnCircle(angle) {
+function line(angle, radius) {
     return {
-        "type": "Point",
-        "coordinates": [
-            Math.cos(angle) * radius,
-            Math.sin(angle) * radius
+        "type": "Feature",
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [
+                [-Math.cos(angle) * radius, -Math.sin(angle) * radius + 1],
+                [Math.cos(angle) * radius, Math.sin(angle) * radius + 1],
+            ]
+        }
+    };
+}
+
+function crossWithAngle(angle) {
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            line(angle, radius),
+            line(angle, radius + Math.PI / 2)
         ]
     };
 }
 
 map.on('load', function () {
     // Add a source and layer displaying a point which will be animated in a circle.
-    map.addSource('point', {
+    map.addSource('lines', {
         "type": "geojson",
-        "data": pointOnCircle(0)
+        "data": crossWithAngle(0)
     });
 
     map.addLayer({
-        "id": "point",
-        "source": "point",
-        "type": "circle",
+        "id": "lines",
+        "source": "lines",
+        "type": "line",
         "paint": {
-            "circle-radius": 10,
-            "circle-color": "#007cbf"
+            "line-width": 4,
+            "line-color": "#007cbf"
         }
     });
+
+    var updates = 0;
+
+    map.on('data', function (d) {
+        if (d.sourceDataType === 'content') {
+            updates++;
+        }
+    });
+
+    setInterval(function () {
+        console.log(updates + ' updates per second');
+        updates = 0;
+    }, 1000);
 
     function animateMarker(timestamp) {
         // Update the data to a new position based on the animation timestamp. The
         // divisor in the expression `timestamp / 1000` controls the animation speed.
-        map.getSource('point').setData(pointOnCircle(timestamp / 1000));
+        map.getSource('lines').setData(crossWithAngle(timestamp / 1000));
 
         // Request the next frame of the animation.
         requestAnimationFrame(animateMarker);

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {bindAll} from './util';
+import {bindAll, isWorker} from './util';
 import {serialize, deserialize} from './web_worker_transfer';
 import ThrottledInvoker from './throttled_invoker';
 
@@ -22,7 +22,6 @@ class Actor {
     target: any;
     parent: any;
     mapId: ?number;
-    isWorker: boolean;
     callbacks: { number: any };
     name: string;
     tasks: { number: any };
@@ -34,7 +33,6 @@ class Actor {
         this.target = target;
         this.parent = parent;
         this.mapId = mapId;
-        this.isWorker = typeof mapId !== 'number';
         this.callbacks = {};
         this.tasks = {};
         this.taskQueue = [];
@@ -117,7 +115,7 @@ class Actor {
             // process() flow to one at a time.
             this.tasks[id] = data;
             this.taskQueue.push(id);
-            if (this.isWorker) {
+            if (isWorker()) {
                 this.invoker.trigger();
             } else {
                 // In the main thread, process messages immediately so that other work does not slip in


### PR DESCRIPTION
Fix #8701 by processing messages immediately on the main thread and only queueing them up in workers. Updated `animate.html` to reproduce the issue since the performance issues started happening when geojson animation touches multiple tiles, so each `setData` request triggers multiple `reloadTile` messages and responses to them start piling up in the main thread. In chrome on Mac OSX, processed `setData` requests increased from <10 per second before this change to 30-40 after the change.

Before:
![before](https://user-images.githubusercontent.com/1480504/67640455-f5121600-f8d0-11e9-86c9-28656b410e0f.gif)
Funny thing is that reported updated per second goes up whenever I start a screen capture.

After:
![after2](https://user-images.githubusercontent.com/1480504/67640526-6b167d00-f8d1-11e9-8b20-2dac47169e4d.gif)


You can still see some renders where one tile shows new data and another tile shows old data. It would be nice to get rid of that entirely, but this at least brings performance back to what it was before 1.3.0.


 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality (not sure if one makes sense?)
 - [x] manually test the debug page
