### PR TITLE
Update navigation map style links in Map API ref doc

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -192,8 +192,8 @@ const defaultOptions = {
  * such JSON.
  *
  * To load a style from the Mapbox API, you can use a URL of the form `mapbox://styles/:owner/:style`,
- * where `:owner` is your Mapbox account name and `:style` is the style ID. Or you can use one of the following
- * [the predefined Mapbox styles](https://www.mapbox.com/maps/):
+ * where `:owner` is your Mapbox account name and `:style` is the style ID. Or you can use a
+ * [Mapbox-owned style](https://docs.mapbox.com/api/maps/styles/#mapbox-styles):
  *
  *  * `mapbox://styles/mapbox/streets-v11`
  *  * `mapbox://styles/mapbox/outdoors-v11`
@@ -201,10 +201,8 @@ const defaultOptions = {
  *  * `mapbox://styles/mapbox/dark-v10`
  *  * `mapbox://styles/mapbox/satellite-v9`
  *  * `mapbox://styles/mapbox/satellite-streets-v11`
- *  * `mapbox://styles/mapbox/navigation-preview-day-v4`
- *  * `mapbox://styles/mapbox/navigation-preview-night-v4`
- *  * `mapbox://styles/mapbox/navigation-guidance-day-v4`
- *  * `mapbox://styles/mapbox/navigation-guidance-night-v4`
+ *  * `mapbox://styles/mapbox/navigation-day-v1`
+ *  * `mapbox://styles/mapbox/navigation-night-v1`
  *
  * Tilesets hosted with Mapbox can be style-optimized if you append `?optimize=true` to the end of your style URL, like `mapbox://styles/mapbox/streets-v11?optimize=true`.
  * Learn more about style-optimized vector tiles in our [API documentation](https://www.mapbox.com/api-documentation/maps/#retrieve-tiles).


### PR DESCRIPTION
- Updates [Map Options Style](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters) to match the [list of Mapbox styles on Style API](https://docs.mapbox.com/api/maps/styles/#mapbox-styles).

We updated the Styles API list ^ [based on info](https://github.com/mapbox/api-documentation/pull/1152#issuecomment-821267488) from @ClareTrainor:

> The latest navigation styles on v8 data deployed to the styles api are mapbox://styles/mapbox/navigation-day-v1 and mapbox://styles/mapbox/navigation-night-v1. While building the components, we condensed the 4 styles into 2. There is some ongoing conversation about adding sky and fog to these styles and doing a new API release soon.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
