### PR TITLE
fix #9519 click map event on touch devices

### DIFF
--- a/src/ui/handler/tap_recognizer.js
+++ b/src/ui/handler/tap_recognizer.js
@@ -125,7 +125,6 @@ export class TapRecognizer {
             this.lastTap = tap;
 
             if (this.count === this.numTaps) {
-                e.preventDefault();
                 this.reset();
                 return tap;
             }

--- a/src/ui/handler/tap_zoom.js
+++ b/src/ui/handler/tap_zoom.js
@@ -47,6 +47,7 @@ export default class TapZoomHandler {
 
         if (zoomInPoint) {
             this._active = true;
+            e.preventDefault();
             setTimeout(() => this.reset(), 0);
             return {
                 cameraAnimation: (map: Map) => map.easeTo({
@@ -57,6 +58,7 @@ export default class TapZoomHandler {
             };
         } else if (zoomOutPoint) {
             this._active = true;
+            e.preventDefault();
             setTimeout(() => this.reset(), 0);
             return {
                 cameraAnimation: (map: Map) => map.easeTo({


### PR DESCRIPTION
The TapRecognizer used by the TapDragZoomHandler was often calling .preventDefault() on the touchend event of a single tap. This prevented the `mousedown`/`mouseup`/`click` events from being fired by the browser.

The fix is the to not prevent default in the recognizer, and instead only do that within the handlers that need it (`TapZoom`).

I didn't add a regression test because:
- I couldn't quickly figure out how to use selenium for this
- the touch event mocking we're using doesn't support `e.defaultPrevented` so we can't check the value of that

I've opened an issue for adding a regression test for this without blocking the release: https://github.com/mapbox/mapbox-gl-js/issues/9527

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [n/a] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [n/a] document any changes to public APIs
 - [n/a] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

