### PR TITLE
optimize findLoadedParent

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -368,16 +368,15 @@ class SourceCache extends Evented {
      */
     findLoadedParent(tileID: OverscaledTileID, minCoveringZoom: number): ?Tile {
         for (let z = tileID.overscaledZ - 1; z >= minCoveringZoom; z--) {
-            const parent = tileID.scaledTo(z);
-            if (!parent) return;
-            const id = String(parent.key);
-            const tile = this._tiles[id];
+            const parentKey = tileID.calculateScaledKey(z, true);
+            const tile = this._tiles[parentKey];
             if (tile && tile.hasData()) {
                 return tile;
             }
-            if (this._cache.has(parent)) {
-                return this._cache.get(parent);
-            }
+            // TileCache ignores wrap in lookup.
+            const parentWrappedKey = tileID.calculateScaledKey(z, false);
+            const cachedTile = this._cache.getByKey(parentWrappedKey);
+            if (cachedTile) return cachedTile;
         }
     }
 

--- a/src/source/tile_cache.js
+++ b/src/source/tile_cache.js
@@ -122,6 +122,14 @@ class TileCache {
         return data.value;
     }
 
+    /*
+     * Get the value with the specified (wrapped tile) key.
+     */
+    getByKey(key: number): ?Tile {
+        const data = this.data[key];
+        return data ? data[0].value : null;
+    }
+
     /**
      * Get the value attached to a specific key without removing data
      * from the cache. If the key is not found, returns `null`

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -95,6 +95,21 @@ export class OverscaledTileID {
         }
     }
 
+    /*
+     * calculateScaledKey is an optimization:
+     * when withWrap == true, implements the same as this.scaledTo(z).key,
+     * when withWrap == false, implements the same as this.scaledTo(z).wrapped().key.
+     */
+    calculateScaledKey(targetZ: number, withWrap: boolean) {
+        assert(targetZ <= this.overscaledZ);
+        const zDifference = this.canonical.z - targetZ;
+        if (targetZ > this.canonical.z) {
+            return calculateKey(this.wrap * +withWrap, targetZ, this.canonical.x, this.canonical.y);
+        } else {
+            return calculateKey(this.wrap * +withWrap, targetZ, this.canonical.x >> zDifference, this.canonical.y >> zDifference);
+        }
+    }
+
     isChildOf(parent: OverscaledTileID) {
         if (parent.wrap !== this.wrap) {
             // We can't be a child if we're in a different world copy


### PR DESCRIPTION
Performance optimization when rendering view with a large number of raster tiles.
Measurements on Chrome (Version 78.0.3904.108 with CPU 4x slowdown in performance tab) on MacMini i7 3.2 Ghz, 3840 x 1440 display.

`map.repaint = true` in [debug/satellite.html with pitch of 60 degrees](http://localhost:9966/debug/satellite.html#12.5/38.888/-77.01866/0/60)

FPS count, like on the screenshot below:
master: 19-20FPS
with this patch: 24.5-26 FPS

![Screen Shot 2019-12-01 at 22 40 10](https://user-images.githubusercontent.com/549216/69920109-9ec66300-148c-11ea-8115-1ed16f1d7c69.png)

