### PR TITLE
Remove Hershey Simplex font attribution from the license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016, Mapbox
+Copyright (c) 2020, Mapbox
 
 All rights reserved.
 
@@ -26,9 +26,6 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
--------------------------------------------------------------------------------
-
-Contains Hershey Simplex Font: http://paulbourke.net/dataformats/hershey/
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #9392. 

In #9267, we removed the Hershey simplex font code and no longer need this attribution.