### PR TITLE
10056 image migration

### DIFF
--- a/test/unit/style-spec/migrate.test.js
+++ b/test/unit/style-spec/migrate.test.js
@@ -88,7 +88,7 @@ test('converts stop functions to expressions', (t) => {
     t.end();
 });
 
-test('converts categorical functions to valid expressions', (t) => {
+test('converts categorical function on resolvedImage type to valid expression', (t) => {
     const migrated = migrate({
         version: 8,
         sources: {
@@ -112,6 +112,13 @@ test('converts categorical functions to valid expressions', (t) => {
             }
         }]
     }, spec.latest.$version);
+    t.deepEqual(migrated.layers[0].layout['icon-image'], [
+        "match",
+        ["get", "type" ],
+        "park",
+        "some-icon",
+        ""
+    ]);
     t.deepEqual(validate.parsed(migrated, v8), []);
     t.end();
 });

--- a/test/unit/style-spec/migrate.test.js
+++ b/test/unit/style-spec/migrate.test.js
@@ -88,6 +88,34 @@ test('converts stop functions to expressions', (t) => {
     t.end();
 });
 
+test('converts categorical functions to valid expressions', (t) => {
+    const migrated = migrate({
+        version: 8,
+        sources: {
+            streets: {
+                url: 'mapbox://mapbox.streets',
+                type: 'vector'
+            }
+        },
+        layers: [{
+            id: '1',
+            source: 'streets',
+            'source-layer': 'labels',
+            type: 'symbol',
+            layout: {
+                'icon-image': {
+                    base: 1,
+                    type: 'categorical',
+                    property: 'type',
+                    stops: [['park', 'some-icon']]
+                }
+            }
+        }]
+    }, spec.latest.$version);
+    t.deepEqual(validate.parsed(migrated, v8), []);
+    t.end();
+});
+
 glob.sync(`${__dirname}/fixture/v7-migrate/*.input.json`).forEach((file) => {
     test(path.basename(file), (t) => {
         const outputfile = file.replace('.input', '.output');


### PR DESCRIPTION
<changelog>
Fix bug where legacy functions could be migrated to invalid expressions on properties with `resolvedImage` type.
</changelog>


cc: @mapbox/map-design-team

Closes #10056

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [ ] ~~manually test the debug page~~
 - [x] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
