### PR TITLE
Consistify `Options object.` descriptor in GL JS API docs

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -193,7 +193,7 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param offset `x` and `y` coordinates by which to pan the map.
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
@@ -265,7 +265,7 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param zoom The zoom level to transition to.
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires zoomstart
@@ -293,7 +293,7 @@ class Camera extends Evented {
      * Increases the map's zoom level by 1.
      *
      * @memberof Map#
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires zoomstart
@@ -315,7 +315,7 @@ class Camera extends Evented {
      * Decreases the map's zoom level by 1.
      *
      * @memberof Map#
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires zoomstart
@@ -398,7 +398,7 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @param bearing The desired bearing.
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
@@ -414,7 +414,7 @@ class Camera extends Evented {
      * Rotates the map so that north is up (0° bearing), with an animated transition.
      *
      * @memberof Map#
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
@@ -429,7 +429,7 @@ class Camera extends Evented {
      * Rotates and pitches the map so that north is up (0° bearing) and pitch is 0°, with an animated transition.
      *
      * @memberof Map#
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
@@ -449,7 +449,7 @@ class Camera extends Evented {
      * `bearingSnap` threshold).
      *
      * @memberof Map#
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
@@ -491,7 +491,7 @@ class Camera extends Evented {
      * @param {LngLatBoundsLike} bounds Calculate the center for these bounds in the viewport and use
      *      the highest zoom level up to and including `Map#getMaxZoom()` that fits
      *      in the viewport. LngLatBounds represent a box that is always axis-aligned with bearing 0.
-     * @param options Options object
+     * @param options Options object.
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {number} [options.bearing=0] Desired map bearing at end of animation, in degrees.
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
@@ -783,7 +783,7 @@ class Camera extends Evented {
      * @param p0 First point on screen, in pixel coordinates
      * @param p1 Second point on screen, in pixel coordinates
      * @param bearing Desired map bearing at end of animation, in degrees. This value is ignored if the map has non-zero pitch.
-     * @param options Options object
+     * @param options Options object.
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
      * @param {boolean} [options.linear=false] If `true`, the map transitions using
      *     {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}. See
@@ -864,7 +864,7 @@ class Camera extends Evented {
      * details not specified in `options`.
      *
      * @memberof Map#
-     * @param options Options object
+     * @param options Options object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires zoomstart

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -35,7 +35,7 @@ export default class DragPanHandler {
     /**
      * Enables the "drag to pan" interaction.
      *
-     * @param {Object} [options] Options object
+     * @param {Object} [options] Options object.
      * @param {number} [options.linearity=0] factor used to scale the drag velocity
      * @param {Function} [options.easing=bezier(0, 0, 0.3, 1)] easing function applled to `map.panTo` when applying the drag.
      * @param {number} [options.maxSpeed=1400] the maximum value of the drag velocity.


### PR DESCRIPTION
Related: https://github.com/mapbox/documentation/issues/689

- Adds 12 periods to consistify descriptions from "Options object" to "Options object." for these symbols:

1. jumpTo
2. panBy
3. resetNorth
4. resetNorthPitch
5. rotateTo
6. setFreeCameraOptions
7. snapToNorth
8. zoomIn
9. zoomOut
10. zoomTo
11. DragPanHandler
12. cameraForBounds

new look:

<img src="https://user-images.githubusercontent.com/6026447/116943663-bb317680-ac0f-11eb-95ec-12f00f530dcd.png" width=400 alt="after screenshot"> 


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

Tagging @HeyStenson @mapbox/gl-js for review.