### PR TITLE
[docsprint] Add inline snippet to marker#addTo

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -216,7 +216,7 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Attaches a `Marker` to a `Map` object.
+     * Attaches the `Marker` to a `Map` object.
      * @param {Map} map The Mapbox GL JS map to add the marker to.
      * @returns {Marker} `this`
      * @example

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -222,7 +222,7 @@ export default class Marker extends Evented {
      * @example
      * var marker = new mapboxgl.Marker()
      *   .setLngLat([30.5, 50.5])
-     *   .addTo(map);
+     *   .addTo(map); // add the marker to the map 
      */
     addTo(map: Map) {
         this.remove();

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -222,7 +222,7 @@ export default class Marker extends Evented {
      * @example
      * var marker = new mapboxgl.Marker()
      *   .setLngLat([30.5, 50.5])
-     *   .addTo(map); // add the marker to the map 
+     *   .addTo(map); // add the marker to the map
      */
     addTo(map: Map) {
         this.remove();

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -216,9 +216,13 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Attaches the marker to a map
+     * Attaches a `Marker` to a `Map` object.
      * @param {Map} map The Mapbox GL JS map to add the marker to.
      * @returns {Marker} `this`
+     * @example
+     * var marker = new mapboxgl.Marker()
+     *   .setLngLat([30.5, 50.5])
+     *   .addTo(map);
      */
     addTo(map: Map) {
         this.remove();


### PR DESCRIPTION
Adds inline code snippet for [marker#addTo](https://docs.mapbox.com/mapbox-gl-js/api/#marker#addto), and makes small edits to its description.

## briefly describe the changes in this PR

<img width="902" alt="Screen Shot 2020-04-17 at 2 41 37 PM" src="https://user-images.githubusercontent.com/8186438/79616617-5796e280-80ba-11ea-8017-9ccf78d2976f.png">

cc @asheemmamoowala @danswick @katydecorah
