### PR TITLE
Fog-sky blending

### DIFF
--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -15,7 +15,8 @@ float fog_sky_blending(vec3 camera_dir) {
     return u_fog_opacity * exp(-3.0 * t * t);
 }
 
-float fog_opacity(float depth) {
+float fog_opacity(vec3 pos) {
+    float depth = length(pos);
     float start = u_fog_range.x;
     float end = u_fog_range.y;
 
@@ -37,7 +38,7 @@ float fog_opacity(float depth) {
     // Scale and clip to 1 at the far limit
     falloff = min(1.0, 1.00747 * falloff);
 
-    return falloff * u_fog_opacity;
+    return falloff * u_fog_opacity * fog_sky_blending(pos / depth);;
 }
 
 // Assumes z up
@@ -50,10 +51,7 @@ vec3 fog_apply(vec3 color, vec3 pos) {
     // so that dark fog and light fog obscure similarly for otherwise identical
     // parameters. If we blend in linear RGB, then the parameters to control dark
     // and light fog are fundamentally different.
-    float depth = length(pos);
-    float opacity = fog_opacity(depth);
-    float sky_blend = fog_sky_blending(pos / depth);
-    return mix(color, u_fog_color, opacity * sky_blend);
+    return mix(color, u_fog_color, fog_opacity(pos));
 }
 
 // Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -6,15 +6,13 @@ uniform float u_fog_opacity;
 uniform float u_fog_sky_blend;
 uniform float u_fog_temporal_offset;
 
-vec3 fog_apply_sky_gradient(vec3 cubemap_uv, vec3 sky_color) {
-    vec3 camera_ray = normalize(cubemap_uv);
-    vec3 y_up = vec3(0.0, 1.0, 0.0);
-    float y_blend = dot(camera_ray, y_up);
-    float gradient = smoothstep(0.0, u_fog_sky_blend, y_blend);
-    float fog_falloff = clamp(gradient + (1.0 - u_fog_opacity), 0.0, 1.0);
-
-    // We may or may not wish to use gamma-correct blending
-    return mix(u_fog_color, sky_color, fog_falloff);
+// Assumes z up and camera_dir *normalized* (to avoid computing its length multiple
+// times for different functions).
+float fog_sky_blending(vec3 camera_dir) {
+    float t = max(0.0, camera_dir.z / u_fog_sky_blend);
+    // Factor of 3 chosen to roughly match smoothstep.
+    // See: https://www.desmos.com/calculator/pub31lvshf
+    return u_fog_opacity * exp(-3.0 * t * t);
 }
 
 float fog_opacity(float depth) {
@@ -39,16 +37,30 @@ float fog_opacity(float depth) {
     // Scale and clip to 1 at the far limit
     falloff = min(1.0, 1.00747 * falloff);
 
-
     return falloff * u_fog_opacity;
+}
+
+// Assumes z up
+vec3 fog_apply_sky_gradient(vec3 camera_ray, vec3 sky_color) {
+    return mix(sky_color, u_fog_color, fog_sky_blending(normalize(camera_ray)));
 }
 
 vec3 fog_apply(vec3 color, vec3 pos) {
     // We mix in sRGB color space. sRGB roughly corrects for perceived brightness
     // so that dark fog and light fog obscure similarly for otherwise identical
-    // parameters. If we gamma-correct, then the parameters to control dark and
-    // light fog are fundamentally different.
-    return mix(color, u_fog_color, fog_opacity(length(pos)));
+    // parameters. If we blend in linear RGB, then the parameters to control dark
+    // and light fog are fundamentally different.
+    float depth = length(pos);
+    float opacity = fog_opacity(depth);
+    float sky_blend = fog_sky_blending(pos / depth);
+    return mix(color, u_fog_color, opacity * sky_blend);
+}
+
+// Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For
+// use with colors using premultiplied alpha
+vec4 fog_apply_premultiplied(vec4 color, vec3 pos) {
+    float a = 1e-4 + color.a;
+    return vec4(fog_apply(min(color.rgb / a, vec3(1)), pos) * a, color.a);
 }
 
 vec3 fog_dither(vec3 color) {
@@ -57,13 +69,6 @@ vec3 fog_dither(vec3 color) {
 
 vec4 fog_dither(vec4 color) {
     return vec4(fog_dither(color.rgb), color.a);
-}
-
-// Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For
-// use with colors using premultiplied alpha
-vec4 fog_apply_premultiplied(vec4 color, vec3 pos) {
-    float a = 1e-4 + color.a;
-    return vec4(fog_apply(min(color.rgb / a, vec3(1)), pos) * a, color.a);
 }
 
 #endif

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -38,7 +38,7 @@ float fog_opacity(vec3 pos) {
     // Scale and clip to 1 at the far limit
     falloff = min(1.0, 1.00747 * falloff);
 
-    return falloff * u_fog_opacity * fog_sky_blending(pos / depth);;
+    return falloff * u_fog_opacity;
 }
 
 // Assumes z up

--- a/src/shaders/skybox.fragment.glsl
+++ b/src/shaders/skybox.fragment.glsl
@@ -44,7 +44,8 @@ void main() {
 
 #ifdef FOG
     // Apply fog contribution if enabled
-    sky_color = fog_apply_sky_gradient(v_uv, sky_color);
+    // Swizzle to put z-up (ignoring x-y mirror since fog does not depend on azimuth)
+    sky_color = fog_apply_sky_gradient(v_uv.xzy, sky_color);
 #endif
 
     // Dither [1]

--- a/src/shaders/skybox_gradient.fragment.glsl
+++ b/src/shaders/skybox_gradient.fragment.glsl
@@ -12,7 +12,8 @@ void main() {
 
 #ifdef FOG
     // Apply fog contribution if enabled
-    color.rgb = fog_apply_sky_gradient(v_uv, color.rgb);
+    // Swizzle to put z-up (ignoring x-y mirror since fog does not depend on azimuth)
+    color.rgb = fog_apply_sky_gradient(v_uv.xzy, color.rgb);
 #endif
 
     // Dither


### PR DESCRIPTION
This PR improve fog blending in two ways:

First, it selects a smoother fog-sky blending function. Currently, smoothstep is used. I've instead opted for `exp(-3x^2)`, which results much smoother blending. I don't think the cost of the exp function is prohibitive, though I wouldn't be opposed to a cheap substitute.

Compared so smoothstep (purple), exp(-3x^2) (blue) looks like this:
https://www.desmos.com/calculator/pub31lvshf
<img width="496" alt="Screen Shot 2021-03-31 at 12 25 38 PM" src="https://user-images.githubusercontent.com/572717/113199789-5fdd2480-921c-11eb-9858-2803bb225fd9.png">

This function removes the sharp horizontal band in the sky which is visible especially against dark skies (left: smoothstep, right: exp):

<img width="320" alt="Screen Shot 2021-03-31 at 12 07 22 PM" src="https://user-images.githubusercontent.com/572717/113199899-81d6a700-921c-11eb-84d7-b835f59c7140.png"><img width="320" alt="Screen Shot 2021-03-31 at 12 07 38 PM" src="https://user-images.githubusercontent.com/572717/113199914-869b5b00-921c-11eb-8910-de7910fa67ac.png">

The next change is that it works fog-sky blending into the fog opacity computation via a simple multiplication. This prevents full-fogged hills well above the blending layer from clashing with the sky. This may result in things far away from the camera escaping fog, but I think this is preferable since it only applies to tall mountains viewed above 75 degrees or so.

<img width="320" alt="no fog-sky blending" src="https://user-images.githubusercontent.com/572717/113201443-581e7f80-921e-11eb-8e34-38c6f8022fdc.jpg"><img width="320" alt="with fog-sky blending" src="https://user-images.githubusercontent.com/572717/113201446-5a80d980-921e-11eb-9bf5-9ffa620420bf.jpg">

There is a bug though. Terrain and raster imagery seem to be culled at different depths so that the raster imagery is often dropped when the terrain is not, resulting in black terrain. I don't know the solution to this problem.

![Screen Shot 2021-03-31 at 12 39 15 PM copy](https://user-images.githubusercontent.com/572717/113201766-c2372480-921e-11eb-91fa-b3d85fb94307.jpg)
