### PR TITLE
fix #9676, fire touchmove event while handlers are active

### DIFF
--- a/src/ui/handler/map_event.js
+++ b/src/ui/handler/map_event.js
@@ -68,6 +68,10 @@ export class MapEventHandler {
         return this._firePreventable(new MapTouchEvent(e.type, this._map, e));
     }
 
+    touchmove(e: TouchEvent) {
+        this._map.fire(new MapTouchEvent(e.type, this._map, e));
+    }
+
     touchend(e: TouchEvent) {
         this._map.fire(new MapTouchEvent(e.type, this._map, e));
     }
@@ -112,11 +116,6 @@ export class BlockableMapEventHandler {
     mousemove(e: MouseEvent) {
         // mousemove map events should not be fired when interaction handlers (pan, rotate, etc) are active
         this._map.fire(new MapMouseEvent(e.type, this._map, e));
-    }
-
-    touchmove(e: TouchEvent) {
-        // touchmove map events should not be fired when interaction handlers (pan, rotate, etc) are active
-        this._map.fire(new MapTouchEvent(e.type, this._map, e));
     }
 
     mousedown() {

--- a/test/unit/ui/handler/map_event.test.js
+++ b/test/unit/ui/handler/map_event.test.js
@@ -29,7 +29,6 @@ test('MapEvent handler fires touch events with correct values', (t) => {
     t.deepEqual(touchstart.getCall(0).args[0].point, {x: 0, y: 50});
     t.equal(touchmove.callCount, 0);
     t.equal(touchend.callCount, 0);
-    console.log(touchstart);
 
     simulate.touchmove(map.getCanvas(), {touches: touchesMove, targetTouches: touchesMove});
     t.equal(touchstart.callCount, 1);
@@ -42,6 +41,50 @@ test('MapEvent handler fires touch events with correct values', (t) => {
     t.equal(touchmove.callCount, 1);
     t.equal(touchend.callCount, 1);
     t.deepEqual(touchend.getCall(0).args[0].point, {x: 0, y: 60});
+
+    map.remove();
+    t.end();
+});
+
+test('MapEvent handler fires touchmove even while drag handler is active', (t) => {
+    const map = createMap(t);
+    const target = map.getCanvas();
+    map.dragPan.enable();
+
+    const touchstart = t.spy();
+    const touchmove = t.spy();
+    const touchend = t.spy();
+    const drag = t.spy();
+
+    map.on('touchstart', touchstart);
+    map.on('touchmove', touchmove);
+    map.on('touchend', touchend);
+    map.on('drag', drag);
+
+    const touchesStart = [{target, identifier: 1, clientX: 0, clientY: 50}];
+    const touchesMove = [{target, identifier: 1, clientX: 0, clientY: 60}];
+    const touchesEnd = [{target, identifier: 1, clientX: 0, clientY: 60}];
+
+    simulate.touchstart(map.getCanvas(), {touches: touchesStart, targetTouches: touchesStart});
+    t.equal(touchstart.callCount, 1);
+    t.deepEqual(touchstart.getCall(0).args[0].point, {x: 0, y: 50});
+    t.equal(touchmove.callCount, 0);
+    t.equal(touchend.callCount, 0);
+
+    simulate.touchmove(map.getCanvas(), {touches: touchesMove, targetTouches: touchesMove});
+    t.equal(touchstart.callCount, 1);
+    t.equal(touchmove.callCount, 1);
+    t.deepEqual(touchmove.getCall(0).args[0].point, {x: 0, y: 60});
+    t.equal(touchend.callCount, 0);
+
+    simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touchesEnd});
+    t.equal(touchstart.callCount, 1);
+    t.equal(touchmove.callCount, 1);
+    t.equal(touchend.callCount, 1);
+    t.deepEqual(touchend.getCall(0).args[0].point, {x: 0, y: 60});
+
+    map._renderTaskQueue.run();
+    t.equal(drag.callCount, 1);
 
     map.remove();
     t.end();


### PR DESCRIPTION
In 1.9.1 mousemove [do not fire during drags](https://github.com/mapbox/mapbox-gl-js/blob/84690ba86159e9dd80f22e82594915138fe1dfe6/src/ui/bind_handlers.js#L99-L100). 1.10.0 preserved that behavior but mistakenly extended it to `touchmove`. `touchmove` was [still fired druing drags](https://github.com/mapbox/mapbox-gl-js/blob/84690ba86159e9dd80f22e82594915138fe1dfe6/src/ui/bind_handlers.js#L141-L143) in 1.9.1.

This fixes that regression by firing `touchmove` even while other handlers are active. I also added a regression unit test.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix regression that prevented touchmove events from firing during gestures.</changelog>`
