### PR TITLE
[release-caspian] Fix style-spec isolation for within expression

### DIFF
--- a/src/style-spec/expression/definitions/within.js
+++ b/src/style-spec/expression/definitions/within.js
@@ -7,8 +7,6 @@ import type {Expression} from '../expression';
 import type ParsingContext from '../parsing_context';
 import type EvaluationContext from '../evaluation_context';
 import type {GeoJSON, GeoJSONPolygon, GeoJSONMultiPolygon} from '@mapbox/geojson-types';
-import MercatorCoordinate from '../../../geo/mercator_coordinate';
-import EXTENT from '../../../data/extent';
 import Point from '@mapbox/point-geometry';
 import type {CanonicalTileID} from '../../../source/tile_id';
 
@@ -16,11 +14,21 @@ type GeoJSONPolygons =| GeoJSONPolygon | GeoJSONMultiPolygon;
 
 // minX, minY, maxX, maxY
 type BBox = [number, number, number, number];
+const EXTENT = 8192;
+
 function updateBBox(bbox: BBox, coord: Point) {
     bbox[0] = Math.min(bbox[0], coord[0]);
     bbox[1] = Math.min(bbox[1], coord[1]);
     bbox[2] = Math.max(bbox[2], coord[0]);
     bbox[3] = Math.max(bbox[3], coord[1]);
+}
+
+function mercatorXfromLng(lng: number) {
+    return (180 + lng) / 360;
+}
+
+function mercatorYfromLat(lat: number) {
+    return (180 - (180 / Math.PI * Math.log(Math.tan(Math.PI / 4 + lat * Math.PI / 360)))) / 360;
 }
 
 function boxWithinBox(bbox1: BBox, bbox2: BBox) {
@@ -32,7 +40,7 @@ function boxWithinBox(bbox1: BBox, bbox2: BBox) {
 }
 
 function getTileCoordinates(p, canonical: CanonicalTileID) {
-    const coord = MercatorCoordinate.fromLngLat({lng: p[0], lat: p[1]}, 0);
+    const coord = {x: mercatorXfromLng(p[0]), y: mercatorYfromLat(p[1])};
     const tilesAtZoom = Math.pow(2, canonical.z);
     return [Math.round(coord.x * tilesAtZoom * EXTENT), Math.round(coord.y * tilesAtZoom * EXTENT)];
 }

--- a/src/style-spec/expression/definitions/within.js
+++ b/src/style-spec/expression/definitions/within.js
@@ -40,9 +40,10 @@ function boxWithinBox(bbox1: BBox, bbox2: BBox) {
 }
 
 function getTileCoordinates(p, canonical: CanonicalTileID) {
-    const coord = {x: mercatorXfromLng(p[0]), y: mercatorYfromLat(p[1])};
+    const x = mercatorXfromLng(p[0]);
+    const y = mercatorYfromLat(p[1]);
     const tilesAtZoom = Math.pow(2, canonical.z);
-    return [Math.round(coord.x * tilesAtZoom * EXTENT), Math.round(coord.y * tilesAtZoom * EXTENT)];
+    return [Math.round(x * tilesAtZoom * EXTENT), Math.round(y * tilesAtZoom * EXTENT)];
 }
 
 function onBoundary(p, p1, p2) {

--- a/src/style-spec/rollup.config.js
+++ b/src/style-spec/rollup.config.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import replace from 'rollup-plugin-replace';
 import buble from 'rollup-plugin-buble';
 import resolve from 'rollup-plugin-node-resolve';
@@ -14,6 +15,8 @@ const transforms = {
     modules: esm ? false : undefined
 };
 
+const ROOT_DIR = __dirname;
+
 const config = [{
     input: `${__dirname}/style-spec.js`,
     output: {
@@ -23,6 +26,23 @@ const config = [{
         sourcemap: true
     },
     plugins: [
+        {
+            name: 'dep-checker',
+            resolveId(source, importer) {
+                // Some users reference modules within style-spec package directly, instead of the bundle
+                // This means that files within the style-spec package should NOT import files from the parent mapbox-gl-js tree.
+                // This check will cause the build the fail on CI allowing these issues to be caught.
+                if(importer && !importer.includes('node_modules')){
+                    const resolvedPath = path.join(importer, source);
+                    const fromRoot = path.relative(ROOT_DIR, resolvedPath);
+                    if(fromRoot.length > 2 && fromRoot.slice(0, 2) == '..'){
+                        throw new Error(`Module ${importer} imports ${source} from outside the style-spec package root directory.`);
+                    }
+                }
+
+                return null;
+            }
+        },
         // https://github.com/zaach/jison/issues/351
         replace({
             include: /\/jsonlint-lines-primitives\/lib\/jsonlint.js/,

--- a/src/style-spec/rollup.config.js
+++ b/src/style-spec/rollup.config.js
@@ -32,10 +32,10 @@ const config = [{
                 // Some users reference modules within style-spec package directly, instead of the bundle
                 // This means that files within the style-spec package should NOT import files from the parent mapbox-gl-js tree.
                 // This check will cause the build the fail on CI allowing these issues to be caught.
-                if(importer && !importer.includes('node_modules')){
+                if (importer && !importer.includes('node_modules')) {
                     const resolvedPath = path.join(importer, source);
                     const fromRoot = path.relative(ROOT_DIR, resolvedPath);
-                    if(fromRoot.length > 2 && fromRoot.slice(0, 2) == '..'){
+                    if (fromRoot.length > 2 && fromRoot.slice(0, 2) === '..') {
                         throw new Error(`Module ${importer} imports ${source} from outside the style-spec package root directory.`);
                     }
                 }

--- a/src/style-spec/rollup.config.js
+++ b/src/style-spec/rollup.config.js
@@ -31,7 +31,7 @@ const config = [{
             resolveId(source, importer) {
                 // Some users reference modules within style-spec package directly, instead of the bundle
                 // This means that files within the style-spec package should NOT import files from the parent mapbox-gl-js tree.
-                // This check will cause the build the fail on CI allowing these issues to be caught.
+                // This check will cause the build to fail on CI allowing these issues to be caught.
                 if (importer && !importer.includes('node_modules')) {
                     const resolvedPath = path.join(importer, source);
                     const fromRoot = path.relative(ROOT_DIR, resolvedPath);


### PR DESCRIPTION
Fixes #9524


This fix also adds a check in the style-spec build script, that causes it to error out when an external file is imported.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix files within the style-spec package importing files from the parent repository tree. </changelog>`
