### PR TITLE
Upgrade supercluster to v7.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "potpack": "^1.0.1",
     "quickselect": "^2.0.0",
     "rw": "^1.3.3",
-    "supercluster": "^7.1.2",
+    "supercluster": "^7.1.3",
     "tinyqueue": "^2.0.3",
     "vt-pbf": "^3.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11138,10 +11138,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-supercluster@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.2.tgz#cf02a60283a0118212024f3bf02e4e63bb148e2c"
-  integrity sha512-bGA0pk3DYMjLTY1h+rbh0imi/I8k/Lg0rzdBGfyQs0Xkiix7jK2GUmH1qSD8+jq6U0Vu382QHr3+rbbiHqdKJA==
+supercluster@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.3.tgz#8c5412c7d7e53b010f7514e87f279544babc3425"
+  integrity sha512-7+bR4FbF5SYsmkHfDp61QiwCKtwNDyPsddk9TzfsDA5DQr5Goii5CVD2SXjglweFCxjrzVZf945ahqYfUIk8UA==
   dependencies:
     kdbush "^3.0.0"
 


### PR DESCRIPTION
Fixes a bug where unclustered points in a clustered source would snap to a grid on higher zoom levels. Closes #10422. The actual fix is in https://github.com/mapbox/supercluster/pull/176.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixes a bug where unclustered points in a clustered GeoJSON source would snap to a grid on higher zoom levels.</changelog>`
