### PR TITLE
Allow client to retry RTLTextPlugin load after NetworkError

### DIFF
--- a/debug/rtl.html
+++ b/debug/rtl.html
@@ -30,6 +30,7 @@
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
 <script>
+// badPluginURL allows us to simulate a NetworkError that we can recover from by retrying plugin loading
 var badPluginURL = 'http://localhost:9966/debug/2762.html';
 var goodPluginURL = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js';
 var map = window.map = new mapboxgl.Map({

--- a/debug/rtl.html
+++ b/debug/rtl.html
@@ -30,7 +30,8 @@
 <script src='/dist/mapbox-gl-dev.js'></script>
 <script src='/debug/access_token_generated.js'></script>
 <script>
-var pluginURL = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js';
+var badPluginURL = 'http://localhost:9966/debug/2762.html';
+var goodPluginURL = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js'
 var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 16.5,
@@ -40,13 +41,20 @@ var map = window.map = new mapboxgl.Map({
 });
 
 document.getElementById('loadSync').onclick = function() {
-    mapboxgl.setRTLTextPlugin(pluginURL);
+    mapboxgl.setRTLTextPlugin(goodPluginURL);
 };
 
 document.getElementById('loadAsync').onclick = function() {
-    mapboxgl.setRTLTextPlugin(pluginURL, function(err) {
+    mapboxgl.setRTLTextPlugin(badPluginURL, function(err) {
         if (err) {
-            throw err;
+            mapboxgl.setRTLTextPlugin(goodPluginURL, function (err) {
+                if (err) {
+                    throw err;
+                }
+                else {
+                    console.log('rtl-text-plugin retry loaded successfully');
+                }
+            })
         } else {
             console.log('rtl-text-plugin loaded successfully');
         }

--- a/debug/rtl.html
+++ b/debug/rtl.html
@@ -31,7 +31,7 @@
 <script src='/debug/access_token_generated.js'></script>
 <script>
 var badPluginURL = 'http://localhost:9966/debug/2762.html';
-var goodPluginURL = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js'
+var goodPluginURL = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js';
 var map = window.map = new mapboxgl.Map({
     container: 'map',
     zoom: 16.5,
@@ -50,11 +50,10 @@ document.getElementById('loadAsync').onclick = function() {
             mapboxgl.setRTLTextPlugin(goodPluginURL, function (err) {
                 if (err) {
                     throw err;
-                }
-                else {
+                } else {
                     console.log('rtl-text-plugin retry loaded successfully');
                 }
-            })
+            });
         } else {
             console.log('rtl-text-plugin loaded successfully');
         }

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -31,7 +31,7 @@ export const triggerPluginCompletionEvent = function(error: ?Error) {
     // allow plugin loading to be retried if a NetworkError is encountered
     // the error is a string because it's serialized from the worker so we
     // have to search the string rather than check the error code
-    if (error && error.indexOf('NetworkError') > -1) {
+    if (error && typeof error === 'string' && error.indexOf('NetworkError') > -1) {
         pluginStatus = status.error;
     }
 

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -28,9 +28,7 @@ let pluginStatus = status.unavailable;
 let pluginURL = null;
 
 export const triggerPluginCompletionEvent = function(error: ?Error) {
-    // allow plugin loading to be retried if a NetworkError is encountered
-    // the error is a string because it's serialized from the worker so we
-    // have to search the string rather than check the error code
+    // NetworkError's are not correctly reflected by the plugin status which prevents reloading plugin
     if (error && typeof error === 'string' && error.indexOf('NetworkError') > -1) {
         pluginStatus = status.error;
     }

--- a/src/source/rtl_text_plugin.js
+++ b/src/source/rtl_text_plugin.js
@@ -28,6 +28,13 @@ let pluginStatus = status.unavailable;
 let pluginURL = null;
 
 export const triggerPluginCompletionEvent = function(error: ?Error) {
+    // allow plugin loading to be retried if a NetworkError is encountered
+    // the error is a string because it's serialized from the worker so we
+    // have to search the string rather than check the error code
+    if (error && error.indexOf('NetworkError') > -1) {
+        pluginStatus = status.error;
+    }
+
     if (_completionCallback) {
         _completionCallback(error);
     }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - When the RTLTextPlugin fails due to a `NetworkError`, it's currently impossible to try loading the plugin again. We should allow this to be a recoverable error by setting the `pluginStatus` to `error` so that `setRTLTextPlugin` can be called again
    - the error in `triggerPluginCompletionEvent` is a string in this case because it has to be serialized from the worker. this means we have to check for presence of the `NetworkError` string rather than check for a particular error code
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Correctly set RTL text plugin status if the plugin URL could not be loaded. 
This allows adding retry logic if there was a network error when loading the plugin.</changelog>`
