### PR TITLE
set an interim paint in style_layer

### DIFF
--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -405,7 +405,7 @@ class Tile {
 
             bucket.update(sourceLayerStates, sourceLayer, this.imageAtlas && this.imageAtlas.patternPositions || {});
             const layer = painter && painter.style && painter.style.getLayer(id);
-            if (layer && layer.paint) {
+            if (layer) {
                 this.queryPadding = Math.max(this.queryPadding, layer.queryRadius(bucket));
             }
         }

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -10,7 +10,7 @@ import {
     emitValidationErrors
 } from './validate_style';
 import {Evented} from '../util/evented';
-import {Layout, Transitionable, Transitioning, Properties, PossiblyEvaluatedPropertyValue} from './properties';
+import {Layout, Transitionable, Transitioning, Properties, PossiblyEvaluated, PossiblyEvaluatedPropertyValue} from './properties';
 import {supportsPropertyExpression} from '../style-spec/util/properties';
 
 import type {FeatureState} from '../style-spec/expression';
@@ -90,6 +90,7 @@ class StyleLayer extends Evented {
         }
 
         if (properties.paint) {
+
             this._transitionablePaint = new Transitionable(properties.paint);
 
             for (const property in layer.paint) {
@@ -100,6 +101,13 @@ class StyleLayer extends Evented {
             }
 
             this._transitioningPaint = this._transitionablePaint.untransitioned();
+        }
+
+        if (properties.paint) {
+            // init default paint to cover until recalculate is called
+            // see https://github.com/mapbox/ibm-cognos-collab/issues/154
+            // also flow needs a separate undefined check??
+            this.paint = new PossiblyEvaluated(properties.paint);
         }
     }
 

--- a/test/unit/style/style_layer.test.js
+++ b/test/unit/style/style_layer.test.js
@@ -403,5 +403,12 @@ test('StyleLayer#serialize', (t) => {
         t.end();
     });
 
+    t.test('layer.paint is never undefined', (t) => {
+        const layer = createStyleLayer({type: 'fill'});
+        // paint is never undefined
+        t.ok(layer.paint);
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
this is in place of pr https://github.com/mapbox/mapbox-gl-js/pull/9574

when a StyleLayer is created its paint member is undefined untill recalculate is called. there are render scenarios where paint is accessed between construction and recalculate being called first time

see https://github.com/mapbox/ibm-cognos-collab/issues/154

Instead of checking whether paint is undefined in a layer when it is used, set an interim possiblyEvaluated value if there are any paint properties.

There is a very simple test for this