### PR TITLE
Use glUniform1i for boolean uniforms

### DIFF
--- a/src/render/program/symbol_program.js
+++ b/src/render/program/symbol_program.js
@@ -26,7 +26,7 @@ export type SymbolIconUniformsType = {|
     'u_matrix': UniformMatrix4f,
     'u_label_plane_matrix': UniformMatrix4f,
     'u_coord_matrix': UniformMatrix4f,
-    'u_is_text': Uniform1f,
+    'u_is_text': Uniform1i,
     'u_pitch_with_map': Uniform1i,
     'u_texsize': Uniform2f,
     'u_texture': Uniform1i
@@ -45,13 +45,13 @@ export type SymbolSDFUniformsType = {|
     'u_matrix': UniformMatrix4f,
     'u_label_plane_matrix': UniformMatrix4f,
     'u_coord_matrix': UniformMatrix4f,
-    'u_is_text': Uniform1f,
+    'u_is_text': Uniform1i,
     'u_pitch_with_map': Uniform1i,
     'u_texsize': Uniform2f,
     'u_texture': Uniform1i,
     'u_gamma_scale': Uniform1f,
     'u_device_pixel_ratio': Uniform1f,
-    'u_is_halo': Uniform1f
+    'u_is_halo': Uniform1i
 |};
 
 export type symbolTextAndIconUniformsType = {|
@@ -67,7 +67,7 @@ export type symbolTextAndIconUniformsType = {|
     'u_matrix': UniformMatrix4f,
     'u_label_plane_matrix': UniformMatrix4f,
     'u_coord_matrix': UniformMatrix4f,
-    'u_is_text': Uniform1f,
+    'u_is_text': Uniform1i,
     'u_pitch_with_map': Uniform1i,
     'u_texsize': Uniform2f,
     'u_texsize_icon': Uniform2f,
@@ -75,7 +75,7 @@ export type symbolTextAndIconUniformsType = {|
     'u_texture_icon': Uniform1i,
     'u_gamma_scale': Uniform1f,
     'u_device_pixel_ratio': Uniform1f,
-    'u_is_halo': Uniform1f
+    'u_is_halo': Uniform1i
 |};
 
 const symbolIconUniforms = (context: Context, locations: UniformLocations): SymbolIconUniformsType => ({
@@ -91,7 +91,7 @@ const symbolIconUniforms = (context: Context, locations: UniformLocations): Symb
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
     'u_label_plane_matrix': new UniformMatrix4f(context, locations.u_label_plane_matrix),
     'u_coord_matrix': new UniformMatrix4f(context, locations.u_coord_matrix),
-    'u_is_text': new Uniform1f(context, locations.u_is_text),
+    'u_is_text': new Uniform1i(context, locations.u_is_text),
     'u_pitch_with_map': new Uniform1i(context, locations.u_pitch_with_map),
     'u_texsize': new Uniform2f(context, locations.u_texsize),
     'u_texture': new Uniform1i(context, locations.u_texture)
@@ -110,13 +110,13 @@ const symbolSDFUniforms = (context: Context, locations: UniformLocations): Symbo
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
     'u_label_plane_matrix': new UniformMatrix4f(context, locations.u_label_plane_matrix),
     'u_coord_matrix': new UniformMatrix4f(context, locations.u_coord_matrix),
-    'u_is_text': new Uniform1f(context, locations.u_is_text),
+    'u_is_text': new Uniform1i(context, locations.u_is_text),
     'u_pitch_with_map': new Uniform1i(context, locations.u_pitch_with_map),
     'u_texsize': new Uniform2f(context, locations.u_texsize),
     'u_texture': new Uniform1i(context, locations.u_texture),
     'u_gamma_scale': new Uniform1f(context, locations.u_gamma_scale),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
-    'u_is_halo': new Uniform1f(context, locations.u_is_halo)
+    'u_is_halo': new Uniform1i(context, locations.u_is_halo)
 });
 
 const symbolTextAndIconUniforms = (context: Context, locations: UniformLocations): symbolTextAndIconUniformsType => ({
@@ -132,7 +132,7 @@ const symbolTextAndIconUniforms = (context: Context, locations: UniformLocations
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
     'u_label_plane_matrix': new UniformMatrix4f(context, locations.u_label_plane_matrix),
     'u_coord_matrix': new UniformMatrix4f(context, locations.u_coord_matrix),
-    'u_is_text': new Uniform1f(context, locations.u_is_text),
+    'u_is_text': new Uniform1i(context, locations.u_is_text),
     'u_pitch_with_map': new Uniform1i(context, locations.u_pitch_with_map),
     'u_texsize': new Uniform2f(context, locations.u_texsize),
     'u_texsize_icon': new Uniform2f(context, locations.u_texsize_icon),
@@ -140,7 +140,7 @@ const symbolTextAndIconUniforms = (context: Context, locations: UniformLocations
     'u_texture_icon': new Uniform1i(context, locations.u_texture_icon),
     'u_gamma_scale': new Uniform1f(context, locations.u_gamma_scale),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
-    'u_is_halo': new Uniform1f(context, locations.u_is_halo)
+    'u_is_halo': new Uniform1i(context, locations.u_is_halo)
 });
 
 const symbolIconUniformValues = (


### PR DESCRIPTION
We used `glUniform1f` for some of them, which caused rendering errors in at least Chrome 48. Changing these calls to the correct call `glUniform1i` fixes this issue.

Fixes https://github.com/mapbox/mapbox-gl-js/issues/8742, which has been broken since https://github.com/mapbox/mapbox-gl-js/pull/4455.

Before:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/52399/75372398-c6309e80-58c8-11ea-8595-cc751ddb579c.png">

After:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/52399/75372427-d47eba80-58c8-11ea-80c2-06e39236fa16.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a rendering error in for very old versions of Chrome (ca. 2016) where text would appear much bigger than intended</changelog>`
