### PR TITLE
Pass errors to cluster function callbacks

### DIFF
--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -283,15 +283,36 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     getClusterExpansionZoom(params: {clusterId: number}, callback: Callback<number>) {
-        callback(null, this._geoJSONIndex.getClusterExpansionZoom(params.clusterId));
+        let result;
+
+        try {
+            result = this._geoJSONIndex.getClusterExpansionZoom(params.clusterId);
+            callback(null, result);
+        } catch (e) {
+            callback(e, result);
+        }
     }
 
     getClusterChildren(params: {clusterId: number}, callback: Callback<Array<GeoJSONFeature>>) {
-        callback(null, this._geoJSONIndex.getChildren(params.clusterId));
+        let result;
+
+        try {
+            result = this._geoJSONIndex.getChildren(params.clusterId);
+            callback(null, result);
+        } catch (e) {
+            callback(e, result);
+        }
     }
 
     getClusterLeaves(params: {clusterId: number, limit: number, offset: number}, callback: Callback<Array<GeoJSONFeature>>) {
-        callback(null, this._geoJSONIndex.getLeaves(params.clusterId, params.limit, params.offset));
+        let result;
+
+        try {
+            result = this._geoJSONIndex.getLeaves(params.clusterId, params.limit, params.offset);
+            callback(null, result);
+        } catch (e) {
+            callback(e, result);
+        }
     }
 }
 

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -283,35 +283,26 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     getClusterExpansionZoom(params: {clusterId: number}, callback: Callback<number>) {
-        let result;
-
         try {
-            result = this._geoJSONIndex.getClusterExpansionZoom(params.clusterId);
-            callback(null, result);
+            callback(null, this._geoJSONIndex.getClusterExpansionZoom(params.clusterId));
         } catch (e) {
-            callback(e, result);
+            callback(e);
         }
     }
 
     getClusterChildren(params: {clusterId: number}, callback: Callback<Array<GeoJSONFeature>>) {
-        let result;
-
         try {
-            result = this._geoJSONIndex.getChildren(params.clusterId);
-            callback(null, result);
+            callback(null, this._geoJSONIndex.getChildren(params.clusterId));
         } catch (e) {
-            callback(e, result);
+            callback(e);
         }
     }
 
     getClusterLeaves(params: {clusterId: number, limit: number, offset: number}, callback: Callback<Array<GeoJSONFeature>>) {
-        let result;
-
         try {
-            result = this._geoJSONIndex.getLeaves(params.clusterId, params.limit, params.offset);
-            callback(null, result);
+            callback(null, this._geoJSONIndex.getLeaves(params.clusterId, params.limit, params.offset));
         } catch (e) {
-            callback(e, result);
+            callback(e);
         }
     }
 }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - fixes https://github.com/mapbox/mapbox-gl-js/issues/9132
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Pass errors to "getClusterExpansionZoom", "getClusterChildren", and "getClusterLeaves" callbacks</changelog>`
