### PR TITLE
Add 'localFontFamily' option to support rendering of all glyphs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/point-geometry": "^0.1.0",
-    "@mapbox/tiny-sdf": "^1.1.1",
+    "@mapbox/tiny-sdf": "^1.2.0",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -184,7 +184,7 @@ class GlyphManager {
             bitmap: new AlphaImage({
                 width: sdfWithMetrics.metrics.width + sdfBuffer * 2,
                 height: sdfWithMetrics.metrics.height + sdfBuffer * 2
-            }, sdfWithMetrics.alphaChannel),
+            }, sdfWithMetrics.data),
             metrics: sdfWithMetrics.metrics
         };
     }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -7,7 +7,7 @@ import StyleLayer from './style_layer';
 import createStyleLayer from './create_style_layer';
 import loadSprite from './load_sprite';
 import ImageManager from '../render/image_manager';
-import GlyphManager from '../render/glyph_manager';
+import GlyphManager, {LocalGlyphMode} from '../render/glyph_manager';
 import Light from './light';
 import Terrain from './terrain';
 import LineAtlas from '../render/line_atlas';
@@ -99,6 +99,7 @@ const empty = emptyStyle();
 
 export type StyleOptions = {
     validate?: boolean,
+    localFontFamily?: string,
     localIdeographFontFamily?: string
 };
 
@@ -156,7 +157,11 @@ class Style extends Evented {
         this.dispatcher = new Dispatcher(getWorkerPool(), this);
         this.imageManager = new ImageManager();
         this.imageManager.setEventedParent(this);
-        this.glyphManager = new GlyphManager(map._requestManager, options.localIdeographFontFamily);
+        this.glyphManager = new GlyphManager(map._requestManager,
+            options.localFontFamily ?
+                LocalGlyphMode.all :
+                (options.localIdeographFontFamily ? LocalGlyphMode.ideographs : LocalGlyphMode.none),
+            options.localFontFamily || options.localIdeographFontFamily);
         this.lineAtlas = new LineAtlas(256, 512);
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 


### PR DESCRIPTION
## Launch Checklist

This PR allows GL JS to do local glyph rasterization for _all_ glyphs, instead of just for ideographic glyphs. The existing `localIdeographFontFamily` option remains (and defaults to being turned on), but the new `localFontFamily` option can extend it to all glyphs.

This solves two problems:

- Using the same font family set for both latin and CJK makes for more consistent CJK maps where non-CJK and CJK characters are mixed (although the two sets of glyphs will often come from different fonts, they're still more likely to have consistent look and feel if the browser is choosing both of them, instead of one coming from the browser and the other from the server).
- Extracting glyph metrics is necessary for locally rendering non-ideographic glyphs, but it also allows us to trim down the size of our SDFs, which is an important performance optimization (laying the groundwork for porting high-resolution SDFs to GL JS).

This PR depends on new TinySDF functionality at https://github.com/mapbox/tiny-sdf/pull/24.

**Before**
![Screen Shot 2021-01-08 at 16 04 22](https://user-images.githubusercontent.com/375121/103984841-36879c00-51cb-11eb-8e4e-440c9085d61f.png)

**After**
![Screen Shot 2021-01-08 at 16 02 35](https://user-images.githubusercontent.com/375121/103984723-00e2b300-51cb-11eb-8b43-8318cbeba35f.png)


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: <changelog>Add 'localFontFamily' map option to support local generation of all font glyphs (as opposed to default 'localIdeographicFontFamily' which only locally generates ideographic glyphs)</changelog>

cc @zmiao @mourner @asheemmamoowala 