### PR TITLE
Fix default workerCount in docs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,13 +120,13 @@ const exported = {
 
     /**
      * Gets and sets the number of web workers instantiated on a page with GL JS maps.
-     * By default, it is set to half the number of CPU cores (capped at 6).
+     * By default, it is set to 2.
      * Make sure to set this property before creating any map instances for it to have effect.
      *
      * @var {string} workerCount
      * @returns {number} Number of workers currently configured.
      * @example
-     * mapboxgl.workerCount = 2;
+     * mapboxgl.workerCount = 4;
      */
     get workerCount(): number {
         return WorkerPool.workerCount;


### PR DESCRIPTION
This fixes the documented default value of `workerCount` since it's now hardcoded to 2. Also updates the example for setting a non-default value.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
