### PR TITLE
Fix map.unproject regression in 2D mode

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1012,8 +1012,7 @@ class Transform {
     }
 
     /**
-     * Returns position oh horizon line, from the top, in pixels. If horizon is not
-     * visible, returns 0.
+     * Returns position of horizon line from the top of the map in pixels.
      * @private
      */
     horizonLineFromTop(): number {
@@ -1021,8 +1020,7 @@ class Transform {
         const h = this.height / 2 / Math.tan(this._fov / 2) / Math.tan(Math.max(this._pitch, 0.1)) + this.centerOffset.y;
         // incorporate 3% of the area above center to account for reduced precision.
         const horizonEpsilon = 0.03;
-        const offset = this.height / 2 - h * (1 - horizonEpsilon);
-        return Math.max(0, offset);
+        return this.height / 2 - h * (1 - horizonEpsilon);
     }
 
     /**

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -902,7 +902,7 @@ class Transform {
     pointCoordinate(p: Point): MercatorCoordinate {
         // For p above horizon, don't return point behind camera but clamp p.y at horizon line.
         const horizonOffset = this.horizonLineFromTop();
-        const clamped = horizonOffset > p.y ? new Point(p.x, horizonOffset) : p;
+        const clamped = horizonOffset > 0 && horizonOffset > p.y ? new Point(p.x, horizonOffset) : p;
 
         return this.rayIntersectionCoordinate(this.pointRayIntersection(clamped));
     }
@@ -1012,7 +1012,7 @@ class Transform {
     }
 
     /**
-     * Returns position of horizon line from the top of the map in pixels.
+     * Returns position of horizon line from the top of the map in pixels. If horizon is not visible, returns 0.
      * @private
      */
     horizonLineFromTop(): number {
@@ -1020,7 +1020,8 @@ class Transform {
         const h = this.height / 2 / Math.tan(this._fov / 2) / Math.tan(Math.max(this._pitch, 0.1)) + this.centerOffset.y;
         // incorporate 3% of the area above center to account for reduced precision.
         const horizonEpsilon = 0.03;
-        return this.height / 2 - h * (1 - horizonEpsilon);
+        const offset = this.height / 2 - h * (1 - horizonEpsilon);
+        return Math.max(0, offset);
     }
 
     /**

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -1435,11 +1435,11 @@ test('SourceCache#tilesIn', (t) => {
 
                 t.equal(tiles[0].tile.tileID.key, 16);
                 t.equal(tiles[0].tile.tileSize, 512);
-                t.deepEqual(round(tiles[0].bufferedTilespaceBounds), {min: {x: 4080, y: 4050}, max: {x:8192, y: 8162}});
+                t.deepEqual(round(tiles[0].bufferedTilespaceBounds), {min: {x: 4080, y: 4034}, max: {x:8192, y: 8162}});
 
                 t.equal(tiles[1].tile.tileID.key, 528);
                 t.equal(tiles[1].tile.tileSize, 512);
-                t.deepEqual(round(tiles[1].bufferedTilespaceBounds), {min: {x: 0, y: 4050}, max: {x: 4112, y: 8162}});
+                t.deepEqual(round(tiles[1].bufferedTilespaceBounds), {min: {x: 0, y: 4034}, max: {x: 4112, y: 8162}});
 
                 t.end();
             }
@@ -1484,11 +1484,11 @@ test('SourceCache#tilesIn', (t) => {
 
                 t.equal(tiles[0].tile.tileID.key, 17);
                 t.equal(tiles[0].tile.tileSize, 1024);
-                t.deepEqual(round(tiles[0].bufferedTilespaceBounds), {min: {x: 4088, y: 4050}, max: {x:8192, y: 8154}});
+                t.deepEqual(round(tiles[0].bufferedTilespaceBounds), {min: {x: 4088, y: 4042}, max: {x:8192, y: 8154}});
 
                 t.equal(tiles[1].tile.tileID.key, 529);
                 t.equal(tiles[1].tile.tileSize, 1024);
-                t.deepEqual(round(tiles[1].bufferedTilespaceBounds), {min: {x: 0, y: 4050}, max: {x: 4104, y: 8154}});
+                t.deepEqual(round(tiles[1].bufferedTilespaceBounds), {min: {x: 0, y: 4042}, max: {x: 4104, y: 8154}});
 
                 t.end();
             }


### PR DESCRIPTION
An attempt at fixing #10215, using @karimnaaji's suggestion. I'm not sure why the `sourceCache.tilesIn` tests behave differently and if it's an issue in practice though. Also @arindam1993 you had an alternative suggestion for a fix in mind — would do a PR for it?

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] tagged @astojilj if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix a regression with map.unproject and map.panBy acting unpredictably in certain cases.</changelog>`
