### PR TITLE
Allow custom HTTP base API URLs to get HTTP responses

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -173,6 +173,11 @@ export class RequestManager {
         urlObject.protocol = apiUrlObject.protocol;
         urlObject.authority = apiUrlObject.authority;
 
+        if (urlObject.protocol === 'http') {
+            const i = urlObject.params.indexOf('secure');
+            if (i >= 0) urlObject.params.splice(i, 1);
+        }
+
         if (apiUrlObject.path !== '/') {
             urlObject.path = `${apiUrlObject.path}${urlObject.path}`;
         }

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -151,6 +151,15 @@ test("mapbox", (t) => {
                 t.end();
             });
 
+            t.test('removes secure params if custom API_URL is http', (t) => {
+                config.API_URL = 'http://test.example.com/api.mapbox.com';
+                t.equal(
+                    manager.normalizeSourceURL('mapbox://one.a'),
+                    'http://test.example.com/api.mapbox.com/v4/one.a.json?access_token=key'
+                );
+                t.end();
+            });
+
             t.end();
         });
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - When `config.API_URL` has an `http` protocol, we remove the `secure` URL parameter 
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Allow custom HTTP base API URLs to get HTTP responses</changelog>`
