### PR TITLE
[docsprint] Add examples to get- and setLayoutProperty

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1867,6 +1867,7 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * map.setLayoutProperty('my-layer', 'visibility', 'none');
+     * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
      */
     setLayoutProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
         this.style.setLayoutProperty(layerId, name, value, options);
@@ -1891,6 +1892,9 @@ class Map extends Camera {
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      * @returns {Map} `this`
+     * @example
+     * map.getLayoutProperty('my-layer', 'visibility');
+     * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
      */
     setLight(light: LightSpecification, options: StyleSetterOptions = {}) {
         this._lazyInitEmptyStyle();


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `getLayoutProperty` to include inline code and related example. Also adds the same related example to `setLayoutProperty`.

![image](https://user-images.githubusercontent.com/12281722/79170374-0fb74900-7da4-11ea-9c6e-a64d07409dd4.png)

cc @danswick @katydecorah @asheemmamoowala 