### PR TITLE
Add related links to GL JS Examples for all Handlers

### DIFF
--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -1,10 +1,10 @@
 // @flow
 
-import DOM from '../../util/dom';
+import DOM from '../../util/dom.js';
 
-import {Event} from '../../util/evented';
+import {Event} from '../../util/evented.js';
 
-import type Map from '../map';
+import type Map from '../map.js';
 
 /**
  * The `BoxZoomHandler` allows the user to zoom the map to fit within a bounding box.

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -1,14 +1,16 @@
 // @flow
 
-import DOM from '../../util/dom.js';
+import DOM from '../../util/dom';
 
-import {Event} from '../../util/evented.js';
+import {Event} from '../../util/evented';
 
-import type Map from '../map.js';
+import type Map from '../map';
 
 /**
  * The `BoxZoomHandler` allows the user to zoom the map to fit within a bounding box.
  * The bounding box is defined by clicking and holding `shift` while dragging the cursor.
+ * @see [Toggle interactions](https://docs.mapbox.com/mapbox-gl-js/example/toggle-interaction-handlers/)
+ * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
  */
 class BoxZoomHandler {
     _map: Map;

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type Map from '../map';
+import type Map from '../map.js';
 
 const defaultOptions = {
     panStep: 100,

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type Map from '../map.js';
+import type Map from '../map';
 
 const defaultOptions = {
     panStep: 100,
@@ -21,6 +21,9 @@ const defaultOptions = {
  * - `Shift+⇠`: Decrease the rotation by 15 degrees.
  * - `Shift+⇡`: Increase the pitch by 10 degrees.
  * - `Shift+⇣`: Decrease the pitch by 10 degrees.
+ * @see [Toggle interactions](https://docs.mapbox.com/mapbox-gl-js/example/toggle-interaction-handlers/)
+ * @see [Navigate the map with game-like controls](https://docs.mapbox.com/mapbox-gl-js/example/game-controls/)
+ * @see [Display map navigation controls](https://docs.mapbox.com/mapbox-gl-js/example/navigation/)
  */
 class KeyboardHandler {
     _enabled: boolean;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -1,17 +1,17 @@
 // @flow
 
 import assert from 'assert';
-import DOM from '../../util/dom';
+import DOM from '../../util/dom.js';
 
-import {ease as _ease, bindAll, bezier} from '../../util/util';
-import browser from '../../util/browser';
-import window from '../../util/window';
-import {number as interpolate} from '../../style-spec/util/interpolate';
-import Point from '@mapbox/point-geometry';
+import {ease as _ease, bindAll, bezier} from '../../util/util.js';
+import browser from '../../util/browser.js';
+import window from '../../util/window.js';
+import {number as interpolate} from '../../style-spec/util/interpolate.js';
+import Point from '@mapbox/point-geometry.js';
 
-import type Map from '../map';
-import type HandlerManager from '../handler_manager';
-import MercatorCoordinate from '../../geo/mercator_coordinate';
+import type Map from '../map.js';
+import type HandlerManager from '../handler_manager.js';
+import MercatorCoordinate from '../../geo/mercator_coordinate.js';
 
 // deltaY value for mouse scroll wheel identification
 const wheelZoomDelta = 4.000244140625;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -7,7 +7,7 @@ import {ease as _ease, bindAll, bezier} from '../../util/util.js';
 import browser from '../../util/browser.js';
 import window from '../../util/window.js';
 import {number as interpolate} from '../../style-spec/util/interpolate.js';
-import Point from '@mapbox/point-geometry.js';
+import Point from '@mapbox/point-geometry';
 
 import type Map from '../map.js';
 import type HandlerManager from '../handler_manager.js';
@@ -170,7 +170,7 @@ class ScrollZoomHandler {
             this._type = null;
             this._lastValue = value;
 
-            // Start a timeout in case this was a singular event, and dely it by up to 40ms.
+            // Start a timeout in case this was a singular event, and delay it by up to 40ms.
             this._timeout = setTimeout(this._onTimeout, 40, e);
 
         } else if (!this._type) {
@@ -202,7 +202,7 @@ class ScrollZoomHandler {
         e.preventDefault();
     }
 
-    _onTimeout(initialEvent: any) {
+    _onTimeout(initialEvent: WheelEvent) {
         this._type = 'wheel';
         this._delta -= this._lastValue;
         if (!this._active) {
@@ -210,7 +210,7 @@ class ScrollZoomHandler {
         }
     }
 
-    _start(e: any) {
+    _start(e: WheelEvent) {
         if (!this._delta) return;
 
         if (this._frameId) {

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -1,17 +1,17 @@
 // @flow
 
 import assert from 'assert';
-import DOM from '../../util/dom.js';
+import DOM from '../../util/dom';
 
-import {ease as _ease, bindAll, bezier} from '../../util/util.js';
-import browser from '../../util/browser.js';
-import window from '../../util/window.js';
-import {number as interpolate} from '../../style-spec/util/interpolate.js';
+import {ease as _ease, bindAll, bezier} from '../../util/util';
+import browser from '../../util/browser';
+import window from '../../util/window';
+import {number as interpolate} from '../../style-spec/util/interpolate';
 import Point from '@mapbox/point-geometry';
 
-import type Map from '../map.js';
-import type HandlerManager from '../handler_manager.js';
-import MercatorCoordinate from '../../geo/mercator_coordinate.js';
+import type Map from '../map';
+import type HandlerManager from '../handler_manager';
+import MercatorCoordinate from '../../geo/mercator_coordinate';
 
 // deltaY value for mouse scroll wheel identification
 const wheelZoomDelta = 4.000244140625;
@@ -27,6 +27,8 @@ const maxScalePerFrame = 2;
 
 /**
  * The `ScrollZoomHandler` allows the user to zoom the map by scrolling.
+ * @see [Toggle interactions](https://docs.mapbox.com/mapbox-gl-js/example/toggle-interaction-handlers/)
+ * @see [Disable scroll zoom](https://docs.mapbox.com/mapbox-gl-js/example/disable-scroll-zoom/)
  */
 class ScrollZoomHandler {
     _map: Map;
@@ -168,7 +170,7 @@ class ScrollZoomHandler {
             this._type = null;
             this._lastValue = value;
 
-            // Start a timeout in case this was a singular event, and delay it by up to 40ms.
+            // Start a timeout in case this was a singular event, and dely it by up to 40ms.
             this._timeout = setTimeout(this._onTimeout, 40, e);
 
         } else if (!this._type) {
@@ -200,7 +202,7 @@ class ScrollZoomHandler {
         e.preventDefault();
     }
 
-    _onTimeout(initialEvent: WheelEvent) {
+    _onTimeout(initialEvent: any) {
         this._type = 'wheel';
         this._delta -= this._lastValue;
         if (!this._active) {
@@ -208,7 +210,7 @@ class ScrollZoomHandler {
         }
     }
 
-    _start(e: WheelEvent) {
+    _start(e: any) {
         if (!this._delta) return;
 
         if (this._frameId) {

--- a/src/ui/handler/shim/dblclick_zoom.js
+++ b/src/ui/handler/shim/dblclick_zoom.js
@@ -1,11 +1,12 @@
 // @flow
 
-import type ClickZoomHandler from '../click_zoom.js';
-import type TapZoomHandler from './../tap_zoom.js';
+import type ClickZoomHandler from '../click_zoom';
+import type TapZoomHandler from './../tap_zoom';
 
 /**
  * The `DoubleClickZoomHandler` allows the user to zoom the map at a point by
  * double clicking or double tapping.
+ * @see [Toggle interactions](https://docs.mapbox.com/mapbox-gl-js/example/toggle-interaction-handlers/)
  */
 export default class DoubleClickZoomHandler {
 

--- a/src/ui/handler/shim/dblclick_zoom.js
+++ b/src/ui/handler/shim/dblclick_zoom.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type ClickZoomHandler from '../click_zoom';
-import type TapZoomHandler from './../tap_zoom';
+import type ClickZoomHandler from '../click_zoom.js';
+import type TapZoomHandler from './../tap_zoom.js';
 
 /**
  * The `DoubleClickZoomHandler` allows the user to zoom the map at a point by

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type {MousePanHandler} from '../mouse';
-import type TouchPanHandler from './../touch_pan';
+import type {MousePanHandler} from '../mouse.js';
+import type TouchPanHandler from './../touch_pan.js';
 
 export type DragPanOptions = {
     linearity?: number;

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type {MousePanHandler} from '../mouse.js';
-import type TouchPanHandler from './../touch_pan.js';
+import type {MousePanHandler} from '../mouse';
+import type TouchPanHandler from './../touch_pan';
 
 export type DragPanOptions = {
     linearity?: number;
@@ -13,6 +13,8 @@ export type DragPanOptions = {
 /**
  * The `DragPanHandler` allows the user to pan the map by clicking and dragging
  * the cursor.
+ * @see [Toggle interactions](https://docs.mapbox.com/mapbox-gl-js/example/toggle-interaction-handlers/)
+ * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
  */
 export default class DragPanHandler {
 

--- a/src/ui/handler/shim/drag_rotate.js
+++ b/src/ui/handler/shim/drag_rotate.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {MouseRotateHandler, MousePitchHandler} from '../mouse';
+import type {MouseRotateHandler, MousePitchHandler} from '../mouse.js';
 
 /**
  * The `DragRotateHandler` allows the user to rotate the map by clicking and

--- a/src/ui/handler/shim/drag_rotate.js
+++ b/src/ui/handler/shim/drag_rotate.js
@@ -1,10 +1,12 @@
 // @flow
 
-import type {MouseRotateHandler, MousePitchHandler} from '../mouse.js';
+import type {MouseRotateHandler, MousePitchHandler} from '../mouse';
 
 /**
  * The `DragRotateHandler` allows the user to rotate the map by clicking and
  * dragging the cursor while holding the right mouse button or `ctrl` key.
+ * @see [Toggle interactions](https://docs.mapbox.com/mapbox-gl-js/example/toggle-interaction-handlers/)
+ * @see [Disable map rotation](https://docs.mapbox.com/mapbox-gl-js/example/disable-rotation/)
  */
 export default class DragRotateHandler {
 

--- a/src/ui/handler/shim/touch_zoom_rotate.js
+++ b/src/ui/handler/shim/touch_zoom_rotate.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type {TouchZoomHandler, TouchRotateHandler} from '../touch_zoom_rotate.js';
-import type TapDragZoomHandler from '../tap_drag_zoom.js';
+import type {TouchZoomHandler, TouchRotateHandler} from '../touch_zoom_rotate';
+import type TapDragZoomHandler from '../tap_drag_zoom';
 
 /**
  * The `TouchZoomRotateHandler` allows the user to zoom and rotate the map by
@@ -9,6 +9,7 @@ import type TapDragZoomHandler from '../tap_drag_zoom.js';
  *
  * They can zoom with one finger by double tapping and dragging. On the second tap,
  * hold the finger down and drag up or down to zoom in or out.
+ * @see [Toggle interactions](https://docs.mapbox.com/mapbox-gl-js/example/toggle-interaction-handlers/)
  */
 export default class TouchZoomRotateHandler {
 

--- a/src/ui/handler/shim/touch_zoom_rotate.js
+++ b/src/ui/handler/shim/touch_zoom_rotate.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type {TouchZoomHandler, TouchRotateHandler} from '../touch_zoom_rotate';
-import type TapDragZoomHandler from '../tap_drag_zoom';
+import type {TouchZoomHandler, TouchRotateHandler} from '../touch_zoom_rotate.js';
+import type TapDragZoomHandler from '../tap_drag_zoom.js';
 
 /**
  * The `TouchZoomRotateHandler` allows the user to zoom and rotate the map by

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Point from '@mapbox/point-geometry';
-import DOM from '../../util/dom';
+import DOM from '../../util/dom.js';
 
 class TwoTouchHandler {
 

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Point from '@mapbox/point-geometry';
-import DOM from '../../util/dom.js';
+import DOM from '../../util/dom';
 
 class TwoTouchHandler {
 
@@ -197,7 +197,8 @@ const ALLOWED_SINGLE_TOUCH_TIME = 100;
 
 /**
  * The `TouchPitchHandler` allows the user to pitch the map by dragging up and down with two fingers.
- */
+ * @see [Set pitch and bearing](https://docs.mapbox.com/mapbox-gl-js/example/set-perspective/)
+*/
 export class TouchPitchHandler extends TwoTouchHandler {
 
     _valid: boolean | void;


### PR DESCRIPTION
Related to: https://github.com/mapbox/mapbox-gl-js/pull/10433

1. Adds 2 related links to 3 GL JS Examples for `BoxZoomHandler`
1. Adds 2 related links to 3 GL JS Examples for `ScrollZoomHandler`
1. Adds 2 related links to 3 GL JS Examples for `DragPanHandler`
1. Adds 2 related links to 3 GL JS Examples for `DragRotateHandler`
1. Adds 3 related links to 3 GL JS Examples for `KeyboardHandler`
1. Adds 1 related link to 3 GL JS Examples for `DoubleClickZoomHandler`
1. Adds 1 related links to 3 GL JS Examples for `TouchZoomRotateHandler`
1. Adds 1 related links to 3 GL JS Examples for `TouchPitchHandler`

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] ~write tests for all new functionality~
 - [ ] ~document any changes to public APIs~
 - [ ] ~post benchmark scores~
 - [ ] ~manually test the debug page~
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] ~add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`~

Screenshot:

<img src="https://user-images.githubusercontent.com/6026447/110056521-1378f480-7d03-11eb-84e6-4d6acbd4d5ef.png" width=200 >

Not sure what is causing this error; keeping PR as draft until this is resolved:

`error Failed at the mapbox-gl@2.2.0-dev lint script.`