### PR TITLE
Patch memory leaks caused by event handlers bound to document

### DIFF
--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -147,13 +147,20 @@ class BoxZoomHandler {
         }
     }
 
-    _finish() {
-        this._active = false;
-
+    _unbind() {
         window.document.removeEventListener('mousemove', this._onMouseMove, false);
         window.document.removeEventListener('keydown', this._onKeyDown, false);
         window.document.removeEventListener('mouseup', this._onMouseUp, false);
+    }
 
+    teardown() {
+        this._unbind();
+    }
+
+    _finish() {
+        this._active = false;
+
+        this._unbind();
         this._container.classList.remove('mapboxgl-crosshair');
 
         if (this._box) {

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -153,7 +153,7 @@ class BoxZoomHandler {
         window.document.removeEventListener('mouseup', this._onMouseUp, false);
     }
 
-    teardown() {
+    remove() {
         this._unbind();
     }
 

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -147,20 +147,16 @@ class BoxZoomHandler {
         }
     }
 
-    _unbind() {
+    remove() {
         window.document.removeEventListener('mousemove', this._onMouseMove, false);
         window.document.removeEventListener('keydown', this._onKeyDown, false);
         window.document.removeEventListener('mouseup', this._onMouseUp, false);
     }
 
-    remove() {
-        this._unbind();
-    }
-
     _finish() {
         this._active = false;
 
-        this._unbind();
+        this.remove();
         this._container.classList.remove('mapboxgl-crosshair');
 
         if (this._box) {

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -345,6 +345,10 @@ class DragPanHandler {
         DOM.removeEventListener(window, 'blur', this._onBlur);
     }
 
+    teardown() {
+        this._unbind();
+    }
+
     _deactivate() {
         if (this._frameId) {
             this._map._cancelRenderFrame(this._frameId);

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -345,7 +345,7 @@ class DragPanHandler {
         DOM.removeEventListener(window, 'blur', this._onBlur);
     }
 
-    teardown() {
+    remove() {
         this._unbind();
     }
 

--- a/src/ui/handler/drag_pan.js
+++ b/src/ui/handler/drag_pan.js
@@ -119,14 +119,14 @@ class DragPanHandler {
         switch (this._state) {
         case 'active':
             this._state = 'disabled';
-            this._unbind();
+            this.remove();
             this._deactivate();
             this._fireEvent('dragend');
             this._fireEvent('moveend');
             break;
         case 'pending':
             this._state = 'disabled';
-            this._unbind();
+            this.remove();
             break;
         default:
             this._state = 'disabled';
@@ -252,13 +252,13 @@ class DragPanHandler {
         case 'active':
             this._state = 'enabled';
             DOM.suppressClick();
-            this._unbind();
+            this.remove();
             this._deactivate();
             this._inertialPan(e);
             break;
         case 'pending':
             this._state = 'enabled';
-            this._unbind();
+            this.remove();
             break;
         default:
             assert(false);
@@ -271,16 +271,16 @@ class DragPanHandler {
             switch (this._state) {
             case 'active':
                 this._state = 'enabled';
-                this._unbind();
+                this.remove();
                 this._deactivate();
                 this._inertialPan(e);
                 break;
             case 'pending':
                 this._state = 'enabled';
-                this._unbind();
+                this.remove();
                 break;
             case 'enabled':
-                this._unbind();
+                this.remove();
                 break;
             default:
                 assert(false);
@@ -312,7 +312,7 @@ class DragPanHandler {
                 this._fireEvent('dragend', e);
                 this._fireEvent('moveend', e);
             }
-            this._unbind();
+            this.remove();
             this._deactivate();
             if ((window.TouchEvent && e instanceof window.TouchEvent) && e.touches.length > 1) {
                 // If there are multiple fingers touching, reattach touchend listener in case
@@ -322,10 +322,10 @@ class DragPanHandler {
             break;
         case 'pending':
             this._state = 'enabled';
-            this._unbind();
+            this.remove();
             break;
         case 'enabled':
-            this._unbind();
+            this.remove();
             break;
         default:
             assert(false);
@@ -337,16 +337,12 @@ class DragPanHandler {
         this._abort(e);
     }
 
-    _unbind() {
+    remove() {
         DOM.removeEventListener(window.document, 'touchmove', this._onMove, {capture: true, passive: false});
         DOM.removeEventListener(window.document, 'touchend', this._onTouchEnd);
         DOM.removeEventListener(window.document, 'mousemove', this._onMove, {capture: true});
         DOM.removeEventListener(window.document, 'mouseup', this._onMouseUp);
         DOM.removeEventListener(window, 'blur', this._onBlur);
-    }
-
-    remove() {
-        this._unbind();
     }
 
     _deactivate() {

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -294,6 +294,10 @@ class DragRotateHandler {
         DOM.enableDrag();
     }
 
+    teardown() {
+        this._unbind();
+    }
+
     _deactivate() {
         if (this._frameId) {
             this._map._cancelRenderFrame(this._frameId);

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -112,7 +112,7 @@ class DragRotateHandler {
         switch (this._state) {
         case 'active':
             this._state = 'disabled';
-            this._unbind();
+            this.remove();
             this._deactivate();
             this._fireEvent('rotateend');
             if (this._pitchWithRotate) {
@@ -122,7 +122,7 @@ class DragRotateHandler {
             break;
         case 'pending':
             this._state = 'disabled';
-            this._unbind();
+            this.remove();
             break;
         default:
             this._state = 'disabled';
@@ -249,13 +249,13 @@ class DragRotateHandler {
         case 'active':
             this._state = 'enabled';
             DOM.suppressClick();
-            this._unbind();
+            this.remove();
             this._deactivate();
             this._inertialRotate(e);
             break;
         case 'pending':
             this._state = 'enabled';
-            this._unbind();
+            this.remove();
             break;
         default:
             assert(false);
@@ -267,7 +267,7 @@ class DragRotateHandler {
         switch (this._state) {
         case 'active':
             this._state = 'enabled';
-            this._unbind();
+            this.remove();
             this._deactivate();
             this._fireEvent('rotateend', e);
             if (this._pitchWithRotate) {
@@ -277,7 +277,7 @@ class DragRotateHandler {
             break;
         case 'pending':
             this._state = 'enabled';
-            this._unbind();
+            this.remove();
             break;
         default:
             assert(false);
@@ -285,17 +285,13 @@ class DragRotateHandler {
         }
     }
 
-    _unbind() {
+    remove() {
         window.document.removeEventListener('mousemove', this._onMouseMove, {capture: true});
         window.document.removeEventListener('mouseup', this._onMouseUp);
         window.document.removeEventListener('touchmove', this._onMouseMove, {capture: true});
         window.document.removeEventListener('touchend', this._onMouseUp);
         window.removeEventListener('blur', this._onBlur);
         DOM.enableDrag();
-    }
-
-    remove() {
-        this._unbind();
     }
 
     _deactivate() {

--- a/src/ui/handler/drag_rotate.js
+++ b/src/ui/handler/drag_rotate.js
@@ -294,7 +294,7 @@ class DragRotateHandler {
         DOM.enableDrag();
     }
 
-    teardown() {
+    remove() {
         this._unbind();
     }
 

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -217,8 +217,7 @@ class TouchZoomRotateHandler {
     }
 
     _onEnd(e: TouchEvent) {
-        DOM.removeEventListener(window.document, 'touchmove', this._onMove, {passive: false});
-        DOM.removeEventListener(window.document, 'touchend', this._onEnd);
+        this._unbind();
 
         const gestureIntent = this._gestureIntent;
         const startScale = this._startScale;
@@ -280,6 +279,15 @@ class TouchZoomRotateHandler {
             around: this._aroundCenter ? map.getCenter() : map.unproject(p),
             noMoveStart: true
         }, {originalEvent: e});
+    }
+
+    _unbind() {
+        DOM.removeEventListener(window.document, 'touchmove', this._onMove, {passive: false});
+        DOM.removeEventListener(window.document, 'touchend', this._onEnd);
+    }
+
+    teardown(){
+        this._unbind();
     }
 
     _drainInertiaBuffer() {

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -217,7 +217,7 @@ class TouchZoomRotateHandler {
     }
 
     _onEnd(e: TouchEvent) {
-        this._unbind();
+        this.remove();
 
         const gestureIntent = this._gestureIntent;
         const startScale = this._startScale;
@@ -281,13 +281,9 @@ class TouchZoomRotateHandler {
         }, {originalEvent: e});
     }
 
-    _unbind() {
+    remove() {
         DOM.removeEventListener(window.document, 'touchmove', this._onMove, {passive: false});
         DOM.removeEventListener(window.document, 'touchend', this._onEnd);
-    }
-
-    remove() {
-        this._unbind();
     }
 
     _drainInertiaBuffer() {

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -286,7 +286,7 @@ class TouchZoomRotateHandler {
         DOM.removeEventListener(window.document, 'touchend', this._onEnd);
     }
 
-    teardown(){
+    teardown() {
         this._unbind();
     }
 

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -286,7 +286,7 @@ class TouchZoomRotateHandler {
         DOM.removeEventListener(window.document, 'touchend', this._onEnd);
     }
 
-    teardown() {
+    remove() {
         this._unbind();
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2302,11 +2302,11 @@ class Map extends Camera {
         removeNode(this._missingCSSCanary);
         this._container.classList.remove('mapboxgl-map');
 
-        //Teardown input handlers
-        this.dragPan.teardown();
-        this.boxZoom.teardown();
-        this.dragRotate.teardown();
-        this.touchZoomRotate.teardown();
+        //remove input handlers
+        this.dragPan.remove();
+        this.boxZoom.remove();
+        this.dragRotate.remove();
+        this.touchZoomRotate.remove();
 
         PerformanceUtils.clearMetrics();
         this.fire(new Event('remove'));

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2302,6 +2302,12 @@ class Map extends Camera {
         removeNode(this._missingCSSCanary);
         this._container.classList.remove('mapboxgl-map');
 
+        //Teardown input handlers
+        this.dragPan.teardown();
+        this.boxZoom.teardown();
+        this.dragRotate.teardown();
+        this.touchZoomRotate.teardown();
+
         PerformanceUtils.clearMetrics();
         this.fire(new Event('remove'));
     }


### PR DESCRIPTION
This potentially addresses https://github.com/mapbox/mapbox-gl-js/issues/9126. 

We temporarily bind handlers to `document` in our event handlers when certain interactions are in flight. If the map is removed during that time, it causes the entire `Map` object to be retained, since its in the scope of the event handlers.

`<changelog>Fixed a memory leak that occurred if the map was removed while certain user interactions were in progress.</changelog>`
