### PR TITLE
Refactor format_section_override out of style-spec

### DIFF
--- a/src/style/format_section_override.js
+++ b/src/style/format_section_override.js
@@ -1,14 +1,16 @@
 // @flow
 
 import assert from 'assert';
-import type {Expression} from '../expression';
-import type EvaluationContext from '../evaluation_context';
-import type {Type} from '../types';
-import type {ZoomConstantExpression} from '../../expression';
-import {NullType} from '../types';
-import {PossiblyEvaluatedPropertyValue} from '../../../style/properties';
-import {register} from '../../../util/web_worker_transfer';
+import type {Expression} from '../style-spec/expression/expression';
+import type EvaluationContext from '../style-spec/expression/evaluation_context';
+import type {Type} from '../style-spec/expression/types';
+import type {ZoomConstantExpression} from '../style-spec/expression';
+import {NullType} from '../style-spec/expression/types';
+import {PossiblyEvaluatedPropertyValue} from './properties';
+import {register} from '../util/web_worker_transfer';
 
+// This is an internal expression class. It is only used in GL JS and
+// has GL JS dependencies which can break the standalone style-spec module
 export default class FormatSectionOverride<T> implements Expression {
     type: Type;
     defaultValue: PossiblyEvaluatedPropertyValue<T>;

--- a/src/style/style_layer/symbol_style_layer.js
+++ b/src/style/style_layer/symbol_style_layer.js
@@ -33,7 +33,7 @@ import type {CanonicalTileID} from '../../source/tile_id';
 import {FormattedType} from '../../style-spec/expression/types';
 import {typeOf} from '../../style-spec/expression/values';
 import Formatted from '../../style-spec/expression/types/formatted';
-import FormatSectionOverride from '../../style-spec/expression/definitions/format_section_override';
+import FormatSectionOverride from '../format_section_override';
 import FormatExpression from '../../style-spec/expression/definitions/format';
 import Literal from '../../style-spec/expression/definitions/literal';
 

--- a/test/unit/style/format_section_override.test.js
+++ b/test/unit/style/format_section_override.test.js
@@ -3,7 +3,7 @@ import {createExpression, ZoomConstantExpression} from '../../../src/style-spec/
 import EvaluationContext from '../../../src/style-spec/expression/evaluation_context';
 import properties from '../../../src/style/style_layer/symbol_style_layer_properties';
 import {PossiblyEvaluatedPropertyValue} from '../../../src/style/properties';
-import FormatSectionOverride from '../../../src/style-spec/expression/definitions/format_section_override';
+import FormatSectionOverride from '../../../src/style/format_section_override';
 
 test('evaluate', (t) => {
 

--- a/test/unit/symbol/symbol_style_layer.test.js
+++ b/test/unit/symbol/symbol_style_layer.test.js
@@ -1,6 +1,6 @@
 import {test} from '../../util/test';
 import SymbolStyleLayer from '../../../src/style/style_layer/symbol_style_layer';
-import FormatSectionOverride from '../../../src/style-spec/expression/definitions/format_section_override';
+import FormatSectionOverride from '../../../src/style/format_section_override';
 import properties from '../../../src/style/style_layer/symbol_style_layer_properties';
 
 function createSymbolLayer(layerProperties) {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - Related to https://github.com/mapbox/mapbox-gl-js/pull/9522
    - `format_section_override` is an internal expression which is only used in `symbol_style_layer`. since it has dependencies outside of the `style-spec` standalone module and is not included in the file build of the module, we should refactor it into GL JS to maintain `style-spec` isolation