### PR TITLE
Add map.queryTerrainElevationAt(lngLat)

### DIFF
--- a/debug/terrain-debug.html
+++ b/debug/terrain-debug.html
@@ -351,6 +351,11 @@ document.onkeypress = function(e) {
     }
 };
 
+map.on('idle', function() {
+    var elevation = map.queryTerrainElevationAt(map.getCenter());
+    console.log("Elevation at center: " + elevation);
+});
+
 </script>
 </body>
 </html>

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -315,7 +315,7 @@ class Transform {
 
         // Compute zoom level from the height of the camera relative to the terrain
         const cameraZoom: number = this._cameraZoom;
-        const elevationAtCenter = this._elevation.getAtPoint(MercatorCoordinate.fromLngLat(this.center));
+        const elevationAtCenter = this._elevation.getAtPoint(MercatorCoordinate.fromLngLat(this.center), 0);
         const mercatorElevation = mercatorZfromAltitude(elevationAtCenter, this.center.lat);
         const altitude  = this._mercatorZfromZoom(cameraZoom);
         const minHeight = this._mercatorZfromZoom(this._maxZoom);
@@ -984,7 +984,7 @@ class Transform {
      * @private
      */
     _coordinatePoint(coord: MercatorCoordinate, sampleTerrainIn3D: boolean) {
-        const elevation = sampleTerrainIn3D && this.elevation ? this.elevation.getAtPoint(coord, this._centerAltitude) : this._centerAltitude;
+        const elevation = sampleTerrainIn3D && this.elevation ? this.elevation.getAtPoint(coord, this._centerAltitude | 0) : this._centerAltitude;
         const p = [coord.x * this.worldSize, coord.y * this.worldSize, elevation + coord.toAltitude(), 1];
         vec4.transformMat4(p, p, this.pixelMatrix);
         return p[3] > 0 ?
@@ -1146,7 +1146,7 @@ class Transform {
 
         const elevation: Elevation = this._elevation;
         this._updateCameraState();
-        const elevationAtCamera = elevation.getAtPoint(this._camera.mercatorPosition);
+        const elevationAtCamera = elevation.getAtPoint(this._camera.mercatorPosition, 0);
 
         const minHeight = this._minimumHeightOverTerrain() *  Math.cos(degToRad(this._maxPitch));
         const terrainElevation = mercatorZfromAltitude(elevationAtCamera, this._center.lat);

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -25,7 +25,10 @@ export class Elevation {
      * point elevation, returns `defaultIfNotLoaded`.
      * Doesn't invoke network request to fetch the data.
      */
-    getAtPoint(point: MercatorCoordinate, defaultIfNotLoaded: number = 0): number {
+    getAtPoint(point: MercatorCoordinate, defaultIfNotLoaded: ?number): number | null {
+        // Force a cast to null for both null and undefined
+        if(defaultIfNotLoaded == null) defaultIfNotLoaded = null;
+
         const src = this._source();
         if (!src) return defaultIfNotLoaded;
         if (point.y < 0.0 || point.y > 1.0) {
@@ -59,7 +62,7 @@ export class Elevation {
         const tilesAtTileZoom = 1 << tileID.canonical.z;
         return this.getAtPoint(new MercatorCoordinate(
             tileID.wrap + (tileID.canonical.x + x / EXTENT) / tilesAtTileZoom,
-            (tileID.canonical.y + y / EXTENT) / tilesAtTileZoom));
+            (tileID.canonical.y + y / EXTENT) / tilesAtTileZoom), 0);
     }
 
     /*

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -133,7 +133,7 @@ class FreeCameraOptions {
             return;
         }
 
-        const altitude = this._elevation ? this._elevation.getAtPoint(MercatorCoordinate.fromLngLat(location)) : 0;
+        const altitude = this._elevation ? this._elevation.getAtPoint(MercatorCoordinate.fromLngLat(location), 0) : 0;
         const pos: MercatorCoordinate = this.position;
         const target = MercatorCoordinate.fromLngLat(location, altitude);
         const forward = [target.x - pos.x, target.y - pos.y, target.z - pos.z];

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -16,6 +16,7 @@ import Hash from './hash.js';
 import HandlerManager from './handler_manager.js';
 import Camera from './camera.js';
 import LngLat from '../geo/lng_lat.js';
+import MercatorCoordinate from '../geo/mercator_coordinate';
 import LngLatBounds from '../geo/lng_lat_bounds.js';
 import Point from '@mapbox/point-geometry';
 import AttributionControl from './control/attribution_control.js';
@@ -2167,6 +2168,23 @@ class Map extends Camera {
      */
     getTerrain(): Terrain | null {
         return this.style.getTerrain();
+    }
+
+    /**
+     * Queries the currently loaded data for elevation at a geographical location.
+     * Returns `null` if `terrain` is disabled or if terrain data for the location hasn't been loaded yet.
+     *
+     * In order to gurantee that the terrain data is loaded ensure that the geographical location is visble and wait for the `idle` event to occur.
+     * @param {LngLatLike} lnglat The geographical location to project.
+     * @returns {number | null} The elevation in meters, accounting for `terrain.exaggeration`.
+     * @example
+     * var coordinate = [-122.420679, 37.772537];
+     * var elevation = map.queryTerrainElevationAt(coordinate);
+     */
+    queryTerrainElevationAt(lngLat: LngLatLike): number | null {
+        if (!this.transform.elevation) return null;
+
+        return this.transform.elevation.getAtPoint(MercatorCoordinate.fromLngLat(lngLat));
     }
 
     /**

--- a/test/unit/terrain/terrain.test.js
+++ b/test/unit/terrain/terrain.test.js
@@ -216,34 +216,34 @@ test('Elevation', (t) => {
                 t.equal(map.painter.terrain.getAtPoint(coord), 0);
 
                 t.test('dx', t => {
-                    const elevationDx = map.painter.terrain.getAtPoint({x: coord.x + dx, y: coord.y});
+                    const elevationDx = map.painter.terrain.getAtPoint({x: coord.x + dx, y: coord.y}, 0);
                     t.assert(Math.abs(elevationDx - 0.1) < 1e-12);
                     t.end();
                 });
 
                 t.test('dy', t => {
-                    const elevationDy = map.painter.terrain.getAtPoint({x: coord.x, y: coord.y + dx});
+                    const elevationDy = map.painter.terrain.getAtPoint({x: coord.x, y: coord.y + dx}, 0);
                     const expectation = TILE_SIZE * 0.1;
                     t.assert(Math.abs(elevationDy - expectation) < 1e-12);
                     t.end();
                 });
 
                 t.test('dx/3 dy/3', t => {
-                    const elevation = map.painter.terrain.getAtPoint({x: coord.x + dx / 3, y: coord.y + dx / 3});
+                    const elevation = map.painter.terrain.getAtPoint({x: coord.x + dx / 3, y: coord.y + dx / 3}, 0);
                     const expectation = (2 * TILE_SIZE + 2) * 0.1 / 6;
                     t.assert(Math.abs(elevation - expectation) < 1e-9);
                     t.end();
                 });
 
                 t.test('-dx -wrap', t => {
-                    const elevation = map.painter.terrain.getAtPoint({x: coord.x - dx, y: coord.y});
+                    const elevation = map.painter.terrain.getAtPoint({x: coord.x - dx, y: coord.y}, 0);
                     const expectation = (TILE_SIZE - 1) * 0.1;
                     t.assert(Math.abs(elevation - expectation) < 1e-12);
                     t.end();
                 });
 
                 t.test('-1.5dx -wrap', t => {
-                    const elevation = map.painter.terrain.getAtPoint({x: coord.x - 1.5 * dx, y: coord.y});
+                    const elevation = map.painter.terrain.getAtPoint({x: coord.x - 1.5 * dx, y: coord.y}, 0);
                     const expectation = (TILE_SIZE - 1.5) * 0.1;
                     t.assert(Math.abs(elevation - expectation) < 1e-12);
                     t.end();


### PR DESCRIPTION
Adds a new `queryTerrainElevationAt` method to `map` to allow users to get the elevation for certain geographical coordinates. 

Named this with` query..` to make it analogous to `queryRenderedFeatures` so its more clear to users that this only works for visible locations since its based on currently loaded tiles.

- Refactored the internal method so it also returns `null`, instead of `0` when terrain data is not found. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add map.queryElevationAt(lngLat) API.</changelog>`
