### PR TITLE
Make sure scale text won't overflow

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -536,6 +536,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     padding: 0 5px;
     color: #333;
     box-sizing: border-box;
+    overflow: hidden;
 }
 
 .mapboxgl-popup {


### PR DESCRIPTION
On certain situations scale text overflows:
![824482D2-4F15-4259-8EFD-45F6016BC0D0_1_201_a](https://user-images.githubusercontent.com/1475902/74230093-59b07f80-4ccc-11ea-8196-44e2d9741c6e.jpeg)

Using `overflow: hidden` fixes that.