### PR TITLE
fix urlRe: Forward slashes must be escaped.

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -197,7 +197,7 @@ function hasCacheDefeatingSku(url: string) {
     return url.indexOf('sku=') > 0 && isMapboxHTTPURL(url);
 }
 
-const urlRe = /^(\w+):\/\/([^/?]*)(\/[^?]+)?\??(.+)?/;
+const urlRe = /^(\w+):\/\/([^\/?]*)(\/[^?]+)?\??(.+)?/;
 
 function parseUrl(url: string): UrlObject {
     const parts = url.match(urlRe);


### PR DESCRIPTION
 - [x] briefly describe the changes in this PR
  fix typo 