### PR TITLE
Upgrade to a newer and faster CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,6 @@ jobs:
   prepare:
     <<: *defaults
     steps:
-      - browser-tools/install-browser-tools
       - checkout
       - restore_cache:
           keys:
@@ -200,6 +199,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - browser-tools/install-browser-tools
       - run: yarn run test-render
       - store_test_results:
           path: test/integration/render-tests
@@ -211,6 +211,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - browser-tools/install-browser-tools
       - run: yarn run test-query
       - store_test_results:
           path: test/integration/query-tests
@@ -237,6 +238,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - browser-tools/install-browser-tools
       - run:
           name: Collect performance stats
           command: node bench/gl-stats.js
@@ -250,6 +252,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - browser-tools/install-browser-tools
       - run: yarn run build-dev
       - run: yarn run build-token
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,8 +252,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - browser-tools/install-chromedriver
-      - browser-tools/install-geckodriver
+      - browser-tools/install-browser-tools
       - run: yarn run build-dev
       - run: yarn run build-token
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
       - run: yarn run test-render
       - store_test_results:
           path: test/integration/render-tests
@@ -211,7 +211,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
       - run: yarn run test-query
       - store_test_results:
           path: test/integration/query-tests
@@ -238,7 +238,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
       - run:
           name: Collect performance stats
           command: node bench/gl-stats.js
@@ -252,7 +252,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chromedriver
+      - browser-tools/install-geckodriver
       - run: yarn run build-dev
       - run: yarn run build-token
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
-  aws-cli: circleci/aws-cli@0.1.16
+  aws-cli: circleci/aws-cli@1.4.0
+  browser-tools: circleci/browser-tools@1.1.1
 
 workflows:
   version: 2
@@ -106,13 +107,14 @@ workflows:
 
 defaults: &defaults
   docker:
-    - image: circleci/node:14.15-browsers
+    - image: cimg/node:14.15-browsers
   working_directory: ~/mapbox-gl-js
 
 jobs:
   prepare:
     <<: *defaults
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - restore_cache:
           keys:


### PR DESCRIPTION
Upgrading CircleCI image that we use to the [next-generation one introduced last year](https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/) makes our Circle runs about 2 times faster! 😱 [Sample run](https://app.circleci.com/pipelines/github/mapbox/mapbox-gl-js/5859/workflows/0371e630-4bec-479a-832a-10e0c76c52eb).

This is especially stunning on `test-render` — it now runs in 3:30 instead of 8:00!

Also potentially closes #10383, although needs more runs to confirm that the `test-browser` job is no longer flaky.