### PR TITLE
Expose loadSprite as style.method

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -250,20 +250,7 @@ class Style extends Evented {
         }
 
         if (json.sprite) {
-            this._spriteRequest = loadSprite(json.sprite, this.map._requestManager, (err, images) => {
-                this._spriteRequest = null;
-                if (err) {
-                    this.fire(new ErrorEvent(err));
-                } else if (images) {
-                    for (const id in images) {
-                        this.imageManager.addImage(id, images[id]);
-                    }
-                }
-
-                this.imageManager.setLoaded(true);
-                this.dispatcher.broadcast('setImages', this.imageManager.listImages());
-                this.fire(new Event('data', {dataType: 'style'}));
-            });
+            this.loadSprite(json.sprite);
         } else {
             this.imageManager.setLoaded(true);
         }
@@ -286,6 +273,23 @@ class Style extends Evented {
 
         this.fire(new Event('data', {dataType: 'style'}));
         this.fire(new Event('style.load'));
+    }
+
+    loadSprite(url: string) {
+        this._spriteRequest = loadSprite(url, this.map._requestManager, (err, images) => {
+            this._spriteRequest = null;
+            if (err) {
+                this.fire(new ErrorEvent(err));
+            } else if (images) {
+                for (const id in images) {
+                    this.imageManager.addImage(id, images[id]);
+                }
+            }
+
+            this.imageManager.setLoaded(true);
+            this.dispatcher.broadcast('setImages', this.imageManager.listImages());
+            this.fire(new Event('data', {dataType: 'style'}));
+        });
     }
 
     _validateLayer(layer: StyleLayer) {


### PR DESCRIPTION
## Launch Checklist

This basically exposes loadSprite as a separate method of the Style class. I think it is also kind of refactoring, since the code is very specific and it makes sense to put the logic out of  _load anyway (even a private method). 
As a public method it allows the user to load its own sprites after the initial loading of the basic style, instead of loading each image one-by-one (#9224) 

Please give me some advises where to put the documentation, and tests, I did't wanted to keep me back with it yet, first need to know what you think about it in general. Thank you.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
