### PR TITLE
Flickering geolocate circle fix

### DIFF
--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -311,8 +311,8 @@ class GeolocateControl extends Evented {
         assert(this._circleElement);
         const y = this._map._container.clientHeight / 2;
         const a = this._map.unproject([0, y]);
-        const b = this._map.unproject([1, y]);
-        const metersPerPixel = a.distanceTo(b);
+        const b = this._map.unproject([100, y]);
+        const metersPerPixel = a.distanceTo(b) / 100;
         const circleDiameter = Math.ceil(2.0 * this._accuracy / metersPerPixel);
         this._circleElement.style.width = `${circleDiameter}px`;
         this._circleElement.style.height = `${circleDiameter}px`;

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -491,6 +491,39 @@ test('GeolocateControl accuracy circle radius matches reported accuracy', (t) =>
     geolocation.send({latitude: 10, longitude: 20, accuracy: 700});
 });
 
+test("GeolocateControl accuracy circle doesn't flicker in size", (t) => {
+    const map = createMap(t);
+    const geolocate = new GeolocateControl({
+        trackUserLocation: true,
+        showUserLocation: true,
+    });
+    map.addControl(geolocate);
+
+    geolocate.once('geolocate', () => {
+        t.ok(geolocate._accuracyCircleMarker._map, 'userLocation accuracy circle marker on map');
+        t.equal(geolocate._accuracy, 150);
+        map.jumpTo({
+            center: [20.123123, 10.123123]
+        });
+        map.once('zoomend', () => {
+            const circleWidth = geolocate._circleElement.style.width;
+            map.once('zoomend', () => {
+                map.once('zoomend', () => {
+                    t.equal(geolocate._circleElement.style.width, circleWidth);
+                    t.end();
+                });
+                map.zoomTo(18, {duration: 0});
+            });
+            map.panBy([123, 123], {duration:0});
+            map.zoomTo(17, {duration: 0});
+        });
+        map.zoomTo(18, {duration: 0});
+    });
+
+    geolocate._geolocateButton.dispatchEvent(new window.Event('click'));
+    geolocation.send({longitude: 20.123123, latitude: 10.123123, accuracy: 150});
+});
+
 test('GeolocateControl shown even if trackUserLocation = false', (t) => {
     const map = createMap(t);
     const geolocate = new GeolocateControl({


### PR DESCRIPTION
fixes #10276

The metersPerPixel calculation introduced rounding errors. By measuring over 100 pixels instead of 1 pixel, the issue goes away.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix for flickering accuracy circle in GeolocateControl.</changelog>`
