### PR TITLE
Fixed dom event coordinates for scaled container

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -168,7 +168,7 @@ class ScrollZoomHandler {
             this._type = null;
             this._lastValue = value;
 
-            // Start a timeout in case this was a singular event, and dely it by up to 40ms.
+            // Start a timeout in case this was a singular event, and delay it by up to 40ms.
             this._timeout = setTimeout(this._onTimeout, 40, e);
 
         } else if (!this._type) {
@@ -200,7 +200,7 @@ class ScrollZoomHandler {
         e.preventDefault();
     }
 
-    _onTimeout(initialEvent: any) {
+    _onTimeout(initialEvent: WheelEvent) {
         this._type = 'wheel';
         this._delta -= this._lastValue;
         if (!this._active) {
@@ -208,7 +208,7 @@ class ScrollZoomHandler {
         }
     }
 
-    _start(e: any) {
+    _start(e: WheelEvent) {
         if (!this._delta) return;
 
         if (this._frameId) {

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -299,7 +299,8 @@ class HandlerManager {
         this._updatingCamera = true;
         assert(e.timeStamp !== undefined);
 
-        const inputEvent = e.type === 'renderFrame' ? undefined : ((e: any): InputEvent);
+        const isRenderFrame = e.type === 'renderFrame';
+        const inputEvent = isRenderFrame ? undefined : ((e: any): InputEvent);
 
         /*
          * We don't call e.preventDefault() for any events by default.
@@ -311,7 +312,9 @@ class HandlerManager {
         const activeHandlers = {};
 
         const mapTouches = e.touches ? this._getMapTouches(((e: any): TouchEvent).touches) : undefined;
-        const points = mapTouches ? DOM.touchPos(this._el, mapTouches) : DOM.mousePos(this._el, ((e: any): MouseEvent));
+        const points = mapTouches ? DOM.touchPos(this._el, mapTouches) :
+            isRenderFrame ? undefined : // renderFrame event doesn't have any points
+            DOM.mousePos(this._el, ((e: any): MouseEvent));
 
         for (const {handlerName, handler, allowed} of this._handlers) {
             if (!handler.isEnabled()) continue;

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -103,22 +103,17 @@ DOM.suppressClick = function() {
     }, 0);
 };
 
-DOM.mousePos = function (el: HTMLElement, e: MouseEvent | window.TouchEvent | Touch) {
+DOM.mousePos = function (el: HTMLElement, e: MouseEvent | WheelEvent) {
     const rect = el.getBoundingClientRect();
-    return new Point(
-        e.clientX - rect.left - el.clientLeft,
-        e.clientY - rect.top - el.clientTop
-    );
+    return getScaledPoint(el, rect, e);
 };
 
 DOM.touchPos = function (el: HTMLElement, touches: TouchList) {
     const rect = el.getBoundingClientRect(),
         points = [];
+
     for (let i = 0; i < touches.length; i++) {
-        points.push(new Point(
-            touches[i].clientX - rect.left - el.clientLeft,
-            touches[i].clientY - rect.top - el.clientTop
-        ));
+        points.push(getScaledPoint(el, rect, touches[i]));
     }
     return points;
 };
@@ -140,3 +135,14 @@ DOM.remove = function(node: HTMLElement) {
         node.parentNode.removeChild(node);
     }
 };
+
+function getScaledPoint(el: HTMLElement, rect: ClientRect, e: MouseEvent | WheelEvent | Touch) {
+    // Until we get support for pointer events (https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent)
+    // we use this dirty trick which would not work for the case of rotated transforms, but works well for
+    // the case of simple scaling:
+    const scaling = el.offsetWidth / rect.width;
+    return new Point(
+        (e.clientX - rect.left) * scaling,
+        (e.clientY - rect.top) * scaling
+    );
+}

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -139,8 +139,9 @@ DOM.remove = function(node: HTMLElement) {
 function getScaledPoint(el: HTMLElement, rect: ClientRect, e: MouseEvent | WheelEvent | Touch) {
     // Until we get support for pointer events (https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent)
     // we use this dirty trick which would not work for the case of rotated transforms, but works well for
-    // the case of simple scaling:
-    const scaling = el.offsetWidth / rect.width;
+    // the case of simple scaling.
+    // Note: `el.offsetWidth === rect.width` eliminates the `0/0` case.
+    const scaling = el.offsetWidth === rect.width ? 1 : el.offsetWidth / rect.width;
     return new Point(
         (e.clientX - rect.left) * scaling,
         (e.clientY - rect.top) * scaling


### PR DESCRIPTION
When map container belongs to a CSS transformed tree, the `getBoundingClientRect()` based solutions report incorrect
coordinates.

This change accounts for scale during DOM events processing and fixes https://github.com/mapbox/mapbox-gl-js/issues/6079

This solution would not work for the cases when css transform includes rotation or skew. But should serve as a decent band-aid for the case of simple scaling.

## Launch Checklist

* Verified that the issue described in https://github.com/mapbox/mapbox-gl-js/issues/6079 is fixed with this change. 
* Verified for both touch and mouse devices
* Verified that there is no jumping behavior when mouse leaves map container

The following items *have not been* done. Please let me know if these are blockers for the merge.

 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality 
 - [ ] post benchmark scores
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
