### PR TITLE
Release testing fixes

### DIFF
--- a/test/release/index.js
+++ b/test/release/index.js
@@ -264,7 +264,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const js = version === 'latest' ? jsLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.js';
             const css = version === 'latest' ? cssLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.css';
 
-            const versionLibRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]\.[0-9]\.[0-9]\/mapbox-gl\.js/g;
+            const versionLibRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]+\.[0-9]+\.[0-9]+\/mapbox-gl\.js/g;
             const versionCSSRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]\.[0-9]\.[0-9]\/mapbox-gl\.css/g;
             const apiKeyRegex = /pk\..*?"/g;
 

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -262,13 +262,12 @@ document.addEventListener('DOMContentLoaded', function() {
             container.appendChild(iframe);
             const iframeDoc = iframe.contentWindow.document.open("text/html", "replace");
 
+            const js = version === 'latest' ? jsLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.js';
+            const css = version === 'latest' ? cssLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.css';
+
             let doc = req.response;
 
             if (!page.url) { // Perform cleanups for pages hosted on docs.mapbox.com, otherwise directly use demo code
-                debugger;
-                const js = version === 'latest' ? jsLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.js';
-                const css = version === 'latest' ? cssLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.css';
-
                 const versionLibRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]+\.[0-9]+\.[0-9]+\/mapbox-gl\.js/g;
                 const versionCSSRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]+\.[0-9]+\.[0-9]+\/mapbox-gl\.css/g;
                 const sentryRegex = /<script src="https:\/\/js\.sentry-cdn\.com\/[0-9a-f]*\.min\.js"\s*crossorigin="anonymous"><\/script>/g;

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -287,8 +287,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 const versionCSSRegex = /<link rel='stylesheet'(.*)mapbox-gl\.css'(.*)\/>/g;
                 const apiKeyRegex = /<script(.*)access_token_generated\.js(.*)\/script>/g;
 
-                doc = doc.replace(versionLibRegex, js);
-                doc = doc.replace(versionCSSRegex, css);
+                doc = doc.replace(versionLibRegex, '<script src="' + js + '"></script>');
+                doc = doc.replace(versionCSSRegex, '<link rel="stylesheet" href="' + css + '" />');
                 doc = doc.replace(apiKeyRegex, '<script>mapboxgl.accessToken="' + params.access_token + '"</script>');
             }
 

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -256,13 +256,15 @@ document.addEventListener('DOMContentLoaded', function() {
             const js = version === 'latest' ? jsLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.js';
             const css = version === 'latest' ? cssLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.css';
 
-            const versionLibRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v(.*)\/mapbox-gl\.js/g;
-            const versionCSSRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v(.*)\/mapbox-gl\.css/g;
+            const versionLibRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]\.[0-9]\.[0-9]\/mapbox-gl\.js/g;
+            const versionCSSRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]\.[0-9]\.[0-9]\/mapbox-gl\.css/g;
 
-            req.response = req.response.replace(versionLibRegex, js);
-            req.response = req.response.replace(versionCSSRegex, css);
+            let doc = req.response;
 
-            iframeDoc.write([req.response].join(''));
+            doc = doc.replace(versionLibRegex, js);
+            doc = doc.replace(versionCSSRegex, css);
+
+            iframeDoc.write([doc].join(''));
             iframeDoc.close();
         }
 

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -19,11 +19,6 @@ const pages = [
         "title": "Get features under the mouse pointer"
     },
     {
-        "key": "queryrenderedfeatures",
-        "title": "Get features under the mouse pointer (3d)",
-        "inject3d": true
-    },
-    {
         "key": "scroll-fly-to",
         "title": "Fly to a location based on scroll position"
     },
@@ -40,11 +35,6 @@ const pages = [
         "title": "Display a satellite map"
     },
     {
-        "key": "satellite-map",
-        "title": "Display a satellite map (3d)",
-        "inject3d": true
-    },
-    {
         "key": "custom-marker-icons",
         "title": "Add custom icons with Markers"
     },
@@ -57,18 +47,8 @@ const pages = [
         "title": "Add a video"
     },
     {
-        "key": "video-on-a-map",
-        "title": "Add a video (3d)",
-        "inject3d": true
-    },
-    {
         "key": "custom-style-layer",
         "title": "Add a custom style layer"
-    },
-    {
-        "key": "custom-style-layer",
-        "title": "Add a custom style layer (3d)",
-        "inject3d": true
     },
     {
         "key": "adjust-layer-opacity",
@@ -87,18 +67,8 @@ const pages = [
         "title": "Display driving directions"
     },
     {
-        "key": "mapbox-gl-directions",
-        "title": "Display driving directions (3d)",
-        "inject3d": true
-    },
-    {
         "key": "mapbox-gl-draw",
         "title": "Show drawn polygon area"
-    },
-    {
-        "key": "mapbox-gl-draw",
-        "title": "Show drawn polygon area (3d)",
-        "inject3d": true
     },
     {
         "key": "mapbox-gl-compare",
@@ -111,11 +81,6 @@ const pages = [
     {
         "key": "heatmap-layer",
         "title": "Add a heatmap layer"
-    },
-    {
-        "key": "heatmap-layer",
-        "title": "Add a heatmap layer (3d)",
-        "inject3d": true
     },
     {
         "key": "add-terrain",
@@ -141,11 +106,6 @@ const pages = [
     {
         "key": "image-on-a-map",
         "title": "Image Source"
-    },
-    {
-        "key": "image-on-a-map",
-        "title": "Image Source (3d)",
-        "inject3d": true
     },
     {
         "key": "extrusion-query",
@@ -204,14 +164,6 @@ document.addEventListener('DOMContentLoaded', function() {
         const entry = param.split('=', 2);
         params[entry[0]] = entry[1];
     });
-
-    if (!params.access_token) {
-        if (mapboxgl.accessToken) {
-            params.access_token = mapboxgl.accessToken;
-        } else {
-            params.access_token = prompt("Access Token");
-        }
-    }
 
     titleElement.addEventListener('click', function() {
         versionItem.classList.remove('active');
@@ -304,63 +256,13 @@ document.addEventListener('DOMContentLoaded', function() {
             const js = version === 'latest' ? jsLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.js';
             const css = version === 'latest' ? cssLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.css';
 
-            let doc = req.response;
-            // Only inject 3d code in version > v1
-            if (page.inject3d && params.version.substr(0, 2) !== 'v1' && params.version.substr(0, 2) !== 'v0') {
-                const regex0 = /new mapboxgl\.Map((.|\n)*?)}\)\);/g;
-                const regex1 = /new mapboxgl\.Map((.|\n)*?)}\);/g;
-                const match = req.response.match(regex0);
-                const regex = match && match.length > 0 ? regex0 : regex1;
-                doc = req.response.replace(regex, '$&' +
-                    `map.on('style.load', function () {
-                        map.addSource('mapbox_dem', {
-                            "type": "raster-dem",
-                            "url": "mapbox://mapbox.mapbox-terrain-dem-v1",
-                            "tileSize": 512,
-                            "maxzoom": 14
-                        });
+            const versionLibRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v(.*)\/mapbox-gl\.js/g;
+            const versionCSSRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v(.*)\/mapbox-gl\.css/g;
 
-                        map.addLayer({
-                            'id': 'sky_layer',
-                            'type': 'sky',
-                            'paint': {
-                                'sky-type': 'atmosphere',
-                                'sky-atmosphere-sun': [0, 0],
-                                'sky-opacity': [
-                                    'interpolate',
-                                    ['exponential', 0.1],
-                                    ['zoom'],
-                                    5,
-                                    0,
-                                    22,
-                                    1
-                                ]
-                            }
-                        });
+            req.response = req.response.replace(versionLibRegex, js);
+            req.response = req.response.replace(versionCSSRegex, css);
 
-                        map.setTerrain({"source": "mapbox_dem", "exaggeration": 1.2});
-                    });`
-                );
-            }
-            iframeDoc.write([
-                '<!DOCTYPE html>',
-                '<html>',
-                '<head>',
-                '    <title>Mapbox GL JS debug page</title>',
-                '    <meta charset="utf-8">',
-                '    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">',
-                '    <script src="' + js + '"><\/script>',
-                '    <script>mapboxgl.accessToken = "' + params.access_token + '";<\/script>',
-                '    <link rel="stylesheet" href="' + css + '" />',
-                '    <style>',
-                '        body { margin: 0; padding: 0; }',
-                '        html, body, #map { height: 100%; }',
-                '    </style>',
-                '</head>',
-                '<body>',
-                doc,
-                '</body>',
-                '</html>' ].join(''));
+            iframeDoc.write([req.response].join(''));
             iframeDoc.close();
         }
 

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -264,7 +264,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
             let doc = req.response;
 
-            if (!page.url) { // Only perform cleanups for pages hosted on docs.mapbox.com, otherwise directly use demo code
+            if (!page.url) { // Perform cleanups for pages hosted on docs.mapbox.com, otherwise directly use demo code
+                debugger;
                 const js = version === 'latest' ? jsLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.js';
                 const css = version === 'latest' ? cssLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.css';
 
@@ -282,6 +283,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 // Remove extraneous analytics
                 doc = doc.replace(instrumentileRegex, '');
                 doc = doc.replace(sentryRegex, '');
+            } else { // Perform cleanups of pages locally referenced
+                const versionLibRegex = /<script src='(.*)mapbox-gl(.*)\.js'><\/script>/g;
+                const versionCSSRegex = /<link rel='stylesheet'(.*)mapbox-gl\.css'(.*)\/>/g;
+                const apiKeyRegex = /<script(.*)access_token_generated\.js(.*)\/script>/g;
+
+                doc = doc.replace(versionLibRegex, js);
+                doc = doc.replace(versionCSSRegex, css);
+                doc = doc.replace(apiKeyRegex, '<script>mapboxgl.accessToken="' + params.access_token + '"</script>');
             }
 
             iframeDoc.write([doc].join(''));

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -288,7 +288,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         req = new XMLHttpRequest();
         req.addEventListener("load", loadedHTML);
-        url = page.url ? page.url : 'https://raw.githubusercontent.com/mapbox/mapbox-gl-js-docs/publisher-production/docs/pages/example/' + page.key + '.html';
+        url = page.url ? page.url : 'https://docs.mapbox.com/mapbox-gl-js/assets/' + page.key + '-demo.html';
         req.open("GET", url);
         req.send();
 

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -265,7 +265,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const css = version === 'latest' ? cssLatest.href : 'https://api.mapbox.com/mapbox-gl-js/' + version + '/mapbox-gl.css';
 
             const versionLibRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]+\.[0-9]+\.[0-9]+\/mapbox-gl\.js/g;
-            const versionCSSRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]\.[0-9]\.[0-9]\/mapbox-gl\.css/g;
+            const versionCSSRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]+\.[0-9]+\.[0-9]+\/mapbox-gl\.css/g;
             const apiKeyRegex = /pk\..*?"/g;
 
             let doc = req.response;

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -165,6 +165,14 @@ document.addEventListener('DOMContentLoaded', function() {
         params[entry[0]] = entry[1];
     });
 
+    if (!params.access_token) {
+        if (mapboxgl.accessToken) {
+            params.access_token = mapboxgl.accessToken;
+        } else {
+            params.access_token = prompt("Access Token");
+        }
+    }
+
     titleElement.addEventListener('click', function() {
         versionItem.classList.remove('active');
         titleItem.classList[titleItem.classList.contains('active') ? 'remove' : 'add']('active');
@@ -258,11 +266,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
             const versionLibRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]\.[0-9]\.[0-9]\/mapbox-gl\.js/g;
             const versionCSSRegex = /https:\/\/api\.mapbox\.com\/mapbox-gl-js\/v[0-9]\.[0-9]\.[0-9]\/mapbox-gl\.css/g;
+            const apiKeyRegex = /pk\..*?"/g;
 
             let doc = req.response;
 
             doc = doc.replace(versionLibRegex, js);
             doc = doc.replace(versionCSSRegex, css);
+            doc = doc.replace(apiKeyRegex, params.access_token + '"');
 
             iframeDoc.write([doc].join(''));
             iframeDoc.close();


### PR DESCRIPTION
- Remove obsolete links to now private docs repo, and point them to docs.mapbox.com/mapbox-gl-js/assets instead. Previously the pages served in the docs repo only contained the scripts necessary for the demo code without anything else, the new publicly available ones need some minor cleanups to be able to inject the library version/css and api key.
- Remove obsolete 3d code injection that was useful in internal code but not anymore, as we can directly point to the 3d examples from the docs page now and this also simplifies the transition to the new endpoint.