### PR TITLE
Fix IE 11 support

### DIFF
--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -107,9 +107,9 @@ class Hash {
             hash.split('&').map(
                 part => part.split('=')
             ).forEach(part => {
-              if (part[0] === this._hashName) {
-                keyval = part;
-              }
+                if (part[0] === this._hashName) {
+                    keyval = part;
+                }
             });
             return (keyval ? keyval[1] || '' : '').split('/');
         }

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -103,9 +103,14 @@ class Hash {
         const hash = window.location.hash.replace('#', '');
         if (this._hashName) {
             // Split the parameter-styled hash into parts and find the value we need
-            const keyval = hash.split('&').map(
+            let keyval;
+            hash.split('&').map(
                 part => part.split('=')
-            ).find(part => part[0] === this._hashName);
+            ).forEach(part => {
+              if (part[0] === this._hashName) {
+                keyval = part;
+              }
+            });
             return (keyval ? keyval[1] || '' : '').split('/');
         }
         return hash.split('/');


### PR DESCRIPTION
IE 11 doesn't support `Array.prototype.find`, this PR fixes that by using `forEach` instead of `find`

## Launch Checklist
 - [x] briefly describe the changes in this PR