### PR TITLE
[docsprint] Add inline example for setZoomRate and setWheelZoomRate of scrollZoomHandler

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -80,6 +80,9 @@ class ScrollZoomHandler {
     /**
      * Set the zoom rate of a trackpad
      * @param {number} [zoomRate=1/100] The rate used to scale trackpad movement to a zoom value.
+     * @example
+     * // Speed up trackpad zoom
+     * map.scrollZoom.setZoomRate(1/25);
      */
     setZoomRate(zoomRate: number) {
         this._defaultZoomRate = zoomRate;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -89,9 +89,12 @@ class ScrollZoomHandler {
     }
 
     /**
-     * Set the zoom rate of a mouse wheel
-     * @param {number} [wheelZoomRate=1/450] The rate used to scale mouse wheel movement to a zoom value.
-     */
+    * Set the zoom rate of a mouse wheel
+    * @param {number} [wheelZoomRate=1/450] The rate used to scale mouse wheel movement to a zoom value.
+    * @example
+    * // Slow down zoom of mouse wheel
+    * map.scrollZoom.setWheelZoomRate(1/600);
+    */
     setWheelZoomRate(wheelZoomRate: number) {
         this._wheelZoomRate = wheelZoomRate;
     }


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Add inline example for how to use `setZoomRate` and `setWheelZoomRate`  of `ScrollZoomHandler`. 

![image](https://user-images.githubusercontent.com/19801577/79619828-dc85fa00-80c2-11ea-8109-9229a526de75.png)
![image](https://user-images.githubusercontent.com/19801577/79622484-49ea5880-80cc-11ea-970c-c4132d33c8b7.png)


@asheemmamoowala @danswick @katydecorah 