### PR TITLE
Un-hardcode test fixtures root path for fixture builder

### DIFF
--- a/test/integration/lib/generate-fixture-json.js
+++ b/test/integration/lib/generate-fixture-json.js
@@ -10,15 +10,16 @@ exports.generateFixtureJson = generateFixtureJson;
 exports.getAllFixtureGlobs = getAllFixtureGlobs;
 
 /**
- * Analyzes the contents of the specified `directory` ,and inlines
+ * Analyzes the contents of the specified `path.join(rootDirectory, suiteDirectory)`, and inlines
  * the contents into a single json file which can then be imported and built into a bundle
  * to be shipped to the browser.
  *
- * @param {string} directory
+ * @param {string} rootDirectory
+ * @param {string} suiteDirectory
  * @param {boolean} includeImages
  */
-function generateFixtureJson(directory, includeImages = false) {
-    const globs = getAllFixtureGlobs(directory);
+function generateFixtureJson(rootDirectory, suiteDirectory, outputDirectory = 'test/integration/dist', includeImages = false) {
+    const globs = getAllFixtureGlobs(rootDirectory, suiteDirectory);
     const jsonPaths = globs[0];
     const imagePaths = globs[1];
     //Extract the filedata into a flat dictionary
@@ -59,7 +60,7 @@ function generateFixtureJson(directory, includeImages = false) {
     // Re-nest by directory path, each directory path defines a testcase.
     const result = {};
     for (const fullPath in allFiles) {
-        const testName = path.dirname(fullPath).replace('test/integration/', '');
+        const testName = path.dirname(fullPath).replace(rootDirectory, '');
         //Skip if test is malformed
         if (malformedTests[testName]) { continue; }
 
@@ -73,7 +74,7 @@ function generateFixtureJson(directory, includeImages = false) {
     }
 
     const outputStr = JSON.stringify(result, null, 4);
-    const outputPath = path.join('test/integration/dist', OUTPUT_FILE);
+    const outputPath = path.join(outputDirectory, OUTPUT_FILE);
 
     return new Promise((resolve, reject) => {
         fs.writeFile(outputPath, outputStr, {encoding: 'utf8'}, (err) => {
@@ -84,7 +85,8 @@ function generateFixtureJson(directory, includeImages = false) {
     });
 }
 
-function getAllFixtureGlobs(basePath) {
+function getAllFixtureGlobs(rootDirectory, suiteDirectory) {
+    const basePath = path.join(rootDirectory, suiteDirectory);
     const jsonPaths = path.join(basePath, '/**/*.json');
     const imagePaths = path.join(basePath, '/**/*.png');
 

--- a/test/integration/lib/operation-handlers.js
+++ b/test/integration/lib/operation-handlers.js
@@ -22,6 +22,16 @@ export const operationHandlers = {
             }
         };
         wait();
+    },
+    idle(map, params, doneCb) {
+        const idle = function() {
+            if (!map.isMoving()) {
+                doneCb();
+            } else {
+                map.once('render', idle);
+            }
+        };
+        idle();
     }
 };
 

--- a/test/integration/testem.js
+++ b/test/integration/testem.js
@@ -12,7 +12,8 @@ const notifier = require('node-notifier');
 const rollupDevConfig = require('../../rollup.config').default;
 const rollupTestConfig = require('./rollup.config.test').default;
 
-const fixturePath = 'test/integration/query-tests';
+const rootFixturePath = 'test/integration/';
+const suitePath = 'query-tests';
 const fixtureBuildInterval = 2000;
 
 let beforeHookInvoked = false;
@@ -79,7 +80,7 @@ module.exports =  {
 // Retuns a promise that resolves when all artifacts are built
 function buildArtifactsCi() {
     //1. Compile fixture data into a json file, so it can be bundled
-    generateFixtureJson(fixturePath, {});
+    generateFixtureJson(rootFixturePath, suitePath);
     //2. Build tape
     const tapePromise = buildTape();
     //3. Build test artifacts in parallel
@@ -94,15 +95,15 @@ function buildArtifactsDev() {
     return buildTape().then(() => {
         // A promise that resolves on the first build of fixtures.json
         return new Promise((resolve, reject) => {
-            fixtureWatcher = chokidar.watch(getAllFixtureGlobs(fixturePath));
+            fixtureWatcher = chokidar.watch(getAllFixtureGlobs(rootFixturePath, suitePath));
             let needsRebuild = false;
             fixtureWatcher.on('ready', () => {
-                generateFixtureJson(fixturePath);
+                generateFixtureJson(rootFixturePath, suitePath);
 
                 //Throttle calls to `generateFixtureJson` to run every 2s
                 setInterval(() => {
                     if (needsRebuild) {
-                        generateFixtureJson(fixturePath);
+                        generateFixtureJson(rootFixturePath, suitePath);
                         needsRebuild = false;
                     }
                 }, fixtureBuildInterval);


### PR DESCRIPTION
This cherrypicks some changes from https://github.com/mapbox/mapbox-gl-js/pull/8931
to allow for building an inlined json fixture from any directory instead of the hardcoded `test/integration` root directory.

This also adds an `idle` operation handler top handle `idle` operations in our test fixtures. 
