### PR TITLE
Wait for sprite to load before parsing tiles

### DIFF
--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -107,7 +107,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * See {@link GeoJSONWorkerSource#loadGeoJSON}.
      * @private
      */
-    constructor(actor: Actor, layerIndex: StyleLayerIndex, availableImages: Array<string>, isSpriteLoaded: Boolean, loadGeoJSON: ?LoadGeoJSON) {
+    constructor(actor: Actor, layerIndex: StyleLayerIndex, availableImages: Array<string>, isSpriteLoaded: boolean, loadGeoJSON: ?LoadGeoJSON) {
         super(actor, layerIndex, availableImages, isSpriteLoaded, loadGeoJSONTile);
         if (loadGeoJSON) {
             this.loadGeoJSON = loadGeoJSON;

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -107,8 +107,8 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * See {@link GeoJSONWorkerSource#loadGeoJSON}.
      * @private
      */
-    constructor(actor: Actor, layerIndex: StyleLayerIndex, availableImages: Array<string>, loadGeoJSON: ?LoadGeoJSON) {
-        super(actor, layerIndex, availableImages, loadGeoJSONTile);
+    constructor(actor: Actor, layerIndex: StyleLayerIndex, availableImages: Array<string>, isSpriteLoaded: Boolean, loadGeoJSON: ?LoadGeoJSON) {
+        super(actor, layerIndex, availableImages, isSpriteLoaded, loadGeoJSONTile);
         if (loadGeoJSON) {
             this.loadGeoJSON = loadGeoJSON;
         }

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -7,7 +7,7 @@ import Protobuf from 'pbf';
 import WorkerTile from './worker_tile';
 import {extend} from '../util/util';
 import {RequestPerformance} from '../util/performance';
-import { Evented } from '../util/evented';
+import {Evented} from '../util/evented';
 
 import type {
     WorkerSource,
@@ -210,7 +210,7 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
             const parseTile = () => {
                 workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, (err, result) => {
                     if (err || !result) return callback(err);
-    
+
                     // Transferring a copy of rawTileData because the worker needs to retain its copy.
                     callback(null, extend({rawTileData: rawTileData.slice(0)}, result, cacheControl, resourceTiming));
                 });

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -144,7 +144,8 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
     loading: {[_: number]: WorkerTile };
     loaded: {[_: number]: WorkerTile };
     deduped: DedupedRequest;
-    isSpriteLoaded: Boolean;
+    isSpriteLoaded: boolean;
+    scheduler: ?Scheduler;
 
     /**
      * @param [loadVectorData] Optional method for custom loading of a VectorTile
@@ -153,7 +154,7 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
      * loads the pbf at `params.url`.
      * @private
      */
-    constructor(actor: Actor, layerIndex: StyleLayerIndex, availableImages: Array<string>, isSpriteLoaded: Boolean, loadVectorData: ?LoadVectorData) {
+    constructor(actor: Actor, layerIndex: StyleLayerIndex, availableImages: Array<string>, isSpriteLoaded: boolean, loadVectorData: ?LoadVectorData) {
         super();
         this.actor = actor;
         this.layerIndex = layerIndex;
@@ -163,6 +164,7 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
         this.loaded = {};
         this.deduped = new DedupedRequest(actor.scheduler);
         this.isSpriteLoaded = isSpriteLoaded;
+        this.scheduler = actor.scheduler;
     }
 
     /**
@@ -219,9 +221,9 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
             if (this.isSpriteLoaded) {
                 parseTile();
             } else {
-                const metadata = {type: 'parseTile', isSymbolTile: params.isSymbolTile, zoom: params.tileZoom};
                 this.once('isSpriteLoaded', () => {
                     if (this.scheduler) {
+                        const metadata = {type: 'parseTile', isSymbolTile: params.isSymbolTile, zoom: params.tileZoom};
                         this.scheduler.add(parseTile, metadata);
                     } else {
                         parseTile();

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -7,6 +7,7 @@ import Protobuf from 'pbf';
 import WorkerTile from './worker_tile';
 import {extend} from '../util/util';
 import {RequestPerformance} from '../util/performance';
+import { Evented } from '../util/evented';
 
 import type {
     WorkerSource,
@@ -135,7 +136,7 @@ export function loadVectorTile(params: RequestedTileParameters, callback: LoadVe
  *
  * @private
  */
-class VectorTileWorkerSource implements WorkerSource {
+class VectorTileWorkerSource extends Evented implements WorkerSource {
     actor: Actor;
     layerIndex: StyleLayerIndex;
     availableImages: Array<string>;
@@ -143,6 +144,7 @@ class VectorTileWorkerSource implements WorkerSource {
     loading: {[_: number]: WorkerTile };
     loaded: {[_: number]: WorkerTile };
     deduped: DedupedRequest;
+    isSpriteLoaded: Boolean;
 
     /**
      * @param [loadVectorData] Optional method for custom loading of a VectorTile
@@ -151,7 +153,8 @@ class VectorTileWorkerSource implements WorkerSource {
      * loads the pbf at `params.url`.
      * @private
      */
-    constructor(actor: Actor, layerIndex: StyleLayerIndex, availableImages: Array<string>, loadVectorData: ?LoadVectorData) {
+    constructor(actor: Actor, layerIndex: StyleLayerIndex, availableImages: Array<string>, isSpriteLoaded: Boolean, loadVectorData: ?LoadVectorData) {
+        super();
         this.actor = actor;
         this.layerIndex = layerIndex;
         this.availableImages = availableImages;
@@ -159,6 +162,7 @@ class VectorTileWorkerSource implements WorkerSource {
         this.loading = {};
         this.loaded = {};
         this.deduped = new DedupedRequest(actor.scheduler);
+        this.isSpriteLoaded = isSpriteLoaded;
     }
 
     /**
@@ -203,13 +207,27 @@ class VectorTileWorkerSource implements WorkerSource {
             // response.vectorTile will be present in the GeoJSON worker case (which inherits from this class)
             // because we stub the vector tile interface around JSON data instead of parsing it directly
             workerTile.vectorTile = response.vectorTile || new vt.VectorTile(new Protobuf(rawTileData));
+            const parseTile = () => {
+                workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, (err, result) => {
+                    if (err || !result) return callback(err);
+    
+                    // Transferring a copy of rawTileData because the worker needs to retain its copy.
+                    callback(null, extend({rawTileData: rawTileData.slice(0)}, result, cacheControl, resourceTiming));
+                });
+            };
 
-            workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, (err, result) => {
-                if (err || !result) return callback(err);
-
-                // Transferring a copy of rawTileData because the worker needs to retain its copy.
-                callback(null, extend({rawTileData: rawTileData.slice(0)}, result, cacheControl, resourceTiming));
-            });
+            if (this.isSpriteLoaded) {
+                parseTile();
+            } else {
+                const metadata = {type: 'parseTile', isSymbolTile: params.isSymbolTile, zoom: params.tileZoom};
+                this.once('isSpriteLoaded', () => {
+                    if (this.scheduler) {
+                        this.scheduler.add(parseTile, metadata);
+                    } else {
+                        parseTile();
+                    }
+                });
+            }
 
             this.loaded = this.loaded || {};
             this.loaded[uid] = workerTile;

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -11,6 +11,7 @@ import {plugin as globalRTLTextPlugin} from './rtl_text_plugin';
 import {enforceCacheSizeLimit} from '../util/tile_request_cache';
 import {extend} from '../util/util';
 import {PerformanceUtils} from '../util/performance';
+import {Event} from '../util/evented';
 
 import type {
     WorkerSource,
@@ -91,8 +92,10 @@ export default class Worker {
         for (const workerSource in this.workerSources[mapId]) {
             const ws = this.workerSources[mapId][workerSource];
             for (const source in ws) {
-                ws[source].isSpriteLoaded = bool;
-                ws[source].fire('isSpriteLoaded');
+                if (ws[source] instanceof VectorTileWorkerSource) {
+                    ws[source].isSpriteLoaded = bool;
+                    ws[source].fire(new Event('isSpriteLoaded'));   
+                }
             }
         }
     }

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -37,6 +37,7 @@ export default class Worker {
     workerSourceTypes: {[_: string]: Class<WorkerSource> };
     workerSources: {[_: string]: {[_: string]: {[_: string]: WorkerSource } } };
     demWorkerSources: {[_: string]: {[_: string]: RasterDEMTileWorkerSource } };
+    isSpriteLoaded: boolean;
     referrer: ?string;
     terrain: ?boolean;
 
@@ -47,6 +48,7 @@ export default class Worker {
 
         this.layerIndexes = {};
         this.availableImages = {};
+        this.isSpriteLoaded = false;
 
         this.workerSourceTypes = {
             vector: VectorTileWorkerSource,
@@ -82,6 +84,17 @@ export default class Worker {
 
     setReferrer(mapID: string, referrer: string) {
         this.referrer = referrer;
+    }
+
+    spriteLoaded(mapId: string, bool: boolean) {
+        this.isSpriteLoaded = bool;
+        for (const workerSource in this.workerSources[mapId]) {
+            const ws = this.workerSources[mapId][workerSource];
+            for (const source in ws) {
+                ws[source].isSpriteLoaded = bool;
+                ws[source].fire('isSpriteLoaded');
+            }
+        }        
     }
 
     setImages(mapId: string, images: Array<string>, callback: WorkerTileCallback) {
@@ -224,7 +237,7 @@ export default class Worker {
                 },
                 scheduler: this.actor.scheduler
             };
-            this.workerSources[mapId][type][source] = new (this.workerSourceTypes[type]: any)((actor: any), this.getLayerIndex(mapId), this.getAvailableImages(mapId));
+            this.workerSources[mapId][type][source] = new (this.workerSourceTypes[type]: any)((actor: any), this.getLayerIndex(mapId), this.getAvailableImages(mapId), this.isSpriteLoaded);
         }
 
         return this.workerSources[mapId][type][source];

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -94,7 +94,7 @@ export default class Worker {
                 ws[source].isSpriteLoaded = bool;
                 ws[source].fire('isSpriteLoaded');
             }
-        }        
+        }
     }
 
     setImages(mapId: string, images: Array<string>, callback: WorkerTileCallback) {

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -94,7 +94,7 @@ export default class Worker {
             for (const source in ws) {
                 if (ws[source] instanceof VectorTileWorkerSource) {
                     ws[source].isSpriteLoaded = bool;
-                    ws[source].fire(new Event('isSpriteLoaded'));   
+                    ws[source].fire(new Event('isSpriteLoaded'));
                 }
             }
         }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -293,6 +293,7 @@ class Style extends Evented {
             this._loadSprite(json.sprite);
         } else {
             this.imageManager.setLoaded(true);
+            this.dispatcher.broadcast('spriteLoaded', true);
         }
 
         this.glyphManager.setURL(json.glyphs);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -336,6 +336,7 @@ class Style extends Evented {
             this.imageManager.setLoaded(true);
             this._availableImages = this.imageManager.listImages();
             this.dispatcher.broadcast('setImages', this._availableImages);
+            this.dispatcher.broadcast('spriteLoaded', true);
             this.fire(new Event('data', {dataType: 'style'}));
         });
     }

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -16,7 +16,7 @@ test('reloadTile', (t) => {
             }
         ];
         const layerIndex = new StyleLayerIndex(layers);
-        const source = new GeoJSONWorkerSource(actor, layerIndex, []);
+        const source = new GeoJSONWorkerSource(actor, layerIndex, [], true);
         const originalLoadVectorData = source.loadVectorData;
         let loadVectorCallCount = 0;
         source.loadVectorData = function(params, callback) {
@@ -128,7 +128,7 @@ test('resourceTiming', (t) => {
         t.stub(perf, 'getEntriesByName').callsFake(() => { return [ exampleResourceTiming ]; });
 
         const layerIndex = new StyleLayerIndex(layers);
-        const source = new GeoJSONWorkerSource(actor, layerIndex, [], (params, callback) => { return callback(null, geoJson); });
+        const source = new GeoJSONWorkerSource(actor, layerIndex, [], true, (params, callback) => { return callback(null, geoJson); });
 
         source.loadData({source: 'testSource', request: {url: 'http://localhost/nonexistent', collectResourceTiming: true}}, (err, result) => {
             t.equal(err, null);
@@ -160,7 +160,7 @@ test('resourceTiming', (t) => {
         t.stub(perf, 'clearMeasures').callsFake(() => { return null; });
 
         const layerIndex = new StyleLayerIndex(layers);
-        const source = new GeoJSONWorkerSource(actor, layerIndex, [], (params, callback) => { return callback(null, geoJson); });
+        const source = new GeoJSONWorkerSource(actor, layerIndex, [], true, (params, callback) => { return callback(null, geoJson); });
 
         source.loadData({source: 'testSource', request: {url: 'http://localhost/nonexistent', collectResourceTiming: true}}, (err, result) => {
             t.equal(err, null);
@@ -171,7 +171,7 @@ test('resourceTiming', (t) => {
 
     t.test('loadData - data', (t) => {
         const layerIndex = new StyleLayerIndex(layers);
-        const source = new GeoJSONWorkerSource(actor, layerIndex, []);
+        const source = new GeoJSONWorkerSource(actor, layerIndex, [], true);
 
         source.loadData({source: 'testSource', data: JSON.stringify(geoJson)}, (err, result) => {
             t.equal(err, null);
@@ -207,7 +207,7 @@ test('loadData', (t) => {
 
     const layerIndex = new StyleLayerIndex(layers);
     function createWorker() {
-        const worker = new GeoJSONWorkerSource(actor, layerIndex, []);
+        const worker = new GeoJSONWorkerSource(actor, layerIndex, [], true);
 
         // Making the call to loadGeoJSON asynchronous
         // allows these tests to mimic a message queue building up

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -10,7 +10,7 @@ import perf from '../../../src/util/performance';
 const actor = {send: () => {}};
 
 test('VectorTileWorkerSource#abortTile aborts pending request', (t) => {
-    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
+    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true);
 
     source.loadTile({
         source: 'source',
@@ -35,7 +35,7 @@ test('VectorTileWorkerSource#abortTile aborts pending request', (t) => {
 });
 
 test('VectorTileWorkerSource#abortTile aborts pending async request', (t) => {
-    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], (params, cb) => {
+    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true, (params, cb) => {
         setTimeout(() => {
             cb(null, {});
         }, 0);
@@ -53,7 +53,7 @@ test('VectorTileWorkerSource#abortTile aborts pending async request', (t) => {
 });
 
 test('VectorTileWorkerSource#removeTile removes loaded tile', (t) => {
-    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
+    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true);
 
     source.loaded = {
         '0': {}
@@ -72,7 +72,7 @@ test('VectorTileWorkerSource#removeTile removes loaded tile', (t) => {
 });
 
 test('VectorTileWorkerSource#reloadTile reloads a previously-loaded tile', (t) => {
-    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
+    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true);
     const parse = t.spy();
 
     source.loaded = {
@@ -94,7 +94,7 @@ test('VectorTileWorkerSource#reloadTile reloads a previously-loaded tile', (t) =
 });
 
 test('VectorTileWorkerSource#reloadTile queues a reload when parsing is in progress', (t) => {
-    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
+    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true);
     const parse = t.spy();
 
     source.loaded = {
@@ -128,7 +128,7 @@ test('VectorTileWorkerSource#reloadTile queues a reload when parsing is in progr
 
 test('VectorTileWorkerSource#reloadTile handles multiple pending reloads', (t) => {
     // https://github.com/mapbox/mapbox-gl-js/issues/6308
-    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
+    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true);
     const parse = t.spy();
 
     source.loaded = {
@@ -176,7 +176,7 @@ test('VectorTileWorkerSource#reloadTile handles multiple pending reloads', (t) =
 });
 
 test('VectorTileWorkerSource#reloadTile does not reparse tiles with no vectorTile data but does call callback', (t) => {
-    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
+    const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), [], true);
     const parse = t.spy();
 
     source.loaded = {
@@ -235,7 +235,7 @@ test('VectorTileWorkerSource provides resource timing information', (t) => {
         type: 'fill'
     }]);
 
-    const source = new VectorTileWorkerSource(actor, layerIndex, [], loadVectorData);
+    const source = new VectorTileWorkerSource(actor, layerIndex, [], true, loadVectorData);
 
     t.stub(perf, 'getEntriesByName').callsFake(() => { return [ exampleResourceTiming ]; });
 
@@ -270,7 +270,7 @@ test('VectorTileWorkerSource provides resource timing information (fallback meth
         type: 'fill'
     }]);
 
-    const source = new VectorTileWorkerSource(actor, layerIndex, [], loadVectorData);
+    const source = new VectorTileWorkerSource(actor, layerIndex, [], true, loadVectorData);
     const url = 'http://localhost:2900/faketile.pbf';
 
     const sampleMarks = {};


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - This addresses https://github.com/mapbox/mapbox-gl-js/issues/10122 by waiting for the sprite to finish loading before parsing tiles. This will ensure that any image expressions embedded in a style will have their sprite images available to them and we can be confident that if an image isn't found, it's because it's not in the sprite, rather than the result of a race condition in which the tile loaded before the sprite.
 - [ ] write tests for all new functionality
    - in progress
 - [x] post benchmark scores
<img width="1231" alt="Screen Shot 2021-01-13 at 4 28 47 PM" src="https://user-images.githubusercontent.com/4523080/104635952-7af5ba80-5657-11eb-884e-d5f970ab466f.png">
This does not seem to have a substantial impact on tile load performance
 
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Ensure sprite has loaded before parsing tiles to avoid race condition when evaluating image expressions</changelog>`

cc @tristen 