### PR TITLE
Clear out the content container rather than deleting it

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -413,7 +413,11 @@ export default class Popup extends Evented {
     setDOMContent(htmlNode: Node) {
         if (this._content) {
             // Clear out children first.
-            while (this._content.firstChild) this._content.firstChild.remove();
+            while (this._content.hasChildNodes()) {
+                if (this._content.firstChild) {
+                    this._content.removeChild(this._content.firstChild);
+                }
+            }
         } else {
             this._content = DOM.create('div', 'mapboxgl-popup-content', this._container);
         }

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -411,7 +411,13 @@ export default class Popup extends Evented {
      *   .addTo(map);
      */
     setDOMContent(htmlNode: Node) {
-        this._createContent();
+        if (this._content) {
+            // Clear out children first.
+            while (this._content.firstChild) this._content.firstChild.remove();
+        } else {
+            this._content = DOM.create('div', 'mapboxgl-popup-content', this._container);
+        }
+
         // The close button should be the last tabbable element inside the popup for a good keyboard UX.
         this._content.appendChild(htmlNode);
         this._createCloseButton();
@@ -477,14 +483,6 @@ export default class Popup extends Evented {
         if (this._container) {
             return this._container.classList.toggle(className);
         }
-    }
-
-    _createContent() {
-        if (this._content) {
-            DOM.remove(this._content);
-        }
-
-        this._content = DOM.create('div', 'mapboxgl-popup-content', this._container);
     }
 
     _createCloseButton() {


### PR DESCRIPTION
## Launch Checklist

This PR changes behavior in popup.js. Currently, when `setDOMContent` is called, it destroys the content container, creates a new one, and populates. This is undesirable under situations where you don't want to introduce a CSS file as a dependency to a plugin and wish to modify the content container using JavaScript. 

Right now I'm calling this every time I want to add new data (which is happening on mouseover when `queryRenderedFeatures` returns a response):

```js
const selector = popup.getElement().querySelector('.mapboxgl-popup-content');
selector.style.padding = '0'
```

| Without modifications | With modifications |
| --- | --- |
| <img width="893" alt="Screen Shot 2020-10-15 at 5 15 15 PM" src="https://user-images.githubusercontent.com/61150/96186887-14eb8100-0f0a-11eb-9252-948cf7c4cd2f.png"> |<img width="892" alt="Screen Shot 2020-10-15 at 5 15 40 PM" src="https://user-images.githubusercontent.com/61150/96186888-15841780-0f0a-11eb-9f48-49e18093f93f.png"> |


I would prefer to modify the DOM once and not have this be repeatedly called. 

I'm a little nervous this constitutes a breaking change even though it's minor. Curious what y'all thoughts are.


 - [x] briefly describe the changes in this PR
 - [ ] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] ~~tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes~~
 - [ ] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Clear out the popup content container instead of deleting it</changelog>`
