### PR TITLE
Update projection.js

### DIFF
--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -319,7 +319,7 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
     }
 
     for (const glyph: any of placedGlyphs) {
-        if(!!glyph.point && glyph.angle) {
+        if (!!glyph.point && glyph.angle) {
             addDynamicAttributes(dynamicLayoutVertexArray, glyph.point, glyph.angle);
         }
     }

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -194,7 +194,7 @@ function updateLineLabels(bucket: SymbolBucket,
         const placeUnflipped: any = placeGlyphsAlongLine(symbol, pitchScaledFontSize, false /*unflipped*/, keepUpright, posMatrix, labelPlaneMatrix, glCoordMatrix,
             bucket.glyphOffsetArray, lineVertexArray, dynamicLayoutVertexArray, anchorPoint, tileAnchorPoint, projectionCache, aspectRatio);
 
-        useVertical = placeUnflipped.useVertical;
+        useVertical = placeUnflipped.useVertical || null;
 
         if (placeUnflipped.notEnoughRoom || useVertical ||
             (placeUnflipped.needsFlipping &&
@@ -319,7 +319,9 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
     }
 
     for (const glyph: any of placedGlyphs) {
-        addDynamicAttributes(dynamicLayoutVertexArray, glyph.point, glyph.angle);
+        if(!!glyph.point && glyph.angle) {
+            addDynamicAttributes(dynamicLayoutVertexArray, glyph.point, glyph.angle);
+        }
     }
     return {};
 }


### PR DESCRIPTION
Fixed glyphs not being rendered after tilting and zoomming consistently.

Basically the error is "Cannot read property useVertical of undefined" and it occurs - at least in the only case I've found out - when using custom glyphs and while zoomming & tilting consistently. At first it doesn't give any error in console and everything works fine; but after a while the library starts to give that error in console until the browser crash. As far as I've understood & debugged the function that contains the line I've modified is called very often and that's why the browser's crash.

Sadly I can't give you a live example since I'm not allowed to share those glyphs, plus I didn't make the logic - in my company - that tells the map to use those glyphs.
