### PR TITLE
Fix data-driven property evaluation in queryRenderedFeatures

### DIFF
--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -11,7 +11,7 @@ import DictionaryCoder from '../util/dictionary_coder';
 import vt from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
 import GeoJSONFeature from '../util/vectortile_to_geojson';
-import {arraysIntersect, mapObject} from '../util/util';
+import {arraysIntersect, mapObject, extend} from '../util/util';
 import {OverscaledTileID} from '../source/tile_id';
 import {register} from '../util/web_worker_transfer';
 import EvaluationParameters from '../style/evaluation_parameters';
@@ -214,7 +214,7 @@ class FeatureIndex {
                 featureState = sourceFeatureState.getState(styleLayer.sourceLayer || '_geojsonTileLayer', id);
             }
 
-            const serializedLayer = serializedLayers[layerID];
+            const serializedLayer = extend({}, serializedLayers[layerID]);
 
             serializedLayer.paint = evaluateProperties(serializedLayer.paint, styleLayer.paint, feature, featureState, availableImages);
             serializedLayer.layout = evaluateProperties(serializedLayer.layout, styleLayer.layout, feature, featureState, availableImages);

--- a/test/integration/query-tests/regressions/mapbox-gl-js#10074/expected.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#10074/expected.json
@@ -1,0 +1,114 @@
+[
+  {
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          13.406662344932556,
+          52.49845542419487
+        ],
+        [
+          13.406715989112854,
+          52.49853706825692
+        ],
+        [
+          13.407037854194641,
+          52.499007335102704
+        ],
+        [
+          13.40782642364502,
+          52.50002296369735
+        ],
+        [
+          13.409215807914734,
+          52.50175045812034
+        ]
+      ]
+    },
+    "type": "Feature",
+    "properties": {
+      "class": "main",
+      "oneway": 0,
+      "osm_id": 4612696,
+      "type": "secondary"
+    },
+    "id": 4612696,
+    "layer": {
+      "id": "road",
+      "type": "circle",
+      "source": "mapbox",
+      "source-layer": "road",
+      "paint": {
+        "circle-radius": 10
+      },
+      "layout": {}
+    },
+    "source": "mapbox",
+    "sourceLayer": "road",
+    "state": {
+      "stateA": 10
+    }
+  },
+  {
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          13.404956459999084,
+          52.50075446300568
+        ],
+        [
+          13.405857682228088,
+          52.500525870779285
+        ],
+        [
+          13.40782642364502,
+          52.50002296369735
+        ],
+        [
+          13.41029942035675,
+          52.49939268890719
+        ],
+        [
+          13.410347700119019,
+          52.49937962612168
+        ],
+        [
+          13.410476446151733,
+          52.49934370344147
+        ],
+        [
+          13.410674929618835,
+          52.499291452217875
+        ],
+        [
+          13.4122896194458,
+          52.498840782836766
+        ]
+      ]
+    },
+    "type": "Feature",
+    "properties": {
+      "class": "street",
+      "oneway": 0,
+      "osm_id": 4612752,
+      "type": "residential"
+    },
+    "id": 4612752,
+    "layer": {
+      "id": "road",
+      "type": "circle",
+      "source": "mapbox",
+      "source-layer": "road",
+      "paint": {
+        "circle-radius": 50
+      },
+      "layout": {}
+    },
+    "source": "mapbox",
+    "sourceLayer": "road",
+    "state": {
+      "stateA": 50
+    }
+  }
+]

--- a/test/integration/query-tests/regressions/mapbox-gl-js#10074/style.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#10074/style.json
@@ -1,0 +1,62 @@
+{
+  "version": 8,
+  "metadata": {
+    "skipLayerDelete": true,
+    "test": {
+      "height": 256,
+      "operations": [
+        [
+            "setFeatureState",
+            {
+                "source": "mapbox",
+                "sourceLayer": "road",
+                "id": 4612696
+            },
+            {
+                "stateA": 10
+            }
+        ], [
+            "setFeatureState",
+            {
+                "source": "mapbox",
+                "sourceLayer": "road",
+                "id": 4612752
+            },
+            {
+                "stateA": 50
+            }
+        ]
+      ],
+      "queryGeometry": [
+        10,
+        100
+      ]
+    }
+  },
+  "center": [
+    13.418056,
+    52.499167
+  ],
+  "zoom": 14,
+  "sources": {
+    "mapbox": {
+      "type": "vector",
+      "maxzoom": 14,
+      "tiles": [
+        "local://tiles/{z}-{x}-{y}.mvt"
+      ]
+    }
+  },
+  "layers": [
+    {
+      "id": "road",
+      "type": "circle",
+      "source": "mapbox",
+      "source-layer": "road",
+      "paint": {
+        "circle-radius": ["feature-state", "stateA"]
+      },
+      "interactive": true
+    }
+  ]
+}


### PR DESCRIPTION
## Bug description
Evaluated properties returned by `queryRenderedValues` have the same values across the same layers, even if they are data-driven and need to be different.

## JSFiddle
https://jsfiddle.net/osvodef/tj8boaxd/17/
This queries all settlement labels and outputs their text fields in the console.

## Solution
This bug was due to serialized layers being cached, and multiple features of the same layer sharing the same serialized layer object. I fixed this by taking a shallow copy of the cached layer for each individual feature.

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page