### PR TITLE
Bump tiny-sdf version for an RTL glyph width fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/point-geometry": "^0.1.0",
-    "@mapbox/tiny-sdf": "^1.2.1",
+    "@mapbox/tiny-sdf": "^1.2.2",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,10 +1102,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz#f3b1af042620716a1289fc41e1e97f610823aefe"
   integrity sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA==
 
-"@mapbox/tiny-sdf@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz#16a20c470741bfe9191deb336f46e194da4a91ff"
-  integrity sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg==
+"@mapbox/tiny-sdf@^1.2.1":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-1.2.2.tgz#536417dd04cd6af4d46eb0e65f932941a7540be1"
+  integrity sha512-GeJdumh5Do1JvnE2QbbLixZmJg6CzOfpzcAuS+qZadWK1Gj+yY/mj7IOVlgXCBg/yDqDmitGwSius+rrTpm8RA==
 
 "@mapbox/unitbezier@^0.0.0":
   version "0.0.0"


### PR DESCRIPTION
https://github.com/mapbox/tiny-sdf/pull/26 prevented crashes on characters from RTL scripts, but could still mis-calculate the glyph width, leading to cut off characters. Poking around in MDN, I realized that the [canvas `textAlign` property](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/textAlign) allows us to force all text to be laid out with left-alignment, which gives us the results the algorithm was expecting in the first place. This PR updates gl-js to use the version of TinySDF fixed with https://github.com/mapbox/tiny-sdf/pull/27.

**Before**
![Screen Shot 2021-01-26 at 9 39 21](https://user-images.githubusercontent.com/375121/105784210-b11e2d00-5fbb-11eb-8cc1-0155d322578b.png)

**After**
![Screen Shot 2021-01-26 at 9 38 54](https://user-images.githubusercontent.com/375121/105784224-b67b7780-5fbb-11eb-9893-5b394e5e4833.png)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

@karimnaaji @mourner 