### PR TITLE
[docsprint] Add inline snippet and related example to getLngLat

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -270,7 +270,13 @@ export default class Marker extends Evented {
      * the marker on screen.
      *
      * @returns {LngLat} A {@link LngLat} describing the marker's location.
-     */
+    * @example
+    * // Store the marker's longitude and latitude coordinates in a variable
+    * var lngLat = marker.getLngLat();
+    * // Print the marker's longitude and latitude values in the console
+    * console.log('Longitude: ' + lngLat.lng + ', Latitude: ' + lngLat.lat )
+    * @see [Create a draggable Marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
+    */
     getLngLat() {
         return this._lngLat;
     }


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Updates the JSDoc for `getLngLat` to include an inline code snippet and links to a related example.

![image](https://user-images.githubusercontent.com/19141701/79615987-d68b1b80-80b8-11ea-906d-a0eed0d6cf9a.png)

I was debating between adding the line with the `console.log()` but decided to keep it to add clarity to what `getLngLat` returns.

cc @danswick @katydecorah @asheemmamoowala 

@danswick I accidentally made my `docsprint-getlnglat` branch off `master` rather than off `docsprint`. Per our conversation, you mentioned that you will cherry-pick my commit, since there are others within this PR. 