### PR TITLE
[docsprint] Describe map style object returned by Map#getStyle

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1326,9 +1326,9 @@ class Map extends Camera {
     }
 
     /**
-     * Returns the map's Mapbox style object, which can be used to recreate the map's style.
+     * Returns the map's Mapbox [style](https://docs.mapbox.com/help/glossary/style/) object, a JSON object which can be used to recreate the map's style.
      *
-     * @returns {Object} The map's style object.
+     * @returns {Object} The map's style JSON object.
      *
      * @example
      * var styleJson = map.getStyle();


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR
Clarifies that the map's style object referenced by the `Object` return value is a JSON object, as outlined in the [style glossary entry](https://docs.mapbox.com/help/glossary/style/). This glossary entry also links out to the Style Specification, for developers interested in more detail about the structure of said JSON object.

cc @danswick @katydecorah @asheemmamoowala