### PR TITLE
add space before units in scale bar

### DIFF
--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -120,7 +120,7 @@ function setScale(container, maxWidth, maxDistance, unit) {
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
     container.style.width = `${maxWidth * ratio}px`;
-    container.innerHTML = distance + " " + unit;
+    container.innerHTML = `${distance} ${unit}`;
 }
 
 function getDecimalRoundNum(d) {

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -120,7 +120,7 @@ function setScale(container, maxWidth, maxDistance, unit) {
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
     container.style.width = `${maxWidth * ratio}px`;
-    container.innerHTML = distance + unit;
+    container.innerHTML = distance + " " + unit;
 }
 
 function getDecimalRoundNum(d) {


### PR DESCRIPTION
Most styles prefer a space before measurement units. See for example:

https://en.wikipedia.org/wiki/International_System_of_Units
https://www.nist.gov/pml/weights-and-measures/writing-metric-units

Sorry, I don't have time go through the checklist below. Just offering this PR if you'd like to use it.

-Geoff

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes

Before
<img width="84" alt="Screen Shot 2020-02-10 at 10 44 28 AM" src="https://user-images.githubusercontent.com/4523080/74179451-58128900-4bf2-11ea-9b01-df6adfad2a81.png">

After
<img width="86" alt="Screen Shot 2020-02-10 at 10 44 02 AM" src="https://user-images.githubusercontent.com/4523080/74179450-5779f280-4bf2-11ea-907d-a202eeced1f8.png">

 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add space between distance and unit in scale control</changelog>`
