### PR TITLE
Sample terrain to estimate de facto camera scale

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -213,7 +213,7 @@ class Transform {
     }
 
     get cameraWorldSize(): number {
-        const distance = Math.max(this._camera.getDistanceToElevation(this._averageElevation), 1e-20);
+        const distance = Math.max(this._camera.getDistanceToElevation(this._averageElevation), Number.EPSILON);
         return this._worldSizeFromZoom(this._zoomFromMercatorZ(distance));
     }
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -319,6 +319,7 @@ class Transform {
 
     sampleAverageElevation(): number {
         if (!this._elevation) return 0;
+        const elevation: Elevation = this._elevation;
 
         const elevationSamplePoints = [
             [0.5, 0.2],
@@ -332,19 +333,17 @@ class Transform {
 
         let elevationSum = 0.0;
         let weightSum = 0.0;
-        if (this._elevation) {
-            for (let i = 0; i < elevationSamplePoints.length; i++) {
-                const pt = new Point(
-                    elevationSamplePoints[i][0] * this.width,
-                    horizon + elevationSamplePoints[i][1] * (this.height - horizon)
-                );
-                const hit = this._elevation.pointCoordinate(pt);
-                if (!hit) continue;
+        for (let i = 0; i < elevationSamplePoints.length; i++) {
+            const pt = new Point(
+                elevationSamplePoints[i][0] * this.width,
+                horizon + elevationSamplePoints[i][1] * (this.height - horizon)
+            );
+            const hit = elevation.pointCoordinate(pt);
+            if (!hit) continue;
 
-                const weight = 1 / Math.hypot(hit[0] - this._camera.position[0], hit[1] - this._camera.position[1]);
-                elevationSum += hit[3] * weight;
-                weightSum += weight;
-            }
+            const weight = 1 / Math.hypot(hit[0] - this._camera.position[0], hit[1] - this._camera.position[1]);
+            elevationSum += hit[3] * weight;
+            weightSum += weight;
         }
 
         if (weightSum === 0) return 0;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -22,10 +22,10 @@ const NUM_WORLD_COPIES = 3;
 const DEFAULT_MIN_ZOOM = 0;
 
 const elevationSamplePoints = [
-    [0.5, 0.4],
-    [0.3, 0.6],
-    [0.5, 0.6],
-    [0.7, 0.6],
+    [0.5, 0.2],
+    [0.3, 0.5],
+    [0.5, 0.5],
+    [0.7, 0.5],
     [0.5, 0.8]
 ];
 
@@ -329,9 +329,14 @@ class Transform {
     sampleAverageElevation(): number {
         if (!this._elevation) return 0;
 
+        const horizon = this.horizonLineFromTop();
+        const points = elevationSamplePoints.map(p => [
+            p[0] * this.width,
+            horizon + p[1] * (this.height - horizon)
+        ]);
+
         /*
         // Phyllotaxis: https://www.desmos.com/calculator/duq27u6vof
-        const points = elevationSamplePoints.map(p => [p[0] * this.width, p[1] * this.height]);
 
         const n = 5;
         const xCenter = this.width * 0.5;
@@ -350,8 +355,8 @@ class Transform {
             ]);
         }*/
 
-        // BEGIN DEBUG
         /*
+        // BEGIN DEBUG
         const DEBUG = true;
         let debugEl;
         if (DEBUG) {
@@ -368,7 +373,7 @@ class Transform {
                 debugEl.style.pointerEvents = 'none';
                 document.body.appendChild(debugEl);
 
-                for (let i = 0; i < elevationSamplePoints.length; i++) {
+                for (let i = 0; i < points.length; i++) {
                     const pt = document.createElement('span');
                     pt.style.position = 'absolute';
                     pt.style.width = '10px'
@@ -382,21 +387,21 @@ class Transform {
                 }
             }
 
-            for (let i = 0; i < elevationSamplePoints.length; i++) {
+            for (let i = 0; i < points.length; i++) {
                 const el = debugEl.children.item(i);
-                el.style.left = `${elevationSamplePoints[i][0] * this.width}px`;
-                el.style.top = `${elevationSamplePoints[i][1] * this.height}px`;
+                el.style.left = `${points[i][0]}px`;
+                el.style.top = `${points[i][1]}px`;
             }
         }
-        */
         // END DEBUG
+        */
 
         let elevationSum = 0.0;
         let weightSum = 0.0;
         if (this._elevation) {
-            for (let i = 0; i < elevationSamplePoints.length; i++) {
-                const p = elevationSamplePoints[i];
-                const hit = this._elevation.pointCoordinate(new Point(p[0] * this.width, p[1] * this.height));
+            for (let i = 0; i < points.length; i++) {
+                const p = points[i];
+                const hit = this._elevation.pointCoordinate(new Point(p[0], p[1]));
                 if (!hit) {
                     /*
                     // BEGIN DEBUG

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -425,7 +425,8 @@ class Transform {
             }
         }
 
-        return elevationSum / Math.max(weightSum, 1e-8);
+        if (weightSum === 0) return 0;
+        return elevationSum / weightSum;
     }
 
     get center(): LngLat { return this._center; }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -329,95 +329,17 @@ class Transform {
         if (!this._elevation) return 0;
 
         const horizon = this.horizonLineFromTop();
-        const points = elevationSamplePoints.map(p => [
-            p[0] * this.width,
-            horizon + p[1] * (this.height - horizon)
-        ]);
-
-        /*
-        // Phyllotaxis: https://www.desmos.com/calculator/duq27u6vof
-
-        const n = 5;
-        const xCenter = this.width * 0.5;
-        const yCenter = this.height * 0.66;
-        const xRadius = this.width * 0.33;
-        const yRadius = this.height * 0.33;
-        const points = [];
-        const thetaScale = Math.PI * (3 - Math.sqrt(5));
-        for (let i = 1; i <= n; ++i) {
-            // Drop the usual square root to bias toward the center
-            const r = i / n;
-            const theta = i * thetaScale;
-            points.push([
-                xCenter + r * xRadius * Math.sin(theta),
-                yCenter - r * yRadius * Math.cos(theta)
-            ]);
-        }*/
-
-        /*
-        // BEGIN DEBUG
-        const DEBUG = true;
-        let debugEl;
-        if (DEBUG) {
-            debugEl = document.getElementById('pts');
-            if (!debugEl) {
-                debugEl = document.createElement('div');
-                debugEl.id = 'pts';
-                debugEl.style.position = 'absolute';
-                debugEl.style.top = 0;
-                debugEl.style.bottom = 0;
-                debugEl.style.left = 0;
-                debugEl.style.right = 0;
-                debugEl.style.zIndex = 10;
-                debugEl.style.pointerEvents = 'none';
-                document.body.appendChild(debugEl);
-
-                for (let i = 0; i < points.length; i++) {
-                    const pt = document.createElement('span');
-                    pt.style.position = 'absolute';
-                    pt.style.width = '10px'
-                    pt.style.height = '10px'
-                    pt.style.borderRadius = '10px';
-                    pt.style.backgroundColor = 'red';
-                    pt.style.transform = 'translate(-5px,-5px)';
-                    pt.style.textIndent = '1em';
-                    pt.style.textShadow = '0 0 2px #ffffff, 0 0 2px #ffffff, 0 0 2px #ffffff, 0 0 2px #ffffff, 0 0 2px #ffffff';
-                    debugEl.appendChild(pt);
-                }
-            }
-
-            for (let i = 0; i < points.length; i++) {
-                const el = debugEl.children.item(i);
-                el.style.left = `${points[i][0]}px`;
-                el.style.top = `${points[i][1]}px`;
-            }
-        }
-        // END DEBUG
-        */
 
         let elevationSum = 0.0;
         let weightSum = 0.0;
         if (this._elevation) {
-            for (let i = 0; i < points.length; i++) {
-                const p = points[i];
-                const hit = this._elevation.pointCoordinate(new Point(p[0], p[1]));
-                if (!hit) {
-                    /*
-                    // BEGIN DEBUG
-                    debugEl.children.item(i).textContent = 'null'
-                    debugEl.children.item(i).style.backgroundColor = 'gray';
-                    // END DEBUG
-                    */
-                    continue;
-                }
-                /*
-                // BEGIN DEBUG
-                if (DEBUG) {
-                    debugEl.children.item(i).textContent = hit[3].toFixed(0);
-                    debugEl.children.item(i).style.backgroundColor = 'blue';
-                }
-                // END DEBUG
-                */
+            for (let i = 0; i < elevationSamplePoints.length; i++) {
+                const pt = new Point(
+                    elevationSamplePoints[i][0] * this.width,
+                    horizon + elevationSamplePoints[i][1] * (this.height - horizon)
+                );
+                const hit = this._elevation.pointCoordinate(pt);
+                if (!hit) continue;
 
                 const weight = 1 / Math.hypot(hit[0] - this._camera.position[0], hit[1] - this._camera.position[1]);
                 elevationSum += hit[3] * weight;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -113,11 +113,11 @@ class Transform {
         this._fogTileMatrixCache = {};
         this._camera = new FreeCamera();
         this._centerAltitude = 0;
+        this._averageElevation = 0;
         this.cameraElevationReference = "ground";
 
         // Move the horizon closer to the center. 0 would not shift the horizon. 1 would put the horizon at the center.
         this._horizonShift = 0.1;
-        this._averageElevation = 0;
     }
 
     clone(): Transform {
@@ -135,12 +135,12 @@ class Transform {
         clone.angle = this.angle;
         clone._fov = this._fov;
         clone._pitch = this._pitch;
+        clone._averageElevation = this._averageElevation;
         clone._unmodified = this._unmodified;
         clone._edgeInsets = this._edgeInsets.clone();
         clone._camera = this._camera.clone();
         clone._calcMatrices();
         clone.freezeTileCoverage = this.freezeTileCoverage;
-        clone._averageElevation = this._averageElevation;
         return clone;
     }
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -318,7 +318,7 @@ class Transform {
         this._cameraZoom = this._zoomFromMercatorZ(terrainElevation + height);
     }
 
-    sampleAverageElevation(map: Map): number {
+    sampleAverageElevation(): number {
         if (!this._elevation) return 0;
 
         const xCenter = this.width * 0.5;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -20,14 +20,6 @@ import type {PaddingOptions} from './edge_insets.js';
 const NUM_WORLD_COPIES = 3;
 const DEFAULT_MIN_ZOOM = 0;
 
-const elevationSamplePoints = [
-    [0.5, 0.2],
-    [0.3, 0.5],
-    [0.5, 0.5],
-    [0.7, 0.5],
-    [0.5, 0.8]
-];
-
 type RayIntersectionResult = { p0: vec4, p1: vec4, t: number};
 type ElevationReference = "sea" | "ground";
 
@@ -327,6 +319,14 @@ class Transform {
 
     sampleAverageElevation(): number {
         if (!this._elevation) return 0;
+
+        const elevationSamplePoints = [
+            [0.5, 0.2],
+            [0.3, 0.5],
+            [0.5, 0.5],
+            [0.7, 0.5],
+            [0.5, 0.8]
+        ];
 
         const horizon = this.horizonLineFromTop();
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -21,6 +21,14 @@ import type Map from '../ui/map.js';
 const NUM_WORLD_COPIES = 3;
 const DEFAULT_MIN_ZOOM = 0;
 
+const elevationSamplePoints = [
+    [0.5, 0.4],
+    [0.3, 0.6],
+    [0.5, 0.6],
+    [0.7, 0.6],
+    [0.5, 0.8]
+];
+
 type RayIntersectionResult = { p0: vec4, p1: vec4, t: number};
 type ElevationReference = "sea" | "ground";
 
@@ -321,13 +329,15 @@ class Transform {
     sampleAverageElevation(): number {
         if (!this._elevation) return 0;
 
+        /*
+        // Phyllotaxis: https://www.desmos.com/calculator/duq27u6vof
+        const points = elevationSamplePoints.map(p => [p[0] * this.width, p[1] * this.height]);
+
+        const n = 5;
         const xCenter = this.width * 0.5;
         const yCenter = this.height * 0.66;
         const xRadius = this.width * 0.33;
         const yRadius = this.height * 0.33;
-
-        // Phyllotaxis: https://www.desmos.com/calculator/duq27u6vof
-        const n = 5;
         const points = [];
         const thetaScale = Math.PI * (3 - Math.sqrt(5));
         for (let i = 1; i <= n; ++i) {
@@ -338,10 +348,11 @@ class Transform {
                 xCenter + r * xRadius * Math.sin(theta),
                 yCenter - r * yRadius * Math.cos(theta)
             ]);
-        }
+        }*/
 
         // BEGIN DEBUG
-        /*const DEBUG = true;
+        /*
+        const DEBUG = true;
         let debugEl;
         if (DEBUG) {
             debugEl = document.getElementById('pts');
@@ -357,7 +368,7 @@ class Transform {
                 debugEl.style.pointerEvents = 'none';
                 document.body.appendChild(debugEl);
 
-                for (let i = 0; i < points.length; i++) {
+                for (let i = 0; i < elevationSamplePoints.length; i++) {
                     const pt = document.createElement('span');
                     pt.style.position = 'absolute';
                     pt.style.width = '10px'
@@ -371,10 +382,10 @@ class Transform {
                 }
             }
 
-            for (let i = 0; i < points.length; i++) {
+            for (let i = 0; i < elevationSamplePoints.length; i++) {
                 const el = debugEl.children.item(i);
-                el.style.left = `${points[i][0]}px`;
-                el.style.top = `${points[i][1]}px`;
+                el.style.left = `${elevationSamplePoints[i][0] * this.width}px`;
+                el.style.top = `${elevationSamplePoints[i][1] * this.height}px`;
             }
         }
         */
@@ -382,10 +393,10 @@ class Transform {
 
         let elevationSum = 0.0;
         let weightSum = 0.0;
-        for (let i = 0; i < points.length; i++) {
-            const p = points[i];
+        for (let i = 0; i < elevationSamplePoints.length; i++) {
+            const p = elevationSamplePoints[i];
             if (this._elevation) {
-                const hit = this._elevation.pointCoordinate(new Point(p[0], p[1]));
+                const hit = this._elevation.pointCoordinate(new Point(p[0] * this.width, p[1] * this.height));
                 if (!hit) {
                     /*
                     // BEGIN DEBUG
@@ -395,14 +406,14 @@ class Transform {
                     */
                     continue;
                 }
-                // BEGIN DEBUG
                 /*
+                // BEGIN DEBUG
                 if (DEBUG) {
                     debugEl.children.item(i).textContent = hit[3].toFixed(0);
                     debugEl.children.item(i).style.backgroundColor = 'blue';
                 }
-                */
                 // END DEBUG
+                */
 
                 const weight = 1 / Math.hypot(hit[0] - this._camera.position[0], hit[1] - this._camera.position[1]);
                 elevationSum += hit[3] * weight;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1604,6 +1604,20 @@ class Transform {
         // matrix for conversion from location to screen coordinates
         this.pixelMatrix = mat4.multiply(new Float64Array(16), this.labelPlaneMatrix, this.projMatrix);
 
+        this._calcFogMatrices();
+
+        // inverse matrix for conversion from screen coordinates to location
+        m = mat4.invert(new Float64Array(16), this.pixelMatrix);
+        if (!m) throw new Error("failed to invert matrix");
+        this.pixelMatrixInverse = m;
+
+        this._projMatrixCache = {};
+        this._alignedProjMatrixCache = {};
+    }
+
+    _calcFogMatrices() {
+        this._fogTileMatrixCache = {};
+
         const cameraWorldSize = this.cameraWorldSize;
         const cameraPixelsPerMeter = this.cameraPixelsPerMeter;
         const cameraPos = this._camera.position;
@@ -1620,7 +1634,7 @@ class Transform {
         vec3.scale(cameraPos, cameraPos, -1);
         vec3.multiply(cameraPos, cameraPos, metersToPixel);
 
-        m = mat4.create();
+        const m = mat4.create();
         mat4.translate(m, m, cameraPos);
         mat4.scale(m, m, metersToPixel);
         this.mercatorFogMatrix = m;
@@ -1628,15 +1642,6 @@ class Transform {
         // The worldToFogMatrix can be used for conversion from world coordinates to relative camera position in
         // units of fractions of the map height. Later composed with tile position to construct the fog tile matrix.
         this.worldToFogMatrix = this._camera.getWorldToCameraPosition(cameraWorldSize, cameraPixelsPerMeter, windowScaleFactor);
-
-        // inverse matrix for conversion from screen coordinates to location
-        m = mat4.invert(new Float64Array(16), this.pixelMatrix);
-        if (!m) throw new Error("failed to invert matrix");
-        this.pixelMatrixInverse = m;
-
-        this._projMatrixCache = {};
-        this._alignedProjMatrixCache = {};
-        this._fogTileMatrixCache = {};
     }
 
     _updateCameraState() {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -341,7 +341,8 @@ class Transform {
             const hit = elevation.pointCoordinate(pt);
             if (!hit) continue;
 
-            const weight = 1 / Math.hypot(hit[0] - this._camera.position[0], hit[1] - this._camera.position[1]);
+            const distanceToHit = Math.hypot(hit[0] - this._camera.position[0], hit[1] - this._camera.position[1]);
+            const weight = 1 / distanceToHit;
             elevationSum += hit[3] * weight;
             weightSum += weight;
         }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -393,9 +393,9 @@ class Transform {
 
         let elevationSum = 0.0;
         let weightSum = 0.0;
-        for (let i = 0; i < elevationSamplePoints.length; i++) {
-            const p = elevationSamplePoints[i];
-            if (this._elevation) {
+        if (this._elevation) {
+            for (let i = 0; i < elevationSamplePoints.length; i++) {
+                const p = elevationSamplePoints[i];
                 const hit = this._elevation.pointCoordinate(new Point(p[0] * this.width, p[1] * this.height));
                 if (!hit) {
                     /*

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -16,7 +16,6 @@ import assert from 'assert';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
 import type {Elevation} from '../terrain/elevation.js';
 import type {PaddingOptions} from './edge_insets.js';
-import type Map from '../ui/map.js';
 
 const NUM_WORLD_COPIES = 3;
 const DEFAULT_MIN_ZOOM = 0;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -266,7 +266,7 @@ class Transform {
     }
     set averageElevation(averageElevation: number) {
         this._averageElevation = averageElevation;
-        this._calcMatrices();
+        this._calcFogMatrices();
     }
 
     get zoom(): number { return this._zoom; }

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -868,6 +868,18 @@ class Painter {
             timeStamps: this.loadTimeStamps
         };
     }
+
+    averageElevationNeedsEasing() {
+        if (!this.transform._elevation) return false;
+
+        const fog = this.style && this.style.fog;
+        if (!fog) return false;
+
+        const fogOpacity = fog.getFogPitchFactor(this.transform.pitch);
+        if (fogOpacity === 0) return false;
+
+        return true;
+    }
 }
 
 export default Painter;

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -1,6 +1,6 @@
 // @flow
 
-import MercatorCoordinate from '../geo/mercator_coordinate.js';
+import MercatorCoordinate, {mercatorZfromAltitude} from '../geo/mercator_coordinate.js';
 import {degToRad, wrap} from '../util/util.js';
 import {vec3, vec4, quat, mat4} from 'gl-matrix';
 import type {Elevation} from '../terrain/elevation.js';
@@ -302,10 +302,10 @@ class FreeCamera {
         return matrix;
     }
 
-    getDistanceToSeaLevel(): number {
+    getDistanceToElevation(elevationMeters: number): number {
+        const z0 = elevationMeters === 0 ? 0 : mercatorZfromAltitude(elevationMeters, this.position[1]);
         const f = this.forward();
-        const pos = this.position;
-        return -pos[2] / f[2];
+        return (z0 - this.position[2]) / f[2];
     }
 
     clone(): FreeCamera {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -77,7 +77,8 @@ type IControl = {
 
 const AVERAGE_ELEVATION_SAMPLING_INTERVAL = 500; // ms
 const AVERAGE_ELEVATION_EASE_TIME = 300; // ms
-const AVERAGE_ELEVATION_CHANGE_THRESHOLD = 0.1; // meters
+const AVERAGE_ELEVATION_EASE_THRESHOLD = 1; // meters
+const AVERAGE_ELEVATION_CHANGE_THRESHOLD = 1e-4; // meters
 
 type MapOptions = {
     hash?: boolean | string,
@@ -2807,10 +2808,10 @@ class Map extends Camera {
             const newElevation = this.transform.sampleAverageElevation();
             const elevationChange = Math.abs(currentElevation - newElevation);
 
-            if (elevationChange > AVERAGE_ELEVATION_CHANGE_THRESHOLD) {
+            if (elevationChange > AVERAGE_ELEVATION_EASE_THRESHOLD) {
                 this._averageElevation.easeTo(newElevation, timeStamp, AVERAGE_ELEVATION_EASE_TIME);
                 return true;
-            } else if (elevationChange > 1e-8) {
+            } else if (elevationChange > AVERAGE_ELEVATION_CHANGE_THRESHOLD) {
                 this._averageElevation.jumpTo(newElevation);
                 this.transform.averageElevation = newElevation;
                 return true;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {version} from '../../package.json';
-import {extend, bindAll, warnOnce, uniqueId, easeCubicInOut} from '../util/util.js';
+import {extend, bindAll, warnOnce, uniqueId} from '../util/util.js';
 import browser from '../util/browser.js';
 import window from '../util/window.js';
 const {HTMLImageElement, HTMLElement, ImageBitmap} = window;
@@ -2804,11 +2804,11 @@ class Map extends Camera {
             this._averageElevationLastSampledAt = timeStamp;
 
             const currentElevation = this.transform.averageElevation;
-            const newElevation = this.transform.sampleAverageElevation(this);
+            const newElevation = this.transform.sampleAverageElevation();
             const elevationChange = Math.abs(currentElevation - newElevation);
 
             if (elevationChange > AVERAGE_ELEVATION_CHANGE_THRESHOLD) {
-                this._averageElevation.easeTo(newElevation, timeStamp, 300);
+                this._averageElevation.easeTo(newElevation, timeStamp, AVERAGE_ELEVATION_EASE_TIME);
                 return true;
             } else if (elevationChange > 1e-8) {
                 this._averageElevation.jumpTo(newElevation);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2791,12 +2791,12 @@ class Map extends Camera {
      *
      * @returns {boolean} true if elevation has changed from the last sampling
      */
-    _updateAverageElevation(timeStamp: number, ignoreTimeout: boolean=false): boolean {
+    _updateAverageElevation(timeStamp: number, ignoreTimeout: boolean = false): boolean {
         const applyUpdate = value => {
             this.transform.averageElevation = value;
             this._update(false);
             return true;
-        }
+        };
 
         if (!this.painter.averageElevationNeedsEasing()) {
             if (this.transform.averageElevation !== 0) return applyUpdate(0);

--- a/src/util/eased_variable.js
+++ b/src/util/eased_variable.js
@@ -40,7 +40,7 @@ class EasedVariable {
      * @returns {boolean} true if ease in progress
      */
     isEasing(timeStamp: number): boolean {
-        return timeStamp > this._startTime && timeStamp < this._endTime;
+        return timeStamp >= this._startTime && timeStamp <= this._endTime;
     }
 
     /**

--- a/src/util/eased_variable.js
+++ b/src/util/eased_variable.js
@@ -57,20 +57,6 @@ class EasedVariable {
     }
 
     /**
-     * Cancel any in progress ease.
-     *
-     * @param timeStamp {number} current time stamp
-     */
-    cancel(timeStamp: number=Infinity) {
-        const currentValue = this.getValue(timeStamp);
-        this._start = currentValue;
-        this._end = currentValue;
-
-        this._startTime = -Infinity;
-        this._endTime = -Infinity;
-    }
-
-    /**
      * Cancel any in-progress ease and begin a new ease.
      *
      * @param value {number} new value to which to ease

--- a/src/util/eased_variable.js
+++ b/src/util/eased_variable.js
@@ -1,0 +1,89 @@
+// @flow
+
+import {easeCubicInOut} from './util.js';
+
+/**
+ * An object for maintaining just enough state to ease a variable.
+ *
+ * @private
+ */
+class EasedVariable {
+    _start: number;
+    _end: number;
+    _startTime: number;
+    _endTime: number;
+
+    constructor(initialValue: number) {
+        this.jumpTo(initialValue);
+    }
+
+    /**
+     * Evaluate the current value, given a timestamp.
+     *
+     * @param timeStamp {number} time at which to evaluate
+     *
+     * @return {number} evaluated value
+     */
+    getValue(timeStamp: number): number {
+        if (timeStamp <= this._startTime) return this._start;
+        if (timeStamp >= this._endTime) return this._end;
+
+        const t = easeCubicInOut((timeStamp - this._startTime) / (this._endTime - this._startTime));
+        return this._start * (1 - t) + this._end * t;
+    }
+
+    /**
+     * Check if an ease is in progress.
+     *
+     * @param timeStamp {number} current time stamp
+     *
+     * @returns {boolean} true if ease in progress
+     */
+    isEasing(timeStamp: number): boolean {
+        return timeStamp > this._startTime && timeStamp < this._endTime;
+    }
+
+    /**
+     * Set the value without easing and cancel any in progress ease.
+     *
+     * @param value {number} new value
+     */
+    jumpTo(value: number) {
+        this._startTime = -Infinity;
+        this._endTime = -Infinity;
+
+        this._start = value;
+        this._end = value;
+    }
+
+    /**
+     * Cancel any in progress ease.
+     *
+     * @param timeStamp {number} current time stamp
+     */
+    cancel(timeStamp: number=Infinity) {
+        const currentValue = this.getValue(timeStamp);
+        this._start = currentValue;
+        this._end = currentValue;
+
+        this._startTime = -Infinity;
+        this._endTime = -Infinity;
+    }
+
+    /**
+     * Cancel any in-progress ease and begin a new ease.
+     *
+     * @param value {number} new value to which to ease
+     * @param timeStamp {number} current time stamp
+     * @param duration {number} ease duration, in same units as timeStamp
+     */
+    easeTo(value: number, timeStamp: number, duration: number) {
+        this._start = this.getValue(timeStamp);
+        this._end = value;
+
+        this._startTime = timeStamp;
+        this._endTime = timeStamp + duration;
+    }
+}
+
+export default EasedVariable;

--- a/test/unit/util/eased_variable.test.js
+++ b/test/unit/util/eased_variable.test.js
@@ -31,11 +31,16 @@ test('EasedVariable', (t) => {
 
     // Start another ease in the middle of the previous
     v.easeTo(20, 2, 2);
+
     t.equal(v.getValue(1), 15);
     t.equal(v.getValue(2), 15);
     t.equal(v.getValue(3), 17.5);
     t.equal(v.getValue(4), 20);
     t.equal(v.getValue(5), 20);
+
+    // Verify cubic easing
+    t.equal(v.getValue(2.5), 15.3125);
+    t.equal(v.getValue(3.5), 19.6875);
 
     t.end();
 });

--- a/test/unit/util/eased_variable.test.js
+++ b/test/unit/util/eased_variable.test.js
@@ -1,0 +1,41 @@
+
+import {test} from '../../util/test.js';
+import EasedVariable from '../../../src/util/eased_variable.js';
+
+test('EasedVariable', (t) => {
+    const v = new EasedVariable(0);
+
+    t.equal(v.isEasing(0), false);
+    t.equal(v.getValue(0), 0);
+
+    v.jumpTo(10);
+
+    t.equal(v.isEasing(1), false);
+    t.equal(v.getValue(0), 10);
+    t.equal(v.getValue(1), 10);
+    t.equal(v.getValue(2), 10);
+
+    v.easeTo(20, 1, 2);
+
+    t.equal(v.isEasing(0), false);
+    t.equal(v.isEasing(1), true);
+    t.equal(v.isEasing(2), true);
+    t.equal(v.isEasing(3), true);
+    t.equal(v.isEasing(4), false);
+
+    t.equal(v.getValue(0), 10);
+    t.equal(v.getValue(1), 10);
+    t.equal(v.getValue(2), 15);
+    t.equal(v.getValue(3), 20);
+    t.equal(v.getValue(4), 20);
+
+    // Start another ease in the middle of the previous
+    v.easeTo(20, 2, 2);
+    t.equal(v.getValue(1), 15);
+    t.equal(v.getValue(2), 15);
+    t.equal(v.getValue(3), 17.5);
+    t.equal(v.getValue(4), 20);
+    t.equal(v.getValue(5), 20);
+
+    t.end();
+});


### PR DESCRIPTION
This PR addresses one of fog's biggest challenges: determining the zoom level to be used with fog. Sampling a single point (i.e. the camera center), is far too discontinuous and doesn't accurately represent what you're looking at. It also is only updated on camera idle, which would lead to fog instantaneously updating on every map idle event.

This PR adds `transform._averageElevation` to answer, roughly speaking, "what is the general elevation of the terrain I'm looking at". It does this by sampling multiple points in a star pattern (pattern stretched vertically between the horizon line and the bottom of the screen):

![Screen Shot 2021-04-30 at 12 09 23 PM copy](https://user-images.githubusercontent.com/572717/116757286-a44a1480-a9c2-11eb-9675-7496317578d1.jpg)

The scale of fog is updated as follows:

1. Average the elevation of the sampled points (weighted by inverse-distance-from-camera) to compute `transform._averageElevation`.
2. Compute `transform.cameraWorldSize` by intersecting the camera centerline with a horizontal plane of elevation `transform._averageElevation`
3. Use `transform.cameraWorldSize` to scale the fog

While the method works and generally samples the points in 0.2-0.4ms on a desktop computer, it's perhaps unnecessary to sample these points on every frame. Thus, the average elevation is time eased (cubic-in-out, 300ms), and not sampled more than once every 500ms. These parameters are currently hard-coded.

To keep any concept of time out of `transform`, this averaging is controlled entirely in the main render loop.

The screenshots below show sea level and high altitude terrain at the same zoom and pitch, with and without the fix. Sea level is only ever so slightly changed, while high altitude is fixed to appear to have roughly the same amount of fog as sea level.

| Sea level, no fix | High altitude, no fix |
| ------- | ------- | 
| ![Screen Shot 2021-04-30 at 2 54 02 PM copy](https://user-images.githubusercontent.com/572717/116757940-fb041e00-a9c3-11eb-809a-64bf401813d0.jpg) | ![no-fix-hi copy](https://user-images.githubusercontent.com/572717/116757688-68fc1580-a9c3-11eb-8e4f-2535711a566c.jpg) |

| Sea level, fixed | High altitude, fixed |
| ------- | ------- | 
| ![fix-lo copy](https://user-images.githubusercontent.com/572717/116757718-7b764f00-a9c3-11eb-8ee9-e18f8a228bd6.jpg) | ![fix-hi copy](https://user-images.githubusercontent.com/572717/116757731-8204c680-a9c3-11eb-9c08-e53d297f684c.jpg) |