### PR TITLE
Add instructions for changelog authoring to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@
  - [ ] tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes
  - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
  - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
- - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog:`<changelog></changelog>`
+ - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,5 @@
  - [ ] tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes
  - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
  - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
- - [ ] `<changelog>...</changelog>`
+ - [ ] write the changelog entry in the PR title - if more space is needed write between the `<changelog>` tags included below
+ - [ ] `<changelog></changelog>`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,4 @@
  - [ ] tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes
  - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
  - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
- - [ ] write the changelog entry in the PR title - if more space is needed write between the `<changelog>` tags included below
- - [ ] `<changelog></changelog>`
+ - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog:`<changelog></changelog>`


### PR DESCRIPTION
Add explainer on including changelog entries to the PR template.

The PR title is used by default and longer entries may be placed in `<changelog>` tags in the body. The PR template instructions should clarify this for contributors.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] `<changelog>...</changelog>`

@mapbox/studio @mapbox/map-design-team @mapbox/gl-js 