### PR TITLE
Fix unresolvable deps in deploy-benchmarks build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,6 @@ workflows:
               only:
                 - master
                 - /release-.*/
-                - fix-deploy-benchmarks
       - deploy-release:
           requires:
             - lint
@@ -234,13 +233,13 @@ jobs:
       - run:
           name: Build
           command: BENCHMARK_VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH} $(git rev-parse --short=7 HEAD)" yarn run build-benchmarks
-      # - aws-cli/install
-      # - run:
-      #     name: Upload benchmark
-      #     command: aws s3 cp --acl public-read --content-type application/javascript bench/versions/benchmarks_generated.js s3://mapbox-gl-js/${CIRCLE_TAG:-$CIRCLE_BRANCH}/benchmarks.js
-      # - run:
-      #     name: Upload source maps
-      #     command: aws s3 cp --acl public-read --content-type application/javascript bench/versions/benchmarks_generated.js.map s3://mapbox-gl-js/${CIRCLE_TAG:-$CIRCLE_BRANCH}/benchmarks.js.map
+      - aws-cli/install
+      - run:
+          name: Upload benchmark
+          command: aws s3 cp --acl public-read --content-type application/javascript bench/versions/benchmarks_generated.js s3://mapbox-gl-js/${CIRCLE_TAG:-$CIRCLE_BRANCH}/benchmarks.js
+      - run:
+          name: Upload source maps
+          command: aws s3 cp --acl public-read --content-type application/javascript bench/versions/benchmarks_generated.js.map s3://mapbox-gl-js/${CIRCLE_TAG:-$CIRCLE_BRANCH}/benchmarks.js.map
 
   deploy-release:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ workflows:
               only:
                 - master
                 - /release-.*/
+                - fix-deploy-benchmarks
       - deploy-release:
           requires:
             - lint
@@ -233,13 +234,13 @@ jobs:
       - run:
           name: Build
           command: BENCHMARK_VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH} $(git rev-parse --short=7 HEAD)" yarn run build-benchmarks
-      - aws-cli/install
-      - run:
-          name: Upload benchmark
-          command: aws s3 cp --acl public-read --content-type application/javascript bench/versions/benchmarks_generated.js s3://mapbox-gl-js/${CIRCLE_TAG:-$CIRCLE_BRANCH}/benchmarks.js
-      - run:
-          name: Upload source maps
-          command: aws s3 cp --acl public-read --content-type application/javascript bench/versions/benchmarks_generated.js.map s3://mapbox-gl-js/${CIRCLE_TAG:-$CIRCLE_BRANCH}/benchmarks.js.map
+      # - aws-cli/install
+      # - run:
+      #     name: Upload benchmark
+      #     command: aws s3 cp --acl public-read --content-type application/javascript bench/versions/benchmarks_generated.js s3://mapbox-gl-js/${CIRCLE_TAG:-$CIRCLE_BRANCH}/benchmarks.js
+      # - run:
+      #     name: Upload source maps
+      #     command: aws s3 cp --acl public-read --content-type application/javascript bench/versions/benchmarks_generated.js.map s3://mapbox-gl-js/${CIRCLE_TAG:-$CIRCLE_BRANCH}/benchmarks.js.map
 
   deploy-release:
     <<: *defaults

--- a/bench/styles/benchmarks.js
+++ b/bench/styles/benchmarks.js
@@ -1,7 +1,7 @@
 import mapboxgl from '../../src';
 import accessToken from '../lib/access_token';
 import locationsWithTileID from '../lib/locations_with_tile_id';
-import {benchmark} from '@mapbox/gazetteer';
+import styleBenchmarkLocations from '@mapbox/gazetteer/benchmark/style-benchmark-locations.json';
 import StyleLayerCreate from '../benchmarks/style_layer_create';
 import Validate from '../benchmarks/style_validate';
 import Layout from '../benchmarks/layout';
@@ -11,7 +11,7 @@ import QueryBox from '../benchmarks/query_box';
 
 import getWorkerPool from '../../src/util/global_worker_pool';
 
-const locations = locationsWithTileID(benchmark.styleBenchmarkLocations.features);
+const locations = locationsWithTileID(styleBenchmarkLocations.features);
 
 mapboxgl.accessToken = accessToken;
 

--- a/bench/versions/benchmarks.js
+++ b/bench/versions/benchmarks.js
@@ -1,7 +1,7 @@
 import mapboxgl from '../../src';
 import accessToken from '../lib/access_token';
 import locationsWithTileID from '../lib/locations_with_tile_id';
-import {benchmark} from '@mapbox/gazetteer';
+import styleBenchmarkLocations from '@mapbox/gazetteer/benchmark/style-benchmark-locations.json';
 import Layout from '../benchmarks/layout';
 import LayoutDDS from '../benchmarks/layout_dds';
 import SymbolLayout from '../benchmarks/symbol_layout';
@@ -21,7 +21,7 @@ import FilterEvaluate from '../benchmarks/filter_evaluate';
 
 import getWorkerPool from '../../src/util/global_worker_pool';
 
-const styleLocations = locationsWithTileID(benchmark.styleBenchmarkLocations.features);
+const styleLocations = locationsWithTileID(styleBenchmarkLocations.features);
 
 mapboxgl.accessToken = accessToken;
 


### PR DESCRIPTION
As of https://github.com/mapbox/mapbox-gl-js/pull/8955 the `deploy-benchmarks` build is broken on master, with rollup giving an [error](https://app.circleci.com/jobs/github/mapbox/mapbox-gl-js/56204) as it fails to resolve builtins used by `jsonlint-lines`, which is a dependency of `@mapbox/geojsonhint` which is in turn used by `@mapbox/gazetteer`.
```
[!] (plugin Rollup Core) Error: Could not load fs (imported by /home/circleci/mapbox-gl-js/node_modules/jsonlint-lines/lib/jsonlint.js): ENOENT: no such file or directory, open 'fs'
```

We were previously not seeing this error because we were not importing all of `@mapbox/gazetteer`, but only the `style-benchmark-locations.json` file we need. This PR fixes the `deploy-benchmarks` build by reverting that change to import the JSON file directly, allowing rollup to avoid seeking to resolve the builtin dependencies. 

To test this PR I am making temporary changes to the CircleCI config, to run a modified `deploy-benchmarks` build (without S3 upload) on this PR branch (`deploy-benchmarks` is usually configured to only run on master & release branches). ~Those changes must be reverted before this is mergeable.~ Changes have been reverted.  

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] make sure `deploy-benchmarks` build is passing on this branch (with modified circleci config)
 - [x] get review on this PR 
 - [x] revert circleci changes & un-draft this PR so it's mergeable
