### PR TITLE
Immediately update map when more than one geolocation watch event is triggered

### DIFF
--- a/debug/multiple.html
+++ b/debug/multiple.html
@@ -63,6 +63,17 @@ function addMap (container) {
         style,
         hash: false
     });
+
+    map.addControl(new mapboxgl.GeolocateControl({
+        positionOptions: {
+            enableHighAccuracy: true
+        },
+        trackUserLocation: true,
+        showUserLocation: true,
+        fitBoundsOptions: {
+            maxZoom: 20
+        }
+    }));
 }
 
 var containers = document.querySelectorAll('.map');

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -437,17 +437,17 @@ class GeolocateControl extends Evented {
                 this._geolocateButton.setAttribute('aria-pressed', 'true');
 
                 numberOfWatches++;
-                let options;
+                let positionOptions;
                 if (numberOfWatches > 1) {
-                    options = {maximumAge:600000, timeout:0};
+                    positionOptions = {maximumAge:600000, timeout:0};
                     noTimeout = true;
                 } else {
-                    options = this.options.positionOptions;
+                    positionOptions = this.options.positionOptions;
                     noTimeout = false;
                 }
 
                 this._geolocationWatchID = window.navigator.geolocation.watchPosition(
-                    this._onSuccess, this._onError, options);
+                    this._onSuccess, this._onError, positionOptions);
             }
         } else {
             window.navigator.geolocation.getCurrentPosition(

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -279,6 +279,7 @@ class GeolocateControl extends Evented {
                 // this represents a forced error state
                 // this was triggered to force immediate geolocation when a watch is already present
                 // see https://github.com/mapbox/mapbox-gl-js/issues/8214
+                // and https://w3c.github.io/geolocation-api/#example-5-forcing-the-user-agent-to-return-a-fresh-cached-position
                 return;
             } else {
                 this._setErrorState();


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - fixes https://github.com/mapbox/mapbox-gl-js/issues/8214
    - in situations where more than one geolocation watch listener is set up (i.e. when `trigger()` is called with `trackUserLocation: true` so that `geolocation.watchPosition()` is used), the second listener would not return `onSuccess` until a more refined geolocation position became available, which resulted in potentially minutes of inactivity, creating the impression that the control was not working. this change forces geolocation to immediately return the most recent cached position so that the control always updates the map right away.
    - the above conditions seem to be possible when there are multiple maps on a screen or when a map component in a React/Angular/Vue app is not destroyed when navigating to another "page" before navigating back to the map
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] `<changelog>Fix bug in GeolocateControl where multiple instances of the control on one page would, in some cases, result in the user location not being updated</changelog>`
