### PR TITLE
Only normalize canonicalized mapbox tile URLs

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -106,7 +106,7 @@ export class RequestManager {
             this._createSkuToken();
         }
 
-        if (tileURL && !isMapboxURL(tileURL) && !isMapboxHTTPURL(tileURL)) return tileURL;
+        if (tileURL && !isMapboxURL(tileURL)) return tileURL;
 
         const urlObject = parseUrl(tileURL);
         const imageExtensionRe = /(\.(png|jpg)\d*)(?=$)/;


### PR DESCRIPTION
fix #9259

Putting a mapbox http url through `normalizeTileURL(...)` would produce something like `https://api.mapbox.com/v4/v4/...`. This was being hit by the benchmarks which call `normalizeTileURL(...)` directly.

@kkaefer is there any reason we should be normalizing urls that are not `mapbox://`? Should we add an `assert(!isMapboxHTTPURL(tileURL))` to the top of `normalizeTileURL(...)`?

I don't think this bug affected any users because -gl-js canonicalizes all mapbox http urls before normalizing them, right?



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

