### PR TITLE
Check whether context is lost before `gl.shaderSource(...)`.

### DIFF
--- a/src/render/program.js
+++ b/src/render/program.js
@@ -45,14 +45,20 @@ class Program<Us: UniformBindings> {
         const fragmentSource = defines.concat(prelude.fragmentSource, source.fragmentSource).join('\n');
         const vertexSource = defines.concat(prelude.vertexSource, source.vertexSource).join('\n');
         const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-        if (this.failedToCreate = gl.isContextLost()) return;
+        if (gl.isContextLost()) {
+            this.failedToCreate = true;
+            return;
+        }
         gl.shaderSource(fragmentShader, fragmentSource);
         gl.compileShader(fragmentShader);
         assert(gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS), (gl.getShaderInfoLog(fragmentShader): any));
         gl.attachShader(this.program, fragmentShader);
 
         const vertexShader = gl.createShader(gl.VERTEX_SHADER);
-        if (this.failedToCreate = gl.isContextLost()) return;
+        if (gl.isContextLost()) {
+            this.failedToCreate = true;
+            return;
+        }
         gl.shaderSource(vertexShader, vertexSource);
         gl.compileShader(vertexShader);
         assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), (gl.getShaderInfoLog(vertexShader): any));

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -27,6 +27,7 @@ class Program<Us: UniformBindings> {
     numAttributes: number;
     fixedUniforms: Us;
     binderUniforms: Array<BinderUniform>;
+    failedToCreate: boolean;
 
     constructor(context: Context,
                 source: {fragmentSource: string, vertexSource: string},
@@ -44,12 +45,14 @@ class Program<Us: UniformBindings> {
         const fragmentSource = defines.concat(prelude.fragmentSource, source.fragmentSource).join('\n');
         const vertexSource = defines.concat(prelude.vertexSource, source.vertexSource).join('\n');
         const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+        if (this.failedToCreate = gl.isContextLost()) return;
         gl.shaderSource(fragmentShader, fragmentSource);
         gl.compileShader(fragmentShader);
         assert(gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS), (gl.getShaderInfoLog(fragmentShader): any));
         gl.attachShader(this.program, fragmentShader);
 
         const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+        if (this.failedToCreate = gl.isContextLost()) return;
         gl.shaderSource(vertexShader, vertexSource);
         gl.compileShader(vertexShader);
         assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), (gl.getShaderInfoLog(vertexShader): any));
@@ -109,6 +112,8 @@ class Program<Us: UniformBindings> {
          dynamicLayoutBuffer2: ?VertexBuffer) {
 
         const gl = context.gl;
+
+        if (this.failedToCreate) return;
 
         context.program.set(this.program);
         context.setDepthMode(depthMode);


### PR DESCRIPTION
fix #8986 fix #6312

When context is lost most gl calls are no-ops but this one can throw. When a program cannot be created `draw(...)` needs to fail silently just like all gl calls.

The thrown errors were unlikely to cause any problems but avoiding them keeps logs clearer.

I tested by triggering context loss just before program creation. I don't know how we can automate testing this.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [?] write tests for all new functionality
 - [ ] post benchmark scores
 - [x] manually test the debug page