### PR TITLE
Add clusterMinPoints option for GeoJSONSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "potpack": "^1.0.1",
     "quickselect": "^2.0.0",
     "rw": "^1.3.3",
-    "supercluster": "^7.0.0",
+    "supercluster": "^7.1.0",
     "tinyqueue": "^2.0.3",
     "vt-pbf": "^3.1.1"
   },

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -138,6 +138,7 @@ class GeoJSONSource extends Evented implements Source {
                 maxZoom: options.clusterMaxZoom !== undefined ?
                     Math.min(options.clusterMaxZoom, this.maxzoom - 1) :
                     (this.maxzoom - 1),
+                minPoints: Math.max(2, options.clusterMinPoints || 2),
                 extent: EXTENT,
                 radius: (options.clusterRadius || 50) * scale,
                 log: false,

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -377,6 +377,10 @@
       "type": "number",
       "doc": "Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less than maxzoom (so that last zoom features are not clustered)."
     },
+    "clusterMinPoints": {
+      "type": "number",
+      "doc": "Minimum number of points necessary to form a cluster if clustering is enabled. Defaults to `2`."
+    },
     "clusterProperties": {
       "type": "*",
       "doc": "An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from clustered points. Has the form `{\"property_name\": [operator, map_expression]}`. `operator` is any expression function that accepts at least 2 operands (e.g. `\"+\"` or `\"max\"`) — it accumulates the property value from clusters/points the cluster contains; `map_expression` produces the value of a single point.\n\nExample: `{\"sum\": [\"+\", [\"get\", \"scalerank\"]]}`.\n\nFor more advanced use cases, in place of `operator`, you can use a custom reduce expression that references a special `[\"accumulated\"]` value, e.g.:\n`{\"sum\": [[\"+\", [\"accumulated\"], [\"get\", \"sum\"]], [\"get\", \"scalerank\"]]}`"

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -176,6 +176,7 @@ test('GeoJSONSource#update', (t) => {
                 t.equal(message, 'geojson.loadData');
                 t.deepEqual(params.superclusterOptions, {
                     maxZoom: 12,
+                    minPoints: 3,
                     extent: 8192,
                     radius: 1600,
                     log: false,
@@ -190,6 +191,7 @@ test('GeoJSONSource#update', (t) => {
             cluster: true,
             clusterMaxZoom: 12,
             clusterRadius: 100,
+            clusterMinPoints: 3,
             generateId: true
         }, mockDispatcher).load();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10299,10 +10299,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-supercluster@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.0.0.tgz#75d474fafb0a055db552ed7bd7bbda583f6ab321"
-  integrity sha512-8VuHI8ynylYQj7Qf6PBMWy1PdgsnBiIxujOgc9Z83QvJ8ualIYWNx2iMKyKeC4DZI5ntD9tz/CIwwZvIelixsA==
+supercluster@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.0.tgz#f0a457426ec0ab95d69c5f03b51e049774b94479"
+  integrity sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==
   dependencies:
     kdbush "^3.0.0"
 


### PR DESCRIPTION
Adds a `clusterMinPoints` option for clustered GeoJSON sources to define how many points are necessary to form a cluster (`2` by default). Closes #6374. Actual implementation in https://github.com/mapbox/supercluster/pull/156

Example with `clusterMinPoints: 2` (default):
<img width="741" alt="Screen Shot 2020-06-02 at 16 29 38" src="https://user-images.githubusercontent.com/25395/83525934-598ff600-a4ee-11ea-9232-cc1ab8812397.png">
Example with `clusterMinPoints: 3`:
<img width="741" alt="Screen Shot 2020-06-02 at 16 29 58" src="https://user-images.githubusercontent.com/25395/83525968-657bb800-a4ee-11ea-9073-6cae7461ae2c.png">

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] ~~write tests for all new functionality~~ (covered in `supercluster`)
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] tagged @mapbox/gl-native — PR needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: 

```
<changelog>Added `clusterMinPoints` option for clustered GeoJSON sources that defines the minimum number of points to form a cluster.</changelog>
```
