### PR TITLE
[release-caspian] Ensure padding is not propagated from fitBounds to transform padding

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -599,6 +599,8 @@ class Camera extends Evented {
         if (!calculatedOptions) return this;
 
         options = extend(calculatedOptions, options);
+        // Explictly remove the padding field because, calculatedOptions already accounts for padding by setting zoom and center accordingly.
+        delete options.padding;
 
         return options.linear ?
             this.easeTo(options, eventData) :

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -1889,6 +1889,21 @@ test('camera', (t) => {
             t.end();
         });
 
+        t.test('padding does not get propagated to transform.padding', (t) => {
+            const camera = createCamera();
+            const bb = [[-133, 16], [-68, 50]];
+
+            camera.fitBounds(bb, {padding: {top: 10, right: 75, bottom: 50, left: 25}, duration:0});
+            const padding = camera.transform.padding;
+            t.deepEqual(padding, {
+                left: 0,
+                right: 0,
+                top: 0,
+                bottom: 0
+            });
+            t.end();
+        });
+
         t.end();
     });
 


### PR DESCRIPTION
Fixes #9477 .
It fixes a bug wherein `padding` passed to `fitBounds` also gets propagated to `easeTo` which causes padding to be accounted for in both the bounds calculation and asymmetric viewport calculation.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: 
<changelog> Fixes a bug in `map.fitBounds` wherein the `padding` passed to options would be applied twice. Fixes [#9477](https://github.com/mapbox/mapbox-gl-js/issues/9477)</changelog>
