### PR TITLE
Use an upload script for publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,18 +304,4 @@ jobs:
       - run:
           name: Deploy release
           command: |
-            function upload {
-                aws s3 cp --acl public-read --content-type $2 dist/$1 s3://mapbox-gl-js/$CIRCLE_TAG/$1
-            }
-
-            upload mapbox-gl.js     application/javascript
-            upload mapbox-gl.js.map application/octet-stream
-            upload mapbox-gl-dev.js application/javascript
-            upload mapbox-gl.css    text/css
-
-            upload mapbox-gl-unminified.js     application/javascript
-            upload mapbox-gl-unminified.js.map application/octet-stream
-            upload mapbox-gl-csp.js            application/javascript
-            upload mapbox-gl-csp.js.map        application/octet-stream
-            upload mapbox-gl-csp-worker.js     application/javascript
-            upload mapbox-gl-csp-worker.js.map application/octet-stream
+            bash ./build/upload.sh

--- a/build/upload.sh
+++ b/build/upload.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# This file uploads the necessary build files to s3
+# which enables them to be served by our CDN.
+# To run locally, you must be logged into AWS,
+# have built the needed files and pass the tag.
+# To build files:
+# yarn run build-prod-min && yarn run build-prod && yarn run build-csp && yarn run build-dev && yarn run build-css
+# The tag should be in the form of vx.x.x:
+# ./upload.sh v2.0.0
+
+# use $CIRCLE_TAG on CircleCI
+# else a tag must be supplied by user
+if [ -n "$CIRCLE_TAG" ]
+then
+	tag=$CIRCLE_TAG
+elif [ -n "$1" ]
+then
+	tag=$1
+else
+	echo "Error: A tag must be set to upload to s3. If running this script manually, pass the tag as an argument: ./upload.sh vx.x.x"
+	exit 1;
+fi
+
+declare -a files=(
+    "mapbox-gl.js"
+    "mapbox-gl.js.map"
+    "mapbox-gl-dev.js"
+    "mapbox-gl.css"
+    "mapbox-gl-unminified.js"
+    "mapbox-gl-unminified.js.map"
+    "mapbox-gl-csp.js"
+    "mapbox-gl-csp.js.map"
+    "mapbox-gl-csp-worker.js"
+    "mapbox-gl-csp-worker.js.map"
+)
+
+for i in "${files[@]}"
+do
+	file=$i
+	# separate the file name on the "."
+	isjs=$(echo $file | cut -d. -f2)
+	ismap=$(echo $file | cut -d. -f3)
+
+	if [ "$isjs" = "js" ]
+	then
+		mimetype="application/javascript"
+		if [ -n "$ismap" ]
+		then
+			mimetype="application/octet-stream"
+		fi
+	else
+		mimetype="text/css"
+	fi
+
+	aws s3 cp --acl public-read --content-type ${mimetype} dist/${file} s3://mapbox-gl-js/${tag}/${file}
+done


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - this PR addresses a shortcoming where there was no way to reliably do a manual update of build files for release on the CDN. by moving the upload step into a bash script, we can use that in CI as well as feel comfortable that running the script locally will produce the desired outcome.
    - I tested this locally by echoing the command rather than running it. The commands produced are correct, but I'm hesitant to do a dry-run. I don't believe we have a staging setup for the CDN so any test I do would be published to the CDN.
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

cc @jseppi for 👀 on this
