### PR TITLE
account for padding in getBounds

### DIFF
--- a/debug/padding.html
+++ b/debug/padding.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+        #getBounds { position: absolute; top: 0; left; 0;}
+        #setBounds { position: absolute; top: 0; left: 78px;}
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<button id="getBounds">getBounds</button>
+<button id="setBounds">setBounds</button>
+
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-122.4194, 37.7749],
+    style: 'mapbox://styles/mapbox/streets-v10',
+    hash: true
+});
+
+map.setPadding({
+    left: 400,
+    top: 50,
+    right: 50,
+    bottom: 50
+});
+map.showPadding = true;
+
+map.on('load', function () {
+    map.addSource('bounds', {
+        type: 'geojson',
+        data: {
+            type: 'FeatureCollection',
+            features: []
+        }
+    });
+    map.addLayer({
+        type: 'line',
+        id: 'bounds',
+        source: 'bounds',
+        paint: {
+            'line-width': 10
+        }
+    });
+})
+
+var bounds;
+document.getElementById('getBounds').addEventListener('click', function () {
+    bounds = map.getBounds();
+    map.getSource('bounds').setData({
+        type: 'Feature',
+        properties: {},
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                bounds.getNorthEast().toArray(),
+                bounds.getSouthEast().toArray(),
+                bounds.getSouthWest().toArray(),
+                bounds.getNorthWest().toArray(),
+                bounds.getNorthEast().toArray()
+            ]]
+        }
+    });
+});
+document.getElementById('setBounds').addEventListener('click', function () {
+    map.fitBounds(bounds, {
+        duration: 0
+    });
+});
+</script>
+</body>
+</html>

--- a/debug/padding.html
+++ b/debug/padding.html
@@ -8,8 +8,8 @@
     <style>
         body { margin: 0; padding: 0; }
         html, body, #map { height: 100%; }
-        #getBounds { position: absolute; top: 0; left; 0;}
-        #setBounds { position: absolute; top: 0; left: 78px;}
+        #getBounds { position: absolute; top: 0; left; 0; }
+        #setBounds { position: absolute; top: 0; left: 78px; }
     </style>
 </head>
 
@@ -54,7 +54,7 @@ map.on('load', function () {
             'line-width': 10
         }
     });
-})
+});
 
 var bounds;
 document.getElementById('getBounds').addEventListener('click', function () {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -984,10 +984,10 @@ class Transform {
     getBounds(): LngLatBounds {
         if (this._terrainEnabled()) return this._getBounds3D();
         return new LngLatBounds()
-            .extend(this.pointLocation(new Point(0, 0)))
-            .extend(this.pointLocation(new Point(this.width, 0)))
-            .extend(this.pointLocation(new Point(this.width, this.height)))
-            .extend(this.pointLocation(new Point(0, this.height)));
+            .extend(this.pointLocation(new Point(this._edgeInsets.left, this._edgeInsets.top)))
+            .extend(this.pointLocation(new Point(this.width - this._edgeInsets.right, this._edgeInsets.top)))
+            .extend(this.pointLocation(new Point(this.width - this._edgeInsets.right, this.height - this._edgeInsets.bottom)))
+            .extend(this.pointLocation(new Point(this._edgeInsets.left, this.height - this._edgeInsets.bottom)));
     }
 
     _getBounds3D(): LngLatBounds {

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -703,6 +703,7 @@ class Camera extends Evented {
     /**
      * Pans and zooms the map to contain its visible area within the specified geographical bounds.
      * This function will also reset the map's bearing to 0 if bearing is nonzero.
+     * If a padding is set on the map, the bounds are fit to the inset.
      *
      * @memberof Map#
      * @param bounds Center these bounds in the viewport and use the highest

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -638,6 +638,7 @@ class Map extends Camera {
     /**
      * Returns the map's geographical bounds. When the bearing or pitch is non-zero, the visible region is not
      * an axis-aligned rectangle, and the result is the smallest bounds that encompasses the visible region.
+     * If a padding is set on the map, the bounds returned are for the inset.
      * @returns {LngLatBounds} The geographical bounds of the map as {@link LngLatBounds}.
      * @example
      * var bounds = map.getBounds();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -702,6 +702,24 @@ test('Map', (t) => {
             t.end();
         });
 
+        t.test('padded bounds', (t) => {
+            const map = createMap(t, {zoom: 1, bearing: 45, skipCSSStub: true, skipAuthenticateStub: true});
+
+            map.setPadding({
+                left: 100,
+                right: 10,
+                top: 10,
+                bottom: 10
+            });
+
+            t.deepEqual(
+                toFixed([[-33.5599507477, -31.7907658998], [33.5599507477, 31.7907658998]]),
+                toFixed(map.getBounds().toArray())
+            );
+
+            t.end();
+        });
+
         t.end();
 
         function toFixed(bounds) {


### PR DESCRIPTION
## Launch Checklist

 - [x] briefly describe the changes in this PR
 
This change proposes to alter `map.getBounds()`, when a global map padding is set, to return the inset bounds rather than the outset bounds (current behaviour).

This probably needs some discussion, not sure if it's considered a breaking change or a bug fix, however by making this the new default it ensures that:

1. box zoom interaction ensures that all the area within the selected box is visible within the inset area (should address #9056)
2. `getBounds` followed by `fitBounds` ensures the map view doesn't change (should address #10169)

My rationale is once you've set your global map padding to account for UI elements then all bounds refer to the inset bounds for consistency.

We could consider adding an option to `getBounds`/`fitBounds` to specify if the bounds should be for the inset or outset padded area, as I can see times when a dev would like to specify this.

 - [x] include before/after visuals or gifs if this PR includes visual changes

## before
getBounds:
![Screenshot from 2021-02-16 13-48-33](https://user-images.githubusercontent.com/117278/108012551-cb4ca780-705d-11eb-92f3-b1eb0eec233a.png)

setBounds:
![Screenshot from 2021-02-16 13-48-46](https://user-images.githubusercontent.com/117278/108012578-d3a4e280-705d-11eb-9a22-39dcf980b4e0.png)

## after:
getBounds/setBounds:
![Screenshot from 2021-02-16 13-47-43](https://user-images.githubusercontent.com/117278/108012596-de5f7780-705d-11eb-92b0-c31196a76809.png)

 - [x] write tests for all new functionality

added one unit test to confirm that `getBounds` returns the inset when padding is set

 - [x] document any changes to public APIs
I've updated the docs for `getBounds`/`fitBounds` to specify it's for the inset when padding is set, however I can see especially with `fitBounds` how someone reading the docs could get confused between the two different kinds of padding (`map.setPadding` and `map.fitBounds` `padding` option), not sure how to improve that.

 - [ ] post benchmark scores
 - [x] manually test the debug page
yes, I added a new debug page

 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
feature or bug? Possibly considered a breaking change.
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Changed `map.getBounds()` to return the inset bounds when a map padding is set</changelog>`
