### PR TITLE
[docsprint] Add inline examples for map zoom-related methods

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -177,6 +177,8 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @returns The map's current zoom level.
+     * @example
+     * map.getZoom();
      */
     getZoom(): number { return this.transform.zoom; }
 
@@ -194,7 +196,7 @@ class Camera extends Evented {
      * @fires zoomend
      * @returns {Map} `this`
      * @example
-     * // zoom the map to 5
+     * // zoom the map to 5 without an animated transition
      * map.setZoom(5);
      */
     setZoom(zoom: number, eventData?: Object) {
@@ -216,6 +218,14 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @returns {Map} `this`
+     * @example
+     * // zoom the map to 5 with an animated transition
+     * map.zoomTo(5);
+     * // zoom the map to 8 with custom animation options
+     * map.zoomTo(8, {
+     *   duration: 2000,
+     *   offset: [100, 50]
+     * });
      */
     zoomTo(zoom: number, options: ? AnimationOptions, eventData?: Object) {
         return this.easeTo(extend({
@@ -236,6 +246,9 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @returns {Map} `this`
+     * @example
+     * // zoom the map in one level with a custom animation duration
+     * map.zoomIn({duration: 1000});
      */
     zoomIn(options?: AnimationOptions, eventData?: Object) {
         this.zoomTo(this.getZoom() + 1, options, eventData);
@@ -255,6 +268,9 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @returns {Map} `this`
+     * @example
+     * // zoom the map out one level with a custom animation offset
+     * map.zoomOut({offset: [80, 60]});
      */
     zoomOut(options?: AnimationOptions, eventData?: Object) {
         this.zoomTo(this.getZoom() - 1, options, eventData);


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Add/expand on inline examples for `Map#getZoom`, `Map#setZoom`, `Map#zoomTo`, `Map#zoomIn`, and `Map#zoomOut`. 

I added some minimal + random `AnimationOptions` in a few places to demonstrate how to use this optional parameter. However, I'm open to removing them to keep the examples as streamlined as possible. 

I opted out of demonstrating any uses of the optional `eventData` parameter where relevant, since I feel that any meaningful use of this parameter would require quite a bit more code to get the point across. 

cc @danswick @katydecorah @asheemmamoowala