### PR TITLE
[docsprint] Add more details to getSource

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1460,14 +1460,22 @@ class Map extends Camera {
     /**
      * Returns the source with the specified ID in the map's style.
      *
+     * This method is often used to update a source using the instance members for the relevant
+     * source type as defined in [Sources](#sources).
+     * For example, setting the `data` for a GeoJSON source or updating the `url` and `coordinates`
+     * of an image source.
+     *
      * @param {string} id The ID of the source to get.
-     * @returns {?Object} The style source with the specified ID, or `undefined`
-     *   if the ID corresponds to no existing sources.
+     * @returns {?Object} The style source with the specified ID or `undefined` if the ID
+     * corresponds to no existing sources.
+     * The shape of the object varies by source type.
+     * A list of options for each source type is available on the Mapbox Style Specification's
+     * [Sources](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) page.
      * @example
      * var sourceObject = map.getSource('points');
-     * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
-     * @see [Animate a point](https://www.mapbox.com/mapbox-gl-js/example/animate-point-along-line/)
-     * @see [Add live realtime data](https://www.mapbox.com/mapbox-gl-js/example/live-geojson/)
+     * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     * @see [Animate a point](https://docs.mapbox.com/mapbox-gl-js/example/animate-point-along-line/)
+     * @see [Add live realtime data](https://docs.mapbox.com/mapbox-gl-js/example/live-geojson/)
      */
     getSource(id: string) {
         return this.style.getSource(id);


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Adds more detail to `map.getSource()` including:

- A brief description of what kind of tasks `getSource` is typically used for including examples.
- A link to the [Mapbox Style Specification's Sources](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) page for more information on what is included in the object that's returned.

@asheemmamoowala does this align with how your team expects users to interact with this method?

<img width="892" alt="Screen Shot 2020-04-17 at 12 20 27 PM" src="https://user-images.githubusercontent.com/10479155/79606955-40022e80-80a7-11ea-8035-d1c1ba99a5d9.png">

cc @danswick @katydecorah @asheemmamoowala