### PR TITLE
Fix image expression

### DIFF
--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -77,6 +77,12 @@ export default class Worker {
 
     setImages(mapId: string, images: Array<string>, callback: WorkerTileCallback) {
         this.availableImages[mapId] = images;
+        for (const workerSource in this.workerSources[mapId]) {
+            const ws = this.workerSources[mapId][workerSource];
+            for (const source in ws) {
+                ws[source].availableImages = images;
+            }
+        }
         callback();
     }
 

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -71,6 +71,7 @@ export type WorkerDEMTileCallback = (err: ?Error, result: ?DEMData) => void;
  * @param layerIndex
  */
 export interface WorkerSource {
+    availableImages: Array<string>,
     // Disabled due to https://github.com/facebook/flow/issues/5208
     // constructor(actor: Actor, layerIndex: StyleLayerIndex): WorkerSource;
 

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -317,10 +317,10 @@ export class Transitioning<Props: Object> {
         this._values = (Object.create(properties.defaultTransitioningPropertyValues): any);
     }
 
-    possiblyEvaluate(parameters: EvaluationParameters, availableImages?: Array<string>): PossiblyEvaluated<Props> {
+    possiblyEvaluate(parameters: EvaluationParameters, canonical?: CanonicalTileID, availableImages?: Array<string>): PossiblyEvaluated<Props> {
         const result = new PossiblyEvaluated(this._properties); // eslint-disable-line no-use-before-define
         for (const property of Object.keys(this._values)) {
-            result._values[property] = this._values[property].possiblyEvaluate(parameters, availableImages);
+            result._values[property] = this._values[property].possiblyEvaluate(parameters, canonical, availableImages);
         }
         return result;
     }
@@ -385,10 +385,10 @@ export class Layout<Props: Object> {
         return result;
     }
 
-    possiblyEvaluate(parameters: EvaluationParameters, availableImages?: Array<string>): PossiblyEvaluated<Props> {
+    possiblyEvaluate(parameters: EvaluationParameters, canonical?: CanonicalTileID, availableImages?: Array<string>): PossiblyEvaluated<Props> {
         const result = new PossiblyEvaluated(this._properties); // eslint-disable-line no-use-before-define
         for (const property of Object.keys(this._values)) {
-            result._values[property] = this._values[property].possiblyEvaluate(parameters, availableImages);
+            result._values[property] = this._values[property].possiblyEvaluate(parameters, canonical, availableImages);
         }
         return result;
     }

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -199,10 +199,10 @@ class StyleLayer extends Evented {
         }
 
         if (this._unevaluatedLayout) {
-            (this: any).layout = this._unevaluatedLayout.possiblyEvaluate(parameters, availableImages);
+            (this: any).layout = this._unevaluatedLayout.possiblyEvaluate(parameters, null, availableImages);
         }
 
-        (this: any).paint = this._transitioningPaint.possiblyEvaluate(parameters, availableImages);
+        (this: any).paint = this._transitioningPaint.possiblyEvaluate(parameters, null, availableImages);
     }
 
     serialize() {

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -199,10 +199,10 @@ class StyleLayer extends Evented {
         }
 
         if (this._unevaluatedLayout) {
-            (this: any).layout = this._unevaluatedLayout.possiblyEvaluate(parameters, null, availableImages);
+            (this: any).layout = this._unevaluatedLayout.possiblyEvaluate(parameters, undefined, availableImages);
         }
 
-        (this: any).paint = this._transitioningPaint.possiblyEvaluate(parameters, null, availableImages);
+        (this: any).paint = this._transitioningPaint.possiblyEvaluate(parameters, undefined, availableImages);
     }
 
     serialize() {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 
 - [x] briefly describe the changes in this PR

This PR addresses two separate issues with the `image` expression operator.
- The changes in `src/style` address https://github.com/mapbox/mapbox-gl-js/issues/9630. https://github.com/mapbox/mapbox-gl-js/pull/9352 introduced an optional parameter in front of `availableImages` in the arguments list which accidentally broke `Layout` and `Transitioning` expression evaluation. This PR addresses that by adding the optional argument for those expression evaluation pathways.
- Fixing ⬆️led us to discover a separate issue in which `image` expressions on layers embedded directly into a style (rather than added at runtime) were being evaluated before `availableImages` was populated in the source's workers. The @mapbox/map-design-team reported the same issue in https://github.com/mapbox/mapbox-core-style-components/issues/917 although it wasn't clear at first that these two issues revealed the same bug.

 - [x] include before/after visuals or gifs if this PR includes visual changes

Before https://github.com/mapbox/mapbox-core-style-components/issues/917:
<img width="122" alt="Screen Shot 2020-05-07 at 6 32 02 PM" src="https://user-images.githubusercontent.com/4523080/81360865-bdf79b00-9091-11ea-8e2a-cdcd69e39d6b.png">
After:
<img width="125" alt="Screen Shot 2020-05-07 at 6 31 08 PM" src="https://user-images.githubusercontent.com/4523080/81360879-c2bc4f00-9091-11ea-91bb-b34425ab9589.png">

Before https://github.com/mapbox/mapbox-gl-js/issues/9630:
_Note: The "not_existing" text label is a fallback to demonstrate the absence of the icon_
<img width="533" alt="Screen Shot 2020-05-07 at 8 39 28 PM" src="https://user-images.githubusercontent.com/4523080/81367771-f0f65a80-90a2-11ea-801b-44436432b19c.png">
After:
<img width="388" alt="Screen Shot 2020-05-07 at 8 38 48 PM" src="https://user-images.githubusercontent.com/4523080/81367759-eb991000-90a2-11ea-8256-b559cf46f2d0.png">

- [ ] write tests for all new functionality
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

Tests and a Flow fix are WIP