### PR TITLE
[docs] fix `zoom` example

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -796,6 +796,7 @@ export type MapEvent =
      * @memberof Map
      * @instance
      * @property {MapMouseEvent | MapTouchEvent} data
+     * @example
      * // Initialize the map
      * var map = new mapboxgl.Map({ // map options });
      * // Set an event listener that fires


### PR DESCRIPTION
## Launch Checklist

This PR fixes the documentation output for [`zoom`](https://docs.mapbox.com/mapbox-gl-js/api/#map.event:zoom) by adding a missing `@example` jsdoc param.



 - [x] briefly describe the changes in this PR

