### PR TITLE
Popup.addClassName() works before popup is on the map (fix #9677)

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -106,11 +106,16 @@ export default class Popup extends Evented {
     _lngLat: LngLat;
     _trackPointer: boolean;
     _pos: ?Point;
+    _classList: DOMTokenList; // stores all user-defined classes
 
     constructor(options: PopupOptions) {
         super();
         this.options = extend(Object.create(defaultOptions), options);
         bindAll(['_update', '_onClose', 'remove', '_onMouseMove', '_onMouseUp', '_onDrag'], this);
+
+        const classListElem = DOM.create('div');
+        classListElem.className = this.options.className;
+        this._classList = classListElem.classList;
     }
 
     /**
@@ -440,6 +445,7 @@ export default class Popup extends Evented {
      * popup.addClassName('some-class')
      */
     addClassName(className: string) {
+        this._classList.add(className);
         if (this._container) {
             this._container.classList.add(className);
         }
@@ -455,21 +461,10 @@ export default class Popup extends Evented {
      * popup.removeClassName('some-class')
      */
     removeClassName(className: string) {
+        this._classList.remove(className);
         if (this._container) {
             this._container.classList.remove(className);
         }
-    }
-
-    /**
-     * Sets the popup's offset.
-     *
-     * @param offset Sets the popup's offset.
-     * @returns {Popup} `this`
-     */
-    setOffset (offset?: Offset) {
-        this.options.offset = offset;
-        this._update();
-        return this;
     }
 
     /**
@@ -484,9 +479,22 @@ export default class Popup extends Evented {
      * popup.toggleClassName('toggleClass')
      */
     toggleClassName(className: string) {
+        this._classList.toggle(className);
         if (this._container) {
             return this._container.classList.toggle(className);
         }
+    }
+
+    /**
+     * Sets the popup's offset.
+     *
+     * @param offset Sets the popup's offset.
+     * @returns {Popup} `this`
+     */
+    setOffset (offset?: Offset) {
+        this.options.offset = offset;
+        this._update();
+        return this;
     }
 
     _createCloseButton() {
@@ -520,9 +528,8 @@ export default class Popup extends Evented {
             this._container = DOM.create('div', 'mapboxgl-popup', this._map.getContainer());
             this._tip       = DOM.create('div', 'mapboxgl-popup-tip', this._container);
             this._container.appendChild(this._content);
-            if (this.options.className) {
-                this.options.className.split(' ').forEach(name =>
-                    this._container.classList.add(name));
+            for (let idx = 0; idx < this._classList.length; idx++) {
+                this._container.classList.add(this._classList.item(idx));
             }
 
             if (this._trackPointer) {

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -571,6 +571,30 @@ test('Popup adds classes from className option, methods for class manipulations 
     t.end();
 });
 
+test('Popup classes can be manipulated before the popup is on the map', (t) => {
+    const map = createMap(t);
+    const popup = new Popup({className: 'some classes'})
+        .setText('Test')
+        .setLngLat([0, 0]);
+
+    popup.addClassName('addedClass');
+    popup.removeClassName('some');
+    popup.toggleClassName('toggle');
+
+    t.throws(() => popup.addClassName('should throw exception'), window.DOMException);
+
+    popup.addTo(map);
+
+    const popupContainer = popup.getElement();
+
+    t.ok(!popupContainer.classList.contains('some'));
+    t.ok(popupContainer.classList.contains('classes'));
+    t.ok(popupContainer.classList.contains('addedClass'));
+    t.ok(popupContainer.classList.contains('toggle'));
+
+    t.end();
+});
+
 test('Cursor-tracked popup disappears on mouseout', (t) => {
     const map = createMap(t);
 


### PR DESCRIPTION
Fixes #9677 by storing user-defined classes in a separate private attribute. Uses `DOMTokenList` to make sure the behavior of all the className-related methods is always the same.

I've added a separate unit test for this situation.  

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a bug where Popup.addClassName() didn't work before the popup is on the map. #9677</changelog>`
