### PR TITLE
Fix map not displaying inside RTL elements

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -3,7 +3,12 @@
     overflow: hidden;
     position: relative;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    text-align: left;
+}
+
+.mapboxgl-canvas {
+    position: absolute;
+    left: 0;
+    top: 0;
 }
 
 .mapboxgl-map:-webkit-full-screen {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2019,7 +2019,6 @@ class Map extends Camera {
         }
 
         this._canvas = DOM.create('canvas', 'mapboxgl-canvas', canvasContainer);
-        this._canvas.style.position = 'absolute';
         this._canvas.addEventListener('webglcontextlost', this._contextLost, false);
         this._canvas.addEventListener('webglcontextrestored', this._contextRestored, false);
         this._canvas.setAttribute('tabindex', '0');


### PR DESCRIPTION
Closes #9329 by reverting #8227 and applying a more general fix that solves both issues (maps inside elements with `dir=rtl` and/or `text-align: center`).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed a bug where maps were not displaying inside elements with dir=rtl.</changelog>`
