### PR TITLE
Rework the fog falloff function

### DIFF
--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -18,18 +18,6 @@ precision mediump float;
 
 const float PI = 3.141592653589793;
 
-vec3 linear_to_srgb(vec3 color) {
-    return pow(color, vec3(1.0 / 2.2));
-}
-
-vec3 srgb_to_linear(vec3 color) {
-    return pow(color, vec3(2.2));
-}
-
-vec3 gamma_mix(vec3 a, vec3 b, float x) {
-    return linear_to_srgb(mix(srgb_to_linear(a), srgb_to_linear(b), x));
-}
-
 highp vec3 hash(highp vec2 p) {
     highp vec3 p3 = fract(p.xyx * vec3(443.8975, 397.2973, 491.1871));
     p3 += dot(p3, p3.yxz + 19.19);

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -14,27 +14,41 @@ vec3 fog_apply_sky_gradient(vec3 cubemap_uv, vec3 sky_color) {
     float fog_falloff = clamp(gradient + (1.0 - u_fog_opacity), 0.0, 1.0);
 
     // We may or may not wish to use gamma-correct blending
-    return gamma_mix(u_fog_color, sky_color, fog_falloff);
+    return mix(u_fog_color, sky_color, fog_falloff);
 }
 
-float fog_opacity(vec3 position) {
-    float depth = length(position);
+float fog_opacity(float depth) {
     float start = u_fog_range.x;
     float end = u_fog_range.y;
 
-    // Fog falls off exponentially, but it also doesn't start at an arbitrary
-    // distance. So we opt for a sigmoid function that results in a very smooth
-    // onset. See: https://www.desmos.com/calculator/boumcg1dwo
-    // Fog power puts the fog at about 0.6% and 99.4% at near and far, respectively
-    // The multiplier puts the far limit at 1.0 since clipping depends on that
-    const float fog_pow = 10.0;
-    float fog_falloff = min(1.0, 1.00675 / (1.0 + exp(-fog_pow * ((depth - start) / (end - start) - 0.5))));
+    // The fog is not physically accurate, so we seek an expression which satisfies a
+    // couple basic constraints:
+    //   - opacity should be 0 at the near limit
+    //   - opacity should be 1 at the far limit
+    //   - the onset should have smooth derivatives to avoid a sharp band
+    // To this end, we use an (1 - e^x)^n, where n is set to 3 to ensure the
+    // function is C2 continuous at the onset. The fog is about 99% opaque at
+    // the far limit, so we simply scale it and clip to achieve 100% opacity.
+    // https://www.desmos.com/calculator/3taufutxid
+    const float decay = 5.5;
+    float falloff = max(0.0, 1.0 - exp(-decay * (depth - start) / (end - start)));
 
-    return fog_falloff * u_fog_opacity;
+    // Cube without pow()
+    falloff *= falloff * falloff;
+
+    // Scale and clip to 1 at the far limit
+    falloff = min(1.0, 1.00747 * falloff);
+
+
+    return falloff * u_fog_opacity;
 }
 
-vec3 fog_apply(vec3 color, vec3 position) {
-    return mix(color, u_fog_color, fog_opacity(position));
+vec3 fog_apply(vec3 color, vec3 pos) {
+    // We mix in sRGB color space. sRGB roughly corrects for perceived brightness
+    // so that dark fog and light fog obscure similarly for otherwise identical
+    // parameters. If we gamma-correct, then the parameters to control dark and
+    // light fog are fundamentally different.
+    return mix(color, u_fog_color, fog_opacity(length(pos)));
 }
 
 vec3 fog_dither(vec3 color) {
@@ -47,9 +61,9 @@ vec4 fog_dither(vec4 color) {
 
 // Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For
 // use with colors using premultiplied alpha
-vec4 fog_apply_premultiplied(vec4 color, vec3 position) {
+vec4 fog_apply_premultiplied(vec4 color, vec3 pos) {
     float a = 1e-4 + color.a;
-    return vec4(fog_apply(min(color.rgb / a, vec3(1)), position) * a, color.a);
+    return vec4(fog_apply(min(color.rgb / a, vec3(1)), pos) * a, color.a);
 }
 
 #endif


### PR DESCRIPTION
***Edit: I'm rewriting this description to reflect updated findings.***

This PR reworks the fog function to satisfy some basic constraints. Fog:

1. does not need to be physically accurate
2. should decay exponentially(ish)
3. onset at the near limit should be at least C2 continuous (smooth second derivative) to avoid a visible band
4. opacity should be 0% at the near limit
5. opacity should be 100% at the far limit
6. Dark fog and light fog should obscure the terrain similarly

To satisfy 1-4, I've used the function:

<img width="246" alt="Screen Shot 2021-03-28 at 12 00 06 PM" src="https://user-images.githubusercontent.com/572717/112764389-278bdb00-8fbd-11eb-922d-3a51a1875db6.png">

with n=near, f=far, p and q arbitrary constants. With some additional clipping to precisely satisfy 5, we get:

<img width="370" alt="Screen Shot 2021-03-28 at 12 00 52 PM" src="https://user-images.githubusercontent.com/572717/112764415-438f7c80-8fbd-11eb-9c65-eabe63b84c6a.png">

with c chosen slightly greater than 1.0 to force fog to 1.0 at the far limit. This function looks like:
https://www.desmos.com/calculator/zxu1xd3zjf
<img width="596" alt="Screen Shot 2021-03-28 at 11 57 01 AM" src="https://user-images.githubusercontent.com/572717/112764431-53a75c00-8fbd-11eb-9ddc-9270337a91e1.png">

The sixth criteria gave me a lot of trouble. This is because I mistakenly thought there was something "correct" about gamma-correct blending, not appreciating that linear RGB blending is only concerned with dealing with amounts of light on a linear scale so that you can correctly add and subtract them. I've since realized that, no matter how many blog posts people write about gradients in sRGB space being evil, I think sRGB is a better fit for this case since the fog is not physically accurate and since we want dark and light fog with identical near and far limits to obscure the terrain similarly.

In the end, I threw out gamma correction and reverted it to a simple `mix()`.

## Water test

### Mixing in sRGB (good)
Light and dark fog over empty water now look roughly the same: 

<img width="300" alt="Screen Shot 2021-03-28 at 12 08 41 PM" src="https://user-images.githubusercontent.com/572717/112764667-8aca3d00-8fbe-11eb-8252-9f0936259d79.png"><img width="300" alt="Screen Shot 2021-03-28 at 12 09 02 PM" src="https://user-images.githubusercontent.com/572717/112764668-8e5dc400-8fbe-11eb-9260-90067a213f5e.png">

### Linear RGB without raising to the third power

(Apologies, I lost the parameters so the limits are slightly different than above, though what's illustrated here is mainly the banding) Without the third power which softens the onset, we only have C0 continuity and what in my opinion is a really unpleasant band at the onset of the fog. I think the third power achieves C3 continuity or something? Looks plenty smooth anyway.

<img width="300" alt="Screen Shot 2021-03-28 at 12 36 17 PM" src="https://user-images.githubusercontent.com/572717/112765520-6a03e680-8fc2-11eb-88fe-deb0c2e0cde3.png"><img width="300" alt="Screen Shot 2021-03-28 at 12 36 02 PM" src="https://user-images.githubusercontent.com/572717/112765522-6d976d80-8fc2-11eb-8ad8-032ca1903524.png">


### Mixing in linear RGB (bad)
Fog mixed in linear RGB looks like this. It's very simply flipped in terms of the amount of light emitted, but that looks very different to our eyes, which perceive on a logarithmic scale.

<img width="300" alt="Screen Shot 2021-03-28 at 12 11 32 PM" src="https://user-images.githubusercontent.com/572717/112764756-ed233d80-8fbe-11eb-8022-787bb3e2cbe0.png"><img width="300" alt="Screen Shot 2021-03-28 at 12 11 22 PM" src="https://user-images.githubusercontent.com/572717/112764759-f01e2e00-8fbe-11eb-8fc6-2b02d9143b35.png">

## Terrain test

### Mixing in sRGB (good)
With terrain and heavy fog, mixing in sRGB space results in fog which obscures the terrain very similarly:

<img width="300" alt="nogamma-light" src="https://user-images.githubusercontent.com/572717/112764999-eba64500-8fbf-11eb-84bc-ae7b7a433b89.png"><img width="300" alt="nogamma-dark" src="https://user-images.githubusercontent.com/572717/112765000-eea13580-8fbf-11eb-9768-1b7034795d61.png">

### Mixing in linear RGB (bad)
Mixing in linear RGB space results in a very different amount of fog, which is entirely what I was trying to avoid in the first place by thinking I needed to worry about gamma, and which is now somewhat obvious.

<img width="300" alt="gamma-light" src="https://user-images.githubusercontent.com/572717/112765015-04aef600-8fc0-11eb-9ad6-9b27c352d2e4.png"><img width="300" alt="gamma-dark" src="https://user-images.githubusercontent.com/572717/112765017-08427d00-8fc0-11eb-9c54-42414cf6a47c.png">

## Satellite test
### Mixing in sRGB (good)
Things seem perfectly reasonable and consistent to control with satellite imagery as well.

<img width="300" alt="Screen Shot 2021-03-28 at 12 26 04 PM" src="https://user-images.githubusercontent.com/572717/112765213-f3b2b480-8fc0-11eb-969c-d7fbb6c22cc8.png"><img width="300" alt="Screen Shot 2021-03-28 at 12 25 54 PM" src="https://user-images.githubusercontent.com/572717/112765216-f7463b80-8fc0-11eb-9a29-2644b2c16502.png">


### Mixing in linear RGB (bad)

Linear RGB doesn't look bad at all, but it makes the near and far limits have a very different effect. More important than colors blended perfectly in linear space (for what reason, exactly, since there's already little physical basis?), I think, is that once you configure the amount of fog, you shouldn't be surprised by its appearance on light or dark maps.

<img width="300" alt="Screen Shot 2021-03-28 at 12 32 06 PM" src="https://user-images.githubusercontent.com/572717/112765398-dfbb8280-8fc1-11eb-8a0b-be0b7c95b9db.png"><img width="300" alt="Screen Shot 2021-03-28 at 12 32 37 PM" src="https://user-images.githubusercontent.com/572717/112765401-e21ddc80-8fc1-11eb-8ab0-e33e0bb312d8.png">

In conclusion, I think this achieves a controllable look free of artifacts. I think there is a place for gamma correction, but this is not it.