### PR TITLE
Prevent creation of unused depth renderbuffer attachments

### DIFF
--- a/src/gl/context.js
+++ b/src/gl/context.js
@@ -203,8 +203,8 @@ class Context {
         return rbo;
     }
 
-    createFramebuffer(width: number, height: number) {
-        return new Framebuffer(this, width, height);
+    createFramebuffer(width: number, height: number, hasDepth: boolean) {
+        return new Framebuffer(this, width, height, hasDepth);
     }
 
     clear({color, depth}: ClearArgs) {

--- a/src/gl/framebuffer.js
+++ b/src/gl/framebuffer.js
@@ -1,5 +1,6 @@
 // @flow
 import {ColorAttachment, DepthAttachment} from './value';
+import assert from 'assert';
 
 import type Context from './context';
 
@@ -11,7 +12,7 @@ class Framebuffer {
     colorAttachment: ColorAttachment;
     depthAttachment: DepthAttachment;
 
-    constructor(context: Context, width: number, height: number) {
+    constructor(context: Context, width: number, height: number, hasDepth: boolean) {
         this.context = context;
         this.width = width;
         this.height = height;
@@ -19,7 +20,11 @@ class Framebuffer {
         const fbo = this.framebuffer = gl.createFramebuffer();
 
         this.colorAttachment = new ColorAttachment(context, fbo);
-        this.depthAttachment = new DepthAttachment(context, fbo);
+        if (hasDepth) {
+            this.depthAttachment = new DepthAttachment(context, fbo);
+        }
+        var status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+        assert(status == gl.FRAMEBUFFER_COMPLETE);
     }
 
     destroy() {
@@ -28,8 +33,10 @@ class Framebuffer {
         const texture = this.colorAttachment.get();
         if (texture) gl.deleteTexture(texture);
 
-        const renderbuffer = this.depthAttachment.get();
-        if (renderbuffer) gl.deleteRenderbuffer(renderbuffer);
+        if (this.depthAttachment) {
+            const renderbuffer = this.depthAttachment.get();
+            if (renderbuffer) gl.deleteRenderbuffer(renderbuffer);
+        }
 
         gl.deleteFramebuffer(this.framebuffer);
     }

--- a/src/gl/framebuffer.js
+++ b/src/gl/framebuffer.js
@@ -23,8 +23,7 @@ class Framebuffer {
         if (hasDepth) {
             this.depthAttachment = new DepthAttachment(context, fbo);
         }
-        const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-        assert(status === gl.FRAMEBUFFER_COMPLETE);
+        assert(gl.checkFramebufferStatus(gl.FRAMEBUFFER) === gl.FRAMEBUFFER_COMPLETE);
     }
 
     destroy() {

--- a/src/gl/framebuffer.js
+++ b/src/gl/framebuffer.js
@@ -23,8 +23,8 @@ class Framebuffer {
         if (hasDepth) {
             this.depthAttachment = new DepthAttachment(context, fbo);
         }
-        var status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-        assert(status == gl.FRAMEBUFFER_COMPLETE);
+        const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+        assert(status === gl.FRAMEBUFFER_COMPLETE);
     }
 
     destroy() {

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -87,7 +87,7 @@ function bindFramebuffer(context, painter, layer) {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
-        fbo = layer.heatmapFbo = context.createFramebuffer(painter.width / 4, painter.height / 4);
+        fbo = layer.heatmapFbo = context.createFramebuffer(painter.width / 4, painter.height / 4, false);
 
         bindTextureToFramebuffer(context, painter, texture, fbo);
 

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -90,7 +90,7 @@ function prepareHillshade(painter, tile, layer, sourceMaxZoom, depthMode, stenci
             const renderTexture = new Texture(context, {width: tileSize, height: tileSize, data: null}, gl.RGBA);
             renderTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
 
-            fbo = tile.fbo = context.createFramebuffer(tileSize, tileSize);
+            fbo = tile.fbo = context.createFramebuffer(tileSize, tileSize, true);
             fbo.colorAttachment.set(renderTexture.texture);
         }
 

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -144,8 +144,6 @@ class Painter {
      * for a new width and height value.
      */
     resize(width: number, height: number) {
-        const gl = this.context.gl;
-
         this.width = width * browser.devicePixelRatio;
         this.height = height * browser.devicePixelRatio;
         this.context.viewport.set([0, 0, this.width, this.height]);
@@ -471,10 +469,6 @@ class Painter {
         // Set defaults for most GL values so that anyone using the state after the render
         // encounters more expected values.
         this.context.setDefault();
-    }
-
-    setupOffscreenDepthRenderbuffer(): void {
-        const context = this.context;
     }
 
     renderLayer(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, coords: Array<OverscaledTileID>) {

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -92,8 +92,6 @@ class Painter {
     emptyProgramConfiguration: ProgramConfiguration;
     width: number;
     height: number;
-    depthRbo: WebGLRenderbuffer;
-    depthRboNeedsClear: boolean;
     tileExtentBuffer: VertexBuffer;
     tileExtentSegments: SegmentVector;
     debugBuffer: VertexBuffer;
@@ -136,8 +134,6 @@ class Painter {
         this.numSublayers = SourceCache.maxUnderzooming + SourceCache.maxOverzooming + 1;
         this.depthEpsilon = 1 / Math.pow(2, 16);
 
-        this.depthRboNeedsClear = true;
-
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 
         this.gpuTimers = {};
@@ -158,11 +154,6 @@ class Painter {
             for (const layerId of this.style._order) {
                 this.style._layers[layerId].resize();
             }
-        }
-
-        if (this.depthRbo) {
-            gl.deleteRenderbuffer(this.depthRbo);
-            this.depthRbo = null;
         }
     }
 
@@ -402,7 +393,6 @@ class Painter {
         // framebuffer, and then save those for rendering back to the map
         // later: in doing this we avoid doing expensive framebuffer restores.
         this.renderPass = 'offscreen';
-        this.depthRboNeedsClear = true;
 
         for (const layerId of layerIds) {
             const layer = this.style._layers[layerId];
@@ -485,10 +475,6 @@ class Painter {
 
     setupOffscreenDepthRenderbuffer(): void {
         const context = this.context;
-        // All of the 3D textures will use the same depth renderbuffer.
-        if (!this.depthRbo) {
-            this.depthRbo = context.createRenderbuffer(context.gl.DEPTH_COMPONENT16, this.width, this.height);
-        }
     }
 
     renderLayer(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, coords: Array<OverscaledTileID>) {


### PR DESCRIPTION
Prevent creation of unused GPU resources for depth renderbuffer attachments:
- painter: should save width * height * 2 bytes of depth renderbuffer memory 
- heatmap: should save (width * height) / 4 * 2 bytes of depth renderbuffer memory

`<changelog>Slightly improve GPU memory footprint</changelog>`