### PR TITLE
Allow transforming non web mercator WMS sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ Here is a recommended way to get setup:
 1. Fork this project
 2. Clone your new fork, `git clone git@github.com:GithubUser/mapbox-gl-js.git`
 3. `cd mapbox-gl-js`
-4. Add the Mapbox repository as an upstream repository: `git add remote upstream git@github.com:mapbox/mapbox-gl-js.git`
+4. Add the Mapbox repository as an upstream repository: `git remote add upstream git@github.com:mapbox/mapbox-gl-js.git`
 5. Create a new branch `git checkout -b your-branch` for your contribution
 6. Write code, open a PR from your branch when you're ready
 7. If you need to rebase your fork's PR branch onto master to resolve conflicts: `git fetch upstream`, `git rebase upstream/master` and force push to Github `git push --force origin your-branch`

--- a/debug/wms_transform.html
+++ b/debug/wms_transform.html
@@ -24,9 +24,9 @@ var fromMapbox = new proj4.Proj('EPSG:3857');
 
 var map = window.map = new mapboxgl.Map({
     container: 'map',
-    zoom: 16,
-    center: [-74.0447, 40.6892],
-    style: 'mapbox://styles/mapbox/streets-v9',
+    zoom: 4,
+    center: [4.72, 47.91],
+    style: 'mapbox://styles/mapbox/light-v10',
     hash: true
 });
 
@@ -40,13 +40,15 @@ map.on('load', function() {
             var array = bbox.split(',').map(function (coord) {
                 return Number(coord);
             });
-            // reproject from web mercator into any other projection
-            var leftUpper = proj4(fromMapbox, toWGS84, array.slice(0, 2));
-            var rightLower = proj4(fromMapbox, toWGS84, array.slice(2));
+            // transform from web mercator into any other projection
+            // in this example, coordinates need to be switche from lng/lat (mapbox)
+            // to lat/lng as well
+            var leftUpper = proj4(fromMapbox, toWGS84, array.slice(0, 2)).reverse();
+            var rightLower = proj4(fromMapbox, toWGS84, array.slice(2)).reverse();
             // return a bbox string
             return leftUpper.concat(rightLower).join(',');
         },
-        "tiles": ['https://img.nj.gov/imagerywms/Natural2015?bbox={bbox-transform}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:4326&transparent=true&width=256&height=256&layers=Natural2015'
+        "tiles": ['https://services.bgr.de/wms/boden/eusr5000/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=5&CRS=EPSG:4326&STYLES=&WIDTH=256&HEIGHT=256&BBOX={bbox-transform}'
         ],
         "tileSize": 256
     });

--- a/debug/wms_transform.html
+++ b/debug/wms_transform.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.6.0/proj4.js"></script>
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+<script>
+/*global proj4*/
+var toWGS84 = new proj4.Proj('EPSG:4326');
+var fromMapbox = new proj4.Proj('EPSG:3857');
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 16,
+    center: [-74.0447, 40.6892],
+    style: 'mapbox://styles/mapbox/streets-v9',
+    hash: true
+});
+
+map.addControl(new mapboxgl.NavigationControl());
+
+map.on('load', function() {
+    map.addSource('wms-test', {
+        "type": "raster",
+        transformBBOX (bbox) {
+            // convert bbox string into an array of (number) coordinates
+            var array = bbox.split(',').map(function (coord) {
+                return Number(coord);
+            });
+            // reproject from web mercator into any other projection
+            var leftUpper = proj4(fromMapbox, toWGS84, array.slice(0, 2));
+            var rightLower = proj4(fromMapbox, toWGS84, array.slice(2));
+            // return a bbox string
+            return leftUpper.concat(rightLower).join(',');
+        },
+        "tiles": ['https://img.nj.gov/imagerywms/Natural2015?bbox={bbox-transform}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:4326&transparent=true&width=256&height=256&layers=Natural2015'
+        ],
+        "tileSize": 256
+    });
+
+    map.addLayer({
+        "id": "wms-test-layer",
+        "type": "raster",
+        "source": "wms-test",
+        "paint": {}
+    });
+});
+
+</script>
+</body>
+</html>

--- a/src/source/raster_tile_source.js
+++ b/src/source/raster_tile_source.js
@@ -30,6 +30,7 @@ class RasterTileSource extends Evented implements Source {
     maxzoom: number;
     url: string;
     scheme: string;
+    transformBBOX: ?(str: string) => string;
     tileSize: number;
 
     bounds: ?[number, number, number, number];
@@ -58,7 +59,7 @@ class RasterTileSource extends Evented implements Source {
         this._loaded = false;
 
         this._options = extend({type: 'raster'}, options);
-        extend(this, pick(options, ['url', 'scheme', 'tileSize']));
+        extend(this, pick(options, ['url', 'scheme', 'transformBBOX', 'tileSize']));
     }
 
     load() {
@@ -110,7 +111,7 @@ class RasterTileSource extends Evented implements Source {
     }
 
     loadTile(tile: Tile, callback: Callback<void>) {
-        const url = this.map._requestManager.normalizeTileURL(tile.tileID.canonical.url(this.tiles, this.scheme), this.tileSize);
+        const url = this.map._requestManager.normalizeTileURL(tile.tileID.canonical.url(this.tiles, this.scheme, this.transformBBOX), this.tileSize);
         tile.request = getImage(this.map._requestManager.transformRequest(url, ResourceType.Tile), (err, img) => {
             delete tile.request;
 

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -29,9 +29,10 @@ export class CanonicalTileID {
     }
 
     // given a list of urls, choose a url template and return a tile URL
-    url(urls: Array<string>, scheme: ?string) {
+    url(urls: Array<string>, scheme: ?string, transformBBOX: ?(str: string) => string) {
         const bbox = getTileBBox(this.x, this.y, this.z);
         const quadkey = getQuadkey(this.z, this.x, this.y);
+        if (!transformBBOX) transformBBOX = string => string;
 
         return urls[(this.x + this.y) % urls.length]
             .replace('{prefix}', (this.x % 16).toString(16) + (this.y % 16).toString(16))
@@ -39,7 +40,8 @@ export class CanonicalTileID {
             .replace('{x}', String(this.x))
             .replace('{y}', String(scheme === 'tms' ? (Math.pow(2, this.z) - this.y - 1) : this.y))
             .replace('{quadkey}', quadkey)
-            .replace('{bbox-epsg-3857}', bbox);
+            .replace('{bbox-epsg-3857}', bbox)
+            .replace('{bbox-transform}', transformBBOX(bbox));
     }
 
     getTilePoint(coord: MercatorCoordinate) {

--- a/test/unit/source/tile_id.test.js
+++ b/test/unit/source/tile_id.test.js
@@ -60,6 +60,11 @@ test('CanonicalTileID', (t) => {
             t.end();
         });
 
+        t.test('replaces {bbox-transform}', (t) => {
+            t.equal(new CanonicalTileID(1, 0, 0).url(['bbox={bbox-transform}'], null, bbox => `${bbox}_transformed`), 'bbox=-20037508.342789244,0,0,20037508.342789244_transformed');
+            t.end();
+        });
+
         t.end();
     });
 


### PR DESCRIPTION
The main purpose of this PR is to allow adding external WMS layers which are not projected in Web Mercator. 

Some publicly available datasets are only available in other, non web mercator projections (e.g. [ETRS89](https://en.wikipedia.org/wiki/European_Terrestrial_Reference_System_1989#cite_note-4) for many local datasets in Europe). To the best of my kownledge, adding them as a layer to a Maxpbox map either requires to transform the coordinates on the fly using a proxy server, or fiddling with the [`transformRequest`](https://docs.mapbox.com/mapbox-gl-js/api/#map) callback in the `map` options.

With the proposed feature in this PR, users would (only) need to define a `transformBBOX` callback in the source object, and add the `BBOX={bbox-transform}` query parameter to their tiles urls:

```js
map.addSource('wms-test', {
        "type": "raster",
        transformBBOX (bbox) {
            // convert bbox string into an array of (number) coordinates
            var array = bbox.split(',').map(function (coord) {
                return Number(coord);
            });
            // transform bbox from web mercator into WGS84 (or any other projection)
            // in this example, coordinates need to be switched from lng/lat (mapbox)
            // to lat/lng as well
            var toWGS84 = new proj4.Proj('EPSG:4326');
            var fromMapbox = new proj4.Proj('EPSG:3857');
            var leftUpper = proj4(fromMapbox, toWGS84, array.slice(0, 2)).reverse();
            var rightLower = proj4(fromMapbox, toWGS84, array.slice(2)).reverse();
            // return a bbox string
            return leftUpper.concat(rightLower).join(',');
        },
        "tiles": ['https://services.bgr.de/wms/boden/eusr5000/?BBOX={bbox-transform}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=true&LAYERS=5&CRS=EPSG:4326&STYLES=&WIDTH=256&HEIGHT=256'
        ],
        "tileSize": 256
    });
```

The callback is called with an `EPSG:3857` formatted BBOX `string`, and should return a BBOX `string` as well. 
When the query parameter `BBOX={bbox-transform}` is present, but no `transformBBOX` method is defined, the BBOX will be projected in `EPSG:3857` (similar to using `BBOX={bbox-epsg-3857}`.

Here's a picture of the above example in action (displaying the different soil regions within Europe):
![image](https://user-images.githubusercontent.com/20703207/78275779-5a1e0780-7512-11ea-98dd-f1f170747fd8.png)

Thank you for this amazing library and for considering my PR!

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [x] manually test the debug page
 - [ ]  tagged @mapbox/map-design-team @mapbox/static-apis if this PR includes style spec API or visual changes
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
