### PR TITLE
Change the type of tile id key to string

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -50,8 +50,8 @@ class Transform {
     _maxPitch: number;
     _center: LngLat;
     _constraining: boolean;
-    _posMatrixCache: {[number]: Float32Array};
-    _alignedPosMatrixCache: {[number]: Float32Array};
+    _posMatrixCache: {[string]: Float32Array};
+    _alignedPosMatrixCache: {[string]: Float32Array};
 
     constructor(minZoom: ?number, maxZoom: ?number, minPitch: ?number, maxPitch: ?number, renderWorldCopies: boolean | void) {
         this.tileSize = 512; // constant

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -103,7 +103,7 @@ class Painter {
     viewportSegments: SegmentVector;
     quadTriangleIndexBuffer: IndexBuffer;
     tileBorderIndexBuffer: IndexBuffer;
-    _tileClippingMaskIDs: { [number]: number };
+    _tileClippingMaskIDs: { [string]: number };
     stencilClearMode: StencilMode;
     style: Style;
     options: PainterOptions;

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -650,10 +650,10 @@ class SourceCache extends Evented {
     _updateLoadedParentTileCache() {
         this._loadedParentTiles = {};
 
-        for (const tile of (Object.values(this._tiles): any)) {
+        for (const tileKey in this._tiles) {
             const path = [];
             let parentTile: ?Tile;
-            let currentId = tile.tileID;
+            let currentId = this._tiles[tileKey].tileID;
 
             // Find the closest loaded ancestor by traversing the tile tree towards the root and
             // caching results along the way
@@ -678,8 +678,8 @@ class SourceCache extends Evented {
             }
 
             // Cache the result of this traversal to all newly visited tiles
-            for (let i = 0; i < path.length; i++) {
-                this._loadedParentTiles[path[i]] = parentTile;
+            for (const key of path) {
+                this._loadedParentTiles[key] = parentTile;
             }
         }
     }
@@ -927,6 +927,9 @@ SourceCache.maxOverzooming = 10;
 SourceCache.maxUnderzooming = 3;
 
 function compareTileId(a: OverscaledTileID, b: OverscaledTileID): number {
+    // Different copies of the world are sorted based on their distance to the center.
+    // Wrap values are converted to unsigned distances by reserving odd number for copies
+    // with negative wrap and even numbers for copies with positive wrap.
     const aWrap = Math.abs(a.wrap * 2) - +(a.wrap < 0);
     const bWrap = Math.abs(b.wrap * 2) - +(b.wrap < 0);
     return a.overscaledZ - b.overscaledZ || bWrap - aWrap || b.canonical.y - a.canonical.y || b.canonical.x - a.canonical.x;

--- a/src/source/tile_cache.js
+++ b/src/source/tile_cache.js
@@ -12,8 +12,8 @@ import type Tile from './tile';
  */
 class TileCache {
     max: number;
-    data: {[key: number | string]: Array<{ value: Tile, timeout: ?TimeoutID}>};
-    order: Array<number>;
+    data: {[key: string]: Array<{ value: Tile, timeout: ?TimeoutID}>};
+    order: Array<string>;
     onRemove: (element: Tile) => void;
     /**
      * @param {number} max number of permitted values
@@ -110,7 +110,7 @@ class TileCache {
     /*
      * Get and remove the value with the specified key.
      */
-    _getAndRemoveByKey(key: number): ?Tile {
+    _getAndRemoveByKey(key: string): ?Tile {
         const data = this.data[key].shift();
         if (data.timeout) clearTimeout(data.timeout);
 
@@ -125,7 +125,7 @@ class TileCache {
     /*
      * Get the value with the specified (wrapped tile) key.
      */
-    getByKey(key: number): ?Tile {
+    getByKey(key: string): ?Tile {
         const data = this.data[key];
         return data ? data[0].value : null;
     }

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -12,7 +12,7 @@ export class CanonicalTileID {
     z: number;
     x: number;
     y: number;
-    key: number;
+    key: string;
 
     constructor(z: number, x: number, y: number) {
         assert(z >= 0 && z <= 25);
@@ -21,7 +21,7 @@ export class CanonicalTileID {
         this.z = z;
         this.x = x;
         this.y = y;
-        this.key = calculateKey(0, z, x, y);
+        this.key = calculateKey(0, z, z, x, y);
     }
 
     equals(id: CanonicalTileID) {
@@ -57,12 +57,12 @@ export class CanonicalTileID {
 export class UnwrappedTileID {
     wrap: number;
     canonical: CanonicalTileID;
-    key: number;
+    key: string;
 
     constructor(wrap: number, canonical: CanonicalTileID) {
         this.wrap = wrap;
         this.canonical = canonical;
-        this.key = calculateKey(wrap, canonical.z, canonical.x, canonical.y);
+        this.key = calculateKey(wrap, canonical.z, canonical.z, canonical.x, canonical.y);
     }
 }
 
@@ -70,7 +70,7 @@ export class OverscaledTileID {
     overscaledZ: number;
     wrap: number;
     canonical: CanonicalTileID;
-    key: number;
+    key: string;
     posMatrix: Float32Array;
 
     constructor(overscaledZ: number, wrap: number, z: number, x: number, y: number) {
@@ -78,7 +78,7 @@ export class OverscaledTileID {
         this.overscaledZ = overscaledZ;
         this.wrap = wrap;
         this.canonical = new CanonicalTileID(z, +x, +y);
-        this.key = calculateKey(wrap, overscaledZ, x, y);
+        this.key = calculateKey(wrap, overscaledZ, z, x, y);
     }
 
     equals(id: OverscaledTileID) {
@@ -100,13 +100,13 @@ export class OverscaledTileID {
      * when withWrap == true, implements the same as this.scaledTo(z).key,
      * when withWrap == false, implements the same as this.scaledTo(z).wrapped().key.
      */
-    calculateScaledKey(targetZ: number, withWrap: boolean) {
+    calculateScaledKey(targetZ: number, withWrap: boolean): string {
         assert(targetZ <= this.overscaledZ);
         const zDifference = this.canonical.z - targetZ;
         if (targetZ > this.canonical.z) {
-            return calculateKey(this.wrap * +withWrap, targetZ, this.canonical.x, this.canonical.y);
+            return calculateKey(this.wrap * +withWrap, targetZ, this.canonical.z, this.canonical.x, this.canonical.y);
         } else {
-            return calculateKey(this.wrap * +withWrap, targetZ, this.canonical.x >> zDifference, this.canonical.y >> zDifference);
+            return calculateKey(this.wrap * +withWrap, targetZ, targetZ, this.canonical.x >> zDifference, this.canonical.y >> zDifference);
         }
     }
 
@@ -179,11 +179,11 @@ export class OverscaledTileID {
     }
 }
 
-function calculateKey(wrap: number, z: number, x: number, y: number) {
+function calculateKey(wrap: number, overscaledZ: number, z: number, x: number, y: number): string {
     wrap *= 2;
     if (wrap < 0) wrap = wrap * -1 - 1;
     const dim = 1 << z;
-    return ((dim * dim * wrap + dim * y + x) * 32) + z;
+    return (dim * dim * wrap + dim * y + x).toString(36) + z.toString(36) + overscaledZ.toString(36);
 }
 
 function getQuadkey(z, x, y) {

--- a/test/unit/source/raster_dem_tile_source.test.js
+++ b/test/unit/source/raster_dem_tile_source.test.js
@@ -98,11 +98,11 @@ test('RasterTileSource', (t) => {
                 source.loadTile(tile, () => {});
 
                 t.deepEqual(Object.keys(tile.neighboringTiles), [
+                    new OverscaledTileID(10, 0, 10, 4, 5).key,
+                    new OverscaledTileID(10, 0, 10, 6, 5).key,
                     new OverscaledTileID(10, 0, 10, 4, 4).key,
                     new OverscaledTileID(10, 0, 10, 5, 4).key,
                     new OverscaledTileID(10, 0, 10, 6, 4).key,
-                    new OverscaledTileID(10, 0, 10, 4, 5).key,
-                    new OverscaledTileID(10, 0, 10, 6, 5).key,
                     new OverscaledTileID(10, 0, 10, 4, 6).key,
                     new OverscaledTileID(10, 0, 10, 5, 6).key,
                     new OverscaledTileID(10, 0, 10, 6, 6).key
@@ -134,13 +134,13 @@ test('RasterTileSource', (t) => {
                 source.loadTile(tile, () => {});
 
                 t.deepEqual(Object.keys(tile.neighboringTiles), [
-                    new OverscaledTileID(5, 0, 5, 30, 4).key,
-                    new OverscaledTileID(5, 0, 5, 31, 4).key,
-                    new OverscaledTileID(5, 0, 5, 30, 5).key,
                     new OverscaledTileID(5, 0, 5, 30, 6).key,
                     new OverscaledTileID(5, 0, 5, 31, 6).key,
-                    new OverscaledTileID(5, 1, 5, 0,  4).key,
+                    new OverscaledTileID(5, 0, 5, 30, 5).key,
                     new OverscaledTileID(5, 1, 5, 0,  5).key,
+                    new OverscaledTileID(5, 0, 5, 30, 4).key,
+                    new OverscaledTileID(5, 0, 5, 31, 4).key,
+                    new OverscaledTileID(5, 1, 5, 0,  4).key,
                     new OverscaledTileID(5, 1, 5, 0,  6).key
                 ]);
                 t.end();

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -779,20 +779,20 @@ test('SourceCache#update', (t) => {
             if (e.sourceDataType === 'metadata') {
                 sourceCache.update(transform);
                 t.deepEqual(sourceCache.getRenderableIds(), [
-                    new OverscaledTileID(16, 0, 16, 8192, 8192).key,
-                    new OverscaledTileID(16, 0, 16, 8191, 8192).key,
-                    new OverscaledTileID(16, 0, 16, 8192, 8191).key,
-                    new OverscaledTileID(16, 0, 16, 8191, 8191).key
+                    new OverscaledTileID(16, 0, 14, 8192, 8192).key,
+                    new OverscaledTileID(16, 0, 14, 8191, 8192).key,
+                    new OverscaledTileID(16, 0, 14, 8192, 8191).key,
+                    new OverscaledTileID(16, 0, 14, 8191, 8191).key
                 ]);
 
                 transform.zoom = 15;
                 sourceCache.update(transform);
 
                 t.deepEqual(sourceCache.getRenderableIds(), [
-                    new OverscaledTileID(16, 0, 16, 8192, 8192).key,
-                    new OverscaledTileID(16, 0, 16, 8191, 8192).key,
-                    new OverscaledTileID(16, 0, 16, 8192, 8191).key,
-                    new OverscaledTileID(16, 0, 16, 8191, 8191).key
+                    new OverscaledTileID(16, 0, 14, 8192, 8192).key,
+                    new OverscaledTileID(16, 0, 14, 8191, 8192).key,
+                    new OverscaledTileID(16, 0, 14, 8192, 8191).key,
+                    new OverscaledTileID(16, 0, 14, 8191, 8191).key
                 ]);
                 t.end();
             }
@@ -877,14 +877,14 @@ test('SourceCache#_updateRetainedTiles', (t) => {
         }
 
         const retained = sourceCache._updateRetainedTiles([idealTile], 3);
-        t.deepEqual(Object.keys(retained), [
+        t.deepEqual(Object.keys(retained).sort(), [
             // parents are requested because ideal ideal tile is not completely covered by
             // loaded child tiles
             new OverscaledTileID(0, 0, 0, 0, 0),
-            new OverscaledTileID(1, 0, 1, 0, 0),
             new OverscaledTileID(2, 0, 2, 0, 1),
+            new OverscaledTileID(1, 0, 1, 0, 0),
             idealTile
-        ].concat(loadedChildren).map(t => String(t.key)));
+        ].concat(loadedChildren).map(t => t.key).sort());
 
         t.end();
     });
@@ -912,12 +912,12 @@ test('SourceCache#_updateRetainedTiles', (t) => {
         // retained tiles include all ideal tiles and any parents that were loaded to cover
         // non-existant tiles
         t.deepEqual(retained, {
-            // parent
-            '0': new OverscaledTileID(0, 0, 0, 0, 0),
-            //  1/0/1
-            '65': new OverscaledTileID(1, 0, 1, 0, 1),
+            // 1/0/1
+            '211': new OverscaledTileID(1, 0, 1, 0, 1),
             // 1/1/1
-            '97': new OverscaledTileID(1, 0, 1, 1, 1)
+            '311': new OverscaledTileID(1, 0, 1, 1, 1),
+            // parent
+            '000': new OverscaledTileID(0, 0, 0, 0, 0)
         });
         addTileSpy.restore();
         getTileSpy.restore();
@@ -970,10 +970,11 @@ test('SourceCache#_updateRetainedTiles', (t) => {
             }
         });
         const idealTile = new OverscaledTileID(1, 0, 1, 0, 1);
+        const parentTile = new OverscaledTileID(0, 0, 0, 0, 0);
         sourceCache._tiles[idealTile.key] = new Tile(idealTile);
         sourceCache._tiles[idealTile.key].state = 'loading';
-        sourceCache._tiles['0'] = new Tile(new OverscaledTileID(0, 0, 0, 0, 0));
-        sourceCache._tiles['0'].state = 'loaded';
+        sourceCache._tiles[parentTile.key] = new Tile(parentTile);
+        sourceCache._tiles[parentTile.key].state = 'loaded';
 
         const addTileSpy = t.spy(sourceCache, '_addTile');
         const getTileSpy = t.spy(sourceCache, 'getTile');
@@ -987,9 +988,9 @@ test('SourceCache#_updateRetainedTiles', (t) => {
 
         t.deepEqual(retained, {
             // parent of ideal tile 0/0/0
-            '0' : new OverscaledTileID(0, 0, 0, 0, 0),
+            '000' : new OverscaledTileID(0, 0, 0, 0, 0),
             // ideal tile id 1/0/1
-            '65' : new OverscaledTileID(1, 0, 1, 0, 1)
+            '211' : new OverscaledTileID(1, 0, 1, 0, 1)
         }, 'retain ideal and parent tile when ideal tiles aren\'t loaded');
 
         addTileSpy.resetHistory();
@@ -1002,7 +1003,7 @@ test('SourceCache#_updateRetainedTiles', (t) => {
         t.ok(getTileSpy.notCalled);
         t.deepEqual(retainedLoaded, {
             // only ideal tile retained
-            '65' : new OverscaledTileID(1, 0, 1, 0, 1)
+            '211' : new OverscaledTileID(1, 0, 1, 0, 1)
         }, 'only retain ideal tiles when they\'re all loaded');
 
         addTileSpy.restore();
@@ -1059,24 +1060,24 @@ test('SourceCache#_updateRetainedTiles', (t) => {
         t.deepEqual(retained, {
             // parent of ideal tile (0, 0, 0) (only partially covered by loaded child
             // tiles, so we still need to load the parent)
-            '0' : new OverscaledTileID(0, 0, 0, 0, 0),
+            '000' : new OverscaledTileID(0, 0, 0, 0, 0),
             // ideal tile id (1, 0, 0)
-            '1' : new OverscaledTileID(1, 0, 1, 0, 0),
+            '011' : new OverscaledTileID(1, 0, 1, 0, 0),
             // loaded child tile (2, 0, 0)
-            '2': new OverscaledTileID(2, 0, 2, 0, 0)
+            '022': new OverscaledTileID(2, 0, 2, 0, 0)
         }, 'retains children and parent when ideal tile is partially covered by a loaded child tile');
 
         getTileSpy.restore();
         // remove child tile and check that it only uses parent tile
-        delete sourceCache._tiles['2'];
+        delete sourceCache._tiles['022'];
         retained = sourceCache._updateRetainedTiles([idealTile], 1);
 
         t.deepEqual(retained, {
             // parent of ideal tile (0, 0, 0) (only partially covered by loaded child
             // tiles, so we still need to load the parent)
-            '0' : new OverscaledTileID(0, 0, 0, 0, 0),
+            '000' : new OverscaledTileID(0, 0, 0, 0, 0),
             // ideal tile id (1, 0, 0)
-            '1' : new OverscaledTileID(1, 0, 1, 0, 0)
+            '011' : new OverscaledTileID(1, 0, 1, 0, 0)
         }, 'only retains parent tile if no child tiles are loaded');
 
         t.end();
@@ -1104,7 +1105,7 @@ test('SourceCache#_updateRetainedTiles', (t) => {
 
         t.deepEqual(retained, {
             // ideal tile id (2, 0, 0)
-            '2' : new OverscaledTileID(2, 0, 2, 0, 0)
+            '022' : new OverscaledTileID(2, 0, 2, 0, 0)
         }, 'doesn\'t retain parent tiles below minzoom');
 
         getTileSpy.restore();
@@ -1134,7 +1135,7 @@ test('SourceCache#_updateRetainedTiles', (t) => {
 
         t.deepEqual(retained, {
             // ideal tile id (2, 0, 0)
-            '2' : new OverscaledTileID(2, 0, 2, 0, 0)
+            '022' : new OverscaledTileID(2, 0, 2, 0, 0)
         }, 'doesn\'t retain child tiles above maxzoom');
 
         getTileSpy.restore();
@@ -1203,10 +1204,10 @@ test('SourceCache#_updateRetainedTiles', (t) => {
         const retained = sourceCache._updateRetainedTiles(idealTiles, 8);
 
         t.deepEqual(Object.keys(retained), [
-            new OverscaledTileID(7, 0, 7, 0, 0).key,
-            new OverscaledTileID(8, 0, 7, 0, 0).key,
             new OverscaledTileID(7, 0, 7, 1, 0).key,
-            new OverscaledTileID(8, 0, 7, 1, 0).key
+            new OverscaledTileID(8, 0, 7, 1, 0).key,
+            new OverscaledTileID(8, 0, 7, 0, 0).key,
+            new OverscaledTileID(7, 0, 7, 0, 0).key
         ]);
 
         t.end();
@@ -1302,12 +1303,12 @@ test('SourceCache#tilesIn', (t) => {
                 tiles.sort((a, b) => { return a.tile.tileID.canonical.x - b.tile.tileID.canonical.x; });
                 tiles.forEach((result) => { delete result.tile.uid; });
 
-                t.equal(tiles[0].tile.tileID.key, 1);
+                t.equal(tiles[0].tile.tileID.key, "011");
                 t.equal(tiles[0].tile.tileSize, 512);
                 t.equal(tiles[0].scale, 1);
                 t.deepEqual(round(tiles[0].queryGeometry), [{x: 4096, y: 4050}, {x:12288, y: 8146}]);
 
-                t.equal(tiles[1].tile.tileID.key, 33);
+                t.equal(tiles[1].tile.tileID.key, "111");
                 t.equal(tiles[1].tile.tileSize, 512);
                 t.equal(tiles[1].scale, 1);
                 t.deepEqual(round(tiles[1].queryGeometry), [{x: -4096, y: 4050}, {x: 4096, y: 8146}]);
@@ -1340,10 +1341,10 @@ test('SourceCache#tilesIn', (t) => {
                 sourceCache.update(transform);
 
                 t.deepEqual(sourceCache.getIds(), [
-                    new OverscaledTileID(2, 0, 2, 1, 1).key,
-                    new OverscaledTileID(2, 0, 2, 0, 1).key,
-                    new OverscaledTileID(2, 0, 2, 1, 0).key,
-                    new OverscaledTileID(2, 0, 2, 0, 0).key
+                    new OverscaledTileID(2, 0, 1, 1, 1).key,
+                    new OverscaledTileID(2, 0, 1, 0, 1).key,
+                    new OverscaledTileID(2, 0, 1, 1, 0).key,
+                    new OverscaledTileID(2, 0, 1, 0, 0).key
                 ]);
 
                 const tiles = sourceCache.tilesIn([
@@ -1354,12 +1355,12 @@ test('SourceCache#tilesIn', (t) => {
                 tiles.sort((a, b) => { return a.tile.tileID.canonical.x - b.tile.tileID.canonical.x; });
                 tiles.forEach((result) => { delete result.tile.uid; });
 
-                t.equal(tiles[0].tile.tileID.key, 2);
+                t.equal(tiles[0].tile.tileID.key, "012");
                 t.equal(tiles[0].tile.tileSize, 1024);
                 t.equal(tiles[0].scale, 1);
                 t.deepEqual(round(tiles[0].queryGeometry), [{x: 4096, y: 4050}, {x:12288, y: 8146}]);
 
-                t.equal(tiles[1].tile.tileID.key, 34);
+                t.equal(tiles[1].tile.tileID.key, "112");
                 t.equal(tiles[1].tile.tileSize, 1024);
                 t.equal(tiles[1].scale, 1);
                 t.deepEqual(round(tiles[1].queryGeometry), [{x: -4096, y: 4050}, {x: 4096, y: 8146}]);

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -229,6 +229,31 @@ test('SourceCache#addTile', (t) => {
         t.end();
     });
 
+    t.test('should load tiles with identical overscaled Z but different canonical Z', (t) => {
+        const sourceCache = createSourceCache();
+
+        const tileIDs = [
+            new OverscaledTileID(1, 0, 0, 0, 0),
+            new OverscaledTileID(1, 0, 1, 0, 0),
+            new OverscaledTileID(1, 0, 1, 1, 0),
+            new OverscaledTileID(1, 0, 1, 0, 1),
+            new OverscaledTileID(1, 0, 1, 1, 1)
+        ];
+
+        for (let i = 0; i < tileIDs.length; i++)
+            sourceCache._addTile(tileIDs[i]);
+
+        for (let i = 0; i < tileIDs.length; i++) {
+            const id = tileIDs[i];
+            const key = id.key;
+
+            t.ok(sourceCache._tiles[key]);
+            t.deepEqual(sourceCache._tiles[key].tileID, id);
+        }
+
+        t.end();
+    });
+
     t.end();
 });
 

--- a/test/unit/source/tile_id.test.js
+++ b/test/unit/source/tile_id.test.js
@@ -23,10 +23,10 @@ test('CanonicalTileID', (t) => {
     });
 
     t.test('.key', (t) => {
-        t.deepEqual(new CanonicalTileID(0, 0, 0).key, 0);
-        t.deepEqual(new CanonicalTileID(1, 0, 0).key, 1);
-        t.deepEqual(new CanonicalTileID(1, 1, 0).key, 33);
-        t.deepEqual(new CanonicalTileID(1, 1, 1).key, 97);
+        t.deepEqual(new CanonicalTileID(0, 0, 0).key, "000");
+        t.deepEqual(new CanonicalTileID(1, 0, 0).key, "011");
+        t.deepEqual(new CanonicalTileID(1, 1, 0).key, "111");
+        t.deepEqual(new CanonicalTileID(1, 1, 1).key, "311");
         t.end();
     });
 
@@ -77,11 +77,11 @@ test('OverscaledTileID', (t) => {
     });
 
     t.test('.key', (t) => {
-        t.deepEqual(new OverscaledTileID(0, 0, 0, 0, 0).key, 0);
-        t.deepEqual(new OverscaledTileID(1, 0, 1, 0, 0).key, 1);
-        t.deepEqual(new OverscaledTileID(1, 0, 1, 1, 0).key, 33);
-        t.deepEqual(new OverscaledTileID(1, 0, 1, 1, 1).key, 97);
-        t.deepEqual(new OverscaledTileID(1, -1, 1, 1, 1).key, 225);
+        t.deepEqual(new OverscaledTileID(0, 0, 0, 0, 0).key, "000");
+        t.deepEqual(new OverscaledTileID(1, 0, 1, 0, 0).key, "011");
+        t.deepEqual(new OverscaledTileID(1, 0, 1, 1, 0).key, "111");
+        t.deepEqual(new OverscaledTileID(1, 0, 1, 1, 1).key, "311");
+        t.deepEqual(new OverscaledTileID(1, -1, 1, 1, 1).key, "711");
         t.end();
     });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -322,11 +322,11 @@ test('Map', (t) => {
             const map = createMap(t, {style});
             t.equal(map.areTilesLoaded(), true, 'returns true if there are no sources on the map');
             map.on('load', () => {
-
+                const fakeTileId = new OverscaledTileID(0, 0, 0, 0, 0);
                 map.addSource('geojson', createStyleSource());
-                map.style.sourceCaches.geojson._tiles.fakeTile = new Tile(new OverscaledTileID(0, 0, 0, 0, 0));
+                map.style.sourceCaches.geojson._tiles[fakeTileId.key] = new Tile(fakeTileId);
                 t.equal(map.areTilesLoaded(), false, 'returns false if tiles are loading');
-                map.style.sourceCaches.geojson._tiles.fakeTile.state = 'loaded';
+                map.style.sourceCaches.geojson._tiles[fakeTileId.key].state = 'loaded';
                 t.equal(map.areTilesLoaded(), true, 'returns true if tiles are loaded');
                 t.end();
             });


### PR DESCRIPTION
### Description

I found a possible bug or misuse in the key calculation of OverscaledTileID. Canonical z is not taken into account when computing the key hash, but it is used in the equality comparison of the class. This will result in hash collisions and undefined behavior if the key is used as a hashmap key.

This bug appears when trying to load tiles from different zoom levels but using constant overscaledZ across all tiles. At one point the code might be requesting a tile (w, oz, z, x, y) `[2, 1, 0, 0, 0]` with key 513. When LOD kicks in this area would be split into 4 smaller tiles: `[2, 1, 1, 0, 0], [2, 1, 1, 1, 0], [2, 1, 1, 0, 1], [2, 1, 1, 1, 1]`. We now have two different tile ids `[2, 1, 0, 0, 0]` and `[2, 1, 1, 0, 0]` that both have the same key 513. This will break the tile cache resulting in wrong tile being rendered.

![image](https://user-images.githubusercontent.com/55925868/68953663-08771980-07cb-11ea-814f-626bfd5c52b9.png)

This bug/misuse is not present in gl-js master because all tiles have same zoom level. Gl-native should work as well because the CanonicalTileID is used properly with hashmaps.

A side note: source_cache unit tests are using wrong OverscaledTileIDs to check equality in multiple places. The following snippet from the unit tests and it passes fine.
```
                t.deepEqual(sourceCache.getRenderableIds(), [
                    new OverscaledTileID(16, 0, 16, 8192, 8192).key,
                    new OverscaledTileID(16, 0, 16, 8191, 8192).key,
                    new OverscaledTileID(16, 0, 16, 8192, 8191).key,
                    new OverscaledTileID(16, 0, 16, 8191, 8191).key
                ]);
```
Same test passes with following modifications to z values.
```
                t.deepEqual(sourceCache.getRenderableIds(), [
                    new OverscaledTileID(16, 0, 16, 8192, 8192).key,
                    new OverscaledTileID(16, 0, 15, 8191, 8192).key,
                    new OverscaledTileID(16, 0, 14, 8192, 8191).key,
                    new OverscaledTileID(16, 0, 14, 8191, 8191).key
                ]);
```
`sourceCache.getRenderableIds()` actually returns a list of ids that have canonical zoom level of 14 which is not captured by these tests.

### Possible fix
There are at least two possible solutions to fix this:
1. Fix the key generation `this.key = calculateKey(wrap, overscaledZ, z, x, y);`. *This is the approach used in this pull request*.
2. The key generation is not inherently broken, but its usage with hashmaps is. The key can be used to find the right hash bucket, but it doesn't work as an identifier without an equality operator. The fix would be to use OverscaledTileID as a hashmap key like it's done in gl-native. 

### TODO
 - [x] Unit tests have to be updated