### PR TITLE
Use prepublishOnly script to build the style spec.

### DIFF
--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "copy-flow-typed": "cp -R ../../flow-typed .",
     "build": "../../node_modules/.bin/rollup -c && ../../node_modules/.bin/rollup -c --environment esm",
-    "prepublish": "git clean -fdx && yarn copy-flow-typed && yarn build",
+    "prepublishOnly": "git clean -fdx && yarn copy-flow-typed && yarn build",
     "postpublish": "rm -r flow-typed dist/index.js"
   },
   "repository": {


### PR DESCRIPTION

The style-spec@13.9.1 Patch release was missing some files in the distribution. I used NPM v7 locally to dry run and publish the package, which changes what scripts are called as part of `npm publish` and `npm publish --dry-run`. See here: https://docs.npmjs.com/cli/v7/using-npm/scripts#npm-publish

This change makes the release and publish steps compatible with v6 and v7. 

Before this change, the build steps are not run for a dry run. After this change, running dry run, results in no errors and includes the build steps.

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

cc @mapbox/studio @mapbox/frontend 