### PR TITLE
Fix Click on Compass on some mobile (add clickTolerance to DragRotateHandler)

### DIFF
--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -103,7 +103,7 @@ class NavigationControl {
             }
             this._map.on('rotate', this._rotateCompassArrow);
             this._rotateCompassArrow();
-            this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass});
+            this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass, clickTolerance: map._clickTolerance});
             DOM.addEventListener(this._compass, 'mousedown', this._handler.onMouseDown);
             DOM.addEventListener(this._compass, 'touchstart', this._handler.onMouseDown, {passive: false});
             this._handler.enable();

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -103,7 +103,8 @@ class NavigationControl {
             }
             this._map.on('rotate', this._rotateCompassArrow);
             this._rotateCompassArrow();
-            this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass, clickTolerance: map._clickTolerance});
+            // Temporary fix with clickTolerance (https://github.com/mapbox/mapbox-gl-js/pull/9015)
+            this._handler = new DragRotateHandler(map, {button: 'left', element: this._compass, clickTolerance: map.dragRotate._clickTolerance});
             DOM.addEventListener(this._compass, 'mousedown', this._handler.onMouseDown);
             DOM.addEventListener(this._compass, 'touchstart', this._handler.onMouseDown, {passive: false});
             this._handler.enable();

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -29,6 +29,7 @@ class DragRotateHandler {
     _eventButton: number;
     _bearingSnap: number;
     _pitchWithRotate: boolean;
+    _clickTolerance: number;
 
     _startPos: Point;
     _prevPos: Point;
@@ -51,7 +52,8 @@ class DragRotateHandler {
         button?: 'right' | 'left',
         element?: HTMLElement,
         bearingSnap?: number,
-        pitchWithRotate?: boolean
+        pitchWithRotate?: boolean,
+        clickTolerance?: number
     }) {
         this._map = map;
         this._el = options.element || map.getCanvasContainer();
@@ -59,6 +61,7 @@ class DragRotateHandler {
         this._button = options.button || 'right';
         this._bearingSnap = options.bearingSnap || 0;
         this._pitchWithRotate = options.pitchWithRotate !== false;
+        this._clickTolerance = options.clickTolerance || 1;
 
         bindAll([
             'onMouseDown',
@@ -173,7 +176,7 @@ class DragRotateHandler {
 
     _onMouseMove(e: MouseEvent) {
         const pos = DOM.mousePos(this._el, e);
-        if (this._lastPos.equals(pos)) {
+        if (this._lastPos.equals(pos) || ((this._state === 'pending') && (pos.dist(this._startPos) < this._clickTolerance))) {
             return;
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -282,6 +282,7 @@ class Map extends Camera {
     _trackResize: boolean;
     _preserveDrawingBuffer: boolean;
     _failIfMajorPerformanceCaveat: boolean;
+    _clickTolerance: number;
     _antialias: boolean;
     _refreshExpiredTiles: boolean;
     _hash: Hash;
@@ -365,6 +366,7 @@ class Map extends Camera {
         this._interactive = options.interactive;
         this._maxTileCacheSize = options.maxTileCacheSize;
         this._failIfMajorPerformanceCaveat = options.failIfMajorPerformanceCaveat;
+        this._clickTolerance = options.clickTolerance;
         this._preserveDrawingBuffer = options.preserveDrawingBuffer;
         this._antialias = options.antialias;
         this._trackResize = options.trackResize;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -282,7 +282,6 @@ class Map extends Camera {
     _trackResize: boolean;
     _preserveDrawingBuffer: boolean;
     _failIfMajorPerformanceCaveat: boolean;
-    _clickTolerance: number;
     _antialias: boolean;
     _refreshExpiredTiles: boolean;
     _hash: Hash;
@@ -366,7 +365,6 @@ class Map extends Camera {
         this._interactive = options.interactive;
         this._maxTileCacheSize = options.maxTileCacheSize;
         this._failIfMajorPerformanceCaveat = options.failIfMajorPerformanceCaveat;
-        this._clickTolerance = options.clickTolerance;
         this._preserveDrawingBuffer = options.preserveDrawingBuffer;
         this._antialias = options.antialias;
         this._trackResize = options.trackResize;

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -827,3 +827,63 @@ test('DragRotateHandler does not begin rotation on spurious mousemove events', (
     map.remove();
     t.end();
 });
+
+test('DragRotateHandler does not begin a mouse drag if moved less than click tolerance', (t) => {
+    const map = createMap(t, {clickTolerance: 4});
+
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
+    const rotatestart = t.spy();
+    const rotate      = t.spy();
+    const rotateend   = t.spy();
+    const pitchstart  = t.spy();
+    const pitch       = t.spy();
+    const pitchend    = t.spy();
+
+    map.on('rotatestart', rotatestart);
+    map.on('rotate',      rotate);
+    map.on('rotateend',   rotateend);
+    map.on('pitchstart',  pitchstart);
+    map.on('pitch',       pitch);
+    map.on('pitchend',    pitchend);
+
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2, clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
+    t.equal(pitchstart.callCount, 0);
+    t.equal(pitch.callCount, 0);
+    t.equal(pitchend.callCount, 0);
+
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 13, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
+    t.equal(pitchstart.callCount, 0);
+    t.equal(pitch.callCount, 0);
+    t.equal(pitchend.callCount, 0);
+
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 13});
+    map._renderTaskQueue.run();
+    t.equal(rotatestart.callCount, 0);
+    t.equal(rotate.callCount, 0);
+    t.equal(rotateend.callCount, 0);
+    t.equal(pitchstart.callCount, 0);
+    t.equal(pitch.callCount, 0);
+    t.equal(pitchend.callCount, 0);
+
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 14, clientY: 13 - 4});
+    map._renderTaskQueue.run();
+    t.equal(rotatestart.callCount, 1);
+    t.equal(rotate.callCount, 1);
+    t.equal(rotateend.callCount, 0);
+    t.equal(pitchstart.callCount, 1);
+    t.equal(pitch.callCount, 1);
+    t.equal(pitchend.callCount, 0);
+
+    map.remove();
+    t.end();
+});


### PR DESCRIPTION
This PR adds `clickTolerance` features to `DragRotateHandler` in order to fix click on compass

The "reset to north" of the compass button in `NavigationControl` was bypassed by the drag event, on some mobile version (like Samsung S8 on Chrome). So the drag rotate/pitch was applied and the user couldn't do a simple click to reset the north. Or at least, it needs to be a precise click/touch (with no moving)
This PR reuses the `clickTolerance` system from `DragPanHandler` to apply to the rotate one.
The clickTolerance value is set from the map options.
This is also applied on desktop version while using the drag on the right click or ctrl + left click.

One test is added
You can easily test it with `events.html`