### PR TITLE
[docsprint] Clarify how map.moveLayer works

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1704,7 +1704,7 @@ class Map extends Camera {
      * Moves a layer to a different z-position.
      *
      * @param {string} id The ID of the layer to move.
-     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. When viewing the map, the layer you are moving will appear beneath the layer with ID `beforeId`. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
+     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. When viewing the map, the `ID` layer will appear beneath the `beforeId` layer. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
      * @returns {Map} `this`
      *
      * @example

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1704,7 +1704,7 @@ class Map extends Camera {
      * Moves a layer to a different z-position.
      *
      * @param {string} id The ID of the layer to move.
-     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. When viewing the map, the `ID` layer will appear beneath the `beforeId` layer. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
+     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. When viewing the map, the `id` layer will appear beneath the `beforeId` layer. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
      * @returns {Map} `this`
      *
      * @example

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1704,7 +1704,7 @@ class Map extends Camera {
      * Moves a layer to a different z-position.
      *
      * @param {string} id The ID of the layer to move.
-     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. The layer you are moving will visually sit beneath the layer with ID `beforeId`. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
+     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. When viewing the map, the layer you are moving will appear beneath the layer with ID `beforeId`. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
      * @returns {Map} `this`
      *
      * @example

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1704,13 +1704,12 @@ class Map extends Camera {
      * Moves a layer to a different z-position.
      *
      * @param {string} id The ID of the layer to move.
-     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before.
-     *   If this argument is omitted, the layer will be appended to the end of the layers array.
+     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. The layer you are moving will visually sit beneath the layer with ID `beforeId`. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
      * @returns {Map} `this`
      *
      * @example
-     * // Move a layer with ID 'label' before the layer with ID 'waterways'.
-     * map.moveLayer('label', 'waterways');
+     * // Move a layer with ID 'polygon' before the layer with ID 'country-label'. The `polygon` layer will appear beneath the `country-label` layer on the map.
+     * map.moveLayer('polygon', 'country-label');
      */
     moveLayer(id: string, beforeId?: string) {
         this.style.moveLayer(id, beforeId);


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the docsprint branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Cleaned up this section and added a description of what `beforeID` param means in terms of how the layer being moved will appear on the map. 

![image](https://user-images.githubusercontent.com/19801577/79299856-f395d380-7e99-11ea-92e3-ce92476190b9.png)


cc @danswick @katydecorah @asheemmamoowala