### PR TITLE
add an extra check for paint member of style layer

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -404,9 +404,9 @@ class Tile {
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 
             bucket.update(sourceLayerStates, sourceLayer, this.imageAtlas && this.imageAtlas.patternPositions || {});
-
-            if (painter && painter.style && painter.style.getLayer(id).paint) {
-                this.queryPadding = Math.max(this.queryPadding, painter.style.getLayer(id).queryRadius(bucket));
+            const layer = painter.style.getLayer(id);
+            if (painter && painter.style && layer.paint) {
+                this.queryPadding = Math.max(this.queryPadding, layer.queryRadius(bucket));
             }
         }
     }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -404,7 +404,8 @@ class Tile {
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 
             bucket.update(sourceLayerStates, sourceLayer, this.imageAtlas && this.imageAtlas.patternPositions || {});
-            if (painter && painter.style) {
+
+            if (painter && painter.style && painter.style.getLayer(id).paint) {
                 this.queryPadding = Math.max(this.queryPadding, painter.style.getLayer(id).queryRadius(bucket));
             }
         }


### PR DESCRIPTION
We are getting a browser dependent, intermittent error from fill_style_layer.js:45
the query radius function expects paint memeber to be truthy and its not
so we have a TypeError: this.paint is undefined

I've been trying for a couple of days to reproduce this in a fiddle and I can't (yet)