### PR TITLE
Make sure we don't transfer zero-length array buffers

### DIFF
--- a/src/data/feature_position_map.js
+++ b/src/data/feature_position_map.js
@@ -63,8 +63,9 @@ export default class FeaturePositionMap {
 
         sort(ids, positions, 0, ids.length - 1);
 
-        if (transferables) {
-            transferables.push(ids.buffer, positions.buffer);
+        if (transferables && ids.length) {
+            transferables.push(ids.buffer);
+            transferables.push(positions.buffer);
         }
 
         return {ids, positions};

--- a/src/util/struct_array.js
+++ b/src/util/struct_array.js
@@ -116,7 +116,7 @@ class StructArray {
 
         array._trim();
 
-        if (transferables) {
+        if (transferables && array.arrayBuffer.byteLength) {
             array.isTransferred = true;
             transferables.push(array.arrayBuffer);
         }

--- a/src/util/web_worker_transfer.js
+++ b/src/util/web_worker_transfer.js
@@ -74,7 +74,7 @@ type SerializedGrid = { buffer: ArrayBuffer };
 
 Grid.serialize = function serialize(grid: Grid, transferables?: Array<Transferable>): SerializedGrid {
     const buffer = grid.toArrayBuffer();
-    if (transferables) {
+    if (transferables && buffer.byteLength) {
         transferables.push(buffer);
     }
     return {buffer};
@@ -134,7 +134,7 @@ export function serialize(input: mixed, transferables: ?Array<Transferable>): Se
     }
 
     if (isArrayBuffer(input)) {
-        if (transferables) {
+        if (transferables && input.byteLength) {
             transferables.push(((input: any): ArrayBuffer));
         }
         return input;
@@ -142,14 +142,14 @@ export function serialize(input: mixed, transferables: ?Array<Transferable>): Se
 
     if (ArrayBuffer.isView(input)) {
         const view: $ArrayBufferView = (input: any);
-        if (transferables) {
+        if (transferables && view.buffer.byteLength) {
             transferables.push(view.buffer);
         }
         return view;
     }
 
     if (input instanceof ImageData) {
-        if (transferables) {
+        if (transferables && input.data.buffer.byteLength) {
             transferables.push(input.data.buffer);
         }
         return input;


### PR DESCRIPTION
Fixes #9019 by making sure we never add zero-length array buffers to the list of transferables. This is a quick fix to make the map work in Chrome Canary, but longer term we will want to investigate why we transfer empty arrays in the first place and potentially put safeguards earlier so that the empty data isn't in the worker payload in the first place.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page