### PR TITLE
[docsprint] Add geolocate trigger example

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -406,10 +406,24 @@ class GeolocateControl extends Evented {
     }
 
     /**
-     * Trigger a geolocation
-     *
-     * @returns {boolean} Returns `false` if called before control was added to a map, otherwise returns `true`.
-     */
+    * Trigger a geolocation
+    *
+    * @returns {boolean} Returns `false` if called before control was added to a map, otherwise returns `true`.
+    * @example
+    * var geolocate = new mapboxgl.GeolocateControl({
+    *  positionOptions: {
+    *  enableHighAccuracy: true
+    *  },
+    *  
+    *  trackUserLocation: true
+    * });
+
+    * map.addControl(geolocate);
+
+    * map.on('load', function() {
+    *   geolocate.trigger();
+    * }
+    */
     trigger() {
         if (!this._setup) {
             warnOnce('Geolocate control triggered before added to a map');

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -412,7 +412,7 @@ class GeolocateControl extends Evented {
     * @example
     * var geolocate = new mapboxgl.GeolocateControl({
     *  positionOptions: {
-    *  enableHighAccuracy: true
+    *    enableHighAccuracy: true
     *  },
     *  
     *  trackUserLocation: true

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -410,16 +410,15 @@ class GeolocateControl extends Evented {
     *
     * @returns {boolean} Returns `false` if called before control was added to a map, otherwise returns `true`.
     * @example
+    * // Initialize the geolocate control.
     * var geolocate = new mapboxgl.GeolocateControl({
     *  positionOptions: {
     *    enableHighAccuracy: true
     *  },
-    *  
     *  trackUserLocation: true
     * });
-
+    * // Add the control to the map.
     * map.addControl(geolocate);
-
     * map.on('load', function() {
     *   geolocate.trigger();
     * }


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `GelocateControl.trigger()` to include an inline code snippet.

![image](https://user-images.githubusercontent.com/1242056/79168166-0dea8700-7d9e-11ea-990c-af4a8fee7a62.png)

cc @danswick @katydecorah @asheemmamoowala 