### PR TITLE
Account for negative terrain elevation in frustum far plane definition

### DIFF
--- a/src/data/dem_tree.js
+++ b/src/data/dem_tree.js
@@ -136,6 +136,7 @@ const aabbSkirtPadding = 100;
 // Each tree node stores the minimum and maximum elevation of its children nodes and a flag whether the node is a leaf.
 // Node data is stored in non-interleaved arrays where the root is at index 0.
 export default class DemMinMaxQuadTree {
+    minimum: number;
     maximums: Array<number>;
     minimums: Array<number>;
     leaves: Array<number>;
@@ -150,6 +151,7 @@ export default class DemMinMaxQuadTree {
         this.leaves = [];
         this.childOffsets = [];
         this.nodeCount = 0;
+        this.minimum = Number.POSITIVE_INFINITY;
         this.dem = dem_;
 
         // Precompute the order of 4 sibling nodes in the memory. Top-left, top-right, bottom-left, bottom-right
@@ -308,6 +310,7 @@ export default class DemMinMaxQuadTree {
     }
 
     _addNode(min: number, max: number, leaf: number) {
+        this.minimum = Math.min(this.minimum, min);
         this.minimums.push(min);
         this.maximums.push(max);
         this.leaves.push(leaf);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1285,7 +1285,7 @@ class Transform {
         const minElevationInPixels = this.elevation ?
             this.elevation.getMinElevationBelowMSL() * pixelsPerMeter :
             0;
-        const cameraToSeaLevelDistance = ((this._camera.position[2] * this.worldSize) + minElevationInPixels) / Math.cos(this._pitch);
+        const cameraToSeaLevelDistance = ((this._camera.position[2] * this.worldSize) - minElevationInPixels) / Math.cos(this._pitch);
         const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * cameraToSeaLevelDistance / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));
         const point = this.point;
         const x = point.x, y = point.y;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1283,7 +1283,7 @@ class Transform {
         // Adjust distance to MSL by the minimum possible elevation visible on screen,
         // this way the far plane is pushed further in the case of negative elevation.
         const minElevationInPixels = this.elevation ?
-            Math.abs(this.elevation.getMinElevationBelowMSL()) * pixelsPerMeter :
+            this.elevation.getMinElevationBelowMSL() * pixelsPerMeter :
             0;
         const cameraToSeaLevelDistance = ((this._camera.position[2] * this.worldSize) + minElevationInPixels) / Math.cos(this._pitch);
         const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * cameraToSeaLevelDistance / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1280,7 +1280,12 @@ class Transform {
         const groundAngle = Math.PI / 2 + this._pitch;
         const fovAboveCenter = this.fovAboveCenter;
 
-        const cameraToSeaLevelDistance = this._camera.position[2] * this.worldSize / Math.cos(this._pitch);
+        // Adjust distance to MSL by the minimum possible elevation visible on screen,
+        // this way the far plane is pushed further in the case of negative elevation.
+        const minElevationInPixels = this.elevation ?
+            Math.abs(this.elevation.getMinElevationBelowMSL()) * pixelsPerMeter :
+            0;
+        const cameraToSeaLevelDistance = ((this._camera.position[2] * this.worldSize) + minElevationInPixels) / Math.cos(this._pitch);
         const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * cameraToSeaLevelDistance / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));
         const point = this.point;
         const x = point.x, y = point.y;

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -107,6 +107,15 @@ export class Elevation {
     }
 
     /**
+     * Get elevation minimum below MSL for the visible tiles. This function accounts for terrain exaggeration.
+     * If no negative elevation is visible, this function returns 0.
+     * @returns {number} The min elevation below sea level of all visible tiles.
+     */
+    getMinElevationBelowMSL(): number {
+        throw new Error('Pure virtual method called.');
+    }
+
+    /**
      * Performs raycast against visible DEM tiles on the screen and returns the distance travelled along the ray.
      * x & y components of the position are expected to be in normalized mercator coordinates [0, 1] and z in meters.
      * @param {vec3} position The ray origin.

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -107,7 +107,9 @@ export class Elevation {
     }
 
     /**
-     * Get elevation minimum below MSL for the visible tiles. This function accounts for terrain exaggeration.
+     * Get elevation minimum below MSL for the visible tiles. This function accounts
+     * for terrain exaggeration and is conservative based on the maximum DEM error,
+     * do not expect accurate values from this function.
      * If no negative elevation is visible, this function returns 0.
      * @returns {number} The min elevation below sea level of all visible tiles.
      */

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -742,12 +742,14 @@ export class Terrain extends Elevation {
     }
 
     getMinElevationBelowMSL(): number {
-        let min = 0;
-        this._visibleDemTiles.filter(tile => tile.dem).map(tile => {
+        let min = 0.0;
+        // The maximum DEM error in meters to be conservative (SRTM).
+        const maxDEMError = 30.0;
+        this._visibleDemTiles.filter(tile => tile.dem).forEach(tile => {
             const minMaxTree = (tile.dem: any).tree;
             min = Math.min(min, minMaxTree.minimum);
         });
-        return min * this._exaggeration;
+        return min === 0.0 ? min : (min - maxDEMError) * this._exaggeration;
     }
 
     // Performs raycast against visible DEM tiles on the screen and returns the distance travelled along the ray.

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -245,6 +245,7 @@ export class Terrain extends Elevation {
         this._tilesDirty = {};
         this.style = style;
         this._useVertexMorphing = true;
+        this._exaggeration = 1;
     }
 
     set style(style: Style) {
@@ -738,6 +739,15 @@ export class Terrain extends Elevation {
         }
 
         return {efficiency: (1.0 - uncacheableLayerCount / drapedLayerCount) * 100.0, firstUndrapedLayer};
+    }
+
+    getMinElevationBelowMSL(): number {
+        let min = 0;
+        this._visibleDemTiles.filter(tile => tile.dem).map(tile => {
+            const minMaxTree = (tile.dem: any).tree;
+            min = Math.min(min, minMaxTree.minimum);
+        });
+        return min * this._exaggeration;
     }
 
     // Performs raycast against visible DEM tiles on the screen and returns the distance travelled along the ray.

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -410,6 +410,7 @@ test('transform', (t) => {
                 }
                 return true;
             },
+            getMinElevationBelowMSL: () => 0
         };
     };
 
@@ -424,6 +425,7 @@ test('transform', (t) => {
                 }
                 return true;
             },
+            getMinElevationBelowMSL: () => 0
         };
     };
 
@@ -438,6 +440,7 @@ test('transform', (t) => {
                 }
                 return true;
             },
+            getMinElevationBelowMSL: () => 0
         };
     };
 
@@ -551,7 +554,8 @@ test('transform', (t) => {
             },
             exaggeration() {
                 return 10; // Low tile zoom used, exaggerate elevation to make impact.
-            }
+            },
+            getMinElevationBelowMSL: () => 0
         };
         transform.elevation = elevation;
         transform.resize(200, 200);
@@ -1157,7 +1161,8 @@ test('transform', (t) => {
             transform._elevation = {
                 getAtPoint: () => groundElevation,
                 exaggeration: () => 1.0,
-                raycast: () => undefined
+                raycast: () => undefined,
+                getMinElevationBelowMSL: () => 0
             };
 
             const expected = new FreeCameraOptions();


### PR DESCRIPTION
Prevent cutoff artifacts by accounting for negative terrain elevation in view frustum definition. We currently assume the minimum bound to always be mean sea level, by taking into account the minimum possible elevation of the current view, we can push the far plane further by that amount to eliminate that visual artifact.

Fixes #10317

**Before / After**

https://user-images.githubusercontent.com/7061573/110015413-aea8a480-7cd8-11eb-85c0-253ca33e2957.mov

https://user-images.githubusercontent.com/7061573/110015405-ac464a80-7cd8-11eb-9d08-19ef565d6c3a.mov

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [n/a] document any changes to public APIs
 - [n/a] post benchmark scores
 - [x] manually test the debug page
 - [n/a] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [x] tagged @mapbox/gl-native as this needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Prevent cutoff artifacts by accounting for negative terrain elevation in view frustum definition</changelog>`
