### PR TITLE
[docsprint] Add inline example for Popup#getElement

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -259,6 +259,14 @@ export default class Popup extends Evented {
 
     /**
      * Returns the `Popup`'s HTML element.
+     * @example
+     * // Change the `Popup` element's font size
+     * var popup = new mapboxgl.Popup()
+     *   .setLngLat([-96, 37.8])
+     *   .setHTML("<p>Hello World!</p>")
+     *   .addTo(map);
+     * var popupElem = popup.getElement();
+     * popupElem.style.fontSize = "25px";
      * @returns {HTMLElement} element
      */
     getElement() {


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR
Adds inline code example for getElement. 

(Please let me know if you think of a better example. I looked at the original request for this feature https://github.com/mapbox/mapbox-gl-js/issues/7425 and saw that the user wanted to dynamically change CSS classes, however, Popup already has class-related utilities.)

![image](https://user-images.githubusercontent.com/2180540/79489491-5e095980-7fe9-11ea-97f7-212c4082cc33.png)



@asheemmamoowala @katydecorah @danswick 