### PR TITLE
[docsprint] Add example to MapMouseEvent

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -22,18 +22,18 @@ import type LngLat from '../geo/lng_lat';
  * });
  */
 export class MapMouseEvent extends Event {
-  /**
-   * The event type (one of [`mousedown`](#map.event:mousedown),
-   * [`mouseup`](#map.event:mouseup),
-   * [`click`](#map.event:click),
-   * [`dblclick`](#map.event:dblclick),
-   * [`mousemove`](#map.event:mousemove),
-   * [`mouseover`](#map.event:mouseover),
-   * [`mouseover`](#map.event:mouseover),
-   * [`mouseover`](#map.event:mouseover),
-   * [`mouseout`](#map.event:mouseout),
-   * [`contextmenu`](#map.event:contextmenu)).
-   */
+    /**
+     * The event type (one of [`mousedown`](#map.event:mousedown),
+     * [`mouseup`](#map.event:mouseup),
+     * [`click`](#map.event:click),
+     * [`dblclick`](#map.event:dblclick),
+     * [`mousemove`](#map.event:mousemove),
+     * [`mouseover`](#map.event:mouseover),
+     * [`mouseover`](#map.event:mouseover),
+     * [`mouseover`](#map.event:mouseover),
+     * [`mouseout`](#map.event:mouseout),
+     * [`contextmenu`](#map.event:contextmenu)).
+     */
     type: 'mousedown'
         | 'mouseup'
         | 'click'

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -29,8 +29,8 @@ export class MapMouseEvent extends Event {
      * [`dblclick`](#map.event:dblclick),
      * [`mousemove`](#map.event:mousemove),
      * [`mouseover`](#map.event:mouseover),
-     * [`mouseover`](#map.event:mouseover),
-     * [`mouseover`](#map.event:mouseover),
+     * [`mouseenter`](#map.event:mouseenter),
+     * [`mouseleave`](#map.event:mouseleave),
      * [`mouseout`](#map.event:mouseout),
      * [`contextmenu`](#map.event:contextmenu)).
      */

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -12,11 +12,28 @@ import type LngLat from '../geo/lng_lat';
 /**
  * `MapMouseEvent` is the event type for mouse-related map events.
  * @extends {Object}
+ * @example
+ * // The `click` event is an example of a `MapMouseEvent`.
+ * // Set up an event listener on the map.
+ * map.on('click', function(e) {
+ *   // The event object (`e`) contains information like the
+ *   // coordinates of the point on the map that was clicked.
+ *   console.log('A click event has occurred at ' + e.lngLat);
+ * });
  */
 export class MapMouseEvent extends Event {
-    /**
-     * The event type.
-     */
+  /**
+   * The event type (one of [`mousedown`](#map.event:mousedown),
+   * [`mouseup`](#map.event:mouseup),
+   * [`click`](#map.event:click),
+   * [`dblclick`](#map.event:dblclick),
+   * [`mousemove`](#map.event:mousemove),
+   * [`mouseover`](#map.event:mouseover),
+   * [`mouseover`](#map.event:mouseover),
+   * [`mouseover`](#map.event:mouseover),
+   * [`mouseout`](#map.event:mouseout),
+   * [`contextmenu`](#map.event:contextmenu)).
+   */
     type: 'mousedown'
         | 'mouseup'
         | 'click'


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Adds an example to `MapMouseEvent` and adds a list of `type`s. 

<img width="899" alt="Screen Shot 2020-04-17 at 5 42 10 PM" src="https://user-images.githubusercontent.com/10479155/79623879-5b832e80-80d3-11ea-8c67-6b5c74e63bc2.png">

cc @danswick @katydecorah @asheemmamoowala