### PR TITLE
change hash without affecting the rest of URL

### DIFF
--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -132,9 +132,10 @@ class Hash {
     }
 
     _updateHashUnthrottled() {
-        const hash = this.getHashString();
+        // Replace if already present else append the updated hash string
+        const location = window.location.href.replace(/(#.+)?$/, this.getHashString());
         try {
-            window.history.replaceState(window.history.state, '', hash);
+            window.history.replaceState(window.history.state, document.title, location);
         } catch (SecurityError) {
             // IE11 does not allow this if the page is within an iframe created
             // with iframe.contentWindow.document.write(...).

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -135,7 +135,7 @@ class Hash {
         // Replace if already present, else append the updated hash string
         const location = window.location.href.replace(/(#.+)?$/, this.getHashString());
         try {
-            window.history.replaceState(window.history.state, document.title, location);
+            window.history.replaceState(window.history.state, null, location);
         } catch (SecurityError) {
             // IE11 does not allow this if the page is within an iframe created
             // with iframe.contentWindow.document.write(...).

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -132,7 +132,7 @@ class Hash {
     }
 
     _updateHashUnthrottled() {
-        // Replace if already present else append the updated hash string
+        // Replace if already present, else append the updated hash string
         const location = window.location.href.replace(/(#.+)?$/, this.getHashString());
         try {
             window.history.replaceState(window.history.state, document.title, location);


### PR DESCRIPTION
Closes #9955 . Hash change currently replaces history state url with only the updated hash, ignoring the current URL (path, query parameters etc). This PR fixes the hash change strategy, so that it updates only the fragment (part in case of a named fragment parameter), while leaving the rest of URL untouched.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix the hash control conflicting with external history state manipulation</changelog>`
