### PR TITLE
[doc] Document `volatile` source property

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -184,7 +184,7 @@
     "volatile": {
       "type": "boolean",
       "default": false,
-      "doc": "Setting this flag to true indicates that the source tiles shall not be stored in the local cache." 
+      "doc": "A setting to determine whether a source's tiles are cached locally."
     },
     "*": {
       "type": "*",
@@ -259,7 +259,7 @@
     "volatile": {
       "type": "boolean",
       "default": false,
-      "doc": "Setting this flag to true indicates that the source tiles shall not be stored in the local cache." 
+      "doc": "A setting to determine whether a source's tiles are cached locally."
     },
     "*": {
       "type": "*",
@@ -334,7 +334,7 @@
     "volatile": {
       "type": "boolean",
       "default": false,
-      "doc": "Setting this flag to true indicates that the source tiles shall not be stored in the local cache." 
+      "doc": "A setting to determine whether a source's tiles are cached locally."
     },
     "*": {
       "type": "*",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -181,6 +181,11 @@
       "type": "promoteId",
       "doc": "A property to use as a feature id (for feature state). Either a property name, or an object of the form `{<sourceLayer>: <propertyName>}`. If specified as a string for a vector tile source, the same property is used across all its source layers."
     },
+    "volatile": {
+      "type": "boolean",
+      "default": false,
+      "doc": "Setting this flag to true indicates that the source tiles shall not be stored in the local cache." 
+    },
     "*": {
       "type": "*",
       "doc": "Other keys to configure the data source."
@@ -251,6 +256,11 @@
       "type": "string",
       "doc": "Contains an attribution to be displayed when the map is shown to a user."
     },
+    "volatile": {
+      "type": "boolean",
+      "default": false,
+      "doc": "Setting this flag to true indicates that the source tiles shall not be stored in the local cache." 
+    },
     "*": {
       "type": "*",
       "doc": "Other keys to configure the data source."
@@ -320,6 +330,11 @@
       },
       "default": "mapbox",
       "doc": "The encoding used by this source. Mapbox Terrain RGB is used by default"
+    },
+    "volatile": {
+      "type": "boolean",
+      "default": false,
+      "doc": "Setting this flag to true indicates that the source tiles shall not be stored in the local cache." 
     },
     "*": {
       "type": "*",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -184,7 +184,15 @@
     "volatile": {
       "type": "boolean",
       "default": false,
-      "doc": "A setting to determine whether a source's tiles are cached locally."
+      "doc": "A setting to determine whether a source's tiles are cached locally.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "Not yet available",
+          "android": "Not yet available",
+          "ios": "Not yet available",
+          "macos": "Not yet available"
+        }
+      }
     },
     "*": {
       "type": "*",
@@ -259,7 +267,15 @@
     "volatile": {
       "type": "boolean",
       "default": false,
-      "doc": "A setting to determine whether a source's tiles are cached locally."
+      "doc": "A setting to determine whether a source's tiles are cached locally.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "Not yet available",
+          "android": "Not yet available",
+          "ios": "Not yet available",
+          "macos": "Not yet available"
+        }
+      }
     },
     "*": {
       "type": "*",
@@ -334,7 +350,15 @@
     "volatile": {
       "type": "boolean",
       "default": false,
-      "doc": "A setting to determine whether a source's tiles are cached locally."
+      "doc": "A setting to determine whether a source's tiles are cached locally.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "Not yet available",
+          "android": "Not yet available",
+          "ios": "Not yet available",
+          "macos": "Not yet available"
+        }
+      }
     },
     "*": {
       "type": "*",

--- a/src/style-spec/types.js
+++ b/src/style-spec/types.js
@@ -89,7 +89,8 @@ export type VectorSourceSpecification = {
     "minzoom"?: number,
     "maxzoom"?: number,
     "attribution"?: string,
-    "promoteId"?: PromoteIdSpecification
+    "promoteId"?: PromoteIdSpecification,
+    "volatile"?: boolean
 }
 
 export type RasterSourceSpecification = {
@@ -101,7 +102,8 @@ export type RasterSourceSpecification = {
     "maxzoom"?: number,
     "tileSize"?: number,
     "scheme"?: "xyz" | "tms",
-    "attribution"?: string
+    "attribution"?: string,
+    "volatile"?: boolean
 }
 
 export type RasterDEMSourceSpecification = {
@@ -113,7 +115,8 @@ export type RasterDEMSourceSpecification = {
     "maxzoom"?: number,
     "tileSize"?: number,
     "attribution"?: string,
-    "encoding"?: "terrarium" | "mapbox"
+    "encoding"?: "terrarium" | "mapbox",
+    "volatile"?: boolean
 }
 
 export type GeoJSONSourceSpecification = {|


### PR DESCRIPTION
The source `volatile` flag value can be defined in the style as following:

```
"example_source": {
   "volatile": true
}
```

For the sources with the `volatile` flag set, the tiles are not stored in the local storage. The `volatile` flag is applicable for all source types, which allow loading tiles from a remote server i.e. `vector`, `raster`, `raster-dem` source types.