### PR TITLE
Support generateId option in clustered sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "potpack": "^1.0.1",
     "quickselect": "^2.0.0",
     "rw": "^1.3.3",
-    "supercluster": "^6.0.1",
+    "supercluster": "^7.0.0",
     "tinyqueue": "^2.0.0",
     "vt-pbf": "^3.1.1"
   },

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -138,7 +138,8 @@ class GeoJSONSource extends Evented implements Source {
                     (this.maxzoom - 1),
                 extent: EXTENT,
                 radius: (options.clusterRadius || 50) * scale,
-                log: false
+                log: false,
+                generateId: options.generateId || false
             },
             clusterProperties: options.clusterProperties
         }, options.workerOptions);

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -170,6 +170,30 @@ test('GeoJSONSource#update', (t) => {
         }, mockDispatcher).load();
     });
 
+    t.test('forwards Supercluster options with worker request', (t) => {
+        const mockDispatcher = wrapDispatcher({
+            send(message, params) {
+                t.equal(message, 'geojson.loadData');
+                t.deepEqual(params.superclusterOptions, {
+                    maxZoom: 12,
+                    extent: 8192,
+                    radius: 1600,
+                    log: false,
+                    generateId: true
+                });
+                t.end();
+            }
+        });
+
+        new GeoJSONSource('id', {
+            data: {},
+            cluster: true,
+            clusterMaxZoom: 12,
+            clusterRadius: 100,
+            generateId: true
+        }, mockDispatcher).load();
+    });
+
     t.test('transforms url before making request', (t) => {
         const mapStub = {
             _requestManager: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9689,10 +9689,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-supercluster@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-6.0.2.tgz#aa2eaae185ef97872f388c683ec29f6991721ee3"
-  integrity sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==
+supercluster@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.0.0.tgz#75d474fafb0a055db552ed7bd7bbda583f6ab321"
+  integrity sha512-8VuHI8ynylYQj7Qf6PBMWy1PdgsnBiIxujOgc9Z83QvJ8ualIYWNx2iMKyKeC4DZI5ntD9tz/CIwwZvIelixsA==
   dependencies:
     kdbush "^3.0.0"
 


### PR DESCRIPTION
Fixes #8223.

`generateId` previously only worked for non-clustered GeoJSON sources. This PR upgrades Supercluster to v7 which added support for `generateId` option.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] ~~document any changes to public APIs~~ already documented in the spec but wasn't working when combined with clustering
 - [x] manually test the debug page
 - [x] tagged @zmiao from the native team — needs a native port (in https://github.com/mapbox/supercluster.hpp and a corresponding `gl-native` PR)