### PR TITLE
fix bug in GeolocateControl where onSuccess and onError callbacks were still being called after control was removed

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -194,6 +194,11 @@ class GeolocateControl extends Evented {
     }
 
     _onSuccess(position: Position) {
+        if (!this._map) {
+            // control has since been removed
+            return;
+        }
+
         if (this._isOutOfMapMaxBounds(position)) {
             this._setErrorState();
 
@@ -294,6 +299,11 @@ class GeolocateControl extends Evented {
     }
 
     _onError(error: PositionError) {
+        if (!this._map) {
+            // control has since been removed
+            return;
+        }
+
         if (this.options.trackUserLocation) {
             if (error.code === 1) {
                 // PERMISSION_DENIED

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -162,6 +162,17 @@ test('GeolocateControl geolocate fitBoundsOptions', (t) => {
     geolocation.send({latitude: 10, longitude: 20, accuracy: 1});
 });
 
+test('GeolocateControl with removed before Geolocation callback', (t) => {
+    const map = createMap(t);
+    t.plan(0);
+
+    const geolocate = new GeolocateControl();
+    map.addControl(geolocate);
+    geolocate.trigger();
+    map.removeControl(geolocate);
+    t.end();
+});
+
 test('GeolocateControl non-zero bearing', (t) => {
     t.plan(3);
 


### PR DESCRIPTION
## Launch Checklist

closes #9290

 - [x] briefly describe the changes in this PR
fix bug where onSuccess and onError callbacks were still being called after control was removed
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
<changlog>Fixed a bug in the GeolocateControl which resulted in an error when `trackUserLocation` was `false` and the control was removed before the Geolocation API had returned a location</changelog>
