### PR TITLE
[docs only] Document EdgeInsets as an internal class

### DIFF
--- a/src/geo/edge_insets.js
+++ b/src/geo/edge_insets.js
@@ -4,6 +4,7 @@ import Point  from "@mapbox/point-geometry";
 import {clamp} from "../util/util.js";
 
 /**
+ * @private
  * An `EdgeInset` object represents screen space padding applied to the edges of the viewport.
  * This shifts the apparent center or the vanishing point of the map. This is useful for adding floating UI elements
  * on top of the map and having the vanishing point shift as UI elements resize.


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js-docs/issues/328

Per chat with @arindam1993, `EdgeInsets` is not intended to be used directly. This PR marks the class as private so it doesn't show up on the documentation site to prevent confusion.