### PR TITLE
Set geolocate onZoom callback only after ui is setup

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -127,7 +127,6 @@ class GeolocateControl extends Evented {
         this._map = map;
         this._container = DOM.create('div', `mapboxgl-ctrl mapboxgl-ctrl-group`);
         checkGeolocationSupport(this._setupUI);
-        this._map.on('zoom', this._onZoom);
         return this._container;
     }
 
@@ -369,6 +368,8 @@ class GeolocateControl extends Evented {
             this._accuracyCircleMarker = new Marker({element: this._circleElement, pitchAlignment: 'map'});
 
             if (this.options.trackUserLocation) this._watchState = 'OFF';
+
+            this._map.on('zoom', this._onZoom);
         }
 
         this._geolocateButton.addEventListener('click',


### PR DESCRIPTION
Fixes issue #9286 and is an alternative to #9279.

Previously, if the map was zoomed before `checkGeolocationSupport` completed (`window.navigator.permissions.query({name: 'geolocation'})` specifically), the `onZoom` callback would try to modify `_circleElement` which had not been created yet.

Now, the `onZoom` callback is set in `setupUI` (after `checkGeolocationSupport` completes).

## No test
I was not able to create a test that exercised this bug unfortunately... maybe someone else has an idea? 

My attempt was to overwrite the `checkGeolocationSupport` with a setTimeout version...
```
test('GeolocateControl can zoom before checkGeolocationSupport completes', (t) => {
    const map = createMap(t);
    const geolocate = new GeolocateControl({
        trackUserLocation: true,
        showUserLocation: true,
        showAccuracyCircle: true,
    });
    
    geolocate.realCheckGeolocationSupport = geolocate.checkGeolocationSupport
    geolocate.checkGeolocationSupport = function(cb){
        setTimeout(() => {
            geolocate.realCheckGeolocationSupport(cb)
        },10000);
    }

    map.addControl(geolocate);

    map.jumpTo({
        center: [10, 20]
    });
    map.once('zoomend', () => {
        t.end();
    });
    map.zoomTo(10, {duration: 0});
});
```