### PR TITLE
Add linked types to MapWheelEvent and MapTouchEvent 

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -194,7 +194,7 @@ export class MapTouchEvent extends Event {
  */
 export class MapWheelEvent extends Event {
     /**
-     * The event type (one of {@link Map.event:wheel}).
+     * The event type ({@link Map.event:wheel}).
      */
     type: 'wheel';
 

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -194,7 +194,8 @@ export class MapTouchEvent extends Event {
  */
 export class MapWheelEvent extends Event {
     /**
-     * The event type (one of {@link Map.event:wheel}.     */
+     * The event type (one of {@link Map.event:wheel}).
+     */
     type: 'wheel';
 
     /**
@@ -813,7 +814,6 @@ export type MapEvent =
      * Fired just after the map completes a transition from one zoom level to another
      * as the result of either user interaction or methods such as {@link Map#flyTo}.
      * The zoom transition will usually end before rendering is finished, so if you
-
      * need to wait for rendering to finish, use the {@link Map#idle} event instead.
      *
      * @event zoomend

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -108,7 +108,9 @@ export class MapMouseEvent extends Event {
  */
 export class MapTouchEvent extends Event {
     /**
-     * The event type.
+     * The event type (one of {@link Map.event:touchstart},
+     * {@link Map.event:touchend},
+     * {@link Map.event:contextmenu}).
      */
     type: 'touchstart'
         | 'touchend'
@@ -192,8 +194,7 @@ export class MapTouchEvent extends Event {
  */
 export class MapWheelEvent extends Event {
     /**
-     * The event type.
-     */
+     * The event type (one of {@link Map.event:wheel}.     */
     type: 'wheel';
 
     /**
@@ -812,6 +813,7 @@ export type MapEvent =
      * Fired just after the map completes a transition from one zoom level to another
      * as the result of either user interaction or methods such as {@link Map#flyTo}.
      * The zoom transition will usually end before rendering is finished, so if you
+
      * need to wait for rendering to finish, use the {@link Map#idle} event instead.
      *
      * @event zoomend


### PR DESCRIPTION
Related to: https://github.com/mapbox/mapbox-gl-js-docs/issues/305 , https://github.com/mapbox/mapbox-gl-js-docs/issues/307

Improves developer experience by explicating event types and offering links.

* Extends the pattern seen in: [#mapmouseevent#type](https://docs.mapbox.com/mapbox-gl-js/api/events/#mapmouseevent#type).
* Adds a list of linked types to `MapWheelEvent` and `MapTouchEvent`.
* Consistifies event documentation on this page.

- [ ] Requesting Docs review from @mapbox/docs 
- [ ] Requesting GL JS review from @mapbox/gl-js 

Before/after screenshot:

<img src="https://user-images.githubusercontent.com/6026447/113078440-d02d6c80-916e-11eb-9e69-06b5ebddb144.png" width=500>

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
