### PR TITLE
Disable depth mode for heatmaps

### DIFF
--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -28,7 +28,6 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
         const context = painter.context;
         const gl = context.gl;
 
-        const depthMode = painter.depthModeForSublayer(0, DepthMode.ReadOnly);
         // Allow kernels to be drawn across boundaries, so that
         // large kernels are not clipped to tiles
         const stencilMode = StencilMode.disabled;
@@ -55,7 +54,7 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
             const program = painter.useProgram('heatmap', programConfiguration);
             const {zoom} = painter.transform;
 
-            program.draw(context, gl.TRIANGLES, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
+            program.draw(context, gl.TRIANGLES, DepthMode.disabled, stencilMode, colorMode, CullFaceMode.disabled,
                 heatmapUniformValues(coord.posMatrix,
                     tile, zoom, layer.paint.get('heatmap-intensity')),
                 layer.id, bucket.layoutVertexBuffer, bucket.indexBuffer,


### PR DESCRIPTION
An equivalent of https://github.com/mapbox/mapbox-gl-native/pull/16252 — we don't use the depth attachment when rendering heatmaps.