### PR TITLE
Add stalebot config for processing stale PR's

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,18 +1,19 @@
 # Configuration for probot-stale - https://github.com/probot/stale
+only: pulls
 
+# conditions by whcih to exempt closing
 exemptMilestones: true
-
-staleLabel: archived
-
 exemptLabels:
   - "DO NOT MERGE"
 
-pulls:
-  daysUntilStale: 30
-  daysUntilClose: -1
-  markComment: false
-  closeComment: >
-    Thanks for your contribution, but this PR has not had any activity for a month and has been automatically
-    detected as stale and is being closed.
-    Please feel free to reopen if you have any additional progress to share :), all automatically closed PR's can be searched
-    for using the "archived" tag.
+staleLabel: archived
+
+daysUntilStale: 30
+daysUntilClose: -1 # Close immediately
+
+markComment: false
+closeComment: >
+  Thanks for your contribution, but this PR has not had any activity for a month and has been automatically
+  detected as stale and is being closed.
+  Please feel free to reopen if you have any additional progress to share :), all automatically closed PR's can be searched
+  for using the "archived" tag.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+exemptMilestones: true
+
+staleLabel: archived
+
+exemptLabels:
+  - "DO NOT MERGE"
+
+pulls:
+  daysUntilStale: 30
+  daysUntilClose: -1
+  markComment: false
+  closeComment: >
+    Thanks for your contribution, but this PR has not had any activity for a month and has been automatically
+    detected as stale and is being closed.
+    Please feel free to reopen if you have any additional progress to share :), all automatically closed PR's can be searched
+    for using the "archived" tag.


### PR DESCRIPTION
This add's a bot that automatically closes PR's that have had no activity for > 30 days.

It also uses the `DO NOT MERGE` label as an explicit way of skipping the auto-close. We could rename that label to `backburner` if that makes more sense.

This also only looks at PR's right now, we can add similar automation for issues later.
