### PR TITLE
[master] Fix binder.setUniform error symbol in draw loop

### DIFF
--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -240,8 +240,6 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
     const depthMode = painter.depthModeForSublayer(0, DepthMode.ReadOnly);
 
-    let program;
-    let size;
     const variablePlacement = layer.layout.get('text-variable-anchor');
 
     const tileRenderState: Array<SymbolTileRenderState> = [];
@@ -259,10 +257,8 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         const sizeData = isText ? bucket.textSizeData : bucket.iconSizeData;
         const transformed = pitchWithMap || tr.pitch !== 0;
 
-        if (!program) {
-            program = painter.useProgram(getSymbolProgramName(isSDF, isText, bucket), programConfiguration);
-            size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
-        }
+        const program = painter.useProgram(getSymbolProgramName(isSDF, isText, bucket), programConfiguration);
+        const size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
 
         let texSize: [number, number];
         let texSizeIcon: [number, number] = [0, 0];


### PR DESCRIPTION
CP of #9491 

## Launch Checklist

`<changelog>Fixes a bug  in which an exception would get thrown when updating symbol layer paint property using `setPaintProperty.</changelog>`
