### PR TITLE
Fix collect-stats job

### DIFF
--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -1,12 +1,11 @@
-/* eslint-disable import/no-commonjs */
+import puppeteer from 'puppeteer';
+import fs from 'fs';
+import zlib from 'zlib';
+import {execSync} from 'child_process';
 
-const puppeteer = require('puppeteer');
-const fs = require('fs');
-const zlib = require('zlib');
 const mapboxGLJSSrc = fs.readFileSync('dist/mapbox-gl.js', 'utf8');
 const mapboxGLCSSSrc = fs.readFileSync('dist/mapbox-gl.css', 'utf8');
 const benchSrc = fs.readFileSync('bench/gl-stats.html', 'utf8');
-const {execSync} = require('child_process');
 
 const benchHTML = benchSrc
     .replace(/<script src="..\/dist\/mapbox-gl.js"><\/script>/, `<script>${mapboxGLJSSrc}</script>`)


### PR DESCRIPTION
Leftover after #10367 — `collect-stats` was failing, but I didn't notice because it only runs on CI.