### PR TITLE
DragRotateHandler should not react to ctrl-alt-click

### DIFF
--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -134,12 +134,13 @@ class DragRotateHandler {
         if (this._state !== 'enabled') return;
 
         const touchEvent = e.type === 'touchstart';
-
         if (touchEvent) {
             this._startTime = Date.now();
         } else {
             if (this._button === 'right') {
                 this._eventButton = DOM.mouseButton(e);
+
+                if (e.altKey) return;
                 if (this._eventButton !== (e.ctrlKey ? 0 : 2)) return;
             } else {
                 if (e.ctrlKey || DOM.mouseButton(e) !== 0) return;

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -134,7 +134,7 @@ class DragRotateHandler {
         if (this._state !== 'enabled') return;
 
         const touchEvent = e.type === 'touchstart';
-        
+
         if (touchEvent) {
             this._startTime = Date.now();
         } else {

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -141,7 +141,7 @@ class DragRotateHandler {
             if (this._button === 'right') {
                 this._eventButton = DOM.mouseButton(e);
 
-                if (e.altKey) return;
+                if (e.altKey || e.metaKey) return;
                 if (this._eventButton !== (e.ctrlKey ? 0 : 2)) return;
             } else {
                 if (e.ctrlKey || DOM.mouseButton(e) !== 0) return;

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -134,6 +134,7 @@ class DragRotateHandler {
         if (this._state !== 'enabled') return;
 
         const touchEvent = e.type === 'touchstart';
+        
         if (touchEvent) {
             this._startTime = Date.now();
         } else {


### PR DESCRIPTION
## Motivation

Received some user feedback related to the drag rotate functionality:

> If I do ctrl-alt click and drag the map still rotates etc. unexpectedly. This has caused issue for us embedding mapbox map that ctrl-alt click mouse gesture could be used for different meaning in our application. It's currently possible to drag rotate using ctrl-alt-click. 

According [the docs](https://docs.mapbox.com/mapbox-gl-js/api/#dragrotatehandler), DragRotateHandler should allow the user to rotate the map by 1) holding the right mouse button and dragging the cursor or 2) pressing the ctrl key while dragging the cursor. It's currently possible to drag rotate the map by pressing ctrl+alt and dragging the cursor. This PR prevents the drag rotate behavior for ctrl+alt+click.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
