### PR TITLE
[docsprint] Add code snippet and related examples for Marker class setLngLat

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -276,10 +276,18 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Set the marker's geographical position and move it.
-     * @param {LngLat} lnglat A {@link LngLat} describing where the marker should be located.
-     * @returns {Marker} `this`
-     */
+    * Set the marker's geographical position and move it.
+    * @param {LngLat} lnglat A {@link LngLat} describing where the marker should be located.
+    * @returns {Marker} `this`
+    * @example
+    * // Create a new marker, set the longitude and latitude, and add it to the map
+    * new mapboxgl.Marker()
+    *   .setLngLat([-65.017, -16.457])
+    *   .addTo(map);
+    * @see [Add custom icons with Markers](https://docs.mapbox.com/mapbox-gl-js/example/custom-marker-icons/)
+    * @see [Create a draggable Marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
+    * @see [Add a marker using a place name](https://docs.mapbox.com/mapbox-gl-js/example/marker-from-geocode/)
+    */
     setLngLat(lnglat: LngLatLike) {
         this._lngLat = LngLat.convert(lnglat);
         this._pos = null;


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the docsprint branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR
Updates the JSDoc for `marker.setLngLat` to include an inline code snippet and links to related examples.

![image](https://user-images.githubusercontent.com/19801577/79170395-1d6cce80-7da4-11ea-9b52-20f789e41b28.png)

cc @danswick @katydecorah @asheemmamoowala