### PR TITLE
Clearing the underlying source's tiles while removing a layer.

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -392,6 +392,8 @@ class Tile {
         const vtLayers = this.latestFeatureIndex.loadVTLayers();
 
         for (const id in this.buckets) {
+            if (!painter.style.isValidLayer(id)) continue;
+
             const bucket = this.buckets[id];
             // Buckets are grouped by common source-layer
             const sourceLayerId = bucket.layers[0]['sourceLayer'] || '_geojsonTileLayer';

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -392,7 +392,7 @@ class Tile {
         const vtLayers = this.latestFeatureIndex.loadVTLayers();
 
         for (const id in this.buckets) {
-            if (!painter.style.isValidLayer(id)) continue;
+            if (!painter.style.hasLayer(id)) continue;
 
             const bucket = this.buckets[id];
             // Buckets are grouped by common source-layer

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -750,6 +750,7 @@ class Style extends Evented {
         this._layerOrderChanged = true;
         this._changed = true;
         this._removedLayers[id] = layer;
+        this._updatedSources[layer.source] = 'clear';
         delete this._layers[id];
         delete this._updatedLayers[id];
         delete this._updatedPaintProps[id];

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -750,7 +750,6 @@ class Style extends Evented {
         this._layerOrderChanged = true;
         this._changed = true;
         this._removedLayers[id] = layer;
-        this._updatedSources[layer.source] = 'clear';
         delete this._layers[id];
         delete this._updatedLayers[id];
         delete this._updatedPaintProps[id];
@@ -768,6 +767,17 @@ class Style extends Evented {
      */
     getLayer(id: string): Object {
         return this._layers[id];
+    }
+
+    /**
+     * Return a boolean specifying if the layer is valid (not deleted) with the given `id`.
+     *
+     * @param {string} id - id of the desired layer
+     * @returns {boolean} a boolean specifying if the given layer is valid
+     */
+    isValidLayer(id: string): boolean {
+        const layerIds = Object.keys(this._layers);
+        return layerIds.includes(id, 0);
     }
 
     setLayerZoomRange(layerId: string, minzoom: ?number, maxzoom: ?number) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -770,12 +770,12 @@ class Style extends Evented {
     }
 
     /**
-     * Return a boolean specifying if the layer is valid (not deleted) with the given `id`.
+     * checks if a specific layer is present within the style.
      *
      * @param {string} id - id of the desired layer
-     * @returns {boolean} a boolean specifying if the given layer is valid
+     * @returns {boolean} a boolean specifying if the given layer is present
      */
-    isValidLayer(id: string): boolean {
+    hasLayer(id: string): boolean {
         const layerIds = Object.keys(this._layers);
         return layerIds.includes(id, 0);
     }


### PR DESCRIPTION
<changelog>Bug</changelog>
This PR fixes #8634 

A summary of the problem:

if we remove a layer, the layer still persist in the existing main thread's tiles and buckets list and if we use SetFeatureState(), while it goes through all the buckets, it gets to invalid layers(deleted layers).

An alternative fix to this problem could be any time we are removing layers, we clear the the underlying source's tiles. Basically call `this._updatedSources[layer.source] = 'clear';` in
https://github.com/mapbox/mapbox-gl-js/blob/master/src/style/style.js#L736
which this could potentially be computationally expensive and would result in seeing a glitch which is not very pleasant.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/32684731/74884368-daecbf80-5327-11ea-9079-a3daa92cdcf3.gif)

Noticed in the gif above, the layer is being removed on click on the map. You can see the glitch.

We can use `this._updatedSources[layer.source] = 'reload';` but that will not fix this issue as well since reload will use the old version of tiles until the workers generate the new version of tiles..

This change won't fix the root cause of this problem (having different versions of tiles in workers and main thread) but will fix this instance of it. Maybe in future we can work on refactoring which can make it easy to keep track of different versions of tiles in workers and main threads. 

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
