### PR TITLE
Avoid errors when requiring the browser bundle in Node

### DIFF
--- a/rollup/bundle_prelude.js
+++ b/rollup/bundle_prelude.js
@@ -14,6 +14,8 @@ if (!shared) {
     var sharedChunk = {};
     shared(sharedChunk);
     mapboxgl = chunk(sharedChunk);
-    mapboxgl.workerUrl = window.URL.createObjectURL(new Blob([workerBundleString], { type: 'text/javascript' }));
+    if (typeof window !== 'undefined') {
+        mapboxgl.workerUrl = window.URL.createObjectURL(new Blob([workerBundleString], { type: 'text/javascript' }));
+    }
 }
 }

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -54,7 +54,7 @@ const exported = {
         return linkEl.href;
     },
 
-    hardwareConcurrency: window.navigator.hardwareConcurrency || 4,
+    hardwareConcurrency: window.navigator && window.navigator.hardwareConcurrency || 4,
 
     get devicePixelRatio() { return window.devicePixelRatio; },
     get prefersReducedMotion(): boolean {

--- a/src/util/browser/window.js
+++ b/src/util/browser/window.js
@@ -2,4 +2,5 @@
 /* eslint-env browser */
 import type {Window} from '../../types/window';
 
-export default (self: Window);
+// shim window for the case of requiring the browser bundle in Node
+export default typeof self !== 'undefined' ? (self: Window) : (({}: any): Window);

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -20,7 +20,7 @@ DOM.createNS = function (namespaceURI: string, tagName: string) {
     return el;
 };
 
-const docStyle = window.document.documentElement.style;
+const docStyle = window.document && window.document.documentElement.style;
 
 function testProp(props) {
     if (!docStyle) return props[0];

--- a/test/build/min.test.js
+++ b/test/build/min.test.js
@@ -36,6 +36,11 @@ test('can be browserified', (t) => {
     });
 });
 
+test('evaluates without errors', (t) => {
+    t.doesNotThrow(() => require(path.join(__dirname, '../../dist/mapbox-gl.js')));
+    t.end();
+});
+
 test('distributed in plain ES5 code', (t) => {
     const linter = new Linter();
     const messages = linter.verify(minBundle, {


### PR DESCRIPTION
Potentially fixes #4593 by adding a shim for the window object when it's not defined and a few guards when accessing it at bundle evaluation.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix reference error when requiring the browser bundle in Node</changelog>`
