### PR TITLE
Run check-bundle-size script after deploying release to avoid a bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,14 @@ workflows:
               only: /v[0-9]+.[0-9]+.[0-9]+(-.+)?/
             branches:
               ignore: /.*/
+      - check-bundle-size:
+          requires:
+            build
+            deploy-release
+          filters:
+            tags:
+              only: /.*/
+              
 
 defaults: &defaults
   docker:
@@ -149,10 +157,6 @@ jobs:
       - run: yarn run build-style-spec
       - run: yarn run build-flow-types
       - run: yarn run test-build
-      - run:
-          name: Check bundle size
-          command: |
-            node build/check-bundle-size.js
       - deploy:
           name: Trigger memory metrics when merging to main
           command: |
@@ -288,3 +292,13 @@ jobs:
             upload mapbox-gl-csp.js.map        application/octet-stream
             upload mapbox-gl-csp-worker.js     application/javascript
             upload mapbox-gl-csp-worker.js.map application/octet-stream
+
+  check-bundle-size:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Check bundle size
+          command: |
+            node build/check-bundle-size.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,8 @@ workflows:
               ignore: /.*/
       - check-bundle-size:
           requires:
-            build
-            deploy-release
+            - build
+            - deploy-release
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,15 @@ jobs:
           at: .
       - aws-cli/install
       - run:
+          name: Check build file for correct SDK version
+          command: |
+            if grep -q "sdkVersion:\"$CIRCLE_TAG\"" mapbox-gl.js; then
+              echo SDK version in mapbox-gl.js matches $CIRCLE_TAG
+            else
+              echo SDK version in mapbox-gl.js does not match $CIRCLE_TAG
+              circleci-agent step halt
+            fi
+      - run:
           name: Deploy release
           command: |
             function upload {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - Closes https://github.com/mapbox/gl-js-team/issues/84
    - This is an attempt to fix a bug in the release process that pushes the `dist` folder from `main` to our CDN rather than the release branch's `dist` folder. This is caused by the `check-bundle-size` script checking out `main` and building the minified files and css before uploading the artifacts. I believe that this will run `check-bundle-size` after `deploy-release` if it's run or otherwise after `build`. See https://discuss.circleci.com/t/jobs-run-if-a-required-job-is-filtered/29598
 - [x] write tests for all new functionality
    - I need to add a test to the `deploy-release` job to ensure that the version string in the minified build files is correct before proceeding with uploading them
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
