### PR TITLE
Fix evented.listens to return false when no listener exists

### DIFF
--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -149,14 +149,14 @@ export class Evented {
     }
 
     /**
-     * Returns a true if this instance of Evented or any forwardeed instances of Evented have a listener for the specified type.
+     * Returns true if this instance of Evented or any forwarded instances of Evented have a listener for the specified type.
      *
      * @param {string} type The event type
      * @returns {boolean} `true` if there is at least one registered listener for specified event type, `false` otherwise
      * @private
      */
     listens(type: string) {
-        return (
+        return !!(
             (this._listeners && this._listeners[type] && this._listeners[type].length > 0) ||
             (this._oneTimeListeners && this._oneTimeListeners[type] && this._oneTimeListeners[type].length > 0) ||
             (this._eventedParent && this._eventedParent.listens(type))

--- a/test/unit/util/evented.test.js
+++ b/test/unit/util/evented.test.js
@@ -93,7 +93,7 @@ test('Evented', (t) => {
         const evented = new Evented();
         evented.on('a', () => {});
         t.ok(evented.listens('a'));
-        t.notOk(evented.listens('b'));
+        t.equals(evented.listens('b'), false);
         t.end();
     });
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - This picks up https://github.com/mapbox/mapbox-gl-js/pull/9985 which has no movement since September and no CLA signed
    - `evented.listens` is documented as returning `false` when no listener is available. instead it returns `undefined`. this ensures that `false` is always returned while also cleaning up some typos in the doc string
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
    - fixes `listens` so that it matches current documentation
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Ensure evented.listens returns 'false' when no listener is available</changelog>`
