### PR TITLE
Fix fog sky blending

### DIFF
--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -1,8 +1,8 @@
 #ifdef FOG
 
 uniform vec3 u_fog_color;
-uniform float u_fog_sky_blend;
 uniform float u_fog_temporal_offset;
+uniform mediump float u_fog_sky_blend;
 uniform mediump vec2 u_fog_range;
 uniform mediump float u_fog_opacity;
 uniform mediump vec4 u_haze_color_linear;
@@ -48,10 +48,12 @@ float fog_opacity(vec3 pos) {
 
 vec3 fog_apply(vec3 color, vec3 pos) {
     // Map [near, far] to [0, 1]
-    float t = (length(pos) - u_fog_range.x) / (u_fog_range.y - u_fog_range.x);
+    float depth = length(pos);
+    float t = (depth - u_fog_range.x) / (u_fog_range.y - u_fog_range.x);
 
     float haze_opac = fog_opacity(t);
     float fog_opac = haze_opac * pow(smoothstep(0.0, 1.0, t), u_fog_exponent);
+    fog_opac *= fog_sky_blending(pos / depth);
 
 #ifdef FOG_HAZE
     vec3 haze = haze_opac * u_haze_color_linear.rgb;

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -17,6 +17,9 @@ vec3 tonemap(vec3 color) {
 
 // Assumes z up and camera_dir *normalized* (to avoid computing its length multiple
 // times for different functions).
+// Must match definitions in:
+// src/shaders/_prelude_fog.vertex.glsl#fog_sky_blending
+// src/style/fog_helpers.js#getFogSkyBlending
 float fog_sky_blending(vec3 camera_dir) {
     float t = max(0.0, camera_dir.z / u_fog_sky_blend);
     // Factor of 3 chosen to roughly match smoothstep.

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -47,7 +47,8 @@ class Fog extends Evented {
     get state(): FogState {
         return {
             range: this.properties.get('range'),
-            density: this.properties.get('density')
+            density: this.properties.get('density'),
+            skyBlend: this.properties.get('sky-blend')
         };
     }
 


### PR DESCRIPTION
This PR restores a small fix which was lost along the way, in which terrain that sits above the horizon at high pitch is still obscured by fog, even though it stands out in stark contrast with the unobscured sky. It does this by multiplying fog by the fog sky blending function. Haze doesn't seem to require this change.

The reason we'd cut this out before was that it didn't play well with culling so that blank terrain showed through the fog. I'm not currently able to find problematic spots, though that doesn't mean we don't still need to consider whether this is valid.

Before: http://localhost:9966/debug/fog.html#15.06/-44.66578/167.90699/-53.6/84

![Screen Shot 2021-04-15 at 9 28 53 AM copy](https://user-images.githubusercontent.com/572717/114905377-bece9c00-9dcd-11eb-89c5-006a0d489bc6.jpg)

After:

![Screen Shot 2021-04-15 at 9 29 06 AM copy](https://user-images.githubusercontent.com/572717/114905381-bf673280-9dcd-11eb-9c45-c6b67552b330.jpg)

