### PR TITLE
Support fog on markers

### DIFF
--- a/debug/fog.html
+++ b/debug/fog.html
@@ -31,8 +31,8 @@ var GUIParams = function() {
     this.enableTerrain = true;
     this.terrainExaggeration = 1.5;
     this.style = 'satellite-streets-v11';
-    this.fogRangeStart = 2000;
-    this.fogRangeEnd = 3000;
+    this.fogRangeStart = 1000;
+    this.fogRangeEnd = 10000;
     this.fogOpacity = 1.0;
     this.fogColor = [255, 255, 255];
     this.fogSkyBlend = 0.1;
@@ -132,24 +132,20 @@ window.onload = function() {
     });
 };
 
-['auto'].forEach((rotationAlignment, i) => {
-    ['auto'].forEach((pitchAlignment, j) => {
-        var popup = new mapboxgl.Popup().setHTML(`Pitch Alignment: ${pitchAlignment}<br>Rotation Alignment: ${rotationAlignment}`);
+var popup = new mapboxgl.Popup().setHTML('Pitch Alignment: auto<br>Rotation Alignment: auto');
 
-        var marker = new mapboxgl.Marker({
-            color: `rgb(200, 0, 0)`,
-            scale: 1,
-            draggable: true,
-            rotationAlignment,
-            pitchAlignment
-        })
-            .setLngLat(map.getCenter())
-            .setPopup(popup)
-            .addTo(map);
+var marker = new mapboxgl.Marker({
+    color: `rgb(200, 0, 0)`,
+    scale: 1,
+    draggable: true,
+    pitchAlignment: 'auto',
+    rotationAlignment: 'auto'
+})
+    .setLngLat(map.getCenter())
+    .setPopup(popup)
+    .addTo(map);
 
-        marker.togglePopup();
-    });
-});
+marker.togglePopup();
 
 map.on('style.load', function() {
     map.addSource('mapbox-dem', {

--- a/debug/fog.html
+++ b/debug/fog.html
@@ -132,6 +132,25 @@ window.onload = function() {
     });
 };
 
+['auto'].forEach((rotationAlignment, i) => {
+    ['auto'].forEach((pitchAlignment, j) => {
+        var popup = new mapboxgl.Popup().setHTML(`Pitch Alignment: ${pitchAlignment}<br>Rotation Alignment: ${rotationAlignment}`);
+
+        var marker = new mapboxgl.Marker({
+            color: `rgb(200, 0, 0)`,
+            scale: 1,
+            draggable: true,
+            rotationAlignment,
+            pitchAlignment
+        })
+            .setLngLat(map.getCenter())
+            .setPopup(popup)
+            .addTo(map);
+
+        marker.togglePopup();
+    });
+});
+
 map.on('style.load', function() {
     map.addSource('mapbox-dem', {
         "type": "raster-dem",

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -673,6 +673,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 }
 
 .mapboxgl-marker-occluded {
+    /* Must match markers.js:TERRAIN_OCCLUDED_OPACITY */
     opacity: 0.2;
 }
 

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -672,11 +672,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     transition: opacity 0.2s;
 }
 
-.mapboxgl-marker-occluded {
-    /* Must match markers.js:TERRAIN_OCCLUDED_OPACITY */
-    opacity: 0.2;
-}
-
 .mapboxgl-user-location-dot {
     background-color: #1da1f2;
     width: 15px;

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -672,6 +672,22 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     transition: opacity 0.2s;
 }
 
+.mapboxgl-marker-occluded {
+    opacity: 0.0;
+}
+
+.mapboxgl-marker-occluded-low {
+    opacity: 0.25;
+}
+
+.mapboxgl-marker-occluded-mid {
+    opacity: 0.5;
+}
+
+.mapboxgl-marker-occluded-high {
+    opacity: 0.75;
+}
+
 .mapboxgl-user-location-dot {
     background-color: #1da1f2;
     width: 15px;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -43,6 +43,7 @@ class Transform {
     pixelsToGLUnits: [number, number];
     cameraToCenterDistance: number;
     mercatorMatrix: Array<number>;
+    mercatorFogMatrix: Array<number>;
     projMatrix: Float64Array;
     invProjMatrix: Float64Array;
     alignedProjMatrix: Float64Array;
@@ -1453,8 +1454,18 @@ class Transform {
         // matrix for conversion from location to screen coordinates
         this.pixelMatrix = mat4.multiply(new Float64Array(16), this.labelPlaneMatrix, this.projMatrix);
 
+        const cameraWorldSize = this.cameraWorldSize;
+        const cameraPixelsPerMeter = this.cameraPixelsPerMeter;
+        const cameraPos = this._camera.position;
+
+        m = mat4.create();
+        const metersToPixel = [cameraWorldSize, cameraWorldSize, cameraPixelsPerMeter];
+        mat4.translate(m, m, vec3.multiply(cameraPos, vec3.scale(cameraPos, cameraPos, -1), metersToPixel));
+        mat4.scale(m, m, metersToPixel);
+        this.mercatorFogMatrix = m;
+
         // matrix for conversion from tile coordinates to relative camera position in pixel coordinates
-        this.cameraMatrix = this._camera.getWorldToCameraPosition(this.cameraWorldSize, this.cameraPixelsPerMeter);
+        this.cameraMatrix = this._camera.getWorldToCameraPosition(cameraWorldSize, cameraPixelsPerMeter);
 
         // inverse matrix for conversion from screen coordinates to location
         m = mat4.invert(new Float64Array(16), this.pixelMatrix);

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -5,6 +5,8 @@ import {endsWith, extend, smoothstep} from '../util/util.js';
 import {Evented} from '../util/evented.js';
 import LngLat from '../geo/lng_lat.js';
 import {vec3} from 'gl-matrix';
+import {UnwrappedTileID} from '../source/tile_id.js';
+import type Transform from '../geo/transform.js';
 import {validateStyle, validateFog, emitValidationErrors} from './validate_style.js';
 import type EvaluationParameters from './evaluation_parameters.js';
 import {Properties, Transitionable, Transitioning, PossiblyEvaluated, DataConstantProperty} from './properties.js';
@@ -56,7 +58,7 @@ export class FogSampler {
 
     getOpacityAtTileCoord(x: number, y: number, z: number, tileId: UnwrappedTileID, transform: Transform): number {
         const mat = transform.calculateCameraMatrix(tileId);
-        const pos = [x, y ,z];
+        const pos = [x, y, z];
         vec3.transformMat4(pos, pos, mat);
         const depth = vec3.length(pos);
 
@@ -124,7 +126,9 @@ class Fog extends Evented {
     }
 
     getSampler(): FogSampler {
-        return new FogSampler(this._transitionable.getValue('range'), this._transitionable.getValue('opacity'));
+        const range = this.properties.get('range');
+        const opacity = this.properties.get('opacity');
+        return new FogSampler(range, opacity);
     }
 
     recalculate(parameters: EvaluationParameters) {

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -55,6 +55,7 @@ export class FogSampler {
         // function is C2 continuous at the onset. The fog is about 99% opaque at
         // the far limit, so we simply scale it and clip to achieve 100% opacity.
         // https://www.desmos.com/calculator/3taufutxid
+        // The output of this function must match src/shaders/_prelude_fog.fragment.glsl
         const decay = 5.5;
         let falloff = Math.max(0.0, 1.0 - Math.exp(-decay * (depth - start) / (end - start)));
 

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -44,7 +44,7 @@ export class FogSampler {
         const props = this.properties;
         const range = props.get('range');
         const fogOpacity = props.get('opacity') * smoothstep(FOG_PITCH_START, FOG_PITCH_END, pitch);
-        const start = range[0], end = range[1];
+        const [start, end] = range;
 
         // The fog is not physically accurate, so we seek an expression which satisfies a
         // couple basic constraints:

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -80,14 +80,8 @@ export class FogSampler {
     getFogOpacityAtLatLng(lngLat: LngLat, transform: Transform): number {
         const meters = MercatorCoordinate.fromLngLat(lngLat);
         const elevation = transform.elevation ? transform.elevation.getAtPoint(meters) : 0;
-        const cameraPos = transform._camera.position;
-        const pos = [meters.x - cameraPos[0], meters.y - cameraPos[1], elevation - cameraPos[2]];
-
-        // Transform to pixel coordinate
-        pos[0] *= transform.cameraWorldSize;
-        pos[1] *= transform.cameraWorldSize;
-        pos[2] *= transform.cameraPixelsPerMeter;
-
+        const pos = [meters.x, meters.y, elevation];
+        vec3.transformMat4(pos, pos, transform.mercatorFogMatrix);
         const depth = vec3.length(pos);
 
         return this.getFogOpacity(depth, transform.pitch);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -529,12 +529,6 @@ class Style extends Evented {
         }
         this.z = parameters.zoom;
 
-        if (this.fog || this.terrain) {
-            for (const marker of this.map._markers) {
-                marker._evaluateOpacity();
-            }
-        }
-
         if (changed) {
             this.fire(new Event('data', {dataType: 'style'}));
         }
@@ -1402,6 +1396,7 @@ class Style extends Evented {
             delete this.stylesheet.terrain;
             this.dispatcher.broadcast('enableTerrain', false);
             this._force3DLayerUpdate();
+            this._updateMarkersOpacity();
             return;
         }
 
@@ -1438,6 +1433,7 @@ class Style extends Evented {
         }
 
         this._updateDrapeFirstLayers();
+        this._updateMarkersOpacity();
     }
 
     _createFog(fogOptions: FogSpecification) {
@@ -1453,6 +1449,12 @@ class Style extends Evented {
         fog.updateTransitions(parameters);
     }
 
+    _updateMarkersOpacity() {
+        for (const marker of this.map._markers) {
+            marker._evaluateOpacity();
+        }
+    }
+
     getFog() {
         return this.fog ? this.fog.get() : null;
     }
@@ -1464,6 +1466,7 @@ class Style extends Evented {
             // Remove fog
             delete this.fog;
             delete this.stylesheet.fog;
+            this._updateMarkersOpacity();
             return;
         }
 
@@ -1490,6 +1493,8 @@ class Style extends Evented {
                 }
             }
         }
+
+        this._updateMarkersOpacity();
     }
 
     _updateDrapeFirstLayers() {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -529,6 +529,12 @@ class Style extends Evented {
         }
         this.z = parameters.zoom;
 
+        if (this.fog || this.terrain) {
+            for (const marker of this.map._markers) {
+                marker._evaluateOpacity();
+            }
+        }
+
         if (changed) {
             this.fire(new Event('data', {dataType: 'style'}));
         }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1450,6 +1450,9 @@ class Style extends Evented {
     }
 
     _updateMarkersOpacity() {
+        if (this.map._markers.length === 0) {
+            return;
+        }
         for (const marker of this.map._markers) {
             marker._evaluateOpacity();
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2180,6 +2180,12 @@ class Map extends Camera {
         return this.style ? this.style.getFog() : null;
     }
 
+    getFogOpacity(lnglat: LngLatLike): number {
+        return this.style && this.style.fog ?
+            this.style.fog.sampler.getFogOpacityAtLatLng(
+                LngLat.convert(lnglat), this.transform) : 0.0;
+    }
+
     /**
      * Sets the `state` of a feature.
      * A feature's `state` is a set of user-defined key-value pairs that are assigned to a feature at runtime.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -27,6 +27,7 @@ import {MapMouseEvent} from './events.js';
 import TaskQueue from '../util/task_queue.js';
 import webpSupported from '../util/webp_supported.js';
 import {PerformanceMarkers, PerformanceUtils} from '../util/performance.js';
+import Marker from '../ui/marker.js';
 
 import {setCacheLimits} from '../util/tile_request_cache.js';
 
@@ -323,6 +324,7 @@ class Map extends Camera {
     _optimizeForTerrain: boolean;
     _renderTaskQueue: TaskQueue;
     _controls: Array<IControl>;
+    _markers: Array<Marker>;
     _logoControl: IControl;
     _mapId: number;
     _localIdeographFontFamily: string;
@@ -423,6 +425,7 @@ class Map extends Camera {
         this._optimizeForTerrain = options.optimizeForTerrain;
         this._renderTaskQueue = new TaskQueue();
         this._controls = [];
+        this._markers = [];
         this._mapId = uniqueId();
         this._locale = extend({}, defaultLocale, options.locale);
         this._clickTolerance = options.clickTolerance;
@@ -2163,7 +2166,7 @@ class Map extends Camera {
      * @returns {Object} terrain Terrain specification properties of the style.
      */
     getTerrain(): Terrain | null {
-        return this.style.getTerrain();
+        return this.style ? this.style.getTerrain() : null;
     }
 
     setFog(fog: FogSpecification) {
@@ -2174,7 +2177,7 @@ class Map extends Camera {
 
     // NOTE: Make fog non-optional
     getFog(): Fog | null {
-        return this.style.getFog();
+        return this.style ? this.style.getFog() : null;
     }
 
     /**
@@ -2408,6 +2411,17 @@ class Map extends Camera {
         // Maintain the same canvas size, potentially downscaling it for HiDPI displays
         this._canvas.style.width = `${width}px`;
         this._canvas.style.height = `${height}px`;
+    }
+
+    _addMarker(marker: Marker) {
+        this._markers.push(marker);
+    }
+
+    _removeMarker(marker: Marker) {
+        const index = this._markers.indexOf(marker);
+        if (index !== -1) {
+            this._markers.splice(index, 1);
+        }
     }
 
     _setupPainter() {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2181,7 +2181,8 @@ class Map extends Camera {
     }
 
     getFogOpacity(lnglat: LngLatLike): number {
-        return this.style && this.style.fog ?
+        if (!this.style || !this.style.fog) return 0.0;
+        return this.style.fog.sampler.getFogOpacityAtLatLng(LngLat.convert(lnglat), this.transform)
             this.style.fog.sampler.getFogOpacityAtLatLng(
                 LngLat.convert(lnglat), this.transform) : 0.0;
     }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2182,9 +2182,7 @@ class Map extends Camera {
 
     getFogOpacity(lnglat: LngLatLike): number {
         if (!this.style || !this.style.fog) return 0.0;
-        return this.style.fog.sampler.getFogOpacityAtLatLng(LngLat.convert(lnglat), this.transform)
-            this.style.fog.sampler.getFogOpacityAtLatLng(
-                LngLat.convert(lnglat), this.transform) : 0.0;
+        return this.style.fog.sampler.getFogOpacityAtLatLng(LngLat.convert(lnglat), this.transform);
     }
 
     /**

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -450,35 +450,29 @@ export default class Marker extends Evented {
 
     _evaluateOpacity() {
         const position = this._pos ? this._pos.sub(this._transformedOffset()) : null;
-        if (this._withinScreenBounds(position)) {
-            const lngLat = this._map.unproject(position);
-            const fog = this._map.getFog();
 
-            let terrainOccluded = false;
-            let fogOpacity = 0.0;
+        if (!this._withinScreenBounds(position)) {
+            this._fadeTimer = null;
+            return;
+        }
 
-            if (fog) {
-                const fogSampler = fog.sampler;
-                fogOpacity = fogSampler.getFogOpacityAtLatLng(lngLat, this._map.transform);
+        const lngLat = this._map.unproject(position);
+
+        let terrainOccluded = false;
+        if (this._map.getTerrain()) {
+            const camera = this._map.getFreeCameraOptions();
+            if (camera.position) {
+                const cameraPos = camera.position.toLngLat();
+                const raycastDistance = cameraPos.distanceTo(lngLat);
+                const posDistance = cameraPos.distanceTo(this._lngLat);
+                terrainOccluded = raycastDistance < posDistance * 0.9;
             }
+        }
 
-            if (this._map.getTerrain()) {
-                // calculate if occluded.
-                const raycastLoc = this._map.unproject(position);
-                const camera = this._map.getFreeCameraOptions();
-                if (camera.position) {
-                    const cameraPos = camera.position.toLngLat();
-                    const raycastDistance = cameraPos.distanceTo(raycastLoc);
-                    const posDistance = cameraPos.distanceTo(this._lngLat);
-                    terrainOccluded = raycastDistance < posDistance * 0.9;
-                }
-            }
-
-            this._element.style.opacity = `${(1.0 - fogOpacity) * (terrainOccluded ? TERRAIN_OCCLUDED_OPACITY : 1.0)}`;
-
-            if (this._popup) {
-                this._popup._setOpacity(`${1.0 - fogOpacity}`);
-            }
+        const fogOpacity = this._map.getFogOpacity(lngLat);
+        this._element.style.opacity = `${(1.0 - fogOpacity) * (terrainOccluded ? TERRAIN_OCCLUDED_OPACITY : 1.0)}`;
+        if (this._popup) {
+            this._popup._setOpacity(`${1.0 - fogOpacity}`);
         }
 
         this._fadeTimer = null;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -524,7 +524,7 @@ export default class Marker extends Evented {
 
         DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
 
-        if (this._map.getTerrain() || this._map.getFog() && !this._fadeTimer) {
+        if ((this._map.getTerrain() || this._map.getFog()) && !this._fadeTimer) {
             this._fadeTimer = setTimeout(this._evaluateOpacity.bind(this), 60);
         }
     }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -456,20 +456,20 @@ export default class Marker extends Evented {
             return;
         }
 
-        const lngLat = this._map.unproject(position);
+        const mapLocation = this._map.unproject(position);
 
         let terrainOccluded = false;
         if (this._map.getTerrain()) {
             const camera = this._map.getFreeCameraOptions();
             if (camera.position) {
                 const cameraPos = camera.position.toLngLat();
-                const raycastDistance = cameraPos.distanceTo(lngLat);
+                const raycastDistance = cameraPos.distanceTo(mapLocation);
                 const posDistance = cameraPos.distanceTo(this._lngLat);
                 terrainOccluded = raycastDistance < posDistance * 0.9;
             }
         }
 
-        const fogOpacity = this._map.getFogOpacity(lngLat);
+        const fogOpacity = this._map.getFogOpacity(mapLocation);
         this._element.style.opacity = `${(1.0 - fogOpacity) * (terrainOccluded ? TERRAIN_OCCLUDED_OPACITY : 1.0)}`;
         if (this._popup) {
             this._popup._setOpacity(`${1.0 - fogOpacity}`);

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -463,17 +463,21 @@ export default class Marker extends Evented {
             const camera = this._map.getFreeCameraOptions();
             if (camera.position) {
                 const cameraPos = camera.position.toLngLat();
-                const raycastDistance = cameraPos.distanceTo(mapLocation);
-                const posDistance = cameraPos.distanceTo(this._lngLat);
-                terrainOccluded = raycastDistance < posDistance * 0.9;
+                // the distance to the marker lat/lng + marker offset location
+                const offsetDistance = cameraPos.distanceTo(mapLocation);
+                const distance = cameraPos.distanceTo(this._lngLat);
+                terrainOccluded = offsetDistance < distance * 0.9;
             }
         }
 
         const fogOpacity = this._map.getFogOpacity(mapLocation);
-        this._element.style.opacity = `${(1.0 - fogOpacity) * (terrainOccluded ? TERRAIN_OCCLUDED_OPACITY : 1.0)}`;
-        if (this._popup) {
-            this._popup._setOpacity(`${1.0 - fogOpacity}`);
-        }
+
+        window.requestAnimationFrame(() => {
+            this._element.style.opacity = `${(1.0 - fogOpacity) * (terrainOccluded ? TERRAIN_OCCLUDED_OPACITY : 1.0)}`;
+            if (this._popup) {
+                this._popup._setOpacity(`${1.0 - fogOpacity}`);
+            }
+        });
 
         this._fadeTimer = null;
     }

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -589,14 +589,10 @@ export default class Popup extends Evented {
     }
 
     _setOpacity(opacity: string) {
-        if (this._content)
-            this._content.style.opacity = opacity;
-        if (this._container)
-            this._container.style.opacity = opacity;
-        if (this._closeButton)
-            this._closeButton.style.opacity = opacity;
-        if (this._tip)
-            this._tip.style.opacity = opacity;
+        if (this._content) this._content.style.opacity = opacity;
+        if (this._container) this._container.style.opacity = opacity;
+        if (this._closeButton) this._closeButton.style.opacity = opacity;
+        if (this._tip) this._tip.style.opacity = opacity;
     }
 }
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -588,7 +588,7 @@ export default class Popup extends Evented {
         this.remove();
     }
 
-    _setOpacity(opacity: number) {
+    _setOpacity(opacity: string) {
         if (this._content)
             this._content.style.opacity = opacity;
         if (this._container)

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -587,6 +587,17 @@ export default class Popup extends Evented {
     _onClose() {
         this.remove();
     }
+
+    _setOpacity(opacity: number) {
+        if (this._content)
+            this._content.style.opacity = opacity;
+        if (this._container)
+            this._container.style.opacity = opacity;
+        if (this._closeButton)
+            this._closeButton.style.opacity = opacity;
+        if (this._tip)
+            this._tip.style.opacity = opacity;
+    }
 }
 
 function normalizeOffset(offset: ?Offset) {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -588,11 +588,8 @@ export default class Popup extends Evented {
         this.remove();
     }
 
-    _setOpacity(opacity: string) {
-        if (this._content) this._content.style.opacity = opacity;
-        if (this._container) this._container.style.opacity = opacity;
-        if (this._closeButton) this._closeButton.style.opacity = opacity;
-        if (this._tip) this._tip.style.opacity = opacity;
+    _setOpacity(occluded: boolean) {
+        if (this._content) this._content.classList.toggle('mapboxgl-marker-occluded', occluded);
     }
 }
 

--- a/test/unit/terrain/terrain.test.js
+++ b/test/unit/terrain/terrain.test.js
@@ -13,7 +13,7 @@ import {VertexMorphing} from '../../../src/terrain/draw_terrain_raster.js';
 import {fixedLngLat, fixedCoord, fixedPoint} from '../../util/fixed.js';
 import Point from '@mapbox/point-geometry';
 import LngLat from '../../../src/geo/lng_lat.js';
-import Marker from '../../../src/ui/marker.js';
+import Marker, {TERRAIN_OCCLUDED_OPACITY} from '../../../src/ui/marker.js';
 import Popup from '../../../src/ui/popup.js';
 import simulate from '../../util/simulate_interaction.js';
 import {createConstElevationDEM, setMockElevationTerrain} from '../../util/dem_mock.js';
@@ -1273,18 +1273,17 @@ test('Marker interaction and raycast', (t) => {
             });
 
             t.test('Occluded', (t) => {
-                marker._occlusionTimer = null;
+                marker._fadeTimer = null;
                 marker.setLngLat(terrainTopLngLat);
                 const bottomLngLat = tr.pointLocation3D(new Point(terrainTop.x, tr.height));
                 // Raycast returns distance to closer point evaluates to occluded marker.
                 t.stub(tr, 'pointLocation3D').returns(bottomLngLat);
                 setTimeout(() => {
-                    t.ok(marker.getElement().classList.contains('mapboxgl-marker-occluded'));
+                    t.deepEqual(marker.getElement().style.opacity, TERRAIN_OCCLUDED_OPACITY);
                     t.end();
                 }, 100);
             });
 
-            map.remove();
             t.end();
         });
     });


### PR DESCRIPTION
- Add marker support on fog (via opacity), for the popup and marker itself
- Consolidate behaviors between terrain and fog marker opacity and fix an issue with terrain not clearing occlusion state after we disable terrain or change its spec properties (exaggeration)
- I'll consolidate the behavior with unit tests once we're finalizing the fog-implementation branch

https://user-images.githubusercontent.com/7061573/112703628-e24c9980-8e54-11eb-89d3-3cad971f7507.mov


