### PR TITLE
map.isMoving() match move events fix #9647

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -853,7 +853,7 @@ class Map extends Camera {
      * var isMoving = map.isMoving();
      */
     isMoving(): boolean {
-        return this._moving || this.handlers.isActive();
+        return this._moving || this.handlers.isMoving();
     }
 
     /**

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -273,6 +273,7 @@ test('DragRotateHandler ensures that map.isMoving() returns true during drag', (
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
+    map._renderTaskQueue.run();
     t.ok(map.isMoving());
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -277,6 +277,7 @@ test('DragRotateHandler ensures that map.isMoving() returns true during drag', (
     t.ok(map.isMoving());
 
     simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
+    map._renderTaskQueue.run();
     t.ok(!map.isMoving());
 
     map.remove();

--- a/test/unit/ui/map/isMoving.test.js
+++ b/test/unit/ui/map/isMoving.test.js
@@ -39,11 +39,17 @@ test('Map#isMoving returns true during a camera zoom animation', (t) => {
 test('Map#isMoving returns true when drag panning', (t) => {
     const map = createMap(t);
 
+    map.on('movestart', () => {
+        t.equal(map.isMoving(), true);
+    });
     map.on('dragstart', () => {
         t.equal(map.isMoving(), true);
     });
 
     map.on('dragend', () => {
+        t.equal(map.isMoving(), false);
+    });
+    map.on('moveend', () => {
         t.equal(map.isMoving(), false);
         map.remove();
         t.end();
@@ -65,11 +71,17 @@ test('Map#isMoving returns true when drag rotating', (t) => {
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
 
+    map.on('movestart', () => {
+        t.equal(map.isMoving(), true);
+    });
     map.on('rotatestart', () => {
         t.equal(map.isMoving(), true);
     });
 
     map.on('rotateend', () => {
+        t.equal(map.isMoving(), false);
+    });
+    map.on('moveend', () => {
         t.equal(map.isMoving(), false);
         map.remove();
         t.end();

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -605,9 +605,9 @@ test(`Map#on click fires subsequent click event if there is no corresponding mou
 test("Map#isMoving() returns false in mousedown/mouseup/click with no movement", (t) => {
     const map = createMap(t, {interactive: true, clickTolerance: 4});
     let mousedown, mouseup, click;
-    map.on('mousedown', () => mousedown = map.isMoving());
-    map.on('mouseup', () => mouseup = map.isMoving());
-    map.on('click', () => click = map.isMoving());
+    map.on('mousedown', () => { mousedown = map.isMoving(); });
+    map.on('mouseup', () => { mouseup = map.isMoving(); });
+    map.on('click', () => { click = map.isMoving(); });
 
     const canvas = map.getCanvas();
     const MouseEvent = window(canvas).MouseEvent;

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -601,3 +601,32 @@ test(`Map#on click fires subsequent click event if there is no corresponding mou
     map.remove();
     t.end();
 });
+
+test("Map#isMoving() returns false in mousedown/mouseup/click with no movement", (t) => {
+    const map = createMap(t, {interactive: true, clickTolerance: 4});
+    let mousedown, mouseup, click;
+    map.on('mousedown', () => mousedown = map.isMoving());
+    map.on('mouseup', () => mouseup = map.isMoving());
+    map.on('click', () => click = map.isMoving());
+
+    const canvas = map.getCanvas();
+    const MouseEvent = window(canvas).MouseEvent;
+
+    canvas.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, clientX: 100, clientY: 100}));
+    t.equal(mousedown, false);
+    map._renderTaskQueue.run();
+    t.equal(mousedown, false);
+
+    canvas.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, clientX: 100, clientY: 100}));
+    t.equal(mouseup, false);
+    map._renderTaskQueue.run();
+    t.equal(mouseup, false);
+
+    canvas.dispatchEvent(new MouseEvent('click', {bubbles: true, clientX: 100, clientY: 100}));
+    t.equal(click, false);
+    map._renderTaskQueue.run();
+    t.equal(click, false);
+
+    map.remove();
+    t.end();
+});


### PR DESCRIPTION
Previously isMoving() would return true if any interaction handler was active. Handlers are sometimes active even if they haven't changed the map yet. This resulted in the isMoving() returning true when the map hasn't moved.

This pr makes isMoving() aligned with movestart/move/moveend events. isMoving() returns true only:
- during a movestart
- after a movestart but before a moveend

Since move events may be fired after several mouse events have been batched, the camera changes a mouseevent will *later* cause won't be reflected in isMoving() when that mouseevent is fired.

For example, if you pan the map (and pause to eliminate inertia) a `mouseup` event will have `isMoving() === true` even though that event will later cause a `moveend` without further camera changes. This behavior existed in 1.9.1 (https://codesandbox.io/s/lucid-hawking-ruywl).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix bug where map.isMoving() returned true while map was not moving.</changelog>`
