### PR TITLE
[release-caspian] Fix binder.setUniform error  symbol in draw loop

### DIFF
--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -240,8 +240,6 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
     const depthMode = painter.depthModeForSublayer(0, DepthMode.ReadOnly);
 
-    let program;
-    let size;
     const variablePlacement = layer.layout.get('text-variable-anchor');
 
     const tileRenderState: Array<SymbolTileRenderState> = [];
@@ -259,10 +257,8 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         const sizeData = isText ? bucket.textSizeData : bucket.iconSizeData;
         const transformed = pitchWithMap || tr.pitch !== 0;
 
-        if (!program) {
-            program = painter.useProgram(getSymbolProgramName(isSDF, isText, bucket), programConfiguration);
-            size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
-        }
+        const program = painter.useProgram(getSymbolProgramName(isSDF, isText, bucket), programConfiguration);
+        const size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
 
         let texSize: [number, number];
         let texSizeIcon: [number, number] = [0, 0];


### PR DESCRIPTION
Fixes #9468 .

This regression was caused as an unintended sideeffect of https://github.com/mapbox/mapbox-gl-js/commit/d85afadd994d93fa7bb42bb614de02217030ee94.

The Uniform caching in that change works as expected, except in the symbol layer wherein the `Program` instance is only initialized once for all tiles in the draw loop.

Since the tiles need a round trip from the worker when certain paint properties are updated, for a few frames there can be mix of old and new tiles on screen, prior to the optimization the uniform bindings would be re-evaluated every frame, so it would self-heal. But the new implementation requires that the instance of `ProgramConfiguration` passed to `Program#constructor` and `Program#draw` be the same.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixes a bug  in which an exception would get thrown when updating symbol layer paint property using `setPaintProperty`</changelog>`
