### PR TITLE
Fix CSP errors caused by using a blobURL to load the rtl-text-plugin

### DIFF
--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -3,7 +3,6 @@
 import {Event, Evented} from '../util/evented';
 import {getArrayBuffer} from '../util/ajax';
 import browser from '../util/browser';
-import window from '../util/window';
 import assert from 'assert';
 import {isWorker} from '../util/util';
 
@@ -17,8 +16,7 @@ const status = {
 
 export type PluginState = {
     pluginStatus: $Values<typeof status>;
-    pluginURL: ?string,
-    pluginBlobURL: ?string
+    pluginURL: ?string
 };
 
 type ErrorCallback = (error: ?Error) => void;
@@ -28,7 +26,6 @@ let _completionCallback = null;
 //Variables defining the current state of the plugin
 let pluginStatus = status.unavailable;
 let pluginURL = null;
-let pluginBlobURL = null;
 
 export const triggerPluginCompletionEvent = function(error: ?Error) {
     if (_completionCallback) {
@@ -37,7 +34,7 @@ export const triggerPluginCompletionEvent = function(error: ?Error) {
 };
 
 function sendPluginStateToWorker() {
-    evented.fire(new Event('pluginStateChange', {pluginStatus, pluginURL, pluginBlobURL}));
+    evented.fire(new Event('pluginStateChange', {pluginStatus, pluginURL}));
 }
 
 export const evented = new Evented();
@@ -48,7 +45,7 @@ export const getRTLTextPluginStatus = function () {
 
 export const registerForPluginStateChange = function(callback: PluginStateSyncCallback) {
     // Do an initial sync of the state
-    callback({pluginStatus, pluginURL, pluginBlobURL});
+    callback({pluginStatus, pluginURL});
     // Listen for all future state changes
     evented.on('pluginStateChange', callback);
     return callback;
@@ -57,10 +54,6 @@ export const registerForPluginStateChange = function(callback: PluginStateSyncCa
 export const clearRTLTextPlugin = function() {
     pluginStatus = status.unavailable;
     pluginURL = null;
-    if (pluginBlobURL) {
-        window.URL.revokeObjectURL(pluginBlobURL);
-    }
-    pluginBlobURL = null;
 };
 
 export const setRTLTextPlugin = function(url: string, callback: ?ErrorCallback, deferred: boolean = false) {
@@ -85,12 +78,10 @@ export const downloadRTLTextPlugin = function() {
     pluginStatus = status.loading;
     sendPluginStateToWorker();
     if (pluginURL) {
-        getArrayBuffer({url: pluginURL}, (error, data) => {
+        getArrayBuffer({url: pluginURL}, (error) => {
             if (error) {
                 triggerPluginCompletionEvent(error);
             } else {
-                const rtlBlob = new window.Blob([data], {type: 'application/javascript'});
-                pluginBlobURL = window.URL.createObjectURL(rtlBlob);
                 pluginStatus = status.loaded;
                 sendPluginStateToWorker();
             }
@@ -106,7 +97,7 @@ export const plugin: {
     isLoading: () => boolean,
     setState: (state: PluginState) => void,
     isParsed: () => boolean,
-    getURLs: () => { blob: ?string, host: ?string }
+    getPluginURL: () => ?string
 } = {
     applyArabicShaping: null,
     processBidirectionalText: null,
@@ -123,7 +114,6 @@ export const plugin: {
 
         pluginStatus = state.pluginStatus;
         pluginURL = state.pluginURL;
-        pluginBlobURL = state.pluginBlobURL;
     },
     isParsed(): boolean {
         assert(isWorker(), 'rtl-text-plugin is only parsed on the worker-threads');
@@ -132,13 +122,9 @@ export const plugin: {
             plugin.processBidirectionalText != null &&
             plugin.processStyledBidirectionalText != null;
     },
-    getURLs(): { blob: ?string, host: ?string } {
-        assert(isWorker(), 'rtl-text-plugin urls can only be queried from the worker threads');
-
-        return {
-            blob: pluginBlobURL,
-            host: pluginURL,
-        };
+    getPluginURL(): ?string {
+        assert(isWorker(), 'rtl-text-plugin url can only be queried from the worker threads');
+        return pluginURL;
     }
 };
 

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -156,15 +156,15 @@ export default class Worker {
     syncRTLPluginState(map: string, state: PluginState, callback: Callback<boolean>) {
         try {
             globalRTLTextPlugin.setState(state);
-            const {blob, host} = globalRTLTextPlugin.getURLs();
+            const pluginURL = globalRTLTextPlugin.getPluginURL();
             if (
                 globalRTLTextPlugin.isLoaded() &&
                 !globalRTLTextPlugin.isParsed() &&
-                blob != null && host != null // Not possible when `isLoaded` is true, but keeps flow happy
+                pluginURL != null // Not possible when `isLoaded` is true, but keeps flow happy
             ) {
-                this.self.importScripts(blob);
+                this.self.importScripts(pluginURL);
                 const complete = globalRTLTextPlugin.isParsed();
-                const error = complete ? undefined : new Error(`RTL Text Plugin failed to import scripts from ${host}`);
+                const error = complete ? undefined : new Error(`RTL Text Plugin failed to import scripts from ${pluginURL}`);
                 callback(error, complete);
             }
         } catch (e) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -159,8 +159,7 @@ class Style extends Evented {
         this._rtlTextPluginCallback = Style.registerForPluginStateChange((event) => {
             const state = {
                 pluginStatus: event.pluginStatus,
-                pluginURL: event.pluginURL,
-                pluginBlobURL: event.pluginBlobURL
+                pluginURL: event.pluginURL
             };
             self.dispatcher.broadcast('syncRTLPluginState', state, (err, results) => {
                 triggerPluginCompletionEvent(err);

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -74,8 +74,7 @@ test('Style', (t) => {
         setRTLTextPlugin("/plugin.js",);
         t.ok(style.dispatcher.broadcast.calledWith('syncRTLPluginState', {
             pluginStatus: 'deferred',
-            pluginURL: "/plugin.js",
-            pluginBlobURL: null
+            pluginURL: "/plugin.js"
         }));
         window.clearFakeWorkerPresence();
         t.end();


### PR DESCRIPTION
This fixes #9118 , instead of turning the plugin into a blob, and sending a blobURL to the worker, this fetches once on the main thread, and once the fetch is done directly send the host url to the workers. This solves the CSP issue since `importScripts` is called on the `https` url directly, and doesn't cause the workers to race as before since downloading it once on the main thread warms up the browser cache with the data.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
`<changelog>Fixes CSP violation errors when using rtl-text-plugin</changelog>`