### PR TITLE
Prevent bearing snap ease interfering with new ease

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1185,7 +1185,7 @@ class Camera extends Evented {
         }
         if (!allowGestures) {
             const handlers = (this: any).handlers;
-            if (handlers) handlers.stop();
+            if (handlers) handlers.stop(false);
         }
         return this;
     }

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -104,7 +104,6 @@ class HandlerManager {
     _updatingCamera: boolean;
     _changes: Array<[HandlerResult, Object, any]>;
     _previousActiveHandlers: { [string]: Handler };
-    _bearingChanged: boolean;
     _listeners: Array<[HTMLElement, string, void | {passive?: boolean, capture?: boolean}]>;
 
     constructor(map: Map, options: { interactive: boolean, pitchWithRotate: boolean, clickTolerance: number, bearingSnap: number}) {
@@ -235,7 +234,7 @@ class HandlerManager {
         this._handlersById[handlerName] = handler;
     }
 
-    stop() {
+    stop(allowEndAnimation: boolean) {
         // do nothing if this method was triggered by a gesture update
         if (this._updatingCamera) return;
 
@@ -243,7 +242,7 @@ class HandlerManager {
             handler.reset();
         }
         this._inertia.clear();
-        this._fireEvents({}, {});
+        this._fireEvents({}, {}, allowEndAnimation);
         this._changes = [];
     }
 
@@ -293,7 +292,7 @@ class HandlerManager {
     handleEvent(e: InputEvent | RenderFrameEvent, eventName?: string) {
 
         if (e.type === 'blur') {
-            this.stop();
+            this.stop(true);
             return;
         }
 
@@ -358,7 +357,7 @@ class HandlerManager {
         const {cameraAnimation} = mergedHandlerResult;
         if (cameraAnimation) {
             this._inertia.clear();
-            this._fireEvents({}, {});
+            this._fireEvents({}, {}, true);
             this._changes = [];
             cameraAnimation(this._map);
         }
@@ -416,7 +415,7 @@ class HandlerManager {
         const tr = map.transform;
 
         if (!hasChange(combinedResult)) {
-            return this._fireEvents(combinedEventsInProgress, deactivatedHandlers);
+            return this._fireEvents(combinedEventsInProgress, deactivatedHandlers, true);
         }
 
         let {panDelta, zoomDelta, bearingDelta, pitchDelta, around, pinchAround} = combinedResult;
@@ -437,11 +436,11 @@ class HandlerManager {
 
         this._map._update();
         if (!combinedResult.noInertia) this._inertia.record(combinedResult);
-        this._fireEvents(combinedEventsInProgress, deactivatedHandlers);
+        this._fireEvents(combinedEventsInProgress, deactivatedHandlers, true);
 
     }
 
-    _fireEvents(newEventsInProgress: { [string]: Object }, deactivatedHandlers: Object) {
+    _fireEvents(newEventsInProgress: { [string]: Object }, deactivatedHandlers: Object, allowEndAnimation: boolean) {
 
         const wasMoving = isMoving(this._eventsInProgress);
         const nowMoving = isMoving(newEventsInProgress);
@@ -464,8 +463,6 @@ class HandlerManager {
         for (const name in startEvents) {
             this._fireEvent(name, startEvents[name]);
         }
-
-        if (newEventsInProgress.rotate) this._bearingChanged = true;
 
         if (nowMoving) {
             this._fireEvent('move', nowMoving.originalEvent);
@@ -493,7 +490,7 @@ class HandlerManager {
         }
 
         const stillMoving = isMoving(this._eventsInProgress);
-        if ((wasMoving || nowMoving) && !stillMoving) {
+        if (allowEndAnimation && (wasMoving || nowMoving) && !stillMoving) {
             this._updatingCamera = true;
             const inertialEase = this._inertia._onMoveEnd(this._map.dragPan._inertiaOptions);
 
@@ -510,7 +507,6 @@ class HandlerManager {
                     this._map.resetNorth();
                 }
             }
-            this._bearingChanged = false;
             this._updatingCamera = false;
         }
 


### PR DESCRIPTION
This is a fix for #9793 

In short, `easeTo` or `flyTo` may interrupt handler driven motion when the map's bearing is within the `bearingSnap` range. This triggers a bearing snap `easeTo` at the same time as the desired `easeTo/flyTo`. The camera can't handle both of these and it freezes and errors.

Further explanation of the chain of events that cause this bug is here https://github.com/mapbox/mapbox-gl-js/issues/9793#issuecomment-661036753

This PR:
- Adds a new argument `allowEndAnimation` to `HandlerManager#stop` to prevent a bearing snap interfering with a new `easeTo` or `flyTo`.
- Removes unused property `_bearingChanged` of `HandlerManager`.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed a bug where bearing snap animations interfere with new easeTo and flyTo animations and freeze the map</changelog>`