### PR TITLE
Use ResizeObserver to trigger a canvas resize when the container size changes

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1959,6 +1959,10 @@ class Map extends Camera {
         const dimensions = this._containerDimensions();
         this._resizeCanvas(dimensions[0], dimensions[1]);
 
+        if (this._trackResize && window.ResizeObserver) {
+            new window.ResizeObserver(() => this.resize()).observe(container);
+        }
+
         const controlContainer = this._controlContainer = DOM.create('div', 'mapboxgl-control-container', container);
         const positions = this._controlPositions = {};
         ['top-left', 'top-right', 'bottom-left', 'bottom-right'].forEach((positionName) => {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/9082 in some browsers by using the new [ResizeObserver API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to track when the map container's size is changing.

Previously, we'd only trigger a canvas resize when the window size was changing. However, when modifying the container size with CSS alone, a manual call to `Map#resize()` is necessary to ensure that the canvas is resized accordingly. If that doesn't happen, the canvas remains at its previous size, but it's either too small, or the protruding parts are hidden because the container has `overflow: hidden`. This results in a discrepancy between what a user sees and what our APIs, like `getCenter()`, report.

To resolve this issue, we need to trigger `Map#resize()` automatically when the container size changes. The `ResizeObserver` API is available in Chrome 64 and Firefox 69. Safari 13 supports it theoretically, but it's disabled by default and can only be enabled in the Developer menu.

Using this API fixes the isssue and eliminates the need to call Map#resize()` manually, but it doesn't work in all browsers supported by Mapbox GL. There's a polyfill available in https://github.com/juggle/resize-observer. However, it essentially uses polling via `requestAnimationFrame` for the first few frames, then adds a global `MutationObserver` (which is supported by all browsers in our list) in addition to a few other event handlers as a heuristic to capture all events that could lead to a dimension change.

I'm not sure what the best option is here:
- Do nothing and rely on users calling `resize()` manually
- Use `ResizeObserver` without polyfill
- Use `ResizeObserver` with polyfill (fairly large file size impact for a minor bug like this)
- Rework our accessor methods like `getCenter()` to perform a resize if needed (performance impact?)

/cc @mapbox/gl-js 