### PR TITLE
Clarification for queryRenderedFeatures `geometry` param

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1200,7 +1200,7 @@ class Map extends Camera {
      * either a single point or bottom left and top right points describing a bounding box, where the origin is at the top left.
      * Omitting this parameter (i.e. calling {@link Map#queryRenderedFeatures} with zero arguments,
      * or with only a `options` argument) is equivalent to passing a bounding box encompassing the entire
-     * map viewport.
+     * map viewport. If the value of this parameter falls outside the visible map viewport, available features will still be returned.
      * @param {Object} [options] Options object.
      * @param {Array<string>} [options.layers] An array of [style layer IDs](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layer-id) for the query to inspect.
      *   Only features within these layers will be returned. If this parameter is undefined, all layers will be checked.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1199,8 +1199,9 @@ class Map extends Camera {
      * @param {PointLike|Array<PointLike>} [geometry] - The geometry of the query region in pixels:
      * either a single point or bottom left and top right points describing a bounding box, where the origin is at the top left.
      * Omitting this parameter (i.e. calling {@link Map#queryRenderedFeatures} with zero arguments,
-     * or with only a `options` argument) is equivalent to passing a bounding box encompassing the entire
-     * map viewport. If the value of this parameter falls outside the visible map viewport, available features will still be returned.
+     * or with only an `options` argument) is equivalent to passing a bounding box encompassing the entire
+     * map viewport.
+     * Only values within the existing viewport are supported.
      * @param {Object} [options] Options object.
      * @param {Array<string>} [options.layers] An array of [style layer IDs](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layer-id) for the query to inspect.
      *   Only features within these layers will be returned. If this parameter is undefined, all layers will be checked.


### PR DESCRIPTION
fixes mapbox/mapbox-gl-js-docs#108

This PR clarifies that if the `geometry` location specified in `queryRenderedFeatures` falls outside of the visible map, it will still return features. This addition is based on limited testing that I was able to do, and I'd appreciate it if someone from the @mapbox/gl-js  could confirm that this is indeed the case. (And, if so, whether there are limits to this. As @andrewharvey asked in https://github.com/mapbox/mapbox-gl-js/pull/10481#issuecomment-802323541 "like how far outside the viewport you can query, is it just loaded tiles?")

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
