### PR TITLE
Fix broken serialization of RasterDEMTileSource

### DIFF
--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -28,17 +28,6 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
         this.encoding = options.encoding || "mapbox";
     }
 
-    serialize() {
-        return {
-            type: 'raster-dem',
-            url: this.url,
-            tileSize: this.tileSize,
-            tiles: this.tiles,
-            bounds: this.bounds,
-            encoding: this.encoding
-        };
-    }
-
     loadTile(tile: Tile, callback: Callback<void>) {
         const url = this.map._requestManager.normalizeTileURL(tile.tileID.canonical.url(this.tiles, this.scheme), this.tileSize);
         tile.request = getImage(this.map._requestManager.transformRequest(url, ResourceType.Tile), imageLoaded.bind(this));


### PR DESCRIPTION
Fixes #8506

I just removed the `serialize()` implementation in `RasterDEMTileSource` to reuse implementation from `RasterTileSource` (returns original options)

Two notes:
  1. Potentially, it breaks backward compatibility (if someone passes `url` option and expects later to see `tiles`, `bounds`, and other options in `map.getStyle()`. I'm not sure how critical is this change.
  2. I haven't added a test for this case because I found no tests for `serialize()` methods in sources. Do we need it?

cc @srmanc @vakila

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a bug where map.getStyle returns incorrect options for "raster-dem" sources. #8605</changelog>`
