### PR TITLE
[docs] Fix setRotationAlignment link

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -597,7 +597,7 @@ export default class Marker extends Evented {
 
     /**
      * Sets the `rotation` property of the marker.
-     * @param {number} [rotation=0] The rotation angle of the marker (clockwise, in degrees), relative to its respective {@link Marker#rotationAlignment} setting.
+     * @param {number} [rotation=0] The rotation angle of the marker (clockwise, in degrees), relative to its respective {@link Marker#setRotationAlignment} setting.
      * @returns {Marker} `this`
      */
     setRotation(rotation: number) {


### PR DESCRIPTION
This PR fixes the link to setRotationAlignment. 

Fixes https://github.com/mapbox/documentation/issues/514

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
