### PR TITLE
Add sdk-support section for `is-supported-script` 

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3459,7 +3459,13 @@
       },
       "is-supported-script": {
         "doc": "Returns `true` if the input string is expected to render legibly. Returns `false` if the input string contains sections that cannot be rendered without potential loss of meaning (e.g. Indic scripts that require complex text shaping, or right-to-left scripts if the the `mapbox-gl-rtl-text` plugin is not in use in Mapbox GL JS).",
-        "group": "String"
+        "group": "String",
+        "sdk-support": {
+            "basic functionality": {
+              "js": "0.45.0",
+              "android": "6.6.0"
+            }
+          }
       },
       "upcase": {
         "doc": "Returns the input string converted to uppercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -644,7 +644,12 @@
       "type": "number",
       "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.",
       "sdk-support": {
+        "basic functionality": {
+            "js": "1.2.0"
+        },
+        "data-driven styling": {
           "js": "1.2.0"
+        }
       },
       "expression": {
         "interpolated": false,
@@ -683,7 +688,12 @@
       "type": "number",
       "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.",
       "sdk-support": {
+        "basic functionality": {
           "js": "1.2.0"
+        },
+        "data-driven styling": {
+          "js": "1.2.0"
+        }
       },
       "expression": {
         "interpolated": false,
@@ -892,7 +902,12 @@
       "type": "number",
       "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.",
       "sdk-support": {
+        "basic functionality": {
           "js": "1.2.0"
+        },
+        "data-driven styling": {
+          "js": "1.2.0"
+        }
       },
       "expression": {
         "interpolated": false,

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -645,7 +645,7 @@
       "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.",
       "sdk-support": {
         "basic functionality": {
-            "js": "1.2.0"
+          "js": "1.2.0"
         },
         "data-driven styling": {
           "js": "1.2.0"
@@ -797,8 +797,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -861,8 +860,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -887,8 +885,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -936,8 +933,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "property-type": "constant"
     }
@@ -970,8 +966,7 @@
           "android": "6.4.0",
           "ios": "4.3.0",
           "macos": "0.10.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -998,8 +993,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -1019,8 +1013,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1077,8 +1070,7 @@
           "android": "6.6.0",
           "ios": "4.5.0",
           "macos": "0.12.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1101,8 +1093,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1125,8 +1116,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1150,8 +1140,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1191,8 +1180,7 @@
           "android": "4.2.0",
           "ios": "3.4.0",
           "macos": "0.3.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1262,8 +1250,7 @@
           "android": "4.2.0",
           "ios": "3.4.0",
           "macos": "0.2.1"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1302,8 +1289,7 @@
           "android": "4.2.0",
           "ios": "3.4.0",
           "macos": "0.2.1"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -1387,8 +1373,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -1409,8 +1394,8 @@
         },
         {
           "symbol-placement": [
-              "line",
-              "line-center"
+            "line",
+            "line-center"
           ]
         }
       ],
@@ -1420,8 +1405,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1549,8 +1533,7 @@
           "android": "5.2.0",
           "ios": "3.7.0",
           "macos": "0.6.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1590,8 +1573,7 @@
           "android": "4.2.0",
           "ios": "3.4.0",
           "macos": "0.3.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1631,8 +1613,7 @@
           "android": "4.2.0",
           "ios": "3.4.0",
           "macos": "0.3.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -1782,8 +1763,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -1940,9 +1920,9 @@
       "requires": [
         "text-field",
         {
-            "symbol-placement": [
-                "point"
-            ]
+          "symbol-placement": [
+            "point"
+          ]
         }
       ],
       "doc": "To increase the chance of placing high-priority labels on the map, you can provide an array of `text-anchor` locations: the render will attempt to place the label at each location, in order, before moving onto the next label. Use `text-justify: auto` to choose justification based on anchor position. To apply an offset, use the `text-radial-offset` or the two-dimensional `text-offset`.",
@@ -1952,12 +1932,6 @@
           "android": "7.4.0",
           "ios": "4.10.0",
           "macos": "0.14.0"
-        },
-        "data-driven styling": {
-          "js": "Not yet supported",
-          "android": "Not yet supported",
-          "ios": "Not yet supported",
-          "macos": "Not yet supported"
         }
       },
       "expression": {
@@ -2038,10 +2012,10 @@
       "requires": [
         "text-field",
         {
-            "symbol-placement": [
-                "line",
-                "line-center"
-            ]
+          "symbol-placement": [
+            "line",
+            "line-center"
+          ]
         }
       ],
       "sdk-support": {
@@ -2050,8 +2024,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -2077,7 +2050,7 @@
         "text-field",
         {
           "symbol-placement": [
-              "point"
+            "point"
           ]
         }
       ],
@@ -2087,12 +2060,6 @@
           "android": "next",
           "ios": "next",
           "macos": "next"
-        },
-        "data-driven styling": {
-          "js": "Not yet supported",
-          "android": "Not yet supported",
-          "ios": "Not yet supported",
-          "macos": "Not yet supported"
         }
       },
       "expression": {
@@ -2150,8 +2117,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -2171,10 +2137,10 @@
           "text-rotation-alignment": "map"
         },
         {
-            "symbol-placement": [
-                "line",
-                "line-center"
-            ]
+          "symbol-placement": [
+            "line",
+            "line-center"
+          ]
         }
       ],
       "sdk-support": {
@@ -2183,8 +2149,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -2248,7 +2213,7 @@
       "requires": [
         "text-field",
         {
-            "!": "text-radial-offset"
+          "!": "text-radial-offset"
         }
       ],
       "sdk-support": {
@@ -2287,8 +2252,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -2311,8 +2275,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -2336,8 +2299,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -2365,8 +2327,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "property-type": "constant"
     }
@@ -2390,8 +2351,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "property-type": "constant"
     }
@@ -2415,8 +2375,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "property-type": "constant"
     }
@@ -3476,11 +3435,11 @@
         "doc": "Returns `true` if the input string is expected to render legibly. Returns `false` if the input string contains sections that cannot be rendered without potential loss of meaning (e.g. Indic scripts that require complex text shaping, or right-to-left scripts if the the `mapbox-gl-rtl-text` plugin is not in use in Mapbox GL JS).",
         "group": "String",
         "sdk-support": {
-            "basic functionality": {
-              "js": "0.45.0",
-              "android": "6.6.0"
-            }
+          "basic functionality": {
+            "js": "0.45.0",
+            "android": "6.6.0"
           }
+        }
       },
       "upcase": {
         "doc": "Returns the input string converted to uppercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.",
@@ -3662,8 +3621,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -3791,8 +3749,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -3823,8 +3780,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -3937,8 +3893,7 @@
           "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -3969,8 +3924,7 @@
           "android": "5.1.0",
           "ios": "3.6.0",
           "macos": "0.5.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -4080,13 +4034,15 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.50.0",
-          "ios" : "4.7.0",
-          "macos" : "0.13.0"
+          "ios": "4.7.0",
+          "macos": "0.13.0"
         }
       },
       "expression": {
         "interpolated": false,
-        "parameters": ["zoom"]
+        "parameters": [
+          "zoom"
+        ]
       },
       "property-type": "data-constant"
     }
@@ -4174,8 +4130,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -4206,8 +4161,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -4570,8 +4524,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -4602,8 +4555,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -4631,8 +4583,7 @@
           "android": "4.2.0",
           "ios": "3.4.0",
           "macos": "0.2.1"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -4660,8 +4611,7 @@
           "android": "5.2.0",
           "ios": "3.7.0",
           "macos": "0.6.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -4837,8 +4787,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -4903,8 +4852,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5102,8 +5050,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5135,8 +5082,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -5333,8 +5279,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5366,8 +5311,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -5392,8 +5336,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5416,8 +5359,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5440,8 +5382,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5464,8 +5405,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5488,8 +5428,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5512,8 +5451,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5541,8 +5479,7 @@
           "android": "6.3.0",
           "ios": "4.2.0",
           "macos": "0.9.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -5565,8 +5502,7 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5591,8 +5527,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5606,10 +5541,10 @@
       "type": "enum",
       "values": {
         "map": {
-            "doc": "The hillshade illumination is relative to the north direction."
+          "doc": "The hillshade illumination is relative to the north direction."
         },
         "viewport": {
-            "doc": "The hillshade illumination is relative to the top of the viewport."
+          "doc": "The hillshade illumination is relative to the top of the viewport."
         }
       },
       "default": "viewport",
@@ -5620,8 +5555,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": false,
@@ -5644,8 +5578,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5666,8 +5599,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5688,8 +5620,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5710,8 +5641,7 @@
           "android": "6.0.0",
           "ios": "4.0.0",
           "macos": "0.7.0"
-        },
-        "data-driven styling": {}
+        }
       },
       "expression": {
         "interpolated": true,
@@ -5759,7 +5689,8 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
-        }
+        },
+        "data-driven styling": {}
       },
       "expression": {
         "interpolated": false,

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -20,6 +20,24 @@ import * as spec from '../../../src/style-spec/style-spec';
     });
 });
 
+test(`v8 Spec SDK Support section`, (t) => {
+    const v = 'v8';
+    const propObjs = [].concat(spec[v].paint).concat(spec[v].layout);
+    propObjs.forEach((objKey) => {
+        const props = spec[v][objKey];
+        const propKeys = Object.keys(props);
+        propKeys.forEach((key) => {
+            t.ok(props[key]["sdk-support"], `${objKey}_${key} is missing sdk support section`);
+        });
+    });
+
+    const expressions = spec[v].expression_name.values;
+    const expressionNames = Object.keys(expressions);
+    expressionNames.forEach((expr) => {
+        t.ok(expressions[expr]["sdk-support"], `expression_${expr} is missing sdk support section`);
+    });
+    t.end();
+});
 function validSchema(k, t, obj, ref, version, kind) {
     const scalar = ['boolean', 'string', 'number'];
     const types = Object.keys(ref).concat(['boolean', 'string', 'number',

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -30,6 +30,11 @@ test(`v8 Spec SDK Support section`, (t) => {
             t.ok(props[key]["sdk-support"], `${objKey}_${key} is missing sdk support section`);
             if (props[key]["sdk-support"]) {
                 t.ok(props[key]["sdk-support"]["basic functionality"], `${objKey}_${key} is missing sdk support section for 'basic functionality'`);
+                if (props[key]["property-type"].includes("constant")) {
+                    t.notOk(props[key]["sdk-support"]["data-driven styling"], `${objKey}_${key} should not have sdk support section for 'data-driven styling'`);
+                } else {
+                    t.ok(props[key]["sdk-support"]["data-driven styling"], `${objKey}_${key} is missing sdk support section for 'data-driven styling'`);
+                }
             }
         });
     });

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -28,6 +28,9 @@ test(`v8 Spec SDK Support section`, (t) => {
         const propKeys = Object.keys(props);
         propKeys.forEach((key) => {
             t.ok(props[key]["sdk-support"], `${objKey}_${key} is missing sdk support section`);
+            if (props[key]["sdk-support"]) {
+                t.ok(props[key]["sdk-support"]["basic functionality"], `${objKey}_${key} is missing sdk support section for 'basic functionality'`);
+            }
         });
     });
 
@@ -35,6 +38,9 @@ test(`v8 Spec SDK Support section`, (t) => {
     const expressionNames = Object.keys(expressions);
     expressionNames.forEach((expr) => {
         t.ok(expressions[expr]["sdk-support"], `expression_${expr} is missing sdk support section`);
+        if (expressions[expr]["sdk-support"]) {
+            t.ok(expressions[expr]["sdk-support"]["basic functionality"], `expression_${expr} is missing sdk support section for 'basic functionality'`);
+        }
     });
     t.end();
 });


### PR DESCRIPTION
This PR makes a few changes to the style spec 
- Fixes #8715. 
- Adds support section for `is-supported-script` 
- Fix SDK support section for `*-sort-key` properties
- Add unit tests to ensure that expressions, paint and layout properties always have correctly structured SDK support sections.
- Remove empty `data-driven styling` sections:
  ![image](https://user-images.githubusercontent.com/11619675/70939163-857cf500-1ffc-11ea-841e-cf278caa9dc6.png)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] tagged @mapbox/studio 

cc @danswick 