### PR TITLE
Support geographically-sized text symbols

### DIFF
--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -58,9 +58,9 @@ void main() {
     float size;
 
     if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
-        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+        size = mix(a_size_min, a_size[1], u_size_t) / (u_is_text ? 1.0 : 128.0);
     } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
-        size = a_size_min / 128.0;
+        size = a_size_min / (u_is_text ? 1.0 : 128.0);
     } else {
         size = u_size;
     }

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -58,9 +58,9 @@ void main() {
     float size;
 
     if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
-        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+        size = mix(a_size_min, a_size[1], u_size_t);
     } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
-        size = a_size_min / 128.0;
+        size = a_size_min;
     } else {
         size = u_size;
     }

--- a/src/symbol/symbol_layout.js
+++ b/src/symbol/symbol_layout.js
@@ -496,19 +496,13 @@ function addTextVertices(bucket: SymbolBucket,
 
     if (sizeData.kind === 'source') {
         textSizeData = [
-            SIZE_PACK_FACTOR * layer.layout.get('text-size').evaluate(feature, {})
+            layer.layout.get('text-size').evaluate(feature, {})
         ];
-        if (textSizeData[0] > MAX_PACKED_SIZE) {
-            warnOnce(`${bucket.layerIds[0]}: Value for "text-size" is >= ${MAX_GLYPH_ICON_SIZE}. Reduce your "text-size".`);
-        }
     } else if (sizeData.kind === 'composite') {
         textSizeData = [
-            SIZE_PACK_FACTOR * sizes.compositeTextSizes[0].evaluate(feature, {}, canonical),
-            SIZE_PACK_FACTOR * sizes.compositeTextSizes[1].evaluate(feature, {}, canonical)
+            sizes.compositeTextSizes[0].evaluate(feature, {}, canonical),
+            sizes.compositeTextSizes[1].evaluate(feature, {}, canonical)
         ];
-        if (textSizeData[0] > MAX_PACKED_SIZE || textSizeData[1] > MAX_PACKED_SIZE) {
-            warnOnce(`${bucket.layerIds[0]}: Value for "text-size" is >= ${MAX_GLYPH_ICON_SIZE}. Reduce your "text-size".`);
-        }
     }
 
     bucket.addSymbols(

--- a/src/symbol/symbol_size.js
+++ b/src/symbol/symbol_size.js
@@ -77,9 +77,9 @@ function evaluateSizeForFeature(sizeData: SizeData,
                                 {uSize, uSizeT}: { uSize: number, uSizeT: number },
                                 {lowerSize, upperSize}: { lowerSize: number, upperSize: number}) {
     if (sizeData.kind === 'source') {
-        return lowerSize / SIZE_PACK_FACTOR;
+        return lowerSize;
     } else if (sizeData.kind === 'composite') {
-        return interpolate(lowerSize / SIZE_PACK_FACTOR, upperSize / SIZE_PACK_FACTOR, uSizeT);
+        return interpolate(lowerSize, upperSize, uSizeT);
     }
     return uSize;
 }


### PR DESCRIPTION
Fixes #7163
Fixes #7563

This PR adds support for text layers that scale with the map by removing the restriction on text-size for `source` and `composite` expressions.

The main problem is that text-size has been given the same precision as icon-size, even though the former is in units of pixels and the latter is in units of relative size. Integer precision is fine for pixel units, but terrible for icon-size units. To support icon-size, these values are scaled by `SIZE_PACK_FACTOR` (previously 256 but recently reduced to 128), packed in to a UInt16, and then divided by `SIZE_PACK_FACTOR` in the shader. This change skips that upscaling and downscaling when we're dealing with text-size instead of icon-size, significantly increasing the upper range of text-size without reducing the precision of icon-size.

Here are some JSFiddles to demonstrate:

Using [v1.6.1](https://jsfiddle.net/82c5zn0L/15/): Note that no text is rendered and a console warning says `Value for "text-size" is >= 255. Reduce your "text-size".`

Using [this fork](https://jsfiddle.net/Ln38bcw1/): Note that you as you zoom, the text scales with the map.

 - [X] briefly describe the changes in this PR
 - [X] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [X] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog:
`<changelog>Adds support for geographically-sized text</changelog>`
