### PR TITLE
Add related links to GL JS Examples for `FreeCameraOptions` and `AnimationOptions`

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -82,7 +82,10 @@ export type CameraOptions = {
  * @property {boolean} animate If `false`, no animation will occur.
  * @property {boolean} essential If `true`, then the animation is considered essential and will not be affected by
  *   [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
- */
+ * @see [Slowly fly to a location](https://docs.mapbox.com/mapbox-gl-js/example/flyto-options/)
+ * @see [Customize camera animations](https://docs.mapbox.com/mapbox-gl-js/example/camera-animation/)
+ * @see [Navigate the map with game-like controls](https://docs.mapbox.com/mapbox-gl-js/example/game-controls/)
+*/
 export type AnimationOptions = {
     duration?: number,
     easing?: (_: number) => number,

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -77,7 +77,7 @@ export function orientationFromFrame(forward: vec3, up: vec3): ?quat {
 }
 
 /**
- * Various options for accessing physical properties of the underlying camera entity.
+ * Options for accessing physical properties of the underlying camera entity.
  * A direct access to these properties allows more flexible and precise controlling of the camera
  * while also being fully compatible and interchangeable with CameraOptions. All fields are optional.
  * See {@link Map#setFreeCameraOptions} and {@link Map#getFreeCameraOptions}
@@ -97,7 +97,9 @@ export function orientationFromFrame(forward: vec3, up: vec3): ?quat {
         Orientation can be set freely but certain constraints still apply
          - Orientation must be representable with only pitch and bearing.
          - Pitch has an upper limit
- */
+ * @see [Animate the camera around a point in 3D terrain](https://docs.mapbox.com/mapbox-gl-js/example/free-camera-point/)
+ * @see [Animate the camera along a path](https://docs.mapbox.com/mapbox-gl-js/example/free-camera-path/)
+*/
 class FreeCameraOptions {
     orientation: ?quat;
     _position: ?MercatorCoordinate;


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js-docs/issues/504

Add related links to 3 GL JS Examples for `FreeCameraOptions`
Add related links to 2 GL JS Examples for `AnimationOptions`

Tagging @ryanhamley @HeyStenson for review.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

Screenshots:

<img src="https://user-images.githubusercontent.com/6026447/110050465-01458900-7cf8-11eb-85bb-0c19668d6655.jpg" width=600> 

<img src="https://user-images.githubusercontent.com/6026447/110050472-04d91000-7cf8-11eb-83f6-b714e3b38e4c.jpg" width=600> 

Not sure what is causing this error; keeping PR as draft until this is resolved:

`Failed at the mapbox-gl@2.2.0-dev lint script.`

