### PR TITLE
Merge branch 'release-v2.1.0' of https://github.com/N3GIS/mapbox-gl-j…

### DIFF
--- a/debug/heatmap-offset.html
+++ b/debug/heatmap-offset.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+        #checkbox {
+            position: absolute;
+            top: 0;
+            left: 0;
+            padding: 10px;
+            background: #fff;
+        }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<div id='checkbox'>
+    <label><input id='terrain' type='checkbox'> terrain</label>
+</div>
+
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 2,
+    center: [0, 0],
+    style: 'mapbox://styles/mapbox/satellite-streets-v10',
+    hash: false
+});
+
+map.addControl(new mapboxgl.NavigationControl());
+map.addControl(new mapboxgl.GeolocateControl());
+
+map.on('load', function() {
+
+    map.addSource('heatmap', {
+        "type": "geojson",
+        "data": "../test/integration/data/places.geojson",
+        "maxzoom": 23
+    });
+
+    map.addLayer({
+        "id": "heatmap",
+        "type": "heatmap",
+        "source": "heatmap",
+        "paint": {
+            "heatmap-radius": 50,
+            "heatmap-weight": {
+                "stops": [[0, 0.5], [4, 2]]
+            },
+            "heatmap-intensity": 0.9,
+            "heatmap-offset": 10000,
+            "heatmap-color": [
+                "interpolate",
+                ["linear"],
+                ["heatmap-density"],
+                0, "rgba(0, 0, 255, 0)",
+                0.1, "royalblue",
+                0.3, "cyan",
+                0.5, "lime",
+                0.7, "yellow",
+                1, "red"
+            ]
+        }
+    }, 'waterway-label');
+
+    map.addSource('mapbox-dem', {
+        "type": "raster-dem",
+        "url": "mapbox://mapbox.terrain-rgb",
+        "tileSize": 512,
+        "maxzoom": 14
+    });
+});
+
+document.getElementById('terrain').onclick = function() {
+    map.setTerrain(this.checked ? {"source": "mapbox-dem"} : undefined);
+};
+
+</script>
+</body>
+</html>

--- a/src/render/program/heatmap_program.js
+++ b/src/render/program/heatmap_program.js
@@ -27,7 +27,8 @@ export type HeatmapTextureUniformsType = {|
     'u_world': Uniform2f,
     'u_image': Uniform1i,
     'u_color_ramp': Uniform1i,
-    'u_opacity': Uniform1f
+    'u_opacity': Uniform1f,
+    'u_offset': Uniform1f
 |};
 
 const heatmapUniforms = (context: Context, locations: UniformLocations): HeatmapUniformsType => ({
@@ -41,7 +42,8 @@ const heatmapTextureUniforms = (context: Context, locations: UniformLocations): 
     'u_world': new Uniform2f(context, locations.u_world),
     'u_image': new Uniform1i(context, locations.u_image),
     'u_color_ramp': new Uniform1i(context, locations.u_color_ramp),
-    'u_opacity': new Uniform1f(context, locations.u_opacity)
+    'u_opacity': new Uniform1f(context, locations.u_opacity),
+    'u_offset': new Uniform1f(context, locations.u_offset)
 });
 
 const heatmapUniformValues = (
@@ -71,7 +73,8 @@ const heatmapTextureUniformValues = (
         'u_world': [gl.drawingBufferWidth, gl.drawingBufferHeight],
         'u_image': textureUnit,
         'u_color_ramp': colorRampUnit,
-        'u_opacity': layer.paint.get('heatmap-opacity')
+        'u_opacity': layer.paint.get('heatmap-opacity'),
+        'u_offset': layer.paint.get('heatmap-offset')
     };
 };
 

--- a/src/shaders/heatmap.vertex.glsl
+++ b/src/shaders/heatmap.vertex.glsl
@@ -3,6 +3,7 @@ uniform mat4 u_matrix;
 uniform float u_extrude_scale;
 uniform float u_opacity;
 uniform float u_intensity;
+uniform float u_offset;
 
 attribute vec2 a_pos;
 
@@ -48,7 +49,8 @@ void main(void) {
 
     // multiply a_pos by 0.5, since we had it * 2 in order to sneak
     // in extrusion data
-    vec4 pos = vec4(floor(a_pos * 0.5) + extrude, elevation(floor(a_pos * 0.5)), 1);
+    //vec4 pos = vec4(floor(a_pos * 0.5) + extrude, elevation(floor(a_pos * 0.5)), 1);
+    vec4 pos = vec4(floor(a_pos * 0.5) + extrude, u_offset, 1);
 
     gl_Position = u_matrix * pos;
 }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -5071,6 +5071,28 @@
         ]
       },
       "property-type": "data-constant"
+    },
+    "heatmap-offset": {
+      "type": "number",
+      "doc": "Sets the offset height of the heatmap layer from the map surface.",
+      "default": 0,
+      "minimum": 0,
+      "transition": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.41.0",
+          "android": "6.0.0",
+          "ios": "4.0.0",
+          "macos": "0.7.0"
+        }
+      },
+      "expression": {
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      },
+      "property-type": "data-driven"
     }
   },
   "paint_symbol": {

--- a/src/style/style_layer/heatmap_style_layer_properties.js
+++ b/src/style/style_layer/heatmap_style_layer_properties.js
@@ -26,6 +26,7 @@ export type PaintProps = {|
     "heatmap-intensity": DataConstantProperty<number>,
     "heatmap-color": ColorRampProperty,
     "heatmap-opacity": DataConstantProperty<number>,
+    "heatmap-offset": DataDrivenProperty<number>,
 |};
 
 const paint: Properties<PaintProps> = new Properties({
@@ -34,6 +35,7 @@ const paint: Properties<PaintProps> = new Properties({
     "heatmap-intensity": new DataConstantProperty(styleSpec["paint_heatmap"]["heatmap-intensity"]),
     "heatmap-color": new ColorRampProperty(styleSpec["paint_heatmap"]["heatmap-color"]),
     "heatmap-opacity": new DataConstantProperty(styleSpec["paint_heatmap"]["heatmap-opacity"]),
+    "heatmap-offset": new DataDrivenProperty(styleSpec["paint_heatmap"]["heatmap-offset"]),
 });
 
 // Note: without adding the explicit type annotation, Flow infers weaker types


### PR DESCRIPTION
heatmap add a heatmap-offset property that sets the offset height of the heatmap layer from the map surface

![image](https://user-images.githubusercontent.com/7942057/109149604-c47f0c80-77a2-11eb-84ee-f4c3faa2e6c3.png)
![image](https://user-images.githubusercontent.com/7942057/109149692-e1b3db00-77a2-11eb-89ef-f32f3697564d.png)
![image](https://user-images.githubusercontent.com/7942057/109149808-05772100-77a3-11eb-89c2-784a7208ed41.png)
Mapbox add 3d model ,3d model has height, we want heatmap layer on the surface of the model, therefore, add heatmap-offset attribute in paint to control the offset of heatmap layer in z direction