### PR TITLE
Avoid throwing errors when popup container is undefined

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -309,7 +309,7 @@ export default class Popup extends Evented {
      * @returns {string} The maximum width of the popup.
      */
     getMaxWidth() {
-        return this._container.style.maxWidth;
+        return this._container && this._container.style.maxWidth;
     }
 
     /**
@@ -356,7 +356,9 @@ export default class Popup extends Evented {
      * popup.addClassName('some-class')
      */
     addClassName(className: string) {
-        this._container.classList.add(className);
+        if (this._container) {
+            this._container.classList.add(className);
+        }
     }
 
     /**
@@ -369,7 +371,9 @@ export default class Popup extends Evented {
      * popup.removeClassName('some-class')
      */
     removeClassName(className: string) {
-        this._container.classList.remove(className);
+        if (this._container) {
+            this._container.classList.remove(className);
+        }
     }
 
     /**
@@ -384,7 +388,9 @@ export default class Popup extends Evented {
      * popup.toggleClassName('toggleClass')
      */
     toggleClassName(className: string) {
-        return this._container.classList.toggle(className);
+        if (this._container) {
+            return this._container.classList.toggle(className);
+        }
     }
 
     _createContent() {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - fixes https://github.com/mapbox/mapbox-gl-js/issues/9429
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Avoid throwing errors when calling certain popup methods before the popup element is created</changelog>`
