### PR TITLE
Add a WebGL error reporter script to debug/

### DIFF
--- a/debug/webgl-error-reporter.js
+++ b/debug/webgl-error-reporter.js
@@ -1,0 +1,71 @@
+(function(WebGLRenderingContext) {
+    // This function implements an error reporter for WebGL shaders. It works by wrapping
+    // the WebGL calls, caching the shader source, and automatically checking for an error
+    // when compileShader is invoked.
+    //
+    // To use, simply include this script in a debug page. For example, add to any of the
+    // HTML files in the debug directory,
+    //
+    //   <script src="./webgl-error-reporter.js"></script>
+    //
+    // No other setup is required.
+    //
+    // This script is not known to have any side effects which should affect the behavior
+    // of MapboxGL, though since these errors should not occur in published source, this
+    // reporting is not included in the source itself.
+
+    const shaderCache = new WeakMap();
+
+    function parseError(error) {
+        const parts = error.match(/.*: ([\d]+):([\d]+):\s+(.*)/);
+        return {errorLine: parseInt(parts[2]), errorMessage: `ERROR: ${parts[3].trim()}`};
+    }
+
+    function wrapWebGLRenderingContext(WebGLRenderingContext) {
+        const {
+            shaderSource,
+            getShaderParameter,
+            compileShader,
+            COMPILE_STATUS,
+            getShaderInfoLog
+        } = WebGLRenderingContext.prototype;
+
+        // Cache the source so that we have it available for logging in case of error
+        WebGLRenderingContext.prototype.shaderSource = function (...args) {
+            const shader = args[0];
+            const source = args[1];
+            shaderCache.set(shader, source);
+            // .call() returns an illegal invocation error (maybe arity?), so apply.
+            return shaderSource.apply(this, args);
+        };
+
+        WebGLRenderingContext.prototype.compileShader = function (shader) {
+            const returnValue = compileShader.call(this, shader);
+
+            if (!getShaderParameter.call(this, shader, COMPILE_STATUS)) {
+                const source = shaderCache.get(shader);
+                const error = getShaderInfoLog.apply(this, [shader]);
+                const {errorLine, errorMessage} = parseError(error);
+
+                const lines = source.split('\n')
+                    .map((line, num) => `${(num + 1).toString().padEnd(5, ' ')} ${line}`);
+
+                const localLines = lines.slice(Math.max(0, errorLine - 2), errorLine + 1);
+                lines.splice(errorLine, 0, `^^^^^\n     ${errorMessage}\n`);
+
+                // I wish the formatting were cleaner, but in order to minimize how invasive this is
+                // in changing the behavior, gl-js will still throw an error *after* this function
+                // returns, thus we really only want to output the annotated source in a collapsed
+                // group with the important info up front
+                console.error(error.trim());
+                console.groupCollapsed(`${localLines.join('\n')}`);
+                console.info(lines.join('\n'));
+                console.groupEnd();
+            }
+
+            return returnValue;
+        }
+    }
+
+    wrapWebGLRenderingContext(WebGLRenderingContext);
+}(window.WebGLRenderingContext));

--- a/debug/webgl-error-reporter.js
+++ b/debug/webgl-error-reporter.js
@@ -48,7 +48,7 @@
                 const {errorLine, errorMessage} = parseError(error);
 
                 const lines = source.split('\n')
-                    .map((line, num) => `${(num + 1).toString().padEnd(5, ' ')} ${line}`);
+                    .map((line, num) => `${(num + 1).toString().padStart(5, ' ')} ${line}`);
 
                 const localLines = lines.slice(Math.max(0, errorLine - 2), errorLine + 1);
                 lines.splice(errorLine, 0, `^^^^^\n     ${errorMessage}\n`);


### PR DESCRIPTION
Tracking down GLSL errors is frustrating and time-consuming since the source is assembled internally and not logged, the errors are formatted poorly, and the line numbers don't match the files. Better logging is a dev-time concern which is probably not desirable to work into the gl-js source itself.

This PR adds a script to the debug directory which can be included as needed. It works by wrapping the WebGL API, caching the shader source, and automatically checking for and reporting errors when compileShader is invoked.

![webgl-error-reporter](https://user-images.githubusercontent.com/572717/112367500-39a50b00-8c97-11eb-8555-5ea5a4c1f043.gif)

To use, simply include this script in a debug page. For example, add to any of the HTML files in the debug directory,

```html
<script src="./webgl-error-reporter.js"></script>
```

No other setup is required. This script is not known to have any side effects which should affect the behavior of MapboxGL.

Other notes

There may be other tools which do this. I don't know. I think [Babylon](https://www.babylonjs.com/) has a WebGL debugger extension, IIRC, but it's heavy and does a *lot* more than what's necessary to track down errors.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [-] document any changes to public APIs
 - [-] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
