### PR TITLE
kiraarghy:rotation-fix-iphone

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -436,9 +436,11 @@ class Map extends Camera {
         if (typeof window !== 'undefined') {
             window.addEventListener('online', this._onWindowOnline, false);
             window.addEventListener('resize', this._onWindowResize, false);
-            if (typeof window.screen.orientation !== 'undefined') {
+            if (typeof window.screen.orientation === 'object') {
+                // ensures browser supports latest ScreenOrientation API
                 window.screen.orientation.addEventListener('change', this._onWindowResize, false);
             } else {
+                // If not then use deprecated 'orientationchange' event
                 window.addEventListener('orientationchange', this._onWindowResize, false);
             }
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -436,6 +436,11 @@ class Map extends Camera {
         if (typeof window !== 'undefined') {
             window.addEventListener('online', this._onWindowOnline, false);
             window.addEventListener('resize', this._onWindowResize, false);
+            if (typeof window.screen.orientation !== 'undefined') {
+                window.screen.orientation.addEventListener('change', this._onWindowResize, false);
+            } else {
+                window.addEventListener('orientationchange', this._onWindowResize, false);
+            }
         }
 
         this.handlers = new HandlerManager(this, options);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -436,13 +436,7 @@ class Map extends Camera {
         if (typeof window !== 'undefined') {
             window.addEventListener('online', this._onWindowOnline, false);
             window.addEventListener('resize', this._onWindowResize, false);
-            if (typeof window.screen.orientation === 'object') {
-                // ensures browser supports latest ScreenOrientation API
-                window.screen.orientation.addEventListener('change', this._onWindowResize, false);
-            } else {
-                // If not then use deprecated 'orientationchange' event
-                window.addEventListener('orientationchange', this._onWindowResize, false);
-            }
+            window.addEventListener('orientationchange', this._onWindowResize, false);
         }
 
         this.handlers = new HandlerManager(this, options);
@@ -2565,11 +2559,7 @@ class Map extends Camera {
         this.setStyle(null);
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);
-            if (typeof window.screen.orientation === 'object') {
-                window.screen.orientation.removeEventListener('change', this._onWindowResize, false);
-            } else {
-                window.removeEventListener('orientationchange', this._onWindowResize, false);
-            }
+            window.removeEventListener('orientationchange', this._onWindowResize, false);
             window.removeEventListener('online', this._onWindowOnline, false);
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2565,6 +2565,11 @@ class Map extends Camera {
         this.setStyle(null);
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);
+            if (typeof window.screen.orientation === 'object') {
+                window.screen.orientation.removeEventListener('change', this._onWindowResize, false);
+            } else {
+                window.removeEventListener('orientationchange', this._onWindowResize, false);
+            }
             window.removeEventListener('online', this._onWindowOnline, false);
         }
 


### PR DESCRIPTION
In response to issue #9639.

Bug:

1. I go to my map on iPhone safari/ chrome.
2. I move my iPhone to landscape.
3. I move my iPhone to portrait.
4. The map does not resize to fit the portrait layout.

Added to map.js a screen orientation change event listener, this will trigger the `_windowResize method` so that when used on devices, orientation changes will trigger a resize. 

Unfortunately, the `orientationchange` event listener seems to be [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Window/orientationchange_event#Browser_compatibility) so to ensure future compatibility I have carried out this fix with the [Screen.Orientation API](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/onchange) with a fallback to the deprecated `orientationchange` event for browsers which don't support the Screen.Orientation API.

I've user tested this locally on a simulated and using a friend's iPhone and this seems to work but additional user testing would be very welcome.

I'm having some trouble getting my head around how testing for this project works, could someone assist me in that?

Thanks!

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix for iPhone orientation change not triggering map resize by adding event listener for orientation change.</changelog>`
