### PR TITLE
[docsprint] Add inline example for getClusterLeaves

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -230,6 +230,22 @@ class GeoJSONSource extends Evented implements Source {
      * @param offset The number of features to skip (e.g. for pagination).
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
      * @returns {GeoJSONSource} this
+     * @example 
+     * // Retrieve cluster leaves on click 
+     *  map.on('click', 'clusters', function(e) {
+     *    var features = map.queryRenderedFeatures(e.point, {
+     *      layers: ['clusters']
+     *    });
+     
+     *    var clusterId = features[0].properties.cluster_id;
+	 *    var pointCount = features[0].properties.point_count;
+	 *	  var clusterSource = map.getSource('clusters');
+
+     *  clusterSource.getClusterLeaves(clusterId, pointCount, 0, (error, features) => {
+     *    // Print cluster leaves in the console
+     *    console.log('Cluster leaves:', error, features);
+  	 *	})
+     * });
      */
     getClusterLeaves(clusterId: number, limit: number, offset: number, callback: Callback<Array<GeoJSONFeature>>) {
         this.actor.send('geojson.getClusterLeaves', {

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -239,7 +239,7 @@ class GeoJSONSource extends Evented implements Source {
      
      *    var clusterId = features[0].properties.cluster_id;
 	 *    var pointCount = features[0].properties.point_count;
-	 *	  var clusterSource = map.getSource('clusters');
+	 *    var clusterSource = map.getSource('clusters');
 
      *  clusterSource.getClusterLeaves(clusterId, pointCount, 0, (error, features) => {
      *    // Print cluster leaves in the console

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -230,17 +230,17 @@ class GeoJSONSource extends Evented implements Source {
      * @param offset The number of features to skip (e.g. for pagination).
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
      * @returns {GeoJSONSource} this
-     * @example 
-     * // Retrieve cluster leaves on click 
+     * @example
+     * // Retrieve cluster leaves on click
      *  map.on('click', 'clusters', function(e) {
      *    var features = map.queryRenderedFeatures(e.point, {
      *      layers: ['clusters']
      *    });
-     
+     *
      *    var clusterId = features[0].properties.cluster_id;
 	 *    var pointCount = features[0].properties.point_count;
 	 *    var clusterSource = map.getSource('clusters');
-
+     *
      *  clusterSource.getClusterLeaves(clusterId, pointCount, 0, (error, features) => {
      *    // Print cluster leaves in the console
      *    console.log('Cluster leaves:', error, features);


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR
Adds inline code example for trackPointer and makes slight copyedits to description.

![image](https://user-images.githubusercontent.com/19801577/79514271-a4b37f80-7ffa-11ea-8a95-0f9324a5a4f1.png)

@asheemmamoowala @danswick @katydecorah I'm wondering if we should also include an example that demonstrates the `limit` and `offset` parameters to be used for pagination. I understand their general purpose, `limit` is for the max number of features that should be returned and `offset` to add the `limit` to with each call of getClusterLeaves() so you are retrieving new features. If we want to add another inline example, I could use some direction in terms of the most straightforward way to demonstrate this. 
