### PR TITLE
Fix ImageSource not working in FF/Safari

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -279,9 +279,11 @@ function arrayBufferToImage(data: ArrayBuffer, callback: (err: ?Error, image: ?H
     img.onload = () => {
         callback(null, img);
         URL.revokeObjectURL(img.src);
-        // prevent image dataURI memory leak in Safari
+        // prevent image dataURI memory leak in Safari;
+        // but don't free the image immediately because it might be uploaded in the next frame
+        // https://github.com/mapbox/mapbox-gl-js/issues/10226
         img.onload = null;
-        img.src = transparentPngUrl;
+        window.requestAnimationFrame(() => { img.src = transparentPngUrl; });
     };
     img.onerror = () => callback(new Error('Could not load image. Please make sure to use a supported image type such as PNG or JPEG. Note that SVGs are not supported.'));
     const blob: Blob = new window.Blob([new Uint8Array(data)], {type: 'image/png'});


### PR DESCRIPTION
Closes #10226. Turns out that since Safari/FF don't support offscreen canvas, so ImageSource uses the old blob url image loading hack, however the image isn't bound to a GL texture immediately because this is deferred to a separate `prepare` step. This leads to image sources trying to upload an image to GL that was already reset.

This is a hacky workaround — wait until the next frame before releasing the image, so that `prepare` passes can happen before. But it may be fragile — we should have a hard look at the architecture here and make it more resilient.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix ImageSource not working in some cases in Firefox & Safari.</changelog>`
