### PR TITLE
Modify flip state logic

### DIFF
--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -320,7 +320,7 @@ function placeGlyphsAlongLine(symbol, fontSize, flip, keepUpright, posMatrix, la
 
         if (keepUpright && !flip) {
             const orientationChange = requiresOrientationChange(symbol, firstPoint, lastPoint, aspectRatio);
-            symbol.needsFlipping = orientationChange ? FlipDecision.flipRequired : FlipDecision.flipNotRequired;
+            symbol.needsFlipping = orientationChange && orientationChange.needsFlipping ? FlipDecision.flipRequired : FlipDecision.flipNotRequired;
             if (orientationChange) {
                 return orientationChange;
             }


### PR DESCRIPTION
See: #10622

This PR proposes a slight modification of @zmiao's PR to prevent unnecessary label flipping. The PR was *very* close to what I think will solve the problem, but I was still observing fast flipping back and forth, just at an angle of 5 degrees from vertical rather than exactly vertical. The main change required was just a small logic change regarding how the current flip state is stored and used.

I think this change should be enough to leave initial display of maps as well as the render tests unaffected.

This PR:

![label-flipping](https://user-images.githubusercontent.com/572717/117222109-91b74d00-adbf-11eb-8178-f771075098f6.gif)

@zmiao I made the following modifications to your PR (it was so close, but forgive me, in the process of working through it, it seemed worth just PRing rather than conveying changes!)