### PR TITLE
Allow needle argument to 'in' expression to be false

### DIFF
--- a/src/style-spec/expression/definitions/in.js
+++ b/src/style-spec/expression/definitions/in.js
@@ -62,7 +62,7 @@ class In implements Expression {
         const needle = (this.needle.evaluate(ctx): any);
         const haystack = (this.haystack.evaluate(ctx): any);
 
-        if (!needle || !haystack) return false;
+        if (needle == null || !haystack) return false;
 
         if (!isComparableRuntimeValue(needle)) {
             throw new RuntimeError(`Expected first argument to be of type boolean, string or number, but found ${toString(typeOf(needle))} instead.`);

--- a/test/integration/expression-tests/in/basic-string/test.json
+++ b/test/integration/expression-tests/in/basic-string/test.json
@@ -24,7 +24,7 @@
       false,
       true,
       true,
-      false,
+      true,
       true,
       false
     ],


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - While implementing the native port of the `in` expression, @Chaoba pointed out confusing behavior in one of the `in` tests. https://github.com/mapbox/mapbox-gl-js/blob/f995141893522d09e3572660e68d11bcf529cd41/test/integration/expression-tests/in/basic-string/test.json#L11 returns `false` because of the check at https://github.com/mapbox/mapbox-gl-js/blob/master/src/style-spec/expression/definitions/in.js#L65 `if (!needle...) return false;` This PR refines that check to filter out `undefined` and `null` needle values while allowing the needle to be a `false` Boolean value
 - [x] write tests for all new functionality
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Allow needle argument to 'in' expression to be false</changelog>`
