### PR TITLE
[docsprint] Add documentation for RequestParameters

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -35,11 +35,33 @@ if (typeof Object.freeze == 'function') {
 }
 
 /**
- * A `RequestParameters` object to be returned from Map.options.transformRequest callbacks.
+ * A `RequestParameters` object to be returned from Map.options.transformRequest callbacks. 
  * @typedef {Object} RequestParameters
  * @property {string} url The URL to be requested.
  * @property {Object} headers The headers to be sent with the request.
+ * @property {string} method Request method `'GET' | 'POST' | 'PUT'`.
+ * @property {string} body Request body. 
+ * @property {string} type Response body type to be returned `'string' | 'json' | 'arrayBuffer'`.
  * @property {string} credentials `'same-origin'|'include'` Use 'include' to send cookies with cross-origin requests.
+ * @property {Boolean} collectResourceTiming If true, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
+ * @example
+ * // transformRequest used to modify requests that begin with `http://myHost`
+ * transformRequest: (url, resourceType)=> {
+ *  if(resourceType === 'Source' && url.startsWith('http://myHost')) {
+ *    return {
+ *      url: url.replace('http', 'https'),
+ *      headers: { 'my-custom-header': true},
+ *      credentials: 'include'  // Include cookies for cross-origin requests
+ *    }
+ *   }
+ *  }
+ * // Example of `RequestParameters` object returned from the above transformRequest function. 
+ * {
+ *  url: 'https://myHost//assets/sample.geojson'
+ *  headers: {'my-custom-header': true}
+ *  credentials: 'include'
+ * }
+ *
  */
 export type RequestParameters = {
     url: string,

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -35,12 +35,12 @@ if (typeof Object.freeze == 'function') {
 }
 
 /**
- * A `RequestParameters` object to be returned from Map.options.transformRequest callbacks. 
+ * A `RequestParameters` object to be returned from Map.options.transformRequest callbacks.
  * @typedef {Object} RequestParameters
  * @property {string} url The URL to be requested.
  * @property {Object} headers The headers to be sent with the request.
  * @property {string} method Request method `'GET' | 'POST' | 'PUT'`.
- * @property {string} body Request body. 
+ * @property {string} body Request body.
  * @property {string} type Response body type to be returned `'string' | 'json' | 'arrayBuffer'`.
  * @property {string} credentials `'same-origin'|'include'` Use 'include' to send cookies with cross-origin requests.
  * @property {Boolean} collectResourceTiming If true, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
@@ -55,7 +55,7 @@ if (typeof Object.freeze == 'function') {
  *    }
  *   }
  *  }
- * // Example of `RequestParameters` object returned from the above transformRequest function. 
+ * // Example of `RequestParameters` object returned from the above transformRequest function.
  * {
  *  url: 'https://myHost//assets/sample.geojson'
  *  headers: {'my-custom-header': true}

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -43,7 +43,7 @@ if (typeof Object.freeze == 'function') {
  * @property {string} body Request body.
  * @property {string} type Response body type to be returned `'string' | 'json' | 'arrayBuffer'`.
  * @property {string} credentials `'same-origin'|'include'` Use 'include' to send cookies with cross-origin requests.
- * @property {Boolean} collectResourceTiming If true, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
+ * @property {boolean} collectResourceTiming If true, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
  * @example
  * // transformRequest used to modify requests that begin with `http://myHost`
  * transformRequest: (url, resourceType)=> {


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR
Documents all properties available for RequestParameters. Pulls from existing transformRequest example to show how the relationship between transformRequest and RequestParameters. 

![image](https://user-images.githubusercontent.com/19801577/79406172-3499f080-7f4b-11ea-93f0-7199b1f9a28f.png)

@asheemmamoowala @katydecorah @danswick 