### PR TITLE
[WIP] Refactor gesture handling & improve gesture support on mobile

### DIFF
--- a/src/ui/handler/handler.js
+++ b/src/ui/handler/handler.js
@@ -1,0 +1,101 @@
+// @flow
+
+import type Map from '../map';
+
+/**
+ * Base class for gesture handlers which control user interaction with the map
+ */
+class Handler {
+  _state: 'disabled' | 'enabled' | 'pending' | 'active';
+  _options: Object;
+  _el: HTMLElement;
+
+  constructor(map: Map, options: ?Object) {
+    // this._map = map;
+    this._el = map.getCanvasContainer();
+    this._options = {};
+    if (options) this.setOptions(options);
+    this._state = 'enabled';
+  }
+
+  /**
+   * Returns a Boolean indicating whether this handler's interaction is enabled.
+   *
+   * @returns {boolean} `true` if the interaction is enabled.
+   */
+  isEnabled() {
+      return this._state !== 'disabled';
+  }
+
+
+  /**
+   * Enables this handler's interaction.
+   *
+   */
+  enable() {
+      if (this.isEnabled()) return;
+      this._state = 'enabled';
+  }
+
+  /**
+   * Disables this handler's interaction.
+   *
+   */
+  disable() {
+      if (!this.isEnabled()) return;
+      this._state = 'disabled';
+  }
+
+  /**
+   * Resets a possibly-active handler to enabled state.
+   *
+   */
+  reset() {
+      if (this.isEnabled()) {
+        this.disable();
+        this.enable();
+      }
+  }
+
+  /**
+   * Set custom options for this handler.
+   *
+   * @param {Object} [options] Object in { option: value } format.
+   */
+  setOptions(options: any) {
+    if (!options) throw new Error('Must provide a valid options object');
+    let unrecognized = [];
+    for (const property in options) {
+      if (this._options[property] === undefined) unrecognized.push(property);
+      else this._options[property] = options[property];
+    }
+    if (unrecognized.length > 0) throw new Error(`Unrecognized option${unrecognized.length > 1 ? 's' : ''}: ${unrecognized.join(', ')}`);
+  }
+
+  /**
+   * Get the current options for this handler.
+   *
+   * @returns {Object} Options object in { option: value } format.
+   */
+  getOptions() {
+    return this._options;
+  }
+
+  /**
+   * Process an interaction event received by the map.
+   * The handler will receive every type of input event, but will only respond to event types for which it has a corresponding method.
+   * Handlers should implement event-type methods (e.g. .touchmove() or .mousedown()) for events they wish to respond to.
+   * Each event-type method should either return an object with target data for a map update, //TODO describe data object shape
+   * or return undefined if no update is required for the event.
+   *
+   * @param {Event} [event] Mouse, Touch, Keyboard or Wheel event to be processed
+   * @returns {Object | undefined} Data (e.g. new transform settings) to be used to update the map, or undefined if no update is required
+   */
+  processInputEvent(e: MouseEvent | TouchEvent | KeyboardEvent | WheelEvent) {
+    if (!e || !e.type) return console.warn('Invalid input event:', e);
+    if (!this[e.type] || !(typeof this[e.type] === 'function')) return;
+    return this[e.type](e);
+  }
+}
+
+export default Handler;

--- a/src/ui/handler/handler.js
+++ b/src/ui/handler/handler.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type Map from '../map';
-
+import type {InputEvent} from '../handler_manager';
 /**
  * Base class for gesture handlers which control user interaction with the map
  */
@@ -50,7 +50,7 @@ class Handler {
    * Resets a possibly-active handler to enabled state.
    *
    */
-  reset() {
+  reset(e: ?InputEvent) {
       if (this.isEnabled()) {
         this.disable();
         this.enable();

--- a/src/ui/handler/touch.js
+++ b/src/ui/handler/touch.js
@@ -1,0 +1,274 @@
+// @flow
+
+import Handler from './handler';
+import DOM from '../../util/dom';
+import window from '../../util/window';
+import browser from '../../util/browser';
+
+import type Map from '../map';
+import type Transform from '../../geo/transform';
+import type Point from '@mapbox/point-geometry';
+
+
+class TouchHandler extends Handler {
+  _el: HTMLElement;
+  _transform: Transform;
+  _startTouchEvent: ?TouchEvent;
+  _startTouchData: ?Object;
+  _startTime: ?number;
+  _lastTouchEvent: ?TouchEvent;
+  _lastTouchData: ?Object;
+
+  constructor(map: Map, options: ?Object) {
+    super(map, options);
+    this._transform = map.transform;
+  }
+
+  _getTouchEventData(e: TouchEvent) {
+      if (!e.touches) throw new Error('no touches', e);
+      const isMultiTouch = e.touches.length > 1;
+      let points = DOM.touchPos(this._el, e);
+      const centerPoint = isMultiTouch ? points[0].add(points[1]).div(2) : points[0];
+      const centerLocation = this._transform.pointLocation(centerPoint);
+      const vector = isMultiTouch ? points[0].sub(points[1]) : null ;
+      return { isMultiTouch, points, centerPoint, centerLocation, vector };
+  }
+
+  _setStartTouch(e: TouchEvent) {
+    this._startTouchEvent = e;
+    this._startTouchData = this._getTouchEventData(e);
+    this._startTime = browser.now();
+  }
+
+  _start(e: TouchEvent) {
+    if (!this.isEnabled()) return;
+    this._setStartTouch(e);
+    if (this._state !== 'active') this._state = 'pending';
+  }
+
+  reset(e: TouchEvent) {
+    this._start(e);
+    if (this._state === 'active') {
+      this._state === 'pending';
+    }
+  }
+
+  touchstart(e: TouchEvent) {
+    this._start(e);
+  }
+
+  touchmove(e: TouchEvent) {
+    if (!(this._state === 'pending' || this._state === 'active')) return;
+    if (!this._startTouchData) return this.touchstart(e);
+    this._lastTouchEvent = e;
+    this._lastTouchData = this._getTouchEventData(e);
+    // TODO check time vs. start time to prevent responding to spurious events?
+    return true; // signal to extended classes that they should continue processing the touchmove event
+  }
+
+  touchend(e: TouchEvent) {
+    if (!e.touches || e.touches.length === 0) this.deactivate();
+  }
+
+  touchcancel(e: TouchEvent) {
+    this.deactivate();
+  }
+
+  deactivate() {
+    delete this._startTouchEvent;
+    delete this._startTouchData;
+    delete this._startTime;
+    delete this._lastTouchEvent;
+    delete this._lastTouchData;
+    if (this._state === 'pending' || this._state === 'active') {
+      this._state = 'enabled';
+    }
+  }
+}
+
+class TouchPanHandler extends TouchHandler {
+
+  get _tapTolerance() {
+    return 1;
+  }
+
+  touchmove(e: TouchEvent) {
+    if (!super.touchmove(e)) return;
+
+    const underTapTolerance = this._lastTouchData.centerPoint.dist(this._startTouchData.centerPoint) < this._tapTolerance;
+    if (underTapTolerance) return;
+
+    const location = this._startTouchData.centerLocation;
+    const point = this._lastTouchData.centerPoint;
+
+    const events = [];
+    if (this._state === 'pending') events.push('dragstart');
+    this._state = 'active';
+    events.push('drag');
+    return { transform: { setLocationAtPoint: [location, point] }, events };
+
+  }
+
+  touchend(e: TouchEvent) {
+    const stateBeforeEnd = this._state;
+    super.touchend(e);
+    if (this._state === 'pending' || this._state === 'active') {
+      // We did not deactivate, as there are still finger(s) touching.
+      // Reset the start event for the remaining finger(s), as if on touchstart
+      this._setStartTouch(e);
+    } else if (stateBeforeEnd === 'active') {
+      return { events: ['dragend'] };
+    }
+  }
+
+  touchcancel(e: TouchEvent) {
+    const stateBeforeCancel = this._state;
+    super.touchcancel(e);
+    if (stateBeforeCancel === 'active') return { events: ['dragend']};
+  }
+}
+
+class MultiTouchHandler extends TouchHandler {
+
+  touchstart(e: TouchEvent) {
+    if (e.touches && e.touches.length > 1) super.touchstart(e);
+  }
+
+  touchmove(e: TouchEvent) {
+    if (e.touches && e.touches.length > 1) return super.touchmove(e);
+  }
+
+  touchend(e: TouchEvent) {
+    if (!e.touches || e.touches.length < 2) this.deactivate();
+  }
+
+  get _horizontalThreshold() { return 70; }
+  get _shoveThreshold() {
+    if (this._state === 'active') return 0;
+    return 5;
+  }
+
+  _pointsAreHorizontal(pointA, pointB) {
+    return Math.abs(pointA.y - pointB.y) < this._horizontalThreshold;
+  }
+
+  _shoveDetected() {
+    const isHorizontal = this._pointsAreHorizontal(this._lastTouchData.points[0], this._lastTouchData.points[1]);
+    const isMovingVertically = Math.abs(this._startTouchData.centerPoint.y - this._lastTouchData.centerPoint.y) > this._shoveThreshold;
+    return isHorizontal && isMovingVertically;
+  }
+}
+
+class TouchZoomHandler extends MultiTouchHandler {
+
+    get _threshold() {
+      return this._state === 'active' ? 0 : 0.15;
+    }
+
+    touchmove(e: TouchEvent) {
+      if (!super.touchmove(e)) return;
+
+      const scale = this._lastTouchData.vector.mag() / this._startTouchData.vector.mag();
+
+      if (Math.abs(1 - scale) > this._threshold) {
+        const events = [];
+        if (this._state === 'pending') events.push('zoomstart');
+        this._state = 'active';
+        const zoomDelta = this._transform.scaleZoom(scale);
+        this._startTouchEvent = this._lastTouchEvent;
+        this._startTouchData = this._lastTouchData;
+        this._startTime = browser.now();
+        events.push('zoom');
+        return { transform: { zoomDelta }, events };
+      }
+    }
+
+    touchend(e: TouchEvent) {
+      const stateBeforeEnd = this._state;
+      super.touchend(e);
+      if (stateBeforeEnd === 'active') return { events: ['zoomend'] };
+    }
+
+    touchcancel(e: TouchEvent) {
+      const stateBeforeCancel = this._state;
+      super.touchcancel(e);
+      if (stateBeforeCancel === 'active') return { events: ['zoomend']};
+    }
+}
+
+class TouchRotateHandler extends MultiTouchHandler {
+
+    get _rotationThreshold() {
+      if (this._state === 'active') return 0;
+      return 2;
+    }
+
+    touchmove(e: TouchEvent) {
+      if (!super.touchmove(e)) return;
+
+      const isVerticalShove = this._shoveDetected();
+      const bearingDelta = this._lastTouchData.vector.angleWith(this._startTouchData.vector) * 180 / Math.PI
+
+      this._startTouchEvent = this._lastTouchEvent;
+      this._startTouchData = this._lastTouchData;
+      this._startTime = browser.now();
+
+      if (!isVerticalShove && Math.abs(bearingDelta) > this._rotationThreshold) {
+        const events = [];
+        if (this._state === 'pending') events.push('rotatestart');
+        this._state = 'active';
+        events.push('rotate');
+        return { transform: { bearingDelta }, events };
+      }
+    }
+
+    touchend(e: TouchEvent) {
+      const stateBeforeEnd = this._state;
+      super.touchend(e);
+      if (stateBeforeEnd === 'active') return { events: ['rotateend'] };
+    }
+
+    touchcancel(e: TouchEvent) {
+      const stateBeforeCancel = this._state;
+      super.touchcancel(e);
+      if (stateBeforeCancel === 'active') return { events: ['rotateend']};
+    }
+}
+
+class TouchPitchHandler extends MultiTouchHandler {
+
+    touchmove(e: TouchEvent) {
+      if (!super.touchmove(e)) return;
+
+      // const isHorizontal = this._pointsAreHorizontal(this._lastTouchData.points[0], this._lastTouchData.points[1]);
+      const isVerticalShove = this._shoveDetected();
+      const pitchDelta = (this._startTouchData.centerPoint.y - this._lastTouchData.centerPoint.y) * 0.4;
+
+      this._startTouchEvent = this._lastTouchEvent;
+      this._startTouchData = this._lastTouchData;
+      this._startTime = browser.now();
+
+      if (isVerticalShove && Math.abs(pitchDelta) > 0) {
+        const events = [];
+        if (this._state === 'pending') events.push('pitchstart');
+        this._state = 'active';
+        events.push('pitch');
+        return { transform: { pitchDelta }, events };
+      }
+    }
+
+    touchend(e: TouchEvent) {
+      const stateBeforeEnd = this._state;
+      super.touchend(e);
+      if (stateBeforeEnd === 'active') return { events: ['pitchend'] };
+    }
+
+    touchcancel(e: TouchEvent) {
+      const stateBeforeCancel = this._state;
+      super.touchcancel(e);
+      if (stateBeforeCancel === 'active') return { events: ['pitchend']};
+    }
+}
+
+
+export { TouchHandler, TouchPanHandler, TouchZoomHandler, TouchRotateHandler, TouchPitchHandler };

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -3,11 +3,19 @@
 import {MapMouseEvent, MapTouchEvent, MapWheelEvent} from '../ui/events';
 import {Event} from '../util/evented';
 import DOM from '../util/dom';
+import browser from '../util/browser';
 import type Map from './map';
 import Handler from './handler/handler';
 import { TouchPanHandler, TouchZoomHandler, TouchRotateHandler, TouchPitchHandler } from './handler/touch';
-import {extend} from '../util/util';
+import {bezier, extend} from '../util/util';
 
+const defaultInertiaOptions = {
+    linearity: 0.15,
+    easing: bezier(0, 0, 0.15, 1),
+    deceleration: 3,
+    maxSpeed: 1.5
+};
+export type InertiaOptions = typeof defaultInertiaOptions;
 
 class HandlerManager {
   _map: Map;
@@ -16,12 +24,15 @@ class HandlerManager {
 
   /**
    * @private
+   * options.inertiaOptions - linearity, easing, duration, maxSpeed
    */
   constructor(map: Map, options?: Object) {
     this._map = map;
     this._el = this._map.getCanvasContainer();
     this._handlers = [];
     this._disableDuring = {};
+    this._inertiaOptions = options.inertiaOptions || defaultInertiaOptions;
+    this._inertiaBuffer = [];
 
     // Track whether map is currently moving, to compute start/move/end events
     this._eventsInProgress = {
@@ -53,7 +64,7 @@ class HandlerManager {
 
   _addDefaultHandlers() {
     this.add('touchRotate', new TouchRotateHandler(this._map), ['touchPitch']);
-    this.add('touchPitch', new TouchPitchHandler(this._map), ['touchRotate']);
+    this.add('touchPitch', new TouchPitchHandler(this._map), ['touchRotate', 'touchPan']);
     this.add('touchZoom', new TouchZoomHandler(this._map), ['touchPitch']);
     this.add('touchPan', new TouchPanHandler(this._map), ['touchPitch']);
   }
@@ -172,7 +183,11 @@ class HandlerManager {
   }
 
   updateMapTransform(settings) {
+    this._map.stop();
     const tr = this._map.transform;
+    this._drainInertiaBuffer();
+    this._inertiaBuffer.push([browser.now(), settings]);
+
     let { zoomDelta, bearingDelta, pitchDelta, setLocationAtPoint } = settings;
     if (zoomDelta) tr.zoom += zoomDelta;
     if (bearingDelta) tr.bearing += bearingDelta;
@@ -184,14 +199,121 @@ class HandlerManager {
     this._map._update();
   }
 
+  _drainInertiaBuffer() {
+      const inertia = this._inertiaBuffer,
+          now = browser.now(),
+          cutoff = 160;   //msec
+
+      while (inertia.length > 0 && now - inertia[0][0] > cutoff)
+          inertia.shift();
+  }
+
   get _moving() {
     for (const e of ['zoom', 'rotate', 'pitch', 'drag']) { if (this._eventsInProgress[e]) return true; }
     return false;
   }
 
+  _clampSpeed(speed) {
+    const { maxSpeed } = this._inertiaOptions;
+    if (Math.abs(speed) > maxSpeed) {
+        if (speed > 0) {
+            return maxSpeed;
+        } else {
+            return -maxSpeed;
+        }
+    } else {
+      return speed;
+    }
+  }
+
+  _onMoveEnd(originalEvent) {
+    this._drainInertiaBuffer();
+    if (this._inertiaBuffer.length < 2) {
+      this._map.fire(new Event('moveend', { originalEvent }));
+      return;
+    }
+
+    const {linearity, easing, maxSpeed, deceleration} = this._inertiaOptions;
+
+    let deltas = {
+      zoom: 0,
+      bearing: 0,
+      pitch: 0
+    };
+    let firstPoint, lastPoint;
+    for (const [time, settings] of this._inertiaBuffer) {
+      deltas.zoom += settings.zoomDelta || 0;
+      deltas.bearing += settings.bearingDelta || 0;
+      deltas.pitch += settings.pitchDelta || 0;
+      if (settings.setLocationAtPoint) {
+        if (!firstPoint) firstPoint = settings.setLocationAtPoint[1];
+        lastPoint = settings.setLocationAtPoint[1];
+      }
+    };
+
+    const lastEntry = this._inertiaBuffer[this._inertiaBuffer.length - 1];
+    const duration = (lastEntry[0] - this._inertiaBuffer[0][0]) / 1000;
+
+    const easeOptions = {};
+
+    // calculate speeds and adjust for increased initial animation speed when easing
+
+    if (firstPoint && lastPoint) {
+
+      let panOffset = lastPoint.sub(firstPoint);
+      const velocity = panOffset.mult(linearity / duration);
+      let panSpeed = velocity.mag(); // px/s
+
+      if (panSpeed > (maxSpeed * 1000)) {
+        panSpeed = maxSpeed * 1000;
+        velocity._unit()._mult(panSpeed);
+      }
+
+      const panEaseDuration = (panSpeed / (deceleration * 1000 * linearity));
+      easeOptions.easeDuration = Math.max(easeOptions.easeDuration || 0, panEaseDuration);
+      easeOptions.offset = velocity.mult(panEaseDuration / 2);
+      easeOptions.center = this._map.transform.center;
+    }
+
+    if (deltas.zoom) {
+      let zoomSpeed = this._clampSpeed((deltas.zoom * linearity) / duration);
+      const zoomEaseDuration = Math.abs(zoomSpeed / (deceleration * linearity)) * 1000;
+      const targetZoom = (this._map.transform.zoom) + zoomSpeed * zoomEaseDuration / 2000;
+      easeOptions.easeDuration = Math.max(easeOptions.easeDuration || 0, zoomEaseDuration);
+      easeOptions.zoom = targetZoom;
+    }
+
+    if (deltas.bearing) {
+      let bearingSpeed = this._clampSpeed((deltas.bearing * linearity) / duration);
+      const bearingEaseDuration = Math.abs(bearingSpeed / (deceleration * linearity)) * 1000;
+      const targetBearing = (this._map.transform.bearing) + bearingSpeed * bearingEaseDuration / 2000;
+      easeOptions.easeDuration = Math.max(easeOptions.easeDuration || 0, bearingEaseDuration);
+      easeOptions.bearing = targetBearing;
+    }
+
+    if (deltas.pitch) {
+      let pitchSpeed = this._clampSpeed((deltas.pitch * linearity) / duration);
+      const pitchEaseDuration = Math.abs(pitchSpeed / (deceleration * linearity)) * 1000;
+      const targetPitch = (this._map.transform.pitch) + pitchSpeed * pitchEaseDuration / 2000;
+      easeOptions.easeDuration = Math.max(easeOptions.easeDuration || 0, pitchEaseDuration);
+      easeOptions.pitch = targetPitch;
+    }
+
+    if (easeOptions.zoom || easeOptions.bearing) {
+      easeOptions.around = lastPoint ? this._map.unproject(lastPoint) : this._map.getCenter();
+    }
+
+    this._map.easeTo(extend(easeOptions, {
+        easing,
+        noMoveStart: true
+    }), { originalEvent });
+
+  }
+
   fireMapEvents(events, originalEvent) {
-    const alreadyMoving = this._moving;
+    let alreadyMoving = this._moving;
     const moveEvents = [];
+
     for (const event of events) {
       const eventType = event.replace('start', '').replace('end', '');
       if (event.endsWith('start')) {
@@ -203,7 +325,6 @@ class HandlerManager {
         if (!this._eventsInProgress[eventType]) { continue; } // spurious end event, don't fire
         else { this._eventsInProgress[eventType] = false; }
         if (!this._moving && moveEvents.indexOf('moveend') < 0) { moveEvents.push('moveend'); }
-
       } else {
         if (!this._eventsInProgress[eventType]) {
           // We never got a corresponding start event for some reason; fire it now & update event progress state
@@ -219,7 +340,14 @@ class HandlerManager {
 
       this._map.fire(new Event(event, { originalEvent }));
     }
-    for (const moveEvent of moveEvents) this._map.fire(new Event(moveEvent, { originalEvent }));
+    for (const moveEvent of moveEvents) {
+      if (moveEvent === 'moveend') {
+        const activeHandlers = this._handlers.filter(([name, handler]) => handler._state === 'active');
+        if (activeHandlers.length === 0) this._onMoveEnd(originalEvent);
+      } else {
+        this._map.fire(new Event(moveEvent, { originalEvent }))
+      }
+    }
   }
 }
 

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -1,0 +1,220 @@
+// @flow
+
+import {MapMouseEvent, MapTouchEvent, MapWheelEvent} from '../ui/events';
+import {Event} from '../util/evented';
+import DOM from '../util/dom';
+import type Map from './map';
+import Handler from './handler/handler';
+import {extend} from '../util/util';
+
+
+class HandlerManager {
+  _map: Map;
+  _el: HTMLElement;
+  _handlers: Array<Handler>;
+
+  /**
+   * @private
+   */
+  constructor(map: Map, options?: Object) {
+    this._map = map;
+    this._el = this._map.getCanvasContainer();
+    this._handlers = [];
+    this._disableDuring = {};
+
+    // Track whether map is currently moving, to compute start/move/end events
+    this._eventsInProgress = {
+      zoom: false,
+      rotate: false,
+      pitch: false,
+      drag: false
+    };
+
+
+    // Bind touchstart and touchmove with passive: false because, even though
+    // they only fire a map events and therefore could theoretically be
+    // passive, binding with passive: true causes iOS not to respect
+    // e.preventDefault() in _other_ handlers, even if they are non-passive
+    // (see https://bugs.webkit.org/show_bug.cgi?id=184251)
+    this.addTouchListener('touchstart', {passive: false});
+    this.addTouchListener('touchmove', {passive: false});
+    this.addTouchListener('touchend');
+    this.addTouchListener('touchcancel');
+
+    this.addMouseListener('mousedown');
+    this.addMouseListener('mousemove');
+    this.addMouseListener('mouseup');
+    this.addMouseListener('mouseover');
+    this.addMouseListener('mouseout');
+  }
+
+  list() {
+    return this._handlers.map(([name, handler]) => name);
+  }
+
+  get length() {
+    return this._handlers.length;
+  }
+
+  add(handlerName: string, handler: Handler, disableDuring: Array<string>) {
+    if (!handlerName || !(/^[a-z]+[a-zA-Z]*$/.test(handlerName))) throw new Error('Must provide a valid handlerName string');
+    if (!handler || !(handler instanceof Handler)) throw new Error('Must provide a valid Handler instance');
+
+    if (this[handlerName]) throw new Error(`Cannot add ${handlerName}: a handler with that name already exists`);
+    for (const [existingName, existingHandler] of this._handlers) {
+      if (existingHandler === handler) throw new Error(`Cannot add ${handler} as ${handlerName}: handler already exists as ${existingName}`);
+    }
+    this._handlers.push([handlerName, handler]);
+    this[handlerName] = handler;
+
+    if (disableDuring) {
+      for (const otherHandler of disableDuring) {
+        if (!this[otherHandler]) throw new Error(`Cannot disable ${handlerName} during ${otherHandler}: No such handler ${otherHandler}`);
+      }
+      this._disableDuring[handlerName] = disableDuring;
+    }
+  }
+
+  remove(handlerName: string) {
+    if (!handlerName || typeof handlerName !== 'string') throw new Error('Must provide a valid handlerName string');
+    if (!this[handlerName]) throw new Error(`Handler ${handlerName} not found`);
+    const newHandlers = this._handlers.filter(([existingName, existingHandler]) => {
+      if (existingName === handlerName) {
+        delete this[handlerName];
+        return false;
+      }
+      return true;
+    });
+    this._handlers = newHandlers;
+  }
+
+  removeAll() {
+    for (const [handlerName, _] of this._handlers) this.remove(handlerName);
+  }
+
+  disableAll() {
+    for (const [_, handler] of this._handlers) handler.disable();
+  }
+
+  enableAll() {
+    for (const [_, handler] of this._handlers) handler.enable();
+  }
+
+  addListener(mapEventClass: Event, eventType: string, options?: Object) {
+    const listener = (e: Event) => {
+      this._map.fire(new mapEventClass(eventType, this._map, e));
+      this.processInputEvent(e);
+    };
+    DOM.addEventListener(this._el, eventType, listener, options);
+  }
+
+  addTouchListener(eventType: string, options?: Object) {
+    this.addListener(MapTouchEvent, eventType, options);
+  }
+
+  addMouseListener(eventType: string, options?: Object) {
+    this.addListener(MapMouseEvent, eventType, options);
+  }
+
+
+  processInputEvent(e: MouseEvent | TouchEvent | KeyboardEvent | WheelEvent) {
+    if (e.cancelable) e.preventDefault();
+    let transformSettings;
+    let activeHandlers = [];
+    let preUpdateEvents = [];
+    let postUpdateEvents = [];
+
+    for (const [name, handler] of this._handlers) {
+      if (!handler.isEnabled()) continue;
+      let data = handler.processInputEvent(e);
+      if (!data) continue;
+
+      if (this._disableDuring[name]) {
+        const conflicts = this._disableDuring[name].filter(otherHandler => activeHandlers.indexOf(otherHandler) > -1);
+        if (conflicts.length > 0) {
+          // A handler that was active but is now overridden should still be able to return end events to fire
+          if (data.events) {
+            data.events.filter(e => e.endsWith('end') && postUpdateEvents.indexOf(e) < 0).map(e => postUpdateEvents.push(e));
+          }
+          handler.reset(e);
+          continue;
+        }
+      }
+
+      if (data.transform) {
+        const merged = data.transform
+        if (!!transformSettings) extend(merged, transformSettings)
+        transformSettings = merged;
+      }
+
+      if (data.events) {
+        for (const event of data.events) {
+          if (event.endsWith('start')) {
+            if (preUpdateEvents.indexOf(event) < 0) preUpdateEvents.push(event);
+          } else if (postUpdateEvents.indexOf(event) < 0) {
+            postUpdateEvents.push(event);
+          }
+        }
+      }
+      activeHandlers.push(name);
+    }
+
+    if (preUpdateEvents.length > 0) this.fireMapEvents(preUpdateEvents, e); // movestart events
+    if (transformSettings) this.updateMapTransform(transformSettings);
+    if (postUpdateEvents.length > 0) this.fireMapEvents(postUpdateEvents, e); // move and moveend events
+  }
+
+  updateMapTransform(settings) {
+    const tr = this._map.transform;
+    let { zoomDelta, bearingDelta, pitchDelta, setLocationAtPoint } = settings;
+    if (zoomDelta) tr.zoom += zoomDelta;
+    if (bearingDelta) tr.bearing += bearingDelta;
+    if (pitchDelta) tr.pitch += pitchDelta;
+    if (setLocationAtPoint && setLocationAtPoint.length === 2) {
+      let [loc, pt] = setLocationAtPoint;
+      tr.setLocationAtPoint(loc, pt);
+    }
+    this._map._update();
+  }
+
+  get _moving() {
+    for (const e of ['zoom', 'rotate', 'pitch', 'drag']) { if (this._eventsInProgress[e]) return true; }
+    return false;
+  }
+
+  fireMapEvents(events, originalEvent) {
+    const alreadyMoving = this._moving;
+    const moveEvents = [];
+    for (const event of events) {
+      const eventType = event.replace('start', '').replace('end', '');
+      if (event.endsWith('start')) {
+        if (this._eventsInProgress[eventType]) { continue; } // spurious start event, don't fire
+        else { this._eventsInProgress[eventType] = true; }
+        if (!alreadyMoving && moveEvents.indexOf('movestart') < 0) { moveEvents.push('movestart'); }
+
+      } else if (event.endsWith('end')) {
+        if (!this._eventsInProgress[eventType]) { continue; } // spurious end event, don't fire
+        else { this._eventsInProgress[eventType] = false; }
+        if (!this._moving && moveEvents.indexOf('moveend') < 0) { moveEvents.push('moveend'); }
+
+      } else {
+        if (!this._eventsInProgress[eventType]) {
+          // We never got a corresponding start event for some reason; fire it now & update event progress state
+          this._map.fire(new Event(eventType + 'start', { originalEvent }));
+          if (!alreadyMoving) {
+            this._map.fire(new Event('movestart', { originalEvent }));
+            alreadyMoving = true;
+          }
+          this._eventsInProgress[eventType] = true;
+        }
+        if (moveEvents.indexOf('move') < 0) { moveEvents.push('move'); }
+      }
+
+      this._map.fire(new Event(event, { originalEvent }));
+    }
+    for (const moveEvent of moveEvents) this._map.fire(new Event(moveEvent, { originalEvent }));
+  }
+}
+
+
+export default HandlerManager;

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -5,6 +5,7 @@ import {Event} from '../util/evented';
 import DOM from '../util/dom';
 import type Map from './map';
 import Handler from './handler/handler';
+import { TouchPanHandler, TouchZoomHandler, TouchRotateHandler, TouchPitchHandler } from './handler/touch';
 import {extend} from '../util/util';
 
 
@@ -31,6 +32,8 @@ class HandlerManager {
     };
 
 
+    this._addDefaultHandlers();
+
     // Bind touchstart and touchmove with passive: false because, even though
     // they only fire a map events and therefore could theoretically be
     // passive, binding with passive: true causes iOS not to respect
@@ -46,6 +49,13 @@ class HandlerManager {
     this.addMouseListener('mouseup');
     this.addMouseListener('mouseover');
     this.addMouseListener('mouseout');
+  }
+
+  _addDefaultHandlers() {
+    this.add('touchRotate', new TouchRotateHandler(this._map), ['touchPitch']);
+    this.add('touchPitch', new TouchPitchHandler(this._map), ['touchRotate']);
+    this.add('touchZoom', new TouchZoomHandler(this._map), ['touchPitch']);
+    this.add('touchPan', new TouchPanHandler(this._map), ['touchPitch']);
   }
 
   list() {
@@ -68,9 +78,6 @@ class HandlerManager {
     this[handlerName] = handler;
 
     if (disableDuring) {
-      for (const otherHandler of disableDuring) {
-        if (!this[otherHandler]) throw new Error(`Cannot disable ${handlerName} during ${otherHandler}: No such handler ${otherHandler}`);
-      }
       this._disableDuring[handlerName] = disableDuring;
     }
   }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -263,6 +263,7 @@ const defaultOptions = {
 class Map extends Camera {
     style: Style;
     painter: Painter;
+    handlers: HandlerManager;
 
     _container: HTMLElement;
     _missingCSSCanary: HTMLElement;
@@ -301,50 +302,49 @@ class Map extends Camera {
     _localIdeographFontFamily: string;
     _requestManager: RequestManager;
     _locale: Object;
-    _handlers: HandlerManager;
 
-    // /**
-    //  * The map's {@link ScrollZoomHandler}, which implements zooming in and out with a scroll wheel or trackpad.
-    //  * Find more details and examples using `scrollZoom` in the {@link ScrollZoomHandler} section.
-    //  */
-    // scrollZoom: ScrollZoomHandler;
-    //
-    // /**
-    //  * The map's {@link BoxZoomHandler}, which implements zooming using a drag gesture with the Shift key pressed.
-    //  * Find more details and examples using `boxZoom` in the {@link BoxZoomHandler} section.
-    //  */
-    // boxZoom: BoxZoomHandler;
-    //
-    // /**
-    //  * The map's {@link DragRotateHandler}, which implements rotating the map while dragging with the right
-    //  * mouse button or with the Control key pressed. Find more details and examples using `dragRotate`
-    //  * in the {@link DragRotateHandler} section.
-    //  */
-    // dragRotate: DragRotateHandler;
-    //
-    // /**
-    //  * The map's {@link DragPanHandler}, which implements dragging the map with a mouse or touch gesture.
-    //  * Find more details and examples using `dragPan` in the {@link DragPanHandler} section.
-    //  */
-    // dragPan: DragPanHandler;
-    //
-    // /**
-    //  * The map's {@link KeyboardHandler}, which allows the user to zoom, rotate, and pan the map using keyboard
-    //  * shortcuts. Find more details and examples using `keyboard` in the {@link KeyboardHandler} section.
-    //  */
-    // keyboard: KeyboardHandler;
-    //
-    // /**
-    //  * The map's {@link DoubleClickZoomHandler}, which allows the user to zoom by double clicking.
-    //  * Find more details and examples using `doubleClickZoom` in the {@link DoubleClickZoomHandler} section.
-    //  */
-    // doubleClickZoom: DoubleClickZoomHandler;
-    //
-    // /**
-    //  * The map's {@link TouchZoomRotateHandler}, which allows the user to zoom or rotate the map with touch gestures.
-    //  * Find more details and examples using `touchZoomRotate` in the {@link TouchZoomRotateHandler} section.
-    //  */
-    // touchZoomRotate: TouchZoomRotateHandler;
+    /**
+     * The map's {@link ScrollZoomHandler}, which implements zooming in and out with a scroll wheel or trackpad.
+     * Find more details and examples using `scrollZoom` in the {@link ScrollZoomHandler} section.
+     */
+    scrollZoom: ScrollZoomHandler;
+
+    /**
+     * The map's {@link BoxZoomHandler}, which implements zooming using a drag gesture with the Shift key pressed.
+     * Find more details and examples using `boxZoom` in the {@link BoxZoomHandler} section.
+     */
+    boxZoom: BoxZoomHandler;
+
+    /**
+     * The map's {@link DragRotateHandler}, which implements rotating the map while dragging with the right
+     * mouse button or with the Control key pressed. Find more details and examples using `dragRotate`
+     * in the {@link DragRotateHandler} section.
+     */
+    dragRotate: DragRotateHandler;
+
+    /**
+     * The map's {@link DragPanHandler}, which implements dragging the map with a mouse or touch gesture.
+     * Find more details and examples using `dragPan` in the {@link DragPanHandler} section.
+     */
+    dragPan: DragPanHandler;
+
+    /**
+     * The map's {@link KeyboardHandler}, which allows the user to zoom, rotate, and pan the map using keyboard
+     * shortcuts. Find more details and examples using `keyboard` in the {@link KeyboardHandler} section.
+     */
+    keyboard: KeyboardHandler;
+
+    /**
+     * The map's {@link DoubleClickZoomHandler}, which allows the user to zoom by double clicking.
+     * Find more details and examples using `doubleClickZoom` in the {@link DoubleClickZoomHandler} section.
+     */
+    doubleClickZoom: DoubleClickZoomHandler;
+
+    /**
+     * The map's {@link TouchZoomRotateHandler}, which allows the user to zoom or rotate the map with touch gestures.
+     * Find more details and examples using `touchZoomRotate` in the {@link TouchZoomRotateHandler} section.
+     */
+    touchZoomRotate: TouchZoomRotateHandler;
 
     constructor(options: MapOptions) {
         PerformanceUtils.mark(PerformanceMarkers.create);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -13,7 +13,8 @@ import EvaluationParameters from '../style/evaluation_parameters';
 import Painter from '../render/painter';
 import Transform from '../geo/transform';
 import Hash from './hash';
-import bindHandlers from './bind_handlers';
+// import bindHandlers from './bind_handlers';
+import HandlerManager from './handler_manager';
 import Camera from './camera';
 import LngLat from '../geo/lng_lat';
 import LngLatBounds from '../geo/lng_lat_bounds';
@@ -300,49 +301,50 @@ class Map extends Camera {
     _localIdeographFontFamily: string;
     _requestManager: RequestManager;
     _locale: Object;
+    _handlers: HandlerManager;
 
-    /**
-     * The map's {@link ScrollZoomHandler}, which implements zooming in and out with a scroll wheel or trackpad.
-     * Find more details and examples using `scrollZoom` in the {@link ScrollZoomHandler} section.
-     */
-    scrollZoom: ScrollZoomHandler;
-
-    /**
-     * The map's {@link BoxZoomHandler}, which implements zooming using a drag gesture with the Shift key pressed.
-     * Find more details and examples using `boxZoom` in the {@link BoxZoomHandler} section.
-     */
-    boxZoom: BoxZoomHandler;
-
-    /**
-     * The map's {@link DragRotateHandler}, which implements rotating the map while dragging with the right
-     * mouse button or with the Control key pressed. Find more details and examples using `dragRotate`
-     * in the {@link DragRotateHandler} section.
-     */
-    dragRotate: DragRotateHandler;
-
-    /**
-     * The map's {@link DragPanHandler}, which implements dragging the map with a mouse or touch gesture.
-     * Find more details and examples using `dragPan` in the {@link DragPanHandler} section.
-     */
-    dragPan: DragPanHandler;
-
-    /**
-     * The map's {@link KeyboardHandler}, which allows the user to zoom, rotate, and pan the map using keyboard
-     * shortcuts. Find more details and examples using `keyboard` in the {@link KeyboardHandler} section.
-     */
-    keyboard: KeyboardHandler;
-
-    /**
-     * The map's {@link DoubleClickZoomHandler}, which allows the user to zoom by double clicking.
-     * Find more details and examples using `doubleClickZoom` in the {@link DoubleClickZoomHandler} section.
-     */
-    doubleClickZoom: DoubleClickZoomHandler;
-
-    /**
-     * The map's {@link TouchZoomRotateHandler}, which allows the user to zoom or rotate the map with touch gestures.
-     * Find more details and examples using `touchZoomRotate` in the {@link TouchZoomRotateHandler} section.
-     */
-    touchZoomRotate: TouchZoomRotateHandler;
+    // /**
+    //  * The map's {@link ScrollZoomHandler}, which implements zooming in and out with a scroll wheel or trackpad.
+    //  * Find more details and examples using `scrollZoom` in the {@link ScrollZoomHandler} section.
+    //  */
+    // scrollZoom: ScrollZoomHandler;
+    //
+    // /**
+    //  * The map's {@link BoxZoomHandler}, which implements zooming using a drag gesture with the Shift key pressed.
+    //  * Find more details and examples using `boxZoom` in the {@link BoxZoomHandler} section.
+    //  */
+    // boxZoom: BoxZoomHandler;
+    //
+    // /**
+    //  * The map's {@link DragRotateHandler}, which implements rotating the map while dragging with the right
+    //  * mouse button or with the Control key pressed. Find more details and examples using `dragRotate`
+    //  * in the {@link DragRotateHandler} section.
+    //  */
+    // dragRotate: DragRotateHandler;
+    //
+    // /**
+    //  * The map's {@link DragPanHandler}, which implements dragging the map with a mouse or touch gesture.
+    //  * Find more details and examples using `dragPan` in the {@link DragPanHandler} section.
+    //  */
+    // dragPan: DragPanHandler;
+    //
+    // /**
+    //  * The map's {@link KeyboardHandler}, which allows the user to zoom, rotate, and pan the map using keyboard
+    //  * shortcuts. Find more details and examples using `keyboard` in the {@link KeyboardHandler} section.
+    //  */
+    // keyboard: KeyboardHandler;
+    //
+    // /**
+    //  * The map's {@link DoubleClickZoomHandler}, which allows the user to zoom by double clicking.
+    //  * Find more details and examples using `doubleClickZoom` in the {@link DoubleClickZoomHandler} section.
+    //  */
+    // doubleClickZoom: DoubleClickZoomHandler;
+    //
+    // /**
+    //  * The map's {@link TouchZoomRotateHandler}, which allows the user to zoom or rotate the map with touch gestures.
+    //  * Find more details and examples using `touchZoomRotate` in the {@link TouchZoomRotateHandler} section.
+    //  */
+    // touchZoomRotate: TouchZoomRotateHandler;
 
     constructor(options: MapOptions) {
         PerformanceUtils.mark(PerformanceMarkers.create);
@@ -368,7 +370,7 @@ class Map extends Camera {
         const transform = new Transform(options.minZoom, options.maxZoom, options.minPitch, options.maxPitch, options.renderWorldCopies);
         super(transform, options);
 
-        this._interactive = options.interactive;
+        // this._interactive = options.interactive;
         this._maxTileCacheSize = options.maxTileCacheSize;
         this._failIfMajorPerformanceCaveat = options.failIfMajorPerformanceCaveat;
         this._preserveDrawingBuffer = options.preserveDrawingBuffer;
@@ -424,7 +426,9 @@ class Map extends Camera {
             window.addEventListener('resize', this._onWindowResize, false);
         }
 
-        bindHandlers(this, options);
+        // bindHandlers(this, options);
+        this.handlers = new HandlerManager(this, options);
+
 
         const hashName = (typeof options.hash === 'string' && options.hash) || undefined;
         this._hash = options.hash && (new Hash(hashName)).addTo(this);
@@ -829,10 +833,7 @@ class Map extends Camera {
      * var isMoving = map.isMoving();
      */
     isMoving(): boolean {
-        return this._moving ||
-            this.dragPan.isActive() ||
-            this.dragRotate.isActive() ||
-            this.scrollZoom.isActive();
+        return this._moving;
     }
 
     /**
@@ -841,8 +842,7 @@ class Map extends Camera {
      * var isZooming = map.isZooming();
      */
     isZooming(): boolean {
-        return this._zooming ||
-            this.scrollZoom.isZooming();
+        return this._zooming;
     }
 
     /**
@@ -851,8 +851,7 @@ class Map extends Camera {
      * map.isRotating();
      */
     isRotating(): boolean {
-        return this._rotating ||
-            this.dragRotate.isActive();
+        return this._rotating;
     }
 
     _createDelegatedListener(type: MapEvent, layerId: any, listener: any) {

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -115,7 +115,7 @@ DOM.mousePos = function (el: HTMLElement, e: MouseEvent | window.TouchEvent | To
 DOM.touchPos = function (el: HTMLElement, e: TouchEvent) {
     const rect = el.getBoundingClientRect(),
         points = [];
-    const touches = (e.type === 'touchend') ? e.changedTouches : e.touches;
+    const touches = (e.type === 'touchend' && e.touches.length === 0) ? e.changedTouches : e.touches;
     for (let i = 0; i < touches.length; i++) {
         points.push(new Point(
             touches[i].clientX - rect.left - el.clientLeft,

--- a/test/unit/ui/handler/handler.test.js
+++ b/test/unit/ui/handler/handler.test.js
@@ -1,0 +1,61 @@
+import {test} from '../../../util/test';
+import Handler from '../../../../src/ui/handler/handler';
+import window from '../../../../src/util/window';
+import Map from '../../../../src/ui/map';
+import DOM from '../../../../src/util/dom';
+
+
+function createMap(t) {
+    t.stub(Map.prototype, '_detectMissingCSS');
+    return new Map({
+        container: DOM.create('div', '', window.document.body),
+    });
+}
+
+
+test('Methods .enable(), .disable(), and .isEnabled() work as expected', (t) => {
+    const map = createMap(t);
+    const h = new Handler(map);
+    t.ok(h.isEnabled());
+    t.equal(h._state, 'enabled');
+    h.disable();
+    t.notOk(h.isEnabled());
+    t.equal(h._state, 'disabled');
+    h.enable();
+    t.ok(h.isEnabled());
+    t.end();
+});
+
+test('New Handler is enabled by default', (t) => {
+    const map = createMap(t);
+    const h = new Handler(map);
+    t.ok(h.isEnabled(), 'should be enabled');
+    t.end();
+});
+
+test('Methods .setOptions() and .getOptions() work as expected', (t) => {
+    const map = createMap(t);
+    const h = new Handler(map);
+    t.deepEqual(h.getOptions(), {}, '.getOptions() should return options object');
+    t.throws(() => h.setOptions({ happy: true }), /happy/, '.setOptions() should throw error on unrecognized options');
+    h._options.happy = false;
+    t.doesNotThrow(() => h.setOptions({ happy: true }), '.setOptions() should not throw error on recognized options');
+    t.ok(h._options.happy, 'options should be set as ._options properties');
+    t.deepEqual(h.getOptions(), { happy: true }, '.getOptions() should return the up to date options');
+    t.end();
+});
+
+test('.processInputEvent() method delegates to event-type methods accordingly', (t) => {
+    const warnings = [];
+    t.stub(console, 'warn').callsFake((...args) => warnings.push(args.join(' ')));
+    const map = createMap(t);
+    const h = new Handler(map);
+    const touchstart = new window.TouchEvent('touchstart', { touches: [{ clientX: 1, clientY: 1 }] });
+    t.doesNotThrow(() => h.processInputEvent('notanevent'), '.processInputEvent() should not throw error, even for unrecognized event types');
+    t.ok(/notanevent/.test(warnings[0]), 'should give appropriate warning if input event is not a valid type');
+    t.doesNotThrow(() => h.processInputEvent(touchstart), '.processInputEvent() should not throw error, even for unrecognized event types');
+    t.notOk(h.processInputEvent(touchstart), 'if no method exists for the event type, .processInputEvent() should return nothing');
+    h.touchstart = function(e) { return e.touches[0].clientX; };
+    t.equal(h.processInputEvent(touchstart), 1, 'if a method exists for the event type, .processInputEvent() should pass through its return value');
+    t.end();
+});

--- a/test/unit/ui/handler/keyboard.test.js
+++ b/test/unit/ui/handler/keyboard.test.js
@@ -1,0 +1,158 @@
+import {test} from '../../../util/test';
+import KeyboardHandler from '../../../../src/ui/handler/keyboard';
+import Map from '../../../../src/ui/map';
+import DOM from '../../../../src/util/dom';
+import window from '../../../../src/util/window';
+import simulate from '../../../util/simulate_interaction';
+import {extend} from '../../../../src/util/util';
+
+function createMap(t, options) {
+    t.stub(Map.prototype, '_detectMissingCSS');
+    return new Map(extend({
+        container: DOM.create('div', '', window.document.body),
+    }, options));
+}
+
+test('New KeyboardHandler is in "enabled" state', (t) => {
+    const map = createMap(t);
+    const h = new KeyboardHandler(map);
+    t.ok(h.isEnabled());
+    t.equal(h._state, 'enabled');
+    t.end();
+});
+
+
+test('KeyboardHandler is added to manager by default', (t) => {
+    const map = createMap(t);
+    const hm = map.handlers;
+    t.ok(hm.keyboard);
+    const h = hm.keyboard;
+    t.ok(h.isEnabled());
+    t.end();
+});
+
+test('KeyboardHandler responds to keydown events', (t) => {
+    const map = createMap(t);
+    const hm = map.handlers;
+    const h = hm.keyboard;
+    t.spy(h, 'keydown');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 32, key: " " });
+    t.ok(h.keydown.called, 'handler keydown method should be called on keydown event');
+    t.equal(h.keydown.getCall(0).args[0].keyCode, 32, 'keydown method should be called with the correct event');
+    t.end();
+});
+
+test('KeyboardHandler pans map in response to arrow keys', (t) => {
+    const map = createMap(t, {zoom: 10, center: [0,0]});
+    const hm = map.handlers;
+    const h = hm.keyboard;
+    t.spy(map, 'easeTo');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 32, key: " " });
+    t.notOk(map.easeTo.called, 'pressing a non-arrow key should have no effect');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 37, key: "ArrowLeft" });
+    t.ok(map.easeTo.called, 'pressing the left arrow key should trigger an easeTo animation');
+    let easeToArgs = map.easeTo.getCall(0).args[0];
+    t.equal(easeToArgs.offset[0], 100, 'pressing the left arrow key should offset map positively in X direction');
+    t.equal(easeToArgs.offset[1], 0, 'pressing the left arrow key should not offset map in Y direction');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 39, key: "ArrowRight" });
+    t.ok(map.easeTo.callCount === 2, 'pressing the right arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(1).args[0];
+    t.equal(easeToArgs.offset[0], -100, 'pressing the right arrow key should offset map negatively in X direction');
+    t.equal(easeToArgs.offset[1], 0, 'pressing the right arrow key should not offset map in Y direction');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 40, key: "ArrowDown" });
+    t.ok(map.easeTo.callCount === 3, 'pressing the down arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(2).args[0];
+    t.equal(easeToArgs.offset[0], 0, 'pressing the down arrow key should not offset map in X direction');
+    t.equal(easeToArgs.offset[1], -100, 'pressing the down arrow key should offset map negatively in Y direction');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 38, key: "ArrowUp" });
+    t.ok(map.easeTo.callCount === 4, 'pressing the up arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(3).args[0];
+    t.equal(easeToArgs.offset[0], 0, 'pressing the up arrow key should not offset map in X direction');
+    t.equal(easeToArgs.offset[1], 100, 'pressing the up arrow key should offset map positively in Y direction');
+
+    t.end();
+});
+
+test('KeyboardHandler rotates map in response to Shift+left/right arrow keys', async (t) => {
+    const map = createMap(t, {zoom: 10, center: [0,0], bearing: 0});
+    const hm = map.handlers;
+    const h = hm.keyboard;
+    t.spy(map, 'easeTo');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 32, key: " " });
+    t.notOk(map.easeTo.called, 'pressing a non-arrow key should have no effect');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 37, key: "ArrowLeft", shiftKey: true });
+    t.ok(map.easeTo.called, 'pressing Shift + left arrow key should trigger an easeTo animation');
+    let easeToArgs = map.easeTo.getCall(0).args[0];
+    t.equal(easeToArgs.bearing, -15, 'pressing Shift + left arrow key should rotate map clockwise');
+    t.equal(easeToArgs.offset[0], 0, 'pressing Shift + left arrow key should not offset map in X direction');
+
+    map.setBearing(0);
+    simulate.keydown(map.getCanvas(), { keyCode: 39, key: "ArrowRight", shiftKey: true });
+    t.ok(map.easeTo.callCount === 2, 'pressing Shift + right arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(1).args[0];
+    t.equal(easeToArgs.bearing, 15, 'pressing Shift + right arrow key should rotate map counterclockwise');
+    t.equal(easeToArgs.offset[0], 0, 'pressing Shift + right arrow key should not offset map in X direction');
+
+    t.end();
+});
+
+test('KeyboardHandler pitches map in response to Shift+up/down arrow keys', async (t) => {
+    const map = createMap(t, {zoom: 10, center: [0,0], pitch: 30});
+    const hm = map.handlers;
+    const h = hm.keyboard;
+    t.spy(map, 'easeTo');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 32, key: " " });
+    t.notOk(map.easeTo.called, 'pressing a non-arrow key should have no effect');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 40, key: "ArrowDown", shiftKey: true });
+    t.ok(map.easeTo.called, 'pressing Shift + down arrow key should trigger an easeTo animation');
+    let easeToArgs = map.easeTo.getCall(0).args[0];
+    t.equal(easeToArgs.pitch, 20, 'pressing Shift + down arrow key should pitch map less');
+    t.equal(easeToArgs.offset[1], 0, 'pressing Shift + down arrow key should not offset map in Y direction');
+
+    map.setPitch(30);
+    simulate.keydown(map.getCanvas(), { keyCode: 38, key: "ArrowUp", shiftKey: true });
+    t.ok(map.easeTo.callCount === 2, 'pressing Shift + up arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(1).args[0];
+    t.equal(easeToArgs.pitch, 40, 'pressing Shift + up arrow key should pitch map more');
+    t.equal(easeToArgs.offset[1], 0, 'pressing Shift + up arrow key should not offset map in Y direction');
+
+    t.end();
+});
+
+test('KeyboardHandler zooms map in response to -/+ keys', (t) => {
+    const map = createMap(t, {zoom: 10, center: [0,0]});
+    const hm = map.handlers;
+    const h = hm.keyboard;
+    t.spy(map, 'easeTo');
+
+    simulate.keydown(map.getCanvas(), { keyCode: 187, key: "Equal" });
+    t.equal(map.easeTo.callCount, 1, 'pressing the +/= key should trigger an easeTo animation');
+    t.equal(map.easeTo.getCall(0).args[0].zoom, 11, 'pressing the +/= key should zoom map in');
+
+    map.setZoom(10);
+    simulate.keydown(map.getCanvas(), { keyCode: 187, key: "Equal", shiftKey: true });
+    t.equal(map.easeTo.callCount, 2, 'pressing Shift + +/= key should trigger an easeTo animation');
+    t.equal(map.easeTo.getCall(1).args[0].zoom, 12, 'pressing Shift + +/= key should zoom map in more');
+
+    map.setZoom(10);
+    simulate.keydown(map.getCanvas(), { keyCode: 189, key: "Minus" });
+    t.equal(map.easeTo.callCount, 3, 'pressing the -/_ key should trigger an easeTo animation');
+    t.equal(map.easeTo.getCall(2).args[0].zoom, 9, 'pressing the -/_ key should zoom map out');
+
+    map.setZoom(10);
+    simulate.keydown(map.getCanvas(), { keyCode: 189, key: "Minus", shiftKey: true });
+    t.equal(map.easeTo.callCount, 4, 'pressing Shift + -/_ key should trigger an easeTo animation');
+    t.equal(map.easeTo.getCall(3).args[0].zoom, 8, 'pressing Shift + -/_ key should zoom map out more');
+
+    t.end();
+});

--- a/test/unit/ui/handler/touch.test.js
+++ b/test/unit/ui/handler/touch.test.js
@@ -1,0 +1,443 @@
+import {test} from '../../../util/test';
+import { TouchZoomHandler } from '../../../../src/ui/handler/touch';
+import Map from '../../../../src/ui/map';
+import DOM from '../../../../src/util/dom';
+import window from '../../../../src/util/window';
+import simulate from '../../../util/simulate_interaction';
+import {extend} from '../../../../src/util/util';
+
+function createMap(t, options) {
+    t.stub(Map.prototype, '_detectMissingCSS');
+    return new Map(extend({
+        container: DOM.create('div', '', window.document.body),
+    }, options));
+}
+
+function setupEventSpies(eventTypes, map, t) {
+  const spies = {};
+  for (const eventType of eventTypes) {
+    for (const eventStage of ['start', '', 'end']) {
+      const event = eventType + eventStage;
+      const spy = t.spy();
+      spies[event] = spy;
+      map.on(event, spy);
+    }
+  }
+  return spies;
+};
+
+test('New TouchZoomHandler is in "enabled" state', (t) => {
+    const map = createMap(t);
+    const h = new TouchZoomHandler(map);
+    t.ok(h.isEnabled());
+    t.equal(h._state, 'enabled');
+    t.end();
+});
+
+test('TouchPanHandler is added to manager by default', (t) => {
+    const map = createMap(t);
+    const hm = map.handlers;
+    t.ok(hm.touchPan);
+    const h = hm.touchPan;
+    t.ok(h.isEnabled());
+    t.end();
+});
+
+test('TouchZoomHandler is added to manager by default', (t) => {
+    const map = createMap(t);
+    const hm = map.handlers;
+    t.ok(hm.touchZoom);
+    const h = hm.touchZoom;
+    t.ok(h.isEnabled());
+    t.end();
+});
+
+test('TouchRotateHandler is added to manager by default', (t) => {
+    const map = createMap(t);
+    const hm = map.handlers;
+    t.ok(hm.touchRotate);
+    const h = hm.touchRotate;
+    t.ok(h.isEnabled());
+    t.end();
+});
+
+test('TouchPitchHandler is added to manager by default', (t) => {
+    const map = createMap(t);
+    const hm = map.handlers;
+    t.ok(hm.touchPitch);
+    const h = hm.touchPitch;
+    t.ok(h.isEnabled());
+    t.end();
+});
+
+test('TouchPanHandler responds to touchstart/end/cancel events', (t) => {
+    const map = createMap(t, {zoom: 5});
+    const h = map.handlers.touchPan;
+
+    const spies = setupEventSpies(['drag', 'move'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
+    t.equal(h._state, 'pending', 'single-touch touchstart event should trigger "pending" state');
+    t.ok(h._startTouchEvent);
+    t.equal(h._startTouchEvent.touches.length, 1);
+    t.notOk(h._startTouchData.isMultiTouch);
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired on touchstart');
+
+    simulate.touchend(map.getCanvas(), {changedTouches: [{clientX: 1, clientY: 1}]});
+    t.equal(h._state, 'enabled', 'touchend should reset handler to "enabled" state');
+    t.notOk(h._startTouchEvent);
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired on touchend if handler was never active');
+
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 3, clientY: 4}]});
+    t.equal(h._startTouchEvent.touches.length, 2);
+    t.ok(h._startTouchData.isMultiTouch);
+    t.equal(h._state, 'pending', 'multi-touch touchstart event should trigger "pending" state');
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired on touchstart');
+
+    simulate.touchend(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}], changedTouches: [{clientX: 3, clientY: 4}]});
+    t.equal(h._state, 'pending', 'touchend should not deactivate handler if any fingers are still touching');
+    t.equal(h._startTouchEvent.touches.length, 1);
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired on touchend if handler was never active');
+
+
+    simulate.touchcancel(map.getCanvas(), {changedTouches: [{clientX: 0, clientY: 0}]});
+    t.equal(h._state, 'enabled', 'touchcancel should reset handler to "enabled" state');
+    t.notOk(h._startTouchEvent);
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired on touchcancel if handler was never active');
+    t.end();
+});
+
+test('TouchPanHandler pans map & fires events appropriately on single-finger drag', (t) => {
+    const map = createMap(t, {zoom: 1, center: [0,0]});
+    const hm = map.handlers;
+    hm.disableAll();
+    const h = map.handlers.touchPan;
+    h.enable();
+    t.spy(h, 'touchstart');
+    t.spy(h, 'touchmove');
+
+    const spies = setupEventSpies(['drag', 'move'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
+    for (const startEvent of ['dragstart', 'movestart']) t.equal(spies[startEvent].callCount, 0, `${startEvent} should not be fired until first movement`);
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 1, clientY: 1.5}]});
+    t.equal(h._state, 'pending', 'moving less than tapTolerance should not activate the handler');
+    t.ok(h.touchmove.called && !h.touchmove.returnValues[0], '.touchmove() should be called but return nothing');
+    t.ok(map.getCenter().lng === 0 && map.getCenter().lat === 0, 'manager should not pan the map');
+    for (const event in spies) t.equal(spies[event].callCount, 0, `${event} should not be fired if handler was not activated`);
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 3, clientY: 4}]});
+    t.equal(h._state, 'active', 'moving more than clickTolerance should activate the handler');
+    t.equal(h.touchmove.returnValues[1].transform.setLocationAtPoint.length, 2, '.touchmove() should return new location for transform');
+    t.deepEqual(h.touchmove.returnValues[1].events, ['dragstart', 'drag'], '.touchmove() should return start and move events to fire');
+    t.notEqual(map.getCenter().lng, 0, 'manager should change the map center lng');
+    t.notEqual(map.getCenter().lat, 0, 'manager should change the map center lat');
+
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0,  `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should be fired on first movement`);
+      else t.equal(spies[event].callCount, 1, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchend(map.getCanvas());
+    for (const endEvent of ['dragend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
+
+    t.end();
+});
+
+test('TouchPanHandler fires events appropriately when touch is canceled', (t) => {
+    const map = createMap(t, {zoom: 1, center: [0,0]});
+    const hm = map.handlers;
+    hm.disableAll();
+    hm.touchPan.enable();
+
+    const spies = setupEventSpies(['dragend', 'moveend'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 3, clientY: 4}]});
+    simulate.touchcancel(map.getCanvas());
+    for (const endEvent of ['dragend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchcancel if handler was active`);
+
+    t.end();
+});
+
+test('TouchPanHandler pans map & fires events appropriately when transitioning between single & multi-finger drag', (t) => {
+    const map = createMap(t, {zoom: 1, center: [0,0]});
+    const hm = map.handlers;
+    hm.disableAll();
+    const h = map.handlers.touchPan;
+    h.enable();
+    t.spy(h, 'touchmove');
+
+    const spies = setupEventSpies(['drag', 'move'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 3, clientY: 4}]});
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 3, clientY: 4}, {clientX: 1, clientY: 2}]});
+    t.equal(h._state, 'active', 'adding a finger should leave the handler active');
+    for (const startEvent of ['dragstart', 'movestart']) t.equal(spies[startEvent].callCount, 1, `${startEvent} should not be fired more than once`);
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 8, clientY: 4}, {clientX: 5, clientY: 2}]});
+    t.equal(h._state, 'active', 'multi-finger move should leave the handler active');
+    t.ok(h.touchmove.returnValues[1].transform.setLocationAtPoint.length, 2, '.touchmove() should return new location for transform');
+    t.deepEqual(h.touchmove.returnValues[1].events, ['drag'], '.touchmove() should return drag event to fire');
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0, `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should not be fired more than once`);
+      else t.equal(spies[event].callCount, 2, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchend(map.getCanvas(), {touches: [{clientX: 8, clientY: 4}], changedTouches: [{clientX: 5, clientY: 2}]});
+    for (const endEvent of ['dragend', 'moveend']) t.equal(spies[endEvent].callCount, 0, `${endEvent} should not be fired on touchend if any touches remain`);
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 3, clientY: 4}]});
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0, `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should not be fired more than once`);
+      else t.equal(spies[event].callCount, 3, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchend(map.getCanvas());
+    for (const endEvent of ['dragend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if no touches remain`);
+
+    t.end();
+});
+
+test('TouchPanHandler does not cause map to jump when removing first touch point', (t) => {
+  // Bug https://github.com/mapbox/mapbox-gl-js/issues/9136
+  const map = createMap(t, {center: [0,0]});
+  const hm = map.handlers;
+  const h = map.handlers.touchPan;
+
+  simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 2}, {clientX: 3, clientY: 4}]});
+  let oldCenter = map.getCenter();
+  simulate.touchmove(map.getCanvas(), {touches: [{clientX: 5, clientY: 2}, {clientX: 8, clientY: 4}]});
+  t.equal(h._state, 'active', 'multi-touch event should activate the handler');
+  t.ok(map.getCenter().lng !== oldCenter.lng && map.getCenter().lat !== oldCenter.lat, 'manager should pan the map');
+
+  oldCenter = map.getCenter();
+  simulate.touchend(map.getCanvas(), {touches: [{clientX: 8, clientY: 4}], changedTouches: [{clientX: 5, clientY: 2}]});
+  t.equal(h._state, 'active', 'multi-touch touchend should not deactivate the handler if there are touches remaining');
+  simulate.touchmove(map.getCanvas(), {touches: [{clientX: 8, clientY: 4}]});
+  t.ok(map.getCenter().lng === oldCenter.lng && map.getCenter().lat === oldCenter.lat, 'manager should not pan the map if remaining touch has not moved');
+
+  t.end();
+})
+
+
+test('TouchZoomHandler responds to touchstart/end/cancel events', (t) => {
+    const map = createMap(t, {zoom: 5});
+    const h = map.handlers.touchZoom;
+    const spies = setupEventSpies(['zoom', 'move'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
+    t.equal(h._state, 'enabled', 'single-touch event should not trigger "pending" state');
+    t.notOk(h._startTouchEvent);
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired if handler does not activate');
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 3, clientY: 4}]});
+    t.equal(h._state, 'pending', 'multi-touch event should trigger "pending" state');
+    t.equal(h._startTouchEvent.touches.length, 2);
+    t.ok(h._startTouchData.isMultiTouch);
+    t.equal(h._startTouchData.vector.mag(), 5);
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired on touchstart');
+
+    simulate.touchend(map.getCanvas(), {changedTouches: [{clientX: 0, clientY: 0}, {clientX: 3, clientY: 4}]});
+    t.equal(h._state, 'enabled', 'touchend should reset handler to "enabled" state');
+    t.notOk(h._startTouchEvent);
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired on touchend if handler was never active');
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 3, clientY: 4}]});
+    simulate.touchcancel(map.getCanvas(), {changedTouches: [{clientX: 0, clientY: 0}, {clientX: 3, clientY: 4}]});
+    t.equal(h._state, 'enabled', 'touchcancel should reset handler to "enabled" state');
+    t.notOk(h._startTouchEvent);
+    for (const event in spies) t.equal(spies[event].callCount, 0, 'no events should be fired on touchcancel if handler was never active');
+
+    t.end();
+});
+
+test('TouchZoomHandler scales map appropriately on touchmove events', (t) => {
+    const map = createMap(t, {zoom: 5});
+    const hm = map.handlers;
+    hm.disableAll(); // The dummy touches below are so close together, they activate touchPitch handler
+    const h = map.handlers.touchZoom;
+    h.enable();
+    t.spy(h, 'touchstart');
+    t.spy(h, 'touchmove');
+
+    const spies = setupEventSpies(['zoom', 'move'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
+    for (const startEvent of ['zoomstart', 'movestart']) t.equal(spies[startEvent].callCount, 0, `${startEvent} should not be fired until first movement`);
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 1, clientY: 2}]});
+    t.equal(h._state, 'enabled', 'single-touch event should not do anything');
+    t.ok(h.touchmove.called && !h.touchmove.returnValues[0], '.touchmove() should be called but return nothing');
+    for (const event in spies) t.equal(spies[event].callCount, 0, `${event} should not be fired if handler was not activated`);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 3, clientY: 4}]});
+    for (const startEvent of ['zoomstart', 'movestart']) t.equal(spies[startEvent].callCount, 0, `${startEvent} should not be fired until first movement`);
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 6, clientY: 8}]});
+    t.equal(h._state, 'active', 'multi-touch event should activate the handler');
+    t.equal(h.touchmove.returnValues[1].transform.zoomDelta, 1, '.touchmove() should return delta to apply to transform');
+    t.deepEqual(h.touchmove.returnValues[1].events, ['zoomstart', 'zoom'], '.touchmove() should return start and move events to fire');
+    t.equal(map.getZoom(), 6, 'manager should zoom in the map');
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0,  `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should be fired on first movement`);
+      else t.equal(spies[event].callCount, 1, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 1.5, clientY: 2}]});
+    t.equal(h._state, 'active', 'multi-touch event should activate the handler');
+    t.equal(h.touchmove.returnValues[2].transform.zoomDelta, -2, '.touchmove() should return delta to apply to transform');
+    t.equal(map.getZoom(), 4, 'manager should zoom out the map');
+    for (const event of ['zoom', 'move']) t.equal(spies[event].callCount, 2, `${event} should be fired on every movement`);
+
+    simulate.touchend(map.getCanvas());
+    for (const endEvent of ['zoomend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
+
+    t.end();
+});
+
+test('TouchRotateHandler rotates map appropriately on touchmove events', (t) => {
+    const map = createMap(t, {bearing: 0});
+    const hm = map.handlers;
+    hm.disableAll();
+    const h = map.handlers.touchRotate;
+    h.enable();
+    t.spy(h, 'touchstart');
+    t.spy(h, 'touchmove');
+
+    const spies = setupEventSpies(['rotate', 'move'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
+    for (const startEvent of ['rotatestart', 'movestart']) t.equal(spies[startEvent].callCount, 0, `${startEvent} should not be fired until first movement`);
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 1, clientY: 2}]});
+    t.equal(h._state, 'enabled', 'single-touch event should not do anything');
+    t.ok(h.touchmove.called && !h.touchmove.returnValues[0], '.touchmove() should be called but return nothing');
+    for (const event in spies) t.equal(spies[event].callCount, 0, `${event} should not be fired if handler was not activated`);
+
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 3, clientY: 0}]});
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 0, clientY: 3}]});
+    t.equal(h._state, 'active', 'multi-touch event should activate the handler');
+    t.equal(h.touchmove.returnValues[1].transform.bearingDelta, -90, '.touchmove() should return delta to apply to transform');
+    t.deepEqual(h.touchmove.returnValues[1].events, ['rotatestart', 'rotate'], '.touchmove() should return start and move events to fire');
+    t.equal(map.getBearing(), -90, 'manager should rotate the map clockwise');
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0,  `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should be fired on first movement`);
+      else t.equal(spies[event].callCount, 1, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 80, clientY: 80}]});
+    t.equal(h._state, 'active', 'multi-touch event should activate the handler');
+    t.equal(h.touchmove.returnValues[2].transform.bearingDelta, 45, '.touchmove() should return delta to apply to transform');
+    t.equal(map.getBearing(), -45, 'manager should rotate the map counterclockwise');
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0,  `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should not be fired more than once`);
+      else t.equal(spies[event].callCount, 2, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchend(map.getCanvas());
+    for (const endEvent of ['rotateend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
+
+    t.end();
+});
+
+test('TouchPitchHandler pitches map appropriately on touchmove events', (t) => {
+    const map = createMap(t, {pitch: 0});
+    const hm = map.handlers;
+    hm.disableAll();
+    const h = map.handlers.touchPitch;
+    h.enable();
+    t.spy(h, 'touchstart');
+    t.spy(h, 'touchmove');
+
+    const spies = setupEventSpies(['pitch', 'move'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 1, clientY: 2}]});
+    t.equal(h._state, 'enabled', 'single-touch event should not do anything');
+    t.ok(h.touchmove.called && !h.touchmove.returnValues[0], '.touchmove() should be called but return nothing');
+    for (const event in spies) t.equal(spies[event].callCount, 0, `${event} should not be fired if handler was not activated`);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 20}, {clientX: 11, clientY: 20}]});
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 1, clientY: 0}, {clientX: 11, clientY: 0}]});
+    t.equal(h._state, 'active', 'multi-touch event should activate the handler');
+    t.equal(h.touchmove.returnValues[1].transform.pitchDelta, 8, '.touchmove() should return delta to apply to transform');
+    t.deepEqual(h.touchmove.returnValues[1].events, ['pitchstart', 'pitch'], '.touchmove() should return start and move events to fire');
+    t.equal(map.getPitch(), 8, 'manager should pitch the map more');
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0,  `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should be fired on first movement`);
+      else t.equal(spies[event].callCount, 1, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 1, clientY: 10}, {clientX: 11, clientY: 10}]});
+    t.equal(h._state, 'active', 'multi-touch event should activate the handler');
+    t.equal(h.touchmove.returnValues[2].transform.pitchDelta, -4, '.touchmove() should return delta to apply to transform');
+    t.equal(map.getPitch(), 4, 'manager should pitch the map less');
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0,  `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should not be fired more than once`);
+      else t.equal(spies[event].callCount, 2, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchend(map.getCanvas());
+    for (const endEvent of ['pitchend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
+
+    t.end();
+});
+
+
+test('TouchZoomHandler and TouchRotateHandler can update the map simultaneously', (t) => {
+    const map = createMap(t, {zoom: 5, bearing: 0});
+    const hm = map.handlers;
+    hm.touchPitch.disable();
+    const rh = map.handlers.touchRotate;
+    const zh = map.handlers.touchZoom;
+    t.spy(rh, 'touchstart');
+    t.spy(rh, 'touchmove');
+    t.spy(zh, 'touchstart');
+    t.spy(zh, 'touchmove');
+
+    const spies = setupEventSpies(['rotate', 'zoom', 'move'], map, t);
+
+    simulate.touchstart(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 300, clientY: 0}]});
+    t.notOk(rh.touchmove.called, 'touchstart should not call touchmove method');
+    t.notOk(zh.touchmove.called, 'touchstart should not call touchmove method');
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 0, clientY: 600}]});
+
+    t.equal(rh.touchmove.returnValues[0].transform.bearingDelta, -90, '.touchmove() should return delta to apply to transform');
+    t.equal(map.getBearing(), -90, 'manager should rotate the map clockwise');
+    t.equal(zh.touchmove.returnValues[0].transform.zoomDelta, 1, '.touchmove() should return delta to apply to transform');
+    t.equal(map.getZoom(), 6, 'manager should zoom in the map');
+    t.deepEqual(rh.touchmove.returnValues[0].events, ['rotatestart', 'rotate'], '.touchmove() should return start and move events to fire');
+    t.deepEqual(zh.touchmove.returnValues[0].events, ['zoomstart', 'zoom'], '.touchmove() should return start and move events to fire');
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0,  `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should be fired on first movement`);
+      else t.equal(spies[event].callCount, 1, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchmove(map.getCanvas(), {touches: [{clientX: 0, clientY: 0}, {clientX: 100, clientY: 100}]});
+    t.equal(rh.touchmove.returnValues[1].transform.bearingDelta, 45, '.touchmove() should return delta to apply to transform');
+    t.equal(map.getBearing(), -45, 'manager should rotate the map counterclockwise');
+    t.equal(Math.round(zh.touchmove.returnValues[1].transform.zoomDelta), -2, '.touchmove() should return delta to apply to transform');
+    t.equal(Math.round(map.getZoom()), 4, 'manager should zoom out the map');
+    for (const event in spies) {
+      if (event.endsWith('end')) t.equal(spies[event].callCount, 0,  `${event} should not be fired until movement has stopped`);
+      else if (event.endsWith('start')) t.equal(spies[event].callCount, 1, `${event} should not be fired more than once`);
+      else t.equal(spies[event].callCount, 2, `${event} should be fired on every movement`);
+    }
+
+    simulate.touchend(map.getCanvas());
+    for (const endEvent of ['rotateend', 'zoomend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
+
+    t.end();
+});

--- a/test/unit/ui/handler/touch.test.js
+++ b/test/unit/ui/handler/touch.test.js
@@ -199,8 +199,7 @@ test('TouchPanHandler pans map & fires events appropriately when transitioning b
     }
 
     simulate.touchend(map.getCanvas());
-    for (const endEvent of ['dragend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if no touches remain`);
-
+    t.equal(spies['dragend'].callCount, 1, `dragend should be fired on touchend if no touches remain`);
     t.end();
 });
 
@@ -296,8 +295,7 @@ test('TouchZoomHandler scales map appropriately on touchmove events', (t) => {
     for (const event of ['zoom', 'move']) t.equal(spies[event].callCount, 2, `${event} should be fired on every movement`);
 
     simulate.touchend(map.getCanvas());
-    for (const endEvent of ['zoomend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
-
+    t.equal(spies['zoomend'].callCount, 1, `zoomend should be fired on touchend if handler was active`);
     t.end();
 });
 
@@ -344,8 +342,7 @@ test('TouchRotateHandler rotates map appropriately on touchmove events', (t) => 
     }
 
     simulate.touchend(map.getCanvas());
-    for (const endEvent of ['rotateend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
-
+    t.equal(spies['rotateend'].callCount, 1, `rotateend should be fired on touchend if handler was active`);
     t.end();
 });
 
@@ -357,7 +354,6 @@ test('TouchPitchHandler pitches map appropriately on touchmove events', (t) => {
     h.enable();
     t.spy(h, 'touchstart');
     t.spy(h, 'touchmove');
-
     const spies = setupEventSpies(['pitch', 'move'], map, t);
 
     simulate.touchstart(map.getCanvas(), {touches: [{clientX: 1, clientY: 1}]});
@@ -389,8 +385,7 @@ test('TouchPitchHandler pitches map appropriately on touchmove events', (t) => {
     }
 
     simulate.touchend(map.getCanvas());
-    for (const endEvent of ['pitchend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
-
+    t.equal(spies['pitchend'].callCount, 1, `pitchend should be fired on touchend if handler was active`);
     t.end();
 });
 
@@ -437,7 +432,7 @@ test('TouchZoomHandler and TouchRotateHandler can update the map simultaneously'
     }
 
     simulate.touchend(map.getCanvas());
-    for (const endEvent of ['rotateend', 'zoomend', 'moveend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
+    for (const endEvent of ['rotateend', 'zoomend']) t.equal(spies[endEvent].callCount, 1, `${endEvent} should be fired on touchend if handler was active`);
 
     t.end();
 });

--- a/test/unit/ui/handler_manager.test.js
+++ b/test/unit/ui/handler_manager.test.js
@@ -11,9 +11,9 @@ test('HandlerManager contains default handlers', (t) => {
     const map = createMap(t);
     const hm = map.handlers;
     t.equal(typeof hm.length, 'number', 'should have a numeric .length property');
-    t.equal(hm.length, 4, '.length should be accurate'); //TODO will change
+    t.equal(hm.length, 5, '.length should be accurate'); //TODO will change
     t.ok(hm.touchZoom, 'default handlers should be available through named properties');
-    t.deepEqual(hm.list(), ['touchRotate', 'touchPitch', 'touchZoom', 'touchPan'], '.list() method should return an array of handler names'); //TODO will change
+    t.deepEqual(hm.list(), ['touchRotate', 'touchPitch', 'touchZoom', 'touchPan', 'keyboard'], '.list() method should return an array of handler names'); //TODO will change
     t.end();
 });
 

--- a/test/unit/ui/handler_manager.test.js
+++ b/test/unit/ui/handler_manager.test.js
@@ -1,0 +1,187 @@
+import {test} from '../../util/test';
+import {extend} from '../../../src/util/util';
+import Map from '../../../src/ui/map';
+import HandlerManager from '../../../src/ui/handler_manager';
+import Handler from '../../../src/ui/handler/handler';
+import {createMap} from '../../util';
+import simulate, {window} from '../../util/simulate_interaction';
+
+
+test('HandlerManager contains a collection of handlers', (t) => {
+    const map = createMap(t);
+    const hm = map.handlers;
+    t.equal(typeof hm.length, 'number', 'should have a numeric .length property');
+    const myHandler = new Handler(map);
+    hm.add('myHandler', myHandler);
+    t.equal(hm.length, 1, '.length should be accurate'); //TODO will change
+    t.deepEqual(hm.list(), ['myHandler'], '.list() method should return an array of handler names'); //TODO will change
+    t.end();
+});
+
+test('Handler array can be updated with .add(), .remove(), and .removeAll() methods', (t) => {
+  const map = createMap(t);
+  const hm = map.handlers;
+
+  hm.removeAll();
+  t.equal(hm.length, 0, 'after .removeAll() length should be zero');
+  t.deepEqual(hm._handlers, [], 'after .removeAll() the collection should be empty');
+
+  t.throws(() => hm.add(handy), '.add() throws error if no name provided');
+  t.throws(() => hm.add('handy'), '.add() throws error if no handler provided');
+  t.throws(() => hm.add('notgonnawork', new Date()), '.add() throws error if handler is not an instance of Handler');
+  const handy = new Handler(map);
+  t.throws(() => hm.add('not a good Handler-Name', handy), '.add() throws error if handlerName is improperly formatted');
+  hm.add('handy', handy);
+  t.ok(hm.length === 1, '.add() should increase .length');
+  t.ok(hm._handlers[0][1] === handy, '.add() should append the handler to the collection');
+  t.equal(hm.handy, handy, '.add() should make the new handler available as a property with the given name');
+
+  t.throws(() => hm.add('handy', handy), '.add() throws error if handler already exists');
+  t.throws(() => hm.add('handier', handy), '.add() throws error if handler already exists with a different name');
+  const handier = new Handler(map);
+  t.throws(() => hm.add('handy', handier), '.add() throws error if there is already a handler with this name');
+  hm.add('handier', handier);
+  t.ok(hm.length === 2, '.add() should increase .length');
+  t.ok(hm._handlers[1][1] === handier, '.add() should append the handler to the collection');
+
+  t.throws(() => hm.remove(), '.remove() throws error if no handlerName is provided');
+  t.throws(() => hm.remove(handy), '.remove() throws error if handlerName is not a String');
+  t.throws(() => hm.remove('notathing'), '.remove() throws error if handler name does not exist');
+  hm.remove('handy');
+  t.ok(hm.length === 1, '.remove() should decrease .length');
+  t.ok(hm._handlers[0][1] === handier, '.remove() should remove the handler from the collection');
+  t.notOk(hm.handy, '.remove() should delete the named handler property');
+
+  t.end();
+});
+
+test('Handlers can be en/disabled with en/disableAll() methods', (t) => {
+    const map = createMap(t);
+    const hm = map.handlers;
+    const handlerNames = hm.list();
+
+    hm.disableAll();
+    handlerNames.map((h) => t.notOk(hm[h].isEnabled(), 'disableAll() should disable each handler'));
+
+    hm.enableAll();
+    handlerNames.map((h) => t.ok(hm[h].isEnabled(), 'enableAll() should disable each handler'));
+
+    t.end();
+});
+
+test('Constructor sets up event listeners to fire map events and call handler event processors', (t) => {
+  const map = createMap(t);
+  const hm = map.handlers;
+  const handy = new Handler(map);
+  handy.mousedown = (e) => {
+    t.equal(e.type, 'mousedown');
+  };
+  t.spy(handy, 'mousedown');
+  hm.add('handy', handy);
+
+
+  for (const touchType of ['start', 'move', 'end', 'cancel']) {
+    const eventType = 'touch' + touchType;
+
+    const spy = t.spy(function (e) {
+      t.equal(this, map);
+      t.equal(e.type, eventType);
+    });
+    map.on(eventType, spy);
+
+    simulate[eventType](map.getCanvasContainer());
+    t.ok(spy.called);
+    t.equal(spy.callCount, 1);
+  }
+
+  for (const mouseType of ['down', 'up', 'move', 'over', 'out']) {
+    const eventType = 'mouse' + mouseType;
+
+    const spy = t.spy(function (e) {
+      t.equal(this, map);
+      t.equal(e.type, eventType);
+    });
+
+    map.on(eventType, spy);
+
+    simulate[eventType](map.getCanvasContainer());
+    t.ok(spy.called);
+    t.equal(spy.callCount, 1);
+  }
+
+  t.end();
+});
+
+test('HandlerManager applies transforms requested by handler event processors', (t) => {
+  const map = createMap(t, { zoom: 5 });
+  const hm = map.handlers;
+  hm.removeAll();
+
+  const handy = new Handler(map);
+  handy.mousedown = (e) => {
+    t.equal(e.type, 'mousedown');
+    return { transform: { zoomDelta: 5 }};
+  };
+  t.spy(handy, 'mousedown');
+  hm.add('handy', handy);
+
+  simulate.mousedown(map.getCanvasContainer());
+  t.equal(map.getZoom(), 10);
+
+  t.end();
+});
+
+test('HandlerManager fires map movement events as requested by handlers', (t) => {
+  const map = createMap(t);
+  const hm = map.handlers;
+  hm.removeAll();
+
+  const handy = new Handler(map);
+  handy.mousedown = (e) => { handy._state = 'pending'; };
+  handy.mousemove = (e) => {
+    handy._state = 'active';
+    return { events: ['zoomstart', 'pitchstart', 'rotatestart', 'dragstart', 'zoom', 'pitch', 'rotate', 'drag'] };
+  };
+  handy.mouseup = (e) => {
+    handy._state = 'enabled';
+    return { events: ['zoomend', 'pitchend', 'rotateend', 'dragend'] };
+  };
+  hm.add('handy', handy);
+
+  const spies = {};
+  for (const eventType of ['move', 'zoom', 'pitch', 'rotate', 'drag']) {
+    for (const eventStage of ['start', '', 'end']) {
+      const event = eventType + eventStage;
+      const spy = t.spy();
+      spies[event] = spy;
+      map.on(event, spy);
+    }
+  };
+
+  simulate.mousedown(map.getCanvasContainer());
+  for (const event in spies) {
+    t.equal(spies[event].callCount, 0, `${event} should not be fired until the map is updated`);
+  }
+  simulate.mousemove(map.getCanvasContainer(), {clientX: 10, clientY: 10});
+  for (const event in spies) {
+    if (event.endsWith('end')) {
+      t.equal(spies[event].callCount, 0, `${event} should not be fired until movement stops`);
+    } else if (event.endsWith('start')) {
+      t.equal(spies[event].callCount, 1, `${event} should be fired on first movement`);
+    } else {
+      t.equal(spies[event].callCount, 1, `${event} should be fired on each movement`);
+    }
+  }
+  simulate.mouseup(map.getCanvasContainer());
+  for (const event in spies) {
+    if (event.endsWith('end')) {
+      t.equal(spies[event].callCount, 1, `${event} should be fired when movement stops`);
+    } else if (event.endsWith('start')) {
+      t.equal(spies[event].callCount, 1, `${event} should not be fired more than once`);
+    } else {
+      t.equal(spies[event].callCount, 1, `${event} should be fired only on movement`);
+    }
+  }
+
+  t.end();
+});

--- a/test/util/simulate_interaction.js
+++ b/test/util/simulate_interaction.js
@@ -40,11 +40,13 @@ events.dblclick = function (target, options) {
     target.dispatchEvent(new MouseEvent('dblclick', options));
 };
 
-events.keypress = function (target, options) {
+['keydown', 'keyup', 'keypress'].forEach((event) => {
+  events[event] = function (target, options) {
     options = Object.assign({bubbles: true}, options);
     const KeyboardEvent = window(target).KeyboardEvent;
-    target.dispatchEvent(new KeyboardEvent('keypress', options));
-};
+    target.dispatchEvent(new KeyboardEvent(event, options));
+  };
+});
 
 [ 'mouseup', 'mousedown', 'mouseover', 'mousemove', 'mouseout' ].forEach((event) => {
     events[event] = function (target, options) {


### PR DESCRIPTION
This PR refactors the input gesture handling architecture to reduce bugs & improve extensibility. It also adds support for touch gestures to pan, zoom, rotate, and pitch the map. 

This is work in progress; API(s) & gesture handling behavior is still subject to change. 

## Overview

Previously, individual handlers representing arguably-related groups of interactions (e.g. `TouchZoomRotateHandler`) managed both gesture detection and the resulting map animation simultaneously, which led to several problems including: 
- brittle & difficult-to-extend handlers & APIs, 
- duplication of logic shared by multiple handlers, 
- bugs due to multiple handlers competing for control of the map, and 
- a painful and/or tedious developer experience when attempting to customize interactivity.

The new architecture aims to better separate concerns between gesture detection and the animation of the map in response to these gestures. Furthermore, we now have a mechanism for managing conflicts between different gesture handlers, and controlling their hierarchy and mutual exclusivity.  

### `HandlerManager`

The module `src/ui/handler_manager.js` defines a `HandlerManager` object, accessed through the map as `map.handlers`. The manager: 
- Stores an ordered hierarchy of potentially-competing `Handler` objects (see below), with builtin handlers attached by default 
- Provides access to individual handlers through named properties, e.g. `map.handlers.touchPitch`
- Provides `.add()` and `.remove()` methods to allow overriding builtin handlers and/or attaching custom handlers extending the `Handler` class
- Exposes the list of available handlers dynamically through the `.list()` method
- Attaches map listeners for input events (e.g. `touchstart`, `mouseup`), allows enabled handlers to process these events, and receives "recommendations" for how to update the map from applicable handlers (see below)
- Decides which updates to apply, merging compatible handlers' effects and resolving any conflicts between competing handlers
- Performs the actual map animation, at most once per input event
- Fires "output" events from the map (e.g. `movestart`, `zoomstart`) as needed

Eventually it will: 
- Accept high-level `interactive` option(s) and enable/disable handlers accordingly 
- Provide additional convenience methods to quickly modify multiple handlers, e.g. `map.handlers.disableTouch()`

### `Handler` classes 

Handler objects are responsible for processing relevant input events by calculating desired updates to the map & returning information describing those updates to the manager. 

The `Handler` base class (`src/ui/handler/handler.js`) provides methods common to all handlers, e.g. `.enable()` and `.disable()`. 

Custom handlers can be implemented by extending the base `Handler` class and implementing event-processing methods for any relevant input events (e.g. `.mouseup(e)`, `.keydown(e)`). Handlers are ideally small and single-purpose, focused on only one type of interaction. 

Upon detecting an input event (e.g. `touchmove`), the manager looks for a method with the same name on any enabled handlers (e.g. `touchZoom.touchmove(e)`), calling each such method with the original input event. 

Handler event-processing methods may return an object specifying which map updates should be applied (e.g. `transform: { zoomDelta: -1 }` , and which output events should be fired (e.g. `events: [ 'zoomstart', 'zoom']`). 

If a handler's method for a detected input event (e.g. `.touchmove(e)`) returns such an object to the manager, the manager may apply the specified update(s) to the map and fire the specified event(s), after all handlers have had a chance to process the input event and any conflicts have been resolved.

See the `TouchPanHandler`, `TouchZoomHandler`, `TouchRotateHandler`, and `TouchPitchHandler` classes in `src/ui/handler/touch.js` for examples. 


### Changes to current API

Under the new architecture, the map's former mixed-concern handlers (e.g. `map.touchZoomRotate`) no longer exist as such. The old handler classes are either replaced or ported to the new architecture, and the old `bind_handlers` module has been removed in favor of the high-level control provided by the `HandlerManager`. 

To avoid breaking changes, the current API can be shimmed to map existing properties/methods to the new handler architecture (e.g. `map.touchZoomRotate.disableRotation()` mapped to `map.touchRotate.disable()`). 

## Next steps
- [ ] [in progress] More documentation
- [ ] [in progress] Port old handlers to new single-concern handlers  (handlers in _italics_ should be straightforward to port from the old architecture)
  - [x] touchPan
  - [x] touchRotate
  - [x] touchZoom
  - [x] touchPitch
  - [ ] tapZoom
  - [ ] quickZoom
  - [ ] mousePan
  - [ ] mouseRotate
  - [ ] mousePitch
  - [ ] _scrollZoom_
  - [ ] _dblclickZoom_
  - [ ] boxZoom
  - [x] _keyboard_
- [ ] Toggle (and rename?) container CSS classes (e.g. `mapboxgl-touch-zoom-rotate`) from manager
- [ ] Expand high-level API (`map.handlers.disableRotation()` etc) 
- [ ] Shim existing handler API, adding deprecation warnings (can be skipped if this ends up in major release)
- [ ] Fix flow & test errors
- [ ] Once this is merged, fix #9036 and check for similar (mis)uses of old handlers

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

