### PR TITLE
Small fixes to GL JS API docs (product docs report card)

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -76,7 +76,7 @@ class ScrollZoomHandler {
     }
 
     /**
-     * Set the zoom rate of a trackpad
+     * Sets the zoom rate of a trackpad.
      * @param {number} [zoomRate=1/100] The rate used to scale trackpad movement to a zoom value.
      * @example
      * // Speed up trackpad zoom
@@ -87,7 +87,7 @@ class ScrollZoomHandler {
     }
 
     /**
-    * Set the zoom rate of a mouse wheel
+    * Sets the zoom rate of a mouse wheel.
     * @param {number} [wheelZoomRate=1/450] The rate used to scale mouse wheel movement to a zoom value.
     * @example
     * // Slow down zoom of mouse wheel

--- a/src/ui/handler/shim/touch_zoom_rotate.js
+++ b/src/ui/handler/shim/touch_zoom_rotate.js
@@ -77,7 +77,7 @@ export default class TouchZoomRotateHandler {
     /**
      * Returns true if the handler is enabled and has detected the start of a zoom/rotate gesture.
      *
-     * @returns {boolean} //eslint-disable-line
+     * @returns {boolean}
      */
     isActive() {
         return this._touchZoom.isActive() || this._touchRotate.isActive() || this._tapDragZoom.isActive();

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -267,7 +267,7 @@ export class TouchPitchHandler extends TwoTouchHandler {
     }
 
     /**
-     * Checks if the "drag to pitch" interaction is enabled.
+     * Returns a Boolean indicating whether the "drag to pitch" interaction is enabled.
      *
      * @memberof TouchPitchHandler
      * @name isEnabled
@@ -276,7 +276,7 @@ export class TouchPitchHandler extends TwoTouchHandler {
      */
 
     /**
-     * Checks if the "drag to pitch" interaction is actively being used.
+     * Returns a Boolean indicating whether the "drag to pitch" interaction is active, i.e. currently being used.
      *
      * @memberof TouchPitchHandler
      * @name isActive

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -267,7 +267,7 @@ export class TouchPitchHandler extends TwoTouchHandler {
     }
 
     /**
-     * Returns a Boolean indicating whether the "drag to pitch" interaction is enabled.
+     * Checks if the "drag to pitch" interaction is enabled.
      *
      * @memberof TouchPitchHandler
      * @name isEnabled
@@ -276,7 +276,7 @@ export class TouchPitchHandler extends TwoTouchHandler {
      */
 
     /**
-     * Returns a Boolean indicating whether the "drag to pitch" interaction is active, i.e. currently being used.
+     * Checks if the "drag to pitch" interaction is actively being used.
      *
      * @memberof TouchPitchHandler
      * @name isActive


### PR DESCRIPTION
- removes an instance of `//eslint-disable-line` that is visible to users
- changes 2 verbs set --> sets (to agree with subject 'it")
- adds 2 periods at the end of descriptions.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

@HeyStenson and @mapbox/gl-js for review