### PR TITLE
Convert recursive quicksort into iterative to avoid stack overflow

### DIFF
--- a/src/data/feature_position_map.js
+++ b/src/data/feature_position_map.js
@@ -95,25 +95,42 @@ function getNumericId(value: mixed) {
 }
 
 // custom quicksort that sorts ids, indices and offsets together (by ids)
-function sort(ids, positions, left, right) {
-    if (left >= right) return;
+// implemented using iterative method rather than recursive
+function sort(ids, positions, _left, _right) {
 
-    const pivot = ids[(left + right) >> 1];
-    let i = left - 1;
-    let j = right + 1;
+    const stack = [];
 
-    while (true) {
-        do i++; while (ids[i] < pivot);
-        do j--; while (ids[j] > pivot);
-        if (i >= j) break;
-        swap(ids, i, j);
-        swap(positions, 3 * i, 3 * j);
-        swap(positions, 3 * i + 1, 3 * j + 1);
-        swap(positions, 3 * i + 2, 3 * j + 2);
+    stack.push(_left);
+    stack.push(_right);
+
+    while (stack.length > 0) {
+        const left = stack.shift();
+        const right = stack.shift();
+
+        if (left >= right) {
+            continue;
+        }
+
+        const pivot = ids[(left + right) >> 1];
+        let i = left - 1;
+        let j = right + 1;
+
+        while (true) {
+            do { i++; } while (ids[i] < pivot);
+            do { j--; } while (ids[j] > pivot);
+            if (i >= j) { break; }
+            swap(ids, i, j);
+            swap(positions, 3 * i, 3 * j);
+            swap(positions, 3 * i + 1, 3 * j + 1);
+            swap(positions, 3 * i + 2, 3 * j + 2);
+        }
+
+        stack.push(left);
+        stack.push(j);
+
+        stack.push(j + 1);
+        stack.push(right);
     }
-
-    sort(ids, positions, left, j);
-    sort(ids, positions, j + 1, right);
 }
 
 function swap(arr, i, j) {


### PR DESCRIPTION
## Launch Checklist

We've recently switched to using the feature state property in our mapbox implementation. We found during one test - which includes rendering 30000+ points - a stack-overflow eminating from feature_position_map.js. This was in the sort function which is implemented as a custom quick sort using recursion. The issue is that there are certain circumstances where quicksort can have a worst-case scenario. The pivot position chosen can end up being the next sorted item in the list - whick leads to a recusion to sort the remaining N-1 items. If this happens continuously we can infact recurse through all items to be sorted which causes stack overflow issues. This change simply rewrites the sort to use a queue and an iterative approach. 

 - [ x ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix "Maximum call stack size exceeded" error when using feature-state.</changelog>`
