### PR TITLE
Letting `LngLatBounds.extend` accepts LngLatLike and LngLatBoundsLike as well.

### DIFF
--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -66,7 +66,7 @@ class LngLatBounds {
      * @param {LngLat|LngLatBounds} obj object to extend to
      * @returns {LngLatBounds} `this`
      */
-    extend(obj: LngLat | LngLatBounds) {
+    extend(obj: LngLatLike | LngLatBoundsLike) {
         const sw = this._sw,
             ne = this._ne;
         let sw2, ne2;
@@ -83,7 +83,9 @@ class LngLatBounds {
 
         } else {
             if (Array.isArray(obj)) {
-                if (obj.every(Array.isArray)) {
+                // if every element in the Obj array is also an array or
+                // if the LngLatBoundLike is defiend as a array of 4 numbers
+                if (obj.length > 2 || obj.every(Array.isArray)) {
                     return this.extend(LngLatBounds.convert(obj));
                 } else {
                     return this.extend(LngLat.convert(obj));

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -61,9 +61,9 @@ class LngLatBounds {
     }
 
     /**
-     * Extend the bounds to include a given LngLatLike or LngLatBoundsLike.
+     * Extend the bounds to include a given LngLat, LngLatLike, LngLatBounds or LngLatBoundsLike.
      *
-     * @param {LngLatLike|LngLatBoundsLike} obj object to extend to
+     * @param {LngLat|LngLatLike|LngLatBounds|LngLatBoundsLike} obj object to extend to
      * @returns {LngLatBounds} `this`
      */
     extend(obj: LngLatLike | LngLatBoundsLike) {

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -83,9 +83,7 @@ class LngLatBounds {
 
         } else {
             if (Array.isArray(obj)) {
-                // obj is LngLatBounds object if every element in the Obj array is also an array or
-                // if the LngLatBoundLike is defiend as a array of 4 numbers
-                if (obj.length > 2 || obj.every(Array.isArray)) {
+                if (obj.length === 4 || obj.every(Array.isArray)) {
                     return this.extend(LngLatBounds.convert(obj));
                 } else {
                     return this.extend(LngLat.convert(obj));

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -61,9 +61,9 @@ class LngLatBounds {
     }
 
     /**
-     * Extend the bounds to include a given LngLat or LngLatBounds.
+     * Extend the bounds to include a given LngLatLike or LngLatBoundsLike.
      *
-     * @param {LngLat|LngLatBounds} obj object to extend to
+     * @param {LngLatLike|LngLatBoundsLike} obj object to extend to
      * @returns {LngLatBounds} `this`
      */
     extend(obj: LngLatLike | LngLatBoundsLike) {
@@ -83,7 +83,7 @@ class LngLatBounds {
 
         } else {
             if (Array.isArray(obj)) {
-                // if every element in the Obj array is also an array or
+                // obj is LngLatBounds object if every element in the Obj array is also an array or
                 // if the LngLatBoundLike is defiend as a array of 4 numbers
                 if (obj.length > 2 || obj.every(Array.isArray)) {
                     return this.extend(LngLatBounds.convert(obj));

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -61,9 +61,9 @@ class LngLatBounds {
     }
 
     /**
-     * Extend the bounds to include a given LngLat, LngLatLike, LngLatBounds or LngLatBoundsLike.
+     * Extend the bounds to include a given LngLatLike or LngLatBoundsLike.
      *
-     * @param {LngLat|LngLatLike|LngLatBounds|LngLatBoundsLike} obj object to extend to
+     * @param {LngLatLike|LngLatBoundsLike} obj object to extend to
      * @returns {LngLatBounds} `this`
      */
     extend(obj: LngLatLike | LngLatBoundsLike) {
@@ -84,9 +84,11 @@ class LngLatBounds {
         } else {
             if (Array.isArray(obj)) {
                 if (obj.length === 4 || obj.every(Array.isArray)) {
-                    return this.extend(LngLatBounds.convert(obj));
+                    const lngLatBoundsObj = ((obj: any): LngLatBoundsLike);
+                    return this.extend(LngLatBounds.convert(lngLatBoundsObj));
                 } else {
-                    return this.extend(LngLat.convert(obj));
+                    const lngLatObj = ((obj: any): LngLatLike);
+                    return this.extend(LngLat.convert(lngLatObj));
                 }
             }
             return this;

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -66,6 +66,7 @@ test('LngLatBounds', (t) => {
     t.test('#extend with bounds', (t) => {
         const bounds1 = new LngLatBounds([0, 0], [10, 10]);
         const bounds2 = new LngLatBounds([-10, -10], [10, 10]);
+
         bounds1.extend(bounds2);
 
         t.equal(bounds1.getSouth(), -10);
@@ -80,6 +81,14 @@ test('LngLatBounds', (t) => {
         t.equal(bounds1.getWest(), -15);
         t.equal(bounds1.getNorth(), 15);
         t.equal(bounds1.getEast(), 15);
+
+        const bounds4 = new LngLatBounds([-20, -20, 20, 20]);
+        bounds1.extend(bounds4);
+
+        t.equal(bounds1.getSouth(), -20);
+        t.equal(bounds1.getWest(), -20);
+        t.equal(bounds1.getNorth(), 20);
+        t.equal(bounds1.getEast(), 20);
 
         t.end();
     });

--- a/test/unit/geo/lng_lat_bounds.test.js
+++ b/test/unit/geo/lng_lat_bounds.test.js
@@ -60,6 +60,13 @@ test('LngLatBounds', (t) => {
         t.equal(bounds.getNorth(), 10);
         t.equal(bounds.getEast(), 10);
 
+        bounds.extend([-20, -20, 100]);
+
+        t.equal(bounds.getSouth(), -20);
+        t.equal(bounds.getWest(), -20);
+        t.equal(bounds.getNorth(), 10);
+        t.equal(bounds.getEast(), 10);
+
         t.end();
     });
 
@@ -130,6 +137,17 @@ test('LngLatBounds', (t) => {
         t.equal(bounds.getWest(), 0);
         t.equal(bounds.getNorth(), 15);
         t.equal(bounds.getEast(), 15);
+
+        t.end();
+    });
+
+    t.test('#extend with empty array', (t) => {
+        const point = new LngLat(0, 0);
+        const bounds = new LngLatBounds(point, point);
+
+        t.throws(() => {
+            bounds.extend([]);
+        }, "`LngLatLike` argument must be specified as a LngLat instance, an object {lng: <lng>, lat: <lat>}, an object {lon: <lng>, lat: <lat>}, or an array of [<lng>, <lat>]", 'detects and throws on invalid input');
 
         t.end();
     });


### PR DESCRIPTION
This PR is to address issue #8065 

Previously in the code base, `extend` function in `LngLatBounds` class would only accept LngLat and LngLatBounds. This resulted into seeing a typescript types check failure. 

With this change we will be able to pass an object of types: `LngLat`, `LngLatBounds`, `LngLatLike` or `LngLatBoundsLike` to `LngLatBounds.extend` function.

Also, previously, while we were checking to see if the passed object is an array or not, we have missed a case which `LngLatBoundsLike` could have be define as an array of four numbers. Updated the code and also the test file to capture that case as well.

tested the change using `debug/bounds.html`. Will appreciate more test scenarios to see if the change is working or not.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 </changelog>`
