### PR TITLE
Rename cameraMatrix --> fogTileMatrix

### DIFF
--- a/src/render/fog.js
+++ b/src/render/fog.js
@@ -6,7 +6,7 @@ import type {UniformLocations} from './uniform_binding.js';
 import {Uniform1f, Uniform2f, Uniform3f, UniformMatrix4f} from './uniform_binding.js';
 
 export type FogUniformsType = {|
-    'u_cam_matrix': UniformMatrix4f,
+    'u_fog_matrix': UniformMatrix4f,
     'u_fog_range': Uniform2f,
     'u_fog_color': Uniform3f,
     'u_fog_exponent': Uniform1f,
@@ -18,7 +18,7 @@ export type FogUniformsType = {|
 |};
 
 export const fogUniforms = (context: Context, locations: UniformLocations): FogUniformsType => ({
-    'u_cam_matrix': new UniformMatrix4f(context, locations.u_cam_matrix),
+    'u_fog_matrix': new UniformMatrix4f(context, locations.u_fog_matrix),
     'u_fog_range': new Uniform2f(context, locations.u_fog_range),
     'u_fog_color': new Uniform3f(context, locations.u_fog_color),
     'u_fog_exponent': new Uniform1f(context, locations.u_fog_exponent),

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -847,7 +847,7 @@ class Painter {
             const hazeColorLinear = [Math.pow(hazeColor.r, 2.2), Math.pow(hazeColor.g, 2.2), Math.pow(hazeColor.b, 2.2)];
             const uniforms = {};
 
-            uniforms['u_cam_matrix'] = tileID ? this.transform.calculateCameraMatrix(tileID) : this.identityMat;
+            uniforms['u_fog_matrix'] = tileID ? this.transform.calculateFogTileMatrix(tileID) : this.identityMat;
             uniforms['u_fog_range'] = fog.properties.get('range');
             uniforms['u_fog_color'] = [fogColor.r, fogColor.g, fogColor.b];
             uniforms['u_fog_exponent'] = Math.max(1e-3, 12 * Math.pow(1 - fog.properties.get('strength'), 2));

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -1,11 +1,11 @@
 #ifdef FOG
 
-uniform mat4 u_cam_matrix;
+uniform mat4 u_fog_matrix;
 
 vec3 fog_position(vec3 pos) {
-    // The following function requires that u_cam_matrix be affine and result in
+    // The following function requires that u_fog_matrix be affine and result in
     // a vector with w = 1. Otherwise we must divide by w.
-    return (u_cam_matrix * vec4(pos, 1)).xyz;
+    return (u_fog_matrix * vec4(pos, 1)).xyz;
 }
 
 // Accept either 2D or 3D positions

--- a/src/style/fog_helpers.js
+++ b/src/style/fog_helpers.js
@@ -51,7 +51,7 @@ export function getFogOpacity(state: FogState, depth: number, pitch: number): nu
 }
 
 export function getOpacityAtTileCoord(state: FogState, x: number, y: number, z: number, tileId: UnwrappedTileID, transform: Transform): number {
-    const mat = transform.calculateCameraMatrix(tileId);
+    const mat = transform.calculateFogTileMatrix(tileId);
     const pos = [x, y, z];
     vec3.transformMat4(pos, pos, mat);
     const depth = vec3.length(pos);


### PR DESCRIPTION
Camera matrix originally translated and scaled coordinates to be centered around the camera. There were also two different matrices, both called "cameraMatrix". I've renamed:

- `cameraMatrix` (the one which precomputes world coords to camera-centered coords) --> `worldToFogMatrix`
- `cameraMatrix`(adds tile->world transform to the above, used in shaders) --> `fogTileMatrix`