### PR TITLE
Fix benchmark view JSX transform

### DIFF
--- a/bench/benchmarks_view.js
+++ b/bench/benchmarks_view.js
@@ -1,7 +1,11 @@
+/* eslint-disable indent */
 import React from 'react';
 import ReactDOM from 'react-dom';
+import htm from 'htm';
 import * as d3 from 'd3';
 import {kde, probabilitiesOfSuperiority, summaryStatistics, regression} from './lib/statistics.js';
+
+const html = htm.bind(React.createElement);
 
 const versionColor = d3.scaleOrdinal(['#1b9e77', '#7570b3', '#d95f02']);
 const formatSample = d3.format(".3r");
@@ -28,60 +32,57 @@ function center(scale) {
     };
 }
 
-class Axis extends React.Component {
-    render() {
-        const scale = this.props.scale;
-        const orient = this.props.orientation || 'left';
-        const tickArguments = this.props.ticks ? [].concat(this.props.ticks) : [];
-        const tickValues = this.props.tickValues || null;
-        const tickFormat = this.props.tickFormat || null;
-        const tickSizeInner = this.props.tickSize || this.props.tickSizeInner || 6;
-        const tickSizeOuter = this.props.tickSize || this.props.tickSizeOuter || 6;
-        const tickPadding = this.props.tickPadding || 3;
+function Axis(props) {
+    const scale = props.scale;
+    const orient = props.orientation || 'left';
+    const tickArguments = props.ticks ? [].concat(props.ticks) : [];
+    const tickFormat = props.tickFormat || null;
+    const tickSizeInner = 6;
+    const tickSizeOuter = 6;
+    const tickPadding = 3;
 
-        const k = orient === 'top' || orient === 'left' ? -1 : 1;
-        const x = orient === 'left' || orient === 'right' ? 'x' : 'y';
-        const transform = orient === 'top' || orient === 'bottom' ? translateX : translateY;
+    const k = orient === 'top' || orient === 'left' ? -1 : 1;
+    const x = orient === 'left' || orient === 'right' ? 'x' : 'y';
+    const transform = orient === 'top' || orient === 'bottom' ? translateX : translateY;
 
-        const values = tickValues == null ? (scale.ticks ? scale.ticks(...tickArguments) : scale.domain()) : tickValues;
-        const format = tickFormat == null ? (scale.tickFormat ? scale.tickFormat(...tickArguments) : identity) : tickFormat;
-        const spacing = Math.max(tickSizeInner, 0) + tickPadding;
-        const range = scale.range();
-        const range0 = +range[0] + 0.5;
-        const range1 = +range[range.length - 1] + 0.5;
-        const position = (scale.bandwidth ? center : number)(scale.copy());
+    const values = scale.ticks ? scale.ticks(...tickArguments) : scale.domain();
+    const format = tickFormat == null ? (scale.tickFormat ? scale.tickFormat(...tickArguments) : identity) : tickFormat;
+    const spacing = tickSizeInner + tickPadding;
+    const range = scale.range();
+    const range0 = +range[0] + 0.5;
+    const range1 = +range[range.length - 1] + 0.5;
+    const position = (scale.bandwidth ? center : number)(scale.copy());
 
-        return (
-            <g
-                fill='none'
-                fontSize={10}
-                fontFamily='sans-serif'
-                textAnchor={orient === 'right' ? 'start' : orient === 'left' ? 'end' : 'middle'}
-                transform={this.props.transform}>
-                <path
-                    className='domain'
-                    stroke='#000'
-                    d={orient === 'left' || orient === 'right' ?
-                        `M${k * tickSizeOuter},${range0}H0.5V${range1}H${k * tickSizeOuter}` :
-                        `M${range0},${k * tickSizeOuter}V0.5H${range1}V${k * tickSizeOuter}`} />
-                {values.map((d, i) =>
-                    <g
-                        key={i}
-                        className='tick'
-                        transform={transform(position(d))}>
-                        <line
-                            stroke='#000'
-                            {...{[`${x}2`]: k * tickSizeInner}}/>
-                        <text
-                            fill='#000'
-                            dy={orient === 'top' ? '0em' : orient === 'bottom' ? '0.71em' : '0.32em'}
-                            {...{[x]: k * spacing}}>{format(d)}</text>
-                    </g>
-                )}
-                {this.props.children}
-            </g>
-        );
-    }
+    return html`
+        <g
+            fill='none'
+            fontSize='10'
+            fontFamily='sans-serif'
+            textAnchor=${orient === 'right' ? 'start' : orient === 'left' ? 'end' : 'middle'}
+            transform=${props.transform}>
+            <path
+                className='domain'
+                stroke='#000'
+                d=${orient === 'left' || orient === 'right' ?
+                    `M${k * tickSizeOuter},${range0}H0.5V${range1}H${k * tickSizeOuter}` :
+                    `M${range0},${k * tickSizeOuter}V0.5H${range1}V${k * tickSizeOuter}`} />
+            ${values.map((d, i) =>
+                html`<g
+                    key=${i}
+                    className='tick'
+                    transform=${transform(position(d))}>
+                    <line
+                        stroke='#000'
+                        ...${{[`${x}2`]: k * tickSizeInner}}/>
+                    <text
+                        fill='#000'
+                        dy=${orient === 'top' ? '0em' : orient === 'bottom' ? '0.71em' : '0.32em'}
+                        ...${{[x]: k * spacing}}>${format(d)}</text>
+                </g>`
+            )}
+            ${props.children}
+        </g>
+    `;
 }
 
 class StatisticsPlot extends React.Component {
@@ -131,25 +132,25 @@ class StatisticsPlot extends React.Component {
             .y(d => t(d[0]))
             .x(d => p(d[1]));
 
-        return (
+        return html`
             <svg
                 width="100%"
-                height={height + margin.top + margin.bottom}
-                style={{overflow: 'visible'}}
-                ref={(ref) => { this.ref = ref; }}>
+                height=${height + margin.top + margin.bottom}
+                style=${{overflow: 'visible'}}
+                ref=${(ref) => { this.ref = ref; }}>
                 <defs>
                     <g id="up-arrow">
-                        <path transform="translate(-6, -2)" style={{stroke: "inherit", fill: "inherit"}}
+                        <path transform="translate(-6, -2)" style=${{stroke: "inherit", fill: "inherit"}}
                             d="M2,10 L6,2 L10,10"></path>
                     </g>
                 </defs>
-                <g transform={`translate(${margin.left},${margin.top})`}>
-                    <Axis orientation="bottom" scale={p} ticks={[2, "%"]} transform={`translate(0,${height})`}>
-                    </Axis>
-                    <Axis orientation="left" scale={t} tickFormat={formatSample}>
-                        <text fill='#000' textAnchor="end"  y={6} transform="rotate(-90)" dy=".71em">Time (ms)</text>
-                    </Axis>
-                    {versions.map((v, i) => {
+                <g transform=${`translate(${margin.left},${margin.top})`}>
+                    <${Axis} orientation="bottom" scale=${p} ticks=${[2, "%"]} transform=${`translate(0,${height})`}>
+                    <//>
+                    <${Axis} orientation="left" scale=${t} tickFormat=${formatSample}>
+                        <text fill='#000' textAnchor="end"  y='6' transform="rotate(-90)" dy=".71em">Time (ms)</text>
+                    <//>
+                    ${versions.map((v, i) => {
                         if (v.samples.length === 0)
                             return null;
 
@@ -173,105 +174,112 @@ class StatisticsPlot extends React.Component {
 
                         const tMax = t.domain()[1];
 
-                        return <g key={i}>
+                        return html`<g key=${i}>
                             <path
                                 fill="none"
-                                stroke={color}
-                                strokeWidth={2}
-                                strokeOpacity={0.7}
-                                d={line(v.density)} />
-                            <g transform={`translate(${b(v.name)},0)`}>
-                                {v.samples.map((d, i) =>
-                                    <circle
-                                        key={i}
-                                        fill={color}
-                                        cx={scale(i)}
-                                        cy={t(d)}
-                                        r={i === argmin || i === argmax ? 2 : 1}
-                                        style={{
+                                stroke=${color}
+                                strokeWidth='2'
+                                strokeOpacity='0.7'
+                                d=${line(v.density)} />
+                            <g transform=${`translate(${b(v.name)},0)`}>
+                                ${v.samples.map((d, i) =>
+                                    html`<circle
+                                        key=${i}
+                                        fill=${color}
+                                        cx=${scale(i)}
+                                        cy=${t(d)}
+                                        r=${i === argmin || i === argmax ? 2 : 1}
+                                        style=${{
                                             fillOpacity: d < tMax ? 1 : 0
                                         }}
-                                    />
+                                    />`
                                 )}
-                                {v.samples.filter(d => d >= tMax)
+                                ${v.samples.filter(d => d >= tMax)
                                     .map((d, i) =>
-                                        <use key={i}
+                                        html`<use key=${i}
                                             href="#up-arrow"
-                                            x={scale(i)}
-                                            y={t(d)}
-                                            style={{
+                                            x=${scale(i)}
+                                            y=${t(d)}
+                                            style=${{
                                                 stroke:color,
                                                 strokeWidth: i === argmin || i === argmax ? 2 : 1,
                                                 fill: 'rgba(200, 0, 0, 0.5)'
                                             }}
-                                        />
+                                        />`
                                     )
                                 }
-                                <line // quartiles
-                                    x1={bandwidth / 2}
-                                    x2={bandwidth / 2}
-                                    y1={t(q1)}
-                                    y2={t(q3)}
-                                    stroke={color}
-                                    strokeWidth={bandwidth}
-                                    strokeOpacity={0.5} />
-                                <line // median
-                                    x1={bandwidth / 2}
-                                    x2={bandwidth / 2}
-                                    y1={t(q2) - 0.5}
-                                    y2={t(q2) + 0.5}
-                                    stroke={color}
-                                    strokeWidth={bandwidth}
-                                    strokeOpacity={1} />
-                                <use href="#up-arrow" // mean
-                                    style={{stroke: color, fill: color, fillOpacity: 0.4}}
-                                    transform={mean >= tMax ? 'translate(-10, 0)' : `translate(-5, ${t(mean)}) rotate(90)`}
-                                    x={0}
-                                    y={0} />
-                                <use href="#up-arrow" // trimmed mean
-                                    style={{stroke: color, fill: color}}
-                                    transform={`translate(-5, ${t(trimmedMean)}) rotate(90)`}
-                                    x={0}
-                                    y={0} />
-                                {[mean, trimmedMean].map((d, i) =>
-                                    <text // left
-                                        key={i}
-                                        dx={-16}
+                                <!-- quartiles -->
+                                <line
+                                    x1=${bandwidth / 2}
+                                    x2=${bandwidth / 2}
+                                    y1=${t(q1)}
+                                    y2=${t(q3)}
+                                    stroke=${color}
+                                    strokeWidth=${bandwidth}
+                                    strokeOpacity='0.5' />
+                                <!-- median -->
+                                <line
+                                    x1=${bandwidth / 2}
+                                    x2=${bandwidth / 2}
+                                    y1=${t(q2) - 0.5}
+                                    y2=${t(q2) + 0.5}
+                                    stroke=${color}
+                                    strokeWidth=${bandwidth}
+                                    strokeOpacity='1' />
+                                <!-- mean -->
+                                <use href="#up-arrow"
+                                    style=${{stroke: color, fill: color, fillOpacity: 0.4}}
+                                    transform=${mean >= tMax ? 'translate(-10, 0)' : `translate(-5, ${t(mean)}) rotate(90)`}
+                                    x='0'
+                                    y='0' />
+                                <!-- trimmed mean -->
+                                <use href="#up-arrow"
+                                    style=${{stroke: color, fill: color}}
+                                    transform=${`translate(-5, ${t(trimmedMean)}) rotate(90)`}
+                                    x='0'
+                                    y='0' />
+                                ${[mean, trimmedMean].map((d, i) =>
+                                    // left
+                                    html`<text
+                                        key=${i}
+                                        dx='-16'
                                         dy='.3em'
-                                        x={0}
-                                        y={t(d)}
+                                        x='0'
+                                        y=${t(d)}
                                         textAnchor='end'
-                                        fontSize={10}
-                                        fontFamily='sans-serif'>{formatSample(d)}</text>
+                                        fontSize='10'
+                                        fontFamily='sans-serif'>${formatSample(d)}</text>`
                                 )}
-                                {[[argmin, min], [argmax, max]].map((d, i) =>
-                                    <text // extent
-                                        key={i}
-                                        dx={0}
-                                        dy={i === 0 ? '1.3em' : '-0.7em'}
-                                        x={scale(d[0])}
-                                        y={t(d[1])}
+                                ${[[argmin, min], [argmax, max]].map((d, i) =>
+                                    // extent
+                                    html`<text
+                                        key=${i}
+                                        dx='0'
+                                        dy=${i === 0 ? '1.3em' : '-0.7em'}
+                                        x=${scale(d[0])}
+                                        y=${t(d[1])}
                                         textAnchor='middle'
-                                        fontSize={10}
-                                        fontFamily='sans-serif'>{formatSample(d[1])}</text>
+                                        fontSize='10'
+                                        fontFamily='sans-serif'>${formatSample(d[1])}</text>`
                                 )}
-                                {[q1, q2, q3].map((d, i) =>
-                                    <text // right
-                                        key={i}
-                                        dx={6}
+                                ${[q1, q2, q3].map((d, i) =>
+                                    // right
+                                    html`<text
+                                        key=${i}
+                                        dx='6'
                                         dy='.3em'
-                                        x={bandwidth}
-                                        y={t(d)}
+                                        x=${bandwidth}
+                                        y=${t(d)}
                                         textAnchor='start'
-                                        fontSize={10}
-                                        fontFamily='sans-serif'>{formatSample(d)}</text>
+                                        fontSize='10'
+                                        fontFamily='sans-serif'>${formatSample(d)}</text>`
                                 )}
                             </g>
-                        </g>;
+                        </g>`;
                     })}
                 </g>
             </svg>
-        );
+        `;
     }
 
     componentDidMount() {
@@ -305,40 +313,40 @@ class RegressionPlot extends React.Component {
             .x(d => x(d[0]))
             .y(d => y(d[1]));
 
-        return (
+        return html`
             <svg
                 width="100%"
-                height={height + margin.top + margin.bottom}
-                style={{overflow: 'visible'}}
-                ref={(ref) => { this.ref = ref; }}>
-                <g transform={`translate(${margin.left},${margin.top})`}>
-                    <Axis orientation="bottom" scale={x} transform={`translate(0,${height})`}>
-                        <text fill='#000' textAnchor="end" y={-6} x={width}>Iterations</text>
-                    </Axis>
-                    <Axis orientation="left" scale={y} ticks={4} tickFormat={formatSample}>
-                        <text fill='#000' textAnchor="end"  y={6} transform="rotate(-90)" dy=".71em">Time (ms)</text>
-                    </Axis>
-                    {versions.map((v, i) =>
-                        <g
-                            key={i}
-                            fill={versionColor(v.name)}
-                            fillOpacity="0.7">
-                            {v.regression.data.map(([a, b], i) =>
-                                <circle key={i} r="2" cx={x(a)} cy={y(b)}/>
+                height=${height + margin.top + margin.bottom}
+                style=${{overflow: 'visible'}}
+                ref=${(ref) => { this.ref = ref; }}>
+                <g transform=${`translate(${margin.left},${margin.top})`}>
+                    <${Axis} orientation="bottom" scale=${x} transform=${`translate(0,${height})`}>
+                        <text fill='#000' textAnchor="end" y='-6' x=${width}>Iterations</text>
+                    <//>
+                    <${Axis} orientation="left" scale=${y} ticks='4' tickFormat=${formatSample}>
+                        <text fill='#000' textAnchor="end"  y='6' transform="rotate(-90)" dy=".71em">Time (ms)</text>
+                    <//>
+                    ${versions.map((v, i) =>
+                        html`<g
+                            key=${i}
+                            fill=${versionColor(v.name)}
+                            fillOpacity='0.7'>
+                            ${v.regression.data.map(([a, b], i) =>
+                                html`<circle key=${i} r="2" cx=${x(a)} cy=${y(b)}/>`
                             )}
                             <path
-                                stroke={versionColor(v.name)}
-                                strokeWidth={1}
-                                strokeOpacity={0.5}
-                                d={line(v.regression.data.map(d => [
+                                stroke=${versionColor(v.name)}
+                                strokeWidth='1'
+                                strokeOpacity='0.5'
+                                d=${line(v.regression.data.map(d => [
                                     d[0],
                                     d[0] * v.regression.slope + v.regression.intercept
                                 ]))} />
-                        </g>
+                        </g>`
                     )}
                 </g>
             </svg>
-        );
+        `;
     }
 
     componentDidMount() {
@@ -346,18 +354,16 @@ class RegressionPlot extends React.Component {
     }
 }
 
-class BenchmarkStatistic extends React.Component {
-    render() {
-        switch (this.props.status) {
-        case 'waiting':
-            return <p className="quiet"></p>;
-        case 'running':
-            return <p>Running...</p>;
-        case 'error':
-            return <p>{this.props.error.message}</p>;
-        default:
-            return this.props.statistic(this.props);
-        }
+function BenchmarkStatistic(props) {
+    switch (props.status) {
+    case 'waiting':
+        return html`<p className="quiet"></p>`;
+    case 'running':
+        return html`<p>Running...</p>`;
+    case 'error':
+        return html`<p>${props.error.message}</p>`;
+    default:
+        return props.statistic(props);
     }
 }
 
@@ -391,61 +397,61 @@ class BenchmarkRow extends React.Component {
 
             const {superior, inferior} = probabilitiesOfSuperiority(main.samples, current.samples);
 
-            change = <span className={d < 0.2 ? 'quiet' : d < 1.5 ? '' : 'strong'}>(
-                {delta > 0 ? '+' : ''}{formatSample(delta)} ms / {d.toFixed(1)} std devs
-            )</span>;
+            change = html`<span className=${d < 0.2 ? 'quiet' : d < 1.5 ? '' : 'strong'}>
+                (${delta > 0 ? '+' : ''}${formatSample(delta)} ms / ${d.toFixed(1)} std devs)
+            </span>`;
 
             const comparison = inferior > superior ? 'SLOWER' : 'faster';
             const probability = Math.max(inferior, superior);
-            pInferiority = <p className={`center ${probability > 0.90 ? 'strong' : 'quiet'}`}>
-                {(probability * 100).toFixed(0)}%
-                chance that a random <svg width={8} height={8}><circle fill={versionColor(current.name)} cx={4} cy={4} r={4} /></svg> sample is
-                {comparison} than a random <svg width={8} height={8}><circle fill={versionColor(main.name)} cx={4} cy={4} r={4} /></svg> sample.
-            </p>;
+            pInferiority = html`<p className=${`center ${probability > 0.90 ? 'strong' : 'quiet'}`}>
+                ${(probability * 100).toFixed(0)}%
+                chance that a random <svg width='8' height='8'><circle fill=${versionColor(current.name)} cx='4' cy='4' r='4' /></svg> sample is 
+                ${comparison} than a random <svg width='8' height='8'><circle fill=${versionColor(main.name)} cx='4' cy='4' r='4' /></svg> sample.
+            </p>`;
         }
 
-        return (
+        return html`
             <div className="col12 clearfix space-bottom">
                 <table className="fixed space-bottom">
                     <tbody>
-                        <tr><th><h2 className="col4"><a href={`#${this.props.name}`} onClick={this.reload}>{this.props.name}</a></h2></th>
-                            {this.props.versions.map(version => <th style={{color: versionColor(version.name)}} key={version.name}>{version.name}</th>)}</tr>
-                        {this.props.location && <tr>
-                            <th><p style={{color: '#1287A8'}}>{this.props.location.description}</p></th>
-                            <th><p style={{color: '#1287A8'}}>Zoom Level: {this.props.location.zoom}</p></th>
-                            <th><p style={{color: '#1287A8'}}>Lat: {this.props.location.center[1]} Lng: {this.props.location.center[0]}</p></th>
-                        </tr>}
-                        {this.renderStatistic('(20% trimmed) Mean',
-                            (version) => <p>
-                                {formatSample(version.summary.trimmedMean)} ms
-                                {current && version.name === current.name && change}
-                            </p>)}
-                        {this.renderStatistic('(Windsorized) Deviation',
-                            (version) => <p>{formatSample(version.summary.windsorizedDeviation)} ms</p>)}
-                        {this.renderStatistic('R² Slope / Correlation',
-                            (version) => <p>{formatSample(version.regression.slope)} ms / {version.regression.correlation.toFixed(3)} {
+                        <tr><th><h2 className="col4"><a href=${`#${this.props.name}`} onClick=${this.reload}>${this.props.name}</a></h2></th>
+                            ${this.props.versions.map(version => html`<th style=${{color: versionColor(version.name)}} key=${version.name}>${version.name}</th>`)}</tr>
+                        ${this.props.location && html`<tr>
+                            <th><p style=${{color: '#1287A8'}}>${this.props.location.description}</p></th>
+                            <th><p style=${{color: '#1287A8'}}>Zoom Level: ${this.props.location.zoom}</p></th>
+                            <th><p style=${{color: '#1287A8'}}>Lat: ${this.props.location.center[1]} Lng: ${this.props.location.center[0]}</p></th>
+                        </tr>`}
+                        ${this.renderStatistic('(20% trimmed) Mean',
+                            (version) => html`<p>
+                                ${formatSample(version.summary.trimmedMean)} ms
+                                ${current && version.name === current.name && change}
+                            </p>`)}
+                        ${this.renderStatistic('(Windsorized) Deviation',
+                            (version) => html`<p>${formatSample(version.summary.windsorizedDeviation)} ms</p>`)}
+                        ${this.renderStatistic('R² Slope / Correlation',
+                            (version) => html`<p>${formatSample(version.regression.slope)} ms / ${version.regression.correlation.toFixed(3)} ${
                                 version.regression.correlation < 0.9 ? '\u2620\uFE0F' :
-                                version.regression.correlation < 0.99 ? '\u26A0\uFE0F' : ''}</p>)}
-                        {this.renderStatistic('Minimum',
-                            (version) => <p>{formatSample(version.summary.min)} ms</p>)}
-                        {pInferiority && <tr><td colSpan={3}>{pInferiority}</td></tr>}
+                                version.regression.correlation < 0.99 ? '\u26A0\uFE0F' : ''}</p>`)}
+                        ${this.renderStatistic('Minimum',
+                            (version) => html`<p>${formatSample(version.summary.min)} ms</p>`)}
+                        ${pInferiority && html`<tr><td colSpan='3'>${pInferiority}</td></tr>`}
                     </tbody>
                 </table>
-                {endedCount > 0 && <StatisticsPlot versions={this.props.versions}/>}
-                {endedCount > 0 && <RegressionPlot versions={this.props.versions}/>}
+                ${endedCount > 0 && html`<${StatisticsPlot} versions=${this.props.versions}/>`}
+                ${endedCount > 0 && html`<${RegressionPlot} versions=${this.props.versions}/>`}
             </div>
-        );
+        `;
     }
 
     renderStatistic(title, statistic) {
-        return (
+        return html`
             <tr>
-                <th>{title}</th>
-                {this.props.versions.map(version =>
-                    <td key={version.name}><BenchmarkStatistic statistic={statistic} {...version}/></td>
+                <th>${title}</th>
+                ${this.props.versions.map(version =>
+                    html`<td key=${version.name}><${BenchmarkStatistic} statistic=${statistic} ...${version}/></td>`
                 )}
             </tr>
-        );
+        `;
     }
 
     reload() {
@@ -453,27 +459,25 @@ class BenchmarkRow extends React.Component {
     }
 }
 
-class BenchmarksTable extends React.Component {
-    render() {
-        return (
-            <div style={{width: 960, margin: '2em auto'}}>
-                <h1 className="space-bottom1">Mapbox GL JS Benchmarks – {
-                    this.props.finished ?
-                        <span>Finished</span> :
-                        <span>Running</span>}</h1>
-                {this.props.benchmarks.map((benchmark, i) => {
-                    return <BenchmarkRow key={`${benchmark.name}-${i}`} {...benchmark}/>;
-                })}
-            </div>
-        );
-    }
+function BenchmarksTable(props) {
+    return html`
+        <div style=${{width: 960, margin: '2em auto'}}>
+            <h1 className="space-bottom1">Mapbox GL JS Benchmarks – ${
+                props.finished ?
+                    html`<span>Finished</span>` :
+                    html`<span>Running</span>`}</h1>
+            ${props.benchmarks.map((benchmark, i) => {
+                return html`<${BenchmarkRow} key=${`${benchmark.name}-${i}`} ...${benchmark}/>`;
+            })}
+        </div>
+    `;
 }
 
 function updateUI(benchmarks, finished) {
     finished = !!finished;
 
     ReactDOM.render(
-        <BenchmarksTable benchmarks={benchmarks} finished={finished}/>,
+        html`<${BenchmarksTable} benchmarks=${benchmarks} finished=${finished}/>`,
         document.getElementById('benchmarks')
     );
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "flow-bin": "^0.100.0",
     "gl": "^4.5.3",
     "glob": "^7.1.4",
+    "htm": "^3.0.4",
     "is-builtin-module": "^3.0.0",
     "jsdom": "^13.0.0",
     "json-stringify-pretty-compact": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5251,6 +5251,11 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+htm@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/htm/-/htm-3.0.4.tgz#c90c891645d2d792bdb9f8c867964b18e3503718"
+  integrity sha512-VRdvxX3tmrXuT/Ovt59NMp/ORMFi4bceFMDjos1PV4E0mV+5votuID8R60egR9A4U8nLt238R/snlJGz3UYiTQ==
+
 html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"


### PR DESCRIPTION
This is a fix for #10233. It uses [htm](https://github.com/developit/htm) instead of JSX to generate the pretty graphs on the benchmarks view page. `htm` is a JSX-like syntax that transforms at runtime instead of at build time.

Pros:
- It fixes #10233.
- It avoids adding back Buble which is apparently a legacy tool now.

Cons:
- The syntax is (slightly) less familiar than standard JSX.
- It requires `/* eslint-disable indent */`.

Is this a good tradeoff?

Note: React is only used in this one file. I tried removing it completely and rewriting the page in pure d3. The plots are easy to draw but the code is more verbose and generating the statistics table becomes unwieldy without react's declarative nature. Is it worth pursuing further?

 - [x] briefly describe the changes in this PR
