### PR TITLE
Fix map size in benchmarks

### DIFF
--- a/bench/lib/create_map.js
+++ b/bench/lib/create_map.js
@@ -6,9 +6,10 @@ export default function (options: any): Promise<Map> {
     return new Promise((resolve, reject) => {
         const container = document.createElement('div');
         container.style.width = `${options.width || 512}px`;
-        container.style.height = `${options.width || 512}px`;
+        container.style.height = `${options.height || 512}px`;
         container.style.margin = '0 auto';
-        container.style.display = 'none';
+        container.style.display = 'block';
+        container.style.visibility = 'hidden';
         (document.body: any).appendChild(container);
 
         const map = new Map(Object.assign({


### PR DESCRIPTION
`display: none` on Chrome (Chrome 78.0.3904.108 (Official Build) (64-bit) on macos), results with container clientWidth and clientHeight equal to 0.
This [led to container size 400 x 300](https://github.com/mapbox/mapbox-gl-js/blob/3c36a67716d7c8ad8d69b15f7e5fd19b72e7a7ff/src/ui/map.js#L1922) instead of using specified size in e.g. bench/benchmark/layers.js (1024x768).

Edit:
400 x 300 might make more sense as it is faster. Maybe better lo leave it as it is but replace ignored 1024 x 768 by 400 x 300.
