### PR TITLE
[docsprint] CameraOptions - update pitch and bearing definitions, add code examples

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -33,11 +33,26 @@ import type {PaddingOptions} from '../geo/edge_insets';
  * @typedef {Object} CameraOptions
  * @property {LngLatLike} center The desired center.
  * @property {number} zoom The desired zoom level.
- * @property {number} bearing The desired bearing, in degrees. The bearing is the compass direction that
- * is "up"; for example, a bearing of 90° orients the map so that east is up.
- * @property {number} pitch The desired pitch, in degrees.
+ * @property {number} bearing The desired bearing in degrees. The bearing is the compass direction that
+ * is "up". For example, `bearing: 90` orients the map so that east is up.
+ * @property {number} pitch The desired pitch in degrees. The pitch is the angle towards the horizon
+ * measured in degrees with a range between 0 and 60 degrees. For example, `pitch: 0` results in a two-dimensional map,
+ * as if your line of sight forms a perpendicular angle with the earth's surface.
  * @property {LngLatLike} around If `zoom` is specified, `around` determines the point around which the zoom is centered.
  * @property {PaddingOptions} padding Dimensions in pixels applied on each side of the viewport for shifting the vanishing point.
+ * @example
+ * // set the map's initial perspective with CameraOptions
+ * var map = new mapboxgl.Map({
+ *   container: 'map',
+ *   style: 'mapbox://styles/mapbox/streets-v11',
+ *   center: [-73.5804, 45.53483],
+ *   pitch: 60,
+ *   bearing: -60,
+ *   zoom: 10
+ * });
+ * @see [Set pitch and bearing](https://docs.mapbox.com/mapbox-gl-js/example/set-perspective/)
+ * @see [Jump to a series of locations](https://docs.mapbox.com/mapbox-gl-js/example/jump-to/)
+ * @see [Fly to a location](https://docs.mapbox.com/mapbox-gl-js/example/flyto/)
  */
 export type CameraOptions = {
     center?: LngLatLike,


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `#cameraoptions` to include an inline code snippet, links to related examples, and updates the definition for `pitch` (borrowed from https://docs.mapbox.com/help/glossary/camera/) and updates the definition of `bearing` to match.

![image](https://user-images.githubusercontent.com/2180540/79172688-67b17800-7dc3-11ea-9642-4adb011a60cf.png)

Fixes https://github.com/mapbox/mapbox-gl-js-docs/issues/141

cc @danswick @katydecorah @asheemmamoowala
