### PR TITLE
Remove dead code from scroll_zoom.js

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -70,12 +70,7 @@ class ScrollZoomHandler {
         this._defaultZoomRate = defaultZoomRate;
         this._wheelZoomRate = wheelZoomRate;
 
-        bindAll([
-            '_onWheel',
-            '_onTimeout',
-            '_onScrollFrame',
-            '_onScrollFinished'
-        ], this);
+        bindAll(['_onTimeout'], this);
     }
 
     /**

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -236,10 +236,6 @@ class ScrollZoomHandler {
     }
 
     renderFrame() {
-        return this._onScrollFrame();
-    }
-
-    _onScrollFrame() {
         if (!this._frameId) return;
         this._frameId = null;
 


### PR DESCRIPTION
`_onWheel` and `_onScrollFinished` no longer exist. `_onScrollFrame` doesn't need to be bound since all handlers are called as methods.

## Launch Checklist

 - [x] briefly describe the changes in this PR
