### PR TITLE
Remove expression_name enum from bundled spec

### DIFF
--- a/build/rollup_plugin_minify_style_spec.js
+++ b/build/rollup_plugin_minify_style_spec.js
@@ -11,8 +11,12 @@ export default function minifyStyleSpec() {
                 return;
             }
 
+            const spec = JSON.parse(source);
+
+            delete spec['expression_name'];
+
             return {
-                code: JSON.stringify(JSON.parse(source), replacer, 0),
+                code: JSON.stringify(spec, replacer, 0),
                 map: {mappings: ''}
             };
         }


### PR DESCRIPTION
This has no effect on anything except a small bundle size improvement — the `expression_name` namespace in the spec contains all possible expression values but is unused at runtime.