### PR TITLE
Do not prefix /raster/v1/ tile routes with /v4/

### DIFF
--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -111,15 +111,17 @@ export class RequestManager {
         const urlObject = parseUrl(tileURL);
         const imageExtensionRe = /(\.(png|jpg)\d*)(?=$)/;
         const tileURLAPIPrefixRe = /^.+\/v4\//;
-
-        // The v4 mapbox tile API supports 512x512 image tiles only when @2x
-        // is appended to the tile URL. If `tileSize: 512` is specified for
-        // a Mapbox raster source force the @2x suffix even if a non hidpi device.
-        const suffix = browser.devicePixelRatio >= 2 || tileSize === 512 ? '@2x' : '';
         const extension = webpSupported.supported ? '.webp' : '$1';
-        urlObject.path = urlObject.path.replace(imageExtensionRe, `${suffix}${extension}`);
-        // Do not add the v4 prefix in front of raster/v1 tiles URLs
-        if (!urlObject.path.match(/^(\/raster\/v1\/)/)) {
+
+        // Do not add the v4 prefix or @2x suffix in raster/v1 tiles URLs
+        if (urlObject.path.match(/^(\/raster\/v1\/)/)) {
+            urlObject.path = urlObject.path.replace(imageExtensionRe, `${extension}`);
+        } else {
+            // The v4 mapbox tile API supports 512x512 image tiles only when @2x
+            // is appended to the tile URL. If `tileSize: 512` is specified for
+            // a Mapbox raster source force the @2x suffix even if a non hidpi device.
+            const suffix = browser.devicePixelRatio >= 2 || tileSize === 512 ? '@2x' : '';
+            urlObject.path = urlObject.path.replace(imageExtensionRe, `${suffix}${extension}`);
             urlObject.path = urlObject.path.replace(tileURLAPIPrefixRe, '/');
             urlObject.path = `/v4${urlObject.path}`;
         }

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -406,6 +406,11 @@ test("mapbox", (t) => {
                 t.equal(manager.normalizeTileURL("mapbox://tiles/a.b,c.d/0/0/0.pbf"), `https://api.mapbox.com/v4/a.b,c.d/0/0/0.pbf?sku=${manager._skuToken}&access_token=key`);
                 t.equal(manager.normalizeTileURL("mapbox://tiles/raster/v1/a.b/0/0/0.png"), `https://api.mapbox.com/raster/v1/a.b/0/0/0.png?sku=${manager._skuToken}&access_token=key`);
 
+                // Does not add @2x to raster tiles
+                window.devicePixelRatio = 2;
+                t.equal(manager.normalizeTileURL("mapbox://tiles/raster/v1/a.b/0/0/0.png"), `https://api.mapbox.com/raster/v1/a.b/0/0/0.png?sku=${manager._skuToken}&access_token=key`);
+                window.devicePixelRatio = 1;
+
                 config.API_URL = 'https://api.example.com/';
                 t.equal(manager.normalizeTileURL("mapbox://tiles/a.b/0/0/0.png"), `https://api.example.com/v4/a.b/0/0/0.png?sku=${manager._skuToken}&access_token=key`);
                 t.equal(manager.normalizeTileURL("http://path"), "http://path");

--- a/test/unit/util/mapbox.test.js
+++ b/test/unit/util/mapbox.test.js
@@ -307,6 +307,8 @@ test("mapbox", (t) => {
                 "mapbox://tiles/a.b/{z}/{x}/{y}.png");
             t.equals(manager.canonicalizeTileURL("http://api.mapbox.com/v4/a.b/{z}/{x}/{y}.png?access_token=key", tileJSONURL),
                 "mapbox://tiles/a.b/{z}/{x}/{y}.png");
+            t.equals(manager.canonicalizeTileURL("http://api.mapbox.com/raster/v1/a.b/{z}/{x}/{y}.png?access_token=key", tileJSONURL),
+                "mapbox://tiles/raster/v1/a.b/{z}/{x}/{y}.png");
 
             // We don't ever expect to see these inputs, but be safe anyway.
             t.equals(manager.canonicalizeTileURL("http://path"), "http://path");
@@ -402,6 +404,7 @@ test("mapbox", (t) => {
                 t.equal(manager.normalizeTileURL("mapbox://tiles/a.b/0/0/0.png"), `https://api.mapbox.com/v4/a.b/0/0/0.png?sku=${manager._skuToken}&access_token=key`);
                 t.equal(manager.normalizeTileURL("mapbox://tiles/a.b/0/0/0@2x.png"), `https://api.mapbox.com/v4/a.b/0/0/0@2x.png?sku=${manager._skuToken}&access_token=key`);
                 t.equal(manager.normalizeTileURL("mapbox://tiles/a.b,c.d/0/0/0.pbf"), `https://api.mapbox.com/v4/a.b,c.d/0/0/0.pbf?sku=${manager._skuToken}&access_token=key`);
+                t.equal(manager.normalizeTileURL("mapbox://tiles/raster/v1/a.b/0/0/0.png"), `https://api.mapbox.com/raster/v1/a.b/0/0/0.png?sku=${manager._skuToken}&access_token=key`);
 
                 config.API_URL = 'https://api.example.com/';
                 t.equal(manager.normalizeTileURL("mapbox://tiles/a.b/0/0/0.png"), `https://api.example.com/v4/a.b/0/0/0.png?sku=${manager._skuToken}&access_token=key`);


### PR DESCRIPTION
## Background

We want `api.mapbox.com/raster/v1` tiles URLs to be parsed and normalized with the same logic as `api.mapbox.com/v4` tiles URLs.

## Description of changes

All `api.mapbox.com/raster/v1` tile URLs get canonicalized to:

```
mapbox://tiles/raster/v1/...
```

And then get normalized back to `api.mapbox.com/raster/v1`. The logic is very dependent on checking whether `/raster/v1` exists in the URLs or not, so this logic is not extensible to other new tile URL types, but I think that is okay for now.

This does not change any public APIs.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [x] write tests for all new functionality
 - [x] ~~document any changes to public APIs~~
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
