### PR TITLE
Update marker opacity to use viewport-scaled height

### DIFF
--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -42,7 +42,7 @@ export class FogSampler {
     properties: ?PossiblyEvaluated<Props>;
 
     // As defined in _prelude_fog.fragment.glsl#fog_opacity
-    getFogOpacity(depth: number, pitch: number, height: number): number {
+    getFogOpacity(depthPx: number, pitch: number, heightPx: number): number {
         if (!this.properties) { return 0.0; }
 
         const props = this.properties;
@@ -62,7 +62,7 @@ export class FogSampler {
         // https://www.desmos.com/calculator/3taufutxid
         // The output of this function should match src/shaders/_prelude_fog.fragment.glsl
         const decay = 6;
-        const t = (depth / height - start) / (end - start);
+        const t = (depthPx / heightPx - start) / (end - start);
         let falloff = 1.0 - Math.min(1, Math.exp(-decay * t));
 
         // Cube without pow()

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -42,7 +42,7 @@ export class FogSampler {
     properties: ?PossiblyEvaluated<Props>;
 
     // As defined in _prelude_fog.fragment.glsl#fog_opacity
-    getFogOpacity(depth: number, pitch: number): number {
+    getFogOpacity(depth: number, pitch: number, height: number): number {
         if (!this.properties) { return 0.0; }
 
         const props = this.properties;
@@ -62,7 +62,7 @@ export class FogSampler {
         // https://www.desmos.com/calculator/3taufutxid
         // The output of this function should match src/shaders/_prelude_fog.fragment.glsl
         const decay = 6;
-        const t = (depth - start) / (end - start);
+        const t = (depth / height - start) / (end - start);
         let falloff = 1.0 - Math.min(1, Math.exp(-decay * t));
 
         // Cube without pow()
@@ -86,7 +86,7 @@ export class FogSampler {
         vec3.transformMat4(pos, pos, mat);
         const depth = vec3.length(pos);
 
-        return this.getFogOpacity(depth, transform.pitch);
+        return this.getFogOpacity(depth, transform.pitch, transform.height);
     }
 
     getFogOpacityAtLatLng(lngLat: LngLat, transform: Transform): number {
@@ -96,7 +96,7 @@ export class FogSampler {
         vec3.transformMat4(pos, pos, transform.mercatorFogMatrix);
         const depth = vec3.length(pos);
 
-        return this.getFogOpacity(depth, transform.pitch);
+        return this.getFogOpacity(depth, transform.pitch, transform.height);
     }
 }
 


### PR DESCRIPTION
Marker opacity was not working correctly after the merging of #10533. This PR updates the getOpacity functionn to accept the transform height as well, additionally appending `Px` to the variable names to indicate that it accepts pixel units.