### PR TITLE
Work around CacheStorage memory leak in Safari

### DIFF
--- a/test/unit/util/tile_request_cache.test.js
+++ b/test/unit/util/tile_request_cache.test.js
@@ -1,10 +1,11 @@
 import {test} from '../../util/test';
-import {cacheGet, cachePut} from '../../../src/util/tile_request_cache';
+import {cacheGet, cachePut, cacheClose} from '../../../src/util/tile_request_cache';
 import window from '../../../src/util/window';
 import sinon from 'sinon';
 
 test('tile_request_cache', (t) => {
     t.beforeEach(callback => {
+        cacheClose();
         window.caches = sinon.stub();
         callback();
     });


### PR DESCRIPTION
We are periodically removing items from the cache using the CacheStorage API. Unfortunately, Safari seems to leak significant amounts of memory when requesting a new Cache object, then calling `cache.keys()`. Instead of requesting a new Cache object for every operation, we are now reusing the same Cache object for all operations on the cache.

I ticketed this upstream at https://bugs.webkit.org/show_bug.cgi?id=203991