### PR TITLE
[docsprint] Cleanup doc for MapBoxZoomEvent

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -219,7 +219,7 @@ export class MapWheelEvent extends Event {
 
 /**
  * A `MapBoxZoomEvent` is the event type for the boxzoom-related map events emitted by the {@link BoxZoomHandler}.
- * 
+ *
  * @typedef {Object} MapBoxZoomEvent
  * @property {MouseEvent?} originalEvent The DOM event that triggered the box zoom event. Can be a `MouseEvent` or `KeyboardEvent`
  * @property {string} type The type of box zoom event. One of `boxzoomstart`, `boxzoomend` or `boxzoomcancel`

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -218,17 +218,18 @@ export class MapWheelEvent extends Event {
 }
 
 /**
- * A `MapBoxZoomEvent` is the event type for boxzoom-related map events.
- * `originalEvent` can be a {@link Map.event:click} when the zoom is triggered by a UI event.
- *
+ * A `MapBoxZoomEvent` is the event type for the boxzoom-related map events emitted by the {@link BoxZoomHandler}.
+ * 
  * @typedef {Object} MapBoxZoomEvent
- * @property {MouseEvent} originalEvent
+ * @property {MouseEvent?} originalEvent The DOM event that triggered the box zoom event. Can be a `MouseEvent` or `KeyboardEvent`
+ * @property {string} type The type of box zoom event. One of `boxzoomstart`, `boxzoomend` or `boxzoomcancel`
+ * @property {Map} target The `map` instance that triggerred the event
  */
 export type MapBoxZoomEvent = {
     type: 'boxzoomstart'
         | 'boxzoomend'
         | 'boxzoomcancel',
-    map: Map,
+    target: Map,
     originalEvent: MouseEvent
 };
 


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the docsprint branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Cleaned up the documentation of the `MapBoxZoomEvent` type.

![image](https://user-images.githubusercontent.com/11619675/79289428-0dc1b880-7e7e-11ea-8c9f-700f30e82a80.png)

