### PR TITLE
update generate-release-list for new Octokit

### DIFF
--- a/build/generate-release-list.js
+++ b/build/generate-release-list.js
@@ -1,10 +1,11 @@
-import octokit from '@octokit/rest';
+import {Octokit} from '@octokit/rest';
 import fs from 'fs';
 
 const list = {};
 
-octokit()
-    .paginate(octokit.repos.listReleases.endpoint({
+const octokit = new Octokit();
+
+octokit.paginate(octokit.repos.listReleases.endpoint({
         owner: 'mapbox',
         repo: 'mapbox-gl-js'
     }))


### PR DESCRIPTION
Update generate-release-list.js to work with new Octokit.