### PR TITLE
[docsprint] Add inline example for trackPointer

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -235,8 +235,13 @@ export default class Popup extends Evented {
     }
 
     /**
-     * Tracks the popup anchor to the cursor position, on screens with a pointer device (will be hidden on touchscreens). Replaces the setLngLat behavior.
-     * For most use cases, `closeOnClick` and `closeButton` should also be set to `false` here.
+     * Tracks the popup anchor to the cursor position on screens with a pointer device (it will be hidden on touchscreens). Replaces the `setLngLat` behavior.
+     * For most use cases, set `closeOnClick` and `closeButton` to `false`.
+     * @example
+     * var popup = new mapboxgl.Popup({ closeOnClick: false, closeButton: false })
+     *   .setHTML("<h1>Hello World!</h1>")
+     *   .trackPointer()
+     *   .addTo(map);
      * @returns {Popup} `this`
      */
     trackPointer() {


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR
Adds inline code example for trackPointer and makes slight copyedits to description.

![image](https://user-images.githubusercontent.com/2180540/79487107-b76f8980-7fe5-11ea-8b45-aec1187e2e2f.png)


@asheemmamoowala @katydecorah @danswick 