### PR TITLE
Include in package only necessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,11 +163,7 @@
     "codegen": "build/run-node build/generate-style-code.js && build/run-node build/generate-struct-arrays.js"
   },
   "files": [
-    "build/",
-    "dist/mapbox-gl*",
-    "dist/style-spec/",
-    "flow-typed/*.js",
-    "src/",
-    ".flowconfig"
+    "dist/",
+    "src/"
   ]
 }


### PR DESCRIPTION
mapbox-gl package is very big (https://packagephobia.now.sh/result?p=mapbox-gl).

In this diff I'm trying to reduce it a bit but excluding build files.

- .flowconfig and flow-typed in packages are not used by flow
- build scripts are useless without dev dependencies
- all files in dist are published

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
