### PR TITLE
Bypass the DOM rendering queue if map is idle

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2528,6 +2528,10 @@ class Map extends Camera {
         this.painter.setBaseState();
 
         this._renderTaskQueue.run(paintStartTimeStamp);
+        // The queue below may have tasks that need to be run but the queue won't always be ran: to
+        // avoid this, tasks need to be called directly instead of being added to the queue. See
+        // ui/popup.js or ui/marker.js for example. This won't be a performance issue as very few
+        // elements will be concerned by the rendering.
         this._domRenderTaskQueue.run(paintStartTimeStamp);
         // A task queue callback may have fired a user event which may have removed the map
         if (this._removed) return;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -507,11 +507,20 @@ export default class Marker extends Evented {
             this._pos = this._pos.round();
         }
 
-        this._map._domRenderTaskQueue.add(() => {
+        const transformFn = () => {
             if (this._element && this._pos && this._anchor) {
                 DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
             }
-        });
+        };
+
+        // This condition means that the map is idle: the transformation needs to be manually
+        // applied as there won't be a triggered render. This shouldn't impact performance as the
+        // move shoud be limited to very few elements.
+        if (!this._map.isMoving() && this._map.loaded()) {
+            transformFn();
+        } else {
+            this._map._domRenderTaskQueue.add(transformFn);
+        }
     }
 
     /**

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -572,12 +572,22 @@ export default class Popup extends Evented {
         }
 
         const offsetedPos = pos.add(offset[anchor]).round();
-        this._map._domRenderTaskQueue.add(() => {
+
+        const transformFn = () => {
             if (this._container && anchor) {
                 DOM.setTransform(this._container, `${anchorTranslate[anchor]} translate(${offsetedPos.x}px,${offsetedPos.y}px)`);
                 applyAnchorClass(this._container, anchor, 'popup');
             }
-        });
+        };
+
+        // This condition means that the map is idle: the transformation needs to be manually
+        // applied as there won't be a triggered render. This shouldn't impact performance as the
+        // move shoud be limited to very few elements.
+        if (!this._map.isMoving() && this._map.loaded()) {
+            transformFn();
+        } else {
+            this._map._domRenderTaskQueue.add(transformFn);
+        }
     }
 
     _focusFirstElement() {


### PR DESCRIPTION
In #10530 I added a new queue dedicated to the rendering of DOM elements. Unfortunately I made the mistake to run this new queue only in `map._render()`, which won't be called if the map is idle. You can test this problem by trying to move a marker once the map is fully loaded and rendered in `markers.html`.

A mechanism like `map._requestRenderFrame()` could be added, but I feel there is no need to call the whole `_render()` loop all over again for a simple rendering of a DOM element. As far as I understand, this problem happens only when very few elements are moving/rendering. So I'm proposing to call directly the dom task, like it was the case before, only if the map is idle. The condition I choose is the same in `ui/map`, right before setting the map idle.

Note that preventing the map to go idle if there are still some tasks in `domRenderTaskQueue` won't work, as the queue could be filled while the map is already idle.

Tagging @mourner as he followed the previous PR.

Sorry about this mistake, I though I checked correctly in the other PR.