### PR TITLE
Simplify and refactor ProgramConfiguration

### DIFF
--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -88,9 +88,7 @@ interface Binder<T> {
     defines(): Array<string>;
     setConstantPatternPositions(posTo: ImagePosition, posFrom: ImagePosition): void;
 
-    setUniforms(context: Context, uniform: Uniform<*>, globals: GlobalProperties,
-        currentValue: PossiblyEvaluatedPropertyValue<T>, uniformName: string): void;
-
+    setUniforms(uniform: Uniform<*>, globals: GlobalProperties, currentValue: PossiblyEvaluatedPropertyValue<T>, uniformName: string): void;
     getBinding(context: Context, location: WebGLUniformLocation): $Shape<Uniform<*>>;
 }
 
@@ -116,8 +114,7 @@ class ConstantBinder<T> implements Binder<T> {
     upload() {}
     destroy() {}
 
-    setUniforms(context: Context, uniform: Uniform<*>, globals: GlobalProperties,
-                currentValue: PossiblyEvaluatedPropertyValue<T>): void {
+    setUniforms(uniform: Uniform<*>, globals: GlobalProperties, currentValue: PossiblyEvaluatedPropertyValue<T>): void {
         uniform.set(currentValue.constantOr(this.value));
     }
 
@@ -129,14 +126,12 @@ class ConstantBinder<T> implements Binder<T> {
 }
 
 class CrossFadedConstantBinder<T> implements Binder<T> {
-    value: T;
     uniformNames: Array<string>;
     patternPositions: {[string]: ?Array<number>};
     type: string;
     maxValue: number;
 
     constructor(value: T, names: Array<string>, type: string) {
-        this.value = value;
         this.uniformNames = names.map(name => `u_${name}`);
         this.type = type;
         this.maxValue = -Infinity;
@@ -157,8 +152,7 @@ class CrossFadedConstantBinder<T> implements Binder<T> {
         this.patternPositions.patternFrom = posFrom.tlbr;
     }
 
-    setUniforms(context: Context, uniform: Uniform<*>, globals: GlobalProperties,
-                currentValue: PossiblyEvaluatedPropertyValue<T>, uniformName: string) {
+    setUniforms(uniform: Uniform<*>, globals: GlobalProperties, currentValue: PossiblyEvaluatedPropertyValue<T>, uniformName: string) {
         const pos = this.patternPositions;
         if (uniformName === "u_pattern_to" && pos.patternTo) uniform.set(pos.patternTo);
         if (uniformName === "u_pattern_from" && pos.patternFrom) uniform.set(pos.patternFrom);
@@ -243,7 +237,7 @@ class SourceExpressionBinder<T> implements Binder<T> {
         }
     }
 
-    setUniforms(context: Context, uniform: Uniform<*>): void {
+    setUniforms(uniform: Uniform<*>): void {
         uniform.set(0);
     }
 
@@ -341,8 +335,7 @@ class CompositeExpressionBinder<T> implements Binder<T> {
         return clamp(this.expression.interpolationFactor(currentZoom, this.zoom, this.zoom + 1), 0, 1);
     }
 
-    setUniforms(context: Context, uniform: Uniform<*>,
-                globals: GlobalProperties): void {
+    setUniforms(uniform: Uniform<*>, globals: GlobalProperties): void {
         uniform.set(this.interpolationFactor(globals.zoom));
     }
 
@@ -443,7 +436,7 @@ class CrossFadedCompositeBinder<T> implements Binder<T> {
         if (this.zoomInPaintVertexBuffer) this.zoomInPaintVertexBuffer.destroy();
     }
 
-    setUniforms(context: Context, uniform: Uniform<*>): void {
+    setUniforms(uniform: Uniform<*>): void {
         uniform.set(0);
     }
 
@@ -589,7 +582,7 @@ export default class ProgramConfiguration {
         // Uniform state bindings are owned by the Program, but we set them
         // from within the ProgramConfiguraton's binder members.
         for (const {name, property, binding} of binderUniforms) {
-            this.binders[property].setUniforms(context, binding, globals, properties.get(property), name);
+            this.binders[property].setUniforms(binding, globals, properties.get(property), name);
         }
     }
 

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -534,23 +534,19 @@ export default class ProgramConfiguration {
         }
     }
 
-    updatePatternPaintBuffers(crossfade: CrossfadeParameters) {
-        const buffers = [];
+    updatePaintBuffers(crossfade?: CrossfadeParameters) {
+        this._buffers = [];
 
         for (const property in this.binders) {
             const binder = this.binders[property];
-            if (binder instanceof CrossFadedCompositeBinder) {
+            if (crossfade && binder instanceof CrossFadedCompositeBinder) {
                 const patternVertexBuffer = crossfade.fromScale === 2 ? binder.zoomInPaintVertexBuffer : binder.zoomOutPaintVertexBuffer;
-                if (patternVertexBuffer) buffers.push(patternVertexBuffer);
-            } else if ((binder instanceof SourceExpressionBinder ||
-                binder instanceof CompositeExpressionBinder) &&
-                binder.paintVertexBuffer
-            ) {
-                buffers.push(binder.paintVertexBuffer);
+                if (patternVertexBuffer) this._buffers.push(patternVertexBuffer);
+
+            } else if ((binder instanceof SourceExpressionBinder || binder instanceof CompositeExpressionBinder) && binder.paintVertexBuffer) {
+                this._buffers.push(binder.paintVertexBuffer);
             }
         }
-
-        this._buffers = buffers;
     }
 
     upload(context: Context) {
@@ -559,18 +555,7 @@ export default class ProgramConfiguration {
             if (binder instanceof SourceExpressionBinder || binder instanceof CompositeExpressionBinder || binder instanceof CrossFadedCompositeBinder)
                 binder.upload(context);
         }
-
-        const buffers = [];
-        for (const property in this.binders) {
-            const binder = this.binders[property];
-            if ((binder instanceof SourceExpressionBinder ||
-                binder instanceof CompositeExpressionBinder) &&
-                binder.paintVertexBuffer
-            ) {
-                buffers.push(binder.paintVertexBuffer);
-            }
-        }
-        this._buffers = buffers;
+        this.updatePaintBuffers();
     }
 
     destroy() {

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -152,14 +152,12 @@ class SourceExpressionBinder implements AttributeBinder {
         this.expression = expression;
         this.type = type;
         this.maxValue = 0;
-        this.paintVertexAttributes = names.map((name) =>
-            ({
-                name: `a_${name}`,
-                type: 'Float32',
-                components: type === 'color' ? 2 : 1,
-                offset: 0
-            })
-        );
+        this.paintVertexAttributes = names.map((name) => ({
+            name: `a_${name}`,
+            type: 'Float32',
+            components: type === 'color' ? 2 : 1,
+            offset: 0
+        }));
         this.paintVertexArray = new PaintVertexArray();
     }
 
@@ -218,22 +216,19 @@ class CompositeExpressionBinder implements AttributeBinder, UniformBinder {
     paintVertexAttributes: Array<StructArrayMember>;
     paintVertexBuffer: ?VertexBuffer;
 
-    constructor(expression: CompositeExpression, names: Array<string>, type: string, useIntegerZoom: boolean, zoom: number, layout: Class<StructArray>) {
+    constructor(expression: CompositeExpression, names: Array<string>, type: string, useIntegerZoom: boolean, zoom: number, PaintVertexArray: Class<StructArray>) {
         this.expression = expression;
         this.uniformNames = names.map(name => `u_${name}_t`);
         this.type = type;
         this.useIntegerZoom = useIntegerZoom;
         this.zoom = zoom;
         this.maxValue = 0;
-        const PaintVertexArray = layout;
-        this.paintVertexAttributes = names.map((name) => {
-            return {
-                name: `a_${name}`,
-                type: 'Float32',
-                components: type === 'color' ? 4 : 2,
-                offset: 0
-            };
-        });
+        this.paintVertexAttributes = names.map((name) => ({
+            name: `a_${name}`,
+            type: 'Float32',
+            components: type === 'color' ? 4 : 2,
+            offset: 0
+        }));
         this.paintVertexArray = new PaintVertexArray();
     }
 
@@ -282,15 +277,10 @@ class CompositeExpressionBinder implements AttributeBinder, UniformBinder {
         }
     }
 
-    interpolationFactor(currentZoom: number) {
-        if (this.useIntegerZoom) {
-            currentZoom = Math.floor(currentZoom);
-        }
-        return clamp(this.expression.interpolationFactor(currentZoom, this.zoom, this.zoom + 1), 0, 1);
-    }
-
     setUniform(uniform: Uniform<*>, globals: GlobalProperties): void {
-        uniform.set(this.interpolationFactor(globals.zoom));
+        const currentZoom = this.useIntegerZoom ? Math.floor(globals.zoom) : globals.zoom;
+        const factor = clamp(this.expression.interpolationFactor(currentZoom, this.zoom, this.zoom + 1), 0, 1);
+        uniform.set(factor);
     }
 
     getBinding(context: Context, location: WebGLUniformLocation): Uniform1f {
@@ -312,21 +302,18 @@ class CrossFadedCompositeBinder implements AttributeBinder {
     paintVertexAttributes: Array<StructArrayMember>;
 
     constructor(expression: CompositeExpression, names: Array<string>, type: string, useIntegerZoom: boolean, zoom: number, PaintVertexArray: Class<StructArray>, layerId: string) {
-
         this.expression = expression;
         this.type = type;
         this.useIntegerZoom = useIntegerZoom;
         this.zoom = zoom;
         this.layerId = layerId;
 
-        this.paintVertexAttributes = names.map((name) =>
-            ({
-                name: `a_${name}`,
-                type: 'Uint16',
-                components: 4,
-                offset: 0
-            })
-        );
+        this.paintVertexAttributes = names.map((name) => ({
+            name: `a_${name}`,
+            type: 'Uint16',
+            components: 4,
+            offset: 0
+        }));
 
         this.zoomInPaintVertexArray = new PaintVertexArray();
         this.zoomOutPaintVertexArray = new PaintVertexArray();
@@ -360,7 +347,6 @@ class CrossFadedCompositeBinder implements AttributeBinder {
                 imageMid.tl[0], imageMid.tl[1], imageMid.br[0], imageMid.br[1],
                 imageMin.tl[0], imageMin.tl[1], imageMin.br[0], imageMin.br[1]
             );
-
             this.zoomOutPaintVertexArray.emplace(i,
                 imageMid.tl[0], imageMid.tl[1], imageMid.br[0], imageMid.br[1],
                 imageMax.tl[0], imageMax.tl[1], imageMax.br[0], imageMax.br[1]
@@ -639,8 +625,7 @@ function paintAttributeNames(property, type) {
         'fill-extrusion-pattern': ['pattern_to', 'pattern_from'],
     };
 
-    return attributeNameExceptions[property] ||
-        [property.replace(`${type}-`, '').replace(/-/g, '_')];
+    return attributeNameExceptions[property] || [property.replace(`${type}-`, '').replace(/-/g, '_')];
 }
 
 function getLayoutException(property) {
@@ -675,8 +660,7 @@ function layoutType(property, type, binderType) {
     };
 
     const layoutException = getLayoutException(property);
-    return  layoutException && layoutException[binderType] ||
-        defaultLayouts[type][binderType];
+    return  layoutException && layoutException[binderType] || defaultLayouts[type][binderType];
 }
 
 register('ConstantBinder', ConstantBinder);

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -87,7 +87,7 @@ function drawFillTiles(painter, sourceCache, layer, coords, depthMode, colorMode
         if (image) {
             painter.context.activeTexture.set(gl.TEXTURE0);
             tile.imageAtlasTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
-            programConfiguration.updatePatternPaintBuffers(crossfade);
+            programConfiguration.updatePaintBuffers(crossfade);
         }
 
         const constantPattern = patternProperty.constantOr(null);

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -66,7 +66,7 @@ function drawExtrusionTiles(painter, source, layer, coords, depthMode, stencilMo
         if (image) {
             painter.context.activeTexture.set(gl.TEXTURE0);
             tile.imageAtlasTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
-            programConfiguration.updatePatternPaintBuffers(crossfade);
+            programConfiguration.updatePaintBuffers(crossfade);
         }
 
         const constantPattern = patternProperty.constantOr(null);

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -81,7 +81,7 @@ export default function drawLine(painter: Painter, sourceCache: SourceCache, lay
         if (image) {
             context.activeTexture.set(gl.TEXTURE0);
             tile.imageAtlasTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
-            programConfiguration.updatePatternPaintBuffers(crossfade);
+            programConfiguration.updatePaintBuffers(crossfade);
         } else if (dasharray && (programChanged || painter.lineAtlas.dirty)) {
             context.activeTexture.set(gl.TEXTURE0);
             painter.lineAtlas.bind(context);

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -137,8 +137,6 @@ class Painter {
 
         this.depthRboNeedsClear = true;
 
-        this.emptyProgramConfiguration = new ProgramConfiguration();
-
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 
         this.gpuTimers = {};
@@ -599,9 +597,9 @@ class Painter {
         return !imagePosA || !imagePosB;
     }
 
-    useProgram(name: string, programConfiguration: ProgramConfiguration = this.emptyProgramConfiguration): Program<any> {
+    useProgram(name: string, programConfiguration: ?ProgramConfiguration): Program<any> {
         this.cache = this.cache || {};
-        const key = `${name}${programConfiguration.cacheKey || ''}${this._showOverdrawInspector ? '/overdraw' : ''}`;
+        const key = `${name}${programConfiguration ? programConfiguration.cacheKey : ''}${this._showOverdrawInspector ? '/overdraw' : ''}`;
         if (!this.cache[key]) {
             this.cache[key] = new Program(this.context, shaders[name], programConfiguration, programUniforms[name], this._showOverdrawInspector);
         }

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -31,13 +31,13 @@ class Program<Us: UniformBindings> {
 
     constructor(context: Context,
                 source: {fragmentSource: string, vertexSource: string},
-                configuration: ProgramConfiguration,
+                configuration: ?ProgramConfiguration,
                 fixedUniforms: (Context, UniformLocations) => Us,
                 showOverdrawInspector: boolean) {
         const gl = context.gl;
         this.program = gl.createProgram();
 
-        const defines = configuration.defines();
+        const defines = configuration ? configuration.defines() : [];
         if (showOverdrawInspector) {
             defines.push('#define OVERDRAW_INSPECTOR;');
         }
@@ -68,7 +68,7 @@ class Program<Us: UniformBindings> {
         // ProgramInterface so that we don't dynamically link an unused
         // attribute at position 0, which can cause rendering to fail for an
         // entire layer (see #4607, #4728)
-        const layoutAttributes = configuration.layoutAttributes || [];
+        const layoutAttributes = configuration ? configuration.layoutAttributes : [];
         for (let i = 0; i < layoutAttributes.length; i++) {
             gl.bindAttribLocation(this.program, i, layoutAttributes[i].name);
         }
@@ -97,7 +97,7 @@ class Program<Us: UniformBindings> {
         }
 
         this.fixedUniforms = fixedUniforms(context, uniformLocations);
-        this.binderUniforms = configuration.getUniforms(context, uniformLocations);
+        this.binderUniforms = configuration ? configuration.getUniforms(context, uniformLocations) : [];
     }
 
     draw(context: Context,

--- a/src/style/query_utils.js
+++ b/src/style/query_utils.js
@@ -12,8 +12,7 @@ export function getMaximumPaintValue(property: string, layer: StyleLayer, bucket
     if (value.kind === 'constant') {
         return value.value;
     } else {
-        const binders = bucket.programConfigurations.get(layer.id).binders;
-        return binders[property].maxValue;
+        return bucket.programConfigurations.get(layer.id).getMaxValue(property);
     }
 }
 


### PR DESCRIPTION
In this PR, I'll be working on rewriting ProgramConfiguration into a simpler and easier to understand set of classes, removing code repetition, unused state, and vague interfaces with disjoint set of responsibilities.

I might add more commits while this is reviewed, but it can be merged at any time — I'm keeping individual commits self-contained.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
