### PR TITLE
9662 bug a11y focus popup content

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -419,6 +419,7 @@ class Map extends Camera {
         bindAll([
             '_onWindowOnline',
             '_onWindowResize',
+            '_onMapScroll',
             '_contextLost',
             '_contextRestored'
         ], this);
@@ -2295,6 +2296,8 @@ class Map extends Camera {
         ['top-left', 'top-right', 'bottom-left', 'bottom-right'].forEach((positionName) => {
             positions[positionName] = DOM.create('div', `mapboxgl-ctrl-${positionName}`, controlContainer);
         });
+
+        this._container.addEventListener('scroll', this._onMapScroll, false);
     }
 
     _resizeCanvas(width: number, height: number) {
@@ -2343,6 +2346,15 @@ class Map extends Camera {
         this.resize();
         this._update();
         this.fire(new Event('webglcontextrestored', {originalEvent: event}));
+    }
+
+    _onMapScroll(event: Event) {
+        if (event.target !== this._container) return;
+
+       // Revert any scroll which would move the canvas outside of the view
+        this._container.scrollTop = 0;
+        this._container.scrollLeft = 0;
+        return false;
     }
 
     /**

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2348,10 +2348,10 @@ class Map extends Camera {
         this.fire(new Event('webglcontextrestored', {originalEvent: event}));
     }
 
-    _onMapScroll(event: Event) {
+    _onMapScroll(event: *) {
         if (event.target !== this._container) return;
 
-       // Revert any scroll which would move the canvas outside of the view
+        // Revert any scroll which would move the canvas outside of the view
         this._container.scrollTop = 0;
         this._container.scrollLeft = 0;
         return false;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -213,12 +213,6 @@ export default class Marker extends Evented {
             // prevent focusing on click
             e.preventDefault();
         });
-        this._element.addEventListener('focus', () => {
-            // revert the default scrolling action of the container
-            const el = this._map.getContainer();
-            el.scrollTop = 0;
-            el.scrollLeft = 0;
-        });
         applyAnchorClass(this._element, this._anchor, 'marker');
 
         this._popup = null;

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -38,7 +38,7 @@ export type PopupOptions = {
 const focusQuerySelector = [
     "a[href]",
     "[tabindex]:not([tabindex='-1'])",
-    "contenteditable",
+    "[contenteditable]:not([contenteditable='false'])",
     "button:not([disabled])",
     "input:not([disabled])",
     "select:not([disabled])",

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -17,6 +17,7 @@ import type {PointLike} from '@mapbox/point-geometry';
 const defaultOptions = {
     closeButton: true,
     closeOnClick: true,
+    focusAfterOpen: true,
     className: '',
     maxWidth: "240px"
 };
@@ -27,11 +28,22 @@ export type PopupOptions = {
     closeButton?: boolean,
     closeOnClick?: boolean,
     closeOnMove?: boolean,
+    focusAfterOpen?: boolean,
     anchor?: Anchor,
     offset?: Offset,
     className?: string,
     maxWidth?: string
 };
+
+const focusQuerySelector = [
+    "a[href]",
+    "[tabindex]:not([tabindex='-1'])",
+    "contenteditable",
+    "button:not([disabled])",
+    "input:not([disabled])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+].join(", ");
 
 /**
  * A popup component.
@@ -43,6 +55,8 @@ export type PopupOptions = {
  *   map is clicked.
  * @param {boolean} [options.closeOnMove=false] If `true`, the popup will closed when the
  *   map moves.
+ * @param {boolean} [options.focusAfterOpen=true] If `true`, the popup will try to focus the
+ *   first focusable element inside the popup.
  * @param {string} [options.anchor] - A string indicating the part of the Popup that should
  *   be positioned closest to the coordinate set via {@link Popup#setLngLat}.
  *   Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
@@ -549,23 +563,9 @@ export default class Popup extends Evented {
     }
 
     _focusFirstElement() {
-        if (!this._container) return;
+        if (!this.options.focusAfterOpen || !this._container) return;
 
-        // This approach isn't covering all the quirks and cases but it should be good enough.
-        // If we would want to be really thorough we would need much more code, see e.g.:
-        // https://github.com/angular/components/blob/master/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
-        const selectors = [
-            "a[href]",
-            "[tabindex]:not([tabindex='-1'])",
-            "contenteditable",
-            "button:not([disabled])",
-            "input:not([disabled])",
-            "select:not([disabled])",
-            "textarea:not([disabled])",
-        ];
-        const firstFocusable = this._container.querySelector(
-            selectors.join(", ")
-        );
+        const firstFocusable = this._container.querySelector(focusQuerySelector);
 
         if (firstFocusable) firstFocusable.focus();
     }

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -732,3 +732,16 @@ test('If popup content contains a disabled input followed by a focusable element
     t.equal(window.document.activeElement, focusableEl);
     t.end();
 });
+
+test('Popup with disabled focusing does not change the active element', (t) => {
+    const dummyFocusedEl = window.document.createElement('button');
+    dummyFocusedEl.focus();
+
+    new Popup({closeButton: false, focusAfterOpen: false})
+        .setHTML('<span tabindex="0" data-testid="abc">Test</span>')
+        .setLngLat([0, 0])
+        .addTo(createMap(t));
+
+    t.equal(window.document.activeElement, dummyFocusedEl);
+    t.end();
+});

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -712,17 +712,22 @@ test('Element with tabindex="-1" is not focused', (t) => {
         .setLngLat([0, 0])
         .addTo(createMap(t));
 
-    const focusableEl = popup._container.querySelector("[data-testid='abc']");
+    const nonFocusableEl = popup._container.querySelector("[data-testid='abc']");
+    const closeButton = popup._container.querySelector("button[aria-label='Close popup']");
 
-    t.notEqual(window.document.activeElement, focusableEl);
+    t.notEqual(window.document.activeElement, nonFocusableEl);
+    t.equal(window.document.activeElement, closeButton);
     t.end();
 });
 
-test('If popup content contains a disabled input followed by a focusable element then the latter is focused', (t) => {
+test('If popup contains a disabled button and a focusable element then the latter is focused', (t) => {
     const popup = new Popup({closeButton: true})
         .setHTML(`
             <button disabled>No focus here</button>
-            <span tabindex="0" data-testid="abc">Test</span>
+            <select data-testid="abc">
+                <option value="1">1</option>
+                <option value="2">2</option>
+            </select>
         `)
         .setLngLat([0, 0])
         .addTo(createMap(t));

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -651,3 +651,84 @@ test('Popup closes on Map#remove', (t) => {
     t.ok(!popup.isOpen());
     t.end();
 });
+
+test('Adding popup with no focusable content (Popup#setText) does not change the active element', (t) => {
+    const dummyFocusedEl = window.document.createElement('button');
+    dummyFocusedEl.focus();
+
+    new Popup({closeButton: false})
+        .setText('Test')
+        .setLngLat([0, 0])
+        .addTo(createMap(t));
+
+    t.equal(window.document.activeElement, dummyFocusedEl);
+    t.end();
+});
+
+test('Adding popup with no focusable content (Popup#setHTML) does not change the active element', (t) => {
+    const dummyFocusedEl = window.document.createElement('button');
+    dummyFocusedEl.focus();
+
+    new Popup({closeButton: false})
+        .setHTML('<span>Test</span>')
+        .setLngLat([0, 0])
+        .addTo(createMap(t));
+
+    t.equal(window.document.activeElement, dummyFocusedEl);
+    t.end();
+});
+
+test('Close button is focused if it is the only focusable element', (t) => {
+    const dummyFocusedEl = window.document.createElement('button');
+    dummyFocusedEl.focus();
+
+    const popup = new Popup({closeButton: true})
+        .setHTML('<span>Test</span>')
+        .setLngLat([0, 0])
+        .addTo(createMap(t));
+
+    // Suboptimal because the string matching is case-sensitive
+    const closeButton = popup._container.querySelector("[aria-label^='Close']");
+
+    t.equal(window.document.activeElement, closeButton);
+    t.end();
+});
+
+test('If popup content contains a focusable element it is focused', (t) => {
+    const popup = new Popup({closeButton: true})
+        .setHTML('<span tabindex="0" data-testid="abc">Test</span>')
+        .setLngLat([0, 0])
+        .addTo(createMap(t));
+
+    const focusableEl = popup._container.querySelector("[data-testid='abc']");
+
+    t.equal(window.document.activeElement, focusableEl);
+    t.end();
+});
+
+test('Element with tabindex="-1" is not focused', (t) => {
+    const popup = new Popup({closeButton: true})
+        .setHTML('<span tabindex="-1" data-testid="abc">Test</span>')
+        .setLngLat([0, 0])
+        .addTo(createMap(t));
+
+    const focusableEl = popup._container.querySelector("[data-testid='abc']");
+
+    t.notEqual(window.document.activeElement, focusableEl);
+    t.end();
+});
+
+test('If popup content contains a disabled input followed by a focusable element then the latter is focused', (t) => {
+    const popup = new Popup({closeButton: true})
+        .setHTML(`
+            <button disabled>No focus here</button>
+            <span tabindex="0" data-testid="abc">Test</span>
+        `)
+        .setLngLat([0, 0])
+        .addTo(createMap(t));
+
+    const focusableEl = popup._container.querySelector("[data-testid='abc']");
+
+    t.equal(window.document.activeElement, focusableEl);
+    t.end();
+});


### PR DESCRIPTION
Hi folks - this is my first PR - so please shout if I missed some of your rules or anything!

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page

PR for bug: https://github.com/mapbox/mapbox-gl-js/issues/9662

### Commit b546e09

**Q1**: Should consumers be able to disable this auto-focus functionality?

**Q2** Should <kbd>Esc</kbd> close the opened popup? Currently it doesn't.

Otherwise it's nothing big - for better keyboard UX I changed the order in which elements in popup are added to DOM - this shouldn't change anything since the close button has `position: absolute;`.

I also wanted to add functionality that re-focuses the previously focused element when popup is closed.
But it was getting messy in one scenario:

- **user opens a popup** -> popup stores a reference to a previously focused element
- **user clicks on a different marker** -> new popup is opened and *after* that the old popup is removed - this would result in a situation where the new popup would store a reference to a focusable element from the old popup (already bad but not too bad)
- **user clicks on a different marker** -> same thing happens **but** since the new popup is added before the old one is removed we would first focus element in the new popup and then the popup which is on its way to DOM graveyard would jump in and it would try to re-focus the element from the very first popup which is long gone - so the third popup would lose focus and `document.activeElement` would be either `null` or `document.body`.

Both popup's removal (popup.js) and popup's appearing (marker.js) are driven by map's "click" event and I don't see an easy way how to ensure they happen in different order.

So I was thinking that the marker could pass a reference to its DOM element to the popup instance.
Then popup would focus it when it'll be closed - but only if popup was closed by the 'x' button - i.e. not by clicking on another marker.
It' an easy change and it would give users good keyboard UX. (I'm happy to add it to the PR if you think it's a good idea)

### Commit 068d10d  

I added a lot of details to the commit message but I don't know mapbox-gl-js that well so please think if there are some valid cases when map's container is scrolled (it's the `div` with id "mapid")
