### PR TITLE
Fix dynamically added props not appearing in queryRenderedFeatures results

### DIFF
--- a/test/integration/query-tests/regressions/mapbox-gl-js#10102/expected.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#10102/expected.json
@@ -1,0 +1,37 @@
+[
+  {
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          0,
+          0
+        ],
+        [
+          5.009765625,
+          14.987239525774243
+        ]
+      ]
+    },
+    "type": "Feature",
+    "properties": {},
+    "id": 1,
+    "layer": {
+      "id": "line",
+      "type": "line",
+      "source": "mapbox",
+      "paint": {
+        "line-width": 20,
+        "line-color": {
+          "r": 0,
+          "g": 0,
+          "b": 0,
+          "a": 1
+        }
+      },
+      "layout": {}
+    },
+    "source": "mapbox",
+    "state": {}
+  }
+]

--- a/test/integration/query-tests/regressions/mapbox-gl-js#10102/style.json
+++ b/test/integration/query-tests/regressions/mapbox-gl-js#10102/style.json
@@ -1,0 +1,48 @@
+{
+    "version": 8,
+    "metadata": {
+        "skipLayerDelete": true,
+        "test": {
+            "width": 64,
+            "height": 64,
+            "operations": [
+                ["setPaintProperty", "line", "line-color", "#000000"]
+            ],
+            "queryGeometry": [
+                32,
+                16
+            ]
+        }
+    },
+    "sources": {
+        "mapbox": {
+            "type": "geojson",
+            "data": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "id": 1,
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [
+                                [ 0, 0],
+                                [ 5, 15]
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "layers": [
+        {
+            "id": "line",
+            "type": "line",
+            "source": "mapbox",
+            "paint": {
+                "line-width": 20
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Bug description
Optional layout and paint properties don't appear in `queryRenderedFeatures` results if they're set after layer creation.

## JSFiddle
https://jsfiddle.net/osvodef/f45dapvu/10/
This sets a `text-opacity` property to a label and then queries it.

## Solution
Like in https://github.com/mapbox/mapbox-gl-js/pull/10074, the bug occurs because of serialized layers caching. I modified `evaluateProperties` so that it iterates over `styleLayer._transitionablePaint._values` and `styleLayer._unevaluatedLayout._values` objects instead of the outdated serialized `layout` and `paint` objects.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] write tests for all new functionality
