### PR TITLE
Fix incorrect style serialization when using raster DEM tile sources

### DIFF
--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -29,14 +29,7 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
     }
 
     serialize() {
-        return {
-            type: 'raster-dem',
-            url: this.url,
-            tileSize: this.tileSize,
-            tiles: this.tiles,
-            bounds: this.bounds,
-            encoding: this.encoding
-        };
+        return extend({}, this._options);
     }
 
     loadTile(tile: Tile, callback: Callback<void>) {

--- a/src/source/raster_dem_tile_source.js
+++ b/src/source/raster_dem_tile_source.js
@@ -28,10 +28,6 @@ class RasterDEMTileSource extends RasterTileSource implements Source {
         this.encoding = options.encoding || "mapbox";
     }
 
-    serialize() {
-        return extend({}, this._options);
-    }
-
     loadTile(tile: Tile, callback: Callback<void>) {
         const url = this.map._requestManager.normalizeTileURL(tile.tileID.canonical.url(this.tiles, this.scheme), false, this.tileSize);
         tile.request = getImage(this.map._requestManager.transformRequest(url, ResourceType.Tile), imageLoaded.bind(this));

--- a/test/unit/source/raster_dem_tile_source.test.js
+++ b/test/unit/source/raster_dem_tile_source.test.js
@@ -3,6 +3,7 @@ import RasterDEMTileSource from '../../../src/source/raster_dem_tile_source.js';
 import window from '../../../src/util/window.js';
 import {OverscaledTileID} from '../../../src/source/tile_id.js';
 import {RequestManager} from '../../../src/util/mapbox.js';
+import {extend} from '../../../src/util/util.js';
 
 function createSource(options, transformCallback) {
     const source = new RasterDEMTileSource('id', options, {send() {}}, options.eventedParent);
@@ -28,6 +29,28 @@ test('RasterTileSource', (t) => {
     t.afterEach((callback) => {
         window.restore();
         callback();
+    });
+
+    t.test('create and serialize source', (t) => {
+        window.server.respondWith('/source.json', JSON.stringify({}));
+        const transformSpy = t.spy((url) => {
+            return {url};
+        });
+        const options = {
+            url: "/source.json",
+            minzoom: 0,
+            maxzoom: 22,
+            attribution: "Mapbox",
+            tiles: ["http://example.com/{z}/{x}/{y}.png"],
+            bounds: [-47, -7, -45, -5],
+            encoding: "terrarium",
+            tileSize: 512,
+            volatile: false
+        };
+        const source = createSource(options, transformSpy);
+        source.load();
+        t.deepEqual(source.serialize(), extend({type: "raster-dem"}, options));
+        t.end();
     });
 
     t.test('transforms request for TileJSON URL', (t) => {


### PR DESCRIPTION
Fix for #10416, introducing incorrect diffing of styles when using raster dem tile sources, which resulted in reloading the scene in Studio when making any sort of style changes while using terrain.

Before vs After in studio:

https://user-images.githubusercontent.com/7061573/109366142-7ff97c80-7847-11eb-93fd-ef7867f73d35.mov

https://user-images.githubusercontent.com/7061573/109366145-81c34000-7847-11eb-857f-80c3651266fd.mov

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [n/a] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [n/a] document any changes to public APIs
 - [n/a] post benchmark scores
 - [x] manually test the debug page
 - [n/a] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [n/a] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix incorrect diffing of styles when using raster DEM tile sources</changelog>`
