### PR TITLE
Apply correct fog+blending in shaders

### DIFF
--- a/src/render/draw_hillshade.js
+++ b/src/render/draw_hillshade.js
@@ -61,6 +61,8 @@ function renderHillshade(painter, coord, tile, layer, depthMode, stencilMode, co
 
     const uniformValues = hillshadeUniformValues(painter, tile, layer, painter.terrain ? coord.projMatrix : null);
 
+    painter.prepareDrawProgram(context, program, coord.toUnwrapped());
+
     program.draw(context, gl.TRIANGLES, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
         uniformValues, layer.id, painter.rasterBoundsBuffer,
         painter.quadTriangleIndexBuffer, painter.rasterBoundsSegments);

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -741,7 +741,9 @@ class Painter {
 
         const defines = [];
         if (terrain) defines.push('TERRAIN');
-        if (fog) defines.push('FOG');
+        // When terrain is active, fog is rendered as part of draping, not as part of tile
+        // rendering. Removing the fog flag during tile rendering avoids additional defines.
+        if (fog && !rtt) defines.push('FOG');
         if (rtt) defines.push('RENDER_TO_TEXTURE');
         if (this._showOverdrawInspector) defines.push('OVERDRAW_INSPECTOR');
         return defines;

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -18,16 +18,19 @@ precision mediump float;
 
 const float PI = 3.141592653589793;
 
+// Comment to globally disable gamma correction (presently only wrt fog):
 #define GAMMA_CORRECT
 
 vec3 linearToSRGB(vec3 color) {
 // TODO: Make a choice and remove this conditional before production
-// TODO: Just use pow(*, 2.2). It's approximate and completely adequate.
 #ifdef GAMMA_CORRECT
+    return pow(color, vec3(1.0 / 2.2));
+    /*
     vec3 a = 12.92 * color;
     vec3 b = 1.055 * pow(color, vec3(1.0 / 2.4)) - 0.055;
     vec3 c = step(vec3(0.0031308), color);
     return mix(a, b, c);
+    */
 #else
     return color;
 #endif
@@ -35,12 +38,14 @@ vec3 linearToSRGB(vec3 color) {
 
 vec3 srgbToLinear(vec3 color) {
 // TODO: Make a choice and remove this conditional before production
-// TODO: Just use pow(*, 2.2). It's approximate and completely adequate.
 #ifdef GAMMA_CORRECT
+    return pow(color, vec3(2.2));
+    /*
     vec3 a = color / 12.92;
     vec3 b = pow((color + 0.055) / 1.055, vec3(2.4));
     vec3 c = step(vec3(0.04045), color);
     return mix(a, b, c);
+    */
 #else
     return color;
 #endif

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -22,6 +22,7 @@ const float PI = 3.141592653589793;
 
 vec3 linearToSRGB(vec3 color) {
 // TODO: Make a choice and remove this conditional before production
+// TODO: Just use pow(*, 2.2). It's approximate and completely adequate.
 #ifdef GAMMA_CORRECT
     vec3 a = 12.92 * color;
     vec3 b = 1.055 * pow(color, vec3(1.0 / 2.4)) - 0.055;
@@ -34,6 +35,7 @@ vec3 linearToSRGB(vec3 color) {
 
 vec3 srgbToLinear(vec3 color) {
 // TODO: Make a choice and remove this conditional before production
+// TODO: Just use pow(*, 2.2). It's approximate and completely adequate.
 #ifdef GAMMA_CORRECT
     vec3 a = color / 12.92;
     vec3 b = pow((color + 0.055) / 1.055, vec3(2.4));

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -17,3 +17,33 @@ precision mediump float;
 #endif
 
 const float PI = 3.141592653589793;
+
+#define GAMMA_CORRECT
+
+vec3 linearToSRGB(vec3 color) {
+// TODO: Make a choice and remove this conditional before production
+#ifdef GAMMA_CORRECT
+    vec3 a = 12.92 * color;
+    vec3 b = 1.055 * pow(color, vec3(1.0 / 2.4)) - 0.055;
+    vec3 c = step(vec3(0.0031308), color);
+    return mix(a, b, c);
+#else
+    return color;
+#endif
+}
+
+vec3 srgbToLinear(vec3 color) {
+// TODO: Make a choice and remove this conditional before production
+#ifdef GAMMA_CORRECT
+    vec3 a = color / 12.92;
+    vec3 b = pow((color + 0.055) / 1.055, vec3(2.4));
+    vec3 c = step(vec3(0.04045), color);
+    return mix(a, b, c);
+#else
+    return color;
+#endif
+}
+
+vec3 gammaMix(vec3 a, vec3 b, float x) {
+    return linearToSRGB(mix(srgbToLinear(a), srgbToLinear(b), x));
+}

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -18,37 +18,12 @@ precision mediump float;
 
 const float PI = 3.141592653589793;
 
-// Comment to globally disable gamma correction (presently only wrt fog):
-#define GAMMA_CORRECT
-
 vec3 linear_to_srgb(vec3 color) {
-// TODO: Make a choice and remove this conditional before production
-#ifdef GAMMA_CORRECT
     return pow(color, vec3(1.0 / 2.2));
-    /*
-    vec3 a = 12.92 * color;
-    vec3 b = 1.055 * pow(color, vec3(1.0 / 2.4)) - 0.055;
-    vec3 c = step(vec3(0.0031308), color);
-    return mix(a, b, c);
-    */
-#else
-    return color;
-#endif
 }
 
 vec3 srgb_to_linear(vec3 color) {
-// TODO: Make a choice and remove this conditional before production
-#ifdef GAMMA_CORRECT
     return pow(color, vec3(2.2));
-    /*
-    vec3 a = color / 12.92;
-    vec3 b = pow((color + 0.055) / 1.055, vec3(2.4));
-    vec3 c = step(vec3(0.04045), color);
-    return mix(a, b, c);
-    */
-#else
-    return color;
-#endif
 }
 
 vec3 gamma_mix(vec3 a, vec3 b, float x) {

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -21,7 +21,7 @@ const float PI = 3.141592653589793;
 // Comment to globally disable gamma correction (presently only wrt fog):
 #define GAMMA_CORRECT
 
-vec3 linearToSRGB(vec3 color) {
+vec3 linear_to_srgb(vec3 color) {
 // TODO: Make a choice and remove this conditional before production
 #ifdef GAMMA_CORRECT
     return pow(color, vec3(1.0 / 2.2));
@@ -36,7 +36,7 @@ vec3 linearToSRGB(vec3 color) {
 #endif
 }
 
-vec3 srgbToLinear(vec3 color) {
+vec3 srgb_to_linear(vec3 color) {
 // TODO: Make a choice and remove this conditional before production
 #ifdef GAMMA_CORRECT
     return pow(color, vec3(2.2));
@@ -51,6 +51,6 @@ vec3 srgbToLinear(vec3 color) {
 #endif
 }
 
-vec3 gammaMix(vec3 a, vec3 b, float x) {
-    return linearToSRGB(mix(srgbToLinear(a), srgbToLinear(b), x));
+vec3 gamma_mix(vec3 a, vec3 b, float x) {
+    return linear_to_srgb(mix(srgb_to_linear(a), srgb_to_linear(b), x));
 }

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -11,28 +11,36 @@ vec3 fog_apply_sky_gradient(vec3 cubemap_uv, vec3 sky_color) {
     float y_blend = dot(camera_ray, y_up);
     float gradient = smoothstep(0.0, u_fog_sky_blend, y_blend);
     float fog_falloff = clamp(gradient + (1.0 - u_fog_opacity), 0.0, 1.0);
-    return mix(u_fog_color, sky_color, fog_falloff);
+    return gammaMix(u_fog_color, sky_color, fog_falloff);
 }
 
-vec3 fog_apply(vec3 color, float depth) {
+float fog_opacity(vec3 position) {
+    float depth = length(position);
     float start = u_fog_range.x;
     float end = u_fog_range.y;
+
     // Apply a constant to push the function closer to 1.0 on the far end
     // of the fog range, refer https://www.desmos.com/calculator/x5gopnb91a
-    float exp_constant = 5.5;
+    const float exp_constant = 5.5;
+    const float fog_power = 2.0;
     float fog_falloff = exp(-exp_constant * (depth - start) / (end - start));
-    fog_falloff = 1.0 - clamp(fog_falloff, 0.0, 1.0);
-    return mix(color, u_fog_color, fog_falloff * u_fog_opacity);
+    float fog_opacity = pow(max((1.0 - fog_falloff) * u_fog_opacity, 0.0), fog_power);
+
+    // Clip to actually return 100% opacity at end
+    fog_opacity = min(1.0, fog_opacity * 1.02);
+
+    return fog_opacity;
 }
 
-#else
-
-vec3 fog_apply(vec3 color, float depth) {
-    return color;
+vec3 fog_apply(vec3 color, vec3 position) {
+    return gammaMix(color, u_fog_color, fog_opacity(position));
 }
 
-vec3 fog_apply_sky_gradient(vec3 cubemap_uv, vec3 sky_color) {
-    return sky_color;
+// Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For
+// use with colors using premultiplied alpha
+vec4 fog_apply_premultiplied(vec4 color, vec3 position) {
+    float a = 1e-4 + color.a;
+    return vec4(fog_apply(min(color.rgb / a, vec3(1)), position) * a, color.a);
 }
 
 #endif

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -13,7 +13,7 @@ vec3 fog_apply_sky_gradient(vec3 cubemap_uv, vec3 sky_color) {
     float fog_falloff = clamp(gradient + (1.0 - u_fog_opacity), 0.0, 1.0);
 
     // We may or may not wish to use gamma-correct blending
-    return gammaMix(u_fog_color, sky_color, fog_falloff);
+    return gamma_mix(u_fog_color, sky_color, fog_falloff);
 }
 
 float fog_opacity(vec3 position) {
@@ -36,7 +36,7 @@ float fog_opacity(vec3 position) {
 
 vec3 fog_apply(vec3 color, vec3 position) {
     // We may or may not wish to use gamma-correct blending
-    return gammaMix(color, u_fog_color, fog_opacity(position));
+    return gamma_mix(color, u_fog_color, fog_opacity(position));
 }
 
 // Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -11,6 +11,8 @@ vec3 fog_apply_sky_gradient(vec3 cubemap_uv, vec3 sky_color) {
     float y_blend = dot(camera_ray, y_up);
     float gradient = smoothstep(0.0, u_fog_sky_blend, y_blend);
     float fog_falloff = clamp(gradient + (1.0 - u_fog_opacity), 0.0, 1.0);
+
+    // We may or may not wish to use gamma-correct blending
     return gammaMix(u_fog_color, sky_color, fog_falloff);
 }
 
@@ -22,17 +24,18 @@ float fog_opacity(vec3 position) {
     // Apply a constant to push the function closer to 1.0 on the far end
     // of the fog range, refer https://www.desmos.com/calculator/x5gopnb91a
     const float exp_constant = 5.5;
-    const float fog_power = 2.0;
     float fog_falloff = exp(-exp_constant * (depth - start) / (end - start));
+
+    // Apply a power remove the C1 discontinuity at the near limit
+    const float fog_power = 2.0;
     float fog_opacity = pow(max((1.0 - fog_falloff) * u_fog_opacity, 0.0), fog_power);
 
     // Clip to actually return 100% opacity at end
-    fog_opacity = min(1.0, fog_opacity * 1.02);
-
-    return fog_opacity;
+    return min(1.0, fog_opacity * 1.02);
 }
 
 vec3 fog_apply(vec3 color, vec3 position) {
+    // We may or may not wish to use gamma-correct blending
     return gammaMix(color, u_fog_color, fog_opacity(position));
 }
 

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -28,14 +28,13 @@ float fog_opacity(vec3 position) {
 
     // Apply a power remove the C1 discontinuity at the near limit
     const float fog_power = 2.0;
-    float fog_opacity = pow(max((1.0 - fog_falloff) * u_fog_opacity, 0.0), fog_power);
+    float opacity = pow(max((1.0 - fog_falloff) * u_fog_opacity, 0.0), fog_power);
 
     // Clip to actually return 100% opacity at end
-    return min(1.0, fog_opacity * 1.02);
+    return min(1.0, opacity * 1.02);
 }
 
 vec3 fog_apply(vec3 color, vec3 position) {
-    // We may or may not wish to use gamma-correct blending
     return gamma_mix(color, u_fog_color, fog_opacity(position));
 }
 

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -7,6 +7,7 @@ vec3 fog_position(vec3 pos) {
     return p.xyz / p.w;
 }
 
+// Accept either 2D or 3D positions
 vec3 fog_position(vec2 pos) {
     return fog_position(vec3(pos, 0));
 }

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -1,3 +1,14 @@
 #ifdef FOG
 
+uniform mat4 u_cam_matrix;
+
+vec3 fog_position(vec3 pos) {
+    vec4 p = u_cam_matrix * vec4(pos, 1);
+    return p.xyz / p.w;
+}
+
+vec3 fog_position(vec2 pos) {
+    return fog_position(vec3(pos, 0));
+}
+
 #endif

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -3,8 +3,9 @@
 uniform mat4 u_cam_matrix;
 
 vec3 fog_position(vec3 pos) {
-    vec4 p = u_cam_matrix * vec4(pos, 1);
-    return p.xyz / p.w;
+    // The following function requires that u_cam_matrix be affine and result in
+    // a vector with w = 1. Otherwise we must divide by w.
+    return (u_cam_matrix * vec4(pos, 1)).xyz;
 }
 
 // Accept either 2D or 3D positions

--- a/src/shaders/background.fragment.glsl
+++ b/src/shaders/background.fragment.glsl
@@ -9,7 +9,7 @@ void main() {
     vec4 out_color = u_color;
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
     gl_FragColor = out_color * u_opacity;

--- a/src/shaders/background.fragment.glsl
+++ b/src/shaders/background.fragment.glsl
@@ -1,18 +1,18 @@
 uniform vec4 u_color;
 uniform float u_opacity;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 void main() {
-    vec4 out_color = u_color * u_opacity;
+    vec4 out_color = u_color;
 
-#ifdef FOG
-    out_color.rgb = fog_apply(out_color.rgb, v_depth);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
 #endif
 
-    gl_FragColor = out_color;
+    gl_FragColor = out_color * u_opacity;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/background.fragment.glsl
+++ b/src/shaders/background.fragment.glsl
@@ -1,14 +1,14 @@
 uniform vec4 u_color;
 uniform float u_opacity;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
 void main() {
     vec4 out_color = u_color;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 

--- a/src/shaders/background.vertex.glsl
+++ b/src/shaders/background.vertex.glsl
@@ -2,14 +2,14 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
-#ifdef FOG
-    v_depth = length(gl_Position.xyz);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/background.vertex.glsl
+++ b/src/shaders/background.vertex.glsl
@@ -2,14 +2,14 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/background_pattern.fragment.glsl
+++ b/src/shaders/background_pattern.fragment.glsl
@@ -11,6 +11,10 @@ uniform sampler2D u_image;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
+#ifdef FOG
+varying vec3 v_fog_pos;
+#endif
+
 void main() {
     vec2 imagecoord = mod(v_pos_a, 1.0);
     vec2 pos = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, imagecoord);
@@ -20,7 +24,13 @@ void main() {
     vec2 pos2 = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, imagecoord_b);
     vec4 color2 = texture2D(u_image, pos2);
 
-    gl_FragColor = mix(color1, color2, u_mix) * u_opacity;
+    vec4 out_color = mix(color1, color2, u_mix);
+
+#ifdef FOG
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+#endif
+
+    gl_FragColor = out_color * u_opacity;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/background_pattern.vertex.glsl
+++ b/src/shaders/background_pattern.vertex.glsl
@@ -12,7 +12,7 @@ attribute vec2 a_pos;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -22,7 +22,7 @@ void main() {
     v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_a * u_pattern_size_a, u_tile_units_to_pixels, a_pos);
     v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_b * u_pattern_size_b, u_tile_units_to_pixels, a_pos);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/background_pattern.vertex.glsl
+++ b/src/shaders/background_pattern.vertex.glsl
@@ -12,9 +12,17 @@ attribute vec2 a_pos;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
     v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_a * u_pattern_size_a, u_tile_units_to_pixels, a_pos);
     v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_b * u_pattern_size_b, u_tile_units_to_pixels, a_pos);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
+#endif
 }

--- a/src/shaders/circle.fragment.glsl
+++ b/src/shaders/circle.fragment.glsl
@@ -1,6 +1,10 @@
 varying vec3 v_data;
 varying float v_visibility;
 
+#ifdef FOG
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define mediump float radius
 #pragma mapbox: define lowp float blur
@@ -32,7 +36,13 @@ void main() {
         extrude_length - radius / (radius + stroke_width)
     );
 
-    gl_FragColor = v_visibility * opacity_t * mix(color * opacity, stroke_color * stroke_opacity, color_t);
+    vec4 out_color = mix(color * opacity, stroke_color * stroke_opacity, color_t);
+
+#ifdef FOG
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+#endif
+
+    gl_FragColor = out_color * v_visibility * opacity_t;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/circle.fragment.glsl
+++ b/src/shaders/circle.fragment.glsl
@@ -42,7 +42,7 @@ void main() {
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
-    gl_FragColor = out_color * v_visibility * opacity_t;
+    gl_FragColor = out_color * (v_visibility * opacity_t);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/circle.vertex.glsl
+++ b/src/shaders/circle.vertex.glsl
@@ -14,6 +14,10 @@ attribute vec2 a_pos;
 varying vec3 v_data;
 varying float v_visibility;
 
+#ifdef FOG
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define mediump float radius
 #pragma mapbox: define lowp float blur
@@ -137,4 +141,8 @@ void main(void) {
     lowp float antialiasblur = 1.0 / u_device_pixel_ratio / (radius + stroke_width);
 
     v_data = vec3(extrude.x, extrude.y, antialiasblur);
+
+#ifdef FOG
+    v_fog_pos = fog_position(world_center.xyz);
+#endif
 }

--- a/src/shaders/fill.fragment.glsl
+++ b/src/shaders/fill.fragment.glsl
@@ -1,7 +1,7 @@
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float opacity
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -11,7 +11,7 @@ void main() {
 
     vec4 out_color = color;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 

--- a/src/shaders/fill.fragment.glsl
+++ b/src/shaders/fill.fragment.glsl
@@ -12,7 +12,7 @@ void main() {
     vec4 out_color = color;
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
     gl_FragColor = out_color * opacity;

--- a/src/shaders/fill.fragment.glsl
+++ b/src/shaders/fill.fragment.glsl
@@ -1,21 +1,21 @@
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float opacity
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 void main() {
     #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float opacity
 
-    vec4 out_color = color * opacity;
+    vec4 out_color = color;
 
-#ifdef FOG
-    out_color.rgb = fog_apply(out_color.rgb, v_depth);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
 #endif
 
-    gl_FragColor = out_color;
+    gl_FragColor = out_color * opacity;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/fill.vertex.glsl
+++ b/src/shaders/fill.vertex.glsl
@@ -2,7 +2,7 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -15,7 +15,7 @@ void main() {
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/fill.vertex.glsl
+++ b/src/shaders/fill.vertex.glsl
@@ -2,8 +2,8 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define highp vec4 color
@@ -15,7 +15,7 @@ void main() {
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
-#ifdef FOG
-    v_depth = length(gl_Position.xyz);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -1,13 +1,13 @@
 varying vec4 v_color;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 void main() {
     vec4 color = v_color;
-#ifdef FOG
-    color.rgb = fog_apply(color.rgb, v_depth);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    color.rgb = fog_apply(color.rgb, v_fog_pos);
 #endif
     gl_FragColor = color;
 

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -7,7 +7,7 @@ varying vec3 v_fog_pos;
 void main() {
     vec4 color = v_color;
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    color.rgb = fog_apply(color.rgb, v_fog_pos);
+    color = fog_apply_premultiplied(color, v_fog_pos);
 #endif
     gl_FragColor = color;
 

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -1,12 +1,12 @@
 varying vec4 v_color;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
 void main() {
     vec4 color = v_color;
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     color = fog_apply_premultiplied(color, v_fog_pos);
 #endif
     gl_FragColor = color;

--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -10,7 +10,7 @@ attribute vec2 a_centroid_pos;
 
 varying vec4 v_color;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -87,7 +87,7 @@ void main() {
     v_color.rgb += clamp(color.rgb * directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));
     v_color *= u_opacity;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/fill_extrusion.vertex.glsl
+++ b/src/shaders/fill_extrusion.vertex.glsl
@@ -10,8 +10,8 @@ attribute vec2 a_centroid_pos;
 
 varying vec4 v_color;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define highp float base
@@ -47,9 +47,11 @@ void main() {
     float c_ele = flat_roof ? centroid_pos.y == 0.0 ? elevationFromUint16(centroid_pos.x) : flatElevation(centroid_pos) : ele;
     // If centroid elevation lower than vertex elevation, roof at least 2 meters height above base.
     float h = flat_roof ? max(c_ele + height, ele + base + 2.0) : ele + (t > 0.0 ? height : base == 0.0 ? -5.0 : base);
-    gl_Position = mix(u_matrix * vec4(pos_nx.xy, h, 1), AWAY, hidden);
+    vec3 pos = vec3(pos_nx.xy, h);
+    gl_Position = mix(u_matrix * vec4(pos, 1), AWAY, hidden);
 #else
-    gl_Position = u_matrix * vec4(pos_nx.xy, t > 0.0 ? height : base, 1);
+    vec3 pos = vec3(pos_nx.xy, t > 0.0 ? height : base);
+    gl_Position = u_matrix * vec4(pos, 1);
 #endif
 
     // Relative luminance (how dark/bright is the surface color?)
@@ -85,7 +87,7 @@ void main() {
     v_color.rgb += clamp(color.rgb * directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));
     v_color *= u_opacity;
 
-#ifdef FOG
-    v_depth = length(gl_Position.xyz);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/fill_extrusion_pattern.fragment.glsl
+++ b/src/shaders/fill_extrusion_pattern.fragment.glsl
@@ -7,8 +7,8 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec4 v_lighting;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define lowp float base
@@ -43,8 +43,8 @@ void main() {
 
     out_color = out_color * v_lighting;
 
-#ifdef FOG
-    out_color.rgb = fog_apply(out_color.rgb, v_depth);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
 #endif
 
     gl_FragColor = out_color;

--- a/src/shaders/fill_extrusion_pattern.fragment.glsl
+++ b/src/shaders/fill_extrusion_pattern.fragment.glsl
@@ -7,7 +7,7 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec4 v_lighting;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -43,7 +43,7 @@ void main() {
 
     out_color = out_color * v_lighting;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 

--- a/src/shaders/fill_extrusion_pattern.fragment.glsl
+++ b/src/shaders/fill_extrusion_pattern.fragment.glsl
@@ -44,7 +44,7 @@ void main() {
     out_color = out_color * v_lighting;
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
     gl_FragColor = out_color;

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -17,7 +17,7 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec4 v_lighting;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -102,7 +102,7 @@ void main() {
     v_lighting.rgb += clamp(directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));
     v_lighting *= u_opacity;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -17,8 +17,8 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec4 v_lighting;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define lowp float base
@@ -73,9 +73,11 @@ void main() {
     float c_ele = flat_roof ? centroid_pos.y == 0.0 ? elevationFromUint16(centroid_pos.x) : flatElevation(centroid_pos) : ele;
     // If centroid elevation lower than vertex elevation, roof at least 2 meters height above base.
     float h = flat_roof ? max(c_ele + height, ele + base + 2.0) : ele + (t > 0.0 ? height : base == 0.0 ? -5.0 : base);
-    gl_Position = mix(u_matrix * vec4(pos_nx.xy, h, 1), AWAY, hidden);
+    vec3 pos = vec3(pos_nx.xy, h);
+    gl_Position = mix(u_matrix * vec4(pos, 1), AWAY, hidden);
 #else
-    gl_Position = u_matrix * vec4(pos_nx.xy, z, 1);
+    vec3 pos = vec3(pos_nx.xy, z);
+    gl_Position = u_matrix * vec4(pos, 1);
 #endif
 
     vec2 pos = normal.z == 1.0
@@ -100,7 +102,7 @@ void main() {
     v_lighting.rgb += clamp(directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));
     v_lighting *= u_opacity;
 
-#ifdef FOG
-    v_depth = length(gl_Position.xyz);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -73,11 +73,11 @@ void main() {
     float c_ele = flat_roof ? centroid_pos.y == 0.0 ? elevationFromUint16(centroid_pos.x) : flatElevation(centroid_pos) : ele;
     // If centroid elevation lower than vertex elevation, roof at least 2 meters height above base.
     float h = flat_roof ? max(c_ele + height, ele + base + 2.0) : ele + (t > 0.0 ? height : base == 0.0 ? -5.0 : base);
-    vec3 pos = vec3(pos_nx.xy, h);
-    gl_Position = mix(u_matrix * vec4(pos, 1), AWAY, hidden);
+    vec3 p = vec3(pos_nx.xy, h);
+    gl_Position = mix(u_matrix * vec4(p, 1), AWAY, hidden);
 #else
-    vec3 pos = vec3(pos_nx.xy, z);
-    gl_Position = u_matrix * vec4(pos, 1);
+    vec3 p = vec3(pos_nx.xy, z);
+    gl_Position = u_matrix * vec4(p, 1);
 #endif
 
     vec2 pos = normal.z == 1.0
@@ -103,6 +103,6 @@ void main() {
     v_lighting *= u_opacity;
 
 #ifdef FOG
-    v_fog_pos = fog_position(pos);
+    v_fog_pos = fog_position(p);
 #endif
 }

--- a/src/shaders/fill_outline.fragment.glsl
+++ b/src/shaders/fill_outline.fragment.glsl
@@ -3,8 +3,8 @@ varying vec2 v_pos;
 #pragma mapbox: define highp vec4 outline_color
 #pragma mapbox: define lowp float opacity
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 void main() {
@@ -15,8 +15,8 @@ void main() {
     float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
     vec4 out_color = outline_color * (alpha * opacity);
 
-#ifdef FOG
-    out_color.rgb = fog_apply(out_color.rgb, v_depth);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
 #endif
 
     gl_FragColor = out_color;

--- a/src/shaders/fill_outline.fragment.glsl
+++ b/src/shaders/fill_outline.fragment.glsl
@@ -13,13 +13,13 @@ void main() {
 
     float dist = length(v_pos * gl_FragCoord.w - gl_FragCoord.xy);
     float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
-    vec4 out_color = outline_color * (alpha * opacity);
+    vec4 out_color = outline_color;
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
-    gl_FragColor = out_color;
+    gl_FragColor = out_color * (alpha * opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/fill_outline.fragment.glsl
+++ b/src/shaders/fill_outline.fragment.glsl
@@ -3,7 +3,7 @@ varying vec2 v_pos;
 #pragma mapbox: define highp vec4 outline_color
 #pragma mapbox: define lowp float opacity
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -15,7 +15,7 @@ void main() {
     float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
     vec4 out_color = outline_color;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 

--- a/src/shaders/fill_outline.vertex.glsl
+++ b/src/shaders/fill_outline.vertex.glsl
@@ -5,7 +5,7 @@ uniform vec2 u_world;
 
 varying vec2 v_pos;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -23,7 +23,7 @@ void main() {
     // gl_Position.w in the vertex shader and by gl_FragCoord.w (e.g. 1/gl_Position.w) later in the fragment shader.
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world * gl_Position.w;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/fill_outline.vertex.glsl
+++ b/src/shaders/fill_outline.vertex.glsl
@@ -5,8 +5,8 @@ uniform vec2 u_world;
 
 varying vec2 v_pos;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define highp vec4 outline_color
@@ -23,7 +23,7 @@ void main() {
     // gl_Position.w in the vertex shader and by gl_FragCoord.w (e.g. 1/gl_Position.w) later in the fragment shader.
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world * gl_Position.w;
 
-#ifdef FOG
-    v_depth = length(gl_Position.xyz);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/fill_outline_pattern.fragment.glsl
+++ b/src/shaders/fill_outline_pattern.fragment.glsl
@@ -7,8 +7,8 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec2 v_pos;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define lowp float opacity
@@ -40,8 +40,8 @@ void main() {
 
     vec4 out_color = mix(color1, color2, u_fade) * alpha * opacity;
 
-#ifdef FOG
-    out_color.rgb = fog_apply(out_color.rgb, v_depth);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
 #endif
 
     gl_FragColor = out_color;

--- a/src/shaders/fill_outline_pattern.fragment.glsl
+++ b/src/shaders/fill_outline_pattern.fragment.glsl
@@ -38,13 +38,13 @@ void main() {
     float dist = length(v_pos - gl_FragCoord.xy);
     float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
 
-    vec4 out_color = mix(color1, color2, u_fade) * alpha * opacity;
+    vec4 out_color = mix(color1, color2, u_fade);
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
-    gl_FragColor = out_color;
+    gl_FragColor = out_color * alpha * opacity;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/fill_outline_pattern.fragment.glsl
+++ b/src/shaders/fill_outline_pattern.fragment.glsl
@@ -44,7 +44,7 @@ void main() {
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
-    gl_FragColor = out_color * alpha * opacity;
+    gl_FragColor = out_color * (alpha * opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/fill_outline_pattern.fragment.glsl
+++ b/src/shaders/fill_outline_pattern.fragment.glsl
@@ -7,7 +7,7 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec2 v_pos;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -40,7 +40,7 @@ void main() {
 
     vec4 out_color = mix(color1, color2, u_fade);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 

--- a/src/shaders/fill_outline_pattern.vertex.glsl
+++ b/src/shaders/fill_outline_pattern.vertex.glsl
@@ -10,7 +10,7 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec2 v_pos;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -46,7 +46,7 @@ void main() {
 
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/fill_outline_pattern.vertex.glsl
+++ b/src/shaders/fill_outline_pattern.vertex.glsl
@@ -10,8 +10,8 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec2 v_pos;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define lowp float opacity
@@ -46,7 +46,7 @@ void main() {
 
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
 
-#ifdef FOG
-    v_depth = length(gl_Position.xyz);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/fill_pattern.fragment.glsl
+++ b/src/shaders/fill_pattern.fragment.glsl
@@ -6,7 +6,7 @@ uniform sampler2D u_image;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -34,7 +34,7 @@ void main() {
 
     vec4 out_color = mix(color1, color2, u_fade);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 

--- a/src/shaders/fill_pattern.fragment.glsl
+++ b/src/shaders/fill_pattern.fragment.glsl
@@ -32,13 +32,13 @@ void main() {
     vec2 pos2 = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, imagecoord_b);
     vec4 color2 = texture2D(u_image, pos2);
 
-    vec4 out_color = mix(color1, color2, u_fade) * opacity;
+    vec4 out_color = mix(color1, color2, u_fade);
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
-    gl_FragColor = out_color;
+    gl_FragColor = out_color * opacity;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/fill_pattern.fragment.glsl
+++ b/src/shaders/fill_pattern.fragment.glsl
@@ -6,8 +6,8 @@ uniform sampler2D u_image;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define lowp float opacity
@@ -34,8 +34,8 @@ void main() {
 
     vec4 out_color = mix(color1, color2, u_fade) * opacity;
 
-#ifdef FOG
-    out_color.rgb = fog_apply(out_color.rgb, v_depth);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    out_color.rgb = fog_apply(out_color.rgb, v_fog_pos);
 #endif
 
     gl_FragColor = out_color;

--- a/src/shaders/fill_pattern.vertex.glsl
+++ b/src/shaders/fill_pattern.vertex.glsl
@@ -8,7 +8,7 @@ attribute vec2 a_pos;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -41,7 +41,7 @@ void main() {
     v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, fromScale * display_size_a, tileZoomRatio, a_pos);
     v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, toScale * display_size_b, tileZoomRatio, a_pos);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/fill_pattern.vertex.glsl
+++ b/src/shaders/fill_pattern.vertex.glsl
@@ -8,8 +8,8 @@ attribute vec2 a_pos;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
-#ifdef FOG
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 #pragma mapbox: define lowp float opacity
@@ -41,7 +41,7 @@ void main() {
     v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, fromScale * display_size_a, tileZoomRatio, a_pos);
     v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, toScale * display_size_b, tileZoomRatio, a_pos);
 
-#ifdef FOG
-    v_depth = length(gl_Position.xyz);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/heatmap.fragment.glsl
+++ b/src/shaders/heatmap.fragment.glsl
@@ -2,7 +2,7 @@ uniform highp float u_intensity;
 
 varying vec2 v_extrude;
 
-#if defined( FOG )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -20,7 +20,7 @@ void main() {
 
     gl_FragColor = vec4(val, 1.0, 1.0, 1.0);
 
-#if defined( FOG )
+#ifdef FOG
     // Heatmaps work differently than other layers, so we operate on the accumulated
     // density rather than a final color. The power is chosen so that the density
     // fades into the fog at a reasonable rate.

--- a/src/shaders/heatmap.fragment.glsl
+++ b/src/shaders/heatmap.fragment.glsl
@@ -2,6 +2,10 @@ uniform highp float u_intensity;
 
 varying vec2 v_extrude;
 
+#if defined( FOG )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define highp float weight
 
 // Gaussian kernel coefficient: 1 / sqrt(2 * PI)
@@ -15,6 +19,13 @@ void main() {
     float val = weight * u_intensity * GAUSS_COEF * exp(d);
 
     gl_FragColor = vec4(val, 1.0, 1.0, 1.0);
+
+#if defined( FOG )
+    // Heatmaps work differently than other layers, so we operate on the accumulated
+    // density rather than a final color. The power is chosen so that the density
+    // fades into the fog at a reasonable rate.
+    gl_FragColor.r *= pow(1.0 - fog_opacity(v_fog_pos), 2.0);
+#endif
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/heatmap.vertex.glsl
+++ b/src/shaders/heatmap.vertex.glsl
@@ -8,6 +8,10 @@ attribute vec2 a_pos;
 
 varying vec2 v_extrude;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define highp float weight
 #pragma mapbox: define mediump float radius
 
@@ -48,7 +52,11 @@ void main(void) {
 
     // multiply a_pos by 0.5, since we had it * 2 in order to sneak
     // in extrusion data
-    vec4 pos = vec4(floor(a_pos * 0.5) + extrude, elevation(floor(a_pos * 0.5)), 1);
+    vec3 pos = vec3(floor(a_pos * 0.5) + extrude, elevation(floor(a_pos * 0.5)));
 
-    gl_Position = u_matrix * pos;
+    gl_Position = u_matrix * vec4(pos, 1);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(pos);
+#endif
 }

--- a/src/shaders/heatmap.vertex.glsl
+++ b/src/shaders/heatmap.vertex.glsl
@@ -8,7 +8,7 @@ attribute vec2 a_pos;
 
 varying vec2 v_extrude;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -56,7 +56,7 @@ void main(void) {
 
     gl_Position = u_matrix * vec4(pos, 1);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/heatmap_texture.fragment.glsl
+++ b/src/shaders/heatmap_texture.fragment.glsl
@@ -6,6 +6,7 @@ varying vec2 v_pos;
 void main() {
     float t = texture2D(u_image, v_pos).r;
     vec4 color = texture2D(u_color_ramp, vec2(t, 0.5));
+
     gl_FragColor = color * u_opacity;
 
 #ifdef OVERDRAW_INSPECTOR

--- a/src/shaders/hillshade.fragment.glsl
+++ b/src/shaders/hillshade.fragment.glsl
@@ -1,6 +1,10 @@
 uniform sampler2D u_image;
 varying vec2 v_pos;
 
+#ifdef FOG
+varying vec3 v_fog_pos;
+#endif
+
 uniform vec2 u_latrange;
 uniform vec2 u_light;
 uniform vec4 u_shadow;
@@ -43,6 +47,10 @@ void main() {
     float shade = abs(mod((aspect + azimuth) / PI + 0.5, 2.0) - 1.0);
     vec4 shade_color = mix(u_shadow, u_highlight, shade) * sin(scaledSlope) * clamp(intensity * 2.0, 0.0, 1.0);
     gl_FragColor = accent_color * (1.0 - shade_color.a) + shade_color;
+
+#ifdef FOG
+    gl_FragColor = fog_apply_premultiplied(gl_FragColor, v_fog_pos);
+#endif
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/hillshade.vertex.glsl
+++ b/src/shaders/hillshade.vertex.glsl
@@ -5,7 +5,7 @@ attribute vec2 a_texture_pos;
 
 varying vec2 v_pos;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -13,7 +13,7 @@ void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = a_texture_pos / 8192.0;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/hillshade.vertex.glsl
+++ b/src/shaders/hillshade.vertex.glsl
@@ -5,7 +5,15 @@ attribute vec2 a_texture_pos;
 
 varying vec2 v_pos;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = a_texture_pos / 8192.0;
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
+#endif
 }

--- a/src/shaders/hillshade_prepare.vertex.glsl
+++ b/src/shaders/hillshade_prepare.vertex.glsl
@@ -6,10 +6,18 @@ attribute vec2 a_texture_pos;
 
 varying vec2 v_pos;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
     highp vec2 epsilon = 1.0 / u_dimension;
     float scale = (u_dimension.x - 2.0) / u_dimension.x;
     v_pos = (a_texture_pos / 8192.0) * scale + epsilon;
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
+#endif
 }

--- a/src/shaders/hillshade_prepare.vertex.glsl
+++ b/src/shaders/hillshade_prepare.vertex.glsl
@@ -6,7 +6,7 @@ attribute vec2 a_texture_pos;
 
 varying vec2 v_pos;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -17,7 +17,7 @@ void main() {
     float scale = (u_dimension.x - 2.0) / u_dimension.x;
     v_pos = (a_texture_pos / 8192.0) * scale + epsilon;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/hillshade_prepare.vertex.glsl
+++ b/src/shaders/hillshade_prepare.vertex.glsl
@@ -6,18 +6,10 @@ attribute vec2 a_texture_pos;
 
 varying vec2 v_pos;
 
-#ifdef FOG
-varying vec3 v_fog_pos;
-#endif
-
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
     highp vec2 epsilon = 1.0 / u_dimension;
     float scale = (u_dimension.x - 2.0) / u_dimension.x;
     v_pos = (a_texture_pos / 8192.0) * scale + epsilon;
-
-#ifdef FOG
-    v_fog_pos = fog_position(a_pos);
-#endif
 }

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -4,7 +4,7 @@ varying vec2 v_width2;
 varying vec2 v_normal;
 varying float v_gamma_scale;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -26,11 +26,13 @@ void main() {
     float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
     float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    color = fog_apply_premultiplied(color, v_fog_pos);
+    vec4 out_color = color;
+
+#ifdef FOG
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
-    gl_FragColor = color * (alpha * opacity);
+    gl_FragColor = out_color * (alpha * opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -27,7 +27,7 @@ void main() {
     float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    color.rgb = fog_apply(color.rgb, v_fog_pos);
+    color = fog_apply_premultiplied(color, v_fog_pos);
 #endif
 
     gl_FragColor = color * (alpha * opacity);

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -4,6 +4,10 @@ varying vec2 v_width2;
 varying vec2 v_normal;
 varying float v_gamma_scale;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
@@ -21,6 +25,10 @@ void main() {
     // (v_width2.s)
     float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
     float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    color.rgb = fog_apply(color.rgb, v_fog_pos);
+#endif
 
     gl_FragColor = color * (alpha * opacity);
 

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -18,7 +18,7 @@ varying vec2 v_normal;
 varying vec2 v_width2;
 varying float v_gamma_scale;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -86,7 +86,7 @@ void main() {
 #endif
     v_width2 = vec2(outset, inset);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -18,6 +18,10 @@ varying vec2 v_normal;
 varying vec2 v_width2;
 varying float v_gamma_scale;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
@@ -81,4 +85,8 @@ void main() {
     v_gamma_scale = 1.0;
 #endif
     v_width2 = vec2(outset, inset);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(pos);
+#endif
 }

--- a/src/shaders/line_gradient.fragment.glsl
+++ b/src/shaders/line_gradient.fragment.glsl
@@ -6,7 +6,7 @@ varying vec2 v_normal;
 varying float v_gamma_scale;
 varying highp vec2 v_uv;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -30,7 +30,7 @@ void main() {
     // entire line, the gradient ramp is stored in a texture.
     vec4 color = texture2D(u_image, v_uv);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     color = fog_apply_premultiplied(color, v_fog_pos);
 #endif
 

--- a/src/shaders/line_gradient.fragment.glsl
+++ b/src/shaders/line_gradient.fragment.glsl
@@ -6,6 +6,10 @@ varying vec2 v_normal;
 varying float v_gamma_scale;
 varying highp vec2 v_uv;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
 
@@ -25,6 +29,10 @@ void main() {
     // For gradient lines, v_lineprogress is the ratio along the
     // entire line, the gradient ramp is stored in a texture.
     vec4 color = texture2D(u_image, v_uv);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    color.rgb = fog_apply(color.rgb, v_fog_pos);
+#endif
 
     gl_FragColor = color * (alpha * opacity);
 

--- a/src/shaders/line_gradient.fragment.glsl
+++ b/src/shaders/line_gradient.fragment.glsl
@@ -31,7 +31,7 @@ void main() {
     vec4 color = texture2D(u_image, v_uv);
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    color.rgb = fog_apply(color.rgb, v_fog_pos);
+    color = fog_apply_premultiplied(color, v_fog_pos);
 #endif
 
     gl_FragColor = color * (alpha * opacity);

--- a/src/shaders/line_gradient.vertex.glsl
+++ b/src/shaders/line_gradient.vertex.glsl
@@ -22,6 +22,10 @@ varying vec2 v_width2;
 varying float v_gamma_scale;
 varying highp vec2 v_uv;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
 #pragma mapbox: define mediump float gapwidth
@@ -88,4 +92,8 @@ void main() {
     v_gamma_scale = 1.0;
 #endif
     v_width2 = vec2(outset, inset);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(pos);
+#endif
 }

--- a/src/shaders/line_gradient.vertex.glsl
+++ b/src/shaders/line_gradient.vertex.glsl
@@ -22,7 +22,7 @@ varying vec2 v_width2;
 varying float v_gamma_scale;
 varying highp vec2 v_uv;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -93,7 +93,7 @@ void main() {
 #endif
     v_width2 = vec2(outset, inset);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/line_pattern.fragment.glsl
+++ b/src/shaders/line_pattern.fragment.glsl
@@ -74,7 +74,7 @@ void main() {
     color = fog_apply_premultiplied(color, v_fog_pos);
 #endif
 
-    gl_FragColor = color * alpha * opacity;
+    gl_FragColor = color * (alpha * opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/line_pattern.fragment.glsl
+++ b/src/shaders/line_pattern.fragment.glsl
@@ -11,6 +11,10 @@ varying float v_linesofar;
 varying float v_gamma_scale;
 varying float v_width;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define lowp vec4 pattern_from
 #pragma mapbox: define lowp vec4 pattern_to
 #pragma mapbox: define lowp float pixel_ratio_from
@@ -65,6 +69,10 @@ void main() {
     vec2 pos_b = mix(pattern_tl_b * texel_size - texel_size, pattern_br_b * texel_size + texel_size, vec2(x_b, y));
 
     vec4 color = mix(texture2D(u_image, pos_a), texture2D(u_image, pos_b), u_fade);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    color = fog_apply_premultiplied(color, v_fog_pos);
+#endif
 
     gl_FragColor = color * alpha * opacity;
 

--- a/src/shaders/line_pattern.fragment.glsl
+++ b/src/shaders/line_pattern.fragment.glsl
@@ -11,7 +11,7 @@ varying float v_linesofar;
 varying float v_gamma_scale;
 varying float v_width;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -70,7 +70,7 @@ void main() {
 
     vec4 color = mix(texture2D(u_image, pos_a), texture2D(u_image, pos_b), u_fade);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     color = fog_apply_premultiplied(color, v_fog_pos);
 #endif
 

--- a/src/shaders/line_pattern.vertex.glsl
+++ b/src/shaders/line_pattern.vertex.glsl
@@ -21,7 +21,7 @@ varying float v_linesofar;
 varying float v_gamma_scale;
 varying float v_width;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -101,7 +101,7 @@ void main() {
     v_width2 = vec2(outset, inset);
     v_width = floorwidth;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/line_pattern.vertex.glsl
+++ b/src/shaders/line_pattern.vertex.glsl
@@ -21,6 +21,10 @@ varying float v_linesofar;
 varying float v_gamma_scale;
 varying float v_width;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
 #pragma mapbox: define lowp float offset
@@ -96,4 +100,8 @@ void main() {
     v_linesofar = a_linesofar;
     v_width2 = vec2(outset, inset);
     v_width = floorwidth;
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(pos);
+#endif
 }

--- a/src/shaders/line_sdf.fragment.glsl
+++ b/src/shaders/line_sdf.fragment.glsl
@@ -10,7 +10,7 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -41,11 +41,13 @@ void main() {
     float sdfdist = mix(sdfdist_a, sdfdist_b, u_mix);
     alpha *= smoothstep(0.5 - u_sdfgamma / floorwidth, 0.5 + u_sdfgamma / floorwidth, sdfdist);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    color = fog_apply_premultiplied(color, v_fog_pos);
+    vec4 out_color = color;
+
+#ifdef FOG
+    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
 #endif
 
-    gl_FragColor = color * (alpha * opacity);
+    gl_FragColor = out_color * (alpha * opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/line_sdf.fragment.glsl
+++ b/src/shaders/line_sdf.fragment.glsl
@@ -42,7 +42,7 @@ void main() {
     alpha *= smoothstep(0.5 - u_sdfgamma / floorwidth, 0.5 + u_sdfgamma / floorwidth, sdfdist);
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    color.rgb = fog_apply(color.rgb, v_fog_pos);
+    color = fog_apply_premultiplied(color, v_fog_pos);
 #endif
 
     gl_FragColor = color * (alpha * opacity);

--- a/src/shaders/line_sdf.fragment.glsl
+++ b/src/shaders/line_sdf.fragment.glsl
@@ -10,6 +10,10 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
@@ -36,6 +40,10 @@ void main() {
     float sdfdist_b = texture2D(u_image, v_tex_b).a;
     float sdfdist = mix(sdfdist_a, sdfdist_b, u_mix);
     alpha *= smoothstep(0.5 - u_sdfgamma / floorwidth, 0.5 + u_sdfgamma / floorwidth, sdfdist);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    color.rgb = fog_apply(color.rgb, v_fog_pos);
+#endif
 
     gl_FragColor = color * (alpha * opacity);
 

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -25,6 +25,10 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
@@ -95,4 +99,8 @@ void main() {
     v_tex_b = vec2(a_linesofar * u_patternscale_b.x / floorwidth, normal.y * u_patternscale_b.y + u_tex_y_b);
 
     v_width2 = vec2(outset, inset);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(pos);
+#endif
 }

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -25,7 +25,7 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -100,7 +100,7 @@ void main() {
 
     v_width2 = vec2(outset, inset);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(pos);
 #endif
 }

--- a/src/shaders/raster.fragment.glsl
+++ b/src/shaders/raster.fragment.glsl
@@ -12,7 +12,7 @@ uniform float u_saturation_factor;
 uniform float u_contrast_factor;
 uniform vec3 u_spin_weights;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -50,7 +50,7 @@ void main() {
 
     vec3 out_color = mix(u_high_vec, u_low_vec, rgb);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     out_color = fog_apply(out_color, v_fog_pos);
 #endif
 

--- a/src/shaders/raster.fragment.glsl
+++ b/src/shaders/raster.fragment.glsl
@@ -12,6 +12,10 @@ uniform float u_saturation_factor;
 uniform float u_contrast_factor;
 uniform vec3 u_spin_weights;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 void main() {
 
     // read and cross-fade colors from the main and parent tiles
@@ -45,6 +49,10 @@ void main() {
     vec3 u_low_vec = vec3(u_brightness_high, u_brightness_high, u_brightness_high);
 
     gl_FragColor = vec4(mix(u_high_vec, u_low_vec, rgb) * color.a, color.a);
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    gl_FragColor.rgb = fog_apply(gl_FragColor.rgb, v_fog_pos);
+#endif
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/raster.fragment.glsl
+++ b/src/shaders/raster.fragment.glsl
@@ -48,11 +48,13 @@ void main() {
     vec3 u_high_vec = vec3(u_brightness_low, u_brightness_low, u_brightness_low);
     vec3 u_low_vec = vec3(u_brightness_high, u_brightness_high, u_brightness_high);
 
-    gl_FragColor = vec4(mix(u_high_vec, u_low_vec, rgb) * color.a, color.a);
+    vec3 out_color = mix(u_high_vec, u_low_vec, rgb);
 
 #if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
-    gl_FragColor.rgb = fog_apply(gl_FragColor.rgb, v_fog_pos);
+    out_color = fog_apply(out_color, v_fog_pos);
 #endif
+
+    gl_FragColor = vec4(out_color * color.a, color.a);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/raster.vertex.glsl
+++ b/src/shaders/raster.vertex.glsl
@@ -9,6 +9,10 @@ attribute vec2 a_texture_pos;
 varying vec2 v_pos0;
 varying vec2 v_pos1;
 
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
+#endif
+
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     // We are using Int16 for texture position coordinates to give us enough precision for
@@ -18,4 +22,8 @@ void main() {
     // so math for modifying either is consistent.
     v_pos0 = (((a_texture_pos / 8192.0) - 0.5) / u_buffer_scale ) + 0.5;
     v_pos1 = (v_pos0 * u_scale_parent) + u_tl_parent;
+
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(a_pos);
+#endif
 }

--- a/src/shaders/raster.vertex.glsl
+++ b/src/shaders/raster.vertex.glsl
@@ -9,7 +9,7 @@ attribute vec2 a_texture_pos;
 varying vec2 v_pos0;
 varying vec2 v_pos1;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -23,7 +23,7 @@ void main() {
     v_pos0 = (((a_texture_pos / 8192.0) - 0.5) / u_buffer_scale ) + 0.5;
     v_pos1 = (v_pos0 * u_scale_parent) + u_tl_parent;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(a_pos);
 #endif
 }

--- a/src/shaders/skybox.fragment.glsl
+++ b/src/shaders/skybox.fragment.glsl
@@ -54,8 +54,10 @@ void main() {
 
     vec3 sky_color = textureCube(u_cubemap, uv).rgb;
 
+#ifdef FOG
     // Apply fog contribution if enabled
     sky_color = fog_apply_sky_gradient(v_uv, sky_color);
+#endif
 
     // Dither [1]
     sky_color.rgb = dither(sky_color.rgb, gl_FragCoord.xy + u_temporal_offset);

--- a/src/shaders/skybox_gradient.fragment.glsl
+++ b/src/shaders/skybox_gradient.fragment.glsl
@@ -22,8 +22,10 @@ void main() {
     float progress = acos(dot(normalize(v_uv), u_center_direction)) / u_radius;
     vec4 color = texture2D(u_color_ramp, vec2(progress, 0.5)) * u_opacity;
 
+#ifdef FOG
     // Apply fog contribution if enabled
     color.rgb = fog_apply_sky_gradient(v_uv, color.rgb);
+#endif
 
     // Dither
     color.rgb = dither(color.rgb, gl_FragCoord.xy + u_temporal_offset);

--- a/src/shaders/terrain_raster.fragment.glsl
+++ b/src/shaders/terrain_raster.fragment.glsl
@@ -2,13 +2,13 @@ uniform sampler2D u_image0;
 varying vec2 v_pos0;
 
 #ifdef FOG
-varying float v_depth;
+varying vec3 v_fog_pos;
 #endif
 
 void main() {
     vec4 color = texture2D(u_image0, v_pos0);
 #ifdef FOG
-    color.rgb = fog_apply(color.rgb, v_depth);
+    color.rgb = fog_apply(color.rgb, v_fog_pos);
 #endif
     gl_FragColor = color;
 #ifdef TERRAIN_WIREFRAME

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -6,7 +6,7 @@ attribute vec2 a_texture_pos;
 
 varying vec2 v_pos0;
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
 varying vec3 v_fog_pos;
 #endif
 
@@ -23,7 +23,7 @@ void main() {
     vec2 decodedPos = a_pos - vec2(skirt * skirtOffset, 0.0);
     gl_Position = u_matrix * vec4(decodedPos, elevation, 1.0);
 
-#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+#ifdef FOG
     v_fog_pos = fog_position(vec3(decodedPos, elevation));
 #endif
 }

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -6,9 +6,8 @@ attribute vec2 a_texture_pos;
 
 varying vec2 v_pos0;
 
-#ifdef FOG
-uniform mat4 u_cam_matrix;
-varying float v_depth;
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+varying vec3 v_fog_pos;
 #endif
 
 const float skirtOffset = 24575.0;
@@ -24,8 +23,7 @@ void main() {
     vec2 decodedPos = a_pos - vec2(skirt * skirtOffset, 0.0);
     gl_Position = u_matrix * vec4(decodedPos, elevation, 1.0);
 
-#ifdef FOG
-    vec4 depthPos = u_cam_matrix * vec4(decodedPos, elevation, 1.0);
-    v_depth = length(depthPos.xyz);
+#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )
+    v_fog_pos = fog_position(vec3(decodedPos, elevation));
 #endif
 }


### PR DESCRIPTION
This PR applies fog to most of the shaders (exhaustive list to follow before merging).

To do:

- [x] Decide: gamma correct or don't gamma correct
- [x] Possibly decide now which fog function to use. Applying a power after the exponential removes the discontinuity at the fog start and seems defensible since real fog doesn't start at an arbitrary position and contain this discontinuity. By discontinuity, I mean the C1 discontinuity at x=5000 where the function goes from clipped to zero to increasing: https://www.desmos.com/calculator/x5gopnb91a
- [x] Apply the functions to remaining layers (circles? background-pattern?)
- [x] See if we can simplify the `#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )` conditional

Notes/explanations:

- Un-premultiplying the alpha, then blending fog, then re-premultiplying seems necessary to achieve correct blending. Not sure if that’s the cleanest to undo it and redo in the shader, but it does yield the correct results. The following shows a line-pattern with a transparent texture, correctly blending only as a result of the `fog_apply_premultiplied` function.
 
![screen_shot_2021-03-22_at_10 36 40_pm](https://user-images.githubusercontent.com/572717/112102037-e59a0980-8b64-11eb-94c5-0a307eeb7926.png)

- The conditional `#if defined( FOG ) && !defined( RENDER_TO_TEXTURE )`  got the terrain/no-terrain behavior correct (while checking for `TERRAIN` did not, for reasons I didn't fully figure out), but it’d be nice if this condition weren’t so verbose since it’s repeated a lot

- I think the fog depends on the aspect ratio… need to revisit but perhaps outside of this PR

- most of the layers (including: heatmap, excluding: symbols and a couple exceptions like circles which I just haven’t addressed yet) work… correctly, I think?? :party-face: Here’s quite a few of them at least…

![screen_shot_2021-03-22_at_11 01 48_pm](https://user-images.githubusercontent.com/572717/112102210-26921e00-8b65-11eb-8b05-cc46b427d3e7.png)

- heatmap works differently, so I just applied fog opacity while accumulating the kernel density estimation :shrug:  Basically works like expected, I think?

![heatmap-sm-1](https://user-images.githubusercontent.com/572717/112102229-30b41c80-8b65-11eb-9b1a-8ca711ab5169.gif)
