### PR TITLE
Remove unused clearTimeout() from camera.js

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -121,7 +121,6 @@ class Camera extends Evented {
     _padding: boolean;
 
     _bearingSnap: number;
-    _easeEndTimeoutID: TimeoutID;
     _easeStart: number;
     _easeOptions: {duration: number, easing: (_: number) => number};
     _easeId: string | void;
@@ -837,8 +836,6 @@ class Camera extends Evented {
 
         this._easeId = options.easeId;
         this._prepareEase(eventData, options.noMoveStart, currently);
-
-        clearTimeout(this._easeEndTimeoutID);
 
         this._ease((k) => {
             if (this._zooming) {


### PR DESCRIPTION
This removes unused timeout code from camera.js. It looks like this had been dead code since the `delayEndEvents` argument was removed from `camera.easeTo` in #9365.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
