### PR TITLE
Pinch to zoom

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -39,6 +39,7 @@ class ScrollZoomHandler {
     _aroundCenter: boolean;
     _aroundPoint: Point;
     _aroundCoord: MercatorCoordinate;
+    _requireCtrl: boolean;
     _type: 'wheel' | 'trackpad' | null;
     _lastValue: number;
     _timeout: ?TimeoutID; // used for delayed-handling of a single wheel movement
@@ -106,6 +107,16 @@ class ScrollZoomHandler {
         return !!this._enabled;
     }
 
+    /**
+     * Returns a Boolean indicating whether to require the CTRL key for zoom events. Modern browsers treat
+     * pinch gestures as WheelEvents with the CTRL key pressed.
+     *
+     * @returns {boolean} `true` if the "require CTRL" option is enabled.
+     */
+    requiresCtrl() {
+        return !!this._requireCtrl;
+    }
+
     /*
     * Active state is turned on and off with every scroll wheel event and is set back to false before the map
     * render is called, so _active is not a good candidate for determining if a scroll zoom animation is in
@@ -134,6 +145,7 @@ class ScrollZoomHandler {
         if (this.isEnabled()) return;
         this._enabled = true;
         this._aroundCenter = options && options.around === 'center';
+        this._requireCtrl = options && options.requireCtrl === true;
     }
 
     /**
@@ -149,6 +161,7 @@ class ScrollZoomHandler {
 
     wheel(e: WheelEvent) {
         if (!this.isEnabled()) return;
+        if (this.requiresCtrl() && !e.ctrlKey) return;
 
         // Remove `any` cast when https://github.com/facebook/flow/issues/4879 is fixed.
         let value = e.deltaMode === (window.WheelEvent: any).DOM_DELTA_LINE ? e.deltaY * 40 : e.deltaY;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -133,19 +133,22 @@ class ScrollZoomHandler {
     /**
      * Enables the "scroll to zoom" interaction.
      *
-     * @param {Object} [options] Options object.
-     * @param {string} [options.around] If "center" is passed, map will zoom around center of map
+     * @param {Object}  [options] Options object.
+     * @param {string}  [options.around] If "center" is passed, map will zoom around center of map
+     * @param {boolean} [options.requireCtrl] If `true` is passed, map will only zoom when Ctrl key is pressed
      *
      * @example
      *   map.scrollZoom.enable();
      * @example
      *  map.scrollZoom.enable({ around: 'center' })
+     * @example
+     *  map.scrollZoom.enable({ requireCtrl: true })
      */
-    enable(options: any) {
+    enable(options: ?{around?: 'center', requireCtrl?: false}) {
         if (this.isEnabled()) return;
         this._enabled = true;
-        this._aroundCenter = options && options.around === 'center';
-        this._requireCtrl = options && options.requireCtrl === true;
+        this._aroundCenter = !!options && options.around === 'center';
+        this._requireCtrl = !!options && options.requireCtrl === true;
     }
 
     /**

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -3,7 +3,7 @@
 import assert from 'assert';
 import DOM from '../../util/dom.js';
 
-import {ease as _ease, bindAll, bezier} from '../../util/util.js';
+import {ease as _ease, bindAll, bezier, isSafari} from '../../util/util.js';
 import browser from '../../util/browser.js';
 import window from '../../util/window.js';
 import {number as interpolate} from '../../style-spec/util/interpolate.js';
@@ -111,10 +111,12 @@ class ScrollZoomHandler {
      * Returns a Boolean indicating whether to require the CTRL key for zoom events. Modern browsers treat
      * pinch gestures as WheelEvents with the CTRL key pressed.
      *
+     * Return false if we're currently in Safari as Safari uses pinch gestures for the tab switcher.
+     *
      * @returns {boolean} `true` if the "require CTRL" option is enabled.
      */
     requiresCtrl() {
-        return !!this._requireCtrl;
+        return this._requireCtrl && !isSafari();
     }
 
     /*

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -48,6 +48,30 @@ test('ScrollZoomHandler', (t) => {
         t.end();
     });
 
+    t.test('respects requireCtrl option', (t) => {
+        const clock = sinon.useFakeTimers(now);
+        const map = createMap(t);
+        map._renderTaskQueue.run();
+
+        map.scrollZoom.disable();
+        map.scrollZoom.enable({requireCtrl: true});
+
+        let startZoom = map.getZoom();
+        simulate.wheel(map.getCanvas(), {type: 'trackpad', deltaY: -50});
+        clock.tick(200);
+        map._renderTaskQueue.run();
+        t.equal(map.getZoom() - startZoom,  0);
+
+        startZoom = map.getZoom();
+        simulate.wheel(map.getCanvas(), {type: 'trackpad', deltaY: -50, ctrlKey: true});
+        clock.tick(200);
+        map._renderTaskQueue.run();
+        equalWithPrecision(t, map.getZoom() - startZoom,  0.0779, 0.001);
+
+        clock.restore();
+        t.end();
+    });
+
     t.test('Zooms for single mouse wheel tick with non-magical deltaY', (t) => {
         const map = createMap(t);
         map._renderTaskQueue.run();


### PR DESCRIPTION
# Add option to enable pinch to zoom exclusively

## Description
Issue #10227 describes a feature request for the ability to enable pinch-to-zoom in the browser, independent of the default `scrollZoom`. Specifically, a user should be able to pinch to zoom in and out, but not scroll to zoom.

Since most modern browsers treat pinch gestures as `WheelEvent`s with the Ctrl key pressed, we can watch for the Ctrl key on our scroll events, and, if `scrollZoom.requireCtrl` is set to `true`, ignore `WheelEvent`s where the Ctrl key is not pressed.

On Safari, where pinch-to-zoom is _not_ mapped to a `WheelEvent` + Ctrl key, we fall back to default `scrollZoom` behaviour.

## Testing
### Automated tests
I've added a test to `scroll_zoom.test.js`, which can be run by calling:
```
yarn test-unit ui/handler/scroll_zoom.test.js
```

### Manual testing
1. Start the debug server and load up the [default debug page](http://localhost:9966/debug). Using a touchpad/trackpad, scrolling should zoom the map in/out as usual.
2. Change the `new mapboxgl.Map()` call to include the `scrollZoom.requireCtrl` option:
```js
var map = window.map = new mapboxgl.Map({
    container: 'map',
    zoom: 12.5,
    center: [-122.4194, 37.7749],
    style: 'mapbox://styles/mapbox/streets-v10',
    hash: true,
    scrollZoom: {requireCtrl: true}
});
```
3. Once the changes have been picked up by the watcher, reload the page in Chrome (or other Chromium-based browser) or Firefox.
4. Regular scroll events should have no effect, but pinch effects should zoom the map in and out as expected.
5. If you have access to Safari on macOS, load the debug page. The map should zoom in and out on regular scroll events.

## Questions
- I've tried to update the types for `map.scrollZoom.enable(opts)` and add JSDoc where possible; **is there anywhere else I should add documentation for this feature?**
- Falling back to default scroll behaviour on Safari might not be quite what the developer intends. **What are your thoughts on this?**

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

## Checklist
 - [x] briefly describe the changes in this PR
 - [ ] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] ~~tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes~~
 - [ ] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Add requireCtrl option to scrollZoom to enable exclusive pinch-to-zoom</changelog>`
