### PR TITLE
[docsprint] Clarify meaning of Map#isSourceLoaded

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1393,7 +1393,8 @@ class Map extends Camera {
     }
 
     /**
-     * Returns a Boolean indicating whether the source is loaded.
+     * Returns a Boolean indicating whether the source is loaded. True if the source with
+     * the given ID in the map's style has no outstanding network requests.
      *
      * @param {string} id The ID of the source to be checked.
      * @returns {boolean} A Boolean indicating whether the source is loaded.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1393,8 +1393,8 @@ class Map extends Camera {
     }
 
     /**
-     * Returns a Boolean indicating whether the source is loaded. True if the source with
-     * the given ID in the map's style has no outstanding network requests.
+     * Returns a Boolean indicating whether the source is loaded. Returns `true` if the source with
+     * the given ID in the map's style has no outstanding network requests, otherwise `false`.
      *
      * @param {string} id The ID of the source to be checked.
      * @returns {boolean} A Boolean indicating whether the source is loaded.


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

In the docstring for `Map#isSourceLoaded`, clarifies what "source is loaded" means. Uses the same definition as the docstring for the `MapDataEvent` type in `src/ui/events.js`, i.e.:
```
* @property {boolean} [isSourceLoaded] True if the event has a `dataType` of `source` 
* and the source has no outstanding network requests.
```

![Screen Shot 2020-04-17 at 1 32 22 PM](https://user-images.githubusercontent.com/15935667/79611708-0681f100-80b0-11ea-85b2-1aca9e2948c9.png)


cc @danswick @katydecorah @asheemmamoowala