### PR TITLE
Add setOffset to popup

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -433,6 +433,18 @@ export default class Popup extends Evented {
     }
 
     /**
+     * Sets the popup's offset.
+     *
+     * @param offset Sets the popup's offset.
+     * @returns {Popup} `this`
+     */
+    setOffset (offset?: Offset) {
+        this.options.offset = offset;
+        this._update();
+        return this;
+    }
+
+    /**
      * Add or remove the given CSS class on the popup container, depending on whether the container currently has that class.
      *
      * @param {string} className Non-empty string with CSS class name to add/remove

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -480,6 +480,22 @@ test('Popup is offset via an incomplete object offset option', (t) => {
     t.end();
 });
 
+test('Popup offset can be set via setOffset', (t) => {
+    const map = createMap(t);
+
+    const popup = new Popup({offset: 5})
+        .setLngLat([0, 0])
+        .setText('Test')
+        .addTo(map);
+
+    t.equal(popup.options.offset, 5);
+
+    popup.setOffset(10);
+
+    t.equal(popup.options.offset, 10);
+    t.end();
+});
+
 test('Popup can be removed and added again (#1477)', (t) => {
     const map = createMap(t);
 


### PR DESCRIPTION
## Launch Checklist

Adds `Popup.prototype.setOffset` which allows offset to be applied after popup is already created.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

