### PR TITLE
Removes a stray period from the `pitch` description

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -570,7 +570,7 @@ export type MapEvent =
     | 'pitchstart'
 
     /**
-     * Fired whenever the map's pitch (tilt) changes as.
+     * Fired whenever the map's pitch (tilt) changes as
      * the result of either user interaction or methods such as {@link Map#flyTo}.
      *
      * @event pitch


### PR DESCRIPTION
Removes a stray period from the `pitch` description.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

