### PR TITLE
Fix syntax error in getFeatureState example

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2218,7 +2218,7 @@ class Map extends Camera {
      *   if (e.features.length > 0) {
      *     map.getFeatureState({
      *       source: 'my-source',
-     *       sourceLayer: 'my-source-layer'
+     *       sourceLayer: 'my-source-layer',
      *       id: e.features[0].id
      *     });
      *   }


### PR DESCRIPTION
Fixes a syntax error in [`getFeatureState` inline example](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#getfeaturestate) in the API reference docs.