### PR TITLE
Unit test for #10444

### DIFF
--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -694,6 +694,23 @@ test('transform', (t) => {
             t.end();
         });
 
+        t.test('zoom 22 somewhere in Mile High City should load only visible tiles', (t) => {
+            tilesDefaultElevation = null;
+            centerElevation = 1600;
+            tileElevation[new OverscaledTileID(14, 0, 14, 3413, 6218).key] = 1600;
+            transform.resize(768, 768);
+            transform.zoom = options.maxzoom = 22;
+            transform.center = {lng: -104.99813327, lat: 39.72784465999999};
+            options.roundZoom = true;
+            t.deepEqual(transform.coveringTiles(options), [
+                new OverscaledTileID(22, 0, 22, 873835, 1592007),
+                new OverscaledTileID(22, 0, 22, 873834, 1592007),
+                new OverscaledTileID(22, 0, 22, 873835, 1592006),
+                new OverscaledTileID(22, 0, 22, 873834, 1592006)
+            ]);
+            t.end();
+        });
+
         t.end();
     });
 


### PR DESCRIPTION
Unit test for [zoom 22 at Mile High City.](https://github.com/mapbox/mapbox-gl-js/pull/10444#issue-587866412) Previous code resulted with 24 satellite tiles in cover, 4 tiles with this patch.

![Screen Shot 2021-03-09 at 13 53 02](https://user-images.githubusercontent.com/549216/110539198-9a780380-812d-11eb-8561-a3d8c9b3ce92.png)