### PR TITLE
add a guard check to Attribute binder expression

### DIFF
--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -26,6 +26,7 @@ import type {StructArray, StructArrayMember} from '../util/struct_array';
 import type VertexBuffer from '../gl/vertex_buffer';
 import type {ImagePosition} from '../render/image_atlas';
 import type {
+    Expression,
     Feature,
     FeatureState,
     GlobalProperties,
@@ -477,9 +478,11 @@ export default class ProgramConfiguration {
                          binder instanceof CrossFadedCompositeBinder) && (binder: any).expression.isStateDependent === true) {
                         //AHM: Remove after https://github.com/mapbox/mapbox-gl-js/issues/6255
                         const value = layer.paint.get(property);
-                        (binder: any).expression = value.value;
-                        (binder: AttributeBinder).updatePaintArray(pos.start, pos.end, feature, featureStates[id], imagePositions);
-                        dirty = true;
+                        if (value.value && value.value.evaluate && typeof (value.value.evaluate) === 'function') {
+                            (binder: any).expression = value.value;
+                            (binder: AttributeBinder).updatePaintArray(pos.start, pos.end, feature, featureStates[id], imagePositions);
+                            dirty = true;
+                        }
                     }
                 }
             }

--- a/src/data/program_configuration.js
+++ b/src/data/program_configuration.js
@@ -26,7 +26,6 @@ import type {StructArray, StructArrayMember} from '../util/struct_array';
 import type VertexBuffer from '../gl/vertex_buffer';
 import type {ImagePosition} from '../render/image_atlas';
 import type {
-    Expression,
     Feature,
     FeatureState,
     GlobalProperties,
@@ -182,7 +181,7 @@ class SourceExpressionBinder implements AttributeBinder {
     }
 
     updateExpression(expression: SourceExpression) {
-        if (expression)
+        if (expression && typeof expression.evaluate === 'function')
             this.expression = expression;
     }
 


### PR DESCRIPTION
intermittent console error: http://api.mapbox.com/mapbox-gl-js/v1.10.1/mapbox-gl.js 28:193407 Uncaught TypeError: this.expression.evaluate is not a function

These are speculative changes intended to be the start of a discussion, as I'm not sure this gets to the heart of the matter
