### PR TITLE
Remove Object.values usage that was causing IE11 to fail

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -6,7 +6,7 @@ import Tile from './tile';
 import {Event, ErrorEvent, Evented} from '../util/evented';
 import TileCache from './tile_cache';
 import MercatorCoordinate from '../geo/mercator_coordinate';
-import {keysDifference} from '../util/util';
+import {keysDifference, values} from '../util/util';
 import EXTENT from '../data/extent';
 import Context from '../gl/context';
 import Point from '@mapbox/point-geometry';
@@ -182,7 +182,7 @@ class SourceCache extends Evented {
      * Return all tile ids ordered with z-order, and cast to numbers
      */
     getIds(): Array<string> {
-        return (Object.values(this._tiles): any).map((tile: Tile) => tile.tileID).sort(compareTileId).map(id => id.key);
+        return (values(this._tiles): any).map((tile: Tile) => tile.tileID).sort(compareTileId).map(id => id.key);
     }
 
     getRenderableIds(symbolLayer?: boolean): Array<string> {


### PR DESCRIPTION
(cherry picked from commit ab43140ab714b740cc67488bdda2e2265d71353b)
Le title.

