### PR TITLE
Clean up browser hacks that are no longer necessary

### DIFF
--- a/build/check-bundle-size.js
+++ b/build/check-bundle-size.js
@@ -53,6 +53,7 @@ const repo = 'mapbox-gl-js';
     execSync(`git reset --hard && git checkout origin/main`);
     execSync('yarn install');
     execSync('yarn run build-prod-min');
+    execSync('yarn run build-css');
     const priorSizes = FILES.map(([label, filePath]) => [label, getSize(filePath)]);
     console.log(priorSizes);
 

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -22,12 +22,8 @@
 
 .mapboxgl-canvas-container.mapboxgl-interactive,
 .mapboxgl-ctrl-group button.mapboxgl-ctrl-compass {
-    cursor: -webkit-grab;
-    cursor: -moz-grab;
     cursor: grab;
-    -moz-user-select: none;
     -webkit-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }
 
@@ -37,8 +33,6 @@
 
 .mapboxgl-canvas-container.mapboxgl-interactive:active,
 .mapboxgl-ctrl-group button.mapboxgl-ctrl-compass:active {
-    cursor: -webkit-grabbing;
-    cursor: -moz-grabbing;
     cursor: grabbing;
 }
 
@@ -84,8 +78,6 @@
 }
 
 .mapboxgl-ctrl-group:not(:empty) {
-    -moz-box-shadow: 0 0 2px rgba(0, 0, 0, 0.1);
-    -webkit-box-shadow: 0 0 2px rgba(0, 0, 0, 0.1);
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
 }
 
@@ -127,12 +119,6 @@
     .mapboxgl-ctrl-group button + button {
         border-top: 1px solid ButtonText;
     }
-}
-
-/* https://bugzilla.mozilla.org/show_bug.cgi?id=140562 */
-.mapboxgl-ctrl button::-moz-focus-inner {
-    border: 0;
-    padding: 0;
 }
 
 .mapboxgl-ctrl-attrib-button:focus,
@@ -326,10 +312,6 @@
 }
 
 .mapboxgl-ctrl button.mapboxgl-ctrl-geolocate.mapboxgl-ctrl-geolocate-waiting .mapboxgl-ctrl-icon {
-    -webkit-animation: mapboxgl-spin 2s infinite linear;
-    -moz-animation: mapboxgl-spin 2s infinite linear;
-    -o-animation: mapboxgl-spin 2s infinite linear;
-    -ms-animation: mapboxgl-spin 2s infinite linear;
     animation: mapboxgl-spin 2s infinite linear;
 }
 
@@ -367,26 +349,6 @@
     .mapboxgl-ctrl button.mapboxgl-ctrl-geolocate:disabled .mapboxgl-ctrl-icon {
         background-image: svg-inline(ctrl-geolocate-disabled-black);
     }
-}
-
-@-webkit-keyframes mapboxgl-spin {
-    0% { -webkit-transform: rotate(0deg); }
-    100% { -webkit-transform: rotate(360deg); }
-}
-
-@-moz-keyframes mapboxgl-spin {
-    0% { -moz-transform: rotate(0deg); }
-    100% { -moz-transform: rotate(360deg); }
-}
-
-@-o-keyframes mapboxgl-spin {
-    0% { -o-transform: rotate(0deg); }
-    100% { -o-transform: rotate(360deg); }
-}
-
-@-ms-keyframes mapboxgl-spin {
-    0% { -ms-transform: rotate(0deg); }
-    100% { -ms-transform: rotate(360deg); }
 }
 
 @keyframes mapboxgl-spin {
@@ -561,7 +523,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     position: absolute;
     top: 0;
     left: 0;
-    display: -webkit-flex;
     display: flex;
     will-change: transform;
     pointer-events: none;
@@ -570,24 +531,20 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 .mapboxgl-popup-anchor-top,
 .mapboxgl-popup-anchor-top-left,
 .mapboxgl-popup-anchor-top-right {
-    -webkit-flex-direction: column;
     flex-direction: column;
 }
 
 .mapboxgl-popup-anchor-bottom,
 .mapboxgl-popup-anchor-bottom-left,
 .mapboxgl-popup-anchor-bottom-right {
-    -webkit-flex-direction: column-reverse;
     flex-direction: column-reverse;
 }
 
 .mapboxgl-popup-anchor-left {
-    -webkit-flex-direction: row;
     flex-direction: row;
 }
 
 .mapboxgl-popup-anchor-right {
-    -webkit-flex-direction: row-reverse;
     flex-direction: row-reverse;
 }
 
@@ -599,14 +556,12 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 }
 
 .mapboxgl-popup-anchor-top .mapboxgl-popup-tip {
-    -webkit-align-self: center;
     align-self: center;
     border-top: none;
     border-bottom-color: #fff;
 }
 
 .mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip {
-    -webkit-align-self: flex-start;
     align-self: flex-start;
     border-top: none;
     border-left: none;
@@ -614,7 +569,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 }
 
 .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
-    -webkit-align-self: flex-end;
     align-self: flex-end;
     border-top: none;
     border-right: none;
@@ -622,14 +576,12 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 }
 
 .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip {
-    -webkit-align-self: center;
     align-self: center;
     border-bottom: none;
     border-top-color: #fff;
 }
 
 .mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip {
-    -webkit-align-self: flex-start;
     align-self: flex-start;
     border-bottom: none;
     border-left: none;
@@ -637,7 +589,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 }
 
 .mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
-    -webkit-align-self: flex-end;
     align-self: flex-end;
     border-bottom: none;
     border-right: none;
@@ -645,14 +596,12 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 }
 
 .mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
-    -webkit-align-self: center;
     align-self: center;
     border-left: none;
     border-right-color: #fff;
 }
 
 .mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
-    -webkit-align-self: center;
     align-self: center;
     border-right: none;
     border-left-color: #fff;
@@ -741,9 +690,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     height: 15px;
     border-radius: 50%;
     position: absolute;
-    -webkit-animation: mapboxgl-user-location-dot-pulse 2s infinite;
-    -moz-animation: mapboxgl-user-location-dot-pulse 2s infinite;
-    -ms-animation: mapboxgl-user-location-dot-pulse 2s infinite;
     animation: mapboxgl-user-location-dot-pulse 2s infinite;
 }
 
@@ -758,18 +704,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     width: 19px;
     box-sizing: border-box;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.35);
-}
-
-@-webkit-keyframes mapboxgl-user-location-dot-pulse {
-    0%   { -webkit-transform: scale(1); opacity: 1; }
-    70%  { -webkit-transform: scale(3); opacity: 0; }
-    100% { -webkit-transform: scale(1); opacity: 0; }
-}
-
-@-ms-keyframes mapboxgl-user-location-dot-pulse {
-    0%   { -ms-transform: scale(1); opacity: 1; }
-    70%  { -ms-transform: scale(3); opacity: 0; }
-    100% { -ms-transform: scale(1); opacity: 0; }
 }
 
 @keyframes mapboxgl-user-location-dot-pulse {

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -46,12 +46,8 @@ class FullscreenControl {
         ], this);
         if ('onfullscreenchange' in window.document) {
             this._fullscreenchange = 'fullscreenchange';
-        } else if ('onmozfullscreenchange' in window.document) {
-            this._fullscreenchange = 'mozfullscreenchange';
         } else if ('onwebkitfullscreenchange' in window.document) {
             this._fullscreenchange = 'webkitfullscreenchange';
-        } else if ('onmsfullscreenchange' in window.document) {
-            this._fullscreenchange = 'MSFullscreenChange';
         }
     }
 
@@ -77,8 +73,6 @@ class FullscreenControl {
     _checkFullscreenSupport() {
         return !!(
             window.document.fullscreenEnabled ||
-            (window.document: any).mozFullScreenEnabled ||
-            (window.document: any).msFullscreenEnabled ||
             (window.document: any).webkitFullscreenEnabled
         );
     }
@@ -109,9 +103,7 @@ class FullscreenControl {
     _changeIcon() {
         const fullscreenElement =
             window.document.fullscreenElement ||
-            (window.document: any).mozFullScreenElement ||
-            (window.document: any).webkitFullscreenElement ||
-            (window.document: any).msFullscreenElement;
+            (window.document: any).webkitFullscreenElement;
 
         if ((fullscreenElement === this._container) !== this._fullscreen) {
             this._fullscreen = !this._fullscreen;
@@ -125,19 +117,11 @@ class FullscreenControl {
         if (this._isFullscreen()) {
             if (window.document.exitFullscreen) {
                 (window.document: any).exitFullscreen();
-            } else if (window.document.mozCancelFullScreen) {
-                (window.document: any).mozCancelFullScreen();
-            } else if (window.document.msExitFullscreen) {
-                (window.document: any).msExitFullscreen();
             } else if (window.document.webkitCancelFullScreen) {
                 (window.document: any).webkitCancelFullScreen();
             }
         } else if (this._container.requestFullscreen) {
             this._container.requestFullscreen();
-        } else if ((this._container: any).mozRequestFullScreen) {
-            (this._container: any).mozRequestFullScreen();
-        } else if ((this._container: any).msRequestFullscreen) {
-            (this._container: any).msRequestFullscreen();
         } else if ((this._container: any).webkitRequestFullscreen) {
             (this._container: any).webkitRequestFullscreen();
         }

--- a/src/ui/hash.js
+++ b/src/ui/hash.js
@@ -134,13 +134,7 @@ class Hash {
     _updateHashUnthrottled() {
         // Replace if already present, else append the updated hash string
         const location = window.location.href.replace(/(#.+)?$/, this.getHashString());
-        try {
-            window.history.replaceState(window.history.state, null, location);
-        } catch (SecurityError) {
-            // IE11 does not allow this if the page is within an iframe created
-            // with iframe.contentWindow.document.write(...).
-            // https://github.com/mapbox/mapbox-gl-js/issues/7410
-        }
+        window.history.replaceState(window.history.state, null, location);
     }
 
 }

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -3,16 +3,6 @@
 import window from './window';
 import type {Cancelable} from '../types/cancelable';
 
-const raf = window.requestAnimationFrame ||
-    window.mozRequestAnimationFrame ||
-    window.webkitRequestAnimationFrame ||
-    window.msRequestAnimationFrame;
-
-const cancel = window.cancelAnimationFrame ||
-    window.mozCancelAnimationFrame ||
-    window.webkitCancelAnimationFrame ||
-    window.msCancelAnimationFrame;
-
 let linkEl;
 
 let reducedMotionQuery: MediaQueryList;
@@ -49,8 +39,8 @@ const exported = {
 
     frame(fn: (paintStartTimestamp: number) => void): Cancelable {
         if (errorState) return {cancel: () => {  }};
-        const frame = raf(fn);
-        return {cancel: () => cancel(frame)};
+        const frame = window.requestAnimationFrame(fn);
+        return {cancel: () => window.cancelAnimationFrame(frame)};
     },
 
     getImageData(img: CanvasImageSource, padding?: number = 0): ImageData {

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -21,18 +21,7 @@ DOM.createNS = function (namespaceURI: string, tagName: string) {
 };
 
 const docStyle = window.document && window.document.documentElement.style;
-
-function testProp(props) {
-    if (!docStyle) return props[0];
-    for (let i = 0; i < props.length; i++) {
-        if (props[i] in docStyle) {
-            return props[i];
-        }
-    }
-    return props[0];
-}
-
-const selectProp = testProp(['userSelect', 'MozUserSelect', 'WebkitUserSelect', 'msUserSelect']);
+const selectProp = docStyle && docStyle.userSelect !== undefined ? 'userSelect' : 'WebkitUserSelect';
 let userSelect;
 
 DOM.disableDrag = function () {
@@ -48,12 +37,8 @@ DOM.enableDrag = function () {
     }
 };
 
-const transformProp = testProp(['transform', 'WebkitTransform']);
-
 DOM.setTransform = function(el: HTMLElement, value: string) {
-    // https://github.com/facebook/flow/issues/7754
-    // $FlowFixMe
-    el.style[transformProp] = value;
+    el.style.transform = value;
 };
 
 // Feature detection for {passive: false} support in add/removeEventListener.


### PR DESCRIPTION
This PR removes some hacks (mostly CSS prefixes) that are no longer necessary — either because of dropping IE 11, or because the corresponding browsers didn't need them for years. Specifically, here are the dates for browsers supporting non-hacky version that I pulled from MDN:

- animation
    - Chrome - 2015
    - Firefox - 2012
    - Safari - 2015
- grab/grabbing cursor
    - Chrome - July 2018
    - Firefox - 2014
- flex
    - Chrome - 2013
    - Safari - 2015
- align-self
    - Chrome - 2014
    - Safari - 2015
- user-select
    - Firefox - 2016 (webkit-prefixed)
- transform
    - Chrome - 2014
    - Safari - 2015
- requestAnimationFrame
    - Chrome - 2013
    - Firefox - 2013
    - Safari - 2014

I left hacks that may still be relevant (e.g. `-webkit-user-select`, `-webkit-full-screen`, `-ms-high-contrast`).

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
