### PR TITLE
Correct mouse/touch position for elements scaled via CSS transform

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -20,6 +20,11 @@
     background-color: salmon;
 }
 
+.mapboxgl-canvas-container {
+    width: 100%;
+    height: 100%;
+}
+
 .mapboxgl-canvas-container.mapboxgl-interactive,
 .mapboxgl-ctrl-group button.mapboxgl-ctrl-compass {
     cursor: -webkit-grab;

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -104,22 +104,26 @@ DOM.suppressClick = function() {
 };
 
 DOM.mousePos = function (el: HTMLElement, e: MouseEvent | window.TouchEvent | Touch) {
-    const rect = el.getBoundingClientRect();
+    const rect = el.getBoundingClientRect(),
+        factorX = rect.width ? el.offsetWidth / rect.width : 1,
+        factorY = rect.height ? el.offsetHeight / rect.height : 1;
     const t = window.TouchEvent && (e instanceof window.TouchEvent) ? e.touches[0] : e;
     return new Point(
-        t.clientX - rect.left - el.clientLeft,
-        t.clientY - rect.top - el.clientTop
+        (t.clientX - rect.left) * factorX - el.clientLeft,
+        (t.clientY - rect.top) * factorY - el.clientTop
     );
 };
 
 DOM.touchPos = function (el: HTMLElement, e: TouchEvent) {
     const rect = el.getBoundingClientRect(),
+        factorX = rect.width ? el.offsetWidth / rect.width : 1,
+        factorY = rect.height ? el.offsetHeight / rect.height : 1,
         points = [];
     const touches = (e.type === 'touchend') ? e.changedTouches : e.touches;
     for (let i = 0; i < touches.length; i++) {
         points.push(new Point(
-            touches[i].clientX - rect.left - el.clientLeft,
-            touches[i].clientY - rect.top - el.clientTop
+            (touches[i].clientX - rect.left) * factorX - el.clientLeft,
+            (touches[i].clientY - rect.top) * factorY - el.clientTop
         ));
     }
     return points;

--- a/test/browser/fixtures/scaled-land.html
+++ b/test/browser/fixtures/scaled-land.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../../../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+        #map { transform: scale(2); }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='../../../dist/mapbox-gl-dev.js'></script>
+<script src='../../../debug/access_token_generated.js'></script>
+
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 1,
+    fadeDuration: 0,
+    center: [0, 0],
+    style: {
+        version: 8,
+        sources: {
+            land: {
+                type: 'geojson',
+                data: `${location.origin}/test/browser/fixtures/land.json`
+            }
+        },
+        layers: [
+            {
+                id: 'background',
+                type: 'background',
+                paint: {
+                    'background-color': '#72d0f2'
+                }
+            },
+            {
+                id: 'land',
+                type: 'fill',
+                source: 'land',
+                paint: {
+                    'fill-color': '#f0e9e1'
+                }
+            }
+        ]
+    }
+});
+
+</script>
+
+</body>
+</html>

--- a/test/browser/zoom.test.js
+++ b/test/browser/zoom.test.js
@@ -1,11 +1,12 @@
 import {test} from '../util/test';
 import browser from './util/browser';
+import {equalWithPrecision} from '../util';
 
 test("zooming", async t => {
     const {driver} = browser;
 
     await t.test("double click at the center", async t => {
-        const canvas = await browser.getMapCanvas(`${browser.basePath}/test/browser/fixtures/land.html`);
+        const canvas = await browser.getMapCanvas(`${browser.basePath}/test/browser/fixtures/land.html`, 'canvas');
 
         // Double-click on the center of the map.
         await driver.executeScript(browser.doubleClick, canvas);
@@ -17,5 +18,21 @@ test("zooming", async t => {
         });
 
         t.equals(zoom, 2, 'zoomed in by 1 zoom level');
+    });
+
+    await t.test("double click at the center with scaled map", async t => {
+        const canvas = await browser.getMapCanvas(`${browser.basePath}/test/browser/fixtures/scaled-land.html`);
+
+        // Double-click on the center of the map.
+        await driver.executeScript(browser.doubleClick, canvas);
+
+        // Wait until the map has settled, then report the zoom level back.
+        const center = await driver.executeAsyncScript(callback => {
+            /* eslint-disable no-undef */
+            map.once('idle', () => callback(map.getCenter()));
+        });
+
+        equalWithPrecision(t, center.lng, -0.044, 0.001);
+        equalWithPrecision(t, center.lat, 0, 0.001);
     });
 });


### PR DESCRIPTION
Inspired by https://github.com/mapbox/mapbox-gl-js/pull/9014, I looked at correcting mouse/touch interaction when the Map is transformed via the CSS `transform: scale()` property. It scales the screen pixel coordinates to logical map coordinates.

This is distinct from pixelRatio.

I tested in Safari, Chrome and Firefox on macOS.