### PR TITLE
update queryRenderedFeatures documentation to be clearer the geometry…

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1190,7 +1190,7 @@ class Map extends Camera {
      * representing visible features that satisfy the query parameters.
      *
      * @param {PointLike|Array<PointLike>} [geometry] - The geometry of the query region:
-     * either a single point or southwest and northeast points describing a bounding box.
+     * either a single point or southwest and northeast points describing a bounding box in screen coordinates as pixels.
      * Omitting this parameter (i.e. calling {@link Map#queryRenderedFeatures} with zero arguments,
      * or with only a `options` argument) is equivalent to passing a bounding box encompassing the entire
      * map viewport.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1189,8 +1189,8 @@ class Map extends Camera {
      * [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2)
      * representing visible features that satisfy the query parameters.
      *
-     * @param {PointLike|Array<PointLike>} [geometry] - The geometry of the query region:
-     * either a single point or southwest and northeast points describing a bounding box in screen coordinates as pixels.
+     * @param {PointLike|Array<PointLike>} [geometry] - The geometry of the query region in pixels:
+     * either a single point or bottom left and top right points describing a bounding box, where the origin is at the top left.
      * Omitting this parameter (i.e. calling {@link Map#queryRenderedFeatures} with zero arguments,
      * or with only a `options` argument) is equivalent to passing a bounding box encompassing the entire
      * map viewport.


### PR DESCRIPTION
… is in screen coordinates and in pixels

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

[queryRenderedFeatures](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#queryrenderedfeatures) accepts a geometry parameter which is documented as type PointLike.

Unfortunately it's all too easy for both new developers and [veteran developers](https://twitter.com/stevage1/status/1361289762087137280) alike to mistake this for a geographic geometry. The southwest/northeast terminology got me confused, ~~although I'm not proposing we change those terms, just clarify this is in screen coordinates in pixels.~~ (based on @stevage's feedback, I am proposing to change these terms)

The keyword pixels should make this much clearer.

 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

