### PR TITLE
shader compilation speedup

### DIFF
--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -72,7 +72,7 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
         this.layoutVertexArray = new CircleLayoutArray();
         this.indexArray = new TriangleIndexArray();
         this.segments = new SegmentVector();
-        this.programConfigurations = new ProgramConfigurationSet(layoutAttributes, options.layers, options.zoom);
+        this.programConfigurations = new ProgramConfigurationSet(options.layers, options.zoom);
         this.stateDependentLayerIds = this.layers.filter((l) => l.isStateDependent()).map((l) => l.id);
     }
 

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -68,7 +68,7 @@ class FillBucket implements Bucket {
         this.layoutVertexArray = new FillLayoutArray();
         this.indexArray = new TriangleIndexArray();
         this.indexArray2 = new LineIndexArray();
-        this.programConfigurations = new ProgramConfigurationSet(layoutAttributes, options.layers, options.zoom);
+        this.programConfigurations = new ProgramConfigurationSet(options.layers, options.zoom);
         this.segments = new SegmentVector();
         this.segments2 = new SegmentVector();
         this.stateDependentLayerIds = this.layers.filter((l) => l.isStateDependent()).map((l) => l.id);

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -82,7 +82,7 @@ class FillExtrusionBucket implements Bucket {
 
         this.layoutVertexArray = new FillExtrusionLayoutArray();
         this.indexArray = new TriangleIndexArray();
-        this.programConfigurations = new ProgramConfigurationSet(layoutAttributes, options.layers, options.zoom);
+        this.programConfigurations = new ProgramConfigurationSet(options.layers, options.zoom);
         this.segments = new SegmentVector();
         this.stateDependentLayerIds = this.layers.filter((l) => l.isStateDependent()).map((l) => l.id);
 

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -111,7 +111,7 @@ class LineBucket implements Bucket {
 
         this.layoutVertexArray = new LineLayoutArray();
         this.indexArray = new TriangleIndexArray();
-        this.programConfigurations = new ProgramConfigurationSet(layoutAttributes, options.layers, options.zoom);
+        this.programConfigurations = new ProgramConfigurationSet(options.layers, options.zoom);
         this.segments = new SegmentVector();
 
         this.stateDependentLayerIds = this.layers.filter((l) => l.isStateDependent()).map((l) => l.id);

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -382,8 +382,8 @@ class SymbolBucket implements Bucket {
     }
 
     createArrays() {
-        this.text = new SymbolBuffers(new ProgramConfigurationSet(symbolLayoutAttributes.members, this.layers, this.zoom, property => /^text/.test(property)));
-        this.icon = new SymbolBuffers(new ProgramConfigurationSet(symbolLayoutAttributes.members, this.layers, this.zoom, property => /^icon/.test(property)));
+        this.text = new SymbolBuffers(new ProgramConfigurationSet(this.layers, this.zoom, property => /^text/.test(property)));
+        this.icon = new SymbolBuffers(new ProgramConfigurationSet(this.layers, this.zoom, property => /^icon/.test(property)));
 
         this.glyphOffsetArray = new GlyphOffsetArray();
         this.lineVertexArray = new SymbolLineVertexArray();

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -398,13 +398,11 @@ class CrossFadedCompositeBinder implements AttributeBinder {
 export default class ProgramConfiguration {
     binders: {[_: string]: (AttributeBinder | UniformBinder) };
     cacheKey: string;
-    layoutAttributes: Array<StructArrayMember>;
 
     _buffers: Array<VertexBuffer>;
 
-    constructor(layer: TypedStyleLayer, zoom: number, filterProperties: (_: string) => boolean, layoutAttributes: Array<StructArrayMember>) {
+    constructor(layer: TypedStyleLayer, zoom: number, filterProperties: (_: string) => boolean) {
         this.binders = {};
-        this.layoutAttributes = layoutAttributes;
         this._buffers = [];
 
         const keys = [];
@@ -500,6 +498,32 @@ export default class ProgramConfiguration {
         return result;
     }
 
+    getBinderAttributes(): Array<string> {
+        const result = [];
+        for (const property in this.binders) {
+            const binder = this.binders[property];
+            if (binder instanceof CrossFadedCompositeBinder || binder instanceof SourceExpressionBinder || binder instanceof CompositeExpressionBinder) {
+                for (let i = 0; i < binder.paintVertexAttributes.length; i++) {
+                    result.push(binder.paintVertexAttributes[i].name);
+                }
+            }
+        }
+        return result;
+    }
+
+    getBinderUniforms(): Array<string> {
+        const uniforms = [];
+        for (const property in this.binders) {
+            const binder = this.binders[property];
+            if (binder instanceof ConstantBinder || binder instanceof CrossFadedConstantBinder || binder instanceof CompositeExpressionBinder) {
+                for (const uniformName of binder.uniformNames) {
+                    uniforms.push(uniformName);
+                }
+            }
+        }
+        return uniforms;
+    }
+
     getPaintVertexBuffers(): Array<VertexBuffer> {
         return this._buffers;
     }
@@ -567,10 +591,10 @@ export class ProgramConfigurationSet<Layer: TypedStyleLayer> {
     _featureMap: FeaturePositionMap;
     _bufferOffset: number;
 
-    constructor(layoutAttributes: Array<StructArrayMember>, layers: $ReadOnlyArray<Layer>, zoom: number, filterProperties: (_: string) => boolean = () => true) {
+    constructor(layers: $ReadOnlyArray<Layer>, zoom: number, filterProperties: (_: string) => boolean = () => true) {
         this.programConfigurations = {};
         for (const layer of layers) {
-            this.programConfigurations[layer.id] = new ProgramConfiguration(layer, zoom, filterProperties, layoutAttributes);
+            this.programConfigurations[layer.id] = new ProgramConfiguration(layer, zoom, filterProperties);
         }
         this.needsUpload = false;
         this._featureMap = new FeaturePositionMap();

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -502,9 +502,13 @@ export default class ProgramConfiguration {
         const result = [];
         for (const property in this.binders) {
             const binder = this.binders[property];
-            if (binder instanceof CrossFadedCompositeBinder || binder instanceof SourceExpressionBinder || binder instanceof CompositeExpressionBinder) {
+            if (binder instanceof SourceExpressionBinder || binder instanceof CompositeExpressionBinder) {
                 for (let i = 0; i < binder.paintVertexAttributes.length; i++) {
                     result.push(binder.paintVertexAttributes[i].name);
+                }
+            } else if (binder instanceof CrossFadedCompositeBinder) {
+                for (let i = 0; i < patternAttributes.members.length; i++) {
+                    result.push(patternAttributes.members[i].name);
                 }
             }
         }

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -599,7 +599,7 @@ class Painter {
         this.cache = this.cache || {};
         const key = `${name}${programConfiguration ? programConfiguration.cacheKey : ''}${this._showOverdrawInspector ? '/overdraw' : ''}`;
         if (!this.cache[key]) {
-            this.cache[key] = new Program(this.context, shaders[name], programConfiguration, programUniforms[name], this._showOverdrawInspector);
+            this.cache[key] = new Program(this.context, name, shaders[name], programConfiguration, programUniforms[name], this._showOverdrawInspector);
         }
         return this.cache[key];
     }

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -88,24 +88,10 @@ class Program<Us: UniformBindings> {
         assert(gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS), (gl.getShaderInfoLog(vertexShader): any));
         gl.attachShader(this.program, vertexShader);
 
-        // Manually bind layout attributes in the order defined by their
-        // ProgramInterface so that we don't dynamically link an unused
-        // attribute at position 0, which can cause rendering to fail for an
-        // entire layer (see #4607, #4728)
-
-        this.numAttributes = allAttrInfo.length;
-        for (let i = 0; i < this.numAttributes; i++) {
-            gl.bindAttribLocation(this.program, i, allAttrInfo[i]);
-        }
-
-        gl.linkProgram(this.program);
-        assert(gl.getProgramParameter(this.program, gl.LINK_STATUS), (gl.getProgramInfoLog(this.program): any));
-
-        gl.deleteShader(vertexShader);
-        gl.deleteShader(fragmentShader);
-
         this.attributes = {};
         const uniformLocations = {};
+
+        this.numAttributes = allAttrInfo.length;
 
         for (let i = 0; i < this.numAttributes; i++) {
             if (allAttrInfo[i]) {
@@ -113,6 +99,12 @@ class Program<Us: UniformBindings> {
                 this.attributes[allAttrInfo[i]] = i;
             }
         }
+
+        gl.linkProgram(this.program);
+        assert(gl.getProgramParameter(this.program, gl.LINK_STATUS), (gl.getProgramInfoLog(this.program): any));
+
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
 
         const uniformsArray = Array.from(allUniformsInfo);
         for (let it = 0; it < uniformsArray.length; it++) {

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -21,6 +21,16 @@ export type DrawMode =
     | $PropertyType<WebGLRenderingContext, 'TRIANGLES'>
     | $PropertyType<WebGLRenderingContext, 'LINE_STRIP'>;
 
+function getTokenizedAttributesAndUniforms (array: Array<string>): Array<string> {
+    const result = [];
+
+    for (let i = 0; i < array.length; i++) {
+        if (array[i] === null) continue;
+        const token = array[i].split(' ');
+        result.push(token.pop());
+    }
+    return result;
+}
 class Program<Us: UniformBindings> {
     program: WebGLProgram;
     attributes: {[_: string]: number};
@@ -30,12 +40,26 @@ class Program<Us: UniformBindings> {
     failedToCreate: boolean;
 
     constructor(context: Context,
-                source: {fragmentSource: string, vertexSource: string},
-                configuration: ?ProgramConfiguration,
-                fixedUniforms: (Context, UniformLocations) => Us,
-                showOverdrawInspector: boolean) {
+            name: string,
+            source: {fragmentSource: string, vertexSource: string, staticAttributes: Array<string>, staticUniforms: Array<string>},
+            configuration: ?ProgramConfiguration,
+            fixedUniforms: (Context, UniformLocations) => Us,
+            showOverdrawInspector: boolean) {
         const gl = context.gl;
         this.program = gl.createProgram();
+
+        const staticAttrInfo = getTokenizedAttributesAndUniforms(source.staticAttributes);
+        const dynamicAttrInfo = configuration ? configuration.getBinderAttributes() : [];
+        const allAttrInfo = staticAttrInfo.concat(dynamicAttrInfo);
+
+        const staticUniformsInfo = source.staticUniforms ? getTokenizedAttributesAndUniforms(source.staticUniforms) : [];
+        const dynamicUniformsInfo = configuration ? configuration.getBinderUniforms() : [];
+        // remove duplicate uniforms
+        const uniformList = staticUniformsInfo.concat(dynamicUniformsInfo);
+        const allUniformsInfo = [];
+        for (const uniform of uniformList) {
+            if (allUniformsInfo.indexOf(uniform) < 0) allUniformsInfo.push(uniform);
+        }
 
         const defines = configuration ? configuration.defines() : [];
         if (showOverdrawInspector) {
@@ -68,9 +92,10 @@ class Program<Us: UniformBindings> {
         // ProgramInterface so that we don't dynamically link an unused
         // attribute at position 0, which can cause rendering to fail for an
         // entire layer (see #4607, #4728)
-        const layoutAttributes = configuration ? configuration.layoutAttributes : [];
-        for (let i = 0; i < layoutAttributes.length; i++) {
-            gl.bindAttribLocation(this.program, i, layoutAttributes[i].name);
+
+        this.numAttributes = allAttrInfo.length;
+        for (let i = 0; i < this.numAttributes; i++) {
+            gl.bindAttribLocation(this.program, i, allAttrInfo[i]);
         }
 
         gl.linkProgram(this.program);
@@ -79,23 +104,24 @@ class Program<Us: UniformBindings> {
         gl.deleteShader(vertexShader);
         gl.deleteShader(fragmentShader);
 
-        this.numAttributes = gl.getProgramParameter(this.program, gl.ACTIVE_ATTRIBUTES);
-
         this.attributes = {};
         const uniformLocations = {};
 
         for (let i = 0; i < this.numAttributes; i++) {
-            const attribute = gl.getActiveAttrib(this.program, i);
-            if (attribute) {
-                this.attributes[attribute.name] = gl.getAttribLocation(this.program, attribute.name);
+            if (allAttrInfo[i]) {
+                gl.bindAttribLocation(this.program, i, allAttrInfo[i]);
+                this.attributes[allAttrInfo[i]] = i;
             }
         }
 
-        const numUniforms = gl.getProgramParameter(this.program, gl.ACTIVE_UNIFORMS);
-        for (let i = 0; i < numUniforms; i++) {
-            const uniform = gl.getActiveUniform(this.program, i);
-            if (uniform) {
-                uniformLocations[uniform.name] = gl.getUniformLocation(this.program, uniform.name);
+        const uniformsArray = Array.from(allUniformsInfo);
+        for (let it = 0; it < uniformsArray.length; it++) {
+            const uniform = uniformsArray[it];
+            if (uniform && !uniformLocations[uniform]) {
+                const uniformLocation = gl.getUniformLocation(this.program, uniform);
+                if (uniformLocation) {
+                    uniformLocations[uniform] = uniformLocation;
+                }
             }
         }
 

--- a/src/shaders/shaders.js
+++ b/src/shaders/shaders.js
@@ -87,6 +87,11 @@ export const symbolTextAndIcon = compile(symbolTextAndIconFrag, symbolTextAndIco
 function compile(fragmentSource, vertexSource) {
     const re = /#pragma mapbox: ([\w]+) ([\w]+) ([\w]+) ([\w]+)/g;
 
+    const staticAttributes = vertexSource.match(/attribute ([\w]+) ([\w]+)/g);
+    const fragmentUniforms = fragmentSource.match(/uniform ([\w]+) ([\w]+)([\s]*)([\w]*)/g);
+    const vertexUniforms = vertexSource.match(/uniform ([\w]+) ([\w]+)([\s]*)([\w]*)/g);
+    const staticUniforms = vertexUniforms ? vertexUniforms.concat(fragmentUniforms) : fragmentUniforms;
+
     const fragmentPragmas = {};
 
     fragmentSource = fragmentSource.replace(re, (match, operation, precision, type, name) => {
@@ -176,5 +181,5 @@ uniform ${precision} ${type} u_${name};
         }
     });
 
-    return {fragmentSource, vertexSource};
+    return {fragmentSource, vertexSource, staticAttributes, staticUniforms};
 }


### PR DESCRIPTION
After some investigation, we realized that some of the calls to `getActiveAttrib`, `getActiveUniform`, `getProgramParameter` and `getAttribLocation` since these are the information we can get from our styling pipeline and program configuration.

The changes that is being introduced with this change:

Removed the layout Attributes from program configuration since it is no longer being used in program class. With the new changes, we are now getting the run time attributes and uniforms information from binders. The only dependency to `gl` we have is for `getUniformLocation`. 

These are some of the benchmark results which compares this local branch to master:
Layer Line:
![LayerLine](https://user-images.githubusercontent.com/32684731/78703199-a8d6f300-78be-11ea-90d5-1696cb46c6d1.png)

Layer Circle:
![LayerCircle](https://user-images.githubusercontent.com/32684731/78703262-b7250f00-78be-11ea-8b1d-8632c5803fa1.png)

Layer Fill:
![LayerFill](https://user-images.githubusercontent.com/32684731/78703280-c0ae7700-78be-11ea-85ed-b6368838b51d.png)

Paint:
![Paint](https://user-images.githubusercontent.com/32684731/78703218-ad9ba700-78be-11ea-836c-9a8bbf3d38a6.png)

Also, this is a screen shot of the performance with recent changes. You can see that the main time consuming operation is regarding getUniformLocation:

![image](https://user-images.githubusercontent.com/32684731/78703833-c0fb4200-78bf-11ea-8e6e-0a67e33e0796.png)


 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] post benchmark scores
 - [x] manually test the debug page
