### PR TITLE
Update the worker images once an image is added or removed.

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -518,6 +518,7 @@ class Style extends Evented {
         this._availableImages = this.imageManager.listImages();
         this._changedImages[id] = true;
         this._changed = true;
+        this.dispatcher.broadcast('setImages', this._availableImages);
         this.fire(new Event('data', {dataType: 'style'}));
     }
 
@@ -537,6 +538,7 @@ class Style extends Evented {
         this._availableImages = this.imageManager.listImages();
         this._changedImages[id] = true;
         this._changed = true;
+        this.dispatcher.broadcast('setImages', this._availableImages);
         this.fire(new Event('data', {dataType: 'style'}));
     }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -515,11 +515,7 @@ class Style extends Evented {
             return this.fire(new ErrorEvent(new Error('An image with this name already exists.')));
         }
         this.imageManager.addImage(id, image);
-        this._availableImages = this.imageManager.listImages();
-        this._changedImages[id] = true;
-        this._changed = true;
-        this.dispatcher.broadcast('setImages', this._availableImages);
-        this.fire(new Event('data', {dataType: 'style'}));
+        this._afterImageUpdated(id);
     }
 
     updateImage(id: string, image: StyleImage) {
@@ -535,6 +531,10 @@ class Style extends Evented {
             return this.fire(new ErrorEvent(new Error('No image with this name exists.')));
         }
         this.imageManager.removeImage(id);
+        this._afterImageUpdated(id);
+    }
+
+    _afterImageUpdated(id: string) {
         this._availableImages = this.imageManager.listImages();
         this._changedImages[id] = true;
         this._changed = true;


### PR DESCRIPTION
This fix a bug when a fallback image was not used when it was added via `addImage`.

For instance, the following style with a missing image `nonexistant` and an added image `shop` would show nothing.

```
   "icon-image": [
      "coalesce",
      ['image', 'nonexistant'],
      ['image', 'shop']
    ]
```
I also updated the list of images on the worker when an image is removed to keep it synchronized.
