### PR TITLE
Don't reload the entire font range when a glyph is missing in a font

### DIFF
--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -52,26 +52,26 @@ class GlyphManager {
             if (!entry) {
                 entry = this.entries[stack] = {
                     glyphs: {},
-                    requests: {}
+                    requests: {},
+                    ranges: {},
                 };
-            }
-
-            let glyph = entry.glyphs[id];
-            if (glyph !== undefined) {
-                callback(null, {stack, id, glyph});
-                return;
-            }
-
-            glyph = this._tinySDF(entry, stack, id);
-            if (glyph) {
-                entry.glyphs[id] = glyph;
-                callback(null, {stack, id, glyph});
-                return;
             }
 
             const range = Math.floor(id / 256);
             if (range * 256 > 65535) {
                 callback(new Error('glyphs > 65535 not supported'));
+                return;
+            }
+
+            if (entry.ranges[range]) {
+                callback(null, {stack, id, glyph: entry.glyphs[id]});
+                return;
+            }
+
+            const glyph = this._tinySDF(entry, stack, id);
+            if (glyph) {
+                entry.glyphs[id] = glyph;
+                callback(null, {stack, id, glyph});
                 return;
             }
 
@@ -86,6 +86,7 @@ class GlyphManager {
                                     entry.glyphs[+id] = response[+id];
                                 }
                             }
+                            entry.ranges[range] = true;
                         }
                         for (const cb of requests) {
                             cb(err, response);

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -57,6 +57,20 @@ class GlyphManager {
                 };
             }
 
+
+            let glyph = entry.glyphs[id];
+            if (glyph !== undefined) {
+                callback(null, {stack, id, glyph});
+                return;
+            }
+
+            glyph = this._tinySDF(entry, stack, id);
+            if (glyph) {
+                entry.glyphs[id] = glyph;
+                callback(null, {stack, id, glyph});
+                return;
+            }
+
             const range = Math.floor(id / 256);
             if (range * 256 > 65535) {
                 callback(new Error('glyphs > 65535 not supported'));
@@ -64,14 +78,7 @@ class GlyphManager {
             }
 
             if (entry.ranges[range]) {
-                callback(null, {stack, id, glyph: entry.glyphs[id]});
-                return;
-            }
-
-            const glyph = this._tinySDF(entry, stack, id);
-            if (glyph) {
-                entry.glyphs[id] = glyph;
-                callback(null, {stack, id, glyph});
+                callback(null, {stack, id, glyph: null});
                 return;
             }
 

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -77,7 +77,7 @@ class GlyphManager {
             }
 
             if (entry.ranges[range]) {
-                callback(null, {stack, id, glyph: null});
+                callback(null, {stack, id, glyph});
                 return;
             }
 

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -15,6 +15,7 @@ type Entry = {
     // null means we've requested the range, but the glyph wasn't included in the result.
     glyphs: {[id: number]: StyleGlyph | null},
     requests: {[range: number]: Array<Callback<{[_: number]: StyleGlyph | null}>>},
+    ranges: {[range: number]: boolean | null},
     tinySDF?: TinySDF
 };
 

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -53,7 +53,7 @@ class GlyphManager {
                 entry = this.entries[stack] = {
                     glyphs: {},
                     requests: {},
-                    ranges: {},
+                    ranges: {}
                 };
             }
 

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -57,7 +57,6 @@ class GlyphManager {
                 };
             }
 
-
             let glyph = entry.glyphs[id];
             if (glyph !== undefined) {
                 callback(null, {stack, id, glyph});

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -8,18 +8,27 @@ for (const glyph of parseGlyphPBF(fs.readFileSync('./test/fixtures/0-255.pbf')))
     glyphs[glyph.id] = glyph;
 }
 
-test('GlyphManager requests 0-255 PBF', (t) => {
-    const identityTransform = (url) => ({url});
-    t.stub(GlyphManager, 'loadGlyphRange').callsFake((stack, range, urlTemplate, transform, callback) => {
+const identityTransform = (url) => ({url});
+
+const createLoadGlyphRangeStub = (t) => {
+    return t.stub(GlyphManager, 'loadGlyphRange').callsFake((stack, range, urlTemplate, transform, callback) => {
         t.equal(stack, 'Arial Unicode MS');
         t.equal(range, 0);
         t.equal(urlTemplate, 'https://localhost/fonts/v1/{fontstack}/{range}.pbf');
         t.equal(transform, identityTransform);
         setImmediate(() => callback(null, glyphs));
     });
+};
 
-    const manager = new GlyphManager(identityTransform);
+const createGlyphManager = (font) => {
+    const manager = new GlyphManager(identityTransform, font);
     manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    return manager;
+};
+
+test('GlyphManager requests 0-255 PBF', (t) => {
+    createLoadGlyphRangeStub(t);
+    const manager = createGlyphManager();
 
     manager.getGlyphs({'Arial Unicode MS': [55]}, (err, glyphs) => {
         t.ifError(err);
@@ -29,17 +38,8 @@ test('GlyphManager requests 0-255 PBF', (t) => {
 });
 
 test('GlyphManager doesn\'t request twice 0-255 PBF if a glyph is missing', (t) => {
-    const identityTransform = (url) => ({url});
-    const stub = t.stub(GlyphManager, 'loadGlyphRange').callsFake((stack, range, urlTemplate, transform, callback) => {
-        t.equal(stack, 'Arial Unicode MS');
-        t.equal(range, 0);
-        t.equal(urlTemplate, 'https://localhost/fonts/v1/{fontstack}/{range}.pbf');
-        t.equal(transform, identityTransform);
-        setImmediate(() => callback(null, glyphs));
-    });
-
-    const manager = new GlyphManager(identityTransform);
-    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    const stub = createLoadGlyphRangeStub(t);
+    const manager = createGlyphManager();
 
     manager.getGlyphs({'Arial Unicode MS': [0.5]}, (err) => {
         t.ifError(err);
@@ -63,8 +63,7 @@ test('GlyphManager requests remote CJK PBF', (t) => {
         setImmediate(() => callback(null, glyphs));
     });
 
-    const manager = new GlyphManager((url) => ({url}));
-    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    const manager = createGlyphManager();
 
     manager.getGlyphs({'Arial Unicode MS': [0x5e73]}, (err, glyphs) => {
         t.ifError(err);
@@ -89,8 +88,7 @@ test('GlyphManager does not cache CJK chars that should be rendered locally', (t
             return new Uint8ClampedArray(900);
         }
     });
-    const manager = new GlyphManager((url) => ({url}), 'sans-serif');
-    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    const manager = createGlyphManager('sans-serif');
 
     //Request char that overlaps Katakana range
     manager.getGlyphs({'Arial Unicode MS': [0x3005]}, (err, glyphs) => {
@@ -116,8 +114,7 @@ test('GlyphManager generates CJK PBF locally', (t) => {
         }
     });
 
-    const manager = new GlyphManager((url) => ({url}), 'sans-serif');
-    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    const manager = createGlyphManager('sans-serif');
 
     manager.getGlyphs({'Arial Unicode MS': [0x5e73]}, (err, glyphs) => {
         t.ifError(err);
@@ -134,8 +131,7 @@ test('GlyphManager generates Katakana PBF locally', (t) => {
         }
     });
 
-    const manager = new GlyphManager((url) => ({url}), 'sans-serif');
-    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    const manager = createGlyphManager('sans-serif');
 
     // Katakana letter te
     manager.getGlyphs({'Arial Unicode MS': [0x30c6]}, (err, glyphs) => {
@@ -153,8 +149,7 @@ test('GlyphManager generates Hiragana PBF locally', (t) => {
         }
     });
 
-    const manager = new GlyphManager((url) => ({url}), 'sans-serif');
-    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    const manager = createGlyphManager('sans-serif');
 
     //Hiragana letter te
     manager.getGlyphs({'Arial Unicode MS': [0x3066]}, (err, glyphs) => {
@@ -174,8 +169,7 @@ test('GlyphManager caches locally generated glyphs', (t) => {
         }
     });
 
-    const manager = new GlyphManager((url) => ({url}), 'sans-serif');
-    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    const manager = createGlyphManager('sans-serif');
 
     // Katakana letter te
     manager.getGlyphs({'Arial Unicode MS': [0x30c6]}, (err, glyphs) => {

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -41,7 +41,7 @@ test('GlyphManager doesn\'t request twice 0-255 PBF if a glyph is missing', (t) 
     const manager = new GlyphManager(identityTransform);
     manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
 
-    manager.getGlyphs({'Arial Unicode MS': [0.5]}, (err, glyphs) => {
+    manager.getGlyphs({'Arial Unicode MS': [0.5]}, (err) => {
         t.ifError(err);
         t.equal(manager.entries['Arial Unicode MS'].ranges[0], true);
         t.equal(stub.calledOnce, true);
@@ -49,7 +49,7 @@ test('GlyphManager doesn\'t request twice 0-255 PBF if a glyph is missing', (t) 
         // We remove all requests as in getGlyphs code.
         delete manager.entries['Arial Unicode MS'].requests[0];
 
-        manager.getGlyphs({'Arial Unicode MS': [0.5]}, (err, glyphs) => {
+        manager.getGlyphs({'Arial Unicode MS': [0.5]}, (err) => {
             t.ifError(err);
             t.equal(manager.entries['Arial Unicode MS'].ranges[0], true);
             t.equal(stub.calledOnce, true);

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -47,7 +47,7 @@ test('GlyphManager doesn\'t request twice 0-255 PBF if a glyph is missing', (t) 
         t.equal(stub.calledOnce, true);
 
         // We remove all requests as in getGlyphs code.
-        delete manager.entries['Arial Unicode MS'].requests;
+        delete manager.entries['Arial Unicode MS'].requests[0];
 
         manager.getGlyphs({'Arial Unicode MS': [0.5]}, (err, glyphs) => {
             t.ifError(err);

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -1,4 +1,4 @@
-import {test, only} from '../../util/test';
+import {test} from '../../util/test';
 import parseGlyphPBF from '../../../src/style/parse_glyph_pbf';
 import GlyphManager from '../../../src/render/glyph_manager';
 import fs from 'fs';


### PR DESCRIPTION
Fix #8027 

Don't reload the entire font range when a glyph is missing in a font.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Don't reload the entire font range when a glyph is missing in a font.
</changelog>`
