### PR TITLE
Reset internal attribution control cache when removing from map

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -83,6 +83,7 @@ class AttributionControl {
         this._map.off('resize', this._updateCompact);
 
         this._map = (undefined: any);
+        this._attribHTML = (undefined: any);
     }
 
     _updateEditLink() {

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -177,6 +177,19 @@ test('AttributionControl shows custom attribution if customAttribution option is
     t.end();
 });
 
+test('AttributionControl shows custom attribution if customAttribution option is provided, control is removed and added back', (t) => {
+    const map = createMap(t);
+    const attributionControl = new AttributionControl({
+        customAttribution: 'Custom string'
+    });
+    map.addControl(attributionControl);
+    map.removeControl(attributionControl);
+    map.addControl(attributionControl);
+
+    t.equal(attributionControl._innerContainer.innerHTML, 'Custom string');
+    t.end();
+});
+
 test('AttributionControl in compact mode shows custom attribution if customAttribution option is provided', (t) => {
     const map = createMap(t);
     const attributionControl = new AttributionControl({


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/9051

When creating an attribution control, we're caching the HTML string in the AttributionControl object. That cache wasn't reset when the control was removed from the map. Upon re-adding, we incorrectly assumed that the HTML was already up-to-date because our internal cache said so. This patch fixes it by clearing the internal cache so that attribution shows up properly when re-adding the control.

h/t @cs09g

