### PR TITLE
[docs] Add Android SDK version support for stretchable icons

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1271,6 +1271,7 @@
         },
         "stretchable icons": {
           "js": "1.6.0",
+          "android": "9.2.0",
           "ios": "5.8.0",
           "macos": "0.15.0"
         }


### PR DESCRIPTION
While cherrypicking docs updates in https://github.com/mapbox/mapbox-gl-js/pull/9671, I realized that I missed updating that v9.2.0 of the Android map SDK supports adding stretchable icons at runtime.