### PR TITLE
Removing Array.from which resulted in breaking IE11

### DIFF
--- a/src/render/program.js
+++ b/src/render/program.js
@@ -106,9 +106,8 @@ class Program<Us: UniformBindings> {
         gl.deleteShader(vertexShader);
         gl.deleteShader(fragmentShader);
 
-        const uniformsArray = Array.from(allUniformsInfo);
-        for (let it = 0; it < uniformsArray.length; it++) {
-            const uniform = uniformsArray[it];
+        for (let it = 0; it < allUniformsInfo.length; it++) {
+            const uniform = allUniformsInfo[it];
             if (uniform && !uniformLocations[uniform]) {
                 const uniformLocation = gl.getUniformLocation(this.program, uniform);
                 if (uniformLocation) {


### PR DESCRIPTION
Fixes [9735](https://github.com/mapbox/mapbox-gl-js/issues/9735)

The breaking change was introduced by [9497](https://github.com/mapbox/mapbox-gl-js/pull/9497). This patch will remove the Array.from from the code.
