### PR TITLE
Add budgets to Actor queue flushing

### DIFF
--- a/debug/tile-cancellation.html
+++ b/debug/tile-cancellation.html
@@ -26,12 +26,12 @@ var map = window.map = new mapboxgl.Map({
     hash: true
 });
 
-map.once('idle', function(){
-    map.easeTo({ center: [-77.01866, 38.888], zoom: 1, duration: 1000});
+map.once('idle', function() {
+    map.easeTo({center: [-77.01866, 38.888], zoom: 1, duration: 1000});
 
-    setTimeout(function(){
-        map.easeTo({ center: [-77.01866, 38.888], zoom: 12.5, duration: 1000});
-    }, 1200)
+    setTimeout(function() {
+        map.easeTo({center: [-77.01866, 38.888], zoom: 12.5, duration: 1000});
+    }, 1200);
 });
 
 </script>

--- a/debug/tile-cancellation.html
+++ b/debug/tile-cancellation.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-77.01866, 38.888],
+    style: 'mapbox://styles/mapbox/streets-v10',
+    hash: true
+});
+
+map.once('idle', function(){
+    map.easeTo({ center: [-77.01866, 38.888], zoom: 1, duration: 1000});
+
+    setTimeout(function(){
+        map.easeTo({ center: [-77.01866, 38.888], zoom: 12.5, duration: 1000});
+    }, 1200)
+});
+
+</script>
+</body>
+</html>

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -143,8 +143,8 @@ class Actor {
             this._processQueueTop();
             taskCtr++;
         }
-        // We've reached our budget for this frame, defer processing to the rest for the next tick, this allows
-        // the deferred tasks to be preempted on slower browsers.
+        // We've reached our budget for this frame, defer processing of the rest of the tasks to the next tick,
+        // this allows the deferred tasks to be preempted on slower browsers.
         if (this.taskQueue.length) {
             this.invoker.trigger();
         }

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -134,8 +134,6 @@ class Actor {
             return;
         }
 
-        //If this is a worker actor, then flush the entire task queue since we don't need to wait for
-        //cancel messages on the worker side, only on the main thread side, so we have Infinite budget for processing messages.
         const timeBudget = this.isWorker ? WORKER_THREAD_TIME_BUDGET : MAIN_THREAD_TIME_BUDGET;
         const taskBudget = this.isWorker ? WORKER_THREAD_TASK_BUDGET : MAIN_THREAD_TASK_BUDGET;
 
@@ -145,8 +143,8 @@ class Actor {
             this._processQueueTop();
             taskCtr++;
         }
-        // We've reached our budget for this frame, defer processingo the rest for the netx frame, this lets
-        // the deferred tasks bet preempted on slower browsers.
+        // We've reached our budget for this frame, defer processing to the rest for the next tick, this allows
+        // the deferred tasks to be preempted on slower browsers.
         if (this.taskQueue.length) {
             this.invoker.trigger();
         }

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -119,11 +119,9 @@ class Actor {
             this.tasks[id] = data;
             this.taskQueue.push(id);
             if (isWorker()) {
-                this.invoker.trigger();
-            } else {
-                // In the main thread, process messages immediately so that other work does not slip in
-                // between getting partial data back from workers.
                 this.process();
+            } else {
+                this.invoker.trigger();
             }
         }
     }
@@ -132,68 +130,69 @@ class Actor {
         if (!this.taskQueue.length) {
             return;
         }
-        const id = this.taskQueue.shift();
-        const task = this.tasks[id];
-        delete this.tasks[id];
-        // Schedule another process call if we know there's more to process _before_ invoking the
-        // current task. This is necessary so that processing continues even if the current task
-        // doesn't execute successfully.
-        if (this.taskQueue.length) {
-            this.invoker.trigger();
-        }
-        if (!task) {
-            // If the task ID doesn't have associated task data anymore, it was canceled.
-            return;
-        }
-
-        if (task.type === '<response>') {
-            // The done() function in the counterpart has been called, and we are now
-            // firing the callback in the originating actor, if there is one.
-            const callback = this.callbacks[id];
-            delete this.callbacks[id];
-            if (callback) {
-                // If we get a response, but don't have a callback, the request was canceled.
-                if (task.error) {
-                    callback(deserialize(task.error));
-                } else {
-                    callback(null, deserialize(task.data));
+        while(this.taskQueue.length > 0){
+            const id = this.taskQueue.shift();
+            const task = this.tasks[id];
+            delete this.tasks[id];
+            // Schedule another process call if we know there's more to process _before_ invoking the
+            // current task. This is necessary so that processing continues even if the current task
+            // doesn't execute successfully.
+            // if (this.taskQueue.length) {
+            //     this.invoker.trigger();
+            // }
+            if (!task) {
+                // If the task ID doesn't have associated task data anymore, it was canceled.
+                return;
+            }
+            if (task.type === '<response>') {
+                // The done() function in the counterpart has been called, and we are now
+                // firing the callback in the originating actor, if there is one.
+                const callback = this.callbacks[id];
+                delete this.callbacks[id];
+                if (callback) {
+                    // If we get a response, but don't have a callback, the request was canceled.
+                    if (task.error) {
+                        callback(deserialize(task.error));
+                    } else {
+                        callback(null, deserialize(task.data));
+                    }
                 }
-            }
-        } else {
-            let completed = false;
-            const buffers: ?Array<Transferable> = isSafari(this.globalScope) ? undefined : [];
-            const done = task.hasCallback ? (err, data) => {
-                completed = true;
-                delete this.cancelCallbacks[id];
-                this.target.postMessage({
-                    id,
-                    type: '<response>',
-                    sourceMapId: this.mapId,
-                    error: err ? serialize(err) : null,
-                    data: serialize(data, buffers)
-                }, buffers);
-            } : (_) => {
-                completed = true;
-            };
-
-            let callback = null;
-            const params = (deserialize(task.data): any);
-            if (this.parent[task.type]) {
-                // task.type == 'loadTile', 'removeTile', etc.
-                callback = this.parent[task.type](task.sourceMapId, params, done);
-            } else if (this.parent.getWorkerSource) {
-                // task.type == sourcetype.method
-                const keys = task.type.split('.');
-                const scope = (this.parent: any).getWorkerSource(task.sourceMapId, keys[0], params.source);
-                callback = scope[keys[1]](params, done);
             } else {
-                // No function was found.
-                done(new Error(`Could not find function ${task.type}`));
-            }
+                let completed = false;
+                const buffers: ?Array<Transferable> = isSafari(this.globalScope) ? undefined : [];
+                const done = task.hasCallback ? (err, data) => {
+                    completed = true;
+                    delete this.cancelCallbacks[id];
+                    this.target.postMessage({
+                        id,
+                        type: '<response>',
+                        sourceMapId: this.mapId,
+                        error: err ? serialize(err) : null,
+                        data: serialize(data, buffers)
+                    }, buffers);
+                } : (_) => {
+                    completed = true;
+                };
 
-            if (!completed && callback && callback.cancel) {
-                // Allows canceling the task as long as it hasn't been completed yet.
-                this.cancelCallbacks[id] = callback.cancel;
+                let callback = null;
+                const params = (deserialize(task.data): any);
+                if (this.parent[task.type]) {
+                    // task.type == 'loadTile', 'removeTile', etc.
+                    callback = this.parent[task.type](task.sourceMapId, params, done);
+                } else if (this.parent.getWorkerSource) {
+                    // task.type == sourcetype.method
+                    const keys = task.type.split('.');
+                    const scope = (this.parent: any).getWorkerSource(task.sourceMapId, keys[0], params.source);
+                    callback = scope[keys[1]](params, done);
+                } else {
+                    // No function was found.
+                    done(new Error(`Could not find function ${task.type}`));
+                }
+
+                if (!completed && callback && callback.cancel) {
+                    // Allows canceling the task as long as it hasn't been completed yet.
+                    this.cancelCallbacks[id] = callback.cancel;
+                }
             }
         }
     }

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -143,13 +143,13 @@ class Actor {
 
         const start = browser.now();
         let taskCtr = 0;
-        while(browser.now() - start < timeBudget && taskCtr < taskBudget && this.taskQueue.length > 0 ){
+        while (browser.now() - start < timeBudget && taskCtr < taskBudget && this.taskQueue.length > 0) {
             this._processQueueTop();
             taskCtr++;
         }
         // We've reached our budget for this frame, defer processingo the rest for the netx frame, this lets
         // the deferred tasks bet preempted on slower browsers.
-        if(this.taskQueue.length){
+        if (this.taskQueue.length) {
             this.invoker.trigger();
         }
     }

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -50,7 +50,7 @@ class Actor {
         bindAll(['receive', 'process'], this);
         this.invoker = new ThrottledInvoker(this.process);
         this.target.addEventListener('message', this.receive, false);
-        this.globalScope = isWorker ? target : window;
+        this.globalScope = this.isWorker ? target : window;
     }
 
     /**

--- a/src/util/throttled_invoker.js
+++ b/src/util/throttled_invoker.js
@@ -1,5 +1,6 @@
 // @flow
 import window from './window';
+import {isWorker} from './util';
 
 const raf = window.requestAnimationFrame ||
     window.mozRequestAnimationFrame ||
@@ -9,29 +10,55 @@ const raf = window.requestAnimationFrame ||
  * Invokes the wrapped function in a non-blocking way when trigger() is called. Invocation requests
  * are ignored until the function was actually invoked.
  *
+ * On the main thread, this uses requestAnimationFrame so the deferral of tasks is as low-latency with the render loop as possible.
+ * In the WebWorker context, we use a `MessageChannel` to send a message back to the same context, with a fallback to `setTimeout(..,0)`.
+ *
  * @private
  */
 class ThrottledInvoker {
+    _channel: ?MessageChannel;
     _triggered: boolean;
-    _callback: Function
+    _callback: Function;
+    _bindFunc: Function;
+    _isWorker: boolean;
 
     constructor(callback: Function) {
         this._callback = callback;
         this._triggered = false;
+        // The function actually bound to the callback runner.
+        this._bindFunc = () => {
+            this._triggered = false;
+            this._callback();
+        };
+        this._isWorker = isWorker();
+        if(this._isWorker){
+            if (typeof MessageChannel !== 'undefined') {
+                this._channel = new MessageChannel();
+                this._channel.port2.onmessage = this._bindFunc;
+            }
+        }
     }
 
     trigger() {
         if (!this._triggered) {
-            raf(() => {
-                this._triggered = false;
-                this._callback();
-            });
             this._triggered = true;
+            //Invoker is MessageChannel/setTimeout on worker side
+            if(this._isWorker){
+                if (this._channel) {
+                    this._channel.port1.postMessage(true);
+                } else {
+                    setTimeout(this._bindFunc, 0);
+                }
+            // requestAnimationFrame on the Main Thread.
+            }else{
+                raf(this._bindFunc);
+            }
         }
     }
 
     remove() {
         this._callback = () => {};
+        this._bindFunc = () => {};
     }
 }
 

--- a/src/util/throttled_invoker.js
+++ b/src/util/throttled_invoker.js
@@ -31,7 +31,7 @@ class ThrottledInvoker {
             this._callback();
         };
         this._isWorker = isWorker();
-        if(this._isWorker){
+        if (this._isWorker) {
             if (typeof MessageChannel !== 'undefined') {
                 this._channel = new MessageChannel();
                 this._channel.port2.onmessage = this._bindFunc;
@@ -43,14 +43,14 @@ class ThrottledInvoker {
         if (!this._triggered) {
             this._triggered = true;
             //Invoker is MessageChannel/setTimeout on worker side
-            if(this._isWorker){
+            if (this._isWorker) {
                 if (this._channel) {
                     this._channel.port1.postMessage(true);
                 } else {
                     setTimeout(this._bindFunc, 0);
                 }
             // requestAnimationFrame on the Main Thread.
-            }else{
+            } else {
                 raf(this._bindFunc);
             }
         }


### PR DESCRIPTION
This PR tries to achieve some middleground between the issues reported in #8998 and #8913.
It tries to do this with 2 main changes:
- The Actor on processes messages in batches, based on time or size budgets, whichever is reached first.
- On the main thread the `ThrottledInvoker` uses `requestAnimationFrame` instead of `MessageChannel` in order to reduce latency for animations. 

I've tried to adjust the batch sizes on the main-thread and worker side so we can have a balance between being able to pre-empt and cancel tasks, while maintaining enough throughput for smooth animation.

Testing with IE11, which needs pre-empting the most, the number of requests sent out for the tile-cancellation debug page went down to ~60 from the ~120 on `1.5.1-beta`. But its still higher than the ~25 on `1.5.0`.
Animation performance on `Chrome` is roughly the same for me.

@msbarry , would really appreciate if you could take a look at this as well!

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 