### PR TITLE
Dont throw an error for aborted requests

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -162,7 +162,9 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
             }
             complete = true;
             callback(null, result, response.headers.get('Cache-Control'), response.headers.get('Expires'));
-        }).catch(err => callback(new Error(err.message)));
+        }).catch(err => {
+            if (!aborted) callback(new Error(err.message));
+        });
     };
 
     if (cacheIgnoringSearch) {


### PR DESCRIPTION
Closes #7614.

A `Fetch` request can be aborted while it is still being read, in which case the resulting exception should be eaten, since it is not caused by an unexpected event. 

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
