### PR TITLE
Prevent changing bearing via URL hash when rotation is disabled

### DIFF
--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -119,10 +119,11 @@ class Hash {
     _onHashChange() {
         const loc = this._getCurrentHash();
         if (loc.length >= 3 && !loc.some(v => isNaN(v))) {
+            const bearing = this._map.dragRotate.isEnabled() && this._map.touchZoomRotate.isEnabled() ? +loc[3] : this._map.getBearing() || 0;
             this._map.jumpTo({
                 center: [+loc[2], +loc[1]],
                 zoom: +loc[0],
-                bearing: +(loc[3] || 0),
+                bearing,
                 pitch: +(loc[4] || 0)
             });
             return true;

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -119,7 +119,7 @@ class Hash {
     _onHashChange() {
         const loc = this._getCurrentHash();
         if (loc.length >= 3 && !loc.some(v => isNaN(v))) {
-            const bearing = this._map.dragRotate.isEnabled() && this._map.touchZoomRotate.isEnabled() ? +loc[3] : this._map.getBearing() || 0;
+            const bearing = this._map.dragRotate.isEnabled() && this._map.touchZoomRotate.isEnabled() ? +loc[3] : this._map.getBearing();
             this._map.jumpTo({
                 center: [+loc[2], +loc[1]],
                 zoom: +loc[0],

--- a/test/unit/ui/hash.test.js
+++ b/test/unit/ui/hash.test.js
@@ -57,6 +57,11 @@ test('hash', (t) => {
         t.equal(map.getBearing(), 0);
         t.equal(map.getPitch(), 0);
 
+        // map is created with `interactive: false`
+        // so explicitly enable rotation for this test
+        map.dragRotate.enable();
+        map.touchZoomRotate.enable();
+
         window.location.hash = '#5/1.00/0.50/30/60';
 
         hash._onHashChange();
@@ -66,6 +71,33 @@ test('hash', (t) => {
         t.equal(map.getZoom(), 5);
         t.equal(map.getBearing(), 30);
         t.equal(map.getPitch(), 60);
+
+        // disable rotation to test that updating
+        // the hash's bearing won't change the map
+        map.dragRotate.disable();
+        map.touchZoomRotate.disable();
+
+        window.location.hash = '#5/1.00/0.50/-45/60';
+
+        hash._onHashChange();
+
+        t.equal(map.getCenter().lng, 0.5);
+        t.equal(map.getCenter().lat, 1);
+        t.equal(map.getZoom(), 5);
+        t.equal(map.getBearing(), 30);
+        t.equal(map.getPitch(), 60);
+
+        // test that a hash with no bearing resets
+        // to the previous bearing when rotation is disabled
+        window.location.hash = '#5/1.00/0.50/';
+
+        hash._onHashChange();
+
+        t.equal(map.getCenter().lng, 0.5);
+        t.equal(map.getCenter().lat, 1);
+        t.equal(map.getZoom(), 5);
+        t.equal(map.getBearing(), 30);
+        t.equal(window.location.hash, '#5/1/0.5/30');
 
         window.location.hash = '#4/wrongly/formed/hash';
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Fixes https://github.com/mapbox/mapbox-gl-js/issues/9148

 - [x] briefly describe the changes in this PR
    - This PR prevents the user from changing the bearing of the map via the URL hash if both `touchZoomRotate` and `dragRotate` are disabled
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] `<changelog>Prevent changing bearing via URL hash when rotation is disabled</changelog>`
