### PR TITLE
Fix heading level of 13.18.1 release in style-spec changelog

### DIFF
--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added array support to minimums and maximums, allowing for validation of multi-dimensional style-spec value constraints. ([#10272](https://github.com/mapbox/mapbox-gl-js/pull/10272))
 
-# 13.18.1
+## 13.18.1
 
 ### 🐞 Bug fixes
 * Fixed a bug where `map.setStyle` couldn't be used to enable terrain. ([#10177](https://github.com/mapbox/mapbox-gl-js/pull/10177))


### PR DESCRIPTION
## Launch Checklist

Just a small markdown fix in the style-spec changelog.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
