### PR TITLE
Start quickly with Streets v11

### DIFF
--- a/docs/components/quickstart.js
+++ b/docs/components/quickstart.js
@@ -36,7 +36,7 @@ class Quickstart extends React.Component {
 mapboxgl.accessToken = '${this.state.userAccessToken}';
 var map = new mapboxgl.Map({
     container: 'map',
-    style: 'mapbox://styles/mapbox/streets-v9'
+    style: 'mapbox://styles/mapbox/streets-v11'
 });
 </script>
 `}</Copyable>


### PR DESCRIPTION
#8056 upgraded most of the codebase to Streets v11, but the “Quickstart” section of the “Overview” page still referred to Streets v9.

/cc @mapbox/docs