### PR TITLE
[docsprint] Add inline snippet and related examples to map.triggerRepaint

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2344,6 +2344,10 @@ class Map extends Camera {
      * Trigger the rendering of a single frame. Use this method with custom layers to
      * repaint the map when the layer changes. Calling this multiple times before the
      * next frame is rendered will still result in only a single frame being rendered.
+     * @example
+     * map.triggerRepaint();
+     * @see [Add a 3D model](https://docs.mapbox.com/mapbox-gl-js/example/add-3d-model/)
+     * @see [Add an animated icon to the map](https://docs.mapbox.com/mapbox-gl-js/example/add-image-animated/)
      */
     triggerRepaint() {
         if (this.style && !this._frame) {


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `map.triggerRepaint` to include an inline code snippet and links to related examples.

![image](https://user-images.githubusercontent.com/12281722/79172417-81de5c80-7da9-11ea-9e50-001d0e5f29c0.png)

cc @danswick @katydecorah @asheemmamoowala 