### PR TITLE
Upgrade mapbox-gl-supported to v2.0.0

### DIFF
--- a/flow-typed/mapbox-gl-supported.js
+++ b/flow-typed/mapbox-gl-supported.js
@@ -1,9 +1,16 @@
 // @flow
 'use strict';
 declare module "@mapbox/mapbox-gl-supported" {
-    declare type isSupported = {
-        (options?: {failIfMajorPerformanceCaveat: boolean}): boolean,
+    declare type SupportedOptions = {failIfMajorPerformanceCaveat: boolean};
+
+    declare type SupportedFn = {
+        (options?: SupportedOptions): boolean,
         webGLContextAttributes: WebGLContextAttributes
     };
-    declare module.exports: isSupported;
+    declare function notSupportedReason(options?: SupportedOptions): ?string;
+
+    declare module.exports: {
+        supported: SupportedFn;
+        notSupportedReason: typeof notSupportedReason;
+    }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mapbox/geojson-rewind": "^0.5.0",
     "@mapbox/geojson-types": "^1.0.2",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-    "@mapbox/mapbox-gl-supported": "^1.5.0",
+    "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/point-geometry": "^0.1.0",
     "@mapbox/tiny-sdf": "^1.1.1",
     "@mapbox/unitbezier": "^0.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import assert from 'assert';
-import supported from '@mapbox/mapbox-gl-supported';
+import {supported} from '@mapbox/mapbox-gl-supported';
 
 import {version} from '../package.json';
 import Map from './ui/map';

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -20,7 +20,7 @@ import LngLatBounds from '../geo/lng_lat_bounds';
 import Point from '@mapbox/point-geometry';
 import AttributionControl from './control/attribution_control';
 import LogoControl from './control/logo_control';
-import isSupported from '@mapbox/mapbox-gl-supported';
+import {supported} from '@mapbox/mapbox-gl-supported';
 import {RGBAImage} from '../util/image';
 import {Event, ErrorEvent} from '../util/evented';
 import {MapMouseEvent} from './events';
@@ -2364,7 +2364,7 @@ class Map extends Camera {
     }
 
     _setupPainter() {
-        const attributes = extend({}, isSupported.webGLContextAttributes, {
+        const attributes = extend({}, supported.webGLContextAttributes, {
             failIfMajorPerformanceCaveat: this._failIfMajorPerformanceCaveat,
             preserveDrawingBuffer: this._preserveDrawingBuffer,
             antialias: this._antialias || false

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,10 +1076,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.2.3.tgz#a26ecfb3f0061456d93ee8570dd9587d226ea8bd"
   integrity sha512-RaCYfnxULUUUxNwcUimV9C/o2295ktTyLEUzD/+VWkqXqvaVfFcZ5slytGzb2Sd/Jj4MlbxD0DCZbfa6CzcmMw==
 
-"@mapbox/mapbox-gl-supported@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz#f60b6a55a5d8e5ee908347d2ce4250b15103dc8e"
-  integrity sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==
+"@mapbox/mapbox-gl-supported@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.0.tgz#bb133cd91e562c006713fbc83f21e4b6f711a388"
+  integrity sha512-zu4udqYiBrKMQKwpKJ4hhPON7tz0QR/JZ3iGpHnNWFmH3Sv/ysxlICATUtGCFpsyJf2v1WpFhlzaZ3GhhKmPMA==
 
 "@mapbox/mvt-fixtures@^3.6.0":
   version "3.6.0"


### PR DESCRIPTION
Upgrade `@mapbox/mapbox-gl-supported` [to v2.0.0](https://github.com/mapbox/mapbox-gl-supported/releases/tag/v2.0.0). Technically this doesn't make a difference, but it's nice to make sure GL JS internally uses the same version as the one we publish separately for checking v2.0 support.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
