### PR TITLE
Zoom independent distance matrix for fog

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -198,7 +198,7 @@ class Transform {
         return this.tileSize * this.scale;
     }
 
-    get cameraWorldSize(): number{
+    get cameraWorldSize(): number {
         return this._worldSizeFromZoom(this._zoomFromMercatorZ(this._camera.getDistanceToSeaLevel()));
     }
 
@@ -1080,7 +1080,7 @@ class Transform {
         mat4.translate(posMatrix, posMatrix, [unwrappedX * scale, canonical.y * scale, 0]);
         mat4.scale(posMatrix, posMatrix, [scale / EXTENT, scale / EXTENT, 1]);
 
-        return posMatrix
+        return posMatrix;
     }
 
     /**
@@ -1090,7 +1090,7 @@ class Transform {
      * @param {UnwrappedTileID} unwrappedTileID;
      * @private
      */
-    calculateCameraMatrix(unwrappedTileID: UnwrappedTileID): Float32Array{
+    calculateCameraMatrix(unwrappedTileID: UnwrappedTileID): Float32Array {
         const camMatrixKey = unwrappedTileID.key;
         const cache = this._cameraMatrixCache;
         if (cache[camMatrixKey]) {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1343,6 +1343,9 @@ class Transform {
         const nearZ = this.height / 50;
 
         const worldToCamera = this._camera.getWorldToCamera(this.worldSize, pixelsPerMeter);
+        // matrix for convertion from tile coordinates to relative to camera position in pixel coordinates
+        // console.log(`${this.worldSize}  ${this._worldSizeFromZoom(this._cameraZoom || this._zoom)}`);
+        this.cameraMatrix = this._camera.getWorldToCameraPosition(this.worldSize, pixelsPerMeter);
         const cameraToClip = this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, nearZ, farZ);
 
         // Apply center of perspective offset
@@ -1406,9 +1409,6 @@ class Transform {
         m = mat4.invert(new Float64Array(16), this.pixelMatrix);
         if (!m) throw new Error("failed to invert matrix");
         this.pixelMatrixInverse = m;
-
-        // matrix for convertion from tile coordinates to relative to camera position in pixel coordinates
-        this.cameraMatrix = this._camera.getWorldToCameraPosition(this.worldSize, pixelsPerMeter);
 
         this._projMatrixCache = {};
         this._alignedProjMatrixCache = {};

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -198,8 +198,16 @@ class Transform {
         return this.tileSize * this.scale;
     }
 
+    get cameraWorldSize(): number{
+        return this._worldSizeFromZoom(this._zoomFromMercatorZ(this._camera.getDistanceToSeaLevel()));
+    }
+
     get pixelsPerMeter(): number {
         return mercatorZfromAltitude(1, this.center.lat) * this.worldSize;
+    }
+
+    get cameraPixelsPerMeter(): number {
+        return mercatorZfromAltitude(1, this.center.lat) * this.cameraWorldSize;
     }
 
     get centerOffset(): Point {
@@ -1063,9 +1071,9 @@ class Transform {
         }
     }
 
-    calculatePosMatrix(unwrappedTileID: UnwrappedTileID): Float32Array {
+    calculatePosMatrix(unwrappedTileID: UnwrappedTileID, worldSize: number): Float32Array {
         const canonical = unwrappedTileID.canonical;
-        const scale = this.worldSize / this.zoomScale(canonical.z);
+        const scale = worldSize / this.zoomScale(canonical.z);
         const unwrappedX = canonical.x + Math.pow(2, canonical.z) * unwrappedTileID.wrap;
 
         const posMatrix = mat4.identity(new Float64Array(16));
@@ -1089,7 +1097,7 @@ class Transform {
             return cache[camMatrixKey];
         }
 
-        const posMatrix = this.calculatePosMatrix(unwrappedTileID);
+        const posMatrix = this.calculatePosMatrix(unwrappedTileID, this.cameraWorldSize);
         mat4.multiply(posMatrix, this.cameraMatrix, posMatrix);
 
         cache[camMatrixKey] = new Float32Array(posMatrix);
@@ -1108,7 +1116,7 @@ class Transform {
             return cache[projMatrixKey];
         }
 
-        const posMatrix = this.calculatePosMatrix(unwrappedTileID);
+        const posMatrix = this.calculatePosMatrix(unwrappedTileID, this.worldSize);
         mat4.multiply(posMatrix, aligned ? this.alignedProjMatrix : this.projMatrix, posMatrix);
 
         cache[projMatrixKey] = new Float32Array(posMatrix);
@@ -1343,9 +1351,6 @@ class Transform {
         const nearZ = this.height / 50;
 
         const worldToCamera = this._camera.getWorldToCamera(this.worldSize, pixelsPerMeter);
-        // matrix for convertion from tile coordinates to relative to camera position in pixel coordinates
-        // console.log(`${this.worldSize}  ${this._worldSizeFromZoom(this._cameraZoom || this._zoom)}`);
-        this.cameraMatrix = this._camera.getWorldToCameraPosition(this.worldSize, pixelsPerMeter);
         const cameraToClip = this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, nearZ, farZ);
 
         // Apply center of perspective offset
@@ -1404,6 +1409,9 @@ class Transform {
 
         // matrix for conversion from location to screen coordinates
         this.pixelMatrix = mat4.multiply(new Float64Array(16), this.labelPlaneMatrix, this.projMatrix);
+
+        // matrix for convertion from tile coordinates to relative to camera position in pixel coordinates
+        this.cameraMatrix = this._camera.getWorldToCameraPosition(this.cameraWorldSize, this.cameraPixelsPerMeter);
 
         // inverse matrix for conversion from screen coordinates to location
         m = mat4.invert(new Float64Array(16), this.pixelMatrix);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1061,7 +1061,7 @@ class Transform {
      * @param {UnwrappedTileID} unwrappedTileID;
      * @private
      */
-    calculatePosMatrix(unwrappedTileID: UnwrappedTileID, aligned: boolean = false): Float32Array {
+    calculateProjMatrix(unwrappedTileID: UnwrappedTileID, aligned: boolean = false): Float32Array {
         const posMatrixKey = unwrappedTileID.key;
         const cache = aligned ? this._alignedPosMatrixCache : this._posMatrixCache;
         if (cache[posMatrixKey]) {

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -46,7 +46,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
 
     const crossfade = layer.getCrossfadeParameters();
     for (const tileID of tileIDs) {
-        const matrix = coords ? tileID.posMatrix : painter.transform.calculatePosMatrix(tileID.toUnwrapped());
+        const matrix = coords ? tileID.projMatrix : painter.transform.calculateProjMatrix(tileID.toUnwrapped());
         painter.prepareDrawTile(tileID);
 
         const uniformValues = image ?

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -46,14 +46,15 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
 
     const crossfade = layer.getCrossfadeParameters();
     for (const tileID of tileIDs) {
-        const matrix = coords ? tileID.projMatrix : painter.transform.calculateProjMatrix(tileID.toUnwrapped());
+        const unwrappedTileID = tileID.toUnwrapped();
+        const matrix = coords ? tileID.projMatrix : painter.transform.calculateProjMatrix(unwrappedTileID);
         painter.prepareDrawTile(tileID);
 
         const uniformValues = image ?
             backgroundPatternUniformValues(matrix, opacity, painter, image, {tileID, tileSize}, crossfade) :
             backgroundUniformValues(matrix, opacity, color);
 
-        painter.prepareDrawProgram(context, program);
+        painter.prepareDrawProgram(context, program, unwrappedTileID);
 
         program.draw(context, gl.TRIANGLES, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
             uniformValues, layer.id, painter.tileExtentBuffer,

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -111,7 +111,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
         const segments = segmentsState.segments;
         if (painter.terrain) painter.terrain.setupElevationDraw(tile, program, {useDepthForOcclusion: true});
 
-        painter.prepareDrawProgram(context, program, unwrappedTileID);
+        painter.prepareDrawProgram(context, program, tile.tileID.toUnwrapped());
 
         program.draw(context, gl.TRIANGLES, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
             uniformValues, layer.id,

--- a/src/render/draw_circle.js
+++ b/src/render/draw_circle.js
@@ -111,7 +111,7 @@ function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleSt
         const segments = segmentsState.segments;
         if (painter.terrain) painter.terrain.setupElevationDraw(tile, program, {useDepthForOcclusion: true});
 
-        painter.prepareDrawProgram(context, program);
+        painter.prepareDrawProgram(context, program, unwrappedTileID);
 
         program.draw(context, gl.TRIANGLES, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
             uniformValues, layer.id,

--- a/src/render/draw_collision_debug.js
+++ b/src/render/draw_collision_debug.js
@@ -41,9 +41,9 @@ function drawCollisionDebug(painter: Painter, sourceCache: SourceCache, layer: S
         const tile = sourceCache.getTile(coord);
         const bucket: ?SymbolBucket = (tile.getBucket(layer): any);
         if (!bucket) continue;
-        let posMatrix = coord.posMatrix;
+        let posMatrix = coord.projMatrix;
         if (translate[0] !== 0 || translate[1] !== 0) {
-            posMatrix = painter.translatePosMatrix(coord.posMatrix, tile, translate, translateAnchor);
+            posMatrix = painter.translatePosMatrix(coord.projMatrix, tile, translate, translateAnchor);
         }
         const buffers = isText ? bucket.textCollisionBox : bucket.iconCollisionBox;
         // Get collision circle data of this bucket

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -79,7 +79,7 @@ function drawTileQueryGeometry(painter, sourceCache, coord: OverscaledTileID) {
     const context = painter.context;
     const gl = context.gl;
 
-    const posMatrix = coord.posMatrix;
+    const posMatrix = coord.projMatrix;
     const program = painter.useProgram('debug');
     const tile = sourceCache.getTileByID(coord.key);
     if (painter.terrain) painter.terrain.setupElevationDraw(tile, program);
@@ -122,7 +122,7 @@ function drawDebugTile(painter, sourceCache, coord: OverscaledTileID) {
     const context = painter.context;
     const gl = context.gl;
 
-    const posMatrix = coord.posMatrix;
+    const posMatrix = coord.projMatrix;
     const program = painter.useProgram('debug');
     const tile = sourceCache.getTileByID(coord.key);
     if (painter.terrain) painter.terrain.setupElevationDraw(tile, program);

--- a/src/render/draw_fill.js
+++ b/src/render/draw_fill.js
@@ -99,7 +99,7 @@ function drawFillTiles(painter, sourceCache, layer, coords, depthMode, colorMode
             if (posTo && posFrom) programConfiguration.setConstantPatternPositions(posTo, posFrom);
         }
 
-        const tileMatrix = painter.translatePosMatrix(coord.posMatrix, tile,
+        const tileMatrix = painter.translatePosMatrix(coord.projMatrix, tile,
             layer.paint.get('fill-translate'), layer.paint.get('fill-translate-anchor'));
 
         if (!isOutline) {
@@ -117,7 +117,7 @@ function drawFillTiles(painter, sourceCache, layer, coords, depthMode, colorMode
                 fillOutlineUniformValues(tileMatrix, drawingBufferSize);
         }
 
-        painter.prepareDrawProgram(painter.context, program);
+        painter.prepareDrawProgram(painter.context, program, coord.toUnwrapped());
 
         program.draw(painter.context, drawMode, depthMode,
             painter.stencilModeForClipping(coord), colorMode, CullFaceMode.disabled, uniformValues,

--- a/src/render/draw_fill_extrusion.js
+++ b/src/render/draw_fill_extrusion.js
@@ -91,7 +91,7 @@ function drawExtrusionTiles(painter, source, layer, coords, depthMode, stencilMo
         }
 
         const matrix = painter.translatePosMatrix(
-            coord.posMatrix,
+            coord.projMatrix,
             tile,
             layer.paint.get('fill-extrusion-translate'),
             layer.paint.get('fill-extrusion-translate-anchor'));
@@ -101,7 +101,7 @@ function drawExtrusionTiles(painter, source, layer, coords, depthMode, stencilMo
             fillExtrusionPatternUniformValues(matrix, painter, shouldUseVerticalGradient, opacity, coord, crossfade, tile) :
             fillExtrusionUniformValues(matrix, painter, shouldUseVerticalGradient, opacity);
 
-        painter.prepareDrawProgram(context, program);
+        painter.prepareDrawProgram(context, program, coord.toUnwrapped());
 
         program.draw(context, context.gl.TRIANGLES, depthMode, stencilMode, colorMode, CullFaceMode.backCCW,
             uniformValues, layer.id, bucket.layoutVertexBuffer, bucket.indexBuffer,

--- a/src/render/draw_heatmap.js
+++ b/src/render/draw_heatmap.js
@@ -55,10 +55,10 @@ function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapS
             const {zoom} = painter.transform;
             if (painter.terrain) painter.terrain.setupElevationDraw(tile, program);
 
-            painter.prepareDrawProgram(context, program);
+            painter.prepareDrawProgram(context, program, coord.toUnwrapped());
 
             program.draw(context, gl.TRIANGLES, DepthMode.disabled, stencilMode, colorMode, CullFaceMode.disabled,
-                heatmapUniformValues(coord.posMatrix,
+                heatmapUniformValues(coord.projMatrix,
                     tile, zoom, layer.paint.get('heatmap-intensity')),
                 layer.id, bucket.layoutVertexBuffer, bucket.indexBuffer,
                 bucket.segments, layer.paint, painter.transform.zoom,

--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -59,7 +59,7 @@ function renderHillshade(painter, coord, tile, layer, depthMode, stencilMode, co
     context.activeTexture.set(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, fbo.colorAttachment.get());
 
-    const uniformValues = hillshadeUniformValues(painter, tile, layer, painter.terrain ? coord.posMatrix : null);
+    const uniformValues = hillshadeUniformValues(painter, tile, layer, painter.terrain ? coord.projMatrix : null);
 
     program.draw(context, gl.TRIANGLES, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
         uniformValues, layer.id, painter.rasterBoundsBuffer,

--- a/src/render/draw_line.js
+++ b/src/render/draw_line.js
@@ -67,7 +67,7 @@ export default function drawLine(painter: Painter, sourceCache: SourceCache, lay
             if (posTo && posFrom) programConfiguration.setConstantPatternPositions(posTo, posFrom);
         }
 
-        const matrix = painter.terrain ? coord.posMatrix : null;
+        const matrix = painter.terrain ? coord.projMatrix : null;
         const uniformValues = image ? linePatternUniformValues(painter, tile, layer, crossfade, matrix) :
             dasharray ? lineSDFUniformValues(painter, tile, layer, dasharray, crossfade, matrix) :
             gradient ? lineGradientUniformValues(painter, tile, layer, matrix, bucket.lineClipsArray.length) :
@@ -115,7 +115,7 @@ export default function drawLine(painter: Painter, sourceCache: SourceCache, lay
             gradientTexture.bind(layer.stepInterpolant ? gl.NEAREST : gl.LINEAR, gl.CLAMP_TO_EDGE);
         }
 
-        painter.prepareDrawProgram(context, program);
+        painter.prepareDrawProgram(context, program, coord.toUnwrapped());
 
         program.draw(context, gl.TRIANGLES, depthMode,
             painter.stencilModeForClipping(coord), colorMode, CullFaceMode.disabled, uniformValues,

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -45,8 +45,8 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
         const tile = sourceCache.getTile(coord);
         if (renderingToTexture && !(tile && tile.hasData())) continue;
 
-        const posMatrix = (renderingToTexture) ? coord.posMatrix :
-            painter.transform.calculatePosMatrix(coord.toUnwrapped(), align);
+        const projMatrix = (renderingToTexture) ? coord.projMatrix :
+            painter.transform.calculateProjMatrix(coord.toUnwrapped(), align);
 
         const stencilMode = painter.terrain && renderingToTexture ?
             painter.terrain.stencilModeForRTTOverlap(coord) :
@@ -77,7 +77,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
             tile.texture.bind(textureFilter, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_NEAREST);
         }
 
-        const uniformValues = rasterUniformValues(posMatrix, parentTL || [0, 0], parentScaleBy || 1, fade, layer);
+        const uniformValues = rasterUniformValues(projMatrix, parentTL || [0, 0], parentScaleBy || 1, fade, layer);
 
         painter.prepareDrawProgram(context, program);
 

--- a/src/render/draw_raster.js
+++ b/src/render/draw_raster.js
@@ -42,11 +42,12 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
         const depthMode = renderingToTexture ? DepthMode.disabled : painter.depthModeForSublayer(coord.overscaledZ - minTileZ,
             layer.paint.get('raster-opacity') === 1 ? DepthMode.ReadWrite : DepthMode.ReadOnly, gl.LESS);
 
+        const unwrappedTileID = coord.toUnwrapped();
         const tile = sourceCache.getTile(coord);
         if (renderingToTexture && !(tile && tile.hasData())) continue;
 
         const projMatrix = (renderingToTexture) ? coord.projMatrix :
-            painter.transform.calculateProjMatrix(coord.toUnwrapped(), align);
+            painter.transform.calculateProjMatrix(unwrappedTileID, align);
 
         const stencilMode = painter.terrain && renderingToTexture ?
             painter.terrain.stencilModeForRTTOverlap(coord) :
@@ -79,7 +80,7 @@ function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterSty
 
         const uniformValues = rasterUniformValues(projMatrix, parentTL || [0, 0], parentScaleBy || 1, fade, layer);
 
-        painter.prepareDrawProgram(context, program);
+        painter.prepareDrawProgram(context, program, unwrappedTileID);
 
         if (source instanceof ImageSource) {
             program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.disabled,

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -127,7 +127,7 @@ function updateVariableAnchors(coords, painter, layer, sourceCache, rotationAlig
         const size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
 
         const pixelToTileScale = pixelsToTileUnits(tile, 1, painter.transform.zoom);
-        const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.posMatrix, pitchWithMap, rotateWithMap, painter.transform, pixelToTileScale);
+        const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.projMatrix, pitchWithMap, rotateWithMap, painter.transform, pixelToTileScale);
         const updateTextFitIcon = layer.layout.get('icon-text-fit') !== 'none' &&  bucket.hasIconData();
 
         if (size) {
@@ -135,7 +135,7 @@ function updateVariableAnchors(coords, painter, layer, sourceCache, rotationAlig
             const elevation = tr.elevation;
             const getElevation = elevation ? (p => elevation.getAtTileOffset(coord, p.x, p.y)) : (_ => 0);
             updateVariableAnchorsForBucket(bucket, rotateWithMap, pitchWithMap, variableOffsets, symbolSize,
-                                  tr, labelPlaneMatrix, coord.posMatrix, tileScale, size, updateTextFitIcon, getElevation);
+                                  tr, labelPlaneMatrix, coord.projMatrix, tileScale, size, updateTextFitIcon, getElevation);
         }
     }
 }
@@ -292,10 +292,10 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         }
 
         const s = pixelsToTileUnits(tile, 1, painter.transform.zoom);
-        const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.posMatrix, pitchWithMap, rotateWithMap, painter.transform, s);
+        const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.projMatrix, pitchWithMap, rotateWithMap, painter.transform, s);
         // labelPlaneMatrixInv is used for converting vertex pos to tile coordinates needed for sampling elevation.
         const labelPlaneMatrixInv = painter.terrain && pitchWithMap && alongLine ? mat4.invert(new Float32Array(16), labelPlaneMatrix) : identityMat4;
-        const glCoordMatrix = symbolProjection.getGlCoordMatrix(coord.posMatrix, pitchWithMap, rotateWithMap, painter.transform, s);
+        const glCoordMatrix = symbolProjection.getGlCoordMatrix(coord.projMatrix, pitchWithMap, rotateWithMap, painter.transform, s);
 
         const hasVariableAnchors = variablePlacement && bucket.hasTextData();
         const updateTextFitIcon = layer.layout.get('icon-text-fit') !== 'none' &&
@@ -305,10 +305,10 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         if (alongLine) {
             const elevation = tr.elevation;
             const getElevation = elevation ? (p => elevation.getAtTileOffset(coord, p.x, p.y)) : null;
-            symbolProjection.updateLineLabels(bucket, coord.posMatrix, painter, isText, labelPlaneMatrix, glCoordMatrix, pitchWithMap, keepUpright, getElevation);
+            symbolProjection.updateLineLabels(bucket, coord.projMatrix, painter, isText, labelPlaneMatrix, glCoordMatrix, pitchWithMap, keepUpright, getElevation);
         }
 
-        const matrix = painter.translatePosMatrix(coord.posMatrix, tile, translate, translateAnchor),
+        const matrix = painter.translatePosMatrix(coord.projMatrix, tile, translate, translateAnchor),
             uLabelPlaneMatrix = (alongLine || (isText && variablePlacement) || updateTextFitIcon) ? identityMat4 : labelPlaneMatrix,
             uglCoordMatrix = painter.translatePosMatrix(glCoordMatrix, tile, translate, translateAnchor, true);
 

--- a/src/render/fog.js
+++ b/src/render/fog.js
@@ -3,9 +3,10 @@
 import Context from '../gl/context.js';
 import type {UniformLocations} from './uniform_binding.js';
 
-import {Uniform1f, Uniform2f, Uniform3f} from './uniform_binding.js';
+import {Uniform1f, Uniform2f, Uniform3f, UniformMatrix4f} from './uniform_binding.js';
 
 export type FogUniformsType = {|
+    'u_cam_matrix': UniformMatrix4f,
     'u_fog_range': Uniform2f,
     'u_fog_color': Uniform3f,
     'u_fog_opacity': Uniform1f,
@@ -13,6 +14,7 @@ export type FogUniformsType = {|
 |};
 
 export const fogUniforms = (context: Context, locations: UniformLocations): FogUniformsType => ({
+    'u_cam_matrix': new UniformMatrix4f(context, locations.u_cam_matrix),
     'u_fog_range': new Uniform2f(context, locations.u_fog_range),
     'u_fog_color': new Uniform3f(context, locations.u_fog_color),
     'u_fog_opacity': new Uniform1f(context, locations.u_fog_opacity),

--- a/src/render/program/circle_program.js
+++ b/src/render/program/circle_program.js
@@ -50,7 +50,7 @@ const circleUniformValues = (
     return {
         'u_camera_to_center_distance': transform.cameraToCenterDistance,
         'u_matrix': painter.translatePosMatrix(
-            coord.posMatrix,
+            coord.projMatrix,
             tile,
             layer.paint.get('circle-translate'),
             layer.paint.get('circle-translate-anchor')),

--- a/src/render/program/hillshade_program.js
+++ b/src/render/program/hillshade_program.js
@@ -74,7 +74,7 @@ const hillshadeUniformValues = (
     }
     const align = !painter.options.moving;
     return {
-        'u_matrix': matrix ? matrix : painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped(), align),
+        'u_matrix': matrix ? matrix : painter.transform.calculateProjMatrix(tile.tileID.toUnwrapped(), align),
         'u_image': 0,
         'u_latrange': getTileLatRange(painter, tile.tileID),
         'u_light': [layer.paint.get('hillshade-exaggeration'), azimuthal],

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -196,7 +196,7 @@ function calculateTileRatio(tile: Tile, transform: Transform) {
 
 function calculateMatrix(painter, tile, layer, matrix) {
     return painter.translatePosMatrix(
-        matrix ? matrix : tile.tileID.posMatrix,
+        matrix ? matrix : tile.tileID.projMatrix,
         tile,
         layer.paint.get('line-translate'),
         layer.paint.get('line-translate-anchor')

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -25,7 +25,7 @@ void main() {
     gl_Position = u_matrix * vec4(decodedPos, elevation, 1.0);
 
 #ifdef FOG
-    vec4 depthPos = u_cam_matrix * vec4(decodedPos, 0.0, 1.0);
-    v_depth = length(depthPos.xy/depthPos.w);
+    vec4 depthPos = u_cam_matrix * vec4(decodedPos, elevation, 1.0);
+    v_depth = length(depthPos.xyz/depthPos.w);
 #endif
 }

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -7,6 +7,7 @@ attribute vec2 a_texture_pos;
 varying vec2 v_pos0;
 
 #ifdef FOG
+uniform mat4 u_cam_matrix;
 varying float v_depth;
 #endif
 
@@ -24,6 +25,7 @@ void main() {
     gl_Position = u_matrix * vec4(decodedPos, elevation, 1.0);
 
 #ifdef FOG
-    v_depth = length(gl_Position.xyz);
+    vec4 depthPos = u_cam_matrix * vec4(decodedPos, 0.0, 1.0);
+    v_depth = length(depthPos.xy/depthPos.w);
 #endif
 }

--- a/src/source/query_features.js
+++ b/src/source/query_features.js
@@ -17,7 +17,7 @@ function getPixelPosMatrix(transform, tileID) {
     const t = mat4.identity([]);
     mat4.scale(t, t, [transform.width * 0.5, -transform.height * 0.5, 1]);
     mat4.translate(t, t, [1, -1, 0]);
-    return mat4.multiply(t, t, transform.calculatePosMatrix(tileID.toUnwrapped()));
+    return mat4.multiply(t, t, transform.calculateProjMatrix(tileID.toUnwrapped()));
 }
 
 export function queryRenderedFeatures(sourceCache: SourceCache,

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -843,7 +843,7 @@ class SourceCache extends Evented {
     getVisibleCoordinates(symbolLayer?: boolean): Array<OverscaledTileID> {
         const coords = this.getRenderableIds(symbolLayer).map((id) => this._tiles[id].tileID);
         for (const coord of coords) {
-            coord.posMatrix = this.transform.calculatePosMatrix(coord.toUnwrapped());
+            coord.projMatrix = this.transform.calculateProjMatrix(coord.toUnwrapped());
         }
         return coords;
     }

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -79,7 +79,7 @@ export class OverscaledTileID {
     wrap: number;
     canonical: CanonicalTileID;
     key: number;
-    posMatrix: Float32Array;
+    projMatrix: Float32Array;
 
     constructor(overscaledZ: number, wrap: number, z: number, x: number, y: number) {
         assert(overscaledZ >= z);
@@ -219,4 +219,4 @@ function getQuadkey(z, x, y) {
 }
 
 register('CanonicalTileID', CanonicalTileID);
-register('OverscaledTileID', OverscaledTileID, {omit: ['posMatrix']});
+register('OverscaledTileID', OverscaledTileID, {omit: ['projMatrix']});

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -232,7 +232,7 @@ export class Placement {
         const scale = Math.pow(2, this.transform.zoom - tile.tileID.overscaledZ);
         const textPixelRatio = tile.tileSize / EXTENT;
 
-        const posMatrix = this.transform.calculatePosMatrix(tile.tileID.toUnwrapped());
+        const posMatrix = this.transform.calculateProjMatrix(tile.tileID.toUnwrapped());
 
         const pitchWithMap = layout.get('text-pitch-alignment') === 'map';
         const rotateWithMap = layout.get('text-rotation-alignment') === 'map';

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -180,13 +180,13 @@ function drawTerrainRaster(painter: Painter, terrain: Terrain, sourceCache: Sour
                 elevationOptions = {morphing: {srcDemTile: morph.from, dstDemTile: morph.to, phase: easeCubicInOut(morph.phase)}};
             }
 
-            const uniformValues = terrainRasterUniformValues(coord.posMatrix, isEdgeTile(coord.canonical, tr.renderWorldCopies) ? skirt / 10 : skirt);
+            const uniformValues = terrainRasterUniformValues(coord.projMatrix, isEdgeTile(coord.canonical, tr.renderWorldCopies) ? skirt / 10 : skirt);
 
             setShaderMode(shaderMode, isWireframe);
 
             terrain.setupElevationDraw(tile, program, elevationOptions);
 
-            painter.prepareDrawProgram(context, program);
+            painter.prepareDrawProgram(context, program, coord.toUnwrapped());
 
             program.draw(context, primitive, depthMode, stencilMode, colorMode, CullFaceMode.backCCW,
                 uniformValues, "terrain_raster", terrain.gridBuffer, buffer, segments);
@@ -205,7 +205,7 @@ function drawTerrainDepth(painter: Painter, terrain: Terrain, sourceCache: Sourc
 
     for (const coord of tileIDs) {
         const tile = sourceCache.getTile(coord);
-        const uniformValues = terrainRasterUniformValues(coord.posMatrix, 0);
+        const uniformValues = terrainRasterUniformValues(coord.projMatrix, 0);
         terrain.setupElevationDraw(tile, program);
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, ColorMode.unblended, CullFaceMode.backCCW,
             uniformValues, "terrain_depth", terrain.gridBuffer, terrain.gridIndexBuffer, terrain.gridNoSkirtSegments);

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -405,7 +405,7 @@ export class Terrain extends Elevation {
         this._invalidateRenderCache = false;
         const coords = this.proxyCoords = psc.getIds().map((id) => {
             const tileID = psc.getTileByID(id).tileID;
-            tileID.posMatrix = tr.calculatePosMatrix(tileID.toUnwrapped());
+            tileID.projMatrix = tr.calculateProjMatrix(tileID.toUnwrapped());
             return tileID;
         });
         sortByDistanceToCamera(coords, this.painter);

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -153,10 +153,10 @@ class ProxySourceCache extends SourceCache {
 class ProxiedTileID extends OverscaledTileID {
     proxyTileKey: number;
 
-    constructor(tileID: OverscaledTileID, proxyTileKey: number, posMatrix: Float32Array) {
+    constructor(tileID: OverscaledTileID, proxyTileKey: number, projMatrix: Float32Array) {
         super(tileID.overscaledZ, tileID.wrap, tileID.canonical.z, tileID.canonical.x, tileID.canonical.y);
         this.proxyTileKey = proxyTileKey;
-        this.posMatrix = posMatrix;
+        this.projMatrix = projMatrix;
     }
 }
 
@@ -379,7 +379,7 @@ export class Terrain extends Elevation {
     // For every renderable coordinate in every source cache, assign one proxy
     // tile (see _setupProxiedCoordsForOrtho). Mapping of source tile to proxy
     // tile is modeled by ProxiedTileID. In general case, source and proxy tile
-    // are of different zoom: ProxiedTileID.posMatrix models ortho, scale and
+    // are of different zoom: ProxiedTileID.projMatrix models ortho, scale and
     // translate from source to proxy. This matrix is used when rendering source
     // tile to proxy tile's texture.
     // One proxy tile can have multiple source tiles, or pieces of source tiles,
@@ -1066,7 +1066,7 @@ export class Terrain extends Elevation {
             program.draw(context, gl.TRIANGLES, DepthMode.disabled,
                 // Tests will always pass, and ref value will be written to stencil buffer.
                 new StencilMode({func: gl.ALWAYS, mask: 0}, id, 0xFF, gl.KEEP, gl.KEEP, gl.REPLACE),
-                ColorMode.disabled, CullFaceMode.disabled, clippingMaskUniformValues(tileID.posMatrix),
+                ColorMode.disabled, CullFaceMode.disabled, clippingMaskUniformValues(tileID.projMatrix),
                 '$clipping', painter.tileExtentBuffer,
                 painter.quadTriangleIndexBuffer, painter.tileExtentSegments);
         }

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -304,6 +304,14 @@ class FreeCamera {
         return matrix;
     }
 
+    getDistanceToSeaLevel(): number {
+        const f = this.forward();
+        const pos = this.position;
+        const pitch = Math.atan2(Math.sqrt(f[0] * f[0] + f[1] * f[1]), -f[2]);
+
+        return pos[2] / Math.cos(pitch);
+    }
+
     clone(): FreeCamera {
         return new FreeCamera([...this.position], [...this.orientation]);
     }

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -247,6 +247,22 @@ class FreeCamera {
         return cameraToWorld;
     }
 
+    getWorldToCameraPosition(worldSize: number, pixelsPerMeter: number): Float64Array {
+        const invPosition = this.position;
+
+        vec3.scale(invPosition, invPosition, -worldSize);
+        const matrix = new Float64Array(16);
+        mat4.fromTranslation(matrix, invPosition);
+
+        // Post-multiply z (3rd column)
+        matrix[8] *= pixelsPerMeter;
+        matrix[9] *= pixelsPerMeter;
+        matrix[10] *= pixelsPerMeter;
+        matrix[11] *= pixelsPerMeter;
+
+        return matrix;
+    }
+
     getWorldToCamera(worldSize: number, pixelsPerMeter: number): Float64Array {
         // transformation chain from world space to camera space:
         // 1. Height value (z) of renderables is in meters. Scale z coordinate by pixelsPerMeter


### PR DESCRIPTION
- Calculate a terrain-independent zoom based on distance of camera from plane at z=0
- Add `cameraMatrix` which is the position of the camera in this space
- Refactor posMatrix to projMatrix to separate out tile projection and positioning logic.

TODO:
[ ] Make `cameraMatrix` account for translate properties
