### PR TITLE
Add haziness property to fog

### DIFF
--- a/debug/fog.html
+++ b/debug/fog.html
@@ -36,6 +36,9 @@ var GUIParams = function() {
     this.fogRangeStart = 1.5;
     this.fogRangeEnd = 2.0;
     this.fogColor = [255, 255, 255];
+    this.fogHazeColor = [109, 123, 180];
+    this.fogHazeEnergy = 1.0;
+    this.fogStrength = 1.0;
     this.fogSkyBlend = 0.1;
     this.showTileBoundaries = false;
 };
@@ -100,35 +103,59 @@ window.onload = function() {
         map.setFog(value ? {
             "range": [guiParams.fogRangeStart, guiParams.fogRangeEnd],
             "color": 'rgba(' + guiParams.fogColor[0] + ', ' + guiParams.fogColor[1] + ', ' + guiParams.fogColor[2] + ', 1.0)',
+            "haze-color": 'rgba(' + guiParams.fogHazeColor[0] + ', ' + guiParams.fogHazeColor[1] + ', ' + guiParams.fogHazeColor[2] + ', 1.0)',
+            "haze-energy": guiParams.fogHazeEnergy,
+            "strength": guiParams.fogStrength,
             "sky-blend": guiParams.fogSkyBlend
         } : null);
     });
 
-    var fogColor = fog.addColor(guiParams, 'fogColor');
-    fogColor.onFinishChange((value) => {
-        map.setFog({
-            "color": 'rgba(' + value[0] + ', ' + value[1] + ', ' + value[2] + ', 1.0)',
-        });
-    });
-
     var fogRangeStart = fog.add(guiParams, 'fogRangeStart', 0.0, 15.0);
-    fogRangeStart.onFinishChange((value) => {
+    fogRangeStart.onChange((value) => {
         map.setFog({
             "range": [value, guiParams.fogRangeEnd],
         });
     });
 
     var fogRangeEnd = fog.add(guiParams, 'fogRangeEnd', 0.0, 15.0);
-    fogRangeEnd.onFinishChange((value) => {
+    fogRangeEnd.onChange((value) => {
         map.setFog({
             "range": [guiParams.fogRangeStart, value],
         });
     });
 
+    var fogStrength = fog.add(guiParams, 'fogStrength', 0, 1);
+    fogStrength.onChange((value) => {
+        map.setFog({
+            "strength": value,
+        });
+    });
+
+    var fogHazeEnergy = fog.add(guiParams, 'fogHazeEnergy', 0, 2);
+    fogHazeEnergy.onChange((value) => {
+        map.setFog({
+            "haze-energy": value,
+        });
+    });
+
     var fogSkyBlend = fog.add(guiParams, 'fogSkyBlend', 0.0, 1.0);
-    fogSkyBlend.onFinishChange((value) => {
+    fogSkyBlend.onChange((value) => {
         map.setFog({
             "sky-blend": value,
+        });
+    });
+
+    var fogColor = fog.addColor(guiParams, 'fogColor');
+    fogColor.onChange((value) => {
+        map.setFog({
+            "color": 'rgba(' + value[0] + ', ' + value[1] + ', ' + value[2] + ', 1.0)',
+        });
+    });
+
+    var fogHazeColor = fog.addColor(guiParams, 'fogHazeColor');
+    fogHazeColor.onChange((value) => {
+        map.setFog({
+            "haze-color": 'rgba(' + value[0] + ', ' + value[1] + ', ' + value[2] + ', 1.0)',
         });
     });
 };
@@ -190,6 +217,9 @@ map.on('style.load', function() {
     map.setFog(guiParams.enableFog ? {
         "range": [guiParams.fogRangeStart, guiParams.fogRangeEnd],
         "color": 'rgba(' + guiParams.fogColor[0] + ', ' + guiParams.fogColor[1] + ', ' + guiParams.fogColor[2] + ', 1.0)',
+        "haze-color": 'rgba(' + guiParams.fogHazeColor[0] + ', ' + guiParams.fogHazeColor[1] + ', ' + guiParams.fogHazeColor[2] + ', 1.0)',
+        "strength": guiParams.fogStrength,
+        "haze-energy": guiParams.fogHazeEnergy,
         "sky-blend": guiParams.fogSkyBlend
     } : null);
 

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -673,7 +673,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 }
 
 .mapboxgl-marker-occluded {
-    opacity: 0.0;
+    opacity: 0;
 }
 
 .mapboxgl-marker-occluded-low {

--- a/src/render/fog.js
+++ b/src/render/fog.js
@@ -9,16 +9,22 @@ export type FogUniformsType = {|
     'u_cam_matrix': UniformMatrix4f,
     'u_fog_range': Uniform2f,
     'u_fog_color': Uniform3f,
+    'u_fog_exponent': Uniform1f,
     'u_fog_opacity': Uniform1f,
     'u_fog_sky_blend': Uniform1f,
     'u_fog_temporal_offset': Uniform1f,
+    'u_haze_color_linear': Uniform3f,
+    'u_haze_energy': Uniform1f,
 |};
 
 export const fogUniforms = (context: Context, locations: UniformLocations): FogUniformsType => ({
     'u_cam_matrix': new UniformMatrix4f(context, locations.u_cam_matrix),
     'u_fog_range': new Uniform2f(context, locations.u_fog_range),
     'u_fog_color': new Uniform3f(context, locations.u_fog_color),
+    'u_fog_exponent': new Uniform1f(context, locations.u_fog_exponent),
     'u_fog_opacity': new Uniform1f(context, locations.u_fog_opacity),
     'u_fog_sky_blend': new Uniform1f(context, locations.u_fog_sky_blend),
     'u_fog_temporal_offset': new Uniform1f(context, locations.u_fog_temporal_offset),
+    'u_haze_color_linear': new Uniform3f(context, locations.u_haze_color_linear),
+    'u_haze_energy': new Uniform1f(context, locations.u_haze_energy),
 });

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -844,6 +844,7 @@ class Painter {
             const temporalOffset = (this.frameCounter / 1000.0) % 1;
             const fogColor = fog.properties.get('color');
             const hazeColor = fog.properties.get('haze-color');
+            const hazeColorLinear = [Math.pow(hazeColor.r, 2.2), Math.pow(hazeColor.g, 2.2), Math.pow(hazeColor.b, 2.2)];
             const uniforms = {};
 
             uniforms['u_cam_matrix'] = tileID ? this.transform.calculateCameraMatrix(tileID) : this.identityMat;
@@ -853,7 +854,7 @@ class Painter {
             uniforms['u_fog_opacity'] = fog.getFogPitchFactor(this.transform.pitch);
             uniforms['u_fog_sky_blend'] = fog.properties.get('sky-blend');
             uniforms['u_fog_temporal_offset'] = temporalOffset;
-            uniforms['u_haze_color_linear'] = [hazeColor.r, hazeColor.g, hazeColor.b].map(c => Math.pow(c, 2.2));
+            uniforms['u_haze_color_linear'] = hazeColorLinear;
             uniforms['u_haze_energy'] = fog.properties.get('haze-energy');
 
             program.setFogUniformValues(context, uniforms);

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -760,7 +760,7 @@ class Painter {
         // rendering. Removing the fog flag during tile rendering avoids additional defines.
         if (fog && !rtt) {
             defines.push('FOG');
-            if (haze) defines.push('HAZE');
+            if (haze) defines.push('FOG_HAZE');
         }
         if (rtt) defines.push('RENDER_TO_TEXTURE');
         if (this._showOverdrawInspector) defines.push('OVERDRAW_INSPECTOR');

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -158,7 +158,9 @@ class Program<Us: UniformBindings> {
         context.program.set(this.program);
 
         for (const name in fogUniformsValues) {
-            uniforms[name].set(fogUniformsValues[name]);
+            if (uniforms[name].location) {
+                uniforms[name].set(fogUniformsValues[name]);
+            }
         }
     }
 

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -28,3 +28,12 @@ vec3 dither(vec3 color, highp vec2 seed) {
     vec3 rnd = hash(seed) + hash(seed + 0.59374) - 0.5;
     return color + rnd / 255.0;
 }
+
+vec3 linear_to_srgb(vec3 color) {
+    return pow(color, vec3(1.0 / 2.2));
+}
+
+vec3 srgb_to_linear(vec3 color) {
+    return pow(color, vec3(2.2));
+}
+

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -25,10 +25,11 @@ float fog_sky_blending(vec3 camera_dir) {
     return u_fog_opacity * exp(-3.0 * t * t);
 }
 
-// This function gives the fog opacity when strength is 1. Otherwise it's multiplied
+// Computes the fog opacity when fog strength = 1. Otherwise it's multiplied
 // by a smoothstep to a power to decrease the amount of fog relative to haze.
-// This function much match src/style/fog.js
+//   - t: depth, rescaled to 0 at fogStart and 1 at fogEnd
 // See: https://www.desmos.com/calculator/3taufutxid
+// This function much match src/style/fog.js
 float fog_opacity(float t) {
     const float decay = 6.0;
     float falloff = 1.0 - min(1.0, exp(-decay * t));
@@ -40,6 +41,8 @@ float fog_opacity(float t) {
     return u_fog_opacity * min(1.0, 1.00747 * falloff);
 }
 
+// This function is only used in rare places like heatmap where opacity is used
+// directly, outside the normal fog_apply method.
 float fog_opacity (vec3 pos) {
     return fog_opacity((length(pos) - u_fog_range.x) / (u_fog_range.y - u_fog_range.x));
 }
@@ -51,7 +54,7 @@ vec3 fog_apply(vec3 color, vec3 pos) {
     float haze_opac = fog_opacity(pos);
     float fog_opac = haze_opac * pow(smoothstep(0.0, 1.0, t), u_fog_exponent);
 
-#ifdef HAZE
+#ifdef FOG_HAZE
     vec3 haze = (haze_opac * u_haze_energy) * u_haze_color_linear;
 
     // The smoothstep fades in tonemapping slightly before the fog layer. This causes

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3731,6 +3731,71 @@
         }
       }
     },
+    "haze-color": {
+      "type": "color",
+      "property-type": "data-constant",
+      "default": "#7287d5",
+      "expression": {
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      },
+      "transition": true,
+      "doc": "",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "",
+          "android": "",
+          "ios": "",
+          "macos": ""
+        }
+      }
+    },
+    "strength": {
+      "type": "number",
+      "property-type": "data-constant",
+      "default": 1.0,
+      "minimum": 0.0,
+      "expression": {
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      },
+      "transition": true,
+      "doc": "",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "",
+          "android": "",
+          "ios": "",
+          "macos": ""
+        }
+      }
+    },
+    "haze-energy": {
+      "type": "number",
+      "property-type": "data-constant",
+      "default": 1.0,
+      "minimum": 0.0,
+      "expression": {
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      },
+      "transition": true,
+      "doc": "",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "",
+          "android": "",
+          "ios": "",
+          "macos": ""
+        }
+      }
+    },
     "sky-blend": {
       "type": "number",
       "property-type": "data-constant",

--- a/src/style-spec/types.js
+++ b/src/style-spec/types.js
@@ -91,7 +91,8 @@ export type FogSpecification = {|
     "range"?: PropertyValueSpecification<[number, number]>,
     "color"?: PropertyValueSpecification<ColorSpecification>,
     "haze-color"?: PropertyValueSpecification<ColorSpecification>,
-    "haziness"?: PropertyValueSpecification<number>,
+    "strength"?: PropertyValueSpecification<number>,
+    "haze-energy"?: PropertyValueSpecification<number>,
     "sky-blend"?: PropertyValueSpecification<number>
 |}
 

--- a/src/style-spec/types.js
+++ b/src/style-spec/types.js
@@ -90,6 +90,8 @@ export type TerrainSpecification = {|
 export type FogSpecification = {|
     "range"?: PropertyValueSpecification<[number, number]>,
     "color"?: PropertyValueSpecification<ColorSpecification>,
+    "haze-color"?: PropertyValueSpecification<ColorSpecification>,
+    "haziness"?: PropertyValueSpecification<number>,
     "sky-blend"?: PropertyValueSpecification<number>
 |}
 

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -77,8 +77,6 @@ export class FogSampler {
         // Account for fog strength
         falloff *= Math.pow(smoothstep(0, 1, t), fogExponent);
 
-        // We may wish to account for haze's effect on obscuring symbols
-
         return falloff * fogOpacity;
     }
 


### PR DESCRIPTION
***Update***: *I've updated the following description to match the current state of the PR.*

This PR adds a "haziness" property to fog. The requirements of this PR are to:

- improve the visual appearance of a (not-physically-based) atmosphere
- not interfere with fog as currently implemented
- add minimal cost to the rendering

A big additional advantage is that haze is more nicely visible than fog without looking like pea soup. It accomplishes this by simply adding the haze color and then tone-mapping the result to avoid blown out colors. It's too bad this isn't even minimally based on a proper atmospheric model so that it would match time of day with the skybox. It might be possible without excessive computational or implementation cost, but I don't know if that's reasonable to add at this time.

It adds three properties to fog:

- `strength`: [0, 1]: how strong is the fog? Fog layers on top of haze, and as this goes to zero, you're left with just haze.
- `haze-color`: Color of the haze
- `haze-energy`: A multiplicative factor for the fog color. Overlaps with the lightness of haze-color but allows you to change the amount of haze without changing its color.

When the haze color is black, haze disappears. When `haze-energy` is zero, it exactly reduces to fog.

When fog strength decreases, it multiplies fog opacity by smoothstep to a power. This has the effect of pushing it away from the camera but looks much, much less like it's literally changing the near/far limits, which was very obvious and distracting. Raising the fog opacity to a power has the effect of delaying the onset of fog relative to haze:

![easing](https://user-images.githubusercontent.com/572717/113467638-27df0880-93f9-11eb-9aa9-4cf64efaa313.gif)

Haze is computed with the following algorithm:

1. convert the color from srgb -> linear rgb
2. add haze opacity * haze color
3. tone-map the result (see: https://www.desmos.com/calculator/vb9fax8pc2 )
4. convert the result from linear rgb -> srgb
5. mix the tone-mapped result with the original input color so that unaffected regions are not tone-mapped (bright spots like glaciers otherwise get slightly darkened by tone-mapping)
5. compute fog by mixing colors with the previous algorithm

haze-energy=0, fog-strength=1:

![Screen Shot 2021-04-02 at 9 00 30 PM copy](https://user-images.githubusercontent.com/572717/113467412-b18dd680-93f7-11eb-830b-34f536f8dacb.jpg)

haze-energy=1, fog-strength=0:

![Screen Shot 2021-04-02 at 9 23 00 PM copy](https://user-images.githubusercontent.com/572717/113467720-b9e71100-93f9-11eb-8cd7-b96f51e51226.jpg)
