### PR TITLE
check that latest version appears in changelog

### DIFF
--- a/test/unit/changelog.js
+++ b/test/unit/changelog.js
@@ -1,0 +1,18 @@
+import {test} from '../util/test';
+import fs from 'fs';
+import path from 'path';
+import {version} from '../../package.json';
+
+
+test('changelog', (t) => {
+    const changelog = fs.readFileSync(path.join(__dirname, '../../CHANGELOG.md'), 'utf8');
+    t.test('latest version is in changelog', (t) => {
+        if (version.indexOf('-dev') <= 0) {
+            const versionString = `## ${version}\n`;
+            t.ok(changelog.indexOf(versionString) >= 0);
+        }
+        t.end();
+    });
+
+    t.end();
+});

--- a/test/unit/changelog.js
+++ b/test/unit/changelog.js
@@ -3,7 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import {version} from '../../package.json';
 
-
 test('changelog', (t) => {
     const changelog = fs.readFileSync(path.join(__dirname, '../../CHANGELOG.md'), 'utf8');
     t.test('latest version is in changelog', (t) => {


### PR DESCRIPTION
This prevents an update to package.json from being merged without including a corresponding change to the changelog.

This will prevent me from forgetting to remove `-beta` from the changelog when doing a final release.

I manually tested:
- that `-dev` versions don't error
- that forgetting to remove `-beta.1` errors
- that forgetting to add anything errors

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
