### PR TITLE
[docsprint] Add example to MapDataEvent

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -252,7 +252,7 @@ export type MapBoxZoomEvent = {
  * @property {Coordinate} [coord] The coordinate of the tile if the event has a `dataType` of `source` and
  * the event is related to loading of a tile.
  * @example
- * // The `click` event is an example of `MapDataEvent`.
+ * // The `sourcedata` event is an example of `MapDataEvent`.
  * // Set up an event listener on the map.
  * map.on('sourcedata', function(e) {
  *    if (e.isSourceLoaded) {

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -251,6 +251,15 @@ export type MapBoxZoomEvent = {
  * the event is related to loading of a tile.
  * @property {Coordinate} [coord] The coordinate of the tile if the event has a `dataType` of `source` and
  * the event is related to loading of a tile.
+ * @example
+ * // The `click` event is an example of `MapDataEvent`.
+ * // Set up an event listener on the map.
+ * map.on('sourcedata', function(e) {
+ *    if (e.isSourceLoaded) {
+ *        // Do something when there are no more
+ *        // outstanding network requests
+ *    }
+ * });
  */
 export type MapDataEvent = {
     type: string,


### PR DESCRIPTION
ℹ️ This PR is part of a larger effort to improve generated API documentation. It targets the `docsprint` branch, which will serve as the major feature branch for this work.

## Briefly describe the changes in this PR

Adds an example to `MapDataEvent`.

![image](https://user-images.githubusercontent.com/10479155/79624716-7ad08a80-80d8-11ea-8897-3038e47d7f49.png)

cc @danswick @katydecorah @asheemmamoowala