### PR TITLE
[docsprint] Add inline snippet and tutorial example to map.getCenter

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -119,6 +119,13 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @returns The map's geographical centerpoint.
+     * @example
+     * // return a LngLat object such as {lng: 0, lat: 0} at null island
+     * var center = map.getCenter();
+     * // return longitude and latitude values directly
+     * var longitude = map.getCenter().lng;
+     * var latitude = map.getCenter().lat;
+     * @see [Use Mapbox GL JS in a React app](https://docs.mapbox.com/help/tutorials/use-mapbox-gl-js-with-react/#store-the-new-coordinates)
      */
     getCenter(): LngLat { return new LngLat(this.transform.center.lng, this.transform.center.lat); }
 


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `map.getCenter` to include an inline code snippet and link to example usage within an existing tutorial. 

![image](https://user-images.githubusercontent.com/12281722/79166774-bf87b900-7d9a-11ea-9f09-d79cdda9b669.png)

cc @danswick @katydecorah @asheemmamoowala 