### PR TITLE
updating the sdk-support table for "volatile" source option

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -188,8 +188,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "Not yet available",
-          "android": "Not yet available",
-          "ios": "Not yet available",
+          "android": "9.3.0",
+          "ios": "5.10.0",
           "macos": "Not yet available"
         }
       }
@@ -271,8 +271,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "Not yet available",
-          "android": "Not yet available",
-          "ios": "Not yet available",
+          "android": "9.3.0",
+          "ios": "5.10.0",
           "macos": "Not yet available"
         }
       }
@@ -354,8 +354,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "Not yet available",
-          "android": "Not yet available",
-          "ios": "Not yet available",
+          "android": "9.3.0",
+          "ios": "5.10.0",
           "macos": "Not yet available"
         }
       }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -187,10 +187,8 @@
       "doc": "A setting to determine whether a source's tiles are cached locally.",
       "sdk-support": {
         "basic functionality": {
-          "js": "Not yet available",
           "android": "9.3.0",
-          "ios": "5.10.0",
-          "macos": "Not yet available"
+          "ios": "5.10.0"
         }
       }
     },
@@ -270,10 +268,8 @@
       "doc": "A setting to determine whether a source's tiles are cached locally.",
       "sdk-support": {
         "basic functionality": {
-          "js": "Not yet available",
           "android": "9.3.0",
-          "ios": "5.10.0",
-          "macos": "Not yet available"
+          "ios": "5.10.0"
         }
       }
     },
@@ -353,10 +349,8 @@
       "doc": "A setting to determine whether a source's tiles are cached locally.",
       "sdk-support": {
         "basic functionality": {
-          "js": "Not yet available",
           "android": "9.3.0",
-          "ios": "5.10.0",
-          "macos": "Not yet available"
+          "ios": "5.10.0"
         }
       }
     },


### PR DESCRIPTION
Updating the sdk-support table  for "volatile" source option with correct Android and ios version number. This is an addition to the initial [PR](https://github.com/mapbox/mapbox-gl-js/pull/9702) which introduced this source option. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
