### PR TITLE
Add basic symbol clipping when fog opacity is high

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -44,7 +44,7 @@ import ResolvedImage from '../../style-spec/expression/types/resolved_image.js';
 import {plugin as globalRTLTextPlugin, getRTLTextPluginStatus} from '../../source/rtl_text_plugin.js';
 import {mat4} from 'gl-matrix';
 
-import type {CanonicalTileID} from '../../source/tile_id.js';
+import type {CanonicalTileID, OverscaledTileID} from '../../source/tile_id.js';
 import type {
     Bucket,
     BucketParameters,
@@ -61,7 +61,6 @@ import type {SymbolQuad} from '../../symbol/quads.js';
 import type {SizeData} from '../../symbol/symbol_size.js';
 import type {FeatureStates} from '../../source/source_state.js';
 import type {ImagePosition} from '../../render/image_atlas.js';
-
 export type SingleCollisionBox = {
     x1: number;
     y1: number;
@@ -71,6 +70,7 @@ export type SingleCollisionBox = {
     anchorPointX: number;
     anchorPointY: number;
     elevation?: number;
+    tileID?: OverscaledTileID;
 };
 
 export type CollisionArrays = {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1489,14 +1489,15 @@ class Transform {
         const cameraPixelsPerMeter = this.cameraPixelsPerMeter;
         const cameraPos = this._camera.position;
 
+        const windowScaleFactor = 1.0 / this.height;
         m = mat4.create();
+        mat4.fromScaling(m, [windowScaleFactor, windowScaleFactor, windowScaleFactor]);
         const metersToPixel = [cameraWorldSize, cameraWorldSize, cameraPixelsPerMeter];
         mat4.translate(m, m, vec3.multiply(cameraPos, vec3.scale(cameraPos, cameraPos, -1), metersToPixel));
         mat4.scale(m, m, metersToPixel);
         this.mercatorFogMatrix = m;
 
         // matrix for conversion from tile coordinates to relative camera position in units of fractions of the map height
-        const windowScaleFactor = 1.0 / this.height;
         this.cameraMatrix = this._camera.getWorldToCameraPosition(cameraWorldSize, cameraPixelsPerMeter, windowScaleFactor);
 
         // inverse matrix for conversion from screen coordinates to location

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1490,9 +1490,9 @@ class Transform {
         const cameraPos = this._camera.position;
 
         const windowScaleFactor = 1.0 / this.height;
-        m = mat4.create();
-        mat4.fromScaling(m, [windowScaleFactor, windowScaleFactor, windowScaleFactor]);
         const metersToPixel = [cameraWorldSize, cameraWorldSize, cameraPixelsPerMeter];
+        vec3.scale(metersToPixel, metersToPixel, windowScaleFactor);
+        m = mat4.create();
         mat4.translate(m, m, vec3.multiply(cameraPos, vec3.scale(cameraPos, cameraPos, -1), metersToPixel));
         mat4.scale(m, m, metersToPixel);
         this.mercatorFogMatrix = m;

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -19,7 +19,7 @@ import shaders from '../shaders/shaders.js';
 import Program from './program.js';
 import {programUniforms} from './program/program_uniforms.js';
 import Context from '../gl/context.js';
-import {FOG_PITCH_END} from '../style/fog.js';
+import {FOG_PITCH_END} from '../style/fog_helpers.js';
 import DepthMode from '../gl/depth_mode.js';
 import StencilMode from '../gl/stencil_mode.js';
 import ColorMode from '../gl/color_mode.js';

--- a/src/style/fog_helpers.js
+++ b/src/style/fog_helpers.js
@@ -16,7 +16,7 @@ export type FogState = {
 };
 
 // As defined in _prelude_fog.fragment.glsl#fog_opacity
-export function getFogOpacity(state: FogState, depthPx: number, pitch: number): number {
+export function getFogOpacity(state: FogState, depth: number, pitch: number): number {
     const fogOpacity = smoothstep(FOG_PITCH_START, FOG_PITCH_END, pitch);
     const [start, end] = state.range;
     const fogStrength = state.strength;
@@ -32,7 +32,7 @@ export function getFogOpacity(state: FogState, depthPx: number, pitch: number): 
     // https://www.desmos.com/calculator/3taufutxid
     // The output of this function should match src/shaders/_prelude_fog.fragment.glsl
     const decay = 6;
-    const t = (depthPx - start) / (end - start);
+    const t = (depth - start) / (end - start);
     let falloff = 1.0 - Math.min(1, Math.exp(-decay * t));
 
     // Cube without pow()

--- a/src/style/fog_helpers.js
+++ b/src/style/fog_helpers.js
@@ -16,7 +16,7 @@ export type FogState = {
 };
 
 // As defined in _prelude_fog.fragment.glsl#fog_opacity
-export function getFogOpacity(state: FogState, depthPx: number, pitch: number, heightPx: number): number {
+export function getFogOpacity(state: FogState, depthPx: number, pitch: number): number {
     const fogOpacity = smoothstep(FOG_PITCH_START, FOG_PITCH_END, pitch);
     const [start, end] = state.range;
     const fogStrength = state.strength;
@@ -32,7 +32,7 @@ export function getFogOpacity(state: FogState, depthPx: number, pitch: number, h
     // https://www.desmos.com/calculator/3taufutxid
     // The output of this function should match src/shaders/_prelude_fog.fragment.glsl
     const decay = 6;
-    const t = (depthPx / heightPx - start) / (end - start);
+    const t = (depthPx - start) / (end - start);
     let falloff = 1.0 - Math.min(1, Math.exp(-decay * t));
 
     // Cube without pow()
@@ -56,7 +56,7 @@ export function getOpacityAtTileCoord(state: FogState, x: number, y: number, z: 
     vec3.transformMat4(pos, pos, mat);
     const depth = vec3.length(pos);
 
-    return getFogOpacity(state, depth, transform.pitch, transform.height);
+    return getFogOpacity(state, depth, transform.pitch);
 }
 
 export function getFogOpacityAtLatLng(state: FogState, lngLat: LngLat, transform: Transform): number {
@@ -66,5 +66,5 @@ export function getFogOpacityAtLatLng(state: FogState, lngLat: LngLat, transform
     vec3.transformMat4(pos, pos, transform.mercatorFogMatrix);
     const depth = vec3.length(pos);
 
-    return getFogOpacity(state, depth, transform.pitch, transform.height);
+    return getFogOpacity(state, depth, transform.pitch);
 }

--- a/src/style/fog_helpers.js
+++ b/src/style/fog_helpers.js
@@ -1,0 +1,70 @@
+// @flow
+import {vec3} from 'gl-matrix';
+import MercatorCoordinate from '../geo/mercator_coordinate.js';
+import {smoothstep} from '../util/util.js';
+import type LngLat from '../geo/lng_lat.js';
+import type {UnwrappedTileID} from '../source/tile_id.js';
+import type Transform from '../geo/transform.js';
+
+export const FOG_PITCH_START = 55;
+export const FOG_PITCH_END = 65;
+export const FOG_SYMBOL_CLIPPING_THRESHOLD = 0.9;
+
+export type FogState = {
+    range: [number, number],
+    strength: number
+};
+
+// As defined in _prelude_fog.fragment.glsl#fog_opacity
+export function getFogOpacity(state: FogState, depthPx: number, pitch: number, heightPx: number): number {
+    const fogOpacity = smoothstep(FOG_PITCH_START, FOG_PITCH_END, pitch);
+    const [start, end] = state.range;
+    const fogStrength = state.strength;
+
+    // The fog is not physically accurate, so we seek an expression which satisfies a
+    // couple basic constraints:
+    //   - opacity should be 0 at the near limit
+    //   - opacity should be 1 at the far limit
+    //   - the onset should have smooth derivatives to avoid a sharp band
+    // To this end, we use an (1 - e^x)^n, where n is set to 3 to ensure the
+    // function is C2 continuous at the onset. The fog is about 99% opaque at
+    // the far limit, so we simply scale it and clip to achieve 100% opacity.
+    // https://www.desmos.com/calculator/3taufutxid
+    // The output of this function should match src/shaders/_prelude_fog.fragment.glsl
+    const decay = 6;
+    const t = (depthPx / heightPx - start) / (end - start);
+    let falloff = 1.0 - Math.min(1, Math.exp(-decay * t));
+
+    // Cube without pow()
+    falloff *= falloff * falloff;
+
+    // Scale and clip to 1 at the far limit
+    falloff = Math.min(1.0, 1.00747 * falloff);
+
+    // From src/render/painter.js via fog uniforms:
+    const fogExponent = 12 * Math.pow(1 - fogStrength, 2);
+
+    // Account for fog strength
+    falloff *= Math.pow(smoothstep(0, 1, t), fogExponent);
+
+    return falloff * fogOpacity;
+}
+
+export function getOpacityAtTileCoord(state: FogState, x: number, y: number, z: number, tileId: UnwrappedTileID, transform: Transform): number {
+    const mat = transform.calculateCameraMatrix(tileId);
+    const pos = [x, y, z];
+    vec3.transformMat4(pos, pos, mat);
+    const depth = vec3.length(pos);
+
+    return getFogOpacity(state, depth, transform.pitch, transform.height);
+}
+
+export function getFogOpacityAtLatLng(state: FogState, lngLat: LngLat, transform: Transform): number {
+    const meters = MercatorCoordinate.fromLngLat(lngLat);
+    const elevation = transform.elevation ? transform.elevation.getAtPoint(meters) : 0;
+    const pos = [meters.x, meters.y, elevation];
+    vec3.transformMat4(pos, pos, transform.mercatorFogMatrix);
+    const depth = vec3.length(pos);
+
+    return getFogOpacity(state, depth, transform.pitch, transform.height);
+}

--- a/src/style/pauseable_placement.js
+++ b/src/style/pauseable_placement.js
@@ -9,6 +9,7 @@ import type StyleLayer from './style_layer.js';
 import type SymbolStyleLayer from './style_layer/symbol_style_layer.js';
 import type Tile from '../source/tile.js';
 import type {BucketPart} from '../symbol/placement.js';
+import type {FogState} from './fog_helpers.js';
 
 class LayerPlacement {
     _sortAcrossTiles: boolean;
@@ -72,9 +73,10 @@ class PauseablePlacement {
                 showCollisionBoxes: boolean,
                 fadeDuration: number,
                 crossSourceCollisions: boolean,
-                prevPlacement?: Placement) {
+                prevPlacement?: Placement,
+                fogState: ?FogState) {
 
-        this.placement = new Placement(transform, fadeDuration, crossSourceCollisions, prevPlacement);
+        this.placement = new Placement(transform, fadeDuration, crossSourceCollisions, prevPlacement, fogState);
         this._currentPlacementIndex = order.length - 1;
         this._forceFullPlacement = forceFullPlacement;
         this._showCollisionBoxes = showCollisionBoxes;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1641,7 +1641,7 @@ class Style extends Evented {
         }
 
         if (forceFullPlacement || !this.pauseablePlacement || (this.pauseablePlacement.isDone() && !this.placement.stillRecent(browser.now(), transform.zoom))) {
-            this.pauseablePlacement = new PauseablePlacement(transform, this._order, forceFullPlacement, showCollisionBoxes, fadeDuration, crossSourceCollisions, this.placement);
+            this.pauseablePlacement = new PauseablePlacement(transform, this._order, forceFullPlacement, showCollisionBoxes, fadeDuration, crossSourceCollisions, this.placement, this.fog ? this.fog.state : null);
             this._layerOrderChanged = false;
         }
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -151,6 +151,7 @@ class Style extends Evented {
     _updatedPaintProps: {[layer: string]: true};
     _layerOrderChanged: boolean;
     _availableImages: Array<string>;
+    _markersNeedUpdate: boolean;
 
     crossTileSymbolIndex: CrossTileSymbolIndex;
     pauseablePlacement: PauseablePlacement;
@@ -190,6 +191,7 @@ class Style extends Evented {
         this._availableImages = [];
         this._order  = [];
         this._drapedFirstOrder = [];
+        this._markersNeedUpdate = false;
 
         this._resetUpdates();
 
@@ -528,6 +530,11 @@ class Style extends Evented {
             this.fog.recalculate(parameters);
         }
         this.z = parameters.zoom;
+
+        if (this._markersNeedUpdate) {
+            this._updateMarkersOpacity();
+            this._markersNeedUpdate = false;
+        }
 
         if (changed) {
             this.fire(new Event('data', {dataType: 'style'}));
@@ -1396,7 +1403,7 @@ class Style extends Evented {
             delete this.stylesheet.terrain;
             this.dispatcher.broadcast('enableTerrain', false);
             this._force3DLayerUpdate();
-            this._updateMarkersOpacity();
+            this._markersNeedUpdate = true;
             return;
         }
 
@@ -1433,7 +1440,7 @@ class Style extends Evented {
         }
 
         this._updateDrapeFirstLayers();
-        this._updateMarkersOpacity();
+        this._markersNeedUpdate = true;
     }
 
     _createFog(fogOptions: FogSpecification) {
@@ -1469,7 +1476,7 @@ class Style extends Evented {
             // Remove fog
             delete this.fog;
             delete this.stylesheet.fog;
-            this._updateMarkersOpacity();
+            this._markersNeedUpdate = true;
             return;
         }
 
@@ -1497,7 +1504,7 @@ class Style extends Evented {
             }
         }
 
-        this._updateMarkersOpacity();
+        this._markersNeedUpdate = true;
     }
 
     _updateDrapeFirstLayers() {

--- a/src/symbol/collision_index.js
+++ b/src/symbol/collision_index.js
@@ -8,6 +8,7 @@ import * as intersectionTests from '../util/intersection_tests.js';
 import Grid from './grid_index.js';
 import {mat4, vec4} from 'gl-matrix';
 import ONE_EM from '../symbol/one_em.js';
+import {FOG_SYMBOL_CLIPPING_THRESHOLD, getOpacityAtTileCoord} from '../style/fog_helpers.js';
 import assert from 'assert';
 
 import * as projection from '../symbol/projection.js';
@@ -17,6 +18,7 @@ import type {
     GlyphOffsetArray,
     SymbolLineVertexArray
 } from '../data/array_types.js';
+import type {FogState} from '../style/fog_helpers.js';
 import {OverscaledTileID} from '../source/tile_id.js';
 
 // When a symbol crosses the edge that causes it to be included in
@@ -48,9 +50,11 @@ class CollisionIndex {
     screenBottomBoundary: number;
     gridRightBoundary: number;
     gridBottomBoundary: number;
+    fogState: ?FogState;
 
     constructor(
         transform: Transform,
+        fogState: ?FogState,
         grid: Grid = new Grid(transform.width + 2 * viewportPadding, transform.height + 2 * viewportPadding, 25),
         ignoredGrid: Grid = new Grid(transform.width + 2 * viewportPadding, transform.height + 2 * viewportPadding, 25)
     ) {
@@ -64,11 +68,12 @@ class CollisionIndex {
         this.screenBottomBoundary = transform.height + viewportPadding;
         this.gridRightBoundary = transform.width + 2 * viewportPadding;
         this.gridBottomBoundary = transform.height + 2 * viewportPadding;
+        this.fogState = fogState;
     }
 
     placeCollisionBox(scale: number, collisionBox: SingleCollisionBox, shift: Point, allowOverlap: boolean, textPixelRatio: number, posMatrix: mat4, collisionGroupPredicate?: any): { box: Array<number>, offscreen: boolean } {
         assert(!this.transform.elevation || collisionBox.elevation !== undefined);
-        const projectedPoint = this.projectAndGetPerspectiveRatio(posMatrix, collisionBox.anchorPointX, collisionBox.anchorPointY, collisionBox.elevation);
+        const projectedPoint = this.projectAndGetPerspectiveRatio(posMatrix, collisionBox.anchorPointX, collisionBox.anchorPointY, collisionBox.elevation, collisionBox.tileID);
         const tileToViewport = textPixelRatio * projectedPoint.perspectiveRatio;
         const tlX = (collisionBox.x1 * scale + shift.x - collisionBox.padding) * tileToViewport + projectedPoint.point.x;
         const tlY = (collisionBox.y1 * scale + shift.y - collisionBox.padding) * tileToViewport + projectedPoint.point.y;
@@ -116,7 +121,7 @@ class CollisionIndex {
 
         const tileUnitAnchorPoint = new Point(symbol.anchorX, symbol.anchorY);
         const anchorElevation = getElevation(tileUnitAnchorPoint);
-        const screenAnchorPoint = this.projectAndGetPerspectiveRatio(posMatrix, tileUnitAnchorPoint.x, tileUnitAnchorPoint.y, anchorElevation);
+        const screenAnchorPoint = this.projectAndGetPerspectiveRatio(posMatrix, tileUnitAnchorPoint.x, tileUnitAnchorPoint.y, anchorElevation, tileID);
         const {perspectiveRatio} = screenAnchorPoint;
         const labelPlaneFontSize = pitchWithMap ? fontSize / perspectiveRatio : fontSize * perspectiveRatio;
         const labelPlaneFontScale = labelPlaneFontSize / ONE_EM;
@@ -355,12 +360,19 @@ class CollisionIndex {
         }
     }
 
-    projectAndGetPerspectiveRatio(posMatrix: mat4, x: number, y: number, elevation?: number) {
+    projectAndGetPerspectiveRatio(posMatrix: mat4, x: number, y: number, elevation?: number, tileID: ?OverscaledTileID) {
         const p = [x, y, elevation || 0, 1];
         let aboveHorizon = false;
         if (elevation || this.transform.pitch > 0) {
             vec4.transformMat4(p, p, posMatrix);
-            aboveHorizon = p[2] > p[3];
+
+            let behindFog = false;
+            if (this.fogState && tileID) {
+                const fogOpacity = getOpacityAtTileCoord(this.fogState, x, y, elevation || 0, tileID.toUnwrapped(), this.transform);
+                behindFog = fogOpacity > FOG_SYMBOL_CLIPPING_THRESHOLD;
+            }
+
+            aboveHorizon = p[2] > p[3] || behindFog;
         } else {
             projection.xyTransformMat4(p, p, posMatrix);
         }

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -18,6 +18,7 @@ import type {CollisionBoxArray, CollisionVertexArray, SymbolInstance} from '../d
 import type FeatureIndex from '../data/feature_index.js';
 import type {OverscaledTileID} from '../source/tile_id.js';
 import type {TextAnchor} from './symbol_layout.js';
+import type {FogState} from '../style/fog_helpers.js';
 
 class OpacityState {
     opacity: number;
@@ -198,9 +199,9 @@ export class Placement {
     zoomAtLastRecencyCheck: number;
     collisionCircleArrays: {[any]: CollisionCircleArray};
 
-    constructor(transform: Transform, fadeDuration: number, crossSourceCollisions: boolean, prevPlacement?: Placement) {
+    constructor(transform: Transform, fadeDuration: number, crossSourceCollisions: boolean, prevPlacement?: Placement, fogState: ?FogState) {
         this.transform = transform.clone();
-        this.collisionIndex = new CollisionIndex(this.transform);
+        this.collisionIndex = new CollisionIndex(this.transform, fogState);
         this.placements = {};
         this.opacities = {};
         this.variableOffsets = {};
@@ -431,7 +432,8 @@ export class Placement {
                 verticalTextFeatureIndex = collisionArrays.verticalTextFeatureIndex;
             }
 
-            const updateElevation = (box: SingleCollisionBox) => {
+            const updateBoxData = (box: SingleCollisionBox) => {
+                box.tileID = this.retainedQueryData[bucket.bucketInstanceId].tileID;
                 if (!this.transform.elevation && !box.elevation) return;
                 box.elevation = this.transform.elevation ? this.transform.elevation.getAtTileOffset(
                     this.retainedQueryData[bucket.bucketInstanceId].tileID,
@@ -440,7 +442,7 @@ export class Placement {
 
             const textBox = collisionArrays.textBox;
             if (textBox) {
-                updateElevation(textBox);
+                updateBoxData(textBox);
                 const updatePreviousOrientationIfNotPlaced = (isPlaced) => {
                     let previousOrientation = WritingMode.horizontal;
                     if (bucket.allowVerticalPlacement && !isPlaced && this.prevPlacement) {
@@ -489,7 +491,7 @@ export class Placement {
                     const placeVertical = () => {
                         const verticalTextBox = collisionArrays.verticalTextBox;
                         if (bucket.allowVerticalPlacement && symbolInstance.numVerticalGlyphVertices > 0 && verticalTextBox) {
-                            updateElevation(verticalTextBox);
+                            updateBoxData(verticalTextBox);
                             return placeBox(verticalTextBox, WritingMode.vertical);
                         }
                         return {box: null, offscreen: null};
@@ -518,7 +520,7 @@ export class Placement {
                         const height = (collisionTextBox.y2 - collisionTextBox.y1) * textBoxScale + 2.0 * collisionTextBox.padding;
 
                         const variableIconBox = hasIconTextFit && !iconAllowOverlap ? collisionIconBox : null;
-                        if (variableIconBox) updateElevation(variableIconBox);
+                        if (variableIconBox) updateBoxData(variableIconBox);
 
                         let placedBox: ?{ box: Array<number>, offscreen: boolean }  = {box: [], offscreen: false};
                         const placementAttempts = textAllowOverlap ? anchors.length * 2 : anchors.length;
@@ -550,7 +552,7 @@ export class Placement {
 
                     const placeVertical = () => {
                         const verticalTextBox = collisionArrays.verticalTextBox;
-                        if (verticalTextBox) updateElevation(verticalTextBox);
+                        if (verticalTextBox) updateBoxData(verticalTextBox);
                         const wasPlaced = placed && placed.box && placed.box.length;
                         if (bucket.allowVerticalPlacement && !wasPlaced && symbolInstance.numVerticalGlyphVertices > 0 && verticalTextBox) {
                             return placeBoxForVariableAnchors(verticalTextBox, collisionArrays.verticalIconBox, WritingMode.vertical);
@@ -623,7 +625,7 @@ export class Placement {
             if (collisionArrays.iconBox) {
 
                 const placeIconFeature = iconBox => {
-                    updateElevation(iconBox);
+                    updateBoxData(iconBox);
                     const shiftPoint: Point = hasIconTextFit && shift ?
                         offsetShift(shift.x, shift.y, rotateWithMap, pitchWithMap, this.transform.angle) :
                         new Point(0, 0);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2182,7 +2182,7 @@ class Map extends Camera {
 
     getFogOpacity(lnglat: LngLatLike): number {
         if (!this.style || !this.style.fog) return 0.0;
-        return this.style.fog.sampler.getFogOpacityAtLatLng(LngLat.convert(lnglat), this.transform);
+        return this.style.fog.getOpacityAtLatLng(LngLat.convert(lnglat), this.transform);
     }
 
     /**


### PR DESCRIPTION
This change adds some simple fog based clipping for symbols in the placement phase.

The threshold at which a symbol gets clipped is set to a fogOpacity of 0.9, and is somewhat arbitrarily selected for the point at which the symbol no longer becomes readable.
The goal here to to quickly cull symbol instances that are far off into the fog from collision evaluations, boosting performance somewhat.

