### PR TITLE
Use global variables for shader attributes

### DIFF
--- a/src/shaders/shaders.js
+++ b/src/shaders/shaders.js
@@ -102,12 +102,13 @@ function compile(fragmentSource, vertexSource) {
 varying ${precision} ${type} ${name};
 #else
 uniform ${precision} ${type} u_${name};
+${precision} ${type} ${name};
 #endif
 `;
         } else /* if (operation === 'initialize') */ {
             return `
 #ifdef HAS_UNIFORM_u_${name}
-    ${precision} ${type} ${name} = u_${name};
+    ${name} = u_${name};
 #endif
 `;
         }
@@ -126,6 +127,7 @@ attribute ${precision} ${attrType} a_${name};
 varying ${precision} ${type} ${name};
 #else
 uniform ${precision} ${type} u_${name};
+${precision} ${type} ${name};
 #endif
 `;
             } else /* if (operation === 'initialize') */ {
@@ -135,7 +137,7 @@ uniform ${precision} ${type} u_${name};
 #ifndef HAS_UNIFORM_u_${name}
     ${name} = a_${name};
 #else
-    ${precision} ${type} ${name} = u_${name};
+    ${name} = u_${name};
 #endif
 `;
                 } else {
@@ -143,7 +145,7 @@ uniform ${precision} ${type} u_${name};
 #ifndef HAS_UNIFORM_u_${name}
     ${name} = unpack_mix_${unpackType}(a_${name}, u_${name}_t);
 #else
-    ${precision} ${type} ${name} = u_${name};
+    ${name} = u_${name};
 #endif
 `;
                 }
@@ -157,23 +159,24 @@ attribute ${precision} ${attrType} a_${name};
 #else
 uniform ${precision} ${type} u_${name};
 #endif
+${precision} ${type} ${name};
 `;
             } else /* if (operation === 'initialize') */ {
                 if (unpackType === 'vec4') {
                     // vec4 attributes are only used for cross-faded properties, and are not packed
                     return `
 #ifndef HAS_UNIFORM_u_${name}
-    ${precision} ${type} ${name} = a_${name};
+    ${name} = a_${name};
 #else
-    ${precision} ${type} ${name} = u_${name};
+    ${name} = u_${name};
 #endif
 `;
                 } else /* */{
                     return `
 #ifndef HAS_UNIFORM_u_${name}
-    ${precision} ${type} ${name} = unpack_mix_${unpackType}(a_${name}, u_${name}_t);
+    ${name} = unpack_mix_${unpackType}(a_${name}, u_${name}_t);
 #else
-    ${precision} ${type} ${name} = u_${name};
+    ${name} = u_${name};
 #endif
 `;
                 }


### PR DESCRIPTION
I'm modifying the mapbox shaders in a fork and ran into an issue where attributes would not be exposed to GLSL functions.

This is an issue with the design of `#pragma mapbox`:
- In some instances, the expected variable of name `${name}` (without prefix) gets declared in `define` (Global scope) and other times in `initialize` (Local scope; typically in `main` function).
- Only `initialize` (Local scope) will ensure that a variable of the expected name  (`${name}`) is created (initialized from a global variable of a name with prefix, or no-op if a global variable existed). However, one would expect `define` to handle this.

In the following list, I've marked where `define`/`initialize` leads to global scope with ✔️ , and local scope with ❌ :

- Attributes in fragment-shader:
    - Global scope if they are per-vertex (define: `varying ${name}` ✔️ ).
    - Local scope if they are uniform for all vertices (define: `uniform u_${name}` ❌ ).
- Attributes in vertex-shader that are also used in fragment shader:
    - Global scope if they are per-vertex (define: `attribute a_${name}`+`varying ${name}` ✔️ ).
    - Local scope if they are uniform for all vertices (define: `uniform u_${name}` ❌ ).
- Attributes in vertex-shader that aren't used in fragment shader:
    - Local scope if they are per-vertex (define: `attribute a_${name}` ❌ ).
    - Local scope if they are uniform for all vertices (define: `uniform u_${name}` ❌ ).


This PR fixes this issue, by moving the declaration of the `${name}` variable from `initialize` to `define`.
Thereby, all attributes will always be exposed in global scope with their expected name.

A potential issue that I see, is that the change from this PR allows the user to use un-initialized variables, when using variables from `define` before doing `initialize`. However, I believe this is negligible and also used to be the case for variables which were already in global scope (✔️ in list above).

---

*There are still many other issues with these `#pragma`; namely that they do unexpected type conversions (variable name has an impact on the type) which change their expected type. There is also a lot of redundancy with the user manually having to specify the `initialize` for each variable, when this should be automated. I consider doing more cleanups in other PRs in the future.*
