### PR TITLE
Fix possible undefined exception on paint variable of

### DIFF
--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -30,7 +30,10 @@ class FillExtrusionStyleLayer extends StyleLayer {
     }
 
     queryRadius(): number {
-        return translateDistance(this.paint.get('fill-extrusion-translate'));
+        if (this.paint) {
+            return translateDistance(this.paint.get('fill-extrusion-translate'));
+        }
+        return 0;
     }
 
     is3D(): boolean {
@@ -46,6 +49,9 @@ class FillExtrusionStyleLayer extends StyleLayer {
                            pixelsToTileUnits: number,
                            pixelPosMatrix: Float32Array): boolean | number {
 
+        if (!this.paint) {
+            return false;
+        }
         const translatedPolygon = translate(queryGeometry,
             this.paint.get('fill-extrusion-translate'),
             this.paint.get('fill-extrusion-translate-anchor'),

--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -16,7 +16,7 @@ import type {PaintProps} from './fill_extrusion_style_layer_properties';
 import type Transform from '../../geo/transform';
 import type {LayerSpecification} from '../../style-spec/types';
 
-class FillExtrusionStyleLayer extends StyleLayer {
+export class FillExtrusionStyleLayer extends StyleLayer {
     _transitionablePaint: Transitionable<PaintProps>;
     _transitioningPaint: Transitioning<PaintProps>;
     paint: PossiblyEvaluated<PaintProps>;
@@ -49,6 +49,7 @@ class FillExtrusionStyleLayer extends StyleLayer {
                            pixelsToTileUnits: number,
                            pixelPosMatrix: Float32Array): boolean | number {
 
+        console.log(`paint is ${this.paint}`);
         if (!this.paint) {
             return false;
         }

--- a/src/style/style_layer/fill_extrusion_style_layer.js
+++ b/src/style/style_layer/fill_extrusion_style_layer.js
@@ -49,7 +49,6 @@ export class FillExtrusionStyleLayer extends StyleLayer {
                            pixelsToTileUnits: number,
                            pixelPosMatrix: Float32Array): boolean | number {
 
-        console.log(`paint is ${this.paint}`);
         if (!this.paint) {
             return false;
         }

--- a/test/unit/style/style_layer/fill_extrusion_style_layer.js
+++ b/test/unit/style/style_layer/fill_extrusion_style_layer.js
@@ -1,6 +1,32 @@
 import {test} from '../../../util/test';
 import {getIntersectionDistance} from '../../../../src/style/style_layer/fill_extrusion_style_layer';
+import createStyleLayer from '../../../../src/style/create_style_layer';
 import Point from '@mapbox/point-geometry';
+// 'fill-extrusion'
+
+test('no paint property set', (t) => {
+    t.test('queryIntersectsFeature bails out with no paint property set', (t) => {
+        const layer = createStyleLayer({
+            "id": "fill-extrusion",
+            "type": "fill-extrusion"
+        });
+
+        // function bails out with no paint property set
+        t.equal(layer.queryIntersectsFeature(), false);
+        t.end();
+    });
+
+    t.test('queryRadius bails out with no paint property set', (t) => {
+        const layer = createStyleLayer({
+            "id": "fill-extrusion",
+            "type": "fill-extrusion"
+        });
+
+        // function bails out with no paint property set
+        t.equal(layer.queryRadius(), 0);
+        t.end();
+    });
+});
 
 test('getIntersectionDistance', (t) => {
     const queryPoint = [new Point(100, 100)];

--- a/test/unit/style/style_layer/fill_extrusion_style_layer.test.js
+++ b/test/unit/style/style_layer/fill_extrusion_style_layer.test.js
@@ -12,7 +12,7 @@ test('no paint property set', (t) => {
         });
 
         // function bails out with no paint property set
-        t.equal(layer.queryIntersectsFeature(), false);
+        t.equal(layer.queryIntersectsFeature(null, null, null, [], 0, null, 0, null), false);
         t.end();
     });
 
@@ -26,6 +26,7 @@ test('no paint property set', (t) => {
         t.equal(layer.queryRadius(), 0);
         t.end();
     });
+    t.end();
 });
 
 test('getIntersectionDistance', (t) => {

--- a/test/unit/style/style_layer/fill_extrusion_style_layer.test.js
+++ b/test/unit/style/style_layer/fill_extrusion_style_layer.test.js
@@ -11,6 +11,7 @@ test('no paint property set', (t) => {
             "type": "fill-extrusion"
         });
 
+        t.notOk(layer.paint);
         // function bails out with no paint property set
         t.equal(layer.queryIntersectsFeature(null, null, null, [], 0, null, 0, null), false);
         t.end();
@@ -21,7 +22,7 @@ test('no paint property set', (t) => {
             "id": "fill-extrusion",
             "type": "fill-extrusion"
         });
-
+        t.notOk(layer.paint);
         // function bails out with no paint property set
         t.equal(layer.queryRadius(), 0);
         t.end();


### PR DESCRIPTION
I've added an extra check for fill_extrusion_style_layer paint member being truthy. there seems to be a race condition that can leave it undefined.
I've added a couple of tests for the functions in the style layer to check that they bail out gracefully when paint is not set.
