### PR TITLE
Dedupe calls to performance.measure

### DIFF
--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -2,7 +2,7 @@
 
 import {getJSON} from '../util/ajax.js';
 
-import {RequestPerformance} from '../util/performance.js';
+import {getPerformanceMeasurement} from '../util/performance.js';
 import rewind from '@mapbox/geojson-rewind';
 import GeoJSONWrapper from './geojson_wrapper.js';
 import vtpbf from 'vt-pbf';
@@ -164,8 +164,8 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
         delete this._pendingCallback;
         delete this._pendingLoadDataParams;
 
-        const perf = (params && params.request && params.request.collectResourceTiming) ?
-            new RequestPerformance(params.request) : false;
+        const requestParam = params && params.request;
+        const perf = requestParam && requestParam.collectResourceTiming;
 
         this.loadGeoJSON(params, (err: ?Error, data: ?Object) => {
             if (err || !data) {
@@ -196,7 +196,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
 
                 const result = {};
                 if (perf) {
-                    const resourceTimingData = perf.getMeasurement();
+                    const resourceTimingData = getPerformanceMeasurement(requestParam);
                     // it's necessary to eval the result of getEntriesByName() here via parse/stringify
                     // late evaluation in the main thread causes TypeError: illegal invocation
                     if (resourceTimingData) {

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -196,7 +196,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
 
                 const result = {};
                 if (perf) {
-                    const resourceTimingData = perf.finish();
+                    const resourceTimingData = perf.getMeasurement();
                     // it's necessary to eval the result of getEntriesByName() here via parse/stringify
                     // late evaluation in the main thread causes TypeError: illegal invocation
                     if (resourceTimingData) {

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -56,7 +56,6 @@ export class DedupedRequest {
     _measurePerformance() {
         if (this._perf && this._perf instanceof RequestPerformance) {
             const resourceTimingData = this._perf.getMeasurement();
-            // console.log('resourceTimingData: ', resourceTimingData);
             // it's necessary to eval the result of getEntriesByName() here via parse/stringify
             // late evaluation in the main thread causes TypeError: illegal invocation
             if (resourceTimingData.length > 0) {

--- a/src/source/vector_tile_worker_source.js
+++ b/src/source/vector_tile_worker_source.js
@@ -198,7 +198,8 @@ class VectorTileWorkerSource extends Evented implements WorkerSource {
             if (response.cacheControl) cacheControl.cacheControl = response.cacheControl;
 
             const resourceTiming = {};
-            if (perf) {
+            // because of two-phase tile loading, it's necessary to dedupe perf marking to avoid errors
+            if (perf && !perf._marksWereCleared()) {
                 const resourceTimingData = perf.finish();
                 // it's necessary to eval the result of getEntriesByName() here via parse/stringify
                 // late evaluation in the main thread causes TypeError: illegal invocation

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -178,6 +178,10 @@ export class RequestPerformance {
 
         performance.mark(this._marks.start);
     }
+    
+    _marksWereCleared() {
+        return performance.getEntriesByName(this._marks.start).length === 0;
+    }
 
     finish() {
         performance.mark(this._marks.end);

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -178,7 +178,7 @@ export class RequestPerformance {
 
         performance.mark(this._marks.start);
     }
-    
+
     _marksWereCleared() {
         return performance.getEntriesByName(this._marks.start).length === 0;
     }

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -160,22 +160,9 @@ export const PerformanceUtils = {
     }
 };
 
-/**
- * Safe wrapper for the performance resource timing API in web workers with graceful degradation
- *
- * @param {RequestParameters} request
- * @private
- */
-export class RequestPerformance {
-    _url: string;
-
-    constructor (request: RequestParameters) {
-        this._url = request.url.toString();
-    }
-
-    getMeasurement() {
-        return performance.getEntriesByName(this._url);
-    }
+export function getPerformanceMeasurement(request: ?RequestParameters) {
+    const url = request ? request.url.toString() : undefined;
+    return performance.getEntriesByName(url);
 }
 
 export default performance;

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -167,38 +167,14 @@ export const PerformanceUtils = {
  * @private
  */
 export class RequestPerformance {
-    _marks: {start: string, end: string, measure: string};
+    _url: string;
 
     constructor (request: RequestParameters) {
-        this._marks = {
-            start: [request.url, 'start'].join('#'),
-            end: [request.url, 'end'].join('#'),
-            measure: request.url.toString()
-        };
-
-        performance.mark(this._marks.start);
+        this._url = request.url.toString();
     }
 
-    _marksWereCleared() {
-        return performance.getEntriesByName(this._marks.start).length === 0;
-    }
-
-    finish() {
-        performance.mark(this._marks.end);
-        let resourceTimingData = performance.getEntriesByName(this._marks.measure);
-
-        // fallback if web worker implementation of perf.getEntriesByName returns empty
-        if (resourceTimingData.length === 0) {
-            performance.measure(this._marks.measure, this._marks.start, this._marks.end);
-            resourceTimingData = performance.getEntriesByName(this._marks.measure);
-
-            // cleanup
-            performance.clearMarks(this._marks.start);
-            performance.clearMarks(this._marks.end);
-            performance.clearMeasures(this._marks.measure);
-        }
-
-        return resourceTimingData;
+    getMeasurement() {
+        return performance.getEntriesByName(this._url);
     }
 }
 

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -137,38 +137,6 @@ test('resourceTiming', (t) => {
         });
     });
 
-    t.test('loadData - url (resourceTiming fallback method)', (t) => {
-        const sampleMarks = [100, 350];
-        const marks = {};
-        const measures = {};
-        t.stub(perf, 'getEntriesByName').callsFake((name) => { return measures[name] || []; });
-        t.stub(perf, 'mark').callsFake((name) => {
-            marks[name] = sampleMarks.shift();
-            return null;
-        });
-        t.stub(perf, 'measure').callsFake((name, start, end) => {
-            measures[name] = measures[name] || [];
-            measures[name].push({
-                duration: marks[end] - marks[start],
-                entryType: 'measure',
-                name,
-                startTime: marks[start]
-            });
-            return null;
-        });
-        t.stub(perf, 'clearMarks').callsFake(() => { return null; });
-        t.stub(perf, 'clearMeasures').callsFake(() => { return null; });
-
-        const layerIndex = new StyleLayerIndex(layers);
-        const source = new GeoJSONWorkerSource(actor, layerIndex, [], true, (params, callback) => { return callback(null, geoJson); });
-
-        source.loadData({source: 'testSource', request: {url: 'http://localhost/nonexistent', collectResourceTiming: true}}, (err, result) => {
-            t.equal(err, null);
-            t.deepEquals(result.resourceTiming.testSource, [{"duration": 250, "entryType": "measure", "name": "http://localhost/nonexistent", "startTime": 100}], 'got expected resource timing');
-            t.end();
-        });
-    });
-
     t.test('loadData - data', (t) => {
         const layerIndex = new StyleLayerIndex(layers);
         const source = new GeoJSONWorkerSource(actor, layerIndex, [], true);

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -237,9 +237,7 @@ test('VectorTileWorkerSource provides resource timing information', (t) => {
 
     const source = new VectorTileWorkerSource(actor, layerIndex, [], true, loadVectorData);
 
-    t.stub(perf, 'getEntriesByName').callsFake(() => {
-        return [ exampleResourceTiming ];
-    });
+    t.stub(perf, 'getEntriesByName').callsFake(() => { return [ exampleResourceTiming ]; });
 
     source.loadTile({
         source: 'source',

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -237,7 +237,9 @@ test('VectorTileWorkerSource provides resource timing information', (t) => {
 
     const source = new VectorTileWorkerSource(actor, layerIndex, [], true, loadVectorData);
 
-    t.stub(perf, 'getEntriesByName').callsFake(() => { return [ exampleResourceTiming ]; });
+    t.stub(perf, 'getEntriesByName').callsFake(() => {
+        return [ exampleResourceTiming ];
+    });
 
     source.loadTile({
         source: 'source',
@@ -245,67 +247,11 @@ test('VectorTileWorkerSource provides resource timing information', (t) => {
         tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
         request: {url: 'http://localhost:2900/faketile.pbf', collectResourceTiming: true}
     }, (err, res) => {
+        // simulate a deduped request calling the perf measurement
+        source.deduped._measurePerformance();
+        res.resourceTiming = source.deduped._resourceTiming.resourceTiming;
         t.false(err);
         t.deepEquals(res.resourceTiming[0], exampleResourceTiming, 'resourceTiming resp is expected');
-        t.end();
-    });
-});
-
-test('VectorTileWorkerSource provides resource timing information (fallback method)', (t) => {
-    const rawTileData = fs.readFileSync(path.join(__dirname, '/../../fixtures/mbsv5-6-18-23.vector.pbf'));
-
-    function loadVectorData(params, callback) {
-        return callback(null, {
-            vectorTile: new vt.VectorTile(new Protobuf(rawTileData)),
-            rawData: rawTileData,
-            cacheControl: null,
-            expires: null
-        });
-    }
-
-    const layerIndex = new StyleLayerIndex([{
-        id: 'test',
-        source: 'source',
-        'source-layer': 'test',
-        type: 'fill'
-    }]);
-
-    const source = new VectorTileWorkerSource(actor, layerIndex, [], true, loadVectorData);
-    const url = 'http://localhost:2900/faketile.pbf';
-
-    const sampleMarks = {};
-    sampleMarks[`${url}#start`] = 100;
-    sampleMarks[`${url}#end`] = 350;
-    const marks = {};
-    const measures = {};
-    t.stub(perf, 'getEntriesByName').callsFake((name) => { return measures[name] || []; });
-    t.stub(perf, 'mark').callsFake((name) => {
-        if (sampleMarks[name]) {
-            marks[name] = sampleMarks[name];
-        }
-        return null;
-    });
-    t.stub(perf, 'measure').callsFake((name, start, end) => {
-        measures[name] = measures[name] || [];
-        measures[name].push({
-            duration: marks[end] - marks[start],
-            entryType: 'measure',
-            name,
-            startTime: marks[start]
-        });
-        return null;
-    });
-    t.stub(perf, 'clearMarks').callsFake(() => { return null; });
-    t.stub(perf, 'clearMeasures').callsFake(() => { return null; });
-
-    source.loadTile({
-        source: 'source',
-        uid: 0,
-        tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
-        request: {url, collectResourceTiming: true}
-    }, (err, res) => {
-        t.false(err);
-        t.deepEquals(res.resourceTiming[0], {"duration": 250, "entryType": "measure", "name": "http://localhost:2900/faketile.pbf", "startTime": 100}, 'resourceTiming resp is expected');
         t.end();
     });
 });

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -245,9 +245,6 @@ test('VectorTileWorkerSource provides resource timing information', (t) => {
         tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
         request: {url: 'http://localhost:2900/faketile.pbf', collectResourceTiming: true}
     }, (err, res) => {
-        // simulate a deduped request calling the perf measurement
-        source.deduped._measurePerformance();
-        res.resourceTiming = source.deduped._resourceTiming.resourceTiming;
         t.false(err);
         t.deepEquals(res.resourceTiming[0], exampleResourceTiming, 'resourceTiming resp is expected');
         t.end();


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - This fixes https://github.com/mapbox/mapbox-gl-js/issues/10303
    - I believe the error was always possible to hit but used to be very rare. With the introduction of two-phased tile loading in v2.0.0, the problem became much more prominent. Two-phased tile loading leads to two calls to `loadTile` and ultimately to `perf.finish()`. On the first call to `perf.finish()`, the entries for `this._marks.start` are cleared from the performance entry buffer. On the second call to `perf.finish()`, `performance.measure()` tries to use `this._marks.start` as the start mark but can't find entries in the performance buffer and throws an error.
    - This PR removes the fallback performance measurements because the Performance API is now supported in all GL JS supported browsers. It also moves the performance measurement for vector tiles into the `DedupedRequest` class so that the measurement isn't dependent on `this.scheduler` for timing.
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Prevent collectResourceTiming from causing errors when loading vector tiles</changelog>`
