### PR TITLE
remove `Marker#rotationAlignment` link in `options.rotation`

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -34,7 +34,7 @@ type Options = {
  * @param {PointLike} [options.offset] The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
  * @param {string} [options.color='#3FB1CE'] The color to use for the default marker if options.element is not provided. The default is light blue.
  * @param {boolean} [options.draggable=false] A boolean indicating whether or not a marker is able to be dragged to a new position on the map.
- * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective {@link Marker#rotationAlignment} setting. A positive value will rotate the marker clockwise.
+ * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective `rotationAlignment` setting. A positive value will rotate the marker clockwise.
  * @param {string} [options.pitchAlignment='auto'] `map` aligns the `Marker` to the plane of the map. `viewport` aligns the `Marker` to the plane of the viewport. `auto` automatically matches the value of `rotationAlignment`.
  * @param {string} [options.rotationAlignment='auto'] `map` aligns the `Marker`'s rotation relative to the map, maintaining a bearing as the map rotates. `viewport` aligns the `Marker`'s rotation relative to the viewport, agnostic to map rotations. `auto` is equivalent to `viewport`.
  * @example


### PR DESCRIPTION
Under the Marker section, the link to `Marker#rotationAlignment` (https://docs.mapbox.com/mapbox-gl-js/api/Marker#rotationAlignment) returns a 404. I believe it's meant to be `https://docs.mapbox.com/mapbox-gl-js/api/#Marker#rotationAlignment`, but an id for `rotationAlignment` does not exist. Since `rotationAlignment` is two cells down on the table, this PR proposes to remove the link.

Stage | Image
---|---
Current |  ![image](https://user-images.githubusercontent.com/2180540/74155972-6dcc8200-4be3-11ea-90f9-b3e6d9fdb2cd.png)
Proposed |  ![image](https://user-images.githubusercontent.com/2180540/74156155-c734b100-4be3-11ea-97ab-e1ec4c6b025a.png)




## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes

