### PR TITLE
Rebuild flow types

### DIFF
--- a/src/style-spec/types.js
+++ b/src/style-spec/types.js
@@ -261,7 +261,7 @@ export type SymbolLayerSpecification = {|
         "text-font"?: DataDrivenPropertyValueSpecification<Array<string>>,
         "text-size"?: DataDrivenPropertyValueSpecification<number>,
         "text-max-width"?: DataDrivenPropertyValueSpecification<number>,
-        "text-line-height"?: PropertyValueSpecification<number>,
+        "text-line-height"?: DataDrivenPropertyValueSpecification<number>,
         "text-letter-spacing"?: DataDrivenPropertyValueSpecification<number>,
         "text-justify"?: DataDrivenPropertyValueSpecification<"auto" | "left" | "center" | "right">,
         "text-radial-offset"?: DataDrivenPropertyValueSpecification<number>,


### PR DESCRIPTION
This PR rebuilds flow types which do not match the current state of the code. The following conditional would catch it and head off this oversight in the future, but it does not yet have a home:

```
if [ ! -z "$(git status src/style-spec/types.js --porcelain)" ]; then; exit 1; fi
```

The fundamental problem is that both the code and artifact generated as part of `test-flow` are committed, but nothing ensures you've actually generated and committed this code. Perhaps this could be inserted in the middle of `test-flow`, after generating flow types but before running `flow`, in order to ensure there was no change.