### PR TITLE
TERRAIN_DEM_NEAREST_FILTER shader support

### DIFF
--- a/src/shaders/_prelude_terrain.vertex.glsl
+++ b/src/shaders/_prelude_terrain.vertex.glsl
@@ -37,6 +37,9 @@ float currentElevation(vec2 apos) {
     vec2 f = r.zw;
 
     float tl = decodeElevation(texture2D(u_dem, pos));
+#ifdef TERRAIN_DEM_NEAREST_FILTER
+    return u_exaggeration * tl;
+#endif
     float tr = decodeElevation(texture2D(u_dem, pos + vec2(dd, 0.0)));
     float bl = decodeElevation(texture2D(u_dem, pos + vec2(0.0, dd)));
     float br = decodeElevation(texture2D(u_dem, pos + vec2(dd, dd)));


### PR DESCRIPTION
Performance optimization: use nearest filter if not over-sampling DEM tiles. Initially implemented in gl-native.
