### PR TITLE
Allow disabling premultiplied alpha in style spec

### DIFF
--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -384,6 +384,7 @@ function getDefaultValue(spec: StylePropertySpecification): Value {
         // back to in case of runtime errors
         return new Color(0, 0, 0, 0);
     } else if (spec.type === 'color') {
+        const premultiplyAlpha = spec.premultiplyAlpha === undefined ? true : spec.premultiplyAlpha;
         return Color.parse(spec.default) || null;
     } else if (spec.default === undefined) {
         return null;

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -385,7 +385,7 @@ function getDefaultValue(spec: StylePropertySpecification): Value {
         return new Color(0, 0, 0, 0);
     } else if (spec.type === 'color') {
         const premultiplyAlpha = spec.premultiplyAlpha === undefined ? true : spec.premultiplyAlpha;
-        return Color.parse(spec.default) || null;
+        return Color.parse(spec.default, premultiplyAlpha) || null;
     } else if (spec.default === undefined) {
         return null;
     } else {

--- a/src/style-spec/function/index.js
+++ b/src/style-spec/function/index.js
@@ -27,17 +27,18 @@ export function createFunction(parameters, propertySpec) {
 
     if (isColor) {
         parameters = extend({}, parameters);
+        const premultiplyAlpha = propertySpec.premultiplyAlpha === undefined ? true : propertySpec.premultiplyAlpha;
 
         if (parameters.stops) {
             parameters.stops = parameters.stops.map((stop) => {
-                return [stop[0], Color.parse(stop[1])];
+                return [stop[0], Color.parse(stop[1], premultiplyAlpha)];
             });
         }
 
         if (parameters.default) {
-            parameters.default = Color.parse(parameters.default);
+            parameters.default = Color.parse(parameters.default, premultiplyAlpha);
         } else {
-            parameters.default = Color.parse(propertySpec.default);
+            parameters.default = Color.parse(propertySpec.default, premultiplyAlpha);
         }
     }
 
@@ -199,7 +200,8 @@ function evaluateExponentialFunction(parameters, propertySpec, input) {
 
 function evaluateIdentityFunction(parameters, propertySpec, input) {
     if (propertySpec.type === 'color') {
-        input = Color.parse(input);
+        const premultiplyAlpha = propertySpec.premultiplyAlpha === undefined ? true : propertySpec.premultiplyAlpha;
+        input = Color.parse(input, premultiplyAlpha);
     } else if (propertySpec.type === 'formatted') {
         input = Formatted.fromString(input.toString());
     } else if (propertySpec.type === 'resolvedImage') {

--- a/src/style-spec/style-spec.js
+++ b/src/style-spec/style-spec.js
@@ -40,7 +40,8 @@ export type StylePropertySpecification = {
     expression?: ExpressionSpecification,
     transition: boolean,
     default?: string,
-    overridable: boolean
+    overridable: boolean,
+    premultiplyAlpha?: boolean
 } | {
     type: 'array',
     value: 'number',

--- a/src/style-spec/util/color.js
+++ b/src/style-spec/util/color.js
@@ -18,12 +18,14 @@ class Color {
     g: number;
     b: number;
     a: number;
+    premultiplyAlpha: boolean;
 
-    constructor(r: number, g: number, b: number, a: number = 1) {
+    constructor(r: number, g: number, b: number, a: number = 1, premultiplyAlpha: boolean = true) {
         this.r = r;
         this.g = g;
         this.b = b;
         this.a = a;
+        this.premultiplyAlpha = premultiplyAlpha;
     }
 
     static black: Color;
@@ -36,7 +38,7 @@ class Color {
      * Parses valid CSS color strings and returns a `Color` instance.
      * @returns A `Color` instance, or `undefined` if the input is not a valid color string.
      */
-    static parse(input?: string | Color | null): Color | void {
+    static parse(input?: string | Color | null, premultiplyAlpha?: boolean = true): Color | void {
         if (!input) {
             return undefined;
         }
@@ -54,11 +56,14 @@ class Color {
             return undefined;
         }
 
+        const factor = premultiplyAlpha ? rgba[3] : 1;
+
         return new Color(
-            rgba[0] / 255 * rgba[3],
-            rgba[1] / 255 * rgba[3],
-            rgba[2] / 255 * rgba[3],
-            rgba[3]
+            rgba[0] / 255 * factor,
+            rgba[1] / 255 * factor,
+            rgba[2] / 255 * factor,
+            rgba[3],
+            premultiplyAlpha
         );
     }
 
@@ -78,11 +83,13 @@ class Color {
     }
 
     toArray(): [number, number, number, number] {
-        const {r, g, b, a} = this;
-        return a === 0 ? [0, 0, 0, 0] : [
-            r * 255 / a,
-            g * 255 / a,
-            b * 255 / a,
+        const {r, g, b, a, premultiplyAlpha} = this;
+        if (premultiplyAlpha && a === 0) return [0, 0, 0, 0];
+        const factor = premultiplyAlpha ? 1 / a : 1;
+        return [
+            r * 255 * factor,
+            g * 255 * factor,
+            b * 255 * factor,
             a
         ];
     }

--- a/test/integration/expression-tests/format/basic/test.json
+++ b/test/integration/expression-tests/format/basic/test.json
@@ -64,7 +64,7 @@
             "image": null,
             "scale": null,
             "fontStack": null,
-            "textColor": {"r":0,"g":1,"b":0,"a":1}
+            "textColor": {"r":0,"g":1,"b":0,"a":1,"premultiplyAlpha":true}
           }
         ]
       }

--- a/test/unit/style-spec/color.js
+++ b/test/unit/style-spec/color.js
@@ -9,6 +9,7 @@ test('Color.parse', (t) => {
     t.deepEqual(Color.parse('invalid'), undefined);
     t.deepEqual(Color.parse(null), undefined);
     t.deepEqual(Color.parse(undefined), undefined);
+    t.deepEqual(Color.parse('rgba(255,0,255,0)', false), new Color(1, 0, 1, 0, false));
     t.end();
 });
 
@@ -17,5 +18,7 @@ test('Color#toString', (t) => {
     t.equal(purple && purple.toString(), 'rgba(128,0,128,1)');
     const translucentGreen = Color.parse('rgba(26, 207, 26, .73)');
     t.equal(translucentGreen && translucentGreen.toString(), 'rgba(26,207,26,0.73)');
+    const unpremultiplied = Color.parse('rgba(26, 207, 26, 0)', false);
+    t.equal(unpremultiplied && unpremultiplied.toString(), 'rgba(26,207,26,0)');
     t.end();
 });

--- a/test/unit/style/format_section_override.test.js
+++ b/test/unit/style/format_section_override.test.js
@@ -8,8 +8,8 @@ import FormatSectionOverride from '../../../src/style/format_section_override.js
 test('evaluate', (t) => {
 
     t.test('override constant', (t) => {
-        const defaultColor = {"r": 0, "g": 1, "b": 0, "a": 1};
-        const overridenColor = {"r": 1, "g": 0, "b": 0, "a": 1};
+        const defaultColor = {"r": 0, "g": 1, "b": 0, "a": 1, premultiplyAlpha: true};
+        const overridenColor = {"r": 1, "g": 0, "b": 0, "a": 1, premultiplyAlpha: true};
         const overriden = new PossiblyEvaluatedPropertyValue(
             properties.paint.properties['text-color'],
             {kind: 'constant', value: defaultColor},
@@ -31,9 +31,9 @@ test('evaluate', (t) => {
     t.test('override expression', (t) => {
         const warn = console.warn;
         console.warn = (_) => {};
-        const defaultColor = {"r": 0, "g": 0, "b": 0, "a": 1};
-        const propertyColor = {"r": 1, "g": 0, "b": 0, "a": 1};
-        const overridenColor = {"r": 0, "g": 0, "b": 1, "a": 1};
+        const defaultColor = {"r": 0, "g": 0, "b": 0, "a": 1, premultiplyAlpha: true};
+        const propertyColor = {"r": 1, "g": 0, "b": 0, "a": 1, premultiplyAlpha: true};
+        const overridenColor = {"r": 0, "g": 0, "b": 1, "a": 1, premultiplyAlpha: true};
         const styleExpr = createExpression(
             ["get", "color"],
             properties.paint.properties['text-color'].specification);


### PR DESCRIPTION
The style spec currently premultiplies alpha as part of parsing. This presents two challenges:

- Not all types of drawing (e.g. fog) use a blending mode which assumes premultiplied alpha. In order to use a color with other blending modes, you must first un-premultiply alpha.
- It is impossible to ignore alpha since, when alpha = 0, then r, g, b values are destroyed on parsing

This PR allows `premultiplyAlpha?: boolean = true` to be specified in a style spec property. Since toArray performs the same un-premultiplication, it stores `premultiplyAlpha` on the color instance so that it can correctly convert to an array.

Submitting a draft PR for consideration, but I haven't yet decided whether or not it would just be better to deal with un-premultiplication and special cases for zero.