### PR TITLE
[wip] add showUserHeading option to GeolocateControl

### DIFF
--- a/debug/debug.html
+++ b/debug/debug.html
@@ -47,6 +47,7 @@ map.addControl(new mapboxgl.GeolocateControl({
     },
     trackUserLocation: true,
     showUserLocation: true,
+    showUserHeading: true,
     fitBoundsOptions: {
         maxZoom: 20
     }

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -746,9 +746,10 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     height: 0;
     border-left: 7.5px solid transparent;
     border-bottom: 7.5px solid #1da1f2;
-    transform: translate(0px, -28px) skewY(-20deg);
+    transform: translate(0, -28px) skewY(-20deg);
     position: absolute;
 }
+
 .mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::after {
     content: "";
     width: 0;

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -735,6 +735,30 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.35);
 }
 
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading {
+    width: 0;
+    height: 0;
+}
+
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-left: 7.5px solid transparent;
+    border-bottom: 7.5px solid #1da1f2;
+    transform: translate(0px, -28px) skewY(-20deg);
+    position: absolute;
+}
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::after {
+    content: "";
+    width: 0;
+    height: 0;
+    border-right: 7.5px solid transparent;
+    border-bottom: 7.5px solid #1da1f2;
+    transform: translate(7.5px, -28px) skewY(20deg);
+    position: absolute;
+}
+
 @-webkit-keyframes mapboxgl-user-location-dot-pulse {
     0%   { -webkit-transform: scale(1); opacity: 1; }
     70%  { -webkit-transform: scale(3); opacity: 0; }

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -283,7 +283,7 @@ class GeolocateControl extends Evented {
         if (position) {
             this._userLocationDotMarker.setLngLat([position.coords.longitude, position.coords.latitude]).addTo(this._map);
 
-            // TODO consider using position.heading in case this is different to deviceorientation
+            // consider using position.coords.heading in case this is different to deviceorientation
         } else {
             this._userLocationDotMarker.remove();
         }
@@ -296,7 +296,7 @@ class GeolocateControl extends Evented {
      */
     _updateMarkerRotation() {
         if (this._userLocationDotMarker && this._heading) {
-            this._userLocationDotMarker.setRotation(this._heading)
+            this._userLocationDotMarker.setRotation(this._heading);
             this._dotElement.classList.add('mapboxgl-user-location-show-heading');
         } else {
             this._dotElement.classList.remove('mapboxgl-user-location-show-heading');

--- a/src/util/throttle.js
+++ b/src/util/throttle.js
@@ -2,7 +2,6 @@
 
 /**
  * Throttle the given function to run at most every `period` milliseconds.
- Throttle the given function to run at most every period milliseconds.
  * @private
  */
 export default function throttle(fn: () => void, time: number): () => ?TimeoutID {


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

Add a `showUserHeading` option to the GeolocateControl to show the device heading as an arrow next to the user location dot.

Sensor access is disabled by default in Safari from iOS 12.2+, so for this to work you need to enable that setting in Safari Settings, once enabled it uses `deviceOrientationEvent.webkitCompassHeading`.

closes #8329
closes #8034

 - [x] include before/after visuals or gifs if this PR includes visual changes

![heading](https://user-images.githubusercontent.com/117278/67915786-e9cc2c80-fbe7-11e9-8feb-820995a02fe5.png)

 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
- [ ] cross device testing
- [ ] investigate if it's better to use https://developer.mozilla.org/en-US/docs/Web/API/Coordinates/heading instead of `deviceorientation`.