### PR TITLE
Use non-breaking space

### DIFF
--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -120,7 +120,7 @@ function setScale(container, maxWidth, maxDistance, unit) {
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
     container.style.width = `${maxWidth * ratio}px`;
-    container.innerHTML = `${distance} ${unit}`;
+    container.innerHTML = `${distance}&nbsp;${unit}`;
 }
 
 function getDecimalRoundNum(d) {


### PR DESCRIPTION
Recent commit adding space between distance and unit introduced an ugly line break on mobile. Non-breaking space fixes that.