### PR TITLE
Fix `fromLatLng` typo in documentation 

### DIFF
--- a/src/geo/mercator_coordinate.js
+++ b/src/geo/mercator_coordinate.js
@@ -112,7 +112,7 @@ class MercatorCoordinate {
      * @returns {LngLat} The `LngLat` object.
      * @example
      * var coord = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
-     * var latLng = coord.toLngLat(); // LngLat(0, 0)
+     * var lngLat = coord.toLngLat(); // LngLat(0, 0)
      */
     toLngLat() {
         return new LngLat(

--- a/src/style/style_layer/custom_style_layer.js
+++ b/src/style/style_layer/custom_style_layer.js
@@ -113,7 +113,7 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => 
  * coordinates to gl coordinates. The mercator coordinate `[0, 0]` represents the
  * top left corner of the mercator world and `[1, 1]` represents the bottom right corner. When
  * the `renderingMode` is `"3d"`, the z coordinate is conformal. A box with identical x, y, and z
- * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate}.fromLatLng
+ * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate}.fromLngLat
  * can be used to project a `LngLat` to a mercator coordinate.
  */
 
@@ -142,7 +142,7 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => 
  * coordinates to gl coordinates. The spherical mercator coordinate `[0, 0]` represents the
  * top left corner of the mercator world and `[1, 1]` represents the bottom right corner. When
  * the `renderingMode` is `"3d"`, the z coordinate is conformal. A box with identical x, y, and z
- * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate}.fromLatLng
+ * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate}.fromLngLat
  * can be used to project a `LngLat` to a mercator coordinate.
  */
 export type CustomLayerInterface = {

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -477,7 +477,7 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {LngLatBoundsLike} bounds Calculate the center for these bounds in the viewport and use
      *      the highest zoom level up to and including `Map#getMaxZoom()` that fits
-     *      in the viewport. LatLngBounds represent a box that is always axis-aligned with bearing 0.
+     *      in the viewport. LngLatBounds represent a box that is always axis-aligned with bearing 0.
      * @param options Options object
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.


### PR DESCRIPTION
## Launch Checklist

fixes https://github.com/mapbox/mapbox-gl-js-docs/issues/339

A reader reported a typo in the docs: `fromLatLng` when it should have been `fromLngLat`. This PR fixes the reported instance as well as a few other cases in which `lat` and `lng` were reversed. 

 - [x] briefly describe the changes in this PR


