### PR TITLE
Fix `versions` benchmark not being able to fetch latest release

### DIFF
--- a/bench/versions/index.html
+++ b/bench/versions/index.html
@@ -18,9 +18,9 @@
         const params = new URLSearchParams(location.search.slice(1));
         Promise.resolve(params.has('compare') ?
             params.getAll('compare').filter(Boolean) :
-            fetch('/package.json')
+            fetch('https://api.github.com/repos/mapbox/mapbox-gl-js/releases/latest')
             .then(response => response.json())
-            .then(pkg => [`v${pkg.version}`, 'master']))
+            .then(pkg => [pkg['tag_name'], 'master']))
             .then(versions => {
                 return versions
                     .map(v => `https://s3.amazonaws.com/mapbox-gl-js/${v}/benchmarks.js`)


### PR DESCRIPTION
Addresses #9078.

`package.json` version is one increment ahead of latest release causing the versions benchmark to break since its trying to look for that tag on S3.

This fixes it by using the github API to query for the latest version instead.