### PR TITLE
Fix an edge case with loadImage in Safari and older Firefox (CP 1.13)

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1756,7 +1756,9 @@ class Map extends Camera {
      * @see [Add an icon to the map](https://www.mapbox.com/mapbox-gl-js/example/add-image/)
      */
     loadImage(url: string, callback: Function) {
-        getImage(this._requestManager.transformRequest(url, ResourceType.Image), callback);
+        getImage(this._requestManager.transformRequest(url, ResourceType.Image), (err, img) => {
+            callback(err, img instanceof HTMLImageElement ? browser.getImageData(img) : img);
+        });
     }
 
     /**


### PR DESCRIPTION
Cherry-pick of #10524 to the v1.13 branch for a potential bugfix release in future.