### PR TITLE
Revert "Add linked types to MapWheelEvent and MapTouchEvent "

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -108,9 +108,7 @@ export class MapMouseEvent extends Event {
  */
 export class MapTouchEvent extends Event {
     /**
-     * The event type (one of {@link Map.event:touchstart},
-     * {@link Map.event:touchend},
-     * {@link Map.event:contextmenu}).
+     * The event type.
      */
     type: 'touchstart'
         | 'touchend'
@@ -194,7 +192,7 @@ export class MapTouchEvent extends Event {
  */
 export class MapWheelEvent extends Event {
     /**
-     * The event type ({@link Map.event:wheel}).
+     * The event type.
      */
     type: 'wheel';
 


### PR DESCRIPTION
Reverts mapbox/mapbox-gl-js#10525

@mapbox/docs team has decided to take a different approach to respond to negative user feedback on the GL JS Events page. These PRs will implement different changes instead:

https://github.com/mapbox/mapbox-gl-js-docs/pull/539 
https://github.com/mapbox/mapbox-gl-js/pull/new/events-gljs-changes 

@mourner I see that these changes...

<img src="https://user-images.githubusercontent.com/6026447/113078440-d02d6c80-916e-11eb-9e69-06b5ebddb144.png" width=300>

...do not appear on this page yet:

* https://docs.mapbox.com/mapbox-gl-js/api/events/

Which is great. I would like to revert this PR so users do not experience this Events doc changing multiple times.

Thank you!