### PR TITLE
Resolving the Studio blocker

### DIFF
--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -520,14 +520,18 @@ class HandlerManager {
         this._map.fire(new Event(type, e ? {originalEvent: e} : {}));
     }
 
+    _requestFrame() {
+        this._map.triggerRepaint();
+        return this._map._renderTaskQueue.add(timeStamp => {
+            delete this._frameId;
+            this.handleEvent(new RenderFrameEvent('renderFrame', {timeStamp}));
+            this._applyChanges();
+        });
+    }
+
     _triggerRenderFrame() {
         if (this._frameId === undefined) {
-            this._map.triggerRepaint();
-            this.frameId = this._map._renderTaskQueue.add(timeStamp => {
-                delete this._frameId;
-                this.handleEvent(new RenderFrameEvent('renderFrame', {timeStamp}));
-                this._applyChanges();
-            });
+            this._frameId = this._requestFrame();
         }
     }
 

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -522,7 +522,8 @@ class HandlerManager {
 
     _triggerRenderFrame() {
         if (this._frameId === undefined) {
-            this._frameId = this._map._requestRenderFrame(timeStamp => {
+            this._map.triggerRepaint();
+            this.frameId = this._map._renderTaskQueue.add(timeStamp => {
                 delete this._frameId;
                 this.handleEvent(new RenderFrameEvent('renderFrame', {timeStamp}));
                 this._applyChanges();

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2383,7 +2383,7 @@ class Map extends Camera {
      * @private
      */
     _requestRenderFrame(callback: () => void): TaskID {
-        this._update();
+        this.triggerRepaint();
         return this._renderTaskQueue.add(callback);
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2383,7 +2383,7 @@ class Map extends Camera {
      * @private
      */
     _requestRenderFrame(callback: () => void): TaskID {
-        this.triggerRepaint();
+        this._update();
         return this._renderTaskQueue.add(callback);
     }
 

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -178,7 +178,7 @@ test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
 
 test('DragPanHandler requests a new render frame after each mousemove event', (t) => {
     const map = createMap(t);
-    const requestFrame = t.spy(map, '_requestRenderFrame');
+    const requestFrame = t.spy(map.handlers, '_requestFrame');
 
     simulate.mousedown(map.getCanvas());
     simulate.mousemove(map.getCanvas(), {buttons, clientX: 10, clientY: 10});

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -499,7 +499,7 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
 
 test('DragRotateHandler requests a new render frame after each mousemove event', (t) => {
     const map = createMap(t);
-    const requestRenderFrame = t.spy(map, '_requestRenderFrame');
+    const requestRenderFrame = t.spy(map.handlers, '_requestFrame');
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);


### PR DESCRIPTION
The problem which is blocking studio to upgrade the gl-js version v1.11.0 is as follow:

The map.loaded() is returning false as result of onClick() which is causing the studio not showing its popup menu. 

mouse events don’t immediately trigger map changes. but they trigger render frames which then combine all the changes since the last frame and apply them once mouseup triggers, because the pan handler goes from being “active” to “inactive” which mark the sources as dirty. This change will avoid updating the map and directly will call the repaint to avoid setting the source as dirty.
