### PR TITLE
add keyboard.disableRotation and tests

### DIFF
--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -131,27 +131,67 @@ class KeyboardHandler {
         };
     }
 
+    /**
+     * Enables the "keyboard rotate and zoom" interaction.
+     *
+     * @example
+     *   map.keyboard.enable();
+     */
     enable() {
         this._enabled = true;
     }
 
+    /**
+     * Disables the "keyboard rotate and zoom" interaction.
+     *
+     * @example
+     *   map.keyboard.disable();
+     */
     disable() {
         this._enabled = false;
         this.reset();
     }
 
+    /**
+     * Returns a Boolean indicating whether the "keyboard rotate and zoom"
+     * interaction is enabled.
+     *
+     * @returns {boolean} `true` if the "keyboard rotate and zoom"
+     * interaction is enabled.
+     */
     isEnabled() {
         return this._enabled;
     }
 
+    /**
+     * Returns true if the handler is enabled and has detected the start of a
+     * zoom/rotate gesture.
+     *
+     * @returns {boolean} `true` if the handler is enabled and has detected the
+     * start of a zoom/rotate gesture.
+     */
     isActive() {
         return this._active;
     }
 
+    /**
+     * Disables the "keyboard pan/rotate" interaction, leaving the
+     * "keyboard zoom" interaction enabled.
+     *
+     * @example
+     *   map.keyboard.disableRotation();
+     */
     disableRotation() {
         this._rotationDisabled = true;
     }
 
+    /**
+     * Enables the "keyboard pan/rotate" interaction.
+     *
+     * @example
+     *   map.keyboard.enable();
+     *   map.keyboard.enableRotation();
+     */
     enableRotation() {
         this._rotationDisabled = false;
     }

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -28,6 +28,7 @@ class KeyboardHandler {
     _panStep: number;
     _bearingStep: number;
     _pitchStep: number;
+    _rotationDisabled: boolean;
 
     /**
     * @private
@@ -37,6 +38,7 @@ class KeyboardHandler {
         this._panStep = stepOptions.panStep;
         this._bearingStep = stepOptions.bearingStep;
         this._pitchStep = stepOptions.pitchStep;
+        this._rotationDisabled = false;
     }
 
     reset() {
@@ -106,6 +108,11 @@ class KeyboardHandler {
             return;
         }
 
+        if (this._rotationDisabled) {
+            bearingDir = 0;
+            pitchDir = 0;
+        }
+
         return {
             cameraAnimation: (map: Map) => {
                 const zoom = map.getZoom();
@@ -139,6 +146,14 @@ class KeyboardHandler {
 
     isActive() {
         return this._active;
+    }
+
+    disableRotation() {
+        this._rotationDisabled = true;
+    }
+
+    enableRotation() {
+        this._rotationDisabled = false;
     }
 }
 

--- a/test/unit/ui/handler/keyboard.test.js
+++ b/test/unit/ui/handler/keyboard.test.js
@@ -57,6 +57,41 @@ test('KeyboardHandler pans map in response to arrow keys', (t) => {
     t.end();
 });
 
+test('KeyboardHandler pans map in response to arrow keys when disableRotation has been called', (t) => {
+    const map = createMap(t, {zoom: 10, center: [0, 0]});
+    t.spy(map, 'easeTo');
+    map.keyboard.disableRotation();
+
+    simulate.keydown(map.getCanvas(), {keyCode: 32, key: " "});
+    t.notOk(map.easeTo.called, 'pressing a non-arrow key should have no effect');
+
+    simulate.keydown(map.getCanvas(), {keyCode: 37, key: "ArrowLeft"});
+    t.ok(map.easeTo.called, 'pressing the left arrow key should trigger an easeTo animation');
+    let easeToArgs = map.easeTo.getCall(0).args[0];
+    t.equal(easeToArgs.offset[0], 100, 'pressing the left arrow key should offset map positively in X direction');
+    t.equal(easeToArgs.offset[1], 0, 'pressing the left arrow key should not offset map in Y direction');
+
+    simulate.keydown(map.getCanvas(), {keyCode: 39, key: "ArrowRight"});
+    t.ok(map.easeTo.callCount === 2, 'pressing the right arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(1).args[0];
+    t.equal(easeToArgs.offset[0], -100, 'pressing the right arrow key should offset map negatively in X direction');
+    t.equal(easeToArgs.offset[1], 0, 'pressing the right arrow key should not offset map in Y direction');
+
+    simulate.keydown(map.getCanvas(), {keyCode: 40, key: "ArrowDown"});
+    t.ok(map.easeTo.callCount === 3, 'pressing the down arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(2).args[0];
+    t.equal(easeToArgs.offset[0], 0, 'pressing the down arrow key should not offset map in X direction');
+    t.equal(easeToArgs.offset[1], -100, 'pressing the down arrow key should offset map negatively in Y direction');
+
+    simulate.keydown(map.getCanvas(), {keyCode: 38, key: "ArrowUp"});
+    t.ok(map.easeTo.callCount === 4, 'pressing the up arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(3).args[0];
+    t.equal(easeToArgs.offset[0], 0, 'pressing the up arrow key should not offset map in X direction');
+    t.equal(easeToArgs.offset[1], 100, 'pressing the up arrow key should offset map positively in Y direction');
+
+    t.end();
+});
+
 test('KeyboardHandler rotates map in response to Shift+left/right arrow keys', async (t) => {
     const map = createMap(t, {zoom: 10, center: [0, 0], bearing: 0});
     t.spy(map, 'easeTo');
@@ -75,6 +110,30 @@ test('KeyboardHandler rotates map in response to Shift+left/right arrow keys', a
     t.ok(map.easeTo.callCount === 2, 'pressing Shift + right arrow key should trigger an easeTo animation');
     easeToArgs = map.easeTo.getCall(1).args[0];
     t.equal(easeToArgs.bearing, 15, 'pressing Shift + right arrow key should rotate map counterclockwise');
+    t.equal(easeToArgs.offset[0], 0, 'pressing Shift + right arrow key should not offset map in X direction');
+
+    t.end();
+});
+
+test('KeyboardHandler does not rotate map in response to Shift+left/right arrow keys when disableRotation has been called', async (t) => {
+    const map = createMap(t, {zoom: 10, center: [0, 0], bearing: 0});
+    t.spy(map, 'easeTo');
+    map.keyboard.disableRotation();
+
+    simulate.keydown(map.getCanvas(), {keyCode: 32, key: " "});
+    t.notOk(map.easeTo.called, 'pressing a non-arrow key should have no effect');
+
+    simulate.keydown(map.getCanvas(), {keyCode: 37, key: "ArrowLeft", shiftKey: true});
+    t.ok(map.easeTo.called, 'pressing Shift + left arrow key should trigger an easeTo animation');
+    let easeToArgs = map.easeTo.getCall(0).args[0];
+    t.equal(easeToArgs.bearing, 0, 'pressing Shift + left arrow key should not rotate map clockwise');
+    t.equal(easeToArgs.offset[0], 0, 'pressing Shift + left arrow key should not offset map in X direction');
+
+    map.setBearing(0);
+    simulate.keydown(map.getCanvas(), {keyCode: 39, key: "ArrowRight", shiftKey: true});
+    t.ok(map.easeTo.callCount === 2, 'pressing Shift + right arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(1).args[0];
+    t.equal(easeToArgs.bearing, 0, 'pressing Shift + right arrow key should not rotate map counterclockwise');
     t.equal(easeToArgs.offset[0], 0, 'pressing Shift + right arrow key should not offset map in X direction');
 
     t.end();
@@ -103,9 +162,60 @@ test('KeyboardHandler pitches map in response to Shift+up/down arrow keys', asyn
     t.end();
 });
 
+test('KeyboardHandler does not pitch map in response to Shift+up/down arrow keys when disableRotation has been called', async (t) => {
+    const map = createMap(t, {zoom: 10, center: [0, 0], pitch: 30});
+    t.spy(map, 'easeTo');
+    map.keyboard.disableRotation();
+
+    simulate.keydown(map.getCanvas(), {keyCode: 32, key: " "});
+    t.notOk(map.easeTo.called, 'pressing a non-arrow key should have no effect');
+
+    simulate.keydown(map.getCanvas(), {keyCode: 40, key: "ArrowDown", shiftKey: true});
+    t.ok(map.easeTo.called, 'pressing Shift + down arrow key should trigger an easeTo animation');
+    let easeToArgs = map.easeTo.getCall(0).args[0];
+    t.equal(easeToArgs.pitch, 30, 'pressing Shift + down arrow key should not pitch the map less');
+    t.equal(easeToArgs.offset[1], 0, 'pressing Shift + down arrow key should not offset map in Y direction');
+
+    map.setPitch(30);
+    simulate.keydown(map.getCanvas(), {keyCode: 38, key: "ArrowUp", shiftKey: true});
+    t.ok(map.easeTo.callCount === 2, 'pressing Shift + up arrow key should trigger an easeTo animation');
+    easeToArgs = map.easeTo.getCall(1).args[0];
+    t.equal(easeToArgs.pitch, 30, 'pressing Shift + up arrow key should not pitch the map more');
+    t.equal(easeToArgs.offset[1], 0, 'pressing Shift + up arrow key should not offset map in Y direction');
+
+    t.end();
+});
+
 test('KeyboardHandler zooms map in response to -/+ keys', (t) => {
     const map = createMap(t, {zoom: 10, center: [0, 0]});
     t.spy(map, 'easeTo');
+
+    simulate.keydown(map.getCanvas(), {keyCode: 187, key: "Equal"});
+    t.equal(map.easeTo.callCount, 1, 'pressing the +/= key should trigger an easeTo animation');
+    t.equal(map.easeTo.getCall(0).args[0].zoom, 11, 'pressing the +/= key should zoom map in');
+
+    map.setZoom(10);
+    simulate.keydown(map.getCanvas(), {keyCode: 187, key: "Equal", shiftKey: true});
+    t.equal(map.easeTo.callCount, 2, 'pressing Shift + +/= key should trigger an easeTo animation');
+    t.equal(map.easeTo.getCall(1).args[0].zoom, 12, 'pressing Shift + +/= key should zoom map in more');
+
+    map.setZoom(10);
+    simulate.keydown(map.getCanvas(), {keyCode: 189, key: "Minus"});
+    t.equal(map.easeTo.callCount, 3, 'pressing the -/_ key should trigger an easeTo animation');
+    t.equal(map.easeTo.getCall(2).args[0].zoom, 9, 'pressing the -/_ key should zoom map out');
+
+    map.setZoom(10);
+    simulate.keydown(map.getCanvas(), {keyCode: 189, key: "Minus", shiftKey: true});
+    t.equal(map.easeTo.callCount, 4, 'pressing Shift + -/_ key should trigger an easeTo animation');
+    t.equal(map.easeTo.getCall(3).args[0].zoom, 8, 'pressing Shift + -/_ key should zoom map out more');
+
+    t.end();
+});
+
+test('KeyboardHandler zooms map in response to -/+ keys when disableRotation has been called', (t) => {
+    const map = createMap(t, {zoom: 10, center: [0, 0]});
+    t.spy(map, 'easeTo');
+    map.keyboard.disableRotation();
 
     simulate.keydown(map.getCanvas(), {keyCode: 187, key: "Equal"});
     t.equal(map.easeTo.callCount, 1, 'pressing the +/= key should trigger an easeTo animation');


### PR DESCRIPTION
fix #3768

adds the option to disable and enable map rotation from the keyboard,

```
// disable
map.keyboard.disableRotation();
// enable
map.keyboard.enableRotation();
```

similar to,

```
// disable
map.touchZoomRotate.disableRotation();
// enable
map.touchZoomRotate.enableRotation();
```

so you do not have to disable all zooming and panning options the keyboard can provide with `map.keyboard.disable()`.

adds unit tests to support,
* map still pans when rotation disabled
* map does not rotate when rotation is disabled
* map does not tilt when rotation is disabled
* map still zooms when rotation is disabled

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>adds disableRotation() and enableRotation() to KeyboardHandler</changelog>`

@mapbox/map-design-team @mapbox/static-apis adds to KeyboardHandler instance members
* https://docs.mapbox.com/mapbox-gl-js/api/map/#map#keyboard
* https://docs.mapbox.com/mapbox-gl-js/api/handlers/#keyboardhandler