### PR TITLE
Add support for using third party worker-loader plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,8 @@ jobs:
           command: |
             cd ./test/build/transpilation &&
             npm install &&
-            npm run build
+            npm run build &&
+            rm -rf node_modules
       - store_artifacts:
           path: "test/build/transpilation"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-webpack:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
       - deploy-benchmarks:
           requires:
             - lint
@@ -199,6 +205,20 @@ jobs:
           path: test/integration/query-tests
       - store_artifacts:
           path: "test/integration/query-tests/index.html"
+
+  test-webpack:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build Webpack
+          command: |
+            cd ./test/build/transpilation &&
+            npm install &&
+            npm run build
+      - store_artifacts:
+          path: "test/build/transpilation"
 
   test-browser:
     <<: *defaults

--- a/src/index.js
+++ b/src/index.js
@@ -177,6 +177,21 @@ const exported = {
     workerUrl: '',
 
     /**
+     * Provides an interface for external module bundlers such as Webpack or Rollup to package
+     * mapbox-gl's WebWorker into a separate class and integrate it with the library.
+     *
+     *
+     * @var {Object} workerClass
+     * @returns {Object|null} a Class object an instance of which exposes the `Worker` interface.
+     * @example
+     * import mapboxgl from 'mapbox-gl/mapbox-gl-csp.js'
+     * import MapboxGLWorker from 'mapbox-gl/mapbox-gl-csp-worker.js'
+     *
+     * mapboxgl.workerClass = MapboxGLWorker;
+     */
+    workerClass: null,
+
+    /**
      * Sets the time used by GL JS internally for all animations. Useful for generating videos from GL JS.
      * @var {number} time
      */

--- a/src/index.js
+++ b/src/index.js
@@ -180,12 +180,13 @@ const exported = {
      * Provides an interface for external module bundlers such as Webpack or Rollup to package
      * mapbox-gl's WebWorker into a separate class and integrate it with the library.
      *
+     * Takes precedence over `mapboxgl.workerUrl`.
      *
      * @var {Object} workerClass
-     * @returns {Object|null} a Class object an instance of which exposes the `Worker` interface.
+     * @returns {Object|null} a Class object, an instance of which exposes the `Worker` interface.
      * @example
-     * import mapboxgl from 'mapbox-gl/mapbox-gl-csp.js'
-     * import MapboxGLWorker from 'mapbox-gl/mapbox-gl-csp-worker.js'
+     * import mapboxgl from 'mapbox-gl/dist/mapbox-gl-csp.js'
+     * import MapboxGLWorker from 'mapbox-gl/dist/mapbox-gl-csp-worker.js'
      *
      * mapboxgl.workerClass = MapboxGLWorker;
      */

--- a/src/util/browser/web_worker.js
+++ b/src/util/browser/web_worker.js
@@ -6,5 +6,5 @@ import mapboxgl from '../../';
 import type {WorkerInterface} from '../web_worker';
 
 export default function (): WorkerInterface {
-    return (mapboxgl.workerClass != null) ? new mapboxgl.workerClass() : (new window.Worker(mapboxgl.workerUrl): any);
+    return (mapboxgl.workerClass != null) ? new mapboxgl.workerClass() : (new window.Worker(mapboxgl.workerUrl): any); // eslint-disable-line new-cap
 }

--- a/src/util/browser/web_worker.js
+++ b/src/util/browser/web_worker.js
@@ -6,5 +6,5 @@ import mapboxgl from '../../';
 import type {WorkerInterface} from '../web_worker';
 
 export default function (): WorkerInterface {
-    return (new window.Worker(mapboxgl.workerUrl): any);
+    return (mapboxgl.workerClass != null) ? new mapboxgl.workerClass() : (new window.Worker(mapboxgl.workerUrl): any);
 }

--- a/test/build/transpilation/index.html
+++ b/test/build/transpilation/index.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="../../../dist/mapbox-gl.css">
+        <style>
+            #map {
+                width: 100%;
+                height: 100%
+            }
+        </style>
+        <div id = "map"></div>
+        <script src="./dist/bundle.js"></script>
+    </head>
+</html>

--- a/test/build/transpilation/index.js
+++ b/test/build/transpilation/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import mapboxgl from '../../../dist/mapbox-gl-csp.js';
 import MapboxGLWorker from '../../../dist/mapbox-gl-csp-worker.js';
 

--- a/test/build/transpilation/index.js
+++ b/test/build/transpilation/index.js
@@ -1,6 +1,7 @@
 import mapboxgl from '../../../dist/mapbox-gl-csp.js';
 import MapboxGLWorker from '../../../dist/mapbox-gl-csp-worker.js';
 
+mapboxgl.accessToken = window.prompt("Enter access token");
 mapboxgl.workerClass = MapboxGLWorker;
 
 const map = new mapboxgl.Map({

--- a/test/build/transpilation/index.js
+++ b/test/build/transpilation/index.js
@@ -1,0 +1,11 @@
+import mapboxgl from '../../../dist/mapbox-gl-csp.js';
+import MapboxGLWorker from '../../../dist/mapbox-gl-csp-worker.js';
+
+mapboxgl.workerClass = MapboxGLWorker;
+
+const map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
+    center: [-74.5, 40], // starting position [lng, lat]
+    zoom: 9 // starting zoom
+});

--- a/test/build/transpilation/package.json
+++ b/test/build/transpilation/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "gl-js-bundling-test",
+    "version": "0.0.1",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+      "build": "webpack"
+    },
+    "author": "",
+    "license": "ISC",
+    "devDependencies": {
+      "@babel/core": "^7.12.10",
+      "@babel/preset-env": "^7.12.10",
+      "babel-loader": "^8.2.2",
+      "url-loader": "^4.1.1",
+      "webpack": "^5.10.0",
+      "webpack-cli": "^4.2.0",
+      "worker-loader": "^3.0.6"
+    }
+  }

--- a/test/build/transpilation/webpack.config.js
+++ b/test/build/transpilation/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 const path = require('path');
 
 module.exports = {
@@ -27,5 +28,4 @@ module.exports = {
       }
     ]
   }
-
 };

--- a/test/build/transpilation/webpack.config.js
+++ b/test/build/transpilation/webpack.config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+
+module.exports = {
+  entry: './index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+    {
+        test: /\bmapbox-gl-csp-worker.js\b/i,
+        use: {
+            loader: "worker-loader" ,
+            options: {
+                inline: 'no-fallback'
+            }
+        },
+    },
+      {
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env']
+          }
+        }
+      }
+    ]
+  }
+
+};


### PR DESCRIPTION
This PR adds support for using WebWorker loader's from external build-systems such as Webpack or rollup.
Both their worker-loader plugins expose the bundled webworker code as a class, that when instantiated exposes the same interface as a raw Worker, i.e it has the `postMessage` and `onMessage` hooks. This means we can seamlessly swap out the global worker with this custom class to allow users to use these tools

PR for extended documentation is here:
https://github.com/mapbox/mapbox-gl-js-docs/pull/461


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add support for bundling the WebWorker with external module bundlers.</changelog>`
