### PR TITLE
[docsprint] Add inline examples for Point & PointLike types

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2582,10 +2582,15 @@ function removeNode(node) {
  * `x` and `y` properties representing screen coordinates in pixels.
  *
  * @typedef {Object} Point
+ * @example
+ * var point = Point(-77, 38);
  */
 
 /**
  * A {@link Point} or an array of two numbers representing `x` and `y` screen coordinates in pixels.
  *
  * @typedef {(Point | Array<number>)} PointLike
+ * @example
+ * var p1 = Point(-77, 38); // a PointLike which is a Point
+ * var p2 = [-77, 38]; // a PointLike which is an array of two numbers
  */

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2583,7 +2583,7 @@ function removeNode(node) {
  *
  * @typedef {Object} Point
  * @example
- * var point = Point(-77, 38);
+ * var point = new mapboxgl.Point(-77, 38);
  */
 
 /**
@@ -2591,6 +2591,6 @@ function removeNode(node) {
  *
  * @typedef {(Point | Array<number>)} PointLike
  * @example
- * var p1 = Point(-77, 38); // a PointLike which is a Point
+ * var p1 = new mapboxgl.Point(-77, 38); // a PointLike which is a Point
  * var p2 = [-77, 38]; // a PointLike which is an array of two numbers
  */


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR
Adds inline code example for the `Point` and `PointLike` types. 

cc @danswick @katydecorah @asheemmamoowala