### PR TITLE
Fix an edge case with loadImage in Safari and older Firefox

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1789,7 +1789,9 @@ class Map extends Camera {
      * @see [Add an icon to the map](https://www.mapbox.com/mapbox-gl-js/example/add-image/)
      */
     loadImage(url: string, callback: Function) {
-        getImage(this._requestManager.transformRequest(url, ResourceType.Image), callback);
+        getImage(this._requestManager.transformRequest(url, ResourceType.Image), (err, img) => {
+            callback(err, img instanceof HTMLImageElement ? browser.getImageData(img) : img);
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes #10180 by getting data out of an `Image` object eagerly when running `loadImage` in case `ImageBitmap` is not supported. 

In the [stretchable images](https://docs.mapbox.com/mapbox-gl-js/example/add-image-stretchable/) example, `loadImage` result was saved to be used later (when both images are loaded), and there could be a situation where the image memory is freed (with the transparent image hack) before it gets passed to `addImage`. This PR fixes this by doing `getImageData` as soon as we load the image, not later at the `addImage` stage, when using the combination of `loadImage` and `addImage` with a delay in between.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality — need to see if it's possible to unit-test this properly
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed a bug where map.loadImage followed by map.addImage with a delay could fail in Safari and Firefox.</changelog>`
