### PR TITLE
Add tests for undocumented but supported ["literal"] expression forms

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -32,6 +32,12 @@ or
 yarn run test-query-node
 ```
 
+To run only the expression tests:
+
+```
+yarn run test-expressions
+```
+
 ### Running specific tests
 
 To run a subset of tests or an individual test, you can pass a specific subdirectory to the `test-render` script. For example, to run all the tests for a given property, e.g. `circle-radius`:

--- a/test/integration/expression-tests/literal/literal-false/test.json
+++ b/test/integration/expression-tests/literal/literal-false/test.json
@@ -1,0 +1,14 @@
+{
+  "expression": ["literal", false],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [false],
+    "serialized": false
+  }
+}

--- a/test/integration/expression-tests/literal/literal-null/test.json
+++ b/test/integration/expression-tests/literal/literal-null/test.json
@@ -1,0 +1,14 @@
+{
+  "expression": ["literal", null],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "null"
+    },
+    "outputs": [null],
+    "serialized": null
+  }
+}

--- a/test/integration/expression-tests/literal/literal-number/test.json
+++ b/test/integration/expression-tests/literal/literal-number/test.json
@@ -1,0 +1,14 @@
+{
+  "expression": ["literal", 7.5],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "number"
+    },
+    "outputs": [7.5],
+    "serialized": 7.5
+  }
+}

--- a/test/integration/expression-tests/literal/literal-string/test.json
+++ b/test/integration/expression-tests/literal/literal-string/test.json
@@ -1,0 +1,14 @@
+{
+  "expression": ["literal", "hello"],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "string"
+    },
+    "outputs": ["hello"],
+    "serialized": "hello"
+  }
+}

--- a/test/integration/expression-tests/literal/literal-true/test.json
+++ b/test/integration/expression-tests/literal/literal-true/test.json
@@ -1,0 +1,14 @@
+{
+  "expression": ["literal", true],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [true],
+    "serialized": true
+  }
+}


### PR DESCRIPTION
Add tests for `["literal"]` null, boolean, number and string forms that are not documented in the Mapbox GL Style Spec but are accepted by the expression compiler.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
