### PR TITLE
Simplify formatted sections code

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -379,8 +379,6 @@ class SymbolBucket implements Bucket {
     }
 
     createArrays() {
-        const layout = this.layers[0].layout;
-
         this.text = new SymbolBuffers(new ProgramConfigurationSet(symbolLayoutAttributes.members, this.layers, this.zoom, property => /^text/.test(property)));
         this.icon = new SymbolBuffers(new ProgramConfigurationSet(symbolLayoutAttributes.members, this.layers, this.zoom, property => /^icon/.test(property)));
 
@@ -643,7 +641,7 @@ class SymbolBucket implements Bucket {
             if (i === quads.length - 1 || sectionIndex !== quads[i + 1].sectionIndex) {
                 arrays.programConfigurations.populatePaintArrays(layoutVertexArray.length, feature, feature.index, {}, sections && sections[sectionIndex]);
             }
-        };
+        }
 
         arrays.placedSymbolArray.emplaceBack(labelAnchor.x, labelAnchor.y,
             glyphOffsetArrayStart, this.glyphOffsetArray.length - glyphOffsetArrayStart, vertexStartIndex,

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -340,7 +340,6 @@ class SymbolBucket implements Bucket {
     symbolInstanceIndexes: Array<number>;
     writingModes: Array<number>;
     allowVerticalPlacement: boolean;
-    hasPaintOverrides: boolean;
     hasRTLText: boolean;
 
     constructor(options: BucketParameters<SymbolStyleLayer>) {
@@ -353,7 +352,6 @@ class SymbolBucket implements Bucket {
         this.pixelRatio = options.pixelRatio;
         this.sourceLayerIndex = options.sourceLayerIndex;
         this.hasPattern = false;
-        this.hasPaintOverrides = false;
         this.hasRTLText = false;
         this.sortKeyRanges = [];
 
@@ -382,7 +380,6 @@ class SymbolBucket implements Bucket {
 
     createArrays() {
         const layout = this.layers[0].layout;
-        this.hasPaintOverrides = SymbolStyleLayer.hasPaintOverrides(layout);
 
         this.text = new SymbolBuffers(new ProgramConfigurationSet(symbolLayoutAttributes.members, this.layers, this.zoom, property => /^text/.test(property)));
         this.icon = new SymbolBuffers(new ProgramConfigurationSet(symbolLayoutAttributes.members, this.layers, this.zoom, property => /^icon/.test(property)));
@@ -614,34 +611,26 @@ class SymbolBucket implements Bucket {
                associatedIconIndex: number) {
         const indexArray = arrays.indexArray;
         const layoutVertexArray = arrays.layoutVertexArray;
-        const dynamicLayoutVertexArray = arrays.dynamicLayoutVertexArray;
 
-        const segment = arrays.segments.prepareSegment(4 * quads.length, arrays.layoutVertexArray, arrays.indexArray, feature.sortKey);
+        const segment = arrays.segments.prepareSegment(4 * quads.length, layoutVertexArray, indexArray, feature.sortKey);
         const glyphOffsetArrayStart = this.glyphOffsetArray.length;
         const vertexStartIndex = segment.vertexLength;
 
         const angle = (this.allowVerticalPlacement && writingMode === WritingMode.vertical) ? Math.PI / 2 : 0;
 
-        const addSymbol = (symbol: SymbolQuad) => {
-            const tl = symbol.tl,
-                tr = symbol.tr,
-                bl = symbol.bl,
-                br = symbol.br,
-                tex = symbol.tex,
-                pixelOffsetTL = symbol.pixelOffsetTL,
-                pixelOffsetBR = symbol.pixelOffsetBR,
-                mfsx = symbol.minFontScaleX,
-                mfsy = symbol.minFontScaleY;
+        const sections = feature.text && feature.text.sections;
 
+        for (let i = 0; i < quads.length; i++) {
+            const {tl, tr, bl, br, tex, pixelOffsetTL, pixelOffsetBR, minFontScaleX, minFontScaleY, glyphOffset, isSDF, sectionIndex} = quads[i];
             const index = segment.vertexLength;
 
-            const y = symbol.glyphOffset[1];
-            addVertex(layoutVertexArray, labelAnchor.x, labelAnchor.y, tl.x, y + tl.y, tex.x, tex.y, sizeVertex, symbol.isSDF, pixelOffsetTL.x, pixelOffsetTL.y, mfsx, mfsy);
-            addVertex(layoutVertexArray, labelAnchor.x, labelAnchor.y, tr.x, y + tr.y, tex.x + tex.w, tex.y, sizeVertex, symbol.isSDF, pixelOffsetBR.x, pixelOffsetTL.y, mfsx, mfsy);
-            addVertex(layoutVertexArray, labelAnchor.x, labelAnchor.y, bl.x, y + bl.y, tex.x, tex.y + tex.h, sizeVertex, symbol.isSDF, pixelOffsetTL.x, pixelOffsetBR.y, mfsx, mfsy);
-            addVertex(layoutVertexArray, labelAnchor.x, labelAnchor.y, br.x, y + br.y, tex.x + tex.w, tex.y + tex.h, sizeVertex, symbol.isSDF, pixelOffsetBR.x, pixelOffsetBR.y, mfsx, mfsy);
+            const y = glyphOffset[1];
+            addVertex(layoutVertexArray, labelAnchor.x, labelAnchor.y, tl.x, y + tl.y, tex.x, tex.y, sizeVertex, isSDF, pixelOffsetTL.x, pixelOffsetTL.y, minFontScaleX, minFontScaleY);
+            addVertex(layoutVertexArray, labelAnchor.x, labelAnchor.y, tr.x, y + tr.y, tex.x + tex.w, tex.y, sizeVertex, isSDF, pixelOffsetBR.x, pixelOffsetTL.y, minFontScaleX, minFontScaleY);
+            addVertex(layoutVertexArray, labelAnchor.x, labelAnchor.y, bl.x, y + bl.y, tex.x, tex.y + tex.h, sizeVertex, isSDF, pixelOffsetTL.x, pixelOffsetBR.y, minFontScaleX, minFontScaleY);
+            addVertex(layoutVertexArray, labelAnchor.x, labelAnchor.y, br.x, y + br.y, tex.x + tex.w, tex.y + tex.h, sizeVertex, isSDF, pixelOffsetBR.x, pixelOffsetBR.y, minFontScaleX, minFontScaleY);
 
-            addDynamicAttributes(dynamicLayoutVertexArray, labelAnchor, angle);
+            addDynamicAttributes(arrays.dynamicLayoutVertexArray, labelAnchor, angle);
 
             indexArray.emplaceBack(index, index + 1, index + 2);
             indexArray.emplaceBack(index + 1, index + 2, index + 3);
@@ -649,41 +638,12 @@ class SymbolBucket implements Bucket {
             segment.vertexLength += 4;
             segment.primitiveLength += 2;
 
-            this.glyphOffsetArray.emplaceBack(symbol.glyphOffset[0]);
+            this.glyphOffsetArray.emplaceBack(glyphOffset[0]);
+
+            if (i === quads.length - 1 || sectionIndex !== quads[i + 1].sectionIndex) {
+                arrays.programConfigurations.populatePaintArrays(layoutVertexArray.length, feature, feature.index, {}, sections && sections[sectionIndex]);
+            }
         };
-
-        if (feature.text && feature.text.sections) {
-            const sections = feature.text.sections;
-
-            if (this.hasPaintOverrides) {
-                let currentSectionIndex;
-                const populatePaintArrayForSection = (sectionIndex?: number, lastSection: boolean) => {
-                    if (currentSectionIndex !== undefined && (currentSectionIndex !== sectionIndex || lastSection)) {
-                        arrays.programConfigurations.populatePaintArrays(arrays.layoutVertexArray.length, feature, feature.index, {}, sections[currentSectionIndex]);
-                    }
-                    currentSectionIndex = sectionIndex;
-                };
-
-                for (const symbol of quads) {
-                    populatePaintArrayForSection(symbol.sectionIndex, false);
-                    addSymbol(symbol);
-                }
-
-                // Populate paint arrays for the last section.
-                populatePaintArrayForSection(currentSectionIndex, true);
-            } else {
-                for (const symbol of quads) {
-                    addSymbol(symbol);
-                }
-                arrays.programConfigurations.populatePaintArrays(arrays.layoutVertexArray.length, feature, feature.index, {}, sections[0]);
-            }
-
-        } else {
-            for (const symbol of quads) {
-                addSymbol(symbol);
-            }
-            arrays.programConfigurations.populatePaintArrays(arrays.layoutVertexArray.length, feature, feature.index, {});
-        }
 
         arrays.placedSymbolArray.emplaceBack(labelAnchor.x, labelAnchor.y,
             glyphOffsetArrayStart, this.glyphOffsetArray.length - glyphOffsetArrayStart, vertexStartIndex,

--- a/src/style/style_layer/symbol_style_layer.js
+++ b/src/style/style_layer/symbol_style_layer.js
@@ -184,15 +184,6 @@ class SymbolStyleLayer extends StyleLayer {
 
         return hasOverrides;
     }
-
-    static hasPaintOverrides(layout: PossiblyEvaluated<LayoutProps>): boolean {
-        for (const overridable of properties.paint.overridableProperties) {
-            if (SymbolStyleLayer.hasPaintOverride(layout, overridable)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }
 
 export default SymbolStyleLayer;

--- a/test/unit/symbol/symbol_style_layer.test.js
+++ b/test/unit/symbol/symbol_style_layer.test.js
@@ -48,35 +48,35 @@ test('setPaintOverrides', (t) => {
 test('hasPaintOverrides', (t) => {
     t.test('undefined', (t) => {
         const layer = createSymbolLayer({});
-        t.equal(SymbolStyleLayer.hasPaintOverrides(layer.layout), false);
+        t.equal(SymbolStyleLayer.hasPaintOverride(layer.layout, 'text-color'), false);
         t.end();
     });
 
     t.test('constant, Formatted type, overriden text-color', (t) => {
         const props = {layout: {'text-field': ["format", "text", {"text-color": "red"}]}};
         const layer = createSymbolLayer(props);
-        t.equal(SymbolStyleLayer.hasPaintOverrides(layer.layout), true);
+        t.equal(SymbolStyleLayer.hasPaintOverride(layer.layout, 'text-color'), true);
         t.end();
     });
 
     t.test('constant, Formatted type, no overrides', (t) => {
         const props = {layout: {'text-field': ["format", "text", {"font-scale": 0.8}]}};
         const layer = createSymbolLayer(props);
-        t.equal(SymbolStyleLayer.hasPaintOverrides(layer.layout), false);
+        t.equal(SymbolStyleLayer.hasPaintOverride(layer.layout, 'text-color'), false);
         t.end();
     });
 
     t.test('format expression, overriden text-color', (t) => {
         const props = {layout: {'text-field': ["format", ["get", "name"], {"text-color":"red"}]}};
         const layer = createSymbolLayer(props);
-        t.equal(SymbolStyleLayer.hasPaintOverrides(layer.layout), true);
+        t.equal(SymbolStyleLayer.hasPaintOverride(layer.layout, 'text-color'), true);
         t.end();
     });
 
     t.test('format expression, no overrides', (t) => {
         const props = {layout: {'text-field': ["format", ["get", "name"], {}]}};
         const layer = createSymbolLayer(props);
-        t.equal(SymbolStyleLayer.hasPaintOverrides(layer.layout), false);
+        t.equal(SymbolStyleLayer.hasPaintOverride(layer.layout, 'text-color'), false);
         t.end();
     });
 
@@ -86,7 +86,7 @@ test('hasPaintOverrides', (t) => {
             "default"];
         const props = {layout: {'text-field': matchExpr}};
         const layer = createSymbolLayer(props);
-        t.equal(SymbolStyleLayer.hasPaintOverrides(layer.layout), true);
+        t.equal(SymbolStyleLayer.hasPaintOverride(layer.layout, 'text-color'), true);
         t.end();
     });
 
@@ -96,7 +96,7 @@ test('hasPaintOverrides', (t) => {
             "default"];
         const props = {layout: {'text-field': matchExpr}};
         const layer = createSymbolLayer(props);
-        t.equal(SymbolStyleLayer.hasPaintOverrides(layer.layout), false);
+        t.equal(SymbolStyleLayer.hasPaintOverride(layer.layout, 'text-color'), false);
         t.end();
     });
 


### PR DESCRIPTION
Untangled some repetitive code while working on a data-driven styling refactor — turns out that the logic is essentially the same for formatted sections regardless whether they have paint overrides or not. `Layout` and `SymbolLayer` benchmarks don't seem to be affected.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
