### PR TITLE
Remove a single "Related" link from the bottom of `Map` API doc

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -275,11 +275,11 @@ const defaultOptions = {
  *     }
  *   }
  * });
- * @see [Web applications getting started guide](https://docs.mapbox.com/help/getting-started/web-apps/)
  * @see Example: [Display a map](https://www.mapbox.com/mapbox-gl-js/examples/)
  * @see Example: [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
  * @see Example: [Display buildings in 3D](https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/)
  * @see Tutorial: [Add custom markers in Mapbox GL JS](https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/)
+ * @see [Web applications getting started guide](https://docs.mapbox.com/help/getting-started/web-apps/)
  */
 class Map extends Camera {
     style: Style;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -275,11 +275,6 @@ const defaultOptions = {
  *     }
  *   }
  * });
- * @see Example: [Display a map](https://www.mapbox.com/mapbox-gl-js/examples/)
- * @see Example: [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
- * @see Example: [Display buildings in 3D](https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/)
- * @see Tutorial: [Add custom markers in Mapbox GL JS](https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/)
- * @see [Web applications getting started guide](https://docs.mapbox.com/help/getting-started/web-apps/)
  */
 class Map extends Camera {
     style: Style;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -275,7 +275,11 @@ const defaultOptions = {
  *     }
  *   }
  * });
- * @see [Display a map](https://www.mapbox.com/mapbox-gl-js/examples/)
+ * @see [Web applications getting started guide](https://docs.mapbox.com/help/getting-started/web-apps/)
+ * @see Example: [Display a map](https://www.mapbox.com/mapbox-gl-js/examples/)
+ * @see Example: [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
+ * @see Example: [Display buildings in 3D](https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/)
+ * @see Tutorial: [Add custom markers in Mapbox GL JS](https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/)
  */
 class Map extends Camera {
     style: Style;


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js-docs/issues/475

- Removes a single "Related" link from the bottom of Map API doc #10639

@HeyStenson and @asheemmamoowala for review

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
