### PR TITLE
Strip more keys from the style spec

### DIFF
--- a/build/rollup_plugin_minify_style_spec.js
+++ b/build/rollup_plugin_minify_style_spec.js
@@ -1,6 +1,7 @@
 
 function replacer(k, v) {
-    return k === 'doc' || k === 'example' || k === 'sdk-support' || k === 'values' || k === 'requires' ? undefined : v;
+    if (k === 'values') Object.keys(v).reduce((obj, key) => (obj[key] = true, obj), {});
+    return k === 'doc' || k === 'example' || k === 'sdk-support' || k === 'requires' ? undefined : v;
 }
 
 export default function minifyStyleSpec() {

--- a/build/rollup_plugin_minify_style_spec.js
+++ b/build/rollup_plugin_minify_style_spec.js
@@ -1,6 +1,6 @@
 
 function replacer(k, v) {
-    return (k === 'doc' || k === 'example' || k === 'sdk-support') ? undefined : v;
+    return k === 'doc' || k === 'example' || k === 'sdk-support' || k === 'values' || k === 'requires' ? undefined : v;
 }
 
 export default function minifyStyleSpec() {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3,10 +3,8 @@
   "$root": {
     "version": {
       "required": true,
-      "type": "enum",
-      "values": [
-        8
-      ],
+      "type": "number",
+      "default": 8,
       "doc": "Style specification version number. Must be 8.",
       "example": 8
     },


### PR DESCRIPTION
Strip more unused keys from the style spec JSON, reducing the build size a little (-1.21KB minified).