### PR TITLE
Add related example link to 'match' expression in style spec

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2699,7 +2699,7 @@
         }
       },
       "match": {
-        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n - a single literal value; or\n - an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the `\"in\"` operator.\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.",
+        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n - a single literal value; or\n - an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the `\"in\"` operator.\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.\n\n**Related:**\n - Example: [Style circles with a data-driven property](https://docs.mapbox.com/mapbox-gl-js/example/data-driven-circle-colors/)",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2699,7 +2699,7 @@
         }
       },
       "match": {
-        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n - a single literal value; or\n - an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the `\"in\"` operator.\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.\n\n**Related:**\n - Example: [Style circles with a data-driven property](https://docs.mapbox.com/mapbox-gl-js/example/data-driven-circle-colors/)",
+        "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n - a single literal value; or\n - an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the `\"in\"` operator.\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.\n\n**Related example:**\n - [Style circles with a data-driven property](https://docs.mapbox.com/mapbox-gl-js/example/data-driven-circle-colors/)",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
Adds a link to an existing example that uses the match expression.

Here's a preview – see the screenshot below marked `PR`.

@mapbox/docs Do y'all think it would be worthwhile to move this item below the code block? (see the screenshot below marked `?`)

I imagine this would mean adding a new element to the JSON, which I like because it sets the stage for consistency in linking to examples and automation for programmatic links between examples and GL JS / style spec documentation.

![Screen Shot 2020-09-22 at 11 15 33 AM](https://user-images.githubusercontent.com/6026447/93922233-8434d300-fcc6-11ea-8f3e-62aae1c48d31.jpg)
