### PR TITLE
[Feature] Add load tile function for a custom source option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,20 @@ const exported = {
     },
 
     /**
+     * Sets a custom load tile function for url that starts with custom://
+     *
+     * @var {Function} loadFn - a function that receives
+     * (requestParameters: RequestParameters, callback: ResponseCallback<any>) and calls the callback with the tile buffer
+     * or with a Error instance
+     * @example
+     * mapboxgl.loadTilesFunction = (requestParameters, callback) => callback(null, tileBuffer, null, null);
+     */
+
+    set loadTilesFunction(loadFn: Function) {
+        config.LOAD_TILES_FUNCTION = loadFn;
+    },
+
+    /**
      * Gets and sets the map's default API URL for requesting tiles, styles, sprites, and glyphs
      *
      * @var {string} baseApiUrl

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -242,6 +242,12 @@ export const makeRequest = function(requestParameters: RequestParameters, callba
     //   some versions (see https://bugs.webkit.org/show_bug.cgi?id=174980#c2)
     // - Requests for resources with the file:// URI scheme don't work with the Fetch API either. In
     //   this case we unconditionally use XHR on the current thread since referrers don't matter.
+    if (/^custom:/.test(requestParameters.url) && isWorker() && self.worker && self.worker.actor) {
+        return self.worker.actor.send('getResource', requestParameters, callback);
+    }
+    if (/^custom:/.test(requestParameters.url) && !isWorker() && config.LOAD_TILES_FUNCTION != null) {
+        return config.LOAD_TILES_FUNCTION(requestParameters, callback);
+    }
     if (!isFileURL(requestParameters.url)) {
         if (window.fetch && window.Request && window.AbortController && window.Request.prototype.hasOwnProperty('signal')) {
             return makeFetchRequest(requestParameters, callback);


### PR DESCRIPTION
Basically what I described in: Custom sources #2920.
By adding a `custom://` url for tile url in the style and adding this function implementation to `mapboxgl.loadTilesFunction` this allows the clients to be able to get tiles from local storage, file system, indexDB and other places.
These are all the required code changes, which I believe are relatively small.
I'm not sure what else and where else to document/test/describe this change.
