### PR TITLE
fire map mouse events during scroll zooming

### DIFF
--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -267,13 +267,13 @@ class HandlerManager {
         this._add('touchRotate', touchRotate, ['touchPan', 'touchZoom']);
         this._add('touchZoom', touchZoom, ['touchPan', 'touchRotate']);
 
+        this._add('blockableMapEvent', new BlockableMapEventHandler(map));
+
         const scrollZoom = map.scrollZoom = new ScrollZoomHandler(map, this);
         this._add('scrollZoom', scrollZoom, ['mousePan']);
 
         const keyboard = map.keyboard = new KeyboardHandler();
         this._add('keyboard', keyboard);
-
-        this._add('blockableMapEvent', new BlockableMapEventHandler(map));
 
         for (const name of ['boxZoom', 'doubleClickZoom', 'tapDragZoom', 'touchPitch', 'dragRotate', 'dragPan', 'touchZoomRotate', 'scrollZoom', 'keyboard']) {
             if (options.interactive && (options: any)[name]) {

--- a/test/unit/ui/handler/map_event.test.js
+++ b/test/unit/ui/handler/map_event.test.js
@@ -94,7 +94,6 @@ test('MapEvent handler fires touchmove even while drag handler is active', (t) =
 
 test('MapEvent handler fires mousemove even while scroll handler is active', (t) => {
     const map = createMap(t);
-    const target = map.getCanvas();
     map.scrollZoom.enable();
     map.dragPan.enable();
 
@@ -106,7 +105,7 @@ test('MapEvent handler fires mousemove even while scroll handler is active', (t)
     map.on('mousemove', mousemove);
     map.on('zoomstart', zoom);
 
-    simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta})
+    simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta});
     t.equal(wheel.callCount, 1);
 
     simulate.mousemove(map.getCanvas(), {buttons: 0, clientX: 10, clientY: 10});

--- a/test/unit/ui/handler/map_event.test.js
+++ b/test/unit/ui/handler/map_event.test.js
@@ -91,3 +91,30 @@ test('MapEvent handler fires touchmove even while drag handler is active', (t) =
     map.remove();
     t.end();
 });
+
+test('MapEvent handler fires mousemove even while scroll handler is active', (t) => {
+    const map = createMap(t);
+    const target = map.getCanvas();
+    map.scrollZoom.enable();
+    map.dragPan.enable();
+
+    const wheel = t.spy();
+    const mousemove = t.spy();
+    const zoom = t.spy();
+
+    map.on('wheel', wheel);
+    map.on('mousemove', mousemove);
+    map.on('zoomstart', zoom);
+
+    simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta})
+    t.equal(wheel.callCount, 1);
+
+    simulate.mousemove(map.getCanvas(), {buttons: 0, clientX: 10, clientY: 10});
+    t.equal(mousemove.callCount, 1);
+    t.deepEqual(mousemove.getCall(0).args[0].point, {x: 10, y: 10});
+
+    map._renderTaskQueue.run();
+    t.equal(zoom.callCount, 1);
+
+    t.end();
+});


### PR DESCRIPTION
fix #10155

Moving BlockableMapEventHandler above ScrollZoomHandler prevents it from being blocked by that handler.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [n/a] document any changes to public APIs
 - [n/a] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix firing map mouse events during scroll zoom.</changelog>`
