### PR TITLE
Offload terrain fog to vertex shader

### DIFF
--- a/src/render/fog.js
+++ b/src/render/fog.js
@@ -3,36 +3,30 @@
 import Context from '../gl/context.js';
 import type {UniformLocations} from './uniform_binding.js';
 
-import {Uniform1f, Uniform2f, Uniform4f, UniformMatrix4f} from './uniform_binding.js';
+import {Uniform1f, Uniform2f, Uniform3f, Uniform4f, UniformMatrix4f} from './uniform_binding.js';
 
 export type FogUniformsType = {|
     'u_fog_matrix': UniformMatrix4f,
     'u_fog_range': Uniform2f,
-    'u_fog_color': Uniform4f,
+    'u_fog_color': Uniform3f,
     'u_fog_exponent': Uniform1f,
     'u_fog_sky_blend': Uniform1f,
     'u_fog_temporal_offset': Uniform1f,
     'u_haze_color_linear': Uniform4f,
 
     // Precision may differ, so we must pass uniforms separately for use in a vertex shader
-    'u_vert_fog_range': Uniform2f,
-    'u_vert_fog_exponent': Uniform1f,
-    'u_vert_fog_opacity': Uniform1f,
-    'u_vert_haze_color_linear': Uniform4f,
+    'u_fog_opacity': Uniform1f,
 
 |};
 
 export const fogUniforms = (context: Context, locations: UniformLocations): FogUniformsType => ({
     'u_fog_matrix': new UniformMatrix4f(context, locations.u_fog_matrix),
     'u_fog_range': new Uniform2f(context, locations.u_fog_range),
-    'u_fog_color': new Uniform4f(context, locations.u_fog_color),
+    'u_fog_color': new Uniform3f(context, locations.u_fog_color),
     'u_fog_exponent': new Uniform1f(context, locations.u_fog_exponent),
     'u_fog_sky_blend': new Uniform1f(context, locations.u_fog_sky_blend),
     'u_fog_temporal_offset': new Uniform1f(context, locations.u_fog_temporal_offset),
     'u_haze_color_linear': new Uniform4f(context, locations.u_haze_color_linear),
 
-    'u_vert_fog_range': new Uniform2f(context, locations.u_vert_fog_range),
-    'u_vert_fog_exponent': new Uniform1f(context, locations.u_vert_fog_exponent),
-    'u_vert_fog_opacity': new Uniform1f(context, locations.u_vert_fog_opacity),
-    'u_vert_haze_color_linear': new Uniform4f(context, locations.u_vert_haze_color_linear),
+    'u_fog_opacity': new Uniform1f(context, locations.u_fog_opacity),
 });

--- a/src/render/fog.js
+++ b/src/render/fog.js
@@ -3,28 +3,36 @@
 import Context from '../gl/context.js';
 import type {UniformLocations} from './uniform_binding.js';
 
-import {Uniform1f, Uniform2f, Uniform3f, UniformMatrix4f} from './uniform_binding.js';
+import {Uniform1f, Uniform2f, Uniform4f, UniformMatrix4f} from './uniform_binding.js';
 
 export type FogUniformsType = {|
     'u_fog_matrix': UniformMatrix4f,
     'u_fog_range': Uniform2f,
-    'u_fog_color': Uniform3f,
+    'u_fog_color': Uniform4f,
     'u_fog_exponent': Uniform1f,
-    'u_fog_opacity': Uniform1f,
     'u_fog_sky_blend': Uniform1f,
     'u_fog_temporal_offset': Uniform1f,
-    'u_haze_color_linear': Uniform3f,
-    'u_haze_energy': Uniform1f,
+    'u_haze_color_linear': Uniform4f,
+
+    // Precision may differ, so we must pass uniforms separately for use in a vertex shader
+    'u_vert_fog_range': Uniform2f,
+    'u_vert_fog_exponent': Uniform1f,
+    'u_vert_fog_opacity': Uniform1f,
+    'u_vert_haze_color_linear': Uniform4f,
+
 |};
 
 export const fogUniforms = (context: Context, locations: UniformLocations): FogUniformsType => ({
     'u_fog_matrix': new UniformMatrix4f(context, locations.u_fog_matrix),
     'u_fog_range': new Uniform2f(context, locations.u_fog_range),
-    'u_fog_color': new Uniform3f(context, locations.u_fog_color),
+    'u_fog_color': new Uniform4f(context, locations.u_fog_color),
     'u_fog_exponent': new Uniform1f(context, locations.u_fog_exponent),
-    'u_fog_opacity': new Uniform1f(context, locations.u_fog_opacity),
     'u_fog_sky_blend': new Uniform1f(context, locations.u_fog_sky_blend),
     'u_fog_temporal_offset': new Uniform1f(context, locations.u_fog_temporal_offset),
-    'u_haze_color_linear': new Uniform3f(context, locations.u_haze_color_linear),
-    'u_haze_energy': new Uniform1f(context, locations.u_haze_energy),
+    'u_haze_color_linear': new Uniform4f(context, locations.u_haze_color_linear),
+
+    'u_vert_fog_range': new Uniform2f(context, locations.u_vert_fog_range),
+    'u_vert_fog_exponent': new Uniform1f(context, locations.u_vert_fog_exponent),
+    'u_vert_fog_opacity': new Uniform1f(context, locations.u_vert_fog_opacity),
+    'u_vert_haze_color_linear': new Uniform4f(context, locations.u_vert_haze_color_linear),
 });

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -752,13 +752,14 @@ class Painter {
         const terrain = this.terrain && !this.terrain.renderingToTexture; // Enables elevation sampling in vertex shader.
         const rtt = this.terrain && this.terrain.renderingToTexture;
         const fog = this.style && this.style.fog;
+        const fogOpacity = fog && fog.getFogPitchFactor(this.transform.pitch);
         const haze = fog && fog.properties && fog.properties.get('haze-energy') > 0;
 
         const defines = [];
         if (terrain) defines.push('TERRAIN');
         // When terrain is active, fog is rendered as part of draping, not as part of tile
         // rendering. Removing the fog flag during tile rendering avoids additional defines.
-        if (fog && !rtt) {
+        if (fog && fogOpacity !== 0.0 && !rtt) {
             defines.push('FOG');
             if (haze) defines.push('FOG_HAZE');
         }
@@ -842,10 +843,10 @@ class Painter {
         const fog = this.style && this.style.fog;
         const haze = fog && fog.properties && fog.properties.get('haze-energy') > 0;
         const terrain = this.terrain && !this.terrain.renderingToTexture;
-        if (fog) {
+        const fogOpacity = (fog && fog.getFogPitchFactor(this.transform.pitch)) || 0.0;
+        if (fog && fogOpacity !== 0.0) {
             const temporalOffset = (this.frameCounter / 1000.0) % 1;
             const fogColor = fog.properties.get('color');
-            const fogOpacity = fog.getFogPitchFactor(this.transform.pitch);
             const uniforms = {};
 
             uniforms['u_fog_matrix'] = tileID ? this.transform.calculateFogTileMatrix(tileID) : this.identityMat;

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -851,10 +851,11 @@ class Painter {
 
             uniforms['u_fog_matrix'] = tileID ? this.transform.calculateFogTileMatrix(tileID) : this.identityMat;
             uniforms['u_fog_range'] = fog.properties.get('range');
-            uniforms['u_fog_color'] = [fogColor.r, fogColor.g, fogColor.b, fogOpacity];
+            uniforms['u_fog_color'] = [fogColor.r, fogColor.g, fogColor.b];
             uniforms['u_fog_exponent'] = Math.max(1e-3, 12 * Math.pow(1 - fog.properties.get('strength'), 2));
             uniforms['u_fog_sky_blend'] = fog.properties.get('sky-blend');
             uniforms['u_fog_temporal_offset'] = temporalOffset;
+            uniforms['u_fog_opacity'] = fogOpacity;
 
             if (haze) {
                 const hazeColor = fog.properties.get('haze-color');
@@ -866,14 +867,6 @@ class Painter {
                 ];
 
                 uniforms['u_haze_color_linear'] = hazeColorLinear;
-            }
-
-            if (terrain) {
-                // Vertex shader fog uniforms
-                uniforms['u_vert_fog_range'] = uniforms['u_fog_range'];
-                uniforms['u_vert_fog_exponent'] = uniforms['u_fog_exponent'];
-                uniforms['u_vert_fog_opacity'] = fogOpacity;
-                if (haze) uniforms['u_vert_haze_color_linear'] = uniforms['u_haze_color_linear'];
             }
 
             program.setFogUniformValues(context, uniforms);

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -841,8 +841,6 @@ class Painter {
 
     prepareDrawProgram(context: Context, program: Program<*>, tileID: ?UnwrappedTileID) {
         const fog = this.style && this.style.fog;
-        const haze = fog && fog.properties && fog.properties.get('haze-energy') > 0;
-        const terrain = this.terrain && !this.terrain.renderingToTexture;
         const fogOpacity = (fog && fog.getFogPitchFactor(this.transform.pitch)) || 0.0;
         if (fog && fogOpacity !== 0.0) {
             const temporalOffset = (this.frameCounter / 1000.0) % 1;
@@ -857,7 +855,7 @@ class Painter {
             uniforms['u_fog_temporal_offset'] = temporalOffset;
             uniforms['u_fog_opacity'] = fogOpacity;
 
-            if (haze) {
+            if (fog.properties.get('haze-energy') > 0) {
                 const hazeColor = fog.properties.get('haze-color');
                 const hazeColorLinear = [
                     Math.pow(hazeColor.r, 2.2),

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -840,22 +840,35 @@ class Painter {
 
     prepareDrawProgram(context: Context, program: Program<*>, tileID: ?UnwrappedTileID) {
         const fog = this.style && this.style.fog;
+        const terrain = this.terrain && !this.terrain.renderingToTexture;
         if (fog) {
             const temporalOffset = (this.frameCounter / 1000.0) % 1;
             const fogColor = fog.properties.get('color');
             const hazeColor = fog.properties.get('haze-color');
-            const hazeColorLinear = [Math.pow(hazeColor.r, 2.2), Math.pow(hazeColor.g, 2.2), Math.pow(hazeColor.b, 2.2)];
+            const fogOpacity = fog.getFogPitchFactor(this.transform.pitch);
+            const hazeColorLinear = [
+                Math.pow(hazeColor.r, 2.2),
+                Math.pow(hazeColor.g, 2.2),
+                Math.pow(hazeColor.b, 2.2),
+                fog.properties.get('haze-energy')
+            ];
             const uniforms = {};
 
             uniforms['u_fog_matrix'] = tileID ? this.transform.calculateFogTileMatrix(tileID) : this.identityMat;
             uniforms['u_fog_range'] = fog.properties.get('range');
-            uniforms['u_fog_color'] = [fogColor.r, fogColor.g, fogColor.b];
+            uniforms['u_fog_color'] = [fogColor.r, fogColor.g, fogColor.b, fogOpacity];
             uniforms['u_fog_exponent'] = Math.max(1e-3, 12 * Math.pow(1 - fog.properties.get('strength'), 2));
-            uniforms['u_fog_opacity'] = fog.getFogPitchFactor(this.transform.pitch);
             uniforms['u_fog_sky_blend'] = fog.properties.get('sky-blend');
             uniforms['u_fog_temporal_offset'] = temporalOffset;
             uniforms['u_haze_color_linear'] = hazeColorLinear;
-            uniforms['u_haze_energy'] = fog.properties.get('haze-energy');
+
+            if (terrain) {
+                // Vertex shader fog uniforms
+                uniforms['u_vert_fog_range'] = uniforms['u_fog_range'];
+                uniforms['u_vert_fog_exponent'] = uniforms['u_fog_exponent'];
+                uniforms['u_vert_fog_opacity'] = fogOpacity;
+                uniforms['u_vert_haze_color_linear'] = uniforms['u_haze_color_linear'];
+            }
 
             program.setFogUniformValues(context, uniforms);
         }

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -1,11 +1,12 @@
 #ifdef FOG
 
-uniform vec2 u_fog_range;
-uniform vec4 u_fog_color;
-uniform vec4 u_haze_color_linear;
+uniform vec3 u_fog_color;
 uniform float u_fog_sky_blend;
 uniform float u_fog_temporal_offset;
-uniform float u_fog_exponent;
+uniform mediump vec2 u_fog_range;
+uniform mediump float u_fog_opacity;
+uniform mediump vec4 u_haze_color_linear;
+uniform mediump float u_fog_exponent;
 
 vec3 tonemap(vec3 color) {
     // Use an exponential smoothmin between y=x and y=1 for tone-mapping
@@ -20,7 +21,7 @@ float fog_sky_blending(vec3 camera_dir) {
     float t = max(0.0, camera_dir.z / u_fog_sky_blend);
     // Factor of 3 chosen to roughly match smoothstep.
     // See: https://www.desmos.com/calculator/pub31lvshf
-    return u_fog_color.a * exp(-3.0 * t * t);
+    return u_fog_opacity * exp(-3.0 * t * t);
 }
 
 // Computes the fog opacity when fog strength = 1. Otherwise it's multiplied
@@ -36,7 +37,7 @@ float fog_opacity(float t) {
     falloff *= falloff * falloff;
 
     // Scale and clip to 1 at the far limit
-    return u_fog_color.a * min(1.0, 1.00747 * falloff);
+    return u_fog_opacity * min(1.0, 1.00747 * falloff);
 }
 
 // This function is only used in rare places like heatmap where opacity is used
@@ -58,13 +59,13 @@ vec3 fog_apply(vec3 color, vec3 pos) {
     // The smoothstep fades in tonemapping slightly before the fog layer. This violates
     // the principle that fog should not have an effect outside the fog layer, but the
     // effect is hardly noticeable except on pure white glaciers.
-    float tonemap_strength = u_fog_color.a * min(1.0, u_haze_color_linear.a) * smoothstep(-0.5, 0.25, t);
+    float tonemap_strength = u_fog_opacity * min(1.0, u_haze_color_linear.a) * smoothstep(-0.5, 0.25, t);
     color = srgb_to_linear(color);
     color = mix(color, tonemap(color + haze), tonemap_strength);
     color = linear_to_srgb(color);
 #endif
 
-    return mix(color, u_fog_color.rgb, fog_opac);
+    return mix(color, u_fog_color, fog_opac);
 }
 
 // Apply fog and haze which were computed in the vertex shader
@@ -79,12 +80,12 @@ vec3 fog_apply_from_vert(vec3 color, float fog_opac
     color = linear_to_srgb(color);
 #endif
 
-    return mix(color, u_fog_color.rgb, fog_opac);
+    return mix(color, u_fog_color, fog_opac);
 }
 
 // Assumes z up
 vec3 fog_apply_sky_gradient(vec3 camera_ray, vec3 sky_color) {
-    return mix(sky_color, u_fog_color.rgb, fog_sky_blending(normalize(camera_ray)));
+    return mix(sky_color, u_fog_color, fog_sky_blending(normalize(camera_ray)));
 }
 
 // Un-premultiply the alpha, then blend fog, then re-premultiply alpha. For

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -67,7 +67,12 @@ vec3 fog_apply(vec3 color, vec3 pos) {
     return mix(color, u_fog_color.rgb, fog_opac);
 }
 
-vec3 fog_apply(vec3 color, float fog_opac, vec4 haze) {
+// Apply fog and haze which were computed in the vertex shader
+vec3 fog_apply_from_vert(vec3 color, float fog_opac
+#ifdef FOG_HAZE
+    , vec4 haze
+#endif
+) {
 #ifdef FOG_HAZE
     color = srgb_to_linear(color);
     color = mix(color, tonemap(color + haze.rgb), haze.a);

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -1,17 +1,17 @@
 #ifdef FOG
 
-uniform float u_vert_fog_opacity;
-uniform float u_vert_fog_exponent;
-uniform vec2 u_vert_fog_range;
-uniform vec4 u_vert_haze_color_linear;
 uniform mat4 u_fog_matrix;
+uniform mediump float u_fog_opacity;
+uniform mediump float u_fog_exponent;
+uniform mediump vec2 u_fog_range;
+uniform mediump vec4 u_haze_color_linear;
 
 // This function much match fog_opacity defined in _prelude_fog.fragment.glsl
 float fog_opacity(float t) {
     const float decay = 6.0;
     float falloff = 1.0 - min(1.0, exp(-decay * t));
     falloff *= falloff * falloff;
-    return u_vert_fog_opacity * min(1.0, 1.00747 * falloff);
+    return u_fog_opacity * min(1.0, 1.00747 * falloff);
 }
 
 vec3 fog_position(vec3 pos) {
@@ -32,18 +32,18 @@ void fog_haze(
 #endif
 ) {
     // Map [near, far] to [0, 1]
-    float t = (length(pos) - u_vert_fog_range.x) / (u_vert_fog_range.y - u_vert_fog_range.x);
+    float t = (length(pos) - u_fog_range.x) / (u_fog_range.y - u_fog_range.x);
 
     float haze_opac = fog_opacity(t);
-    fog_opac = haze_opac * pow(smoothstep(0.0, 1.0, t), u_vert_fog_exponent);
+    fog_opac = haze_opac * pow(smoothstep(0.0, 1.0, t), u_fog_exponent);
 
 #ifdef FOG_HAZE
-    haze.rgb = (haze_opac * u_vert_haze_color_linear.a) * u_vert_haze_color_linear.rgb;
+    haze.rgb = (haze_opac * u_haze_color_linear.a) * u_haze_color_linear.rgb;
 
     // The smoothstep fades in tonemapping slightly before the fog layer. This violates
     // the principle that fog should not have an effect outside the fog layer, but the
     // effect is hardly noticeable except on pure white glaciers.
-    haze.a = u_vert_fog_opacity * min(1.0, u_vert_haze_color_linear.a) * smoothstep(-0.5, 0.25, t);
+    haze.a = u_fog_opacity * min(1.0, u_haze_color_linear.a) * smoothstep(-0.5, 0.25, t);
 #endif
 }
 

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -1,6 +1,18 @@
 #ifdef FOG
 
+uniform float u_vert_fog_opacity;
+uniform float u_vert_fog_exponent;
+uniform vec2 u_vert_fog_range;
+uniform vec4 u_vert_haze_color_linear;
 uniform mat4 u_fog_matrix;
+
+// This function much match fog_opacity defined in _prelude_fog.fragment.glsl
+float fog_opacity(float t) {
+    const float decay = 6.0;
+    float falloff = 1.0 - min(1.0, exp(-decay * t));
+    falloff *= falloff * falloff;
+    return u_vert_fog_opacity * min(1.0, 1.00747 * falloff);
+}
 
 vec3 fog_position(vec3 pos) {
     // The following function requires that u_fog_matrix be affine and result in
@@ -11,6 +23,23 @@ vec3 fog_position(vec3 pos) {
 // Accept either 2D or 3D positions
 vec3 fog_position(vec2 pos) {
     return fog_position(vec3(pos, 0));
+}
+
+void fog_haze(vec3 pos, out float fog_opac, out vec4 haze) {
+    // Map [near, far] to [0, 1]
+    float t = (length(pos) - u_vert_fog_range.x) / (u_vert_fog_range.y - u_vert_fog_range.x);
+
+    float haze_opac = fog_opacity(t);
+    fog_opac = haze_opac * pow(smoothstep(0.0, 1.0, t), u_vert_fog_exponent);
+
+#ifdef FOG_HAZE
+    haze.rgb = (haze_opac * u_vert_haze_color_linear.a) * u_vert_haze_color_linear.rgb;
+
+    // The smoothstep fades in tonemapping slightly before the fog layer. This violates
+    // the principle that fog should not have an effect outside the fog layer, but the
+    // effect is hardly noticeable except on pure white glaciers.
+    haze.a = u_vert_fog_opacity * min(1.0, u_vert_haze_color_linear.a) * smoothstep(-0.5, 0.25, t);
+#endif
 }
 
 #endif

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -25,7 +25,12 @@ vec3 fog_position(vec2 pos) {
     return fog_position(vec3(pos, 0));
 }
 
-void fog_haze(vec3 pos, out float fog_opac, out vec4 haze) {
+void fog_haze(
+    vec3 pos, out float fog_opac
+#ifdef FOG_HAZE
+    , out vec4 haze
+#endif
+) {
     // Map [near, far] to [0, 1]
     float t = (length(pos) - u_vert_fog_range.x) / (u_vert_fog_range.y - u_vert_fog_range.x);
 

--- a/src/shaders/terrain_raster.fragment.glsl
+++ b/src/shaders/terrain_raster.fragment.glsl
@@ -3,13 +3,19 @@ varying vec2 v_pos0;
 
 #ifdef FOG
 varying float v_fog_opacity;
+#ifdef FOG_HAZE
 varying vec4 v_haze_color;
+#endif
 #endif
 
 void main() {
     vec4 color = texture2D(u_image0, v_pos0);
 #ifdef FOG
-    color.rgb = fog_dither(fog_apply(color.rgb, v_fog_opacity, v_haze_color));
+    color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity
+#ifdef FOG_HAZE
+        , v_haze_color
+#endif
+    ));
 #endif
     gl_FragColor = color;
 #ifdef TERRAIN_WIREFRAME

--- a/src/shaders/terrain_raster.fragment.glsl
+++ b/src/shaders/terrain_raster.fragment.glsl
@@ -2,13 +2,14 @@ uniform sampler2D u_image0;
 varying vec2 v_pos0;
 
 #ifdef FOG
-varying vec3 v_fog_pos;
+varying float v_fog_opacity;
+varying vec4 v_haze_color;
 #endif
 
 void main() {
     vec4 color = texture2D(u_image0, v_pos0);
 #ifdef FOG
-    color.rgb = fog_dither(fog_apply(color.rgb, v_fog_pos));
+    color.rgb = fog_dither(fog_apply(color.rgb, v_fog_opacity, v_haze_color));
 #endif
     gl_FragColor = color;
 #ifdef TERRAIN_WIREFRAME

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -8,7 +8,9 @@ varying vec2 v_pos0;
 
 #ifdef FOG
 varying float v_fog_opacity;
+#ifdef FOG_HAZE
 varying vec4 v_haze_color;
+#endif
 #endif
 
 const float skirtOffset = 24575.0;
@@ -25,6 +27,10 @@ void main() {
     gl_Position = u_matrix * vec4(decodedPos, elevation, 1.0);
 
 #ifdef FOG
-    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, v_haze_color);
+    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity
+#ifdef FOG_HAZE
+        , v_haze_color
+#endif
+    );
 #endif
 }

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -7,7 +7,8 @@ attribute vec2 a_texture_pos;
 varying vec2 v_pos0;
 
 #ifdef FOG
-varying vec3 v_fog_pos;
+varying float v_fog_opacity;
+varying vec4 v_haze_color;
 #endif
 
 const float skirtOffset = 24575.0;
@@ -24,6 +25,6 @@ void main() {
     gl_Position = u_matrix * vec4(decodedPos, elevation, 1.0);
 
 #ifdef FOG
-    v_fog_pos = fog_position(vec3(decodedPos, elevation));
+    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, v_haze_color);
 #endif
 }


### PR DESCRIPTION
This PR offloads whatever computation can be offloaded to the vertex shader when rendering fog on terrain. This amounts to maybe half of the fog operations. I also compressed a couple uniforms in to vec4, like `[fog.r, fog.g, fog.b, fog.opacity]` instead of passing the opacity separately.

This may also apply for circles and possibly symbols, but I have not yet addressed that case.

The difference is only visually apparent when the fog range is *very* narrow, for exmaple [1.0, 1.01].

https://user-images.githubusercontent.com/572717/114064565-a0f1bc00-984e-11eb-94a9-3231d95ee18a.mp4
