### PR TITLE
Batch render DOM elements to avoid reflow

### DIFF
--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -91,9 +91,10 @@ class NavigationControl {
             `scale(${1 / Math.pow(Math.cos(this._map.transform.pitch * (Math.PI / 180)), 0.5)}) rotateX(${this._map.transform.pitch}deg) rotateZ(${this._map.transform.angle * (180 / Math.PI)}deg)` :
             `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
 
-        const icon = this._compassIcon;
         this._map._domRenderTaskQueue.add(() => {
-            icon.style.transform = rotate;
+            if (this._compassIcon) {
+                this._compassIcon.style.transform = rotate;
+            }
         });
     }
 

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -91,8 +91,9 @@ class NavigationControl {
             `scale(${1 / Math.pow(Math.cos(this._map.transform.pitch * (Math.PI / 180)), 0.5)}) rotateX(${this._map.transform.pitch}deg) rotateZ(${this._map.transform.angle * (180 / Math.PI)}deg)` :
             `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
 
+        const icon = this._compassIcon;
         this._map._domRenderTaskQueue.add(() => {
-            this._compassIcon.style.transform = rotate;
+            icon.style.transform = rotate;
         });
     }
 

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -91,7 +91,9 @@ class NavigationControl {
             `scale(${1 / Math.pow(Math.cos(this._map.transform.pitch * (Math.PI / 180)), 0.5)}) rotateX(${this._map.transform.pitch}deg) rotateZ(${this._map.transform.angle * (180 / Math.PI)}deg)` :
             `rotate(${this._map.transform.angle * (180 / Math.PI)}deg)`;
 
-        this._compassIcon.style.transform = rotate;
+        this._map._domRenderTaskQueue.add(() => {
+            this._compassIcon.style.transform = rotate;
+        });
     }
 
     onAdd(map: Map) {

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -96,6 +96,7 @@ function updateScale(map, container, options) {
     const left = map.unproject([0, y]);
     const right = map.unproject([maxWidth, y]);
     const maxMeters = left.distanceTo(right);
+    const domQueue = map._domRenderTaskQueue;
     // The real distance corresponding to 100px scale length is rounded off to
     // near pretty number and the scale length for the same is found out.
     // Default unit of the scale is based on User's locale.
@@ -103,24 +104,24 @@ function updateScale(map, container, options) {
         const maxFeet = 3.2808 * maxMeters;
         if (maxFeet > 5280) {
             const maxMiles = maxFeet / 5280;
-            setScale(map, container, maxWidth, maxMiles, map._getUIString('ScaleControl.Miles'));
+            setScale(container, maxWidth, maxMiles, map._getUIString('ScaleControl.Miles'), domQueue);
         } else {
-            setScale(map, container, maxWidth, maxFeet, map._getUIString('ScaleControl.Feet'));
+            setScale(container, maxWidth, maxFeet, map._getUIString('ScaleControl.Feet'), domQueue);
         }
     } else if (options && options.unit === 'nautical') {
         const maxNauticals = maxMeters / 1852;
-        setScale(map, container, maxWidth, maxNauticals, map._getUIString('ScaleControl.NauticalMiles'));
+        setScale(container, maxWidth, maxNauticals, map._getUIString('ScaleControl.NauticalMiles'), domQueue);
     } else if (maxMeters >= 1000) {
-        setScale(map, container, maxWidth, maxMeters / 1000, map._getUIString('ScaleControl.Kilometers'));
+        setScale(container, maxWidth, maxMeters / 1000, map._getUIString('ScaleControl.Kilometers'), domQueue);
     } else {
-        setScale(map, container, maxWidth, maxMeters, map._getUIString('ScaleControl.Meters'));
+        setScale(container, maxWidth, maxMeters, map._getUIString('ScaleControl.Meters'), domQueue);
     }
 }
 
-function setScale(map, container, maxWidth, maxDistance, unit) {
+function setScale(container, maxWidth, maxDistance, unit, domQueue) {
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
-    map._domRenderTaskQueue.add(() => {
+    domQueue.add(() => {
         container.style.width = `${maxWidth * ratio}px`;
         container.innerHTML = `${distance}&nbsp;${unit}`;
     });

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -103,25 +103,27 @@ function updateScale(map, container, options) {
         const maxFeet = 3.2808 * maxMeters;
         if (maxFeet > 5280) {
             const maxMiles = maxFeet / 5280;
-            setScale(container, maxWidth, maxMiles, map._getUIString('ScaleControl.Miles'));
+            setScale(map, container, maxWidth, maxMiles, map._getUIString('ScaleControl.Miles'));
         } else {
-            setScale(container, maxWidth, maxFeet, map._getUIString('ScaleControl.Feet'));
+            setScale(map, container, maxWidth, maxFeet, map._getUIString('ScaleControl.Feet'));
         }
     } else if (options && options.unit === 'nautical') {
         const maxNauticals = maxMeters / 1852;
-        setScale(container, maxWidth, maxNauticals, map._getUIString('ScaleControl.NauticalMiles'));
+        setScale(map, container, maxWidth, maxNauticals, map._getUIString('ScaleControl.NauticalMiles'));
     } else if (maxMeters >= 1000) {
-        setScale(container, maxWidth, maxMeters / 1000, map._getUIString('ScaleControl.Kilometers'));
+        setScale(map, container, maxWidth, maxMeters / 1000, map._getUIString('ScaleControl.Kilometers'));
     } else {
-        setScale(container, maxWidth, maxMeters, map._getUIString('ScaleControl.Meters'));
+        setScale(map, container, maxWidth, maxMeters, map._getUIString('ScaleControl.Meters'));
     }
 }
 
-function setScale(container, maxWidth, maxDistance, unit) {
+function setScale(map, container, maxWidth, maxDistance, unit) {
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
-    container.style.width = `${maxWidth * ratio}px`;
-    container.innerHTML = `${distance}&nbsp;${unit}`;
+    map._domRenderTaskQueue.add(() => {
+        container.style.width = `${maxWidth * ratio}px`;
+        container.innerHTML = `${distance}&nbsp;${unit}`;
+    });
 }
 
 function getDecimalRoundNum(d) {

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -107,12 +107,13 @@ class BoxZoomHandler {
             minY = Math.min(p0.y, pos.y),
             maxY = Math.max(p0.y, pos.y);
 
-        const box = this._box;
         this._map._domRenderTaskQueue.add(() => {
-            DOM.setTransform(box, `translate(${minX}px,${minY}px)`);
+            if (this._box) {
+                DOM.setTransform(this._box, `translate(${minX}px,${minY}px)`);
 
-            box.style.width = `${maxX - minX}px`;
-            box.style.height = `${maxY - minY}px`;
+                this._box.style.width = `${maxX - minX}px`;
+                this._box.style.height = `${maxY - minY}px`;
+            }
         });
     }
 

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -107,11 +107,12 @@ class BoxZoomHandler {
             minY = Math.min(p0.y, pos.y),
             maxY = Math.max(p0.y, pos.y);
 
+        const box = this._box;
         this._map._domRenderTaskQueue.add(() => {
-            DOM.setTransform(this._box, `translate(${minX}px,${minY}px)`);
+            DOM.setTransform(box, `translate(${minX}px,${minY}px)`);
 
-            this._box.style.width = `${maxX - minX}px`;
-            this._box.style.height = `${maxY - minY}px`;
+            box.style.width = `${maxX - minX}px`;
+            box.style.height = `${maxY - minY}px`;
         });
     }
 

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -107,10 +107,12 @@ class BoxZoomHandler {
             minY = Math.min(p0.y, pos.y),
             maxY = Math.max(p0.y, pos.y);
 
-        DOM.setTransform(this._box, `translate(${minX}px,${minY}px)`);
+        this._map._domRenderTaskQueue.add(() => {
+            DOM.setTransform(this._box, `translate(${minX}px,${minY}px)`);
 
-        this._box.style.width = `${maxX - minX}px`;
-        this._box.style.height = `${maxY - minY}px`;
+            this._box.style.width = `${maxX - minX}px`;
+            this._box.style.height = `${maxY - minY}px`;
+        });
     }
 
     mouseupWindow(e: MouseEvent, point: Point) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -320,6 +320,7 @@ class Map extends Camera {
     _collectResourceTiming: boolean;
     _optimizeForTerrain: boolean;
     _renderTaskQueue: TaskQueue;
+    _domRenderTaskQueue: TaskQueue;
     _controls: Array<IControl>;
     _logoControl: IControl;
     _mapId: number;
@@ -420,6 +421,7 @@ class Map extends Camera {
         this._collectResourceTiming = options.collectResourceTiming;
         this._optimizeForTerrain = options.optimizeForTerrain;
         this._renderTaskQueue = new TaskQueue();
+        this._domRenderTaskQueue = new TaskQueue();
         this._controls = [];
         this._mapId = uniqueId();
         this._locale = extend({}, defaultLocale, options.locale);
@@ -2526,6 +2528,7 @@ class Map extends Camera {
         this.painter.setBaseState();
 
         this._renderTaskQueue.run(paintStartTimeStamp);
+        this._domRenderTaskQueue.run(paintStartTimeStamp);
         // A task queue callback may have fired a user event which may have removed the map
         if (this._removed) return;
 
@@ -2770,6 +2773,7 @@ class Map extends Camera {
             this._frame = null;
         }
         this._renderTaskQueue.clear();
+        this._domRenderTaskQueue.clear();
         this.painter.destroy();
         this.handlers.destroy();
         delete this.handlers;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -507,11 +507,10 @@ export default class Marker extends Evented {
             this._pos = this._pos.round();
         }
 
-        const el = this._element;
-        const pos = this._pos;
-        const anchor = this._anchor;
         this._map._domRenderTaskQueue.add(() => {
-            DOM.setTransform(el, `${anchorTranslate[anchor]} translate(${pos.x}px, ${pos.y}px) ${pitch} ${rotation}`);
+            if (this._element && this._pos && this._anchor) {
+                DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
+            }
         });
     }
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -507,8 +507,11 @@ export default class Marker extends Evented {
             this._pos = this._pos.round();
         }
 
+        const el = this._element;
+        const pos = this._pos;
+        const anchor = this._anchor;
         this._map._domRenderTaskQueue.add(() => {
-            DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
+            DOM.setTransform(el, `${anchorTranslate[anchor]} translate(${pos.x}px, ${pos.y}px) ${pitch} ${rotation}`);
         });
     }
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -507,7 +507,9 @@ export default class Marker extends Evented {
             this._pos = this._pos.round();
         }
 
-        DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
+        this._map._domRenderTaskQueue.add(() => {
+            DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
+        });
     }
 
     /**

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -572,9 +572,11 @@ export default class Popup extends Evented {
         }
 
         const offsetedPos = pos.add(offset[anchor]).round();
+        const container = this._container;
+        const _anchor = anchor;
         this._map._domRenderTaskQueue.add(() => {
-            DOM.setTransform(this._container, `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
-            applyAnchorClass(this._container, anchor, 'popup');
+            DOM.setTransform(container, `${anchorTranslate[_anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
+            applyAnchorClass(container, _anchor, 'popup');
         });
     }
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -572,8 +572,10 @@ export default class Popup extends Evented {
         }
 
         const offsetedPos = pos.add(offset[anchor]).round();
-        DOM.setTransform(this._container, `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
-        applyAnchorClass(this._container, anchor, 'popup');
+        this._map._domRenderTaskQueue.add(() => {
+            DOM.setTransform(this._container, `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
+            applyAnchorClass(this._container, anchor, 'popup');
+        });
     }
 
     _focusFirstElement() {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -572,11 +572,11 @@ export default class Popup extends Evented {
         }
 
         const offsetedPos = pos.add(offset[anchor]).round();
-        const container = this._container;
-        const _anchor = anchor;
         this._map._domRenderTaskQueue.add(() => {
-            DOM.setTransform(container, `${anchorTranslate[_anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
-            applyAnchorClass(container, _anchor, 'popup');
+            if (this._container && anchor) {
+                DOM.setTransform(this._container, `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
+                applyAnchorClass(this._container, anchor, 'popup');
+            }
         });
     }
 

--- a/test/unit/ui/control/scale.test.js
+++ b/test/unit/ui/control/scale.test.js
@@ -6,6 +6,7 @@ import ScaleControl from '../../../../src/ui/control/scale_control.js';
 test('ScaleControl appears in bottom-left by default', (t) => {
     const map = createMap(t);
     map.addControl(new ScaleControl());
+    map._domRenderTaskQueue.run();
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale').length, 1);
     t.end();
@@ -14,6 +15,7 @@ test('ScaleControl appears in bottom-left by default', (t) => {
 test('ScaleControl appears in the position specified by the position option', (t) => {
     const map = createMap(t);
     map.addControl(new ScaleControl(), 'top-left');
+    map._domRenderTaskQueue.run();
 
     t.equal(map.getContainer().querySelectorAll('.mapboxgl-ctrl-top-left .mapboxgl-ctrl-scale').length, 1);
     t.end();
@@ -24,11 +26,13 @@ test('ScaleControl should change unit of distance after calling setUnit', (t) =>
     const scale = new ScaleControl();
     const selector = '.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale';
     map.addControl(scale);
+    map._domRenderTaskQueue.run();
 
     let contents = map.getContainer().querySelector(selector).innerHTML;
     t.match(contents, /km/);
 
     scale.setUnit('imperial');
+    map._domRenderTaskQueue.run();
     contents = map.getContainer().querySelector(selector).innerHTML;
     t.match(contents, /mi/);
     t.end();
@@ -41,6 +45,7 @@ test('ScaleControl should respect the maxWidth regardless of the unit and actual
     const selector = '.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-scale';
     map.addControl(scale);
     map.setZoom(12.5);
+    map._domRenderTaskQueue.run();
 
     const el = map.getContainer().querySelector(selector);
     t.ok(parseFloat(el.style.width, 10) <= maxWidth, 'ScaleControl respects maxWidth');

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -219,6 +219,7 @@ test('Marker anchor defaults to center', (t) => {
     const marker = new Marker()
         .setLngLat([0, 0])
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     t.ok(marker.getElement().classList.contains('mapboxgl-marker-anchor-center'));
     t.match(marker.getElement().style.transform, /translate\(-50%,-50%\)/);
@@ -232,6 +233,7 @@ test('Marker anchors as specified by the anchor option', (t) => {
     const marker = new Marker({anchor: 'top'})
         .setLngLat([0, 0])
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     t.ok(marker.getElement().classList.contains('mapboxgl-marker-anchor-top'));
     t.match(marker.getElement().style.transform, /translate\(-50%,0\)/);
@@ -259,6 +261,7 @@ test('Popup offsets around default Marker', (t) => {
         .setLngLat([0, 0])
         .setPopup(new Popup().setText('Test'))
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     t.ok(marker.getPopup().options.offset.bottom[1] < 0, 'popup is vertically offset somewhere above the tip');
     t.ok(marker.getPopup().options.offset.top[1] === 0, 'popup is vertically offset at the tip');
@@ -296,34 +299,42 @@ test('Popup anchors around default Marker', (t) => {
     Object.defineProperty(marker.getPopup()._container, 'offsetHeight', {value: 100});
 
     // marker should default to above since it has enough space
+    map._domRenderTaskQueue.run();
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-bottom'), 'popup anchors above marker');
 
     // move marker to the top forcing the popup to below
     marker.setLngLat(map.unproject([mapHeight / 2, markerTop]));
+    map._domRenderTaskQueue.run();
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-top'), 'popup anchors below marker');
 
     // move marker to the right forcing the popup to the left
     marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight / 2]));
+    map._domRenderTaskQueue.run();
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-right'), 'popup anchors left of marker');
 
     // move marker to the left forcing the popup to the right
     marker.setLngLat(map.unproject([markerRight, mapHeight / 2]));
+    map._domRenderTaskQueue.run();
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-left'), 'popup anchors right of marker');
 
     // move marker to the top left forcing the popup to the bottom right
     marker.setLngLat(map.unproject([markerRight, markerTop]));
+    map._domRenderTaskQueue.run();
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-top-left'), 'popup anchors bottom right of marker');
 
     // move marker to the top right forcing the popup to the bottom left
     marker.setLngLat(map.unproject([mapHeight - markerRight, markerTop]));
+    map._domRenderTaskQueue.run();
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-top-right'), 'popup anchors bottom left of marker');
 
     // move marker to the bottom left forcing the popup to the top right
     marker.setLngLat(map.unproject([markerRight, mapHeight]));
+    map._domRenderTaskQueue.run();
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-bottom-left'), 'popup anchors top right of marker');
 
     // move marker to the bottom right forcing the popup to the top left
     marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight]));
+    map._domRenderTaskQueue.run();
     t.ok(marker.getPopup()._container.classList.contains('mapboxgl-popup-anchor-bottom-right'), 'popup anchors top left of marker');
 
     t.end();
@@ -725,11 +736,13 @@ test('Marker transforms rotation with the map', (t) => {
     const marker = new Marker({rotationAlignment: 'map'})
         .setLngLat([0, 0])
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     const rotationRegex = /rotateZ\(-?([0-9]+)deg\)/;
     const initialRotation = marker.getElement().style.transform.match(rotationRegex)[1];
 
     map.setBearing(map.getBearing() + 180);
+    map._domRenderTaskQueue.run();
 
     const finalRotation = marker.getElement().style.transform.match(rotationRegex)[1];
     t.notEqual(initialRotation, finalRotation);
@@ -745,11 +758,13 @@ test('Marker transforms pitch with the map', (t) => {
         .addTo(map);
 
     map.setPitch(0);
+    map._domRenderTaskQueue.run();
 
     const rotationRegex = /rotateX\(-?([0-9]+)deg\)/;
     const initialPitch = marker.getElement().style.transform.match(rotationRegex)[1];
 
     map.setPitch(45);
+    map._domRenderTaskQueue.run();
 
     const finalPitch = marker.getElement().style.transform.match(rotationRegex)[1];
     t.notEqual(initialPitch, finalPitch);

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -393,6 +393,7 @@ test('Popup anchors as specified by the anchor option', (t) => {
         .setLngLat([0, 0])
         .setText('Test')
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     t.ok(popup.getElement().classList.contains('mapboxgl-popup-anchor-top-left'));
     t.end();
@@ -419,6 +420,7 @@ test('Popup anchors as specified by the anchor option', (t) => {
             .setLngLat([0, 0])
             .setText('Test')
             .addTo(map);
+        map._domRenderTaskQueue.run();
 
         Object.defineProperty(popup.getElement(), 'offsetWidth', {value: 100});
         Object.defineProperty(popup.getElement(), 'offsetHeight', {value: 100});
@@ -426,6 +428,7 @@ test('Popup anchors as specified by the anchor option', (t) => {
         t.stub(map, 'project').returns(point);
         t.stub(map.transform, 'locationPoint3D').returns(point);
         popup.setLngLat([0, 0]);
+        map._domRenderTaskQueue.run();
 
         t.ok(popup.getElement().classList.contains(`mapboxgl-popup-anchor-${anchor}`));
         t.end();
@@ -440,6 +443,7 @@ test('Popup anchors as specified by the anchor option', (t) => {
             .setLngLat([0, 0])
             .setText('Test')
             .addTo(map);
+        map._domRenderTaskQueue.run();
 
         t.equal(popup.getElement().style.transform, transform);
         t.end();
@@ -457,12 +461,14 @@ test('Popup automatically anchors to top if its bottom offset would push it off-
         .setLngLat([0, 0])
         .setText('Test')
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     Object.defineProperty(popup.getElement(), 'offsetWidth', {value: containerWidth / 2});
     Object.defineProperty(popup.getElement(), 'offsetHeight', {value: containerHeight / 2});
 
     t.stub(map, 'project').returns(point);
     popup.setLngLat([0, 0]);
+    map._domRenderTaskQueue.run();
 
     t.ok(popup.getElement().classList.contains('mapboxgl-popup-anchor-top'));
     t.end();
@@ -477,6 +483,7 @@ test('Popup is offset via a PointLike offset option', (t) => {
         .setLngLat([0, 0])
         .setText('Test')
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     t.equal(popup.getElement().style.transform, 'translate(0,0) translate(5px,10px)');
     t.end();
@@ -491,6 +498,7 @@ test('Popup is offset via an object offset option', (t) => {
         .setLngLat([0, 0])
         .setText('Test')
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     t.equal(popup.getElement().style.transform, 'translate(0,0) translate(5px,10px)');
     t.end();
@@ -505,6 +513,7 @@ test('Popup is offset via an incomplete object offset option', (t) => {
         .setLngLat([0, 0])
         .setText('Test')
         .addTo(map);
+    map._domRenderTaskQueue.run();
 
     t.equal(popup.getElement().style.transform, 'translate(-100%,0) translate(0px,0px)');
     t.end();


### PR DESCRIPTION
I noticed there was a lot of DOM reflow in case someone adds markers, popups and other DOM-based elements to the map. This can be visible in the `debug/markers.html` page. [You can read how to avoid this problem here.](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)

What I am proposing is adding a DOM rendering queue on the map, similar to the current render queue, in which you can add all DOM-related layout changes. Note that I tried to use the existing render queue, but the result was that DOM elements were updated too late, so there were moving with a delay on screen.

I am not really sure if this change fits the current architecture, so feel free to direct me where to move this new behavior.

There may also be others places where to apply those changes, as I applied it only where I thought it was relevant.


## Performance
You can see below the difference in the call stack in the `markers.html` page. From manual testing, I would say that the concerned part has seen its time reduced by 5x-10x.

### Before
![Capture d’écran 2021-04-01 à 09 19 53](https://user-images.githubusercontent.com/741255/113259113-0f71cf80-92cd-11eb-8f1f-863da72b0d07.png)
![Capture d’écran 2021-04-01 à 09 21 12](https://user-images.githubusercontent.com/741255/113259125-13055680-92cd-11eb-9f6c-d5e1076f8fba.png)

### After
![Capture d’écran 2021-04-01 à 12 36 08](https://user-images.githubusercontent.com/741255/113282173-df372a80-92e6-11eb-957a-c91872f46b2f.png)
![Capture d’écran 2021-04-01 à 09 57 55](https://user-images.githubusercontent.com/741255/113262318-c3288e80-92d0-11eb-99d5-90a69b6bdcfc.png)


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals
 - [x] manually test the debug page
