### PR TITLE
Simplify haze evaluation

### DIFF
--- a/src/render/fog.js
+++ b/src/render/fog.js
@@ -3,7 +3,7 @@
 import Context from '../gl/context.js';
 import type {UniformLocations} from './uniform_binding.js';
 
-import {Uniform1f, Uniform2f, Uniform3f, Uniform4f, UniformMatrix4f} from './uniform_binding.js';
+import {Uniform1f, Uniform2f, Uniform3f, UniformMatrix4f} from './uniform_binding.js';
 
 export type FogUniformsType = {|
     'u_fog_matrix': UniformMatrix4f,
@@ -12,7 +12,7 @@ export type FogUniformsType = {|
     'u_fog_exponent': Uniform1f,
     'u_fog_horizon_blend': Uniform1f,
     'u_fog_temporal_offset': Uniform1f,
-    'u_haze_color_linear': Uniform4f,
+    'u_haze_color_linear': Uniform3f,
 
     // Precision may differ, so we must pass uniforms separately for use in a vertex shader
     'u_fog_opacity': Uniform1f,
@@ -26,7 +26,7 @@ export const fogUniforms = (context: Context, locations: UniformLocations): FogU
     'u_fog_exponent': new Uniform1f(context, locations.u_fog_exponent),
     'u_fog_horizon_blend': new Uniform1f(context, locations.u_fog_horizon_blend),
     'u_fog_temporal_offset': new Uniform1f(context, locations.u_fog_temporal_offset),
-    'u_haze_color_linear': new Uniform4f(context, locations.u_haze_color_linear),
+    'u_haze_color_linear': new Uniform3f(context, locations.u_haze_color_linear),
 
     'u_fog_opacity': new Uniform1f(context, locations.u_fog_opacity),
 });

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -865,16 +865,11 @@ class Painter {
             if (fog.properties.get('haze-color').a > 0) {
                 const hazeColor = fog.properties.get('haze-color');
                 const hazeBaseAmpl = 5;
-                const hazeColorLinear = [
+                uniforms['u_haze_color_linear'] = [
                     hazeBaseAmpl * Math.pow(hazeColor.r, 2.2),
                     hazeBaseAmpl * Math.pow(hazeColor.g, 2.2),
                     hazeBaseAmpl * Math.pow(hazeColor.b, 2.2),
-                    // Alpha is already premultiplied into the color, so we use haze color alpha to
-                    // specify how much tone mapping to apply, reaching full strength after opacity=0.5.
-                    Math.min(1, 2.0 * hazeColor.a)
                 ];
-
-                uniforms['u_haze_color_linear'] = hazeColorLinear;
             }
 
             program.setFogUniformValues(context, uniforms);

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -865,10 +865,13 @@ class Painter {
             if (fog.properties.get('haze-color').a > 0) {
                 const hazeColor = fog.properties.get('haze-color');
                 const hazeBaseAmpl = 5;
+                // Since there's no significant difference in visual effect, we use approximate
+                // sRGB -> linear RGB conversion with a power of 2 instead of 2.2 in order to
+                // avoid pow() functions in the shader.
                 uniforms['u_haze_color_linear'] = [
-                    hazeBaseAmpl * Math.pow(hazeColor.r, 2.2),
-                    hazeBaseAmpl * Math.pow(hazeColor.g, 2.2),
-                    hazeBaseAmpl * Math.pow(hazeColor.b, 2.2),
+                    hazeBaseAmpl * Math.pow(hazeColor.r, 2),
+                    hazeBaseAmpl * Math.pow(hazeColor.g, 2),
+                    hazeBaseAmpl * Math.pow(hazeColor.b, 2),
                 ];
             }
 

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -28,12 +28,3 @@ vec3 dither(vec3 color, highp vec2 seed) {
     vec3 rnd = hash(seed) + hash(seed + 0.59374) - 0.5;
     return color + rnd / 255.0;
 }
-
-vec3 linear_to_srgb(vec3 color) {
-    return pow(color, vec3(1.0 / 2.2));
-}
-
-vec3 srgb_to_linear(vec3 color) {
-    return pow(color, vec3(2.2));
-}
-

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -43,7 +43,7 @@ float fog_opacity(vec3 pos) {
 }
 
 // This function applies haze to an input color using an approximation of the following algorithm:
-//   1. convert `color` from sRGB to linear RGB
+//   1. convert color from sRGB to linear RGB
 //   2. add haze (presuming haze is in linear RGB)
 //   3. tone-map the output
 //   4. convert the result back to sRGB

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -42,6 +42,14 @@ float fog_opacity(vec3 pos) {
     return fog_opacity((length(pos) - u_fog_range.x) / (u_fog_range.y - u_fog_range.x));
 }
 
+// This function applies haze to an input color using an approximation of the following algorithm:
+//   1. convert `color` from sRGB to linear RGB
+//   2. add haze (presuming haze is in linear RGB)
+//   3. tone-map the output
+//   4. convert the result back to sRGB
+// The equation below is based on a curve fit of the above algorithm, with the additional approximation
+// during linear-srgb conversion that gamma=2, in order to avoid transcendental function evaluations
+// which don't affect the visual quality.
 vec3 haze_apply(vec3 color, vec3 haze) {
     vec3 color2 = color * color;
     return sqrt((color2 + haze) / (1.0 + color2 * color2 * haze));

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -52,7 +52,7 @@ float fog_opacity(vec3 pos) {
 // which don't affect the visual quality.
 vec3 haze_apply(vec3 color, vec3 haze) {
     vec3 color2 = color * color;
-    return sqrt((color2 + haze) / (1.0 + color2 * color2 * haze));
+    return sqrt((color2 + haze) / (1.0 + color2 * color * haze));
 }
 
 vec3 fog_apply(vec3 color, vec3 pos) {

--- a/src/shaders/_prelude_fog.fragment.glsl
+++ b/src/shaders/_prelude_fog.fragment.glsl
@@ -42,6 +42,11 @@ float fog_opacity(vec3 pos) {
     return fog_opacity((length(pos) - u_fog_range.x) / (u_fog_range.y - u_fog_range.x));
 }
 
+vec3 haze_apply(vec3 color, vec3 haze) {
+    vec3 color2 = color * color;
+    return sqrt((color2 + haze) / (1.0 + color2 * color2 * haze));
+}
+
 vec3 fog_apply(vec3 color, vec3 pos) {
     // Map [near, far] to [0, 1]
     float depth = length(pos);
@@ -52,9 +57,7 @@ vec3 fog_apply(vec3 color, vec3 pos) {
     fog_opac *= fog_horizon_blending(pos / depth);
 
 #ifdef FOG_HAZE
-    vec3 haze = haze_opac * u_haze_color_linear;
-    vec3 color2 = color * color;
-    color = sqrt((color2 + haze) / (1.0 + color2 * color2 * haze));
+    color = haze_apply(color, haze_opac * u_haze_color_linear);
 #endif
 
     return mix(color, u_fog_color, fog_opac);
@@ -63,8 +66,7 @@ vec3 fog_apply(vec3 color, vec3 pos) {
 // Apply fog and haze which were computed in the vertex shader
 vec3 fog_apply_from_vert(vec3 color, float fog_opac, vec3 haze) {
 #ifdef FOG_HAZE
-    vec3 color2 = color * color;
-    color = sqrt((color2 + haze) / (1.0 + color2 * color2 * haze));
+    color = haze_apply(color, haze);
 #endif
 
     return mix(color, u_fog_color, fog_opac);

--- a/src/shaders/_prelude_fog.vertex.glsl
+++ b/src/shaders/_prelude_fog.vertex.glsl
@@ -5,7 +5,7 @@ uniform mediump float u_fog_horizon_blend;
 uniform mediump float u_fog_opacity;
 uniform mediump float u_fog_exponent;
 uniform mediump vec2 u_fog_range;
-uniform mediump vec4 u_haze_color_linear;
+uniform mediump vec3 u_haze_color_linear;
 
 // This function much match fog_opacity defined in _prelude_fog.fragment.glsl
 float fog_opacity(float t) {
@@ -32,7 +32,7 @@ vec3 fog_position(vec2 pos) {
     return fog_position(vec3(pos, 0));
 }
 
-void fog_haze(vec3 pos, out float fog_opac, out vec4 haze) {
+void fog_haze(vec3 pos, out float fog_opac, out vec3 haze) {
     // Map [near, far] to [0, 1]
     float depth = length(pos);
     float t = (depth - u_fog_range.x) / (u_fog_range.y - u_fog_range.x);
@@ -42,12 +42,7 @@ void fog_haze(vec3 pos, out float fog_opac, out vec4 haze) {
     fog_opac *= fog_horizon_blending(pos / depth);
 
 #ifdef FOG_HAZE
-    haze.rgb = haze_opac * u_haze_color_linear.rgb;
-
-    // The smoothstep fades in tonemapping slightly before the fog layer. This violates
-    // the principle that fog should not have an effect outside the fog layer, but the
-    // effect is hardly noticeable except on pure white glaciers.
-    haze.a = u_fog_opacity * u_haze_color_linear.a * smoothstep(-0.5, 0.25, t);
+    haze.rgb = haze_opac * u_haze_color_linear;
 #endif
 }
 

--- a/src/shaders/terrain_raster.fragment.glsl
+++ b/src/shaders/terrain_raster.fragment.glsl
@@ -4,7 +4,7 @@ varying vec2 v_pos0;
 #ifdef FOG
 varying float v_fog_opacity;
 #ifdef FOG_HAZE
-varying vec4 v_haze_color;
+varying vec3 v_haze_color;
 #endif
 #endif
 
@@ -14,7 +14,7 @@ void main() {
 #ifdef FOG_HAZE
     color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, v_haze_color));
 #else
-    vec4 unused;
+    vec3 unused;
     color.rgb = fog_dither(fog_apply_from_vert(color.rgb, v_fog_opacity, unused));
 #endif
 #endif

--- a/src/shaders/terrain_raster.vertex.glsl
+++ b/src/shaders/terrain_raster.vertex.glsl
@@ -9,7 +9,7 @@ varying vec2 v_pos0;
 #ifdef FOG
 varying float v_fog_opacity;
 #ifdef FOG_HAZE
-varying vec4 v_haze_color;
+varying vec3 v_haze_color;
 #endif
 #endif
 
@@ -30,7 +30,7 @@ void main() {
 #ifdef FOG_HAZE
     fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, v_haze_color);
 #else
-    vec4 unused;
+    vec3 unused;
     fog_haze(fog_position(vec3(decodedPos, elevation)), v_fog_opacity, unused);
 #endif
 #endif


### PR DESCRIPTION
This PR greatly simplifies the haze evaluation—both in terms of code and computational expense—with very little change in visual effect.

Preface: I’m well aware of the risk of code-golfing this into oblivion until no one can make sense of it, but I think the following change removes most of the negative aspects @ansis was very legitimately concerned about, while maintaining reasonable motivation and resulting in a much more self-contained and easy to maintain application of this coloring.

Update: I've illustrated the following argument in an [interactive notebook](https://observablehq.com/d/c560bfcd269fe678)

The existing process for computing haze is as follows:

1. convert the fragment color from srgb to linear
2. add haze to that color
3. tonemap to avoid blown out fully saturated rgb values
4. convert linear back to srgb

The process makes reasonable physical sense but involves a lot of steps and also lead to small frustrations like having to fight against tonemapping subtly darkening colors. It also raises questions like: do we really want ad hoc color space conversion and tonemapping in the middle of a special purpose function?

This PR maintains the above motivation while consolidating the evaluation into a single step.

For varying values of haze `h` = (0, 0.01, 0.05, 0.25, 0.5), the red curves below illustrate the above four-step process, with input colors on the x-axis and output colors on the y-axis. The tonemapping and color computation functions are given by:

<img width="247" alt="Screen Shot 2021-04-21 at 7 26 23 PM" src="https://user-images.githubusercontent.com/572717/115646750-9d8f1380-a2d7-11eb-9b41-3c4fd374689c.png">
<img width="299" alt="Screen Shot 2021-04-21 at 7 26 30 PM" src="https://user-images.githubusercontent.com/572717/115646756-9f58d700-a2d7-11eb-8406-d4d72898f860.png">

(with k = 8.0 in the [smooth min](https://iquilezles.org/www/articles/smin/smin.htm) tonemapping function). Based on @ansis' observation that we could just scale the curve to pass through (1, 1) exactly, the black lines illustrate the simplified equation (with γ= 2.2):

<img width="172" alt="Screen Shot 2021-04-21 at 7 28 16 PM" src="https://user-images.githubusercontent.com/572717/115646858-c4e5e080-a2d7-11eb-911d-8e1dceb36156.png">

https://www.desmos.com/calculator/nhgqknt2w0
<img width="595" alt="gamma-2 2" src="https://user-images.githubusercontent.com/572717/115647000-f8c10600-a2d7-11eb-8823-23384185f31d.png">

Finally, we can further fudge the gamma just a bit since exceptional physical accuracy is not needed. If we use γ= 2, `pow()` calls disappear and we're left with a single square root as the only transcendental function:

<img width="137" alt="Screen Shot 2021-04-21 at 7 28 19 PM" src="https://user-images.githubusercontent.com/572717/115646969-ed6dda80-a2d7-11eb-93e5-4558ca6efbac.png">

(the x^4 in the denominator is a small touch which prevents the colors from getting too squished together near (1, 1). Without it, they are closer to tangent and visual details is lost.)

<img width="648" alt="gamma-2" src="https://user-images.githubusercontent.com/572717/115646985-f363bb80-a2d7-11eb-88c0-25479ad10e31.png">

Benefits of this approach:

- calls to exp2, log2, and two calls to pow are reduced to a single sqrt (all repeated 3x for r/g/b)
- Significantly less shader code
- avoids the need to pass an extra varying to manage tonemapping
- Output is strictly lighter than the input, so that we don't have to worry about undesirably darkening colors by tonemapping
- It follows the original motivation, which I think is reasonable, while eliminating a lot fo the negatives

The difference in appearance is negligible. Darkening of pure whites due to the tonemapping is just about the only difference which can't be compensated for by a very slight change the parameters.

Original:
<img width="911" alt="tonemapped" src="https://user-images.githubusercontent.com/572717/115647727-32ded780-a2d9-11eb-8db9-4b23af157ce8.png">

Simplified:
<img width="911" alt="simplified" src="https://user-images.githubusercontent.com/572717/115647754-3a05e580-a2d9-11eb-9a4e-c588df1ea3c6.png">

(Strictly speaking, I ever so slightly modified the exponent in the cpu-side approximate srgb-linear conversion. The above shows power 2.2. I've PR'd power 2.0. The difference can entirely be compensated for by *very* slightly changing the input color. The difference does not seem important; I only note it to be precise.)

To be addressed in followup: consolidating and refactoring into a shared vertex/fragment prelude.glsl.