### PR TITLE
Clear marker occlusion timer on Marker#remove

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -279,6 +279,7 @@ export default class Marker extends Evented {
             this._map.off('touchend', this._onUp);
             this._map.off('mousemove', this._onMove);
             this._map.off('touchmove', this._onMove);
+            this._map.off('remove', this._clearOcclusionTimer);
             delete this._map;
         }
         this._clearOcclusionTimer();

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -279,6 +279,10 @@ export default class Marker extends Evented {
             this._map.off('touchmove', this._onMove);
             delete this._map;
         }
+        if (this._occlusionTimer) {
+            clearTimeout(this._occlusionTimer);
+            this._occlusionTimer = null;
+        }
         DOM.remove(this._element);
         if (this._popup) this._popup.remove();
         return this;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -92,7 +92,8 @@ export default class Marker extends Evented {
             '_onUp',
             '_addDragHandler',
             '_onMapClick',
-            '_onKeyPress'
+            '_onKeyPress',
+            '_clearOcclusionTimer'
         ], this);
 
         this._anchor = options && options.anchor || 'center';
@@ -248,6 +249,7 @@ export default class Marker extends Evented {
         map.getCanvasContainer().appendChild(this._element);
         map.on('move', this._update);
         map.on('moveend', this._update);
+        map.on('remove', this._clearOcclusionTimer);
         this.setDraggable(this._draggable);
         this._update();
 
@@ -279,10 +281,7 @@ export default class Marker extends Evented {
             this._map.off('touchmove', this._onMove);
             delete this._map;
         }
-        if (this._occlusionTimer) {
-            clearTimeout(this._occlusionTimer);
-            this._occlusionTimer = null;
-        }
+        this._clearOcclusionTimer();
         DOM.remove(this._element);
         if (this._popup) this._popup.remove();
         return this;
@@ -447,6 +446,13 @@ export default class Marker extends Evented {
     _updateOcclusion() {
         if (!this._occlusionTimer) {
             this._occlusionTimer = setTimeout(this._onOcclusionTimer.bind(this), 60);
+        }
+    }
+
+    _clearOcclusionTimer() {
+        if (this._occlusionTimer) {
+            clearTimeout(this._occlusionTimer);
+            this._occlusionTimer = null;
         }
     }
 


### PR DESCRIPTION
This fixes #10402 by clearing the marker occlusion timer on `Marker#remove` and on the map `'remove'` event.

I reproduced the bug by removing the markers from the `markers.html` debug page while moving the map. I then verified that this change fixes the problem.

`Marker#remove` is not currently covered by unit tests, and I don't see an easy way to test this functionality. Thoughts?

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed a bug where markers may throw an error after being removed from a 3D map.</changelog>`
