### PR TITLE
Fix text-padding affecting positioning of labels with variable anchors

### DIFF
--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -511,9 +511,11 @@ export class Placement {
                         }
                     }
 
+                    const doubleTextPadding = layout.get('text-padding') * 2 / textPixelRatio;
+
                     const placeBoxForVariableAnchors = (collisionTextBox, collisionIconBox, orientation) => {
-                        const width = collisionTextBox.x2 - collisionTextBox.x1;
-                        const height = collisionTextBox.y2 - collisionTextBox.y1;
+                        const width = collisionTextBox.x2 - collisionTextBox.x1 - doubleTextPadding;
+                        const height = collisionTextBox.y2 - collisionTextBox.y1 - doubleTextPadding;
                         const textBoxScale = symbolInstance.textBoxScale;
 
                         const variableIconBox = hasIconTextFit && !iconAllowOverlap ? collisionIconBox : null;


### PR DESCRIPTION
## Steps to reproduce the bug
1. Open http://localhost:9966/debug/#6.91/54.909/83.057
2. Execute: `map.setLayoutProperty('place-city-md-s', 'text-variable-anchor', ['top']);` in the console. This gives the Novosibirsk label a variable anchor instead of a fixed one.
3. Execute:
```
map.setLayoutProperty('place-city-md-s', 'text-padding', 50);
```

## Actual result
Novosibirsk label changes position and moves 50px below its anchor.

## Expected result
`text-padding` should only affect the size of collision boxes, and shouldn't affect label position at all. The label shouldn't move.

## Description
I fixed the bug by subtracting the padding from the width and height that are used for calculating variable layout and rendering shift.

## Checklist
 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
