### PR TITLE
Mapbox Maps SDK for iOS v5.9.0, macOS v0.16.0

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -695,10 +695,16 @@
       "doc": "Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.",
       "sdk-support": {
         "basic functionality": {
-          "js": "1.2.0"
+          "js": "1.2.0",
+          "android": "9.2.0",
+          "ios": "5.9.0",
+          "macos": "0.16.0"
         },
         "data-driven styling": {
-          "js": "1.2.0"
+          "js": "1.2.0",
+          "android": "9.2.0",
+          "ios": "5.9.0",
+          "macos": "0.16.0"
         }
       },
       "expression": {


### PR DESCRIPTION
Updated the compatibility tables for iOS map SDK v5.9.0 and macOS map SDK v0.16.0.

/ref #9655
/cc @ahk @chloekraw