### PR TITLE
Increment style spec minor version for 2.3.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "2.3.0-dev",
+  "version": "2.4.0-dev",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/mapbox-gl-style-spec",
   "description": "a specification for mapbox gl styles",
-  "version": "13.20.0-dev",
+  "version": "13.21.0-dev",
   "author": "Mapbox",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
cc @karimnaaji 

This PR updates the style spec from `13.20.0-dev` to `13.21.0-dev` for work after the 2.3.0 release.

~~The top level package.json was already updated for `2.3.0-dev` by https://github.com/mapbox/mapbox-gl-js/pull/10461~~