### PR TITLE
Add additional resets for culling state

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -755,6 +755,8 @@ class Painter {
         // The default values for this state is meaningful and often expected.
         // Leaving this state dirty could cause a lot of confusion for users.
         this.context.cullFace.setDefault();
+        this.context.frontFace.setDefault();
+        this.context.cullFaceSide.setDefault();
         this.context.activeTexture.setDefault();
         this.context.pixelStoreUnpack.setDefault();
         this.context.pixelStoreUnpackPremultiplyAlpha.setDefault();


### PR DESCRIPTION
Resolves: #10372

Sky rendering may change the culling state. @astojilj pointed out that this code which ought to put WebGL in a predictable state before handing rendering off to custom layers doesn't apply consistent frontFace and cullFaceSide state, depending on whether the sky is rendered or not.

https://github.com/mapbox/mapbox-gl-js/blob/63f39e54e889d573ca627eea86114279e2062895/src/render/painter.js#L756-L758

This PR additionally resets `context.frontFace` and `context.cullFaceSide` to their defaults in `context.reset()`. It wasn't obvious to me how to test this, though I did check that it solves the codepen from #10372.

I'm a bit ambivalent about this change. It makes things more predictable, but it feels it risks snowballing into setting *all* of the WebGL state before handing off to a custom layer. Three.js has a new method called [`resetState()`](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer.resetState) (as a result of buggy Mapbox interactions!) which fixes this problem by performing a more complete reset. I've [updated the Mapbox GL-JS/Three.js example](https://github.com/mapbox/mapbox-gl-js-docs/pull/496) to use that function since it seems like the most robust way moving forward to minimize problems.

There are two options, I guess:
1. Merge this fix since it's still preferable to put GL in a more predictable state. This may still leave gaps in the GL state reset.
2. Omit this fix and make weaker guarantees about the state when handing off to a custom layer, putting the burden on third party libraries to enforce the state they need.

I think my preference is for 1 for this particular issue, but with an eye on this getting out of hand when third party libraries can perfectly well enforce the state they require.

cc @astojilj @karimnaaji @arindam1993 @mourner 
(cc's probably not spot on; still trying to figure out how best to identify the most interested parties)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Reset WebGL culling state before drawing custom layers</changelog>`
