### PR TITLE
add 2 examples of customlayerinterface

### DIFF
--- a/src/style/style_layer/custom_style_layer.js
+++ b/src/style/style_layer/custom_style_layer.js
@@ -73,6 +73,8 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => 
  * map.on('load', function() {
  *     map.addLayer(new NullIslandLayer());
  * });
+ * @see [Add a custom style layer](https://docs.mapbox.com/mapbox-gl-js/example/custom-style-layer/)
+ * @see [Add a 3D model](https://docs.mapbox.com/mapbox-gl-js/example/add-3d-model/)
  */
 
 /**


### PR DESCRIPTION
- closes https://github.com/mapbox/mapbox-gl-js-docs/issues/554
- adds 2 linked examples of `customlayerinterface`
 
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

@HeyStenson for review
@mapbox/gl-js for review