### PR TITLE
[docsprint] Add examples to open and close popup events

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -139,6 +139,16 @@ export default class Popup extends Evented {
          * @instance
          * @type {Object}
          * @property {Popup} popup object that was opened
+         *
+         * @example
+         * // Create a popup
+         * var popup = new mapboxgl.Popup();
+         * // Set an event listener that will fire
+         * // any time the popup is opened
+         * popup.on('open', function(){
+         *   console.log('popup was opened');
+         * });
+         *
          */
         this.fire(new Event('open'));
 
@@ -189,6 +199,16 @@ export default class Popup extends Evented {
          * @instance
          * @type {Object}
          * @property {Popup} popup object that was closed
+         *
+         * @example
+         * // Create a popup
+         * var popup = new mapboxgl.Popup();
+         * // Set an event listener that will fire
+         * // any time the popup is closed
+         * popup.on('close', function(){
+         *   console.log('popup was closed');
+         * });
+         *
          */
         this.fire(new Event('close'));
 


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Adds examples for Popup's `open` and `close` events.

![image](https://user-images.githubusercontent.com/10479155/79292453-01d9f480-7e86-11ea-88f8-58842f114790.png)

![image](https://user-images.githubusercontent.com/10479155/79292538-3948a100-7e86-11ea-9e09-6f5c615b87e6.png)

cc @danswick @katydecorah @asheemmamoowala
