### PR TITLE
Add hasControl method

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -569,10 +569,6 @@ class Map extends Camera {
      * map.hasControl(navigation);
      */
     hasControl(control: IControl) {
-        if (!control || typeof control !== 'object') {
-            return this.fire(new ErrorEvent(new Error(
-                'Invalid argument to map.hasControl(). Argument must be a control.')));
-        }
         return this._controls.indexOf(control) > -1;
     }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -556,6 +556,27 @@ class Map extends Camera {
     }
 
     /**
+     * Checks if a control exists on the map.
+     *
+     * @param {IControl} control The {@link IControl} to check.
+     * @returns {boolean} True if map contains control.
+     * @example
+     * // Define a new navigation control.
+     * var navigation = new mapboxgl.NavigationControl();
+     * // Add zoom and rotation controls to the map.
+     * map.addControl(navigation);
+     * // Check that the navigation control exists on the map.
+     * map.hasControl(navigation);
+     */
+    hasControl(control: IControl) {
+        if (!control || typeof control !== 'object') {
+            return this.fire(new ErrorEvent(new Error(
+                'Invalid argument to map.hasControl(). Argument must be a control.')));
+        }
+        return this._controls.indexOf(control) > -1;
+    }
+
+    /**
      * Resizes the map according to the dimensions of its
      * `container` element.
      *

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1033,7 +1033,7 @@ test('Map', (t) => {
 
     t.test('#hasControl', (t) => {
         const map = createMap(t);
-        function Ctrl() {};
+        function Ctrl() {}
         Ctrl.prototype = {
             onAdd(_) {
                 return window.document.createElement('div');

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1019,6 +1019,34 @@ test('Map', (t) => {
 
     });
 
+    t.test('#hasControl errors on invalid arguments', (t) => {
+        const map = createMap(t);
+        const control = 'control';
+        const stub = t.stub(console, 'error');
+
+        map.addControl(control);
+        map.hasControl(control);
+        t.ok(stub.calledTwice);
+        t.end();
+
+    });
+
+    t.test('#hasControl', (t) => {
+        const map = createMap(t);
+        function Ctrl() {};
+        Ctrl.prototype = {
+            onAdd(_) {
+                return window.document.createElement('div');
+            }
+        };
+
+        const control = new Ctrl();
+        t.equal(map.hasControl(control), false, 'Reference to control is not found');
+        map.addControl(control);
+        t.equal(map.hasControl(control), true, 'Reference to control is found');
+        t.end();
+    });
+
     t.test('#project', (t) => {
         const map = createMap(t);
         t.deepEqual(map.project([0, 0]), {x: 100, y: 100});

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1019,18 +1019,6 @@ test('Map', (t) => {
 
     });
 
-    t.test('#hasControl errors on invalid arguments', (t) => {
-        const map = createMap(t);
-        const control = 'control';
-        const stub = t.stub(console, 'error');
-
-        map.addControl(control);
-        map.hasControl(control);
-        t.ok(stub.calledTwice);
-        t.end();
-
-    });
-
     t.test('#hasControl', (t) => {
         const map = createMap(t);
         function Ctrl() {}


### PR DESCRIPTION
## Launch Checklist

Adds a `hasControl` method to `src/ui/map.js` so clients can detect whether a control already exists before calling `addControl` or `removeControl`.


 - [x] briefly describe the changes in this PR
 - [ ] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] ~~post benchmark scores~~
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes~~
 - [ ] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Adds a `hasControl` method to map</changelog>`
