### PR TITLE
Use husky to run eslint + flow as pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,10 +64,12 @@
     "flow-bin": "^0.100.0",
     "gl": "~4.3.3",
     "glob": "^7.1.4",
+    "husky": "^3.1.0",
     "is-builtin-module": "^3.0.0",
     "jsdom": "^13.0.0",
     "json-stringify-pretty-compact": "^2.0.0",
     "jsonwebtoken": "^8.3.0",
+    "lint-staged": "^9.5.0",
     "mock-geolocation": "^1.0.11",
     "node-notifier": "^5.4.3",
     "npm-run-all": "^4.1.5",
@@ -145,6 +147,26 @@
     "prepublishOnly": "run-s build-flow-types build-dev build-prod-min build-prod build-csp build-css build-style-spec test-build",
     "print-release-url": "node build/print-release-url.js",
     "codegen": "build/run-node build/generate-style-code.js && build/run-node build/generate-struct-arrays.js"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "src/style-spec/reference/v8.json": [
+      "build/run-node build/generate-flow-typed-style-spec"
+    ],
+    "src/**/*.js": [
+      "eslint --cache --ignore-path .gitignore",
+      "flow --color=always"
+    ],
+    "debug/*.html": [
+      "eslint --cache --ignore-path .gitignore"
+    ],
+    "src/**/*.css": [
+      "stylelint"
+    ]
   },
   "files": [
     "build/",


### PR DESCRIPTION
Adds [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged) to run pre-commit hooks. We're running `eslint` and Flowtype on the affected files, as well as eslint on HTML pages and stylelint on CSS files.

This is what a denied commit looks like:

![image](https://user-images.githubusercontent.com/52399/70636306-96f98200-1c35-11ea-82e5-c52e014cbea0.png)

And this is what a successfully checked commit looks like:

![image](https://user-images.githubusercontent.com/52399/70636403-c4463000-1c35-11ea-925e-522f2212a30a.png)
