### PR TITLE
[docs] Update getStyle example

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1423,7 +1423,9 @@ class Map extends Camera {
      * @returns {Object} The map's style JSON object.
      *
      * @example
-     * var styleJson = map.getStyle();
+     * map.on('load', function() {
+     *   var styleJson = map.getStyle();
+     * });
      *
      */
     getStyle() {


### PR DESCRIPTION
Based on some user feedback, this update the `getStyle` example, putting it in `map.on('load', function() { ... })` since the current example may or may not work as expected depending on where it is placed. The user expressed that having a self-contained and complete example would be extremely helpful.

