### PR TITLE
Add dithering to fog

### DIFF
--- a/src/render/fog.js
+++ b/src/render/fog.js
@@ -10,7 +10,8 @@ export type FogUniformsType = {|
     'u_fog_range': Uniform2f,
     'u_fog_color': Uniform3f,
     'u_fog_opacity': Uniform1f,
-    'u_fog_sky_blend': Uniform1f
+    'u_fog_sky_blend': Uniform1f,
+    'u_temporal_fog_offset': Uniform1f,
 |};
 
 export const fogUniforms = (context: Context, locations: UniformLocations): FogUniformsType => ({
@@ -18,5 +19,6 @@ export const fogUniforms = (context: Context, locations: UniformLocations): FogU
     'u_fog_range': new Uniform2f(context, locations.u_fog_range),
     'u_fog_color': new Uniform3f(context, locations.u_fog_color),
     'u_fog_opacity': new Uniform1f(context, locations.u_fog_opacity),
-    'u_fog_sky_blend': new Uniform1f(context, locations.u_fog_sky_blend)
+    'u_fog_sky_blend': new Uniform1f(context, locations.u_fog_sky_blend),
+    'u_temporal_fog_offset': new Uniform1f(context, locations.u_temporal_fog_offset),
 });

--- a/src/render/fog.js
+++ b/src/render/fog.js
@@ -11,7 +11,7 @@ export type FogUniformsType = {|
     'u_fog_color': Uniform3f,
     'u_fog_opacity': Uniform1f,
     'u_fog_sky_blend': Uniform1f,
-    'u_temporal_fog_offset': Uniform1f,
+    'u_fog_temporal_offset': Uniform1f,
 |};
 
 export const fogUniforms = (context: Context, locations: UniformLocations): FogUniformsType => ({
@@ -20,5 +20,5 @@ export const fogUniforms = (context: Context, locations: UniformLocations): FogU
     'u_fog_color': new Uniform3f(context, locations.u_fog_color),
     'u_fog_opacity': new Uniform1f(context, locations.u_fog_opacity),
     'u_fog_sky_blend': new Uniform1f(context, locations.u_fog_sky_blend),
-    'u_temporal_fog_offset': new Uniform1f(context, locations.u_temporal_fog_offset),
+    'u_fog_temporal_offset': new Uniform1f(context, locations.u_fog_temporal_offset),
 });

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -832,7 +832,7 @@ class Painter {
             uniforms['u_fog_color'] = [fogColor.r, fogColor.g, fogColor.b];
             uniforms['u_fog_opacity'] = fog.properties.get('opacity') * fog.getFogPitchFactor(this.transform.pitch);
             uniforms['u_fog_sky_blend'] = fog.properties.get('sky-blend');
-            uniforms['u_temporal_fog_offset'] = temporalOffset;
+            uniforms['u_fog_temporal_offset'] = temporalOffset;
 
             program.setFogUniformValues(context, uniforms);
         }

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -823,6 +823,7 @@ class Painter {
     prepareDrawProgram(context: Context, program: Program<*>, tileID: ?UnwrappedTileID) {
         const fog = this.style && this.style.fog;
         if (fog) {
+            const temporalOffset = (this.frameCounter / 1000.0) % 1;
             const fogColor = fog.properties.get('color');
             const uniforms = {};
 
@@ -831,6 +832,7 @@ class Painter {
             uniforms['u_fog_color'] = [fogColor.r, fogColor.g, fogColor.b];
             uniforms['u_fog_opacity'] = fog.properties.get('opacity') * fog.getFogPitchFactor(this.transform.pitch);
             uniforms['u_fog_sky_blend'] = fog.properties.get('sky-blend');
+            uniforms['u_temporal_fog_offset'] = temporalOffset;
 
             program.setFogUniformValues(context, uniforms);
         }

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -29,3 +29,15 @@ vec3 srgb_to_linear(vec3 color) {
 vec3 gamma_mix(vec3 a, vec3 b, float x) {
     return linear_to_srgb(mix(srgb_to_linear(a), srgb_to_linear(b), x));
 }
+
+highp vec3 hash(highp vec2 p) {
+    highp vec3 p3 = fract(vec3(p.xyx) * vec3(443.8975, 397.2973, 491.1871));
+    p3 += dot(p3, p3.yxz + 19.19);
+    return fract(vec3((p3.x + p3.y) * p3.z, (p3.x + p3.z) * p3.y, (p3.y + p3.z) * p3.x));
+}
+
+vec3 dither(vec3 color, highp vec2 seed) {
+    vec3 rnd = hash(seed) + hash(seed + 0.59374) - 0.5;
+    color.rgb += rnd / 255.0;
+    return color;
+}

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -31,13 +31,12 @@ vec3 gamma_mix(vec3 a, vec3 b, float x) {
 }
 
 highp vec3 hash(highp vec2 p) {
-    highp vec3 p3 = fract(vec3(p.xyx) * vec3(443.8975, 397.2973, 491.1871));
+    highp vec3 p3 = fract(p.xyx * vec3(443.8975, 397.2973, 491.1871));
     p3 += dot(p3, p3.yxz + 19.19);
-    return fract(vec3((p3.x + p3.y) * p3.z, (p3.x + p3.z) * p3.y, (p3.y + p3.z) * p3.x));
+    return fract((p3.xxy + p3.yzz) * p3.zyx);
 }
 
 vec3 dither(vec3 color, highp vec2 seed) {
     vec3 rnd = hash(seed) + hash(seed + 0.59374) - 0.5;
-    color.rgb += rnd / 255.0;
-    return color;
+    return color + rnd / 255.0;
 }

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -4,7 +4,7 @@ uniform vec2 u_fog_range;
 uniform vec3 u_fog_color;
 uniform float u_fog_opacity;
 uniform float u_fog_sky_blend;
-uniform float u_temporal_fog_offset;
+uniform float u_fog_temporal_offset;
 
 vec3 fog_apply_sky_gradient(vec3 cubemap_uv, vec3 sky_color) {
     vec3 camera_ray = normalize(cubemap_uv);
@@ -40,7 +40,7 @@ vec3 fog_apply(vec3 color, vec3 position) {
         color,
         u_fog_color,
         fog_opacity(position)
-    ), gl_FragCoord.xy + u_temporal_fog_offset);
+    ), gl_FragCoord.xy + u_fog_temporal_offset);
 }
 
 // Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -35,7 +35,11 @@ float fog_opacity(vec3 position) {
 }
 
 vec3 fog_apply(vec3 color, vec3 position) {
-    return gamma_mix(color, u_fog_color, fog_opacity(position));
+    return dither(gamma_mix(
+        color,
+        u_fog_color,
+        fog_opacity(position)
+    ), gl_FragCoord.xy);
 }
 
 // Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -36,11 +36,19 @@ float fog_opacity(vec3 position) {
 }
 
 vec3 fog_apply(vec3 color, vec3 position) {
-    return dither(gamma_mix(
+    return gamma_mix(
         color,
         u_fog_color,
         fog_opacity(position)
-    ), gl_FragCoord.xy + u_fog_temporal_offset);
+    );
+}
+
+vec3 fog_dither(vec3 color) {
+    return dither(color, gl_FragCoord.xy + u_fog_temporal_offset);
+}
+
+vec4 fog_dither(vec4 color) {
+    return vec4(fog_dither(color.rgb), color.a);
 }
 
 // Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -4,6 +4,7 @@ uniform vec2 u_fog_range;
 uniform vec3 u_fog_color;
 uniform float u_fog_opacity;
 uniform float u_fog_sky_blend;
+uniform float u_temporal_fog_offset;
 
 vec3 fog_apply_sky_gradient(vec3 cubemap_uv, vec3 sky_color) {
     vec3 camera_ray = normalize(cubemap_uv);
@@ -39,7 +40,7 @@ vec3 fog_apply(vec3 color, vec3 position) {
         color,
         u_fog_color,
         fog_opacity(position)
-    ), gl_FragCoord.xy);
+    ), gl_FragCoord.xy + u_temporal_fog_offset);
 }
 
 // Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For

--- a/src/shaders/background.fragment.glsl
+++ b/src/shaders/background.fragment.glsl
@@ -9,7 +9,7 @@ void main() {
     vec4 out_color = u_color;
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color * u_opacity;

--- a/src/shaders/background_pattern.fragment.glsl
+++ b/src/shaders/background_pattern.fragment.glsl
@@ -27,7 +27,7 @@ void main() {
     vec4 out_color = mix(color1, color2, u_mix);
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color * u_opacity;

--- a/src/shaders/fill.fragment.glsl
+++ b/src/shaders/fill.fragment.glsl
@@ -12,7 +12,7 @@ void main() {
     vec4 out_color = color;
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color * opacity;

--- a/src/shaders/fill_extrusion.fragment.glsl
+++ b/src/shaders/fill_extrusion.fragment.glsl
@@ -7,7 +7,7 @@ varying vec3 v_fog_pos;
 void main() {
     vec4 color = v_color;
 #ifdef FOG
-    color = fog_apply_premultiplied(color, v_fog_pos);
+    color = fog_dither(fog_apply_premultiplied(color, v_fog_pos));
 #endif
     gl_FragColor = color;
 

--- a/src/shaders/fill_extrusion_pattern.fragment.glsl
+++ b/src/shaders/fill_extrusion_pattern.fragment.glsl
@@ -44,7 +44,7 @@ void main() {
     out_color = out_color * v_lighting;
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color;

--- a/src/shaders/fill_outline.fragment.glsl
+++ b/src/shaders/fill_outline.fragment.glsl
@@ -16,7 +16,7 @@ void main() {
     vec4 out_color = outline_color;
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color * (alpha * opacity);

--- a/src/shaders/fill_outline_pattern.fragment.glsl
+++ b/src/shaders/fill_outline_pattern.fragment.glsl
@@ -41,7 +41,7 @@ void main() {
     vec4 out_color = mix(color1, color2, u_fade);
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color * (alpha * opacity);

--- a/src/shaders/fill_pattern.fragment.glsl
+++ b/src/shaders/fill_pattern.fragment.glsl
@@ -35,7 +35,7 @@ void main() {
     vec4 out_color = mix(color1, color2, u_fade);
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color * opacity;

--- a/src/shaders/hillshade.fragment.glsl
+++ b/src/shaders/hillshade.fragment.glsl
@@ -49,7 +49,7 @@ void main() {
     gl_FragColor = accent_color * (1.0 - shade_color.a) + shade_color;
 
 #ifdef FOG
-    gl_FragColor = fog_apply_premultiplied(gl_FragColor, v_fog_pos);
+    gl_FragColor = fog_dither(fog_apply_premultiplied(gl_FragColor, v_fog_pos));
 #endif
 
 #ifdef OVERDRAW_INSPECTOR

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -29,7 +29,7 @@ void main() {
     vec4 out_color = color;
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color * (alpha * opacity);

--- a/src/shaders/line_gradient.fragment.glsl
+++ b/src/shaders/line_gradient.fragment.glsl
@@ -31,7 +31,7 @@ void main() {
     vec4 color = texture2D(u_image, v_uv);
 
 #ifdef FOG
-    color = fog_apply_premultiplied(color, v_fog_pos);
+    color = fog_dither(fog_apply_premultiplied(color, v_fog_pos));
 #endif
 
     gl_FragColor = color * (alpha * opacity);

--- a/src/shaders/line_pattern.fragment.glsl
+++ b/src/shaders/line_pattern.fragment.glsl
@@ -71,7 +71,7 @@ void main() {
     vec4 color = mix(texture2D(u_image, pos_a), texture2D(u_image, pos_b), u_fade);
 
 #ifdef FOG
-    color = fog_apply_premultiplied(color, v_fog_pos);
+    color = fog_dither(fog_apply_premultiplied(color, v_fog_pos));
 #endif
 
     gl_FragColor = color * (alpha * opacity);

--- a/src/shaders/line_sdf.fragment.glsl
+++ b/src/shaders/line_sdf.fragment.glsl
@@ -44,7 +44,7 @@ void main() {
     vec4 out_color = color;
 
 #ifdef FOG
-    out_color = fog_apply_premultiplied(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply_premultiplied(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = out_color * (alpha * opacity);

--- a/src/shaders/raster.fragment.glsl
+++ b/src/shaders/raster.fragment.glsl
@@ -51,7 +51,7 @@ void main() {
     vec3 out_color = mix(u_high_vec, u_low_vec, rgb);
 
 #ifdef FOG
-    out_color = fog_apply(out_color, v_fog_pos);
+    out_color = fog_dither(fog_apply(out_color, v_fog_pos));
 #endif
 
     gl_FragColor = vec4(out_color * color.a, color.a);

--- a/src/shaders/skybox.fragment.glsl
+++ b/src/shaders/skybox.fragment.glsl
@@ -7,18 +7,6 @@ uniform lowp float u_opacity;
 uniform highp float u_temporal_offset;
 uniform highp vec3 u_sun_direction;
 
-highp vec3 hash(highp vec2 p) {
-    highp vec3 p3 = fract(vec3(p.xyx) * vec3(443.8975, 397.2973, 491.1871));
-    p3 += dot(p3, p3.yxz + 19.19);
-    return fract(vec3((p3.x + p3.y) * p3.z, (p3.x + p3.z) * p3.y, (p3.y + p3.z) * p3.x));
-}
-
-vec3 dither(vec3 color, highp vec2 seed) {
-    vec3 rnd = hash(seed) + hash(seed + 0.59374) - 0.5;
-    color.rgb += rnd / 255.0;
-    return color;
-}
-
 float sun_disk(highp vec3 ray_direction, highp vec3 sun_direction) {
     highp float cos_angle = dot(normalize(ray_direction), sun_direction);
 

--- a/src/shaders/skybox_gradient.fragment.glsl
+++ b/src/shaders/skybox_gradient.fragment.glsl
@@ -6,18 +6,6 @@ uniform lowp float u_radius;
 uniform lowp float u_opacity;
 uniform highp float u_temporal_offset;
 
-highp vec3 hash(highp vec2 p) {
-    highp vec3 p3 = fract(vec3(p.xyx) * vec3(443.8975, 397.2973, 491.1871));
-    p3 += dot(p3, p3.yxz + 19.19);
-    return fract(vec3((p3.x + p3.y) * p3.z, (p3.x + p3.z) * p3.y, (p3.y + p3.z) * p3.x));
-}
-
-vec3 dither(vec3 color, highp vec2 seed) {
-    vec3 rnd = hash(seed) + hash(seed + 0.59374) - 0.5;
-    color.rgb += rnd / 255.0;
-    return color;
-}
-
 void main() {
     float progress = acos(dot(normalize(v_uv), u_center_direction)) / u_radius;
     vec4 color = texture2D(u_color_ramp, vec2(progress, 0.5)) * u_opacity;

--- a/src/shaders/terrain_raster.fragment.glsl
+++ b/src/shaders/terrain_raster.fragment.glsl
@@ -8,7 +8,7 @@ varying vec3 v_fog_pos;
 void main() {
     vec4 color = texture2D(u_image0, v_pos0);
 #ifdef FOG
-    color.rgb = fog_apply(color.rgb, v_fog_pos);
+    color.rgb = fog_dither(fog_apply(color.rgb, v_fog_pos));
 #endif
     gl_FragColor = color;
 #ifdef TERRAIN_WIREFRAME


### PR DESCRIPTION
This PR adds dithering to fog by simply hoisting the `dither` function from skybox and dropping it into the general prelude.

Questions:
- Is worth coalescing fog and skybox's temporal offset? That would make it more difficult to define the uniform precisely when it's needed since characters in the codebase and the gl api call to set the uniform is probably the only cost involved.
- If we did check, maybe maybe `style.fog || style.hasLayerType('sky')` is an adequate check? But then we need to ensure skybox and fog don't re-define the same uniform

Fog, with and without dithering (far more visible when animating):

<img width="341" alt="Screen Shot 2021-03-24 at 8 00 41 PM" src="https://user-images.githubusercontent.com/572717/112412732-3b44f200-8cdc-11eb-8823-36fa768ee9c9.png"><img width="328" alt="Screen Shot 2021-03-24 at 8 01 09 PM" src="https://user-images.githubusercontent.com/572717/112412717-37b16b00-8cdc-11eb-9307-b48b871a7adf.png">

Also, for reference, @karimnaaji directed me to this, which has lots of excellent information: https://loopit.dk/banding_in_games.pdf