### PR TITLE
Edit convert functions to output linear interpolation

### DIFF
--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -153,13 +153,11 @@ function convertPropertyFunction(parameters, propertySpec, stops) {
         ];
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
-        const expression =
-
-                [
-                    getInterpolateOperator(parameters),
-                    base === 1 ? ["linear"] : ["exponential", base],
-                    ["number", get]
-                ];
+        const expression = [
+            getInterpolateOperator(parameters),
+            base === 1 ? ["linear"] : ["exponential", base],
+            ["number", get]
+        ];
 
         for (const stop of stops) {
             appendStopPair(expression, stop[0], stop[1], false);
@@ -184,9 +182,7 @@ function convertZoomFunction(parameters, propertySpec, stops, input = ['zoom']) 
         isStep = true;
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
-        expression =
-
-                [getInterpolateOperator(parameters), base === 1 ? ["linear"] : ["exponential", base], input];
+        expression = [getInterpolateOperator(parameters), base === 1 ? ["linear"] : ["exponential", base], input];
 
     } else {
         throw new Error(`Unknown zoom function type "${type}"`);

--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -153,7 +153,18 @@ function convertPropertyFunction(parameters, propertySpec, stops) {
         ];
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
-        const expression = [getInterpolateOperator(parameters), ['exponential', base], ['number', get]];
+        const expression =
+            base === 1 ?
+                [
+                    getInterpolateOperator(parameters),
+                    ["linear"],
+                    ["number", get]
+                ] :
+                [
+                    getInterpolateOperator(parameters),
+                    ["exponential", base],
+                    ["number", get]
+                ];
         for (const stop of stops) {
             appendStopPair(expression, stop[0], stop[1], false);
         }
@@ -177,7 +188,14 @@ function convertZoomFunction(parameters, propertySpec, stops, input = ['zoom']) 
         isStep = true;
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
-        expression = [getInterpolateOperator(parameters), ['exponential', base], input];
+        expression =
+            base === 1 ?
+                [getInterpolateOperator(parameters), ["linear"], input] :
+                [
+                    getInterpolateOperator(parameters),
+                    ["exponential", base],
+                    input
+                ];
     } else {
         throw new Error(`Unknown zoom function type "${type}"`);
     }

--- a/src/style-spec/function/convert.js
+++ b/src/style-spec/function/convert.js
@@ -154,17 +154,13 @@ function convertPropertyFunction(parameters, propertySpec, stops) {
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
         const expression =
-            base === 1 ?
+
                 [
                     getInterpolateOperator(parameters),
-                    ["linear"],
-                    ["number", get]
-                ] :
-                [
-                    getInterpolateOperator(parameters),
-                    ["exponential", base],
+                    base === 1 ? ["linear"] : ["exponential", base],
                     ["number", get]
                 ];
+
         for (const stop of stops) {
             appendStopPair(expression, stop[0], stop[1], false);
         }
@@ -189,13 +185,9 @@ function convertZoomFunction(parameters, propertySpec, stops, input = ['zoom']) 
     } else if (type === 'exponential') {
         const base = parameters.base !== undefined ? parameters.base : 1;
         expression =
-            base === 1 ?
-                [getInterpolateOperator(parameters), ["linear"], input] :
-                [
-                    getInterpolateOperator(parameters),
-                    ["exponential", base],
-                    input
-                ];
+
+                [getInterpolateOperator(parameters), base === 1 ? ["linear"] : ["exponential", base], input];
+
     } else {
         throw new Error(`Unknown zoom function type "${type}"`);
     }

--- a/test/unit/style-spec/migrate.test.js
+++ b/test/unit/style-spec/migrate.test.js
@@ -69,7 +69,7 @@ test('converts stop functions to expressions', (t) => {
     }, spec.latest.$version);
     t.deepEqual(migrated.layers[0].paint['background-opacity'], [
         'interpolate',
-        ['exponential', 1],
+        ['linear'],
         ['zoom'],
         0,
         1,
@@ -78,7 +78,7 @@ test('converts stop functions to expressions', (t) => {
     ]);
     t.deepEqual(migrated.layers[1].paint['background-opacity'], [
         'interpolate',
-        ['exponential', 1],
+        ['linear'],
         ['zoom'],
         0,
         ['literal', [1, 2]],


### PR DESCRIPTION
This PR closes #6840. I edited the convertPropertyFunction and the convertZoomFunction to output linear interpolations when base is 1.

I submitted #9076 earlier but I am resubmitting the PR here without running `yarn lint --fix`