### PR TITLE
[docsprint] Add inline snippet to marker#setPopup, marker#getPopup, and marker#togglePopup

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -378,16 +378,22 @@ export default class Marker extends Evented {
      *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
      *  .addTo(map);
      *
-     * var popupContent = marker.getPopup(); // return the popup instance
-     * console.log(popupContent._content);
+     * console.log(marker.getPopup()); // return the popup instance
      */
     getPopup() {
         return this._popup;
     }
 
     /**
-     * Opens or closes the bound popup, depending on the current state
+     * Opens or closes the Popup instance that is bound to the Marker, depending on the current state of the Popup.
      * @returns {Marker} `this`
+     * @example
+     * var marker = new mapboxgl.Marker()
+     *  .setLngLat([0, 0])
+     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
+     *  .addTo(map);
+     *
+     * marker.togglePopup(); // toggle popup open or closed
      */
     togglePopup() {
         const popup = this._popup;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -297,10 +297,16 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Binds a Popup to the Marker
-     * @param popup an instance of the `Popup` class. If undefined or null, any popup
-     * set on this `Marker` instance is unset
+     * Binds a Popup to the Marker.
+     * @param popup An instance of the `Popup` class. If undefined or null, any popup
+     * set on this `Marker` instance is unset.
      * @returns {Marker} `this`
+     * @example
+     * var marker = new mapboxgl.Marker()
+     *  .setLngLat([0, 0])
+     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>");) // add popup
+     *  .addTo(map);
+     * @see [Attach a popup to a marker instance](https://docs.mapbox.com/mapbox-gl-js/example/set-popup/)
      */
     setPopup(popup: ?Popup) {
         if (this._popup) {

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -297,7 +297,7 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Binds a Popup to the Marker.
+     * Binds a `Popup` to the `Marker`.
      * @param popup An instance of the `Popup` class. If undefined or null, any popup
      * set on this `Marker` instance is unset.
      * @returns {Marker} `this`
@@ -370,7 +370,7 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Returns the Popup instance that is bound to the Marker.
+     * Returns the `Popup` instance that is bound to the `Marker`.
      * @returns {Popup} popup
      * @example
      * var marker = new mapboxgl.Marker()
@@ -385,7 +385,7 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Opens or closes the Popup instance that is bound to the Marker, depending on the current state of the Popup.
+     * Opens or closes the `Popup` instance that is bound to the `Marker`, depending on the current state of the `Popup`.
      * @returns {Marker} `this`
      * @example
      * var marker = new mapboxgl.Marker()

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -304,7 +304,7 @@ export default class Marker extends Evented {
      * @example
      * var marker = new mapboxgl.Marker()
      *  .setLngLat([0, 0])
-     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>");) // add popup
+     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>")) // add popup
      *  .addTo(map);
      * @see [Attach a popup to a marker instance](https://docs.mapbox.com/mapbox-gl-js/example/set-popup/)
      */
@@ -370,8 +370,16 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Returns the Popup instance that is bound to the Marker
+     * Returns the Popup instance that is bound to the Marker.
      * @returns {Popup} popup
+     * @example
+     * var marker = new mapboxgl.Marker()
+     *  .setLngLat([0, 0])
+     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
+     *  .addTo(map);
+     *
+     * var popupContent = marker.getPopup(); // return the popup instance
+     * console.log(popupContent._content);
      */
     getPopup() {
         return this._popup;


### PR DESCRIPTION
## Briefly describe the changes in this PR

Adds inline code snippets for [marker#setPopup](https://docs.mapbox.com/mapbox-gl-js/api/#marker#setpopup), [getPopup](https://docs.mapbox.com/mapbox-gl-js/api/#marker#getpopup), and [togglePopup](https://docs.mapbox.com/mapbox-gl-js/api/#marker#togglepopup), and makes small edits to their descriptions.

<img width="877" alt="Screen Shot 2020-04-16 at 5 06 03 PM" src="https://user-images.githubusercontent.com/8186438/79518776-c286e180-8006-11ea-9785-1476a4928377.png">
<img width="891" alt="Screen Shot 2020-04-16 at 5 06 30 PM" src="https://user-images.githubusercontent.com/8186438/79518781-c87cc280-8006-11ea-828e-0981f1e5aa3c.png">
<img width="881" alt="Screen Shot 2020-04-16 at 5 06 46 PM" src="https://user-images.githubusercontent.com/8186438/79518791-cc104980-8006-11ea-830f-0b077f638bbb.png">

cc @asheemmamoowala @danswick @katydecorah