### PR TITLE
Allows local urls for sprites

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -197,7 +197,7 @@ function hasCacheDefeatingSku(url: string) {
     return url.indexOf('sku=') > 0 && isMapboxHTTPURL(url);
 }
 
-const urlRe = /^(\w+):\/\/([^/?]*)(\/[^?]+)?\??(.+)?/;
+const urlRe = /^(\w+)?:?\/?\/([^/?]*)(\/[^?]+)?\??(.+)?/;
 
 function parseUrl(url: string): UrlObject {
     const parts = url.match(urlRe);
@@ -214,7 +214,7 @@ function parseUrl(url: string): UrlObject {
 
 function formatUrl(obj: UrlObject): string {
     const params = obj.params.length ? `?${obj.params.join('&')}` : '';
-    return `${obj.protocol}://${obj.authority}${obj.path}${params}`;
+    return `${obj.protocol ? `${obj.protocol}://` : '/'}${obj.authority}${obj.path}${params}`;
 }
 
 export {isMapboxURL, isMapboxHTTPURL, hasCacheDefeatingSku};

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -234,6 +234,12 @@ test("mapbox", (t) => {
                 t.end();
             });
 
+            t.test('concantenates path, ratio, and extension for same host urls /', (t) => {
+                t.equal(manager.normalizeSpriteURL('/path/to/bar', '@2x', '.png'), '/path/to/bar@2x.png');
+                t.equal(manager.normalizeSpriteURL('/path/to/bar?style=fresh', '@2x', '.png'), '/path/to/bar@2x.png?style=fresh');
+                t.end();
+            });
+
             t.test('normalizes non-mapbox:// scheme when query string exists', (t) => {
                 t.equal(manager.normalizeSpriteURL('http://www.foo.com/bar?fresh=true', '@2x', '.png'), 'http://www.foo.com/bar@2x.png?fresh=true');
                 t.end();


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality

Local urls for sprites like "sprite: /assets/sprites" were not possible due to the implicit requirement of (protocol://). Slightly changed the "urlRe" to ignore missing protocol and the same for formatUrl. Additional tests were added, no breaking changes.