### PR TITLE
Add check for ImageBitmap type for texture uploads

### DIFF
--- a/src/render/texture.js
+++ b/src/render/texture.js
@@ -1,7 +1,7 @@
 // @flow
 
 import window from '../util/window';
-const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageData} = window;
+const {HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, ImageData, ImageBitmap} = window;
 
 import type Context from '../gl/context';
 import type {RGBAImage, AlphaImage} from '../util/image';
@@ -31,7 +31,8 @@ export type TextureImage =
     | HTMLCanvasElement
     | HTMLVideoElement
     | ImageData
-    | EmptyImage;
+    | EmptyImage
+    | ImageBitmap;
 
 class Texture {
     context: Context;
@@ -65,7 +66,7 @@ class Texture {
         if (resize) {
             this.size = [width, height];
 
-            if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData) {
+            if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || (ImageBitmap && image instanceof ImageBitmap)) {
                 gl.texImage2D(gl.TEXTURE_2D, 0, this.format, this.format, gl.UNSIGNED_BYTE, image);
             } else {
                 gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, gl.UNSIGNED_BYTE, image.data);
@@ -73,7 +74,7 @@ class Texture {
 
         } else {
             const {x, y} = position || {x: 0, y: 0};
-            if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData) {
+            if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || (ImageBitmap && image instanceof ImageBitmap)) {
                 gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, gl.RGBA, gl.UNSIGNED_BYTE, image);
             } else {
                 gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, image.data);


### PR DESCRIPTION
Fixes #9100 .

There was a mistake in `Texture` which caused `ImageBitmap`'s to be sent to the wrong `gltexImage2D` call. 

