### PR TITLE
Fix bug in DragRotateHandler._onMouseUp()

### DIFF
--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -239,7 +239,7 @@ class DragRotateHandler {
             this._el.click();
         }
 
-        if (DOM.mouseButton(e) !== this._eventButton) return;
+        if (!touchEvent && DOM.mouseButton(e) !== this._eventButton) return;
         switch (this._state) {
         case 'active':
             this._state = 'enabled';


### PR DESCRIPTION
A bug in the `DragRotateHandler`'s `_onMouseUp()` method was causing the `NavigationControl`'s instance of this handler to get "stuck" when receiving a `touchend` event from the user tapping the compass button to reset bearing to North, such that the user would not be able to stop the drag-rotate interaction. This was caused by an  assertion error in `DOM.mouseButton()` when receiving a touch event instead of a mouse event as expected, which was preventing the handler from being deactivated on `touchend`.

This adds a check for touch events so that we do not pass a touch event and trigger this error.

To test:
- Open `debug/events.html` on a touch device
- Rotate the map to a nonzero bearing
- Click the compass icon to reset the bearing 
  - Before: Bearing is reset as expected, but `AssertionError`(s) seen in the console
  - After: Bearing resets as expected with no errors
- Attempt to pan the map with one finger
  - Before: Map rotates/pitches instead of panning, as the DragRotate handler is stuck in active mode
  - After: Map pans as expected