### PR TITLE
[docsprint] Mark Debug namespace as private to hide it from the docs

### DIFF
--- a/src/util/debug.js
+++ b/src/util/debug.js
@@ -5,6 +5,8 @@ import window from './window';
 /**
  * This is a private namespace for utility functions that will get automatically stripped
  * out in production builds.
+ *
+ * @private
  */
 export const Debug = {
     extend(dest: Object, ...sources: Array<?Object>): Object {


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Hides the `Debug` namespace from the docs. These methods are private, and not available int he production builds.