### PR TITLE
Fix webgl error on IE11 for mismatching texture formats

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -210,7 +210,7 @@ class Painter {
         this.emptyTexture = new Texture(context, {
             width: 1,
             height: 1,
-            data: new Uint8ClampedArray([0, 0, 0, 0])
+            data: new Uint8Array([0, 0, 0, 0])
         }, context.gl.RGBA);
 
         const gl = this.context.gl;


### PR DESCRIPTION
IE11 reports `INVALID_OPERATION: texImage2D: Typed array type and pixel data type must match` for mismatching formats. Replace `Uint8ClampedArray ` by `Uint8Array`.