### PR TITLE
Trigger memory metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
       - deploy:
           name: Run memory metrics when merging to master
           command: |
-              curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/build?circle-token=${CIRCLE_API_USER_TOKEN}
+              curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/build?circle-token=${WEB_METRICS_TOKEN}
       - store_artifacts:
           path: "dist"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           command: |
             if [ -n "${WEB_METRICS_TOKEN}" ]; then
               if [[ $CIRCLE_BRANCH == trigger-memory-metrics ]]; then
-                curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/tree/master?circle-token=${WEB_METRICS_TOKEN}
+                curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/build?circle-token=${WEB_METRICS_TOKEN}
               fi
             fi
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,9 @@ jobs:
       - deploy:
           name: Run memory metrics when merging to master
           command: |
+          if [[ $CIRCLE_BRANCH == "master" ]]; then
               curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/build?circle-token=${WEB_METRICS_TOKEN}
+          fi
       - store_artifacts:
           path: "dist"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
           name: Trigger memory metrics when merging to master
           command: |
             if [ -n "${WEB_METRICS_TOKEN}" ]; then
-              if [[ $CIRCLE_BRANCH == trigger-memory-metrics ]]; then
+              if [[ $CIRCLE_BRANCH == master ]]; then
                 curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/build?circle-token=${WEB_METRICS_TOKEN}
               fi
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,8 +160,7 @@ jobs:
       - deploy:
           name: Run memory metrics when merging to master
           command: |
-              curl --user ${CIRCLE_API_USER_TOKEN}: \
-                https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/tree/master
+              curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/build?circle-token=${CIRCLE_API_USER_TOKEN}
       - store_artifacts:
           path: "dist"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,11 @@ jobs:
       - run: yarn run build-style-spec
       - run: yarn run build-flow-types
       - run: yarn run test-build
+      - deploy:
+          name: Run memory metrics when merging to master
+          command: |
+              curl --user ${CIRCLE_API_USER_TOKEN}: \
+                https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/tree/master
       - store_artifacts:
           path: "dist"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           command: |
             if [ -n "${WEB_METRICS_TOKEN}" ]; then
               if [[ $CIRCLE_BRANCH == trigger-memory-metrics ]]; then
-                curl https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/tree/master?circle-token=${WEB_METRICS_TOKEN}
+                curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/tree/master?circle-token=${WEB_METRICS_TOKEN}
               fi
             fi
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           command: |
             if [ -n "${WEB_METRICS_TOKEN}" ]; then
               if [[ $CIRCLE_BRANCH == trigger-memory-metrics ]]; then
-                curl -u $WEB_METRICS_TOKEN -d https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/tree/master
+                curl https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/tree/master?circle-token=${WEB_METRICS_TOKEN}
               fi
             fi
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,11 +158,13 @@ jobs:
       - run: yarn run build-flow-types
       - run: yarn run test-build
       - deploy:
-          name: Run memory metrics when merging to master
+          name: Trigger memory metrics when merging to master
           command: |
-          if [[ $CIRCLE_BRANCH == "master" ]]; then
-              curl -X POST https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/build?circle-token=${WEB_METRICS_TOKEN}
-          fi
+            if [ -n "${WEB_METRICS_TOKEN}" ]; then
+              if [[ $CIRCLE_BRANCH == trigger-memory-metrics ]]; then
+                curl -u $WEB_METRICS_TOKEN -d https://circleci.com/api/v1.1/project/github/mapbox/web-metrics/tree/master
+              fi
+            fi
       - store_artifacts:
           path: "dist"
       - store_artifacts:


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
This PR adds a conditional trigger to CircleCI to trigger a metrics build on CircleCI when a commit is made on `master`. This was tested with the conditional set to the current working branch and it successfully triggered a metrics build. Then I changed the conditional to `master` and confirmed that the working branch no longer triggers a metrics build.

This uses the `deploy` step in the `build` job as per the [CircleCI docs](https://circleci.com/docs/2.0/api-job-trigger/#conditionally-running-jobs-with-the-api) to avoid
>triggering N builds, where N is your parallelism value - deploy is a special step that will only run on one container, even when the job parallelism is set greater that one.