### PR TITLE
Correctly detect expressions and legacy filters for the new in expression

### DIFF
--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -21,7 +21,8 @@ function isExpressionFilter(filter: any) {
         return filter.length >= 2 && filter[1] !== '$id' && filter[1] !== '$type';
 
     case 'in':
-        return filter.length >= 3 && Array.isArray(filter[2]);
+        return filter.length >= 3 && (typeof filter[1] !== 'string' || Array.isArray(filter[2]));
+
     case '!in':
     case '!has':
     case 'none':

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -1,5 +1,6 @@
 import {test} from '../../util/test';
-import createFilter from '../../../src/style-spec/feature_filter';
+import {default as createFilter, isExpressionFilter} from '../../../src/style-spec/feature_filter';
+
 import convertFilter from '../../../src/style-spec/feature_filter/convert';
 
 test('filter', t => {
@@ -67,6 +68,36 @@ test('filter', t => {
     });
 
     legacyFilterTests(t, createFilter);
+
+    t.end();
+});
+
+test('legacy filter detection', t => {
+    t.test('definitely legacy filters', t => {
+        // Expressions with more than two arguments.
+        t.notOk(isExpressionFilter(["in", "color", "red", "blue"]));
+
+        // Expressions where the second argument is not a string or array.
+        t.notOk(isExpressionFilter(["in", "value", 42]));
+        t.notOk(isExpressionFilter(["in", "value", true]));
+        t.end();
+    });
+
+    t.test('ambiguous value', t => {
+        // Should err on the side of reporting as a legacy filter. Style authors can force filters
+        // by using a literal expression as the first argument.
+        t.notOk(isExpressionFilter(["in", "color", "red"]));
+        t.end();
+    });
+
+    t.test('definitely expressions', t => {
+        t.ok(isExpressionFilter(["in", ["get", "color"], "reddish"]));
+        t.ok(isExpressionFilter(["in", ["get", "color"], ["red", "blue"]]));
+        t.ok(isExpressionFilter(["in", 42, 42]));
+        t.ok(isExpressionFilter(["in", true, true]));
+        t.ok(isExpressionFilter(["in", "red", ["get", "colors"]]));
+        t.end();
+    });
 
     t.end();
 });


### PR DESCRIPTION
Attempting to solve https://github.com/mapbox/mapbox-gl-js/issues/9373.

We are now detecting expressions more accurately, e.g. when the first argument isn't a string.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] tagged `@mapbox/studio` if this PR includes style spec or visual changes
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Don't attempt to convert expressions as legacy filters in some situations</changelog>`
