### PR TITLE
update pr template team tags

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
  - [ ] document any changes to public APIs
  - [ ] post benchmark scores
  - [ ] manually test the debug page
- - [ ] tagged `@mapbox/map-design-team` `@mapbox/gl-native` `@mapbox/static-apis` if this PR includes style spec API or visual changes
+ - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
  - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
  - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
  - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
  - [ ] document any changes to public APIs
  - [ ] post benchmark scores
  - [ ] manually test the debug page
- - [ ] tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes
+ - [ ] tagged `@mapbox/map-design-team` `@mapbox/gl-native` `@mapbox/static-apis` if this PR includes style spec API or visual changes
  - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
  - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
  - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`


### PR DESCRIPTION
per chat with @riastrad @brsbl, we want to make sure @mapbox/static-apis are aware of style spec changes coming down the pipeline that may affect their product.

I also validated all members of @mapbox/studio are members of @mapbox/map-design-team; there's no need to tag both.
