### PR TITLE
[docsprint] Add inline and related example for panTo

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -156,15 +156,21 @@ class Camera extends Evented {
     }
 
     /**
-     * Pans the map to the specified location, with an animated transition.
+     * Pans the map to the specified location with an animated transition.
      *
      * @memberof Map#
      * @param lnglat The location to pan the map to.
-     * @param options Options object
+     * @param options Options describing the destination and animation of the transition.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
      * @returns {Map} `this`
+     * @example
+     * map.panTo([-74, 38]);
+     * @example
+     * // Change the duration of panTo to 5000 milliseconds.
+     * map.panTo([-74, 38], {duration: 5000});
+     * @see [Update a feature in realtime](https://docs.mapbox.com/mapbox-gl-js/example/live-update-feature/)
      */
     panTo(lnglat: LngLatLike, options?: AnimationOptions, eventData?: Object) {
         return this.easeTo(extend({


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `#map#panTo` to include an inline code snippet, links to related examples, fixes a comma splice, and makes the description for the `Options` param consistent with other methods.

![image](https://user-images.githubusercontent.com/2180540/79158295-0ded8580-7da4-11ea-93d8-283c2c502a95.png)

cc @danswick @katydecorah @asheemmamoowala
