### PR TITLE
Guard against no prior check being found in check-bundle-size

### DIFF
--- a/build/check-bundle-size.js
+++ b/build/check-bundle-size.js
@@ -108,7 +108,7 @@ const repo = 'mapbox-gl-js';
         const priorSize = await getPriorSize(mergeBase, name);
         console.log('priorSize: ', label, priorSize);
 
-        const title = `${formatSize(size.size, priorSize.size)}, gzipped ${formatSize(size.gzipSize, priorSize.gzipSize)}`;
+        const title = `${formatSize(size.size, priorSize ? priorSize.size : null)}, gzipped ${formatSize(size.gzipSize, priorSize ? priorSize.gzipSize : null)}`;
 
         const megabit = Math.pow(2, 12);
         const downloadTime3G = (size.gzipSize / (3 * megabit)).toFixed(0);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - if no prior size check is found by the check-bundle-size job, it can cause an error without guarding against the potential null value
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
