### PR TITLE
Fix chrome path in collect-stats job on CI

### DIFF
--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -24,7 +24,7 @@ function waitForConsole(page) {
 (async () => {
     const browser = await puppeteer.launch({
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        executablePath: process.env.CI ? '/usr/local/bin/google-chrome' : '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        executablePath: process.env.CI ? '/usr/bin/google-chrome' : '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
     });
     const page = await browser.newPage();
 


### PR DESCRIPTION
Apologies, used the wrong path for Google Chrome so `collect-stats` failed after #10387. Also made sure it passes now (by temporarily disabling branch restrictions and then re-enabling).