### PR TITLE
[docsprint] Add clearStorage example

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,8 @@ const exported = {
      *
      * @function clearStorage
      * @param {Function} callback Called with an error argument if there is an error.
+     * @example
+     * mapboxgl.clearStorage();
      */
     clearStorage(callback?: (err: ?Error) => void) {
         clearTileCache(callback);


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Adds an example to the `clearStorage` example. @asheemmamoowala I'm not sure if this example should include anything wrt error handling (I couldn't find any examples of this being used in the wild). 

<img width="769" alt="Screen Shot 2020-04-17 at 1 01 33 PM" src="https://user-images.githubusercontent.com/10479155/79609684-03850180-80ac-11ea-8c45-17094570242e.png">

cc @danswick @katydecorah @asheemmamoowala