### PR TITLE
Clarify in documentation

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2589,7 +2589,7 @@
         }
       },
       "in": {
-        "doc": "Determines whether an item exists in an array or a substring exists in a string.",
+        "doc": "Determines whether an item exists in an array or a substring exists in a string. If the `haystack` argument is an array literal, it must be wrapped in a `literal` expression, e.g. `['in', 1, ['literal', [1, 2, 3]]]`. This is not necessary when the `haystack` is an array returned from a sub-expression, e.g. `['in', 1, ['get', 'myArrayProp']]`.",
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
     - The `in` expression can be confusing because the docs say that the second argument can be an array. However, supplying an array literal throws an error unless the argument is wrapped in the `literal` expression. This PR updates the docs to explicitly call out this nuance.
     - Thanks to @bravecow for bringing this up in https://github.com/mapbox/mapbox-gl-js/issues/9240#issuecomment-579469818