### PR TITLE
[docsprint] Add inline snippet and examples to popup.addTo

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -104,6 +104,11 @@ export default class Popup extends Evented {
      *
      * @param {Map} map The Mapbox GL JS map to add the popup to.
      * @returns {Popup} `this`
+     * @example
+     * new mapboxgl.Popup()
+     *   .setLngLat([0, 0])
+     *   .setHTML("<h1>Null Island</h1>")
+     *   .addTo(map);
      */
     addTo(map: Map) {
         if (this._map) this.remove();

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -109,6 +109,10 @@ export default class Popup extends Evented {
      *   .setLngLat([0, 0])
      *   .setHTML("<h1>Null Island</h1>")
      *   .addTo(map);
+     * @see [Display a popup](https://docs.mapbox.com/mapbox-gl-js/example/popup/)
+     * @see [Display a popup on hover](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
+     * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
+     * @see [Attach a popup to a marker instance](https://docs.mapbox.com/mapbox-gl-js/example/set-popup/)
      */
     addTo(map: Map) {
         if (this._map) this.remove();

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -112,7 +112,7 @@ export default class Popup extends Evented {
      * @see [Display a popup](https://docs.mapbox.com/mapbox-gl-js/example/popup/)
      * @see [Display a popup on hover](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
      * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
-     * @see [Attach a popup to a marker instance](https://docs.mapbox.com/mapbox-gl-js/example/set-popup/)
+     * @see [Show polygon information on click](https://docs.mapbox.com/mapbox-gl-js/example/polygon-popup-on-click/)
      */
     addTo(map: Map) {
         if (this._map) this.remove();


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `popup.addTo` to include an inline code snippet and relevant examples. These examples are redundant across several popup members, but per discussions we will error on the side of redundancy for now. 

![image](https://user-images.githubusercontent.com/12281722/79396496-ee379800-7f30-11ea-917b-1307d1d5344b.png)

cc @danswick @katydecorah @asheemmamoowala 