### PR TITLE
Update attribution on layer visibility changes

### DIFF
--- a/src/style/style.js
+++ b/src/style/style.js
@@ -412,8 +412,12 @@ class Style extends Evented {
             this._resetUpdates();
         }
 
+        const sourcesUsedBefore = {};
+
         for (const sourceId in this.sourceCaches) {
-            this.sourceCaches[sourceId].used = false;
+            const sourceCache = this.sourceCaches[sourceId];
+            sourcesUsedBefore[sourceId] = sourceCache.used;
+            sourceCache.used = false;
         }
 
         for (const layerId of this._order) {
@@ -422,6 +426,13 @@ class Style extends Evented {
             layer.recalculate(parameters, this._availableImages);
             if (!layer.isHidden(parameters.zoom) && layer.source) {
                 this.sourceCaches[layer.source].used = true;
+            }
+        }
+
+        for (const sourceId in sourcesUsedBefore) {
+            const sourceCache = this.sourceCaches[sourceId];
+            if (sourcesUsedBefore[sourceId] !== sourceCache.used) {
+                sourceCache.fire(new Event('data', {sourceDataType: 'visibility', dataType:'source', sourceId}));
             }
         }
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -111,7 +111,7 @@ class AttributionControl {
     }
 
     _updateData(e: any) {
-        if (e && (e.sourceDataType === 'metadata' || e.dataType === 'style')) {
+        if (e && (e.sourceDataType === 'metadata' || e.sourceDataType === 'visibility' || e.dataType === 'style')) {
             this._updateAttributions();
             this._updateEditLink();
         }

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -264,7 +264,7 @@ export type MapBoxZoomEvent = {
  * @property {boolean} [isSourceLoaded] True if the event has a `dataType` of `source` and the source has no outstanding network requests.
  * @property {Object} [source] The [style spec representation of the source](https://www.mapbox.com/mapbox-gl-style-spec/#sources) if the event has a `dataType` of `source`.
  * @property {string} [sourceDataType] Included if the event has a `dataType` of `source` and the event signals
- * that internal data has been received or changed. Possible values are `metadata` and `content`.
+ * that internal data has been received or changed. Possible values are `metadata`, `content` and `visibility`.
  * @property {Object} [tile] The tile being loaded or changed, if the event has a `dataType` of `source` and
  * the event is related to loading of a tile.
  * @property {Coordinate} [coord] The coordinate of the tile if the event has a `dataType` of `source` and

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -239,3 +239,27 @@ test('AttributionControl hides attributions for sources that are not currently v
         }
     });
 });
+
+test('AttributionControl toggles attributions for sources whose visibility changes when zooming', (t) => {
+    const map = createMap(t);
+    const attribution = new AttributionControl();
+    map.addControl(attribution);
+
+    map.on('load', () => {
+        map.addSource('1', {type: 'geojson', data: {type: 'FeatureCollection', features: []}, attribution: 'Used'});
+        map.addLayer({id: '1', type: 'fill', source: '1', minzoom: 12});
+    });
+
+    map.on('data', (e) => {
+        if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+            t.equal(attribution._innerContainer.innerHTML, '');
+            map.setZoom(13);
+        }
+        if (e.dataType === 'source' && e.sourceDataType === 'visibility') {
+            if (map.getZoom() === 13) {
+                t.equal(attribution._innerContainer.innerHTML, 'Used');
+                t.end();
+            }
+        }
+    });
+});


### PR DESCRIPTION
Closes #9824. Attribution is currently updated when the style changes (layers and sources added/removed, properties changed, etc.), but not updated when _source visibility changes during zooming_ — either through going in or out of `minzoom`/`maxzoom` range, or through `opacity` change from zero to non-zero values or vice versa (e.g. through a zoom-based expression). 

This PR introduces a new `sourcedata` event with `sourceDataType: 'visibility'`, which the attribution control subsequently subscribes to for updating the attribution.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a bug where attribution didn't update when layer visibility changed during zooming.</changelog>`
