### PR TITLE
Clarify that `zoomend` can be complete before map rendering is complete.

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -693,8 +693,10 @@ export type MapEvent =
     | 'move'
 
     /**
-     * Fired just after the map completes a transition from one
-     * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.
+     * The `zoomend` event fires as soon as the map completes a transition from one
+     * view to another, as the result of either user interaction or methods such as {@link Map#flyTo}.
+     * The event fires after the zoom transition ends, which will usually be before rendering is finished. 
+     * If you need to wait for rendering to finish, use the {@link Map#idle} event instead.
      *
      * @event moveend
      * @memberof Map

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -693,11 +693,8 @@ export type MapEvent =
     | 'move'
 
     /**
-     * The `zoomend` event fires as soon as the map completes a transition from one
-     * view to another, as the result of either user interaction or methods such as {@link Map#flyTo}.
-     * The event fires after the zoom transition ends, which will usually be before rendering is finished. 
-     * If you need to wait for rendering to finish, use the {@link Map#idle} event instead.
-     *
+     * Fired just after the map completes a transition from one
+     * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.     *
      * @event moveend
      * @memberof Map
      * @instance

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -811,7 +811,7 @@ export type MapEvent =
     /**
      * Fired just after the map completes a transition from one zoom level to another
      * as the result of either user interaction or methods such as {@link Map#flyTo}.
-     * The zoom transition will usually end before rendering is finished, so if you 
+     * The zoom transition will usually end before rendering is finished, so if you
      * need to wait for rendering to finish, use the {@link Map#idle} event instead.
      *
      * @event zoomend

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -694,7 +694,8 @@ export type MapEvent =
 
     /**
      * Fired just after the map completes a transition from one
-     * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.     *
+     * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.
+     *
      * @event moveend
      * @memberof Map
      * @instance

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -811,7 +811,8 @@ export type MapEvent =
     /**
      * Fired just after the map completes a transition from one zoom level to another
      * as the result of either user interaction or methods such as {@link Map#flyTo}.
-     * The transition can end before map rendering is complete.
+     * The zoom transition will usually end before rendering is finished, so if you 
+     * need to wait for rendering to finish, use the {@link Map#idle} event instead.
      *
      * @event zoomend
      * @memberof Map

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -809,8 +809,9 @@ export type MapEvent =
     | 'zoom'
 
     /**
-     * Fired just after the map completes a transition from one zoom level to another,
+     * Fired just after the map completes a transition from one zoom level to another
      * as the result of either user interaction or methods such as {@link Map#flyTo}.
+     * The transition can end before map rendering is complete.
      *
      * @event zoomend
      * @memberof Map


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-gl-js-docs/issues/62

* Adds this to `zoomend` documentation:
`The transition can end before map rendering is complete.`
...to clarify what we mean by `completes a transition`.

Before:
```
     * Fired just after the map completes a transition from one zoom level to another
     * as the result of either user interaction or methods such as {@link Map#flyTo}.
     *
     * @event zoomend
```

After: 
```
     * Fired just after the map completes a transition from one zoom level to another
     * as the result of either user interaction or methods such as {@link Map#flyTo}.
     * The transition can end before map rendering is complete.
     *
     * @event zoomend
```

Tagging @mapbox/gl-js and @danswick for review.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
