### PR TITLE
Retry flaky image loads in render tests

### DIFF
--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -307,7 +307,8 @@ async function runTest(t) {
 }
 
 function drawImage(canvas, ctx, src, getImageData = true) {
-    return new Promise((resolve, reject) => {
+    let attempts = 0;
+    return new Promise(function loadImage(resolve, reject) {
         const image = new Image();
         image.onload = () => {
             canvas.height = image.height;
@@ -320,7 +321,11 @@ function drawImage(canvas, ctx, src, getImageData = true) {
             result.src = src;
             resolve(result);
         };
-        image.onerror = reject;
+        image.onerror = (e) => {
+            // try loading the image several times on error because it sometimes fails randomly
+            if (++attempts < 3) loadImage(resolve, reject);
+            else reject(e);
+        };
         image.src = src;
     });
 }


### PR DESCRIPTION
This change makes image loads in render tests retry for up to 3 attempts if there's an error, which appears to fix most cases of flakiness in render tests. 

The original root cause of these image loads failing is still a mystery to me, and I dug very deeply to try to uncover it — including capturing a detailed network trace with `chrome://net-export/` and exploring it with https://netlog-viewer.appspot.com/. The loads that cause the flaky errors will show as "cancelled" in the network tab, which means they got somehow interrupted, but there's no way to trace the root cause of these interruptions and this seems like some weird race condition outside of our code.

I've seen some other cases of flaky tests, in particular `Error occurred during ["wait"]`, but those seem to be much rarer, so we can leave exploring them for another time.