### PR TITLE
[docsprint] Add inline snippet and examples to map.jumpTo

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -631,6 +631,19 @@ class Camera extends Evented {
      * @fires zoomend
      * @fires pitchend
      * @returns {Map} `this`
+     * @example
+     * // jump to null island at current zoom
+     * map.jumpTo({center: [0, 0]});
+     * // jump with zoom, pitch, and bearing set
+     * map.jumpTo({
+     *   center: [0, 0],
+     *   zoom: 8,
+     *   bearing: 90,
+     *   pitch: 45
+     *   }
+     * });
+     * @see [Jump to a series of locations](https://docs.mapbox.com/mapbox-gl-js/example/jump-to/)
+     * @see [Update a feature in realtime](https://docs.mapbox.com/mapbox-gl-js/example/live-update-feature/)
      */
     jumpTo(options: CameraOptions, eventData?: Object) {
         this.stop();

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -638,8 +638,8 @@ class Camera extends Evented {
      * map.jumpTo({
      *   center: [0, 0],
      *   zoom: 8,
-     *   bearing: 90,
-     *   pitch: 45
+     *   pitch: 45,
+     *   bearing: 90
      *   }
      * });
      * @see [Jump to a series of locations](https://docs.mapbox.com/mapbox-gl-js/example/jump-to/)


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `map.jumpTo` to include an inline code snippet and links to related examples.

![image](https://user-images.githubusercontent.com/12281722/79163468-fd351380-7d93-11ea-8d2d-c45c5a7a4998.png)

cc @danswick @katydecorah @asheemmamoowala