### PR TITLE
Use browser.devicePixelRatio instead of directly calling window.devicePixelRatio

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1967,7 +1967,7 @@ class Map extends Camera {
     }
 
     _resizeCanvas(width: number, height: number) {
-        const pixelRatio = window.devicePixelRatio || 1;
+        const pixelRatio = browser.devicePixelRatio || 1;
 
         // Request the required canvas size taking the pixelratio into account.
         this._canvas.width = pixelRatio * width;


### PR DESCRIPTION
Extracted from https://github.com/mapbox/mapbox-gl-js/pull/9014