### PR TITLE
[docs] clarify that text wrapping is disabled if text-max-width is 0

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1718,7 +1718,7 @@
       "default": 10,
       "minimum": 0,
       "units": "ems",
-      "doc": "The maximum line width for text wrapping.",
+      "doc": "The maximum line width for text wrapping. If `0`, text wrapping is disabled.",
       "requires": [
         "text-field"
       ],


### PR DESCRIPTION
It's a small change, but I think it's worth clarifying explicitly that setting `text-max-width: 0` disables text wrapping. A customer didn't realize this was an option from our docs, and I also felt there was enough ambiguity that I tested it before suggesting it.