### PR TITLE
Fix shader preprocessor define leading to invalid shaders on production build variants

### DIFF
--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -69,11 +69,7 @@ vec3 fog_apply(vec3 color, vec3 pos) {
 }
 
 // Apply fog and haze which were computed in the vertex shader
-vec3 fog_apply_from_vert(vec3 color, float fog_opac
-#ifdef FOG_HAZE
-    , vec4 haze
-#endif
-) {
+vec3 fog_apply_from_vert(vec3 color, float fog_opac, vec4 haze) {
 #ifdef FOG_HAZE
     color = srgb_to_linear(color);
     color = mix(color, tonemap(color + haze.rgb), haze.a);

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -25,12 +25,7 @@ vec3 fog_position(vec2 pos) {
     return fog_position(vec3(pos, 0));
 }
 
-void fog_haze(
-    vec3 pos, out float fog_opac
-#ifdef FOG_HAZE
-    , out vec4 haze
-#endif
-) {
+void fog_haze(vec3 pos, out float fog_opac, out vec4 haze) {
     // Map [near, far] to [0, 1]
     float t = (length(pos) - u_fog_range.x) / (u_fog_range.y - u_fog_range.x);
 

--- a/src/shaders/terrain_raster.fragment.glsl
+++ b/src/shaders/terrain_raster.fragment.glsl
@@ -14,7 +14,8 @@ void main() {
 #ifdef FOG_HAZE
     color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, v_haze_color));
 #else
-    color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, vec4(0.0));
+    vec4 unused;
+    color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, unused));
 #endif
 #endif
     gl_FragColor = color;

--- a/src/shaders/terrain_raster.fragment.glsl
+++ b/src/shaders/terrain_raster.fragment.glsl
@@ -11,9 +11,10 @@ varying vec4 v_haze_color;
 void main() {
     vec4 color = texture2D(u_image0, v_pos0);
 #ifdef FOG
-    color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity
 #ifdef FOG_HAZE
-        , v_haze_color
+    color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, v_haze_color);
+#else
+    color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, vec4(0.0));
 #endif
     ));
 #endif

--- a/src/shaders/terrain_raster.fragment.glsl
+++ b/src/shaders/terrain_raster.fragment.glsl
@@ -12,11 +12,10 @@ void main() {
     vec4 color = texture2D(u_image0, v_pos0);
 #ifdef FOG
 #ifdef FOG_HAZE
-    color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, v_haze_color);
+    color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, v_haze_color));
 #else
     color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, vec4(0.0));
 #endif
-    ));
 #endif
     gl_FragColor = color;
 #ifdef TERRAIN_WIREFRAME

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -30,7 +30,8 @@ void main() {
 #ifdef FOG_HAZE
     fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, v_haze_color);
 #else
-    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, vec4(0.0));
+    vec4 unused;
+    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, unused);
 #endif
 #endif
 }

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -27,9 +27,11 @@ void main() {
     gl_Position = u_matrix * vec4(decodedPos, elevation, 1.0);
 
 #ifdef FOG
-    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity
 #ifdef FOG_HAZE
-        , v_haze_color
+    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, v_haze_color);
+#else
+    vec4 unused = vec4(0.0);
+    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, unused);
 #endif
     );
 #endif

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -30,7 +30,7 @@ void main() {
 #ifdef FOG_HAZE
     fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, v_haze_color);
 #else
-    vec4 unused = vec4(0.0);
+    const vec4 unused = vec4(0.0);
     fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, unused);
 #endif
     );

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -30,8 +30,7 @@ void main() {
 #ifdef FOG_HAZE
     fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, v_haze_color);
 #else
-    const vec4 unused = vec4(0.0);
-    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, unused);
+    fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, vec4(0.0));
 #endif
     );
 #endif

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -32,6 +32,5 @@ void main() {
 #else
     fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, vec4(0.0));
 #endif
-    );
 #endif
 }


### PR DESCRIPTION
Fix that prevents glsl functions to have different signatures between build variants. This led to an invalid shader on production builds due to shader stripping/minification. 