### PR TITLE
replace incorrect LatLngBounds with LngLatBounds

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -411,9 +411,9 @@ class Camera extends Evented {
 
     /**
      * @memberof Map#
-     * @param {LatLngBoundsLike} bounds Calculate the center for these bounds in the viewport and use
+     * @param {LngLatBoundsLike} bounds Calculate the center for these bounds in the viewport and use
      *      the highest zoom level up to and including `Map#getMaxZoom()` that fits
-     *      in the viewport. LatLngBounds represent a box that is always axis-aligned with bearing 0.
+     *      in the viewport. LngLatBounds represent a box that is always axis-aligned with bearing 0.
      * @param options
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR

fixes https://github.com/mapbox/mapbox-gl-js-docs/issues/225

changes two incorrect references to `LatLngBounds` which should be `LngLatBounds`

Given this is a fairly minor change I'd not worry about [porting it to to release branch and updating the submodule in -docs](
https://github.com/mapbox/mapbox-gl-js-docs/blob/publisher-production/README.md#committing-and-publishing-documentation), instead just wait for the next release.

cc @colleenmcginnis 