### PR TITLE
[docs] clarify differences in `symbol-sort-key` with and without overlap

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1025,7 +1025,7 @@
     },
     "symbol-sort-key": {
       "type": "number",
-      "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key when they overlap. Features with a lower sort key will have priority over other features when doing placement.",
+      "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above other features when they overlap. Features with a lower sort key will have priority over other features during placement when they do not overlap.",
       "sdk-support": {
         "basic functionality": {
           "js": "0.53.0",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1025,7 +1025,7 @@
     },
     "symbol-sort-key": {
       "type": "number",
-      "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above other features when they overlap. Features with a lower sort key will have priority over other features during placement when they do not overlap.",
+      "doc": "Sorts features in ascending order based on this value. When `*-allow-overlap` is enabled for symbols, features with a higher sort key will appear above other features. When overlap is disabled, features with a lower sort key will have priority over other features during placement.",
       "sdk-support": {
         "basic functionality": {
           "js": "0.53.0",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1025,7 +1025,7 @@
     },
     "symbol-sort-key": {
       "type": "number",
-      "doc": "Sorts features in ascending order based on this value. When `*-allow-overlap` is enabled for symbols, features with a higher sort key will appear above other features. When overlap is disabled, features with a lower sort key will have priority over other features during placement.",
+      "doc": "Sorts features in ascending order based on this value. Features with lower sort keys are drawn and placed first.  When `icon-allow-overlap` or `text-allow-overlap` is `false`, features with a lower sort key will have priority during placement. When `icon-allow-overlap` or `text-allow-overlap` is set to `true`, features with a higher sort key will overlap over features with a lower sort key.",
       "sdk-support": {
         "basic functionality": {
           "js": "0.53.0",


### PR DESCRIPTION
We've gotten some feedback that https://github.com/mapbox/mapbox-gl-js/issues/9368 is not very obvious from the existing `symbol-sort-key` docs, particularly if you are not that familiar with the renderer. This PR makes it more obvious that the behavior of the sort key is different with and without `*-allow-overlap` by making the two sentences more parallel.