### PR TITLE
Remove `stringContainsRTLText` dependency from within style-spec.

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -131,8 +131,8 @@ function addDynamicAttributes(dynamicLayoutVertexArray: StructArray, p: Point, a
     dynamicLayoutVertexArray.emplaceBack(p.x, p.y, angle);
 }
 
-function containsRTLText(text: Formatted): boolean {
-    for (const section of test.sections) {
+function containsRTLText(formattedText: Formatted): boolean {
+    for (const section of formattedText.sections) {
         if (stringContainsRTLText(section.text)) {
             return true;
         }

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -25,7 +25,7 @@ import {ProgramConfigurationSet} from '../program_configuration';
 import {TriangleIndexArray, LineIndexArray} from '../index_array_type';
 import transformText from '../../symbol/transform_text';
 import mergeLines from '../../symbol/mergelines';
-import {allowsVerticalWritingMode} from '../../util/script_detection';
+import {allowsVerticalWritingMode, stringContainsRTLText} from '../../util/script_detection';
 import {WritingMode} from '../../symbol/shaping';
 import loadGeometry from '../load_geometry';
 import mvt from '@mapbox/vector-tile';
@@ -129,6 +129,15 @@ function addDynamicAttributes(dynamicLayoutVertexArray: StructArray, p: Point, a
     dynamicLayoutVertexArray.emplaceBack(p.x, p.y, angle);
     dynamicLayoutVertexArray.emplaceBack(p.x, p.y, angle);
     dynamicLayoutVertexArray.emplaceBack(p.x, p.y, angle);
+}
+
+function containsRTLText(text: Formatted): boolean {
+    for (const section of test.sections) {
+        if (stringContainsRTLText(section.text)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 export class SymbolBuffers {
@@ -423,7 +432,7 @@ class SymbolBucket implements Bucket {
                 // conversion here.
                 const resolvedTokens = layer.getValueAndResolveTokens('text-field', feature, availableImages);
                 const formattedText = Formatted.factory(resolvedTokens);
-                if (formattedText.containsRTLText()) {
+                if (containsRTLText(formattedText)) {
                     this.hasRTLText = true;
                 }
                 if (

--- a/src/style-spec/expression/types/formatted.js
+++ b/src/style-spec/expression/types/formatted.js
@@ -1,6 +1,4 @@
 // @flow
-
-import {stringContainsRTLText} from "../../../util/script_detection";
 import type Color from '../../util/color';
 import type ResolvedImage from '../types/resolved_image';
 
@@ -48,15 +46,6 @@ export default class Formatted {
     toString(): string {
         if (this.sections.length === 0) return '';
         return this.sections.map(section => section.text).join('');
-    }
-
-    containsRTLText(): boolean {
-        for (const section of this.sections) {
-            if (stringContainsRTLText(section.text)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     serialize(): Array<mixed> {


### PR DESCRIPTION
Importing `stringContainsRTLText` from outside of the `style-spec` package caused certain workflows which rely on referencing files in the `style-spec` package.

This PR reverses that change and moves the logic over to the gl-js side where it was used.

cc @elifitch 
