### PR TITLE
Rebuild flow types (#10654)

### DIFF
--- a/src/style-spec/types.js
+++ b/src/style-spec/types.js
@@ -261,7 +261,7 @@ export type SymbolLayerSpecification = {|
         "text-font"?: DataDrivenPropertyValueSpecification<Array<string>>,
         "text-size"?: DataDrivenPropertyValueSpecification<number>,
         "text-max-width"?: DataDrivenPropertyValueSpecification<number>,
-        "text-line-height"?: PropertyValueSpecification<number>,
+        "text-line-height"?: DataDrivenPropertyValueSpecification<number>,
         "text-letter-spacing"?: DataDrivenPropertyValueSpecification<number>,
         "text-justify"?: DataDrivenPropertyValueSpecification<"auto" | "left" | "center" | "right">,
         "text-radial-offset"?: DataDrivenPropertyValueSpecification<number>,


### PR DESCRIPTION
This PR cherry-picks a fix for a small omission in rebuilt flow types which was caught as part of the v2.3.0 release. See #10654 