### PR TITLE
fix double tap zoom on iOS 13

### DIFF
--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -128,12 +128,14 @@ class HandlerManager {
         const el = this._el;
 
         this._listeners = [
-            // Bind touchstart and touchmove with passive: false because, even though
-            // they only fire a map events and therefore could theoretically be
-            // passive, binding with passive: true causes iOS not to respect
-            // e.preventDefault() in _other_ handlers, even if they are non-passive
-            // (see https://bugs.webkit.org/show_bug.cgi?id=184251)
-            [el, 'touchstart', {passive: false}],
+            // This needs to be `passive: true` so that a double tap fires two
+            // pairs of touchstart/end events in iOS Safari 13. If this is set to
+            // `passive: false` then the second pair of events is only fired if
+            // preventDefault() is called on the first touchstart. Calling preventDefault()
+            // undesirably prevents click events.
+            [el, 'touchstart', {passive: true}],
+            // This needs to be `passive: false` so that scrolls and pinches can be
+            // prevented in browsers that don't support `touch-actions: none`, for example iOS Safari 12.
             [el, 'touchmove', {passive: false}],
             [el, 'touchend', undefined],
             [el, 'touchcancel', undefined],


### PR DESCRIPTION
fix #9756

iOS 13 does not fire the second touchstart/end events in a double tap if the touchstart listener is non-passive. This fix makes it passive.

Calling preventDefault() allows the second event to be fired but suppresses other events like `click`.

`touchmove` needs to remain non-passive so that it can be used to prevent touches from scrolling or scaling the page on some versions of iOS Safari.

---

This fix does NOT work if a parent of the canvas (including the window/document/body) has a non-passive touchstart listener that doesn't call `preventDefault()`. I don't know of a fix for this that doesn't suppress all click dom events as well.

---

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix zooming with a double tap on iOS SafarI 13.</changelog>`

I have done initial testing on iOS safari v12 and v13 but these needs to be tested more thoroughly on other touch devices.
