### PR TITLE
Change return type to boolean for StyleImageInterface type alias

### DIFF
--- a/src/style/style_image.js
+++ b/src/style/style_image.js
@@ -25,7 +25,7 @@ export type StyleImageInterface = {
     width: number,
     height: number,
     data: Uint8Array | Uint8ClampedArray,
-    render?: () => void,
+    render?: () => boolean,
     onAdd?: (map: Map, id: string) => void,
     onRemove?: () => void
 };


### PR DESCRIPTION
As noted in https://github.com/mapbox/mapbox-gl-js/issues/9350, the type alias for `StyleImageInterface` currently specifies a return type of `void` for the `render` function. However, the [docstring](https://github.com/mapbox/mapbox-gl-js/blob/ced93c1624e37e618024f621a1744ff24b279c26/src/style/style_image.js#L102-L117) for `render()` and corresponding [interface](https://github.com/mapbox/mapbox-gl-js/blob/ced93c1624e37e618024f621a1744ff24b279c26/src/style/style_image.js#L45-L100) + [example](https://docs.mapbox.com/mapbox-gl-js/example/add-image-animated/) indicate that the return type should be `boolean`.