### PR TITLE
Simplify and optimize worker task scheduling

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -256,17 +256,17 @@ class GeoJSONSource extends Evented implements Source {
 
             if (err) {
                 this.fire(new ErrorEvent(err));
-                return;
-            }
 
-            // although GeoJSON sources contain no metadata, we fire this event at first
-            // to let the SourceCache know its ok to start requesting tiles.
-            const data: Object = {dataType: 'source', sourceDataType: this._metadataFired ? 'content' : 'metadata'};
-            if (this._collectResourceTiming && result && result.resourceTiming && result.resourceTiming[this.id]) {
-                data.resourceTiming = result.resourceTiming[this.id];
+            } else {
+                // although GeoJSON sources contain no metadata, we fire this event at first
+                // to let the SourceCache know its ok to start requesting tiles.
+                const data: Object = {dataType: 'source', sourceDataType: this._metadataFired ? 'content' : 'metadata'};
+                if (this._collectResourceTiming && result && result.resourceTiming && result.resourceTiming[this.id]) {
+                    data.resourceTiming = result.resourceTiming[this.id];
+                }
+                this.fire(new Event('data', data));
+                this._metadataFired = true;
             }
-            this.fire(new Event('data', data));
-            this._metadataFired = true;
 
             if (this._coalesce) {
                 this._updateWorkerData();

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -311,7 +311,7 @@ class GeoJSONSource extends Evented implements Source {
             tile.loadVectorData(data, this.map.painter, message === 'reloadTile');
 
             return callback(null);
-        });
+        }, undefined, message === 'loadTile');
     }
 
     abortTile(tile: Tile) {

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -15,6 +15,7 @@ import type Actor from '../util/actor.js';
 import type {Callback} from '../types/callback.js';
 import type {GeoJSON, GeoJSONFeature} from '@mapbox/geojson-types';
 import type {GeoJSONSourceSpecification, PromoteIdSpecification} from '../style-spec/types.js';
+import type {Cancelable} from '../types/cancelable.js';
 
 /**
  * A source containing GeoJSON.
@@ -79,9 +80,10 @@ class GeoJSONSource extends Evented implements Source {
     map: Map;
     actor: Actor;
     _loaded: boolean;
+    _coalesce: ?boolean;
+    _metadataFired: ?boolean;
     _collectResourceTiming: boolean;
-    _resourceTiming: Array<PerformanceResourceTiming>;
-    _removed: boolean;
+    _pendingLoad: ?Cancelable;
 
     /**
      * @private
@@ -100,7 +102,6 @@ class GeoJSONSource extends Evented implements Source {
         this.tileSize = 512;
         this.isTileClipped = true;
         this.reparseOverscaled = true;
-        this._removed = false;
         this._loaded = false;
 
         this.actor = dispatcher.getActor();
@@ -110,7 +111,6 @@ class GeoJSONSource extends Evented implements Source {
         this._options = extend({}, options);
 
         this._collectResourceTiming = options.collectResourceTiming;
-        this._resourceTiming = [];
 
         if (options.maxzoom !== undefined) this.maxzoom = options.maxzoom;
         if (options.type) this.type = options.type;
@@ -147,29 +147,9 @@ class GeoJSONSource extends Evented implements Source {
         }, options.workerOptions);
     }
 
-    load() {
-        this.fire(new Event('dataloading', {dataType: 'source'}));
-        this._updateWorkerData((err) => {
-            if (err) {
-                this.fire(new ErrorEvent(err));
-                return;
-            }
-
-            const data: Object = {dataType: 'source', sourceDataType: 'metadata'};
-            if (this._collectResourceTiming && this._resourceTiming && (this._resourceTiming.length > 0)) {
-                data.resourceTiming = this._resourceTiming;
-                this._resourceTiming = [];
-            }
-
-            // although GeoJSON sources contain no metadata, we fire this event to let the SourceCache
-            // know its ok to start requesting tiles.
-            this.fire(new Event('data', data));
-        });
-    }
-
     onAdd(map: Map) {
         this.map = map;
-        this.load();
+        this.setData(this._data);
     }
 
     /**
@@ -180,21 +160,7 @@ class GeoJSONSource extends Evented implements Source {
      */
     setData(data: GeoJSON | string) {
         this._data = data;
-        this.fire(new Event('dataloading', {dataType: 'source'}));
-        this._updateWorkerData((err) => {
-            if (err) {
-                this.fire(new ErrorEvent(err));
-                return;
-            }
-
-            const data: Object = {dataType: 'source', sourceDataType: 'content'};
-            if (this._collectResourceTiming && this._resourceTiming && (this._resourceTiming.length > 0)) {
-                data.resourceTiming = this._resourceTiming;
-                this._resourceTiming = [];
-            }
-            this.fire(new Event('data', data));
-        });
-
+        this._updateWorkerData();
         return this;
     }
 
@@ -262,7 +228,15 @@ class GeoJSONSource extends Evented implements Source {
      * handles loading the geojson data and preparing to serve it up as tiles,
      * using geojson-vt or supercluster as appropriate.
      */
-    _updateWorkerData(callback: Callback<void>) {
+    _updateWorkerData() {
+        // if there's an earlier loadData to finish, wait until it finishes and then do another update
+        if (this._pendingLoad) {
+            this._coalesce = true;
+            return;
+        }
+
+        this.fire(new Event('dataloading', {dataType: 'source'}));
+
         this._loaded = false;
         const options = extend({}, this.workerOptions);
         const data = this._data;
@@ -276,24 +250,28 @@ class GeoJSONSource extends Evented implements Source {
         // target {this.type}.loadData rather than literally geojson.loadData,
         // so that other geojson-like source types can easily reuse this
         // implementation
-        this.actor.send(`${this.type}.loadData`, options, (err, result) => {
-            if (this._removed || (result && result.abandoned)) {
+        this._pendingLoad = this.actor.send(`${this.type}.loadData`, options, (err, result) => {
+            this._loaded = true;
+            this._pendingLoad = null;
+
+            if (err) {
+                this.fire(new ErrorEvent(err));
                 return;
             }
 
-            this._loaded = true;
+            // although GeoJSON sources contain no metadata, we fire this event at first
+            // to let the SourceCache know its ok to start requesting tiles.
+            const data: Object = {dataType: 'source', sourceDataType: this._metadataFired ? 'content' : 'metadata'};
+            if (this._collectResourceTiming && result && result.resourceTiming && result.resourceTiming[this.id]) {
+                data.resourceTiming = result.resourceTiming[this.id];
+            }
+            this.fire(new Event('data', data));
+            this._metadataFired = true;
 
-            if (result && result.resourceTiming && result.resourceTiming[this.id])
-                this._resourceTiming = result.resourceTiming[this.id].slice(0);
-            // Any `loadData` calls that piled up while we were processing
-            // this one will get coalesced into a single call when this
-            // 'coalesce' message is processed.
-            // We would self-send from the worker if we had access to its
-            // message queue. Waiting instead for the 'coalesce' to round-trip
-            // through the foreground just means we're throttling the worker
-            // to run at a little less than full-throttle.
-            this.actor.send(`${this.type}.coalesce`, {source: options.source}, null);
-            callback(err);
+            if (this._coalesce) {
+                this._updateWorkerData();
+                this._coalesce = false;
+            }
         });
     }
 
@@ -350,8 +328,9 @@ class GeoJSONSource extends Evented implements Source {
     }
 
     onRemove() {
-        this._removed = true;
-        this.actor.send('removeSource', {type: this.type, source: this.id});
+        if (this._pendingLoad) {
+            this._pendingLoad.cancel();
+        }
     }
 
     serialize() {

--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -77,7 +77,7 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
 
                 if (!tile.actor || tile.state === 'expired') {
                     tile.actor = this.dispatcher.getActor();
-                    tile.actor.send('loadDEMTile', params, done.bind(this));
+                    tile.actor.send('loadDEMTile', params, done.bind(this), undefined, true);
                 }
             }
         }

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -227,13 +227,13 @@ class VectorTileSource extends Evented implements Source {
                             expires: data.expires,
                             rawData: data.rawData.slice(0)
                         };
-                        if (tile.actor) tile.actor.send('loadTile', params, done.bind(this));
+                        if (tile.actor) tile.actor.send('loadTile', params, done.bind(this), undefined, true);
                     }
                 }, true);
                 tile.request = {cancel};
 
             } else {
-                tile.request = tile.actor.send('loadTile', params, done.bind(this));
+                tile.request = tile.actor.send('loadTile', params, done.bind(this), undefined, true);
             }
 
         } else if (tile.state === 'loading') {
@@ -277,14 +277,14 @@ class VectorTileSource extends Evented implements Source {
             delete tile.request;
         }
         if (tile.actor) {
-            tile.actor.send('abortTile', {uid: tile.uid, type: this.type, source: this.id}, undefined);
+            tile.actor.send('abortTile', {uid: tile.uid, type: this.type, source: this.id});
         }
     }
 
     unloadTile(tile: Tile) {
         tile.unloadVectorData();
         if (tile.actor) {
-            tile.actor.send('removeTile', {uid: tile.uid, type: this.type, source: this.id}, undefined);
+            tile.actor.send('removeTile', {uid: tile.uid, type: this.type, source: this.id});
         }
     }
 

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -235,7 +235,7 @@ export default class Worker {
             // use a wrapped actor so that we can attach a target mapId param
             // to any messages invoked by the WorkerSource
             const actor = {
-                send: (type, data, callback, mustQueue, _, metadata) => {
+                send: (type, data, callback, _, mustQueue, metadata) => {
                     this.actor.send(type, data, callback, mapId, mustQueue, metadata);
                 },
                 scheduler: this.actor.scheduler

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -169,7 +169,7 @@ class WorkerTile {
                     glyphMap = result;
                     maybePrepare.call(this);
                 }
-            }, undefined, true, taskMetadata);
+            }, undefined, false, taskMetadata);
         } else {
             glyphMap = {};
         }
@@ -182,7 +182,7 @@ class WorkerTile {
                     iconMap = result;
                     maybePrepare.call(this);
                 }
-            }, undefined, true, taskMetadata);
+            }, undefined, false, taskMetadata);
         } else {
             iconMap = {};
         }
@@ -195,7 +195,7 @@ class WorkerTile {
                     patternMap = result;
                     maybePrepare.call(this);
                 }
-            }, undefined, true, taskMetadata);
+            }, undefined, false, taskMetadata);
         } else {
             patternMap = {};
         }

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -169,7 +169,7 @@ class WorkerTile {
                     glyphMap = result;
                     maybePrepare.call(this);
                 }
-            }, undefined, undefined, taskMetadata);
+            }, undefined, true, taskMetadata);
         } else {
             glyphMap = {};
         }
@@ -182,7 +182,7 @@ class WorkerTile {
                     iconMap = result;
                     maybePrepare.call(this);
                 }
-            }, undefined, undefined, taskMetadata);
+            }, undefined, true, taskMetadata);
         } else {
             iconMap = {};
         }
@@ -195,7 +195,7 @@ class WorkerTile {
                     patternMap = result;
                     maybePrepare.call(this);
                 }
-            }, undefined, undefined, taskMetadata);
+            }, undefined, true, taskMetadata);
         } else {
             patternMap = {};
         }

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -121,13 +121,14 @@ class Actor {
                 // In the main thread, process messages immediately so that other work does not slip in
                 // between getting partial data back from workers.
                 // Do the same for worker tasks that need processing as soon as possible.
+                const m = isWorker() ? PerformanceUtils.beginMeasure('workerTask') : undefined;
                 this.processTask(id, data);
+                if (m) PerformanceUtils.endMeasure(m);
             }
         }
     }
 
     processTask(id: number, task: any) {
-        const m = isWorker() ? PerformanceUtils.beginMeasure('workerTask') : undefined;
         if (task.type === '<response>') {
             // The done() function in the counterpart has been called, and we are now
             // firing the callback in the originating actor, if there is one.
@@ -169,7 +170,6 @@ class Actor {
                 done(new Error(`Could not find function ${task.type}`));
             }
         }
-        if (m) PerformanceUtils.endMeasure(m);
     }
 
     remove() {

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -151,6 +151,7 @@ class Actor {
                     type: '<response>',
                     sourceMapId: this.mapId,
                     error: err ? serialize(err) : null,
+                    mustQueue: task.mustQueue,
                     data: serialize(data, buffers)
                 }, buffers);
             } : (_) => {

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -107,13 +107,12 @@ class Actor {
                 cancel.cancel();
             }
         } else {
-            if (isWorker() || data.mustQueue) {
-                // In workers, store the tasks that we need to process before actually processing them. This
-                // is necessary because we want to keep receiving messages, and in particular,
-                // <cancel> messages. Some tasks may take a while in the worker thread, so before
-                // executing the next task in our queue, postMessage preempts this and <cancel>
-                // messages can be processed. We're using a MessageChannel object to get throttle the
-                // process() flow to one at a time.
+            if (data.mustQueue) {
+                // for tasks that are often cancelled, such as loadTile, store them before actually
+                // processing them. This is necessary because we want to keep receiving <cancel> messages.
+                // Some tasks may take a while in the worker thread, so before executing the next task
+                // in our queue, postMessage preempts this and <cancel> messages can be processed.
+                // We're using a MessageChannel object to get throttle the process() flow to one at a time.
                 const callback = this.callbacks[id];
                 const metadata = (callback && callback.metadata) || {type: "message"};
                 this.cancelCallbacks[id] = this.scheduler.add(() => this.processTask(id, data), metadata);

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -107,8 +107,8 @@ class Actor {
                 cancel.cancel();
             }
         } else {
-            if (data.mustQueue) {
-                // for tasks that are often cancelled, such as loadTile, store them before actually
+            if (isWorker() && data.mustQueue) {
+                // for worker tasks that are often cancelled, such as loadTile, store them before actually
                 // processing them. This is necessary because we want to keep receiving <cancel> messages.
                 // Some tasks may take a while in the worker thread, so before executing the next task
                 // in our queue, postMessage preempts this and <cancel> messages can be processed.

--- a/src/util/actor.js
+++ b/src/util/actor.js
@@ -108,7 +108,7 @@ class Actor {
                 cancel.cancel();
             }
         } else {
-            if (isWorker() && data.mustQueue) {
+            if (data.mustQueue) {
                 // for worker tasks that are often cancelled, such as loadTile, store them before actually
                 // processing them. This is necessary because we want to keep receiving <cancel> messages.
                 // Some tasks may take a while in the worker thread, so before executing the next task
@@ -151,7 +151,6 @@ class Actor {
                     type: '<response>',
                     sourceMapId: this.mapId,
                     error: err ? serialize(err) : null,
-                    mustQueue: task.mustQueue,
                     data: serialize(data, buffers)
                 }, buffers);
             } : (_) => {

--- a/test/unit/source/geojson_source.test.js
+++ b/test/unit/source/geojson_source.test.js
@@ -77,13 +77,13 @@ test('GeoJSONSource#setData', (t) => {
             source.once('data', t.end);
             source.setData({});
         });
-        source.load();
+        source.setData({});
     });
 
     t.test('fires "dataloading" event', (t) => {
         const source = createSource();
         source.on('dataloading', t.end);
-        source.load();
+        source.setData({});
     });
 
     t.test('respects collectResourceTiming parameter on source', (t) => {
@@ -106,25 +106,6 @@ test('GeoJSONSource#setData', (t) => {
     t.end();
 });
 
-test('GeoJSONSource#onRemove', (t) => {
-    t.test('broadcasts "removeSource" event', (t) => {
-        const source = new GeoJSONSource('id', {data: {}}, wrapDispatcher({
-            send(type, data, callback) {
-                t.false(callback);
-                t.equal(type, 'removeSource');
-                t.deepEqual(data, {type: 'geojson', source: 'id'});
-                t.end();
-            },
-            broadcast() {
-                // Ignore
-            }
-        }));
-        source.onRemove();
-    });
-
-    t.end();
-});
-
 test('GeoJSONSource#update', (t) => {
     const transform = new Transform();
     transform.resize(200, 200);
@@ -142,7 +123,7 @@ test('GeoJSONSource#update', (t) => {
         });
 
         /* eslint-disable no-new */
-        new GeoJSONSource('id', {data: {}}, mockDispatcher).load();
+        new GeoJSONSource('id', {data: {}}, mockDispatcher).setData({});
     });
 
     t.test('forwards geojson-vt options with worker request', (t) => {
@@ -167,7 +148,7 @@ test('GeoJSONSource#update', (t) => {
             tolerance: 0.25,
             buffer: 16,
             generateId: true
-        }, mockDispatcher).load();
+        }, mockDispatcher).setData({});
     });
 
     t.test('forwards Supercluster options with worker request', (t) => {
@@ -193,7 +174,7 @@ test('GeoJSONSource#update', (t) => {
             clusterRadius: 100,
             clusterMinPoints: 3,
             generateId: true
-        }, mockDispatcher).load();
+        }, mockDispatcher).setData({});
     });
 
     t.test('transforms url before making request', (t) => {
@@ -224,7 +205,7 @@ test('GeoJSONSource#update', (t) => {
             if (e.sourceDataType === 'metadata') t.end();
         });
 
-        source.load();
+        source.setData({});
     });
 
     t.test('fires "error"', (t) => {
@@ -243,7 +224,7 @@ test('GeoJSONSource#update', (t) => {
             t.end();
         });
 
-        source.load();
+        source.setData({});
     });
 
     t.test('sends loadData request to dispatcher after data update', (t) => {
@@ -271,7 +252,7 @@ test('GeoJSONSource#update', (t) => {
             }
         });
 
-        source.load();
+        source.setData({});
     });
 
     t.end();
@@ -285,8 +266,7 @@ test('GeoJSONSource#serialize', (t) => {
     };
     t.test('serialize source with inline data', (t) => {
         const source = new GeoJSONSource('id', {data: hawkHill}, mockDispatcher);
-        source.map = mapStub;
-        source.load();
+        source.onAdd(mapStub);
         t.deepEqual(source.serialize(), {
             type: 'geojson',
             data: hawkHill
@@ -296,8 +276,7 @@ test('GeoJSONSource#serialize', (t) => {
 
     t.test('serialize source with url', (t) => {
         const source = new GeoJSONSource('id', {data: 'local://data.json'}, mockDispatcher);
-        source.map = mapStub;
-        source.load();
+        source.onAdd(mapStub);
         t.deepEqual(source.serialize(), {
             type: 'geojson',
             data: 'local://data.json'
@@ -307,8 +286,7 @@ test('GeoJSONSource#serialize', (t) => {
 
     t.test('serialize source with updated data', (t) => {
         const source = new GeoJSONSource('id', {data: {}}, mockDispatcher);
-        source.map = mapStub;
-        source.load();
+        source.onAdd(mapStub);
         source.setData(hawkHill);
         t.deepEqual(source.serialize(), {
             type: 'geojson',

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -39,7 +39,6 @@ test('reloadTile', (t) => {
 
         function addData(callback) {
             source.loadData({source: 'sourceId', data: JSON.stringify(geoJson)}, (err) => {
-                source.coalesce({source: 'sourceId'});
                 t.equal(err, null);
                 callback();
             });
@@ -146,93 +145,6 @@ test('resourceTiming', (t) => {
             t.equal(result.resourceTiming, undefined, 'no resourceTiming property when loadData is not sent a URL');
             t.end();
         });
-    });
-
-    t.end();
-});
-
-test('loadData', (t) => {
-    const layers = [
-        {
-            id: 'layer1',
-            source: 'source1',
-            type: 'symbol',
-        },
-        {
-            id: 'layer2',
-            source: 'source2',
-            type: 'symbol',
-        }
-    ];
-
-    const geoJson = {
-        "type": "Feature",
-        "geometry": {
-            "type": "Point",
-            "coordinates": [0, 0]
-        }
-    };
-
-    const layerIndex = new StyleLayerIndex(layers);
-    function createWorker() {
-        const worker = new GeoJSONWorkerSource(actor, layerIndex, [], true);
-
-        // Making the call to loadGeoJSON asynchronous
-        // allows these tests to mimic a message queue building up
-        // (regardless of timing)
-        const originalLoadGeoJSON = worker.loadGeoJSON;
-        worker.loadGeoJSON = function(params, callback) {
-            setTimeout(() => {
-                originalLoadGeoJSON(params, callback);
-            }, 0);
-        };
-        return worker;
-    }
-
-    t.test('abandons coalesced callbacks', (t) => {
-        // Expect first call to run, second to be abandoned,
-        // and third to run in response to coalesce
-        const worker = createWorker();
-        worker.loadData({source: 'source1', data: JSON.stringify(geoJson)}, (err, result) => {
-            t.equal(err, null);
-            t.notOk(result && result.abandoned);
-            worker.coalesce({source: 'source1'});
-        });
-
-        worker.loadData({source: 'source1', data: JSON.stringify(geoJson)}, (err, result) => {
-            t.equal(err, null);
-            t.ok(result && result.abandoned);
-        });
-
-        worker.loadData({source: 'source1', data: JSON.stringify(geoJson)}, (err, result) => {
-            t.equal(err, null);
-            t.notOk(result && result.abandoned);
-            t.end();
-        });
-    });
-
-    t.test('removeSource aborts callbacks', (t) => {
-        // Expect:
-        // First loadData starts running before removeSource arrives
-        // Second loadData is pending when removeSource arrives, gets cancelled
-        // removeSource is executed immediately
-        // First loadData finishes running, sends results back to foreground
-        const worker = createWorker();
-        worker.loadData({source: 'source1', data: JSON.stringify(geoJson)}, (err, result) => {
-            t.equal(err, null);
-            t.notOk(result && result.abandoned);
-            t.end();
-        });
-
-        worker.loadData({source: 'source1', data: JSON.stringify(geoJson)}, (err, result) => {
-            t.equal(err, null);
-            t.ok(result && result.abandoned);
-        });
-
-        worker.removeSource({source: 'source1'}, (err) => {
-            t.notOk(err);
-        });
-
     });
 
     t.end();


### PR DESCRIPTION
Closes #10187. There are two independent commits here. 

The first one simplifies `setData` coalescing logic in GeoJSON source, previously introduced in #5902. I did this first to make worker logic easier to reason about, but theoretically it should improve performance — by moving the coalescing logic to the main thread, we avoid flooding the worker message queue with tasks that will get discarded. Technically the flow and consequently the overall performance characteristics shouldn't change, as I tried to demonstrate on this very rough and clunky chart:

![Image from iOS (1)](https://user-images.githubusercontent.com/25395/109312849-32cdd880-7850-11eb-8f34-b73a75eb093c.jpg)

Previously, any `setData` calls that follow one that's still in progress would get sent to the worker, which remembers the last call while returning the previous one as "abandoned", and waits until that first `setData` call successfully finishes processing and then calls `coalesce` message that tells the worker to additionally do an update for the last `setData` call it caught before.

Now, we simply don't send any worker messages on additional `setData` calls while a `setData` is already in progress, but we remember to issue one more `setData` with the last updated `data` if there are any updates which we previously refused. 

The second commit is the one that fixes the Safari performance issue — it was caused by Safari being too slow to process worker tasks that are delayed to run after the current event loop (introduced in #8633), which we do to make sure `<cancel>` messages are processed _before_ the tasks that were cancelled if both come together to the worker in a batch of `postMessage` calls. Previously, all messages were delayed, then #8913 made it delay only on the worker side, and finally #9031 introduced an explicit `actor.send` parameter to additionally delay `getResource` on the main thread to fix a perf regression. This PR changes the logic so that messages are handled immediately _by default_, and only delayed for `<cancel>` processing explicitly for calls where we commonly expect cancellations (mostly network-related) — in this case `loadTile`, `loadDEMTile` and `getResource`. I confirmed that this fixes the Safari `setData` performance issue in the ticket, while not increasing the percentage of unfulfilled cancellations when browsing the map quickly (it's about 40% before and after the PR).

Tagging @kkaefer @ChrisLoer just in case because it affects the code you added significantly — take a look if you have time but no worries if not.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - write tests for all new functionality (seems sufficiently covered by existing tests)
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixes a performance regression in Safari on frequent GeoJSON setData calls</changelog>`
