### PR TITLE
Clarify mouseleave docs

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -497,8 +497,10 @@ export type MapEvent =
     | 'mouseenter'
 
     /**
-     * Fired when a pointing device (usually a mouse) leaves a visible portion of a specified layer, or leaves
-     * the map canvas.
+     * Fired when a pointing device (usually a mouse) leaves a visible portion of a specified layer or moves
+     * from the specified layer to outside the map canvas.
+     *
+     * **Note:** To detect when the mouse leaves the canvas, independent of layer, use {@link Map.event:mouseout} instead.
      *
      * **Important:** This event can only be listened for when {@link Map#on} includes three arguements,
      * where the second argument specifies the desired layer.

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -502,7 +502,7 @@ export type MapEvent =
      *
      * **Note:** To detect when the mouse leaves the canvas, independent of layer, use {@link Map.event:mouseout} instead.
      *
-     * **Important:** This event can only be listened for when {@link Map#on} includes three arguements,
+     * **Important:** This event can only be listened for when {@link Map#on} includes three arguments,
      * where the second argument specifies the desired layer.
      *
      * @event mouseleave


### PR DESCRIPTION
See: #10594

This PR adds a small clarification to the [`mouseleave`](https://docs.mapbox.com/mapbox-gl-js/api/map/#map.event:mouseleave) docs to be extra clear about its function as well as the relation to `mouseout`.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
