### PR TITLE
[docsprint] Add inline code snippet to map.showTileBoundaries

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2377,6 +2377,8 @@ class Map extends Camera {
      * @type {boolean}
      * @instance
      * @memberof Map
+     * @example
+     * map.showTileBoundaries = true;
      */
     get showTileBoundaries(): boolean { return !!this._showTileBoundaries; }
     set showTileBoundaries(value: boolean) {


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `map.showTileBoundaries` to include an inline code snippet.

![image](https://user-images.githubusercontent.com/12281722/79173521-adaf1180-7dac-11ea-9032-059b3e4f81f1.png)

cc @danswick @katydecorah @asheemmamoowala 