### PR TITLE
Update the docs to show the default limit and offset of getClusterLeaves

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -226,8 +226,8 @@ class GeoJSONSource extends Evented implements Source {
      * For clustered sources, fetches the original points that belong to the cluster (as an array of GeoJSON features).
      *
      * @param clusterId The value of the cluster's `cluster_id` property.
-     * @param limit The maximum number of features to return.
-     * @param offset The number of features to skip (e.g. for pagination).
+     * @param limit The maximum number of features to return. (Defaults to `10` if a falsy value is given.)
+     * @param offset The number of features to skip (e.g. for pagination). (Defaults to `0` if a falsy value is given.)
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
      * @returns {GeoJSONSource} this
      * @example


### PR DESCRIPTION
Providing `null` as a limit worked great on my local dev machine with 3 leaves. When pushed to production it took me some time to figure out why I would get only 10 leaves, although 14 existed. I hope this small hint in the docs will save someone else this time.