### PR TITLE
Collect GL and Bundle size stats. Revert #10161

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ workflows:
             tags:
               ignore: /.*/
             branches:
-              only: main
+              only: restore-gl-stats
       - deploy-benchmarks:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,14 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - collect-stats:
+          requires:
+            - build
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: main
       - deploy-benchmarks:
           requires:
             - lint
@@ -221,6 +229,19 @@ jobs:
             rm -rf node_modules
       - store_artifacts:
           path: "test/build/transpilation"
+
+  collect-stats:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Collect performance stats
+          command: node bench/gl-stats.js
+      - aws-cli/install
+      - run:
+          name: Upload performance stats
+          command: aws s3 cp data.json.gz s3://mapbox-loading-dock/raw/gl_js.perf_metrics_staging/ci/`git show -s --date=short --format=%cd-%h HEAD`.json.gz
 
   test-browser:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ workflows:
             tags:
               ignore: /.*/
             branches:
-              only: restore-gl-stats
+              only: main
       - deploy-benchmarks:
           requires:
             - lint


### PR DESCRIPTION
This PR restores the collect-stats CI job. This collects basic WebGL usage stats and bundle size information that is used for internal tooling. 

It was tested with a temporary commit in this branch, but is only enabled for commits to `main`. Example working commit: https://app.circleci.com/pipelines/github/mapbox/mapbox-gl-js/5696/workflows/c1f8f2bf-991a-4bf3-b1d8-9233cf113ebd/jobs/77968

What remains to be done is run through all the commits introduced in #10160 to account for missing data from those commits until right before this PR is merged. @mourner did you have a driver script for doing this from the initial implementation.