### PR TITLE
Add setColor() and getColor() to Marker API.

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -614,7 +614,7 @@ export default class Marker extends Evented {
      * @returns {Marker} `this`
      */
     setColor(color: ?string) {
-        if ('undefined' !== typeof this._background) {
+        if (typeof this._background !== 'undefined') {
             if (color) {
                 this._color = color;
             } else {

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -609,18 +609,20 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Sets the current `color` property of the marker.
-     * @param {string} [color] Sets the `color` property of the marker. If alignment is 'auto', it will automatically match `rotationAlignment`.
+     * Sets the color of the Marker if using a default marker.
+     * @param {string} [color='#3FB1CE'] The color as a string to use for the default marker. If `color` is not provided the default is light blue.
      * @returns {Marker} `this`
      */
     setColor(color: ?string) {
-        if (color) {
-            this._color = color;
-        } else {
-            this._color = this._defaultColor;
-        }
+        if ('undefined' !== typeof this._background) {
+            if (color) {
+                this._color = color;
+            } else {
+                this._color = this._defaultColor;
+            }
 
-        this._background.setAttributeNS(null, 'fill', this._color);
+            this._background.setAttributeNS(null, 'fill', this._color);
+        }
 
         return this;
     }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -133,13 +133,13 @@ export default class Marker extends Evented {
                 shadow.appendChild(ellipse);
             }
 
-            const background = DOM.createNS('http://www.w3.org/2000/svg', 'g');
-            background.setAttributeNS(null, 'fill', this._color);
+            this._background = DOM.createNS('http://www.w3.org/2000/svg', 'g');
+            this.setColor(this._color);
 
             const bgPath = DOM.createNS('http://www.w3.org/2000/svg', 'path');
             bgPath.setAttributeNS(null, 'd', 'M27,13.5 C27,19.074644 20.250001,27.000002 14.75,34.500002 C14.016665,35.500004 12.983335,35.500004 12.25,34.500002 C6.7499993,27.000002 0,19.222562 0,13.5 C0,6.0441559 6.0441559,0 13.5,0 C20.955844,0 27,6.0441559 27,13.5 Z');
 
-            background.appendChild(bgPath);
+            this._background.appendChild(bgPath);
 
             const border = DOM.createNS('http://www.w3.org/2000/svg', 'g');
             border.setAttributeNS(null, 'opacity', '0.25');
@@ -174,7 +174,7 @@ export default class Marker extends Evented {
             circleContainer.appendChild(circle2);
 
             page1.appendChild(shadow);
-            page1.appendChild(background);
+            page1.appendChild(this._background);
             page1.appendChild(border);
             page1.appendChild(maki);
             page1.appendChild(circleContainer);
@@ -603,5 +603,23 @@ export default class Marker extends Evented {
      */
     getPitchAlignment() {
         return this._pitchAlignment;
+    }
+
+    /**
+     * Sets the current `color` property of the marker.
+     * @param {string} [color] Sets the `color` property of the marker. If alignment is 'auto', it will automatically match `rotationAlignment`.
+     * @returns {Marker} `this`
+     */
+    setColor(color: string) {
+        this._background.setAttributeNS(null, 'fill', color);
+        return this;
+    }
+
+    /**
+     * Returns the current `color` property of the marker.
+     * @returns {string} The current color of the marker.
+     */
+    getColor() {
+        return this._color;
     }
 }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -611,7 +611,8 @@ export default class Marker extends Evented {
      * @returns {Marker} `this`
      */
     setColor(color: string) {
-        this._background.setAttributeNS(null, 'fill', color);
+        this._color = color;
+        this._background.setAttributeNS(null, 'fill', this._color);
         return this;
     }
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -52,7 +52,7 @@ export default class Marker extends Evented {
     _popup: ?Popup;
     _lngLat: LngLat;
     _pos: ?Point;
-    _color: ?string;
+    _color: string;
     _defaultMarker: boolean;
     _draggable: boolean;
     _state: 'inactive' | 'pending' | 'active'; // used for handling drag events
@@ -62,6 +62,7 @@ export default class Marker extends Evented {
     _rotationAlignment: string;
     _originalTabIndex: ?string; // original tabindex of _element
     _background: HTMLElement;
+    _defaultColor: string;
 
     constructor(options?: Options, legacyOptions?: Options) {
         super();
@@ -80,8 +81,9 @@ export default class Marker extends Evented {
             '_onKeyPress'
         ], this);
 
+        this._defaultColor = '#3FB1CE';
         this._anchor = options && options.anchor || 'center';
-        this._color = options && options.color || '#3FB1CE';
+        this._color = options && options.color || this._defaultColor;
         this._draggable = options && options.draggable || false;
         this._state = 'inactive';
         this._rotation = options && options.rotation || 0;
@@ -614,8 +616,11 @@ export default class Marker extends Evented {
     setColor(color: ?string) {
         if (color) {
             this._color = color;
-            this._background.setAttributeNS(null, 'fill', this._color);
+        } else {
+            this._color = this._defaultColor;
         }
+
+        this._background.setAttributeNS(null, 'fill', this._color);
 
         return this;
     }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -61,6 +61,7 @@ export default class Marker extends Evented {
     _pitchAlignment: string;
     _rotationAlignment: string;
     _originalTabIndex: ?string; // original tabindex of _element
+    _background: HTMLElement;
 
     constructor(options?: Options, legacyOptions?: Options) {
         super();
@@ -610,9 +611,12 @@ export default class Marker extends Evented {
      * @param {string} [color] Sets the `color` property of the marker. If alignment is 'auto', it will automatically match `rotationAlignment`.
      * @returns {Marker} `this`
      */
-    setColor(color: string) {
-        this._color = color;
-        this._background.setAttributeNS(null, 'fill', this._color);
+    setColor(color: ?string) {
+        if (color) {
+            this._color = color;
+            this._background.setAttributeNS(null, 'fill', this._color);
+        }
+
         return this;
     }
 

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -623,3 +623,23 @@ test('Marker pitchAlignment when set to auto defaults to rotationAlignment (sett
     map.remove();
     t.end();
 });
+
+test('Marker uses a default marker element and that can set color by setColor()', (t) => {
+    const marker = new Marker();
+    marker.setColor('#123456')
+    t.ok(marker.getElement().innerHTML.includes('#123456'));
+    t.end();
+});
+
+test('Marker uses a default marker element and can get current color', (t) => {
+    const marker = new Marker();
+    marker.setColor('#123456')
+    t.equal('#123456', marker.getColor());
+    t.end();
+});
+
+test('Marker uses a default marker element and can get default color', (t) => {
+    const marker = new Marker();
+    t.equal('#3FB1CE', marker.getColor());
+    t.end();
+});

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -626,14 +626,14 @@ test('Marker pitchAlignment when set to auto defaults to rotationAlignment (sett
 
 test('Marker uses a default marker element and that can set color by setColor()', (t) => {
     const marker = new Marker();
-    marker.setColor('#123456')
+    marker.setColor('#123456');
     t.ok(marker.getElement().innerHTML.includes('#123456'));
     t.end();
 });
 
 test('Marker uses a default marker element and can get current color', (t) => {
     const marker = new Marker();
-    marker.setColor('#123456')
+    marker.setColor('#123456');
     t.equal('#123456', marker.getColor());
     t.end();
 });


### PR DESCRIPTION
## Overview

Added `setColor()` and `getColor()` method into `Marker`.

Example:

```
const marker = new mapbogl.Marker()
const defaultColor = marker.getColor()

marker.getElement().on('mouseenter', () => {
  marker.setColor('#ff0000')
})

marker.getElement().on('mouseleave', () => {
  marker.setColor(defaultColor)
})
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] ~~tagged `@mapbox/studio` and/or `@mapbox/map-design-team` if this PR includes style spec or visual changes~~
 - [x] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

### Changelog

<changelog>Add `setColor()` and `getColor()` to `Marker` API.</changelog>