### PR TITLE
[docs] Add distance expression entry; update other expressions

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -695,10 +695,16 @@
       "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.",
       "sdk-support": {
         "basic functionality": {
-          "js": "1.2.0"
+          "js": "1.2.0",
+          "android": "9.2.0",
+          "ios": "5.9.0",
+          "macos": "0.16.0"
         },
         "data-driven styling": {
-          "js": "1.2.0"
+          "js": "1.2.0",
+          "android": "9.2.0",
+          "ios": "5.9.0",
+          "macos": "0.16.0"
         }
       },
       "expression": {
@@ -1065,17 +1071,17 @@
       "type": "enum",
       "values": {
         "auto": {
-          "doc": "If `symbol-sort-key` is set, sort based on that. Otherwise sort symbols by their y-position relative to the viewport."
+          "doc": "Sorts symbols by `symbol-sort-key` if set. Otherwise, sorts symbols by their y-position relative to the viewport if `icon-allow-overlap` or `text-allow-overlap` is set to `true` or `icon-ignore-placement` or `text-ignore-placement` is `false`. If none of these options are set, no sorting is applied; symbols are rendered in the same order as the source data."
         },
         "viewport-y": {
-          "doc": "Symbols will be sorted by their y-position relative to the viewport."
+          "doc": "Sorts symbols by their y-position relative to the viewport if `icon-allow-overlap` or `text-allow-overlap` is set to `true` or `icon-ignore-placement` or `text-ignore-placement` is `false`."
         },
         "source": {
-          "doc": "Symbols will be rendered in the same order as the source data with no sorting applied."
+          "doc": "Sorts symbols by `symbol-sort-key` if set. Otherwise, no sorting is applied; symbols are rendered in the same order as the source data."
         }
       },
       "default": "auto",
-      "doc": "Controls the order in which overlapping symbols in the same layer are rendered",
+      "doc": "Controls the order in which symbols in the same layer are rendered.",
       "sdk-support": {
         "basic functionality": {
           "js": "0.49.0",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1081,7 +1081,7 @@
         }
       },
       "default": "auto",
-      "doc": "Controls the order in which symbols in the same layer are rendered.",
+      "doc": "Determines whether overlapping symbols in the same layer are rendered in the order that they appear in the data source or by their y-position relative to the viewport. To control the order and prioritization of symbols otherwise, use `symbol-sort-key`.",
       "sdk-support": {
         "basic functionality": {
           "js": "0.49.0",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2621,7 +2621,7 @@
         }
       },
       "index-of": {
-        "doc": "Returns the first index at which an item can be found in an array or a substring can be found in a string, or `-1` if the input is not found. If set, the second argument is used as the start index.",
+        "doc": "Returns the first position at which an item can be found in an array or a substring can be found in a string, or `-1` if the input cannot be found. Accepts an optional index from where to begin the search.",
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -2630,7 +2630,7 @@
         }
       },
       "slice": {
-        "doc": "Returns an item from an array or a substring from a string defined by the first argument as the start index. If set, the second argument is used as the end index. The return value is inclusive of the start index but not of the end index.",
+        "doc": "Returns an item from an array or a substring from a string from a specified start index, or between a start index and an end index if set. The return value is inclusive of the start index but not of the end index.",
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2630,7 +2630,7 @@
         }
       },
       "slice": {
-        "doc": "Returns an item from an array or a substring from a string defined by the first argument as the start index and a second argument, if set, as the end index. The expression is inclusive of the start index, but not of the end index.",
+        "doc": "Returns an item from an array or a substring from a string defined by the first argument as the start index. If set, the second argument is used as the end index. The return value is inclusive of the start index but not of the end index.",
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -2825,7 +2825,7 @@
         }
       },
       "format": {
-        "doc": "Returns a `formatted` string for use in the `text-field` property. The input may contain a plain `string`, an `image` provided through the [`'image'`](#types-image) expression, or a combination  of the two. Supported styling options:\n- `"text-font"`: Overrides the font stack specified by the root layout property.\n- `"text-color"`: Overrides the color specified by the root paint property.\n- `"font-scale"`: Applies the specified a scaling factor relative to the `text-size` specified by the root layout property.",
+        "doc": "Returns a `formatted` string for use in the `text-field` property. The input may contain a plain `string`, an `image` provided through the [`'image'`](#types-image) expression, or a combination  of the two. Supported styling options:\n- `\"text-font\"`: Overrides the font stack specified by the root layout property.\n- `\"text-color\"`: Overrides the color specified by the root paint property.\n- `\"font-scale\"`: Applies the specified a scaling factor relative to the `text-size` specified by the root layout property.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3356,7 +3356,7 @@
         }
       },
       "distance": {
-        "doc": "Returns the shortest distance in meters between the evaluated feature and the input geometry. The evaluated feature and input value can be a valid GeoJSON of type `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Results at zoom level 12 and below may vary in precision, due to precision loss in conversions between tile coordinates and `[Longitude, Latitude]` at lower zoom levels.",
+        "doc": "Returns the shortest distance in meters between the evaluated feature and the input geometry. The evaluated feature and input value can be a valid GeoJSON of type `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Results at zoom level 12 and below may vary in precision due to precision loss in conversions between tile coordinates and `[Longitude, Latitude]` at lower zoom levels.",
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3511,7 +3511,7 @@
         }
       },
       "within": {
-        "doc": "Returns `true` if the evaluated feature is fully contained inside a boundary of the input geometry, `false` otherwise. The input value can be a valid GeoJSON of type `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Supported features for evaluation:\n- `"Point"`: Returns `false` if a point is on the boundary or falls outside the boundary.\n- `"LineString"`: Returns `false` if any part of a line falls outside the boundary, the line intersects the boundary, or a line's endpoint is on the boundary.",
+        "doc": "Returns `true` if the evaluated feature is fully contained inside a boundary of the input geometry, `false` otherwise. The input value can be a valid GeoJSON of type `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Supported features for evaluation:\n- `Point`: Returns `false` if a point is on the boundary or falls outside the boundary.\n- `LineString`: Returns `false` if any part of a line falls outside the boundary, the line intersects the boundary, or a line's endpoint is on the boundary.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2825,7 +2825,7 @@
         }
       },
       "format": {
-        "doc": "Returns a `formatted` string for use in the `text-field` property. The input may contain a plain `string`, an `image` provided through the [`'image'`](#types-image) expression, or a combination  of the two. Supported styling options:\n- `\"text-font\"`: Overrides the font stack specified by the root layout property.\n- `\"text-color\"`: Overrides the color specified by the root paint property.\n- `\"font-scale\"`: Applies the specified a scaling factor relative to the `text-size` specified by the root layout property.",
+        "doc": "Returns a `formatted` string for displaying mixed-format text in the `text-field` property. The input may contain a string literal or expression, including an [`'image'`](#types-image) expression. Strings may be followed by a style override object that supports the following properties:\n- `\"text-font\"`: Overrides the font stack specified by the root layout property.\n- `\"text-color\"`: Overrides the color specified by the root paint property.\n- `\"font-scale\"`: Applies a scaling factor on `text-size` as specified by the root layout property.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3356,7 +3356,7 @@
         }
       },
       "distance": {
-        "doc": "Returns the shortest distance in meters between the evaluated feature and the input geometry. The evaluated feature and input value can be a valid GeoJSON of type `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Results at zoom level 12 and below may vary in precision due to precision loss in conversions between tile coordinates and `[Longitude, Latitude]` at lower zoom levels.",
+        "doc": "Returns the shortest distance in meters between the evaluated feature and the input geometry. The input value can be a valid GeoJSON of type `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Distance values returned may vary in precision due to loss in precision from encoding geometries, particularly below zoom level 13.",
         "group": "Math",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2620,8 +2620,17 @@
           }
         }
       },
-      "index-of": { 
-        "doc": "Returns the first index at which a given element can be found in an array, or for a string, the first occurrence of the specified value. If a second argument is provided, then the search is started from that position. Returns -1 if the value is not found.",
+      "index-of": {
+        "doc": "Returns the first index at which an item can be found in an array or a substring can be found in a string, or `-1` if the input is not found. If set, the second argument is used as the start index.",
+        "group": "Lookup",
+        "sdk-support": {
+          "basic functionality": {
+            "js": "1.10.0"
+          }
+        }
+      },
+      "slice": {
+        "doc": "Returns an item from an array or a substring from a string defined by the first argument as the start index and a second argument, if set, as the end index. The expression is inclusive of the start index, but not of the end index.",
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -2642,7 +2651,7 @@
         }
       },
       "match": {
-        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n * a single literal value; or\n * an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the `\"in\"` operator.\n\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.",
+        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n - a single literal value; or\n - an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the `\"in\"` operator.\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2678,7 +2687,7 @@
         }
       },
       "interpolate": {
-        "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order. The output type must be `number`, `array<number>`, or `color`.\n\nInterpolation types:\n- `[\"linear\"]`: interpolates linearly between the pair of stops just less than and just greater than the input.\n- `[\"exponential\", base]`: interpolates exponentially between the stops just less than and just greater than the input. `base` controls the rate at which the output increases: higher values make the output increase more towards the high end of the range. With values close to 1 the output increases linearly.\n- `[\"cubic-bezier\", x1, y1, x2, y2]`: interpolates using the cubic bezier curve defined by the given control points.",
+        "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order. The output type must be `number`, `array<number>`, or `color`.\n\nInterpolation types:\n- `[\"linear\"]`: Interpolates linearly between the pair of stops just less than and just greater than the input.\n- `[\"exponential\", base]`: Interpolates exponentially between the stops just less than and just greater than the input. `base` controls the rate at which the output increases: higher values make the output increase more towards the high end of the range. With values close to 1 the output increases linearly.\n- `[\"cubic-bezier\", x1, y1, x2, y2]`: Interpolates using the cubic bezier curve defined by the given control points.",
         "group": "Ramps, scales, curves",
         "sdk-support": {
           "basic functionality": {
@@ -2816,7 +2825,7 @@
         }
       },
       "format": {
-        "doc": "Returns `formatted` text containing annotations for use in mixed-format `text-field` entries. For a `text-field` entries of a string type, following option object's properties are supported: If set, the `text-font` value overrides the font specified by the root layout properties. If set, the `font-scale` value specifies a scaling factor relative to the `text-size` specified in the root layout properties. If set, the `text-color` value overrides the color specified by the root paint properties for this layer.",
+        "doc": "Returns a `formatted` string for use in the `text-field` property. The input may contain a plain `string`, an `image` provided through the [`'image'`](#types-image) expression, or a combination  of the two. Supported styling options:\n- `"text-font"`: Overrides the font stack specified by the root layout property.\n- `"text-color"`: Overrides the color specified by the root paint property.\n- `"font-scale"`: Applies the specified a scaling factor relative to the `text-size` specified by the root layout property.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -2845,6 +2854,7 @@
           },
           "image": {
             "js": "1.6.0",
+            "android": "8.6.0",
             "ios": "5.7.0",
             "macos": "0.15.0"
           }
@@ -3013,7 +3023,7 @@
         }
       },
       "geometry-type": {
-        "doc": "Gets the feature's geometry type: Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon.",
+        "doc": "Gets the feature's geometry type: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`.",
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3345,6 +3355,17 @@
           }
         }
       },
+      "distance": {
+        "doc": "Returns the shortest distance in meters between the evaluated feature and the input geometry. The evaluated feature and input value can be a valid GeoJSON of type `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Results at zoom level 12 and below may vary in precision, due to precision loss in conversions between tile coordinates and `[Longitude, Latitude]` at lower zoom levels.",
+        "group": "Math",
+        "sdk-support": {
+          "basic functionality": {
+            "android": "9.2.0",
+            "ios": "5.9.0",
+            "macos": "0.16.0"
+          }
+        }
+      },
       "==": {
         "doc": "Returns `true` if the input values are equal, `false` otherwise. The comparison is strictly typed: values of different runtime types are always considered unequal. Cases where the types are known to be different at parse time are considered invalid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "group": "Decision",
@@ -3490,7 +3511,7 @@
         }
       },
       "within": {
-        "doc": "Returns `true` if the feature being evaluated is inside the pre-defined geometry boundary, `false` otherwise. The expression has one argument which must be a valid GeoJSON Polygon/Multi-Polygon object. The expression only evaluates on `Point` or `LineString` feature. For `Point` feature, The expression will return false if any point of the feature is on the boundary or outside the boundary. For `LineString` feature, the expression will return false if the line is fully outside the boundary, or the line is partially intersecting the boundary, which means either part of the line is outside of the boundary, or end point of the line lies on the boundary.",
+        "doc": "Returns `true` if the evaluated feature is fully contained inside a boundary of the input geometry, `false` otherwise. The input value can be a valid GeoJSON of type `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Supported features for evaluation:\n- `"Point"`: Returns `false` if a point is on the boundary or falls outside the boundary.\n- `"LineString"`: Returns `false` if any part of a line falls outside the boundary, the line intersects the boundary, or a line's endpoint is on the boundary.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -3556,15 +3577,6 @@
             "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
-          }
-        }
-      },
-      "slice": { 
-        "doc": "Returns a portion of a string or an array starting from the provided beginning index. If a second argument is provided, then the return portion will run to, but not include, the end index.",
-        "group": "String",
-        "sdk-support": {
-          "basic functionality": {
-            "js": "1.10.0"
           }
         }
       }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1071,7 +1071,7 @@
       "type": "enum",
       "values": {
         "auto": {
-          "doc": "Sorts symbols by `symbol-sort-key` if set. Otherwise, sorts symbols by their y-position relative to the viewport if `icon-allow-overlap` or `text-allow-overlap` is set to `true` or `icon-ignore-placement` or `text-ignore-placement` is `false`. If none of these options are set, no sorting is applied; symbols are rendered in the same order as the source data."
+          "doc": "Sorts symbols by `symbol-sort-key` if set. Otherwise, sorts symbols by their y-position relative to the viewport if `icon-allow-overlap` or `text-allow-overlap` is set to `true` or `icon-ignore-placement` or `text-ignore-placement` is `false`."
         },
         "viewport-y": {
           "doc": "Sorts symbols by their y-position relative to the viewport if `icon-allow-overlap` or `text-allow-overlap` is set to `true` or `icon-ignore-placement` or `text-ignore-placement` is `false`."

--- a/test/unit/style-spec/expression.test.js
+++ b/test/unit/style-spec/expression.test.js
@@ -11,7 +11,11 @@ const definitionList = Object.keys(definitions).filter((expression) => {
 
 test('v8.json includes all definitions from style-spec', (t) => {
     const v8List = Object.keys(v8.expression_name.values);
-    t.deepEquals(definitionList, v8List.sort());
+    const v8SupportedList = v8List.filter((expression) => {
+        //filter out expressions that are not supported in GL-JS
+        return !!v8.expression_name.values[expression]["sdk-support"]["basic functionality"]["js"];
+    });
+    t.deepEquals(definitionList, v8SupportedList.sort());
     t.end();
 });
 


### PR DESCRIPTION
![Screen Shot 2020-05-08 at 12 34 26 AM](https://user-images.githubusercontent.com/34117059/81383038-38411300-90c4-11ea-8281-e22c61fc8aa2.png)
![Screen Shot 2020-05-08 at 12 34 46 AM](https://user-images.githubusercontent.com/34117059/81383042-3a0ad680-90c4-11ea-9b53-c2249e246a89.png)
![Screen Shot 2020-05-08 at 12 47 47 AM](https://user-images.githubusercontent.com/34117059/81383847-9ae6de80-90c5-11ea-9f3c-efc857c4968f.png)
![Screen Shot 2020-05-08 at 12 47 35 AM](https://user-images.githubusercontent.com/34117059/81383840-991d1b00-90c5-11ea-9430-8cdfe24dcb90.png)
![Screen Shot 2020-05-08 at 12 35 25 AM](https://user-images.githubusercontent.com/34117059/81383054-3ecf8a80-90c4-11ea-96a4-f52e64af151f.png)
<img width="770" alt="Screen Shot 2020-05-08 at 3 23 16 PM" src="https://user-images.githubusercontent.com/34117059/81454014-f0f86800-913f-11ea-8bbd-36f99b3620d0.png">
<img width="774" alt="Screen Shot 2020-05-08 at 3 23 20 PM" src="https://user-images.githubusercontent.com/34117059/81454018-f3f35880-913f-11ea-9d88-b9b8c129ca89.png">

### Changelog:
- `distance`: 
   - added entry and SDK support table
- `within`: 
   - re-organized entry to increase clarity and conciseness
- `format`: 
   - mentioned the `image` expression explicitly in the documentation entry
   - re-formatted with bullet points
   - added version support information for Android SDK
- `index-of`: 
   - reworded entry to match language of `in` expression
   - removed misleading usage of "second argument," which doesn't match how current docs for [`get`](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#get) and [`has`](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#has) use "second argument." Considering `["index-of", needle, haystack, fromIndex]`, it's the third argument that can be optionally provided to configure the start index of the search.
- `slice`: 
   - reworded entry to match language of `in` expression
   - moved group from `String` to `Lookup` because `slice` is closer to the `in` and `index-of` expressions in function than other expressions in the `String` group. No other expressions in the `String` group work on arrays.
   - removed misleading usage of "second argument." Considering `["slice", input, startIndex, endIndex]`, it's the third argument that can be optionally provided to configure the end index.
- `match`: 
   - minor nitpick to match other entries which use `-` instead of `*` for formatting bullet points
- `interpolate`: no changes made

cc @lbutler @zmiao @alexshalamov @1ec5 
