### PR TITLE
Fix corner case with dash-array 0-length collapsing

### DIFF
--- a/src/render/line_atlas.js
+++ b/src/render/line_atlas.js
@@ -162,13 +162,15 @@ class LineAtlas {
         let length = 0;
         for (let i = 0; i < dasharray.length; i++) { length += dasharray[i]; }
 
-        const stretch = this.width / length;
-        const ranges = this.getDashRanges(dasharray, this.width, stretch);
+        if (length !== 0) {
+            const stretch = this.width / length;
+            const ranges = this.getDashRanges(dasharray, this.width, stretch);
 
-        if (round) {
-            this.addRoundDash(ranges, stretch, n);
-        } else {
-            this.addRegularDash(ranges);
+            if (round) {
+                this.addRoundDash(ranges, stretch, n);
+            } else {
+                this.addRegularDash(ranges);
+            }
         }
 
         const dashEntry = {

--- a/test/unit/render/line_atlas.test.js
+++ b/test/unit/render/line_atlas.test.js
@@ -1,0 +1,48 @@
+import {test} from '../../util/test';
+import LineAtlas from '../../../src/render/line_atlas';
+
+test('LineAtlas', (t) => {
+    const lineAtlas = new LineAtlas(64, 64);
+    t.test('round [0, 0]', (t) => {
+        const entry = lineAtlas.addDash([0, 0], true);
+        t.equal(entry.width, 0);
+        t.end();
+    });
+    t.test('round [1, 0]', (t) => {
+        const entry = lineAtlas.addDash([1, 0], true);
+        t.equal(entry.width, 1);
+        t.end();
+    });
+    t.test('round [0, 1]', (t) => {
+        const entry = lineAtlas.addDash([0, 1], true);
+        t.equal(entry.width, 1);
+        t.end();
+    });
+    t.test('odd round [1, 2, 1]', (t) => {
+        const entry = lineAtlas.addDash([1, 2, 1], true);
+        t.equal(entry.width, 4);
+        t.end();
+    });
+
+    t.test('regular [0, 0]', (t) => {
+        const entry = lineAtlas.addDash([0, 0], false);
+        t.equal(entry.width, 0);
+        t.end();
+    });
+    t.test('regular [1, 0]', (t) => {
+        const entry = lineAtlas.addDash([1, 0], false);
+        t.equal(entry.width, 1);
+        t.end();
+    });
+    t.test('regular [0, 1]', (t) => {
+        const entry = lineAtlas.addDash([0, 1], false);
+        t.equal(entry.width, 1);
+        t.end();
+    });
+    t.test('odd regular [1, 2, 1]', (t) => {
+        const entry = lineAtlas.addDash([1, 2, 1], false);
+        t.equal(entry.width, 4);
+        t.end();
+    });
+    t.end();
+});


### PR DESCRIPTION
Fix corner case on an exception discovered and reported by @tristen and add some more test coverage around it.

`<changelog>Prevent exception resulting from 'line-dash-array' of empty length</changelog>`