### PR TITLE
Fix precedence of promoteId over feature id in fill extrusions

### DIFF
--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -101,7 +101,7 @@ class FillExtrusionBucket implements Bucket {
 
             if (!this.layers[0]._featureFilter.filter(new EvaluationParameters(this.zoom), evaluationFeature, canonical)) continue;
 
-            const patternFeature: BucketFeature = {
+            const bucketFeature: BucketFeature = {
                 id,
                 sourceLayerIndex,
                 index,
@@ -111,17 +111,13 @@ class FillExtrusionBucket implements Bucket {
                 patterns: {}
             };
 
-            if (typeof feature.id !== 'undefined') {
-                patternFeature.id = feature.id;
-            }
-
             if (this.hasPattern) {
-                this.features.push(addPatternDependencies('fill-extrusion', this.layers, patternFeature, this.zoom, options));
+                this.features.push(addPatternDependencies('fill-extrusion', this.layers, bucketFeature, this.zoom, options));
             } else {
-                this.addFeature(patternFeature, patternFeature.geometry, index, canonical, {});
+                this.addFeature(bucketFeature, bucketFeature.geometry, index, canonical, {});
             }
 
-            options.featureIndex.insert(feature, patternFeature.geometry, index, sourceLayerIndex, this.index, true);
+            options.featureIndex.insert(feature, bucketFeature.geometry, index, sourceLayerIndex, this.index, true);
         }
     }
 

--- a/test/integration/render-tests/feature-state/promote-id-fill-extrusion/style.json
+++ b/test/integration/render-tests/feature-state/promote-id-fill-extrusion/style.json
@@ -39,6 +39,7 @@
         "type": "FeatureCollection",
         "features": [{
           "type": "Feature",
+          "id": 1,
           "geometry": {
             "type": "Polygon",
             "coordinates": [
@@ -71,6 +72,7 @@
           }
         }, {
           "type": "Feature",
+          "id": 1,
           "geometry": {
             "type": "Polygon",
             "coordinates": [
@@ -103,6 +105,7 @@
           }
         }, {
           "type": "Feature",
+          "id": 1,
           "geometry": {
             "type": "Polygon",
             "coordinates": [


### PR DESCRIPTION
There was a leftover in `fill-extrusion-bucket` code that caused a bug with `promoteId` not working if fill extrusion features already had an `id` present. This PR fixes that, and updates the render test to trigger the bug (so that it fails prior to this PR).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed a bug where promoteId option failed for fill extrusions with defined feature ids.</changelog>`
