### PR TITLE
Add fog demo and transition fixes

### DIFF
--- a/debug/fog-demo.html
+++ b/debug/fog-demo.html
@@ -68,7 +68,7 @@ map.on('style.load', () => {
         'range': ['interpolate', ['exponential', 0.1],
             ['zoom'],
             10, ['literal', [10, 12]],
-            12, ['literal', [-150, 1000]]],
+            12, ['literal', [-1.5, 10]]],
         'color': ['interpolate', ['linear'],
             ['zoom'],
             9, 'black',

--- a/debug/fog-demo.html
+++ b/debug/fog-demo.html
@@ -67,7 +67,7 @@ map.on('style.load', () => {
     map.setFog({
         'range': ['interpolate', ['exponential', 0.1],
             ['zoom'],
-            10, ['literal', [1000, 1200]],
+            10, ['literal', [10, 12]],
             12, ['literal', [-150, 1000]]],
         'color': ['interpolate', ['linear'],
             ['zoom'],

--- a/debug/fog-demo.html
+++ b/debug/fog-demo.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        #map { position: absolute; top: 0; bottom: 0; width: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='access_token_generated.js'></script>
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    zoom: 4,
+    center: [119.94552235709455, -11.48731083806907],
+    pitch: 85,
+    bearing: 0,
+    interactive: false,
+    style: 'mapbox://styles/mapbox/satellite-streets-v11',
+});
+
+map.on('style.load', () => {
+    map.addSource('mapbox-dem', {
+        'type': 'raster-dem',
+        'url': 'mapbox://mapbox.terrain-rgb',
+        'tileSize': 512,
+        'maxzoom': 14
+    });
+
+    map.addLayer({
+        'id': 'sky-day',
+        'type': 'sky',
+        'paint': {
+            'sky-type': 'gradient',
+            'sky-opacity': [
+                'interpolate',
+                ['exponential', 0.1],
+                ['zoom'],
+                10, 0,
+                12, 1
+            ],
+            'sky-opacity-transition': {'duration': 500}
+        }
+    });
+
+    map.addLayer({
+        'id': 'sky-night',
+        'type': 'sky',
+        'paint': {
+            'sky-type': 'atmosphere',
+            'sky-atmosphere-sun': [90, 0],
+            'sky-atmosphere-halo-color': 'rgba(255, 255, 255, 0.5)',
+            'sky-atmosphere-color': 'rgba(255, 255, 255, 0.2)',
+            'sky-opacity': 0,
+            'sky-opacity-transition': {'duration': 500}
+        }
+    });
+
+    map.setFog({
+        'range': ['interpolate', ['exponential', 0.1],
+            ['zoom'],
+            10, ['literal', [1000, 1200]],
+            12, ['literal', [-150, 1000]]],
+        'color': ['interpolate', ['linear'],
+            ['zoom'],
+            9, 'black',
+            11, 'white'],
+        'horizon-blend': ['interpolate', ['linear'],
+            ['zoom'],
+            10, 0.01,
+            12, 0.02],
+        'color-transition': {
+            'duration': 500
+        }
+    });
+
+    map.setTerrain({
+        'source': 'mapbox-dem',
+        'exaggeration': ['interpolate', ['linear'],
+            ['zoom'],
+            10, 0.0,
+            12, 1.5]
+    });
+});
+
+map.on('load', async () => {
+    await map.once('idle');
+
+    map.flyTo({
+        center: [8.11862, 46.58842],
+        zoom: 12.5,
+        bearing: 130,
+        pitch: 75,
+        duration: 12000
+    });
+
+    await map.once('idle');
+
+    let lastTime = 0.0;
+    let animationTime = 0.0;
+    let cycleTime = 0.0;
+    let day = true;
+
+    const initialBearing = map.getBearing();
+
+    function frame(time) {
+        const elapsedTime = 1.0 / (time - lastTime);
+
+        animationTime += elapsedTime;
+        cycleTime += elapsedTime;
+
+        if (cycleTime > 20.0) {
+            if (day) {
+                map.setPaintProperty('sky-day', 'sky-opacity', 1);
+                map.setPaintProperty('sky-night', 'sky-opacity', 0);
+                map.setFog({'color': 'white'});
+            } else {
+                map.setPaintProperty('sky-day', 'sky-opacity', 0);
+                map.setPaintProperty('sky-night', 'sky-opacity', 1);
+                map.setFog({'color': 'rgba(66, 88, 106, 1.0)'});
+            }
+
+            day = !day;
+            cycleTime = 0.0;
+        }
+
+        const rotation = (initialBearing + animationTime);
+        map.setBearing(rotation % 360);
+
+        lastTime = time;
+
+        window.requestAnimationFrame(frame);
+    }
+
+    window.requestAnimationFrame(frame);
+});
+
+</script>
+</body>
+</html>

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -838,7 +838,7 @@ class Painter {
     prepareDrawProgram(context: Context, program: Program<*>, tileID: ?UnwrappedTileID) {
         const fog = this.style.fog;
 
-        // Fog isn not enabled when rendering to texture so we
+        // Fog is not enabled when rendering to texture so we
         // can safely skip uploading uniforms in that case
         if (this.terrain && this.terrain.renderingToTexture) {
             return;

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -837,6 +837,13 @@ class Painter {
 
     prepareDrawProgram(context: Context, program: Program<*>, tileID: ?UnwrappedTileID) {
         const fog = this.style.fog;
+
+        // Fog isn not enabled when rendering to texture so we
+        // can safely skip uploading uniforms in that case
+        if (this.terrain && this.terrain.renderingToTexture) {
+            return;
+        }
+
         if (fog) {
             const fogOpacity = fog.getOpacity(this.transform.pitch);
             if (fogOpacity !== 0.0) {

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -255,10 +255,13 @@ class TransitioningPropertyValue<T, R> {
                 prior: ?TransitioningPropertyValue<T, R>,
                 transition: TransitionSpecification,
                 now: TimePoint) {
+        const delay = transition.delay || 0;
+        const duration = transition.duration || 0;
+        now = now || 0;
         this.property = property;
         this.value = value;
-        this.begin = now + transition.delay || 0;
-        this.end = this.begin + transition.duration || 0;
+        this.begin = now + delay;
+        this.end = this.begin + duration;
         if (property.specification.transition && (transition.delay || transition.duration)) {
             this.prior = prior;
         }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -409,6 +409,10 @@ class Style extends Evented {
             return true;
         }
 
+        if (this.fog && this.fog.hasTransition()) {
+            return true;
+        }
+
         for (const id in this._sourceCaches) {
             if (this._sourceCaches[id].hasTransition()) {
                 return true;

--- a/test/release/fog-demo.html
+++ b/test/release/fog-demo.html
@@ -1,0 +1,1 @@
+../../debug/fog-demo.html

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -158,6 +158,11 @@ const pages = [
         "url": "./3d-playground.html"
     },
     {
+        "key": "fog-demo",
+        "title": "Fog Demo",
+        "url": "./fog-demo.html"
+    },
+    {
         "key": "fog",
         "title": "Fog",
         "url": "./fog.html"


### PR DESCRIPTION
- Skip unnecessary uniform code path when terrain is rendering to texture:
On a typical frame with terrain this was called ~200 times, where only 20 were necessary (~10%)
- Fix invalid transition evaluation:
When `delay` was undefined but not `now`, properties.begin and properties.end were assigned incorrect values, leading to an immediate transition interpolation. This was noticed when testing transitions on fog.
- Fix style.hasTransition() when fog is transitioning values
- Add a fog demo for release:
Split into two main animations, a fly to exercising complex expression zoom transitions, and a rotate exercising transitions.

https://user-images.githubusercontent.com/7061573/117220579-58c9a900-adbc-11eb-8da7-9619523e8913.mov

https://user-images.githubusercontent.com/7061573/117220376-f7093f00-adbb-11eb-8741-75e39529854a.mov


