### PR TITLE
[main] Ensure Image DataURI is released

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -280,6 +280,9 @@ function arrayBufferToImage(data: ArrayBuffer, callback: (err: ?Error, image: ?H
     img.onload = () => {
         callback(null, img);
         URL.revokeObjectURL(img.src);
+        // prevent image dataURI memory leak in Safari
+        img.onload = null;
+        img.src = transparentPngUrl;
     };
     img.onerror = () => callback(new Error('Could not load image. Please make sure to use a supported image type such as PNG or JPEG. Note that SVGs are not supported.'));
     const blob: Blob = new window.Blob([new Uint8Array(data)], {type: 'image/png'});

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -110,7 +110,9 @@ test('ajax', (t) => {
         const jsdomImage = window.Image;
         window.Image = class {
             set src(src) {
-                setTimeout(() => this.onload());
+                setTimeout(() => {
+                    if (this.onload) this.onload();
+                });
             }
         };
 
@@ -200,7 +202,9 @@ test('ajax', (t) => {
         // jsdom doesn't call image onload; fake it https://github.com/jsdom/jsdom/issues/1816
         window.Image = class {
             set src(src) {
-                setTimeout(() => this.onload());
+                setTimeout(() => {
+                    if (this.onload) this.onload();
+                });
             }
         };
 


### PR DESCRIPTION
Partially addresses #9126. Safari leaks memory when loading images as data URI blobs through `img.src`, never freeing it, so it keeps piling up, in particular affecting styles with satellite and hillshade layers.