### PR TITLE
Fix severe performance regression after introduction of image expression

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -408,10 +408,11 @@ class Style extends Evented {
             this.sourceCaches[sourceId].used = false;
         }
 
+        const availableImages = this.imageManager.listImages();
         for (const layerId of this._order) {
             const layer = this._layers[layerId];
 
-            layer.recalculate(parameters, this.imageManager.listImages());
+            layer.recalculate(parameters, availableImages);
             if (!layer.isHidden(parameters.zoom) && layer.source) {
                 this.sourceCaches[layer.source].used = true;
             }


### PR DESCRIPTION
#8684 (that got into v1.4.0) introduced a severe rendering performance regression that has slipped through the cracks — an expensive operation of listing all available images (`Object.keys` on a very big object) is being unnecessarily called for every layer on every frame. 

I noticed this accidentally while profiling the main thread — saw this at the top of the call tree:

![image](https://user-images.githubusercontent.com/25395/73734028-a97bcd80-4745-11ea-88ec-96cad530a058.png)

For some reason, we merged the PR without crossing off "post benchmark scores" in the checklist, otherwise we would have caught this — let's be more strict with this from now on, at least until device farm perf metrics are in place. Here are the results for this PR with a quick fix:

![image](https://user-images.githubusercontent.com/25395/73733695-1773c500-4745-11ea-9022-87ff06e289f8.png)

Perhaps we should follow up with a more sophisticated fix (caching available images and only recaluclating them on `this._changed = true`), but this obvious one mostly eliminates the regression.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed a rendering performance regression accidentally introduced in v1.4.0.</changelog>`
