### PR TITLE
Specify 2.3.0-beta.1 version numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "2.3.0-dev",
+  "version": "2.3.0-beta.1",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/mapbox-gl-style-spec",
   "description": "a specification for mapbox gl styles",
-  "version": "13.20.0-dev",
+  "version": "13.20.0-beta.1",
   "author": "Mapbox",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
This PR specifies version `2.3.0-beta.1` for `mapbox-gl-js` and `13.20.0-beta.1` for `style-spec`.