### PR TITLE
export isExpressionFilter from spec

### DIFF
--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -69,7 +69,8 @@ import diff from './diff';
 import ValidationError from './error/validation_error';
 import ParsingError from './error/parsing_error';
 import {StyleExpression, isExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction} from './expression';
-import featureFilter from './feature_filter';
+import featureFilter, {isExpressionFilter} from './feature_filter';
+
 import convertFilter from './feature_filter/convert';
 import Color from './util/color';
 import {createFunction, isFunction} from './function';
@@ -82,6 +83,7 @@ import validateMapboxApiSupported from './validate_mapbox_api_supported';
 const expression = {
     StyleExpression,
     isExpression,
+    isExpressionFilter,
     createExpression,
     createPropertyExpression,
     normalizePropertyExpression,


### PR DESCRIPTION
This PR adds `isExpressionFilter` to style-spec's export, under `expression.isExpressionFilter`.

Are there tests I should write along with this PR? Not seeing a place to do this.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [-] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - ~~[ ] post benchmark scores~~
 - ~~[ ] manually test the debug page~~
 - [x] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - ~~[] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>adds `isExpressionFilter` to style-spec's export, under `expression.isExpressionFilter`</changelog>`

cc: @mapbox/map-design-team / @mapbox/static-apis – you all might find this useful :)
