### PR TITLE
fix release version check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
       - run:
           name: Check build file for correct SDK version
           command: |
-            if grep -q "sdkVersion:\"${CIRCLE_TAG:1}\"" ./dist/mapbox-gl.js; then
+            if grep -q "\"${CIRCLE_TAG:1}\"" ./dist/mapbox-gl.js; then
               echo SDK version in mapbox-gl.js matches ${CIRCLE_TAG:1}
             else
               echo SDK version in mapbox-gl.js does not match ${CIRCLE_TAG:1}


### PR DESCRIPTION
This updates the version check introduced in https://github.com/mapbox/mapbox-gl-js/pull/10354

It was checking variable name of the version string but we can't rely on that being consistent. It now just checks for the quoted version string.