### PR TITLE
[doscprint] add links to EPSG and minor example changes for LngLat

### DIFF
--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -12,8 +12,10 @@ export const earthRadius = 6371008.8;
 
 /**
  * A `LngLat` object represents a given longitude and latitude coordinate, measured in degrees.
- *
- * Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude) to match GeoJSON.
+ * These coordinates are based on the [WGS84 (EPSG:4326) standard](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84).
+ * 
+ * Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude) to match the 
+ * [GeoJSON specification](https://tools.ietf.org/html/rfc7946).
  *
  * Note that any Mapbox GL method that accepts a `LngLat` object as an argument or option
  * can also accept an `Array` of two numbers and will perform an implicit conversion.
@@ -22,7 +24,8 @@ export const earthRadius = 6371008.8;
  * @param {number} lng Longitude, measured in degrees.
  * @param {number} lat Latitude, measured in degrees.
  * @example
- * var ll = new mapboxgl.LngLat(-73.9749, 40.7736);
+ * var ll = new mapboxgl.LngLat(-123.9749, 40.7736);
+ * ll.lng; // = -123.9749
  * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
  * @see [Display a popup](https://www.mapbox.com/mapbox-gl-js/example/popup/)
  * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -13,8 +13,8 @@ export const earthRadius = 6371008.8;
 /**
  * A `LngLat` object represents a given longitude and latitude coordinate, measured in degrees.
  * These coordinates are based on the [WGS84 (EPSG:4326) standard](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84).
- * 
- * Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude) to match the 
+ *
+ * Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude) to match the
  * [GeoJSON specification](https://tools.ietf.org/html/rfc7946).
  *
  * Note that any Mapbox GL method that accepts a `LngLat` object as an argument or option


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `LngLat` object to include a minor inline code snippet and reference source of [CRS](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84) and [GeoJSON spec](https://tools.ietf.org/html/rfc7946).

![image](https://user-images.githubusercontent.com/134753/79370135-02669f80-7f07-11ea-8d5b-5cc0e11a1a6d.png)

cc @danswick @katydecorah @asheemmamoowala 

