### PR TITLE
Add option to control classList in `mapboxgl-popup-content`

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -18,6 +18,7 @@ const defaultOptions = {
     closeButton: true,
     closeOnClick: true,
     className: '',
+    contentClassName: '',
     maxWidth: "240px"
 };
 
@@ -30,6 +31,7 @@ export type PopupOptions = {
     anchor?: Anchor,
     offset?: Offset,
     className?: string,
+    contentClassName?: string,
     maxWidth?: string
 };
 
@@ -56,6 +58,7 @@ export type PopupOptions = {
  *   - an object of {@link Point}s specifing an offset for each anchor position
  *  Negative offsets indicate left and up.
  * @param {string} [options.className] Space-separated CSS class names to add to popup container
+ * @param {string} [options.contentClassName] Space-separated CSS class names to add to popup content container
  * @param {string} [options.maxWidth='240px'] -
  *  A string that sets the CSS property of the popup's maximum width, eg `'300px'`.
  *  To ensure the popup resizes to fit its content, set this property to `'none'`.
@@ -467,6 +470,10 @@ export default class Popup extends Evented {
         }
 
         this._content = DOM.create('div', 'mapboxgl-popup-content', this._container);
+        if (this.options.contentClassName) {
+            this.options.contentClassName.split(' ').forEach(name =>
+                this._content.classList.add(name));
+        }
         if (this.options.closeButton) {
             this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', this._content);
             this._closeButton.type = 'button';

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -571,6 +571,19 @@ test('Popup adds classes from className option, methods for class manipulations 
     t.end();
 });
 
+test('Popup adds classes from contentClassName option', (t) => {
+    const map = createMap(t);
+    const popup = new Popup({contentClassName: 'some classes'})
+        .setText('Test')
+        .setLngLat([0, 0])
+        .addTo(map);
+
+    const popupContentContainer = popup.getElement().querySelector('.mapboxgl-popup-content');
+    t.ok(popupContentContainer.classList.contains('some'));
+    t.ok(popupContentContainer.classList.contains('classes'));
+    t.end();
+});
+
 test('Cursor-tracked popup disappears on mouseout', (t) => {
     const map = createMap(t);
 


### PR DESCRIPTION
## Launch Checklist

Adds an `option.contentClassName` to the Popup control to allow a consumer to add to the classlist of the `mapboxgl-popup-content` element. I feel a little weird about this change as its intent is the same as https://github.com/mapbox/mapbox-gl-js/issues/6299 but unlike #6299 this targets the container responsible for padding directly.

 - [x] briefly describe the changes in this PR
 - [ ] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes~~
 - [ ] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add `option.contentClassName` to Popup control</changelog>`

---
Closes #10023 

