### PR TITLE
Add derefLayers to the style-spec bundle

### DIFF
--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -64,6 +64,7 @@ import latest from './reference/latest';
 import format from './format';
 import migrate from './migrate';
 import composite from './composite';
+import derefLayers from './deref';
 import diff from './diff';
 import ValidationError from './error/validation_error';
 import ParsingError from './error/parsing_error';
@@ -103,6 +104,7 @@ export {
     format,
     migrate,
     composite,
+    derefLayers,
     diff,
     ValidationError,
     ParsingError,


### PR DESCRIPTION
The [ol-mapbos-style](https://github.com/openlayers/ol-mapbox-style) library makes use of some of the utility functions in src/style-spec. All those are included in the @mapbox/mapbox-gl-style-spec's dist bundle, except for the `derefLayers` function.

Currently, `ol-mapbox-style` imports the function directly, which is not ideal because it contains a `for (const key in objectLiteral)` construct, which is not supported by Internet Explorer.

For the public API, this means that you can now
```js
import {derefLayers} from '@mapbox/mapbox-gl-style-spec' 

const allLayers = derefLayers(styleJson);
```
/cc @mapbox/studio

It would be great if this pull request could be accepted. Thanks!