### PR TITLE
Port high resolution local SDFs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/point-geometry": "^0.1.0",
-    "@mapbox/tiny-sdf": "^1.1.1",
+    "@mapbox/tiny-sdf": "^1.2.0",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/point-geometry": "^0.1.0",
-    "@mapbox/tiny-sdf": "^1.2.0",
+    "@mapbox/tiny-sdf": "^1.2.1",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",

--- a/src/render/glyph_atlas.js
+++ b/src/render/glyph_atlas.js
@@ -1,12 +1,21 @@
 // @flow
 
+import {SDF_SCALE} from '../render/glyph_manager';
 import {AlphaImage} from '../util/image';
 import {register} from '../util/web_worker_transfer';
 import potpack from 'potpack';
 
 import type {GlyphMetrics, StyleGlyph} from '../style/style_glyph';
 
-const padding = 1;
+const glyphPadding = 1;
+/*
+    The glyph padding is just to prevent sampling errors at the boundaries between
+    glyphs in the atlas texture, and for that purpose there's no need to make it
+    bigger with high-res SDFs. However, layout is done based on the glyph size
+    including this padding, so scaling this padding is the easiest way to keep
+    layout exactly the same as the SDF_SCALE changes.
+*/
+const localGlyphPadding = glyphPadding * SDF_SCALE;
 
 export type Rect = {
     x: number,
@@ -38,6 +47,7 @@ export default class GlyphAtlas {
                 const src = glyphs[+id];
                 if (!src || src.bitmap.width === 0 || src.bitmap.height === 0) continue;
 
+                const padding = src.metrics.localGlyph ? localGlyphPadding : glyphPadding;
                 const bin = {
                     x: 0,
                     y: 0,
@@ -59,6 +69,7 @@ export default class GlyphAtlas {
                 const src = glyphs[+id];
                 if (!src || src.bitmap.width === 0 || src.bitmap.height === 0) continue;
                 const bin = positions[stack][id].rect;
+                const padding = src.metrics.localGlyph ? localGlyphPadding : glyphPadding;
                 AlphaImage.copy(src.bitmap, image, {x: 0, y: 0}, {x: bin.x + padding, y: bin.y + padding}, src.bitmap);
             }
         }

--- a/src/render/glyph_manager.js
+++ b/src/render/glyph_manager.js
@@ -19,9 +19,16 @@ type Entry = {
     tinySDF?: TinySDF
 };
 
+export const LocalGlyphMode = {
+    none: 0,
+    ideographs: 1,
+    all: 2
+};
+
 class GlyphManager {
     requestManager: RequestManager;
-    localIdeographFontFamily: ?string;
+    localFontFamily: ?string;
+    localGlyphMode: number;
     entries: {[_: string]: Entry};
     url: ?string;
 
@@ -29,9 +36,10 @@ class GlyphManager {
     static loadGlyphRange: typeof loadGlyphRange;
     static TinySDF: Class<TinySDF>;
 
-    constructor(requestManager: RequestManager, localIdeographFontFamily: ?string) {
+    constructor(requestManager: RequestManager, localGlyphMode: number, localFontFamily: ?string) {
         this.requestManager = requestManager;
-        this.localIdeographFontFamily = localIdeographFontFamily;
+        this.localGlyphMode = localGlyphMode;
+        this.localFontFamily = localFontFamily;
         this.entries = {};
     }
 
@@ -130,17 +138,23 @@ class GlyphManager {
     }
 
     _doesCharSupportLocalGlyph(id: number): boolean {
-        /* eslint-disable new-cap */
-        return !!this.localIdeographFontFamily &&
+        if (this.localGlyphMode === LocalGlyphMode.none) {
+            return false;
+        } else if (this.localGlyphMode === LocalGlyphMode.all) {
+            return !!this.localFontFamily;
+        } else {
+            /* eslint-disable new-cap */
+            return !!this.localFontFamily &&
             (isChar['CJK Unified Ideographs'](id) ||
                 isChar['Hangul Syllables'](id) ||
                 isChar['Hiragana'](id) ||
                 isChar['Katakana'](id));
-        /* eslint-enable new-cap */
+            /* eslint-enable new-cap */
+        }
     }
 
     _tinySDF(entry: Entry, stack: string, id: number): ?StyleGlyph {
-        const family = this.localIdeographFontFamily;
+        const family = this.localFontFamily;
         if (!family) {
             return;
         }
@@ -150,6 +164,7 @@ class GlyphManager {
         }
 
         let tinySDF = entry.tinySDF;
+        const sdfBuffer = 3;
         if (!tinySDF) {
             let fontWeight = '400';
             if (/bold/i.test(stack)) {
@@ -159,19 +174,18 @@ class GlyphManager {
             } else if (/light/i.test(stack)) {
                 fontWeight = '200';
             }
-            tinySDF = entry.tinySDF = new GlyphManager.TinySDF(24, 3, 8, .25, family, fontWeight);
+            tinySDF = entry.tinySDF = new GlyphManager.TinySDF(24, sdfBuffer, 8, .25, family, fontWeight);
         }
+
+        const sdfWithMetrics = tinySDF.drawWithMetrics(String.fromCharCode(id));
 
         return {
             id,
-            bitmap: new AlphaImage({width: 30, height: 30}, tinySDF.draw(String.fromCharCode(id))),
-            metrics: {
-                width: 24,
-                height: 24,
-                left: 0,
-                top: -8,
-                advance: 24
-            }
+            bitmap: new AlphaImage({
+                width: sdfWithMetrics.metrics.width + sdfBuffer * 2,
+                height: sdfWithMetrics.metrics.height + sdfBuffer * 2
+            }, sdfWithMetrics.data),
+            metrics: sdfWithMetrics.metrics
         };
     }
 }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -7,7 +7,7 @@ import StyleLayer from './style_layer';
 import createStyleLayer from './create_style_layer';
 import loadSprite from './load_sprite';
 import ImageManager from '../render/image_manager';
-import GlyphManager from '../render/glyph_manager';
+import GlyphManager, {LocalGlyphMode} from '../render/glyph_manager';
 import Light from './light';
 import Terrain from './terrain';
 import LineAtlas from '../render/line_atlas';
@@ -99,6 +99,7 @@ const empty = emptyStyle();
 
 export type StyleOptions = {
     validate?: boolean,
+    localFontFamily?: string,
     localIdeographFontFamily?: string
 };
 
@@ -156,7 +157,11 @@ class Style extends Evented {
         this.dispatcher = new Dispatcher(getWorkerPool(), this);
         this.imageManager = new ImageManager();
         this.imageManager.setEventedParent(this);
-        this.glyphManager = new GlyphManager(map._requestManager, options.localIdeographFontFamily);
+        this.glyphManager = new GlyphManager(map._requestManager,
+            options.localFontFamily ?
+                LocalGlyphMode.all :
+                (options.localIdeographFontFamily ? LocalGlyphMode.ideographs : LocalGlyphMode.none),
+            options.localFontFamily || options.localIdeographFontFamily);
         this.lineAtlas = new LineAtlas(256, 512);
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 

--- a/src/style/style_glyph.js
+++ b/src/style/style_glyph.js
@@ -7,7 +7,8 @@ export type GlyphMetrics = {
     height: number,
     left: number,
     top: number,
-    advance: number
+    advance: number,
+    localGlyph?: boolean
 };
 
 export type StyleGlyph = {

--- a/src/symbol/quads.js
+++ b/src/symbol/quads.js
@@ -8,6 +8,7 @@ import type Anchor from './anchor';
 import type {PositionedIcon, Shaping} from './shaping';
 import {SHAPING_DEFAULT_OFFSET} from './shaping';
 import {IMAGE_PADDING} from '../render/image_atlas';
+import {SDF_SCALE} from '../render/glyph_manager';
 import type SymbolStyleLayer from '../style/style_layer/symbol_style_layer';
 import type {Feature} from '../style-spec/expression';
 import type {StyleImage} from '../style/style_image';
@@ -278,8 +279,8 @@ export function getGlyphQuads(anchor: Anchor,
 
             const x1 = (positionedGlyph.metrics.left - rectBuffer) * positionedGlyph.scale - halfAdvance + builtInOffset[0];
             const y1 = (-positionedGlyph.metrics.top - rectBuffer) * positionedGlyph.scale + builtInOffset[1];
-            const x2 = x1 + textureRect.w * positionedGlyph.scale / pixelRatio;
-            const y2 = y1 + textureRect.h * positionedGlyph.scale / pixelRatio;
+            const x2 = x1 + textureRect.w * positionedGlyph.scale / (pixelRatio * (positionedGlyph.localGlyph ? SDF_SCALE : 1));
+            const y2 = y1 + textureRect.h * positionedGlyph.scale / (pixelRatio * (positionedGlyph.localGlyph ? SDF_SCALE : 1));
 
             const tl = new Point(x1, y1);
             const tr = new Point(x2, y1);

--- a/src/symbol/shaping.js
+++ b/src/symbol/shaping.js
@@ -38,7 +38,8 @@ export type PositionedGlyph = {
     fontStack: string,
     sectionIndex: number,
     metrics: GlyphMetrics,
-    rect: Rect | null
+    rect: Rect | null,
+    localGlyph?: boolean
 };
 
 export type PositionedLine = {
@@ -642,7 +643,8 @@ function shapeLines(shaping: Shaping,
                     height: size[1],
                     left: IMAGE_PADDING,
                     top: -GLYPH_PBF_BORDER,
-                    advance: vertical ? size[1] : size[0]};
+                    advance: vertical ? size[1] : size[0],
+                    localGlyph: false};
 
                 // Difference between one EM and an image size.
                 // Aligns bottom of an image to a baseline level.
@@ -660,11 +662,11 @@ function shapeLines(shaping: Shaping,
             }
 
             if (!vertical) {
-                positionedGlyphs.push({glyph: codePoint, imageName, x, y: y + baselineOffset, vertical, scale: section.scale, fontStack: section.fontStack, sectionIndex, metrics, rect});
+                positionedGlyphs.push({glyph: codePoint, imageName, x, y: y + baselineOffset, vertical, scale: section.scale, localGlyph: metrics.localGlyph, fontStack: section.fontStack, sectionIndex, metrics, rect});
                 x += metrics.advance * section.scale + spacing;
             } else {
                 shaping.verticalizable = true;
-                positionedGlyphs.push({glyph: codePoint, imageName, x, y: y + baselineOffset, vertical, scale: section.scale, fontStack: section.fontStack, sectionIndex, metrics, rect});
+                positionedGlyphs.push({glyph: codePoint, imageName, x, y: y + baselineOffset, vertical, scale: section.scale, localGlyph: metrics.localGlyph, fontStack: section.fontStack, sectionIndex, metrics, rect});
                 x += verticalAdvance * section.scale + spacing;
             }
         }

--- a/test/expected/text-shaping-default.json
+++ b/test/expected/text-shaping-default.json
@@ -5,6 +5,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": -32.5,
           "y": -17,
           "vertical": false,
@@ -28,6 +29,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": -19.5,
           "y": -17,
           "vertical": false,
@@ -51,6 +53,7 @@
         {
           "glyph": 99,
           "imageName": null,
+          "localGlyph": null,
           "x": -5.5,
           "y": -17,
           "vertical": false,
@@ -74,6 +77,7 @@
         {
           "glyph": 100,
           "imageName": null,
+          "localGlyph": null,
           "x": 5.5,
           "y": -17,
           "vertical": false,
@@ -97,6 +101,7 @@
         {
           "glyph": 101,
           "imageName": null,
+          "localGlyph": null,
           "x": 19.5,
           "y": -17,
           "vertical": false,

--- a/test/expected/text-shaping-images-horizontal.json
+++ b/test/expected/text-shaping-images-horizontal.json
@@ -5,6 +5,7 @@
         {
           "glyph": 70,
           "imageName": null,
+          "localGlyph": null,
           "x": -53,
           "y": -34.5,
           "vertical": false,
@@ -28,6 +29,7 @@
         {
           "glyph": 111,
           "imageName": null,
+          "localGlyph": null,
           "x": -41,
           "y": -34.5,
           "vertical": false,
@@ -51,6 +53,7 @@
         {
           "glyph": 111,
           "imageName": null,
+          "localGlyph": null,
           "x": -27,
           "y": -34.5,
           "vertical": false,
@@ -74,6 +77,7 @@
         {
           "glyph": 57344,
           "imageName": "square",
+          "localGlyph": false,
           "x": -13,
           "y": -31.5,
           "vertical": false,
@@ -84,6 +88,7 @@
             "width": 14,
             "height": 14,
             "left": 1,
+            "localGlyph": false,
             "top": -3,
             "advance": 14
           },
@@ -97,6 +102,7 @@
         {
           "glyph": 57345,
           "imageName": "wide",
+          "localGlyph": false,
           "x": 8,
           "y": -31.5,
           "vertical": false,
@@ -107,6 +113,7 @@
             "width": 30,
             "height": 14,
             "left": 1,
+            "localGlyph": false,
             "top": -3,
             "advance": 30
           },
@@ -125,6 +132,7 @@
         {
           "glyph": 57346,
           "imageName": "tall",
+          "localGlyph": false,
           "x": -42,
           "y": -10.5,
           "vertical": false,
@@ -135,6 +143,7 @@
             "width": 14,
             "height": 30,
             "left": 1,
+            "localGlyph": false,
             "top": -3,
             "advance": 14
           },
@@ -148,6 +157,7 @@
         {
           "glyph": 57347,
           "imageName": "square",
+          "localGlyph": false,
           "x": -21,
           "y": 13.5,
           "vertical": false,
@@ -158,6 +168,7 @@
             "width": 14,
             "height": 14,
             "left": 1,
+            "localGlyph": false,
             "top": -3,
             "advance": 14
           },
@@ -171,6 +182,7 @@
         {
           "glyph": 32,
           "imageName": null,
+          "localGlyph": null,
           "x": 0,
           "y": 10.5,
           "vertical": false,
@@ -194,6 +206,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": 6,
           "y": 10.5,
           "vertical": false,
@@ -217,6 +230,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": 20,
           "y": 10.5,
           "vertical": false,
@@ -240,6 +254,7 @@
         {
           "glyph": 114,
           "imageName": null,
+          "localGlyph": null,
           "x": 33,
           "y": 10.5,
           "vertical": false,

--- a/test/expected/text-shaping-images-vertical.json
+++ b/test/expected/text-shaping-images-vertical.json
@@ -5,6 +5,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": -33,
           "y": -13.5,
           "vertical": true,
@@ -28,6 +29,7 @@
         {
           "glyph": 57344,
           "imageName": "square",
+          "localGlyph": false,
           "x": -9,
           "y": -10.5,
           "vertical": true,
@@ -38,6 +40,7 @@
             "width": 14,
             "height": 14,
             "left": 1,
+            "localGlyph": false,
             "top": -3,
             "advance": 14
           },
@@ -51,6 +54,7 @@
         {
           "glyph": 57345,
           "imageName": "wide",
+          "localGlyph": false,
           "x": 12,
           "y": -10.5,
           "vertical": true,
@@ -61,6 +65,7 @@
             "width": 30,
             "height": 14,
             "left": 1,
+            "localGlyph": false,
             "top": -3,
             "advance": 14
           },
@@ -79,6 +84,7 @@
         {
           "glyph": 57346,
           "imageName": "tall",
+          "localGlyph": false,
           "x": -43.5,
           "y": -10.5,
           "vertical": true,
@@ -89,6 +95,7 @@
             "width": 14,
             "height": 30,
             "left": 1,
+            "localGlyph": false,
             "top": -3,
             "advance": 30
           },
@@ -102,6 +109,7 @@
         {
           "glyph": 57347,
           "imageName": "square",
+          "localGlyph": false,
           "x": 1.5,
           "y": 13.5,
           "vertical": true,
@@ -112,6 +120,7 @@
             "width": 14,
             "height": 14,
             "left": 1,
+            "localGlyph": false,
             "top": -3,
             "advance": 14
           },
@@ -125,6 +134,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": 22.5,
           "y": 10.5,
           "vertical": true,

--- a/test/expected/text-shaping-linebreak.json
+++ b/test/expected/text-shaping-linebreak.json
@@ -5,6 +5,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": -32.5,
           "y": -29,
           "vertical": false,
@@ -28,6 +29,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": -19.5,
           "y": -29,
           "vertical": false,
@@ -51,6 +53,7 @@
         {
           "glyph": 99,
           "imageName": null,
+          "localGlyph": null,
           "x": -5.5,
           "y": -29,
           "vertical": false,
@@ -74,6 +77,7 @@
         {
           "glyph": 100,
           "imageName": null,
+          "localGlyph": null,
           "x": 5.5,
           "y": -29,
           "vertical": false,
@@ -97,6 +101,7 @@
         {
           "glyph": 101,
           "imageName": null,
+          "localGlyph": null,
           "x": 19.5,
           "y": -29,
           "vertical": false,
@@ -125,6 +130,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": -32.5,
           "y": -5,
           "vertical": false,
@@ -148,6 +154,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": -19.5,
           "y": -5,
           "vertical": false,
@@ -171,6 +178,7 @@
         {
           "glyph": 99,
           "imageName": null,
+          "localGlyph": null,
           "x": -5.5,
           "y": -5,
           "vertical": false,
@@ -194,6 +202,7 @@
         {
           "glyph": 100,
           "imageName": null,
+          "localGlyph": null,
           "x": 5.5,
           "y": -5,
           "vertical": false,
@@ -217,6 +226,7 @@
         {
           "glyph": 101,
           "imageName": null,
+          "localGlyph": null,
           "x": 19.5,
           "y": -5,
           "vertical": false,

--- a/test/expected/text-shaping-newline.json
+++ b/test/expected/text-shaping-newline.json
@@ -5,6 +5,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": -32.5,
           "y": -29,
           "vertical": false,
@@ -28,6 +29,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": -19.5,
           "y": -29,
           "vertical": false,
@@ -51,6 +53,7 @@
         {
           "glyph": 99,
           "imageName": null,
+          "localGlyph": null,
           "x": -5.5,
           "y": -29,
           "vertical": false,
@@ -74,6 +77,7 @@
         {
           "glyph": 100,
           "imageName": null,
+          "localGlyph": null,
           "x": 5.5,
           "y": -29,
           "vertical": false,
@@ -97,6 +101,7 @@
         {
           "glyph": 101,
           "imageName": null,
+          "localGlyph": null,
           "x": 19.5,
           "y": -29,
           "vertical": false,
@@ -125,6 +130,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": -32.5,
           "y": -5,
           "vertical": false,
@@ -148,6 +154,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": -19.5,
           "y": -5,
           "vertical": false,
@@ -171,6 +178,7 @@
         {
           "glyph": 99,
           "imageName": null,
+          "localGlyph": null,
           "x": -5.5,
           "y": -5,
           "vertical": false,
@@ -194,6 +202,7 @@
         {
           "glyph": 100,
           "imageName": null,
+          "localGlyph": null,
           "x": 5.5,
           "y": -5,
           "vertical": false,
@@ -217,6 +226,7 @@
         {
           "glyph": 101,
           "imageName": null,
+          "localGlyph": null,
           "x": 19.5,
           "y": -5,
           "vertical": false,

--- a/test/expected/text-shaping-newlines-in-middle.json
+++ b/test/expected/text-shaping-newlines-in-middle.json
@@ -5,6 +5,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": -32.5,
           "y": -41,
           "vertical": false,
@@ -28,6 +29,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": -19.5,
           "y": -41,
           "vertical": false,
@@ -51,6 +53,7 @@
         {
           "glyph": 99,
           "imageName": null,
+          "localGlyph": null,
           "x": -5.5,
           "y": -41,
           "vertical": false,
@@ -74,6 +77,7 @@
         {
           "glyph": 100,
           "imageName": null,
+          "localGlyph": null,
           "x": 5.5,
           "y": -41,
           "vertical": false,
@@ -97,6 +101,7 @@
         {
           "glyph": 101,
           "imageName": null,
+          "localGlyph": null,
           "x": 19.5,
           "y": -41,
           "vertical": false,
@@ -129,6 +134,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": -32.5,
           "y": 7,
           "vertical": false,
@@ -152,6 +158,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": -19.5,
           "y": 7,
           "vertical": false,
@@ -175,6 +182,7 @@
         {
           "glyph": 99,
           "imageName": null,
+          "localGlyph": null,
           "x": -5.5,
           "y": 7,
           "vertical": false,
@@ -198,6 +206,7 @@
         {
           "glyph": 100,
           "imageName": null,
+          "localGlyph": null,
           "x": 5.5,
           "y": 7,
           "vertical": false,
@@ -221,6 +230,7 @@
         {
           "glyph": 101,
           "imageName": null,
+          "localGlyph": null,
           "x": 19.5,
           "y": 7,
           "vertical": false,

--- a/test/expected/text-shaping-null.json
+++ b/test/expected/text-shaping-null.json
@@ -5,6 +5,7 @@
         {
           "glyph": 104,
           "imageName": null,
+          "localGlyph": null,
           "x": -10,
           "y": -17,
           "vertical": false,
@@ -28,6 +29,7 @@
         {
           "glyph": 105,
           "imageName": null,
+          "localGlyph": null,
           "x": 4,
           "y": -17,
           "vertical": false,

--- a/test/expected/text-shaping-spacing.json
+++ b/test/expected/text-shaping-spacing.json
@@ -5,6 +5,7 @@
         {
           "glyph": 97,
           "imageName": null,
+          "localGlyph": null,
           "x": -38.5,
           "y": -17,
           "vertical": false,
@@ -28,6 +29,7 @@
         {
           "glyph": 98,
           "imageName": null,
+          "localGlyph": null,
           "x": -22.5,
           "y": -17,
           "vertical": false,
@@ -51,6 +53,7 @@
         {
           "glyph": 99,
           "imageName": null,
+          "localGlyph": null,
           "x": -5.5,
           "y": -17,
           "vertical": false,
@@ -74,6 +77,7 @@
         {
           "glyph": 100,
           "imageName": null,
+          "localGlyph": null,
           "x": 8.5,
           "y": -17,
           "vertical": false,
@@ -97,6 +101,7 @@
         {
           "glyph": 101,
           "imageName": null,
+          "localGlyph": null,
           "x": 25.5,
           "y": -17,
           "vertical": false,

--- a/test/expected/text-shaping-zero-width-space.json
+++ b/test/expected/text-shaping-zero-width-space.json
@@ -5,6 +5,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": -63,
           "y": -41,
           "vertical": false,
@@ -28,6 +29,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": -42,
           "y": -41,
           "vertical": false,
@@ -51,6 +53,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": -21,
           "y": -41,
           "vertical": false,
@@ -74,6 +77,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": 0,
           "y": -41,
           "vertical": false,
@@ -97,6 +101,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": 21,
           "y": -41,
           "vertical": false,
@@ -120,6 +125,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": 42,
           "y": -41,
           "vertical": false,
@@ -148,6 +154,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": -63,
           "y": -17,
           "vertical": false,
@@ -171,6 +178,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": -42,
           "y": -17,
           "vertical": false,
@@ -194,6 +202,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": -21,
           "y": -17,
           "vertical": false,
@@ -217,6 +226,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": 0,
           "y": -17,
           "vertical": false,
@@ -240,6 +250,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": 21,
           "y": -17,
           "vertical": false,
@@ -263,6 +274,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": 42,
           "y": -17,
           "vertical": false,
@@ -291,6 +303,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": -21,
           "y": 7,
           "vertical": false,
@@ -314,6 +327,7 @@
         {
           "glyph": 19977,
           "imageName": null,
+          "localGlyph": null,
           "x": 0,
           "y": 7,
           "vertical": false,

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -1,6 +1,6 @@
 import {test} from '../../util/test';
 import parseGlyphPBF from '../../../src/style/parse_glyph_pbf';
-import GlyphManager from '../../../src/render/glyph_manager';
+import GlyphManager, {LocalGlyphMode} from '../../../src/render/glyph_manager';
 import fs from 'fs';
 
 const glyphs = {};
@@ -9,6 +9,16 @@ for (const glyph of parseGlyphPBF(fs.readFileSync('./test/fixtures/0-255.pbf')))
 }
 
 const identityTransform = (url) => ({url});
+
+const TinySDF = class {
+    // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
+    drawWithMetrics() {
+        return {
+            alphaChannel: new Uint8ClampedArray(900),
+            metrics: {width: 24, height: 24, advance: 24}
+        };
+    }
+};
 
 const createLoadGlyphRangeStub = (t) => {
     return t.stub(GlyphManager, 'loadGlyphRange').callsFake((stack, range, urlTemplate, transform, callback) => {
@@ -20,8 +30,10 @@ const createLoadGlyphRangeStub = (t) => {
     });
 };
 
-const createGlyphManager = (font) => {
-    const manager = new GlyphManager(identityTransform, font);
+const createGlyphManager = (font, allGlyphs) => {
+    const manager = new GlyphManager(identityTransform,
+        font ? (allGlyphs ? LocalGlyphMode.all : LocalGlyphMode.ideographs) : LocalGlyphMode.none,
+        font);
     manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
     return manager;
 };
@@ -82,12 +94,7 @@ test('GlyphManager does not cache CJK chars that should be rendered locally', (t
         }
         setImmediate(() => callback(null, overlappingGlyphs));
     });
-    t.stub(GlyphManager, 'TinySDF').value(class {
-        // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
-        draw() {
-            return new Uint8ClampedArray(900);
-        }
-    });
+    t.stub(GlyphManager, 'TinySDF').value(TinySDF);
     const manager = createGlyphManager('sans-serif');
 
     //Request char that overlaps Katakana range
@@ -107,12 +114,7 @@ test('GlyphManager does not cache CJK chars that should be rendered locally', (t
 });
 
 test('GlyphManager generates CJK PBF locally', (t) => {
-    t.stub(GlyphManager, 'TinySDF').value(class {
-        // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
-        draw() {
-            return new Uint8ClampedArray(900);
-        }
-    });
+    t.stub(GlyphManager, 'TinySDF').value(TinySDF);
 
     const manager = createGlyphManager('sans-serif');
 
@@ -124,12 +126,7 @@ test('GlyphManager generates CJK PBF locally', (t) => {
 });
 
 test('GlyphManager generates Katakana PBF locally', (t) => {
-    t.stub(GlyphManager, 'TinySDF').value(class {
-        // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
-        draw() {
-            return new Uint8ClampedArray(900);
-        }
-    });
+    t.stub(GlyphManager, 'TinySDF').value(TinySDF);
 
     const manager = createGlyphManager('sans-serif');
 
@@ -142,12 +139,7 @@ test('GlyphManager generates Katakana PBF locally', (t) => {
 });
 
 test('GlyphManager generates Hiragana PBF locally', (t) => {
-    t.stub(GlyphManager, 'TinySDF').value(class {
-        // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
-        draw() {
-            return new Uint8ClampedArray(900);
-        }
-    });
+    t.stub(GlyphManager, 'TinySDF').value(TinySDF);
 
     const manager = createGlyphManager('sans-serif');
 
@@ -163,9 +155,12 @@ test('GlyphManager caches locally generated glyphs', (t) => {
     let drawCallCount = 0;
     t.stub(GlyphManager, 'TinySDF').value(class {
         // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
-        draw() {
+        drawWithMetrics() {
             drawCallCount++;
-            return new Uint8ClampedArray(900);
+            return {
+                alphaChannel: new Uint8ClampedArray(900),
+                metrics: {width: 24, height: 24, advance: 24}
+            };
         }
     });
 
@@ -182,3 +177,24 @@ test('GlyphManager caches locally generated glyphs', (t) => {
     });
 });
 
+test('GlyphManager locally generates latin glyphs', (t) => {
+    t.stub(GlyphManager, 'TinySDF').value(class {
+        // Return empty 18x24 bitmap (made up glyph size + 3 * 2 buffer)
+        drawWithMetrics() {
+            return {
+                alphaChannel: new Uint8ClampedArray(480),
+                metrics: {width: 14, height: 18, advance: 10}
+            };
+        }
+    });
+
+    const manager = createGlyphManager('sans-serif', true);
+
+    manager.getGlyphs({'Arial Unicode MS': ['A']}, (err, glyphs) => {
+        t.ifError(err);
+        t.equal(glyphs['Arial Unicode MS']['A'].metrics.advance, 10);
+        t.equal(glyphs['Arial Unicode MS']['A'].metrics.width, 14);
+        t.equal(glyphs['Arial Unicode MS']['A'].metrics.height, 18);
+        t.end();
+    });
+});

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -11,11 +11,14 @@ for (const glyph of parseGlyphPBF(fs.readFileSync('./test/fixtures/0-255.pbf')))
 const identityTransform = (url) => ({url});
 
 const TinySDF = class {
+    constructor() {
+        this.fontWeight = '400';
+    }
     // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
     drawWithMetrics() {
         return {
             alphaChannel: new Uint8ClampedArray(900),
-            metrics: {width: 24, height: 24, advance: 24}
+            metrics: {width: 48, height: 48, sdfWidth: 30, sdfHeight: 30, advance: 48}
         };
     }
 };
@@ -154,12 +157,15 @@ test('GlyphManager generates Hiragana PBF locally', (t) => {
 test('GlyphManager caches locally generated glyphs', (t) => {
     let drawCallCount = 0;
     t.stub(GlyphManager, 'TinySDF').value(class {
+        constructor() {
+            this.fontWeight = '400';
+        }
         // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
         drawWithMetrics() {
             drawCallCount++;
             return {
                 alphaChannel: new Uint8ClampedArray(900),
-                metrics: {width: 24, height: 24, advance: 24}
+                metrics: {width: 48, height: 48, sdfWidth: 30, sdfHeight: 30, advance: 48}
             };
         }
     });
@@ -179,11 +185,14 @@ test('GlyphManager caches locally generated glyphs', (t) => {
 
 test('GlyphManager locally generates latin glyphs', (t) => {
     t.stub(GlyphManager, 'TinySDF').value(class {
+        constructor() {
+            this.fontWeight = '400';
+        }
         // Return empty 18x24 bitmap (made up glyph size + 3 * 2 buffer)
         drawWithMetrics() {
             return {
                 alphaChannel: new Uint8ClampedArray(480),
-                metrics: {width: 14, height: 18, advance: 10}
+                metrics: {width: 28, height: 36, sdfWidth: 20, sdfHeight: 24, advance: 20}
             };
         }
     });


### PR DESCRIPTION
## Launch Checklist

This PR brings gl-js to parity with gl-native by porting the 2x resolution local glyph generation. It includes:

- 2x resolution local glyphs
- Glyph metrics extraction via `TextMetrics` and support for local generation of non-ideographic glyphs using `localFontFamily` map option. (Previously in PR #10267: I've rolled it into this PR because both PRs depend on the same [TinySDF changes](https://github.com/mapbox/tiny-sdf/pull/24) and I've been testing them together).
- Performance optimizations to offset the cost of doubling the SDF resolution: mainly (1) don't double-generate glyphs that share the same font and (2) trim whitespace from glyphs.

The visual improvement is noticeable on high DPI screens, and can also be seen easily in large labels:

**Before**
![Screen Shot 2021-01-15 at 15 09 23](https://user-images.githubusercontent.com/375121/104689216-7c051580-5745-11eb-87fd-44706c2a01fd.png)
![Screen Shot 2021-01-15 at 15 08 59](https://user-images.githubusercontent.com/375121/104689215-7b6c7f00-5745-11eb-8ba9-63415c009f3b.png)

**After**
![Screen Shot 2021-01-15 at 15 06 31](https://user-images.githubusercontent.com/375121/104689209-76a7cb00-5745-11eb-9195-6e4f323c71c8.png)
![Screen Shot 2021-01-15 at 15 07 07](https://user-images.githubusercontent.com/375121/104689214-7ad3e880-5745-11eb-99eb-cd4dd0408358.png)

For default settings, these changes have negligible performance impact for maps without heavy CJK-use. For CJK maps, the main impact is at load time (generating SDFs for the first time), although there is a small ongoing hit from loading larger glyph atlases (SDF generation is also an ongoing cost once the map is loaded, but the rate of new glyph generation drops off pretty quickly once a set of common characters are loaded). One option we have for ameliorating the load time performance hit is to do SDF generation on the workers. However, if we can get away with it, I'd like to avoid that complexity. For performance testing, I used benchmap-js with a Japanese-language style that rendered three cities at z8, z12, and z16. The main results were:

```
Full load: 160ms/16% slower
Speed index: 96ms/19% slower
FPS: -6.3
Jank: indeterminate
Dropped frames: 7 greater
```

The 16% full-load slow down is similar to the performance hit we accepted on the "Tokyo All Local Glyphs" perf benchmark on the native side.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

cc @mourner @zmiao @asheemmamoowala @alexshalamov @YoshiYazawa @tsuz @ansis