### PR TITLE
update addLayer beforeId documentation to mention how it appears visually in the style

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1798,8 +1798,10 @@ class Map extends Camera {
      * @param {Object} [layer.metadata] (optional) Arbitrary properties useful to track with the layer, but do not influence rendering.
      * @param {string} [layer.renderingMode] This is only applicable for layers with the type `custom`.
      * See {@link CustomLayerInterface} for more information.
-     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before.
-     * If this argument is not specified, the layer will be appended to the end of the layers array.
+     * @param {string} [beforeId] The ID of an existing layer to insert the new layer before,
+     * resulting in the new layer appearing visually beneath the existing layer.
+     * If this argument is not specified, the layer will be appended to the end of the layers array
+     * and appear visually above all other layers.
      *
      * @returns {Map} `this`
      *


### PR DESCRIPTION
While mentioning the before/after order is important since it relates to
the layers array, it requires users to know how the layers array order
relates to visual layering on the map. By specifying both here we hope
to avoid such confusion.