### PR TITLE
Fixed fill-pattern-test allow threshold

### DIFF
--- a/test/integration/render-tests/fill-pattern/3x-on-2x-add-image/style.json
+++ b/test/integration/render-tests/fill-pattern/3x-on-2x-add-image/style.json
@@ -4,6 +4,7 @@
     "test": {
       "width": 64,
       "height": 64,
+      "allowed": 0.001,
       "pixelRatio": 2,
       "operations": [
         [


### PR DESCRIPTION
Test `fill-pattern/3x-on-2x-add-image` has almost the same result (but not enough) because of antialiasing in GL native. Here I increased the threshold a bit.