### PR TITLE
Fix shrink icon loading in CSS

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -199,7 +199,7 @@
 }
 
 .mapboxgl-ctrl button.mapboxgl-ctrl-shrink .mapboxgl-ctrl-icon {
-    background-image: svg-inline(ctrl-shrink);
+    background-image: svg-load('svg/mapboxgl-ctrl-shrink.svg');
 }
 
 @media (-ms-high-contrast: active) {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/8944 by correctly loading the shrink icon.

Unfortunately, postcss doesn't seem to have a mode that exits with a non-zero code when warnings occur.