### PR TITLE
fix DragRotateHandler#isActive

### DIFF
--- a/src/ui/handler/shim/drag_rotate.js
+++ b/src/ui/handler/shim/drag_rotate.js
@@ -62,6 +62,6 @@ export default class DragRotateHandler {
      * @returns {boolean} `true` if the "drag to rotate" interaction is active.
      */
     isActive() {
-        return this._mouseRotate.isEnabled() || this._mousePitch.isEnabled();
+        return this._mouseRotate.isActive() || this._mousePitch.isActive();
     }
 }

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -11,6 +11,30 @@ function createMap(t, options) {
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 
+test('DragRotateHandler#isActive', (t) => {
+    const map = createMap(t);
+
+    // Prevent inertial rotation.
+    t.stub(browser, 'now').returns(0);
+
+    t.equal(map.dragRotate.isActive(), false);
+
+    simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
+    map._renderTaskQueue.run();
+    t.equal(map.dragRotate.isActive(), false);
+
+    simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
+    t.equal(map.dragRotate.isActive(), true);
+
+    simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
+    map._renderTaskQueue.run();
+    t.equal(map.dragRotate.isActive(), false);
+
+    map.remove();
+    t.end();
+});
+
 test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a right-click drag', (t) => {
     const map = createMap(t);
 


### PR DESCRIPTION
I mis-copied something and it was calling `isEnabled()` on it's children. It is now calling `isActive()` correctly.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [n/a] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [n/a] document any changes to public APIs
 - [n/a] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

