### PR TITLE
Add scale to Marker options

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -26,20 +26,6 @@ var map = window.map = new mapboxgl.Map({
     hash: true
 });
 
-var smallerMarker = new mapboxgl.Marker({scale: 0.8})
-    .setLngLat([-77.018, 38.88])
-    .addTo(map);
-
-console.log(smallerMarker.getElement().firstChild.getAttribute('height').includes('32.8'));
-
-smallerMarker.setScale(2);
-console.log("hello " + smallerMarker.getScale());
-console.log(smallerMarker.getElement().firstChild.getAttribute('width'));
-
-smallerMarker.setScale(0.2);
-console.log("hello " + smallerMarker.getScale());
-console.log(smallerMarker.getElement().firstChild.getAttribute('width'));
-
 </script>
 </body>
 </html>

--- a/debug/index.html
+++ b/debug/index.html
@@ -26,6 +26,20 @@ var map = window.map = new mapboxgl.Map({
     hash: true
 });
 
+var smallerMarker = new mapboxgl.Marker({scale: 0.8})
+    .setLngLat([-77.018, 38.88])
+    .addTo(map);
+
+console.log(smallerMarker.getElement().firstChild.getAttribute('height').includes('32.8'));
+
+smallerMarker.setScale(2);
+console.log("hello " + smallerMarker.getScale());
+console.log(smallerMarker.getElement().firstChild.getAttribute('width'));
+
+smallerMarker.setScale(0.2);
+console.log("hello " + smallerMarker.getScale());
+console.log(smallerMarker.getElement().firstChild.getAttribute('width'));
+
 </script>
 </body>
 </html>

--- a/debug/markers.html
+++ b/debug/markers.html
@@ -45,8 +45,11 @@ const spinningMarkers = [];
         var g = Math.round(Math.random() * 255);
         var b = Math.round(Math.random() * 255);
 
+        var sc = Math.random(0, 25);
+
         var marker = new mapboxgl.Marker({
             color: `rgb(${r}, ${g}, ${b})`,
+            scale: sc,
             draggable: true,
             rotationAlignment,
             pitchAlignment

--- a/debug/markers.html
+++ b/debug/markers.html
@@ -45,7 +45,7 @@ const spinningMarkers = [];
         var g = Math.round(Math.random() * 255);
         var b = Math.round(Math.random() * 255);
 
-        var sc = Math.random(0, 25);
+        var sc = Math.random() * 2.5 + 0.5;
 
         var marker = new mapboxgl.Marker({
             color: `rgb(${r}, ${g}, ${b})`,

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -101,7 +101,7 @@ export default class Marker extends Evented {
             svg.setAttributeNS(null, 'display', 'block');
             svg.setAttributeNS(null, 'height', '41px');
             svg.setAttributeNS(null, 'width', '27px');
-            svg.setAttributeNS(null, 'viewBox', '0 0 27 41');
+            svg.setAttributeNS(null, 'viewBox', `0 0 27 41`);
 
             const markerLarge = DOM.createNS('http://www.w3.org/2000/svg', 'g');
             markerLarge.setAttributeNS(null, 'stroke', 'none');
@@ -184,7 +184,9 @@ export default class Marker extends Evented {
             page1.appendChild(circleContainer);
 
             svg.appendChild(page1);
-            svg.setAttributeNS(null, 'transform', `scale(${this._scale})`);
+
+            svg.setAttributeNS(null, 'width', `${27 * this._scale}px`);
+            svg.setAttributeNS(null, 'height', `${41 * this._scale}px`);
 
             this._element.appendChild(svg);
 
@@ -397,6 +399,12 @@ export default class Marker extends Evented {
         }
 
         this._pos = this._map.project(this._lngLat)._add(this._offset);
+
+        const svg = this._element.firstChild;
+        if (svg) {
+            svg.setAttributeNS(null, 'width', `${27 * this._scale}px`);
+            svg.setAttributeNS(null, 'height', `${41 * this._scale}px`);
+        }
 
         let rotation = "";
         if (this._rotationAlignment === "viewport" || this._rotationAlignment === "auto") {

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -34,7 +34,7 @@ type Options = {
  *   Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
  * @param {PointLike} [options.offset] The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
  * @param {string} [options.color='#3FB1CE'] The color to use for the default marker if options.element is not provided. The default is light blue.
- * @param {number} [options.scale=1] The scaled to use for the default marker if options.element is not provided. The default is 1.
+ * @param {number} [options.scale=1] The scale to use for the default marker if options.element is not provided. The default is 1.
  * @param {boolean} [options.draggable=false] A boolean indicating whether or not a marker is able to be dragged to a new position on the map.
  * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective `rotationAlignment` setting. A positive value will rotate the marker clockwise.
  * @param {string} [options.pitchAlignment='auto'] `map` aligns the `Marker` to the plane of the map. `viewport` aligns the `Marker` to the plane of the viewport. `auto` automatically matches the value of `rotationAlignment`.

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -19,6 +19,7 @@ type Options = {
     offset?: PointLike,
     anchor?: Anchor,
     color?: string,
+    scale?: number,
     draggable?: boolean,
     rotation?: number,
     rotationAlignment?: string,
@@ -33,6 +34,7 @@ type Options = {
  *   Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
  * @param {PointLike} [options.offset] The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
  * @param {string} [options.color='#3FB1CE'] The color to use for the default marker if options.element is not provided. The default is light blue.
+ * @param {number} [options.scale=1] The scaled to use for the default marker if options.element is not provided. The default is 1.
  * @param {boolean} [options.draggable=false] A boolean indicating whether or not a marker is able to be dragged to a new position on the map.
  * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective `rotationAlignment` setting. A positive value will rotate the marker clockwise.
  * @param {string} [options.pitchAlignment='auto'] `map` aligns the `Marker` to the plane of the map. `viewport` aligns the `Marker` to the plane of the viewport. `auto` automatically matches the value of `rotationAlignment`.
@@ -53,6 +55,7 @@ export default class Marker extends Evented {
     _lngLat: LngLat;
     _pos: ?Point;
     _color: ?string;
+    _scale: number;
     _defaultMarker: boolean;
     _draggable: boolean;
     _state: 'inactive' | 'pending' | 'active'; // used for handling drag events
@@ -81,6 +84,7 @@ export default class Marker extends Evented {
 
         this._anchor = options && options.anchor || 'center';
         this._color = options && options.color || '#3FB1CE';
+        this._scale = options && options.scale || 1;
         this._draggable = options && options.draggable || false;
         this._state = 'inactive';
         this._rotation = options && options.rotation || 0;
@@ -180,6 +184,7 @@ export default class Marker extends Evented {
             page1.appendChild(circleContainer);
 
             svg.appendChild(page1);
+            svg.setAttributeNS(null, 'transform', `scale(${this._scale})`);
 
             this._element.appendChild(svg);
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -34,7 +34,7 @@ type Options = {
  *   Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
  * @param {PointLike} [options.offset] The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
  * @param {string} [options.color='#3FB1CE'] The color to use for the default marker if options.element is not provided. The default is light blue.
- * @param {number} [options.scale=1] The scale to use for the default marker if options.element is not provided. The default is 1.
+ * @param {number} [options.scale=1] The scale to use for the default marker if options.element is not provided.
  * @param {boolean} [options.draggable=false] A boolean indicating whether or not a marker is able to be dragged to a new position on the map.
  * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective `rotationAlignment` setting. A positive value will rotate the marker clockwise.
  * @param {string} [options.pitchAlignment='auto'] `map` aligns the `Marker` to the plane of the map. `viewport` aligns the `Marker` to the plane of the viewport. `auto` automatically matches the value of `rotationAlignment`.

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -403,9 +403,8 @@ export default class Marker extends Evented {
         this._pos = this._map.project(this._lngLat)._add(this._offset);
 
         if (this._defaultMarker) {
-            const svg = this._element.firstChild;
-            svg.setAttributeNS(null, 'width', `${27 * this._scale}px`);
-            svg.setAttributeNS(null, 'height', `${41 * this._scale}px`);
+            this._defaultSVG.setAttributeNS(null, 'width', `${27 * this._scale}px`);
+            this._defaultSVG.setAttributeNS(null, 'height', `${41 * this._scale}px`);
         }
 
         let rotation = "";

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -51,6 +51,7 @@ export default class Marker extends Evented {
     _anchor: Anchor;
     _offset: Point;
     _element: HTMLElement;
+    _defaultSVG: HTMLElement;
     _popup: ?Popup;
     _lngLat: LngLat;
     _pos: ?Point;
@@ -189,6 +190,7 @@ export default class Marker extends Evented {
             svg.setAttributeNS(null, 'height', `${41 * this._scale}px`);
 
             this._element.appendChild(svg);
+            this._defaultSVG = svg;
 
             // if no element and no offset option given apply an offset for the default marker
             // the -14 as the y value of the default marker offset was determined as follows
@@ -400,8 +402,8 @@ export default class Marker extends Evented {
 
         this._pos = this._map.project(this._lngLat)._add(this._offset);
 
-        const svg = this._element.firstChild;
-        if (svg) {
+        if (this._defaultMarker) {
+            const svg = this._element.firstChild;
             svg.setAttributeNS(null, 'width', `${27 * this._scale}px`);
             svg.setAttributeNS(null, 'height', `${41 * this._scale}px`);
         }
@@ -562,7 +564,7 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Sets the `scale` property of the marker.
+     * Sets the `scale` property of the default marker.
      * @param {number} [scale=1] The scale of the marker, relative to its default size.
      * @returns {Marker} `this`
      */
@@ -573,7 +575,7 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Returns the current `scale` property of the marker.
+     * Returns the current `scale` property of the default marker.
      * @returns {number} The current scale of the marker.
      */
     getScale() {

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -554,6 +554,25 @@ export default class Marker extends Evented {
     }
 
     /**
+     * Sets the `scale` property of the marker.
+     * @param {number} [scale=1] The scale of the marker, relative to its default size.
+     * @returns {Marker} `this`
+     */
+    setScale(scale: number) {
+        this._scale = scale || 1;
+        this._update();
+        return this;
+    }
+
+    /**
+     * Returns the current `scale` property of the marker.
+     * @returns {number} The current scale of the marker.
+     */
+    getScale() {
+        return this._scale;
+    }
+
+    /**
      * Sets the `rotation` property of the marker.
      * @param {number} [rotation=0] The rotation angle of the marker (clockwise, in degrees), relative to its respective {@link Marker#rotationAlignment} setting.
      * @returns {Marker} `this`

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -51,7 +51,6 @@ export default class Marker extends Evented {
     _anchor: Anchor;
     _offset: Point;
     _element: HTMLElement;
-    _defaultSVG: HTMLElement;
     _popup: ?Popup;
     _lngLat: LngLat;
     _pos: ?Point;
@@ -99,10 +98,12 @@ export default class Marker extends Evented {
 
             // create default map marker SVG
             const svg = DOM.createNS('http://www.w3.org/2000/svg', 'svg');
+            const defaultHeight = 41;
+            const defaultWidth = 27;
             svg.setAttributeNS(null, 'display', 'block');
-            svg.setAttributeNS(null, 'height', '41px');
-            svg.setAttributeNS(null, 'width', '27px');
-            svg.setAttributeNS(null, 'viewBox', `0 0 27 41`);
+            svg.setAttributeNS(null, 'height', `${defaultHeight}px`);
+            svg.setAttributeNS(null, 'width', `${defaultWidth}px`);
+            svg.setAttributeNS(null, 'viewBox', `0 0 ${defaultWidth} ${defaultHeight}`);
 
             const markerLarge = DOM.createNS('http://www.w3.org/2000/svg', 'g');
             markerLarge.setAttributeNS(null, 'stroke', 'none');
@@ -186,11 +187,10 @@ export default class Marker extends Evented {
 
             svg.appendChild(page1);
 
-            svg.setAttributeNS(null, 'width', `${27 * this._scale}px`);
-            svg.setAttributeNS(null, 'height', `${41 * this._scale}px`);
+            svg.setAttributeNS(null, 'height', `${defaultHeight * this._scale}px`);
+            svg.setAttributeNS(null, 'width', `${defaultWidth * this._scale}px`);
 
             this._element.appendChild(svg);
-            this._defaultSVG = svg;
 
             // if no element and no offset option given apply an offset for the default marker
             // the -14 as the y value of the default marker offset was determined as follows
@@ -402,11 +402,6 @@ export default class Marker extends Evented {
 
         this._pos = this._map.project(this._lngLat)._add(this._offset);
 
-        if (this._defaultMarker) {
-            this._defaultSVG.setAttributeNS(null, 'width', `${27 * this._scale}px`);
-            this._defaultSVG.setAttributeNS(null, 'height', `${41 * this._scale}px`);
-        }
-
         let rotation = "";
         if (this._rotationAlignment === "viewport" || this._rotationAlignment === "auto") {
             rotation = `rotateZ(${this._rotation}deg)`;
@@ -560,25 +555,6 @@ export default class Marker extends Evented {
      */
     isDraggable() {
         return this._draggable;
-    }
-
-    /**
-     * Sets the `scale` property of the default marker.
-     * @param {number} [scale=1] The scale of the marker, relative to its default size.
-     * @returns {Marker} `this`
-     */
-    setScale(scale: number) {
-        this._scale = scale || 1;
-        this._update();
-        return this;
-    }
-
-    /**
-     * Returns the current `scale` property of the default marker.
-     * @returns {number} The current scale of the marker.
-     */
-    getScale() {
-        return this._scale;
     }
 
     /**

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -34,7 +34,7 @@ type Options = {
  *   Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
  * @param {PointLike} [options.offset] The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
  * @param {string} [options.color='#3FB1CE'] The color to use for the default marker if options.element is not provided. The default is light blue.
- * @param {number} [options.scale=1] The scale to use for the default marker if options.element is not provided.
+ * @param {number} [options.scale=1] The scale to use for the default marker if options.element is not provided. The default scale corresponds to a height of `41px` and a width of `27px`.
  * @param {boolean} [options.draggable=false] A boolean indicating whether or not a marker is able to be dragged to a new position on the map.
  * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective `rotationAlignment` setting. A positive value will rotate the marker clockwise.
  * @param {string} [options.pitchAlignment='auto'] `map` aligns the `Marker` to the plane of the map. `viewport` aligns the `Marker` to the plane of the viewport. `auto` automatically matches the value of `rotationAlignment`.

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -36,14 +36,15 @@ test('Marker uses a default marker element with custom scale', (t) => {
     // scale smaller than default
     marker.setScale(0.8);
     // (27 * 0.8) = 21.6, (41 * 0.8) = 32.8
-    t.ok(marker.getElement.firstChild.getAttribute('width').includes(`21.6`));
-    t.ok(marker.getElement.firstChild.getAttribute('height').includes(`32.8`));
+    t.ok(marker.getElement().firstChild.getAttribute('width').includes(`21.6`));
+    t.ok(marker.getElement().firstChild.getAttribute('height').includes(`32.8`));
 
     // scale larger than default
     marker.setScale(2);
     // (27 * 2) = 54, (41 * 2) = 82
     t.ok(marker.getElement().firstChild.getAttribute('width').includes('54'));
     t.ok(marker.getElement().firstChild.getAttribute('height').includes('82'));
+
     t.end();
 });
 

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -28,8 +28,22 @@ test('Marker uses a default marker element with custom color', (t) => {
 });
 
 test('Marker uses a default marker element with custom scale', (t) => {
-    const marker = new Marker({scale: 0.8});
-    t.ok(marker.getElement().innerHTML.includes('0.8'));
+    const marker = new Marker();
+    // initial dimensions of svg element
+    t.ok(marker.getElement().firstChild.getAttribute('width').includes('27'));
+    t.ok(marker.getElement().firstChild.getAttribute('height').includes('41'));
+
+    // scale smaller than default
+    marker.setScale(0.8);
+    // (27 * 0.8) = 21.6, (41 * 0.8) = 32.8
+    t.ok(marker.getElement.firstChild.getAttribute('width').includes(`21.6`));
+    t.ok(marker.getElement.firstChild.getAttribute('height').includes(`32.8`));
+
+    // scale larger than default
+    marker.setScale(2);
+    // (27 * 2) = 54, (41 * 2) = 82
+    t.ok(marker.getElement().firstChild.getAttribute('width').includes('54'));
+    t.ok(marker.getElement().firstChild.getAttribute('height').includes('82'));
     t.end();
 });
 

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -27,6 +27,12 @@ test('Marker uses a default marker element with custom color', (t) => {
     t.end();
 });
 
+test('Marker uses a default marker element with custom scale', (t) => {
+    const marker = new Marker({scale: 0.8});
+    t.ok(marker.getElement().innerHTML.includes('0.8'));
+    t.end();
+});
+
 test('Marker uses a default marker with custom offset', (t) => {
     const marker = new Marker({offset: [1, 2]});
     t.ok(marker.getElement());

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -28,7 +28,11 @@ test('Marker uses a default marker element with custom color', (t) => {
 });
 
 test('Marker uses a default marker element with custom scale', (t) => {
-    const marker = new Marker();
+    const map = createMap(t);
+    const marker = new Marker()
+        .setLngLat([0, 0])
+        .addTo(map);
+
     // initial dimensions of svg element
     t.ok(marker.getElement().firstChild.getAttribute('width').includes('27'));
     t.ok(marker.getElement().firstChild.getAttribute('height').includes('41'));

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -29,25 +29,29 @@ test('Marker uses a default marker element with custom color', (t) => {
 
 test('Marker uses a default marker element with custom scale', (t) => {
     const map = createMap(t);
-    const marker = new Marker()
+    const defaultMarker = new Marker()
+        .setLngLat([0, 0])
+        .addTo(map);
+    // scale smaller than default
+    const smallerMarker = new Marker({scale: 0.8})
+        .setLngLat([0, 0])
+        .addTo(map);
+    // scale larger than default
+    const largerMarker = new Marker({scale: 2})
         .setLngLat([0, 0])
         .addTo(map);
 
     // initial dimensions of svg element
-    t.ok(marker.getElement().firstChild.getAttribute('width').includes('27'));
-    t.ok(marker.getElement().firstChild.getAttribute('height').includes('41'));
+    t.ok(defaultMarker.getElement().firstChild.getAttribute('height').includes('41'));
+    t.ok(defaultMarker.getElement().firstChild.getAttribute('width').includes('27'));
 
-    // scale smaller than default
-    marker.setScale(0.8);
-    // (27 * 0.8) = 21.6, (41 * 0.8) = 32.8
-    t.ok(marker.getElement().firstChild.getAttribute('width').includes(`21.6`));
-    t.ok(marker.getElement().firstChild.getAttribute('height').includes(`32.8`));
+    // (41 * 0.8) = 32.8, (27 * 0.8) = 21.6
+    t.ok(smallerMarker.getElement().firstChild.getAttribute('height').includes(`32.8`));
+    t.ok(smallerMarker.getElement().firstChild.getAttribute('width').includes(`21.6`));
 
-    // scale larger than default
-    marker.setScale(2);
-    // (27 * 2) = 54, (41 * 2) = 82
-    t.ok(marker.getElement().firstChild.getAttribute('width').includes('54'));
-    t.ok(marker.getElement().firstChild.getAttribute('height').includes('82'));
+    // (41 * 2) = 82, (27 * 2) = 54
+    t.ok(largerMarker.getElement().firstChild.getAttribute('height').includes('82'));
+    t.ok(largerMarker.getElement().firstChild.getAttribute('width').includes('54'));
 
     t.end();
 });


### PR DESCRIPTION
## Overview
Closes https://github.com/mapbox/mapbox-gl-js/issues/9413.

Allows users to customize the size of the default `Marker` by scaling the relevant SVG.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] ~tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes~
 - [x] ~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

**Visuals:**
<img width="932" alt="Screen Shot 2020-03-11 at 10 20 06 PM" src="https://user-images.githubusercontent.com/15935667/76491075-070cd500-63ea-11ea-9e01-b1447efe2337.png">

**Changes to API:**
Adds a new option for the default marker: `scale`.

**Changelog:**
Add `scale` option to markers, to support custom sizing when using the default `Marker` SVG element.