### PR TITLE
Fix style.hasLayer

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -776,8 +776,7 @@ class Style extends Evented {
      * @returns {boolean} a boolean specifying if the given layer is present
      */
     hasLayer(id: string): boolean {
-        const layerIds = Object.keys(this._layers);
-        return layerIds.includes(id, 0);
+        return id in this._layers;
     }
 
     setLayerZoomRange(layerId: string, minzoom: ?number, maxzoom: ?number) {


### PR DESCRIPTION
Fixes a few issues I noticed in #9305 after it was merged: 

- Instead of generating an array of all layer IDs and then calling `indexOf` on it (both linear-time operations), we can directly check if an `id` is present in the `_layers` object in constant time. 
- `includes` [is not supported in IE11](https://caniuse.com/#search=includes).