### PR TITLE
Add specificity to triggerRepaint jsdoc

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2793,7 +2793,7 @@ class Map extends Camera {
 
     /**
      * Trigger the rendering of a single frame. Use this method with custom layers to
-     * repaint the map when the layer's properties or properties associated with the 
+     * repaint the map when the layer's properties or properties associated with the
      * layer's source change. Calling this multiple times before the
      * next frame is rendered will still result in only a single frame being rendered.
      * @example

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2793,7 +2793,8 @@ class Map extends Camera {
 
     /**
      * Trigger the rendering of a single frame. Use this method with custom layers to
-     * repaint the map when the layer changes. Calling this multiple times before the
+     * repaint the map when the layer's properties or properties associated with the 
+     * layer's source change. Calling this multiple times before the
      * next frame is rendered will still result in only a single frame being rendered.
      * @example
      * map.triggerRepaint();


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js-docs/issues/93

The documentation team received some feedback that users were confused about what is meant by "layer changes" in the `triggerRepaint` documentation. This PR adds some specificity. I could use another set of eyes to make sure my addition is factual! 

<img width="677" alt="image" src="https://user-images.githubusercontent.com/2365503/112371076-6d822f80-8c9b-11eb-9fec-c799e564ee83.png">

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [ ] ~~manually test the debug page~~
 - [ ] ~~tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes~~
 - [ ]~~ tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] ~~add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`~~
