### PR TITLE
Clarification in clusterMaxZoom documentation

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -375,7 +375,7 @@
     },
     "clusterMaxZoom": {
       "type": "number",
-      "doc": "Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less than maxzoom (so that last zoom features are not clustered)."
+      "doc": "Max zoom on which to cluster points if clustering is enabled.  Defaults to one zoom less than maxzoom (so that last zoom features are not clustered). Because the clustering algorithm is evaluated at integer zoom levels, setting clusterMaxZoom to 14, for example, means the clusters will show until z15."
     },
     "clusterProperties": {
       "type": "*",

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -375,7 +375,7 @@
     },
     "clusterMaxZoom": {
       "type": "number",
-      "doc": "Max zoom on which to cluster points if clustering is enabled.  Defaults to one zoom less than maxzoom (so that last zoom features are not clustered). Because the clustering algorithm is evaluated at integer zoom levels, setting clusterMaxZoom to 14, for example, means the clusters will show until z15."
+      "doc": "Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less than maxzoom (so that last zoom features are not clustered). Clusters are re-evaluated at integer zoom levels so setting clusterMaxZoom to 14 means the clusters will be displayed until z15."
     },
     "clusterProperties": {
       "type": "*",


### PR DESCRIPTION
One might assume that setting `clusterMaxZoom` to z14 means that the clusters disappear at z14.1. Because the cluster algorithm is evaluated at integer zooms, this is not the case. The clusters will disappear at z15. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
