### PR TITLE
add to-number expression constraint

### DIFF
--- a/src/style-spec/expression/definitions/coercion.js
+++ b/src/style-spec/expression/definitions/coercion.js
@@ -48,6 +48,10 @@ class Coercion implements Expression {
         if ((name === 'to-boolean' || name === 'to-string') && args.length !== 2)
             return context.error(`Expected one argument.`);
 
+        if (name === 'to-number' && !Array.isArray(args[1])) {
+            return context.error('"to-number" expression expects an array argument.');
+        }
+
         const type = types[name];
 
         const parsed = [];

--- a/test/integration/expression-tests/to-number/invalid/test.json
+++ b/test/integration/expression-tests/to-number/invalid/test.json
@@ -1,0 +1,15 @@
+{
+  "expression": ["to-number", "zoom", 5],
+  "inputs": [[{}, {}]],
+  "expected": {
+    "compiled": {
+      "result": "error",
+      "errors": [
+        {
+          "key": "",
+          "error": "\"to-number\" expression expects an array argument."
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Launch Checklist

We've seen users recently using the syntax: `["to-number", "zoom", 5]` instead of `["to-number", ["zoom"], 5]` and would like to throw a friendly error to guide users toward the proper syntax.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>throw an error if to-number expression is passed a non-array argument</changelog>`
