### PR TITLE
Switch to using alphabetic baseline for local glyphs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/point-geometry": "^0.1.0",
-    "@mapbox/tiny-sdf": "^1.2.3",
+    "@mapbox/tiny-sdf": "^1.2.5",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,10 +1158,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz#f3b1af042620716a1289fc41e1e97f610823aefe"
   integrity sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA==
 
-"@mapbox/tiny-sdf@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-1.2.3.tgz#74807b3eab60ca8f9cd2de8238c27928f8f31677"
-  integrity sha512-UH233on+8Okmj/JJFcxyc+HMSzKQcSFiiT339lFf2BMGs0+iEbobX7+GESeKVkPVtTFoh54LuNa1mC8N2ucM2w==
+"@mapbox/tiny-sdf@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz#424c620a96442b20402552be70a7f62a8407cc59"
+  integrity sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==
 
 "@mapbox/unitbezier@^0.0.0":
   version "0.0.0"


### PR DESCRIPTION
This PR integrates the TinySDF changes at https://github.com/mapbox/tiny-sdf/pull/30 which switch to drawing glyphs on the "alphabetic" baseline instead of the "middle" baseline. This gives better visual alignment between fonts. The new version of TinySDF will have to be published before this PR builds successfully.

Here's an overlay of the Meiryo and YaHei fonts, showing how the alphabetic baseline matches expectations (Meiryo "broke" earlier assumption because it has a very large font descender):

![Meiryo vs YaHei baselines](https://user-images.githubusercontent.com/375121/107916950-8287e680-6faa-11eb-8af3-3000574fcb4b.png)

TinySDF's "top" metric now means "distance from alphabetic baseline to top of glyph" which seems pretty intuitive but notably _different_ from what https://github.com/mapbox/sdf-glyph-foundry generates. This PR adjusts to bring the two metrics mostly into line.

Here are some cross browser/font/platform test results (it would be great to figure out a good way to automate this):

*Chrome MacOS Meiryo : Server Arial*
![Chrome MacOS Meiryo : Server Arial](https://user-images.githubusercontent.com/375121/108149666-b41dc080-7116-11eb-82ca-84d03e1166d5.png)
*Chrome macOS Meiryo:Meiryo*
![Chrome macOS Meiryo:Meiryo](https://user-images.githubusercontent.com/375121/108149667-b5e78400-7116-11eb-8a30-f4e83f9a9caf.png)
*Chrome MacOS san-serif all*
![Chrome MacOS san-serif all](https://user-images.githubusercontent.com/375121/108149669-b6801a80-7116-11eb-8047-226995001ac7.png)
*Chrome MacOS sans-serif: server Arial*
![Chrome MacOS sans-serif: server Arial](https://user-images.githubusercontent.com/375121/108149671-b6801a80-7116-11eb-97c2-6eff97ec8ba7.png)
*Chrome Windows 10 : sans-serif all*
![Chrome Windows 10 : sans-serif all](https://user-images.githubusercontent.com/375121/108149673-b718b100-7116-11eb-943d-ad1af5743911.png)
*Chrome Windows 10 sans-serif : Server Arial*
![Chrome Windows 10 sans-serif : Server Arial](https://user-images.githubusercontent.com/375121/108149674-b7b14780-7116-11eb-96d7-12554760b2c7.png)
*Edge Windows 10 sans-serif : Server Arial*
![Edge Windows 10 sans-serif : Server Arial](https://user-images.githubusercontent.com/375121/108149675-b7b14780-7116-11eb-8954-f8bdbda63d8a.png)
*Edge Windows 10 sans-serif all*
![Edge Windows 10 sans-serif all](https://user-images.githubusercontent.com/375121/108149676-b849de00-7116-11eb-95f3-3f66500efb3b.png)
*Firefox MacOS san-serif : Server Arial*
![Firefox MacOS san-serif : Server Arial](https://user-images.githubusercontent.com/375121/108149679-b849de00-7116-11eb-9cdc-4490b4e57722.png)
*Firefox MacOS sans-serif all*
![Firefox MacOS sans-serif all](https://user-images.githubusercontent.com/375121/108149681-b8e27480-7116-11eb-9e0d-f623c710fa66.png)
*Firefox Windows 10 sans-serif : Server Arial Unicode*
![Firefox Windows 10 sans-serif : Server Arial Unicode](https://user-images.githubusercontent.com/375121/108149682-b8e27480-7116-11eb-8e6c-2f341c5c1e27.png)
*Firefox Windows 10 sans-serif all*
![Firefox Windows 10 sans-serif all](https://user-images.githubusercontent.com/375121/108149683-b97b0b00-7116-11eb-9780-5281b86b3c3f.png)

For an example of what was broken before, see this customer screenshot using Meiryo / Server Arial:

![image](https://user-images.githubusercontent.com/5043493/107351925-8e892980-6b0e-11eb-897e-92000e972f15.png)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: 
 ```
<changelog>Switch to using alphabetic baseline for locally-rendered glyphs to avoid misalignment on fonts with large ascenders/descenders.</changelog>
````

@mourner @asheemmamoowala @tsuz 