### PR TITLE
Hide glyphs behind the camera

### DIFF
--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -87,6 +87,10 @@ void main() {
     vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
     gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * max(a_minFontScale, fontScale) + a_pxoffset / 16.0), 0.0, 1.0);
 
+    // Symbols might end up being behind the camera. Modify z-value to be out of visible bounds
+    // if this is the case, otherwise ignore depth. -1.1 is safely out of the visible depth range [-1, 1]
+    gl_Position.z = mix(-1.1 * gl_Position.w, gl_Position.z, float(projected_pos.w > 0.0));
+
     v_tex = a_tex / u_texsize;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -106,6 +106,10 @@ void main() {
     gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * fontScale + a_pxoffset), 0.0, 1.0);
     float gamma_scale = gl_Position.w;
 
+    // Symbols might end up being behind the camera. Modify z-value to be out of visible bounds
+    // if this is the case, otherwise ignore depth. -1.1 is safely out of the visible depth range [-1, 1]
+    gl_Position.z = mix(-1.1 * gl_Position.w, gl_Position.z, float(projected_pos.w > 0.0));
+
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
     float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -185,7 +185,15 @@ function updateLineLabels(bucket: SymbolBucket,
             fontSize / perspectiveRatio;
 
         const tileAnchorPoint = new Point(symbol.anchorX, symbol.anchorY);
-        const anchorPoint = project(tileAnchorPoint, labelPlaneMatrix).point;
+        const transformedTileAnchor = project(tileAnchorPoint, labelPlaneMatrix);
+
+        // Skip labels behind the camera
+        if (transformedTileAnchor.signedDistanceFromCamera <= 0.0) {
+            hideGlyphs(symbol.numGlyphs, dynamicLayoutVertexArray);
+            continue;
+        }
+
+        const anchorPoint = transformedTileAnchor.point;
         const projectionCache = {};
 
         const placeUnflipped: any = placeGlyphsAlongLine(symbol, pitchScaledFontSize, false /*unflipped*/, keepUpright, posMatrix, labelPlaneMatrix, glCoordMatrix,


### PR DESCRIPTION
Our symbol placement and rendering logic is currently ignoring depth values of projected anchor points and symbol vertices. This is fine as most of the projected vertices end up being in front of the camera. But due to the nature of perspective projection where x and y coordinates are divided by depth (w-component), vertices behind the camera have negative depth values and will have inverse coordinates on the screen. For example an anchor in bottom-left part of the clip-space might have a coordinate [-x, -y]. With negative depth value this will end up being [x, y] in homogenous NDC-space after the division by w. Typically GPU will clip these primitives after they've gone through a vertex shader.

This becomes a problem with > 60 pitch angles where screen boundary checks might not catch symbols directly behind the camera.

![symbols_floating_above_ground](https://user-images.githubusercontent.com/55925868/73059454-72ccca00-3e9e-11ea-8489-50c145e0a7eb.png)

This pull request adds few extra depth checks for both line aligned labels and labels that are handled entirely in the shader.
