### PR TITLE
Remove hardcoded image list in expression test harness

### DIFF
--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -49,7 +49,7 @@ run('js', {ignores, tests}, (fixture) => {
         for (const input of fixture.inputs || []) {
             try {
                 const feature = {properties: input[1].properties || {}};
-                availableImages = input[0].availableImages;
+                availableImages = input[0].availableImages || [];
 
                 if ('id' in input[1]) {
                     feature.id = input[1].id;

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -6,7 +6,6 @@ import {toString} from '../src/style-spec/expression/types';
 import ignores from './ignores.json';
 
 let tests;
-const availableImages = ['monument-15'];
 
 if (process.argv[1] === __filename && process.argv.length > 2) {
     tests = process.argv.slice(2);
@@ -14,6 +13,7 @@ if (process.argv[1] === __filename && process.argv.length > 2) {
 
 run('js', {ignores, tests}, (fixture) => {
     const spec = Object.assign({}, fixture.propertySpec);
+    let availableImages = [];
 
     if (!spec['property-type']) {
         spec['property-type'] = 'data-driven';
@@ -49,6 +49,9 @@ run('js', {ignores, tests}, (fixture) => {
         for (const input of fixture.inputs || []) {
             try {
                 const feature = {properties: input[1].properties || {}};
+                if (input[2]) {
+                    availableImages = input[2];
+                }
                 if ('id' in input[1]) {
                     feature.id = input[1].id;
                 }

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -13,7 +13,7 @@ if (process.argv[1] === __filename && process.argv.length > 2) {
 
 run('js', {ignores, tests}, (fixture) => {
     const spec = Object.assign({}, fixture.propertySpec);
-    let availableImages = [];
+    let availableImages;
 
     if (!spec['property-type']) {
         spec['property-type'] = 'data-driven';
@@ -49,9 +49,8 @@ run('js', {ignores, tests}, (fixture) => {
         for (const input of fixture.inputs || []) {
             try {
                 const feature = {properties: input[1].properties || {}};
-                if (input[2]) {
-                    availableImages = input[2];
-                }
+                availableImages = input[2] || [];
+
                 if ('id' in input[1]) {
                     feature.id = input[1].id;
                 }

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -49,7 +49,7 @@ run('js', {ignores, tests}, (fixture) => {
         for (const input of fixture.inputs || []) {
             try {
                 const feature = {properties: input[1].properties || {}};
-                availableImages = input[2] || [];
+                availableImages = input[0].availableImages;
 
                 if ('id' in input[1]) {
                     feature.id = input[1].id;

--- a/test/integration/expression-tests/image/basic/test.json
+++ b/test/integration/expression-tests/image/basic/test.json
@@ -5,9 +5,8 @@
   ],
   "inputs": [
     [
-        {},
-        {},
-        ["monument-15"]
+        {"availableImages": ["monument-15"]},
+        {}
     ]
   ],
   "expected": {

--- a/test/integration/expression-tests/image/basic/test.json
+++ b/test/integration/expression-tests/image/basic/test.json
@@ -5,8 +5,9 @@
   ],
   "inputs": [
     [
-      {},
-      {}
+        {},
+        {},
+        ["monument-15"]
     ]
   ],
   "expected": {

--- a/test/integration/expression-tests/image/coalesce/test.json
+++ b/test/integration/expression-tests/image/coalesce/test.json
@@ -4,7 +4,11 @@
     "type": "resolvedImage"
   },
   "inputs": [
-    [{}, {}]
+    [
+        {},
+        {},
+        ["monument-15"]
+    ]
   ],
   "expected": {
     "compiled": {

--- a/test/integration/expression-tests/image/coalesce/test.json
+++ b/test/integration/expression-tests/image/coalesce/test.json
@@ -5,9 +5,8 @@
   },
   "inputs": [
     [
-        {},
-        {},
-        ["monument-15"]
+        {"availableImages": ["monument-15"]},
+        {}
     ]
   ],
   "expected": {

--- a/test/integration/expression-tests/image/compound/test.json
+++ b/test/integration/expression-tests/image/compound/test.json
@@ -3,7 +3,15 @@
     "image",
     ["get", "icon"]
   ],
-  "inputs": [[{}, {"properties": {"icon": "monument-15"}}]],
+  "inputs": [
+      [
+          {},
+          {
+              "properties": {"icon": "monument-15"}
+          },
+          ["monument-15"]
+      ]
+  ],
   "expected": {
     "compiled": {
       "result": "success",

--- a/test/integration/expression-tests/image/compound/test.json
+++ b/test/integration/expression-tests/image/compound/test.json
@@ -5,11 +5,10 @@
   ],
   "inputs": [
       [
-          {},
+          {"availableImages": ["monument-15"]},
           {
               "properties": {"icon": "monument-15"}
-          },
-          ["monument-15"]
+          }
       ]
   ],
   "expected": {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - fixes https://github.com/mapbox/mapbox-gl-js/issues/8933 by removing hardcoded `availableImages` list in expressions test harness