### PR TITLE
Fix some failed results from Web map tools WCAG 2.1 evaluation

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -479,6 +479,11 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         border: 0;
     }
 
+    .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib-button,
+    .mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-attrib-button {
+        left: 0;
+    }
+
     .mapboxgl-ctrl-attrib.mapboxgl-compact .mapboxgl-ctrl-attrib-button,
     .mapboxgl-ctrl-attrib.mapboxgl-compact-show .mapboxgl-ctrl-attrib-inner {
         display: block;

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -135,6 +135,7 @@
     padding: 0;
 }
 
+.mapboxgl-ctrl-attrib-button:focus,
 .mapboxgl-ctrl-group button:focus {
     box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
 }
@@ -440,35 +441,35 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 @media screen {
     .mapboxgl-ctrl-attrib.mapboxgl-compact {
         min-height: 20px;
-        padding: 0;
+        padding: 2px 24px 2px 0;
         margin: 10px;
         position: relative;
         background-color: #fff;
-        border-radius: 3px 12px 12px 3px;
+        border-radius: 12px;
     }
 
-    .mapboxgl-ctrl-attrib.mapboxgl-compact:hover {
-        padding: 2px 24px 2px 4px;
+    .mapboxgl-ctrl-attrib.mapboxgl-compact-show {
+        padding: 2px 24px 2px 8px;
         visibility: visible;
-        margin-top: 6px;
     }
 
-    .mapboxgl-ctrl-top-left > .mapboxgl-ctrl-attrib.mapboxgl-compact:hover,
-    .mapboxgl-ctrl-bottom-left > .mapboxgl-ctrl-attrib.mapboxgl-compact:hover {
-        padding: 2px 4px 2px 24px;
-        border-radius: 12px 3px 3px 12px;
+    .mapboxgl-ctrl-top-left > .mapboxgl-ctrl-attrib.mapboxgl-compact-show,
+    .mapboxgl-ctrl-bottom-left > .mapboxgl-ctrl-attrib.mapboxgl-compact-show {
+        padding: 2px 8px 2px 24px;
+        border-radius: 12px;
     }
 
     .mapboxgl-ctrl-attrib.mapboxgl-compact .mapboxgl-ctrl-attrib-inner {
         display: none;
     }
 
-    .mapboxgl-ctrl-attrib.mapboxgl-compact:hover .mapboxgl-ctrl-attrib-inner {
+    .mapboxgl-ctrl-attrib.mapboxgl-compact .mapboxgl-ctrl-attrib-button,
+    .mapboxgl-ctrl-attrib.mapboxgl-compact-show .mapboxgl-ctrl-attrib-inner {
         display: block;
     }
 
-    .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
-        content: '';
+    .mapboxgl-ctrl-attrib-button {
+        display: none;
         cursor: pointer;
         position: absolute;
         background-image: svg-load('svg/mapboxgl-ctrl-attrib.svg');
@@ -477,6 +478,13 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         height: 24px;
         box-sizing: border-box;
         border-radius: 12px;
+        outline: none;
+        top: 0;
+        right: 0;
+        border: 0;
+    }
+    .mapboxgl-ctrl-attrib.mapboxgl-compact-show .mapboxgl-ctrl-attrib-button {
+        background-color: rgba(0, 0, 0, 0.05);
     }
 
     .mapboxgl-ctrl-bottom-right > .mapboxgl-ctrl-attrib.mapboxgl-compact::after {

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -449,13 +449,13 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     }
 
     .mapboxgl-ctrl-attrib.mapboxgl-compact-show {
-        padding: 2px 24px 2px 8px;
+        padding: 2px 28px 2px 8px;
         visibility: visible;
     }
 
     .mapboxgl-ctrl-top-left > .mapboxgl-ctrl-attrib.mapboxgl-compact-show,
     .mapboxgl-ctrl-bottom-left > .mapboxgl-ctrl-attrib.mapboxgl-compact-show {
-        padding: 2px 8px 2px 24px;
+        padding: 2px 8px 2px 28px;
         border-radius: 12px;
     }
 

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -463,11 +463,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         display: none;
     }
 
-    .mapboxgl-ctrl-attrib.mapboxgl-compact .mapboxgl-ctrl-attrib-button,
-    .mapboxgl-ctrl-attrib.mapboxgl-compact-show .mapboxgl-ctrl-attrib-inner {
-        display: block;
-    }
-
     .mapboxgl-ctrl-attrib-button {
         display: none;
         cursor: pointer;
@@ -483,6 +478,12 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         right: 0;
         border: 0;
     }
+
+    .mapboxgl-ctrl-attrib.mapboxgl-compact .mapboxgl-ctrl-attrib-button,
+    .mapboxgl-ctrl-attrib.mapboxgl-compact-show .mapboxgl-ctrl-attrib-inner {
+        display: block;
+    }
+
     .mapboxgl-ctrl-attrib.mapboxgl-compact-show .mapboxgl-ctrl-attrib-button {
         background-color: rgba(0, 0, 0, 0.05);
     }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -57,7 +57,6 @@ class AttributionControl {
         this._compactButton = DOM.create('button', 'mapboxgl-ctrl-attrib-button', this._container);
         this._compactButton.addEventListener('click', this._toggleAttribution);
         this._setButtonTitle(this._compactButton, 'ToggleAttribution');
-        this._compactButton.setAttribute('role', 'button');
         this._innerContainer = DOM.create('div', 'mapboxgl-ctrl-attrib-inner', this._container);
         this._innerContainer.setAttribute('role', 'list');
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -202,7 +202,7 @@ class AttributionControl {
         if (this._map.getCanvasContainer().offsetWidth <= 640) {
             this._container.classList.add('mapboxgl-compact');
         } else {
-            this._container.classList.remove('mapboxgl-compact');
+            this._container.classList.remove('mapboxgl-compact', 'mapboxgl-compact-show');
         }
     }
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -29,6 +29,7 @@ class AttributionControl {
     _map: Map;
     _container: HTMLElement;
     _innerContainer: HTMLElement;
+    _compactButton: HTMLButtonElement;
     _editLink: ?HTMLAnchorElement;
     _attribHTML: string;
     styleId: string;
@@ -56,7 +57,7 @@ class AttributionControl {
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-attrib');
         this._compactButton = DOM.create('button', 'mapboxgl-ctrl-attrib-button', this._container);
         this._compactButton.addEventListener('click', this._toggleAttribution);
-        this._setButtonTitle(this._compactButton, 'ToggleAttribution');
+        this._setElementTitle(this._compactButton, 'ToggleAttribution');
         this._innerContainer = DOM.create('div', 'mapboxgl-ctrl-attrib-inner', this._container);
         this._innerContainer.setAttribute('role', 'list');
 
@@ -91,10 +92,10 @@ class AttributionControl {
         this._attribHTML = (undefined: any);
     }
 
-    _setButtonTitle(button: HTMLButtonElement, title: string) {
+    _setElementTitle(element: HTMLElement, title: string) {
         const str = this._map._getUIString(`AttributionControl.${title}`);
-        button.title = str;
-        button.setAttribute('aria-label', str);
+        element.title = str;
+        element.setAttribute('aria-label', str);
     }
 
     _toggleAttribution() {
@@ -128,7 +129,7 @@ class AttributionControl {
             }, `?`);
             editLink.href = `${config.FEEDBACK_URL}/${paramString}${this._map._hash ? this._map._hash.getHashString(true) : ''}`;
             editLink.rel = 'noopener nofollow';
-            this._setButtonTitle(editLink, 'MapFeedback');
+            this._setElementTitle(editLink, 'MapFeedback');
         }
     }
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -38,6 +38,7 @@ class AttributionControl {
         this.options = options;
 
         bindAll([
+            '_toggleAttribution',
             '_updateEditLink',
             '_updateData',
             '_updateCompact'
@@ -53,7 +54,12 @@ class AttributionControl {
 
         this._map = map;
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-attrib');
+        this._compactButton = DOM.create('button', 'mapboxgl-ctrl-attrib-button', this._container);
+        this._compactButton.addEventListener('click', this._toggleAttribution);
+        this._setButtonTitle(this._compactButton, 'ToggleAttribution');
+        this._compactButton.setAttribute('role', 'button');
         this._innerContainer = DOM.create('div', 'mapboxgl-ctrl-attrib-inner', this._container);
+        this._innerContainer.setAttribute('role', 'list');
 
         if (compact) {
             this._container.classList.add('mapboxgl-compact');
@@ -86,6 +92,22 @@ class AttributionControl {
         this._attribHTML = (undefined: any);
     }
 
+    _setButtonTitle(button: HTMLButtonElement, title: string) {
+        const str = this._map._getUIString(`AttributionControl.${title}`);
+        button.title = str;
+        button.setAttribute('aria-label', str);
+    }
+
+    _toggleAttribution() {
+        if (this._container.classList.contains('mapboxgl-compact-show')) {
+            this._container.classList.remove('mapboxgl-compact-show');
+            this._compactButton.setAttribute('aria-pressed', 'false');
+        } else {
+            this._container.classList.add('mapboxgl-compact-show');
+            this._compactButton.setAttribute('aria-pressed', 'true');
+        }
+    }
+
     _updateEditLink() {
         let editLink = this._editLink;
         if (!editLink) {
@@ -93,9 +115,9 @@ class AttributionControl {
         }
 
         const params = [
-            {key: "owner", value: this.styleOwner},
-            {key: "id", value: this.styleId},
-            {key: "access_token", value: this._map._requestManager._customAccessToken || config.ACCESS_TOKEN}
+            {key: 'owner', value: this.styleOwner},
+            {key: 'id', value: this.styleId},
+            {key: 'access_token', value: this._map._requestManager._customAccessToken || config.ACCESS_TOKEN}
         ];
 
         if (editLink) {
@@ -106,7 +128,8 @@ class AttributionControl {
                 return acc;
             }, `?`);
             editLink.href = `${config.FEEDBACK_URL}/${paramString}${this._map._hash ? this._map._hash.getHashString(true) : ''}`;
-            editLink.rel = "noopener nofollow";
+            editLink.rel = 'noopener nofollow';
+            this._setButtonTitle(editLink, 'MapFeedback');
         }
     }
 

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -77,8 +77,12 @@ class NavigationControl {
 
     _updateZoomButtons() {
         const zoom = this._map.getZoom();
-        this._zoomInButton.disabled = zoom === this._map.getMaxZoom();
-        this._zoomOutButton.disabled = zoom === this._map.getMinZoom();
+        const isMax = zoom === this._map.getMaxZoom();
+        const isMin = zoom === this._map.getMinZoom();
+        this._zoomInButton.disabled = isMax;
+        this._zoomOutButton.disabled = isMin;
+        this._zoomInButton.setAttribute('aria-disabled', isMax ? 'true' : 'false');
+        this._zoomOutButton.setAttribute('aria-disabled', isMin ? 'true' : 'false');
     }
 
     _rotateCompassArrow() {
@@ -129,6 +133,7 @@ class NavigationControl {
     _createButton(className: string, fn: () => mixed) {
         const a = DOM.create('button', className, this._container);
         a.type = 'button';
+        a.setAttribute('role', 'button');
         a.addEventListener('click', fn);
         return a;
     }

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -133,7 +133,6 @@ class NavigationControl {
     _createButton(className: string, fn: () => mixed) {
         const a = DOM.create('button', className, this._container);
         a.type = 'button';
-        a.setAttribute('role', 'button');
         a.addEventListener('click', fn);
         return a;
     }

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -81,8 +81,8 @@ class NavigationControl {
         const isMin = zoom === this._map.getMinZoom();
         this._zoomInButton.disabled = isMax;
         this._zoomOutButton.disabled = isMin;
-        this._zoomInButton.setAttribute('aria-disabled', isMax ? 'true' : 'false');
-        this._zoomOutButton.setAttribute('aria-disabled', isMin ? 'true' : 'false');
+        this._zoomInButton.setAttribute('aria-disabled', isMax.toString());
+        this._zoomOutButton.setAttribute('aria-disabled', isMin.toString());
     }
 
     _rotateCompassArrow() {

--- a/src/ui/default_locale.js
+++ b/src/ui/default_locale.js
@@ -1,6 +1,8 @@
 // @flow
 
 const defaultLocale = {
+    'AttributionControl.ToggleAttribution': 'Toggle attribution',
+    'AttributionControl.MapFeedback': 'Map feedback',
     'FullscreenControl.Enter': 'Enter fullscreen',
     'FullscreenControl.Exit': 'Exit fullscreen',
     'GeolocateControl.FindMyLocation': 'Find my location',

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2289,7 +2289,7 @@ class Map extends Camera {
         this._canvas.addEventListener('webglcontextrestored', this._contextRestored, false);
         this._canvas.setAttribute('tabindex', '0');
         this._canvas.setAttribute('aria-label', 'Map');
-        this._canvas.setAttribute('role', 'application');
+        this._canvas.setAttribute('role', 'region');
 
         const dimensions = this._containerDimensions();
         this._resizeCanvas(dimensions[0], dimensions[1]);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2289,6 +2289,7 @@ class Map extends Camera {
         this._canvas.addEventListener('webglcontextrestored', this._contextRestored, false);
         this._canvas.setAttribute('tabindex', '0');
         this._canvas.setAttribute('aria-label', 'Map');
+        this._canvas.setAttribute('role', 'application');
 
         const dimensions = this._containerDimensions();
         this._resizeCanvas(dimensions[0], dimensions[1]);

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -2,6 +2,8 @@ import {test} from '../../../util/test';
 import config from '../../../../src/util/config';
 import AttributionControl from '../../../../src/ui/control/attribution_control';
 import {createMap as globalCreateMap} from '../../../util';
+import window from '../../../../src/util/window';
+import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
     config.ACCESS_TOKEN = 'pk.123';
@@ -72,6 +74,28 @@ test('AttributionControl appears in compact mode if container is less then 640 p
     map.resize();
 
     t.equal(container.querySelectorAll('.mapboxgl-ctrl-attrib.mapboxgl-compact').length, 1);
+    t.end();
+});
+
+test('AttributionControl compact mode control toggles attribution', (t) => {
+    const map = createMap(t);
+    map.addControl(new AttributionControl({
+        compact: true
+    }));
+
+    const container = map.getContainer();
+    const toggle = container.querySelector('.mapboxgl-ctrl-attrib-button');
+
+    t.equal(container.querySelectorAll('.mapboxgl-compact-show').length, 0);
+
+    simulate.click(toggle);
+
+    t.equal(container.querySelectorAll('.mapboxgl-compact-show').length, 1);
+
+    simulate.click(toggle);
+
+    t.equal(container.querySelectorAll('.mapboxgl-compact-show').length, 0);
+
     t.end();
 });
 

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -2,7 +2,6 @@ import {test} from '../../../util/test';
 import config from '../../../../src/util/config';
 import AttributionControl from '../../../../src/ui/control/attribution_control';
 import {createMap as globalCreateMap} from '../../../util';
-import window from '../../../../src/util/window';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {


### PR DESCRIPTION
Addresses some Level A and Level AA failures as outlined in https://github.com/Malvoz/web-maps-wcag-evaluation/blob/ac797a3e5fe984db27662c27ae05077e7b22026b/README.md

### Level A

In https://github.com/Malvoz/web-maps-wcag-evaluation#131-info-and-relationships-level-a

> The "Zoom out" control's disabled state cannot be programmatically determined.

| Change | Screenshot |
| --- | --- |
| Adds `aria-hidden` attribute when min/max controls trigger disabled states | ![disabled-state](https://user-images.githubusercontent.com/61150/93778242-aa3d7300-fbf3-11ea-803a-e3a5b9424eb0.gif) |

In https://github.com/Malvoz/web-maps-wcag-evaluation#211-keyboard-level-a

> Control to display attribution and feedback links is not keyboard accessible.

| Change | Screenshot |
| --- | --- |
| When attribution is compact, the icon now acts as a toggle button to open and close attribution contents. This changes the behavior of it being triggered on hover but I think its a more sensible/predictable change to make. | ![attribution](https://user-images.githubusercontent.com/61150/93780157-ce01b880-fbf5-11ea-8144-38c820223ba7.gif) |

In https://github.com/Malvoz/web-maps-wcag-evaluation#412-name-role-value-level-a

> The "map component" (<canvas tabindex="0">, which acts as a control to both zoom and pan the map display) is missing role.

Added `role:region` to the canvas container.

> Control to display attribution and feedback links is missing name and role.

Added `role:list` to the `.mapboxgl-ctrl-attrib-inner` container. This also requires an upstream change to the TileJSON doc to add [`role:listitem`](https://www.w3.org/TR/wai-aria-1.1/#listitem)

### Level AA

In https://github.com/Malvoz/web-maps-wcag-evaluation#247-focus-visible-level-aa

> 1 tab stop without focus indicator.

This is addressed by turning the compact attribution link into a button toggle with focus.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes~~
 - [ ] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Addresses some Level A and Level AA accesibility recommendations</changelog>`


---

- Closes #3959
