### PR TITLE
populate paint arrays only once per line feature

### DIFF
--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -219,11 +219,13 @@ class LineBucket implements Bucket {
         const roundLimit = layout.get('line-round-limit');
 
         for (const line of geometry) {
-            this.addLine(line, feature, join, cap, miterLimit, roundLimit, index, canonical, imagePositions);
+            this.addLine(line, feature, join, cap, miterLimit, roundLimit);
         }
+
+        this.programConfigurations.populatePaintArrays(this.layoutVertexArray.length, feature, index, imagePositions, canonical);
     }
 
-    addLine(vertices: Array<Point>, feature: BucketFeature, join: string, cap: string, miterLimit: number, roundLimit: number, index: number, canonical: CanonicalTileID, imagePositions: {[_: string]: ImagePosition}) {
+    addLine(vertices: Array<Point>, feature: BucketFeature, join: string, cap: string, miterLimit: number, roundLimit: number) {
         this.distance = 0;
         this.scaledDistance = 0;
         this.totalDistance = 0;
@@ -468,8 +470,6 @@ class LineBucket implements Bucket {
                 }
             }
         }
-
-        this.programConfigurations.populatePaintArrays(this.layoutVertexArray.length, feature, index, imagePositions, canonical);
     }
 
     /**


### PR DESCRIPTION
Call `populatePaintArrays` once per line feature instead of once per linestring in a multiline. This avoids adding duplicate `FeaturePositionMap` entries. Duplicate entries were not causing a bug. This is a minor change that mostly cleans up entries to reduce confusion.

I've tested manually with setFeatureState and a line layer.

Circle, fill, fill-extrusion layers are already correctly calling `populatePaintArrays` once per feature.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [n/a] include before/after visuals or gifs if this PR includes visual changes
 - [n/a] write tests for all new functionality
 - [n/a] document any changes to public APIs
 - [n/a] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
