### PR TITLE
Fix a potential mobile GPU issue on zero-value dashes

### DIFF
--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -98,13 +98,13 @@ void main() {
     float fromScale = u_scale.y;
     float toScale = u_scale.z;
 
-    float widthA = dash_from.z * fromScale;
-    float widthB = dash_to.z * toScale;
+    float scaleA = dash_from.z == 0.0 ? 0.0 : tileZoomRatio / (dash_from.z * fromScale);
+    float scaleB = dash_to.z == 0.0 ? 0.0 : tileZoomRatio / (dash_to.z * toScale);
     float heightA = dash_from.y;
     float heightB = dash_to.y;
 
-    v_tex_a = vec2(a_linesofar * (tileZoomRatio / widthA) / floorwidth, (-normal.y * heightA + dash_from.x + 0.5) / u_texsize.y);
-    v_tex_b = vec2(a_linesofar * (tileZoomRatio / widthB) / floorwidth, (-normal.y * heightB + dash_to.x + 0.5) / u_texsize.y);
+    v_tex_a = vec2(a_linesofar * scaleA / floorwidth, (-normal.y * heightA + dash_from.x + 0.5) / u_texsize.y);
+    v_tex_b = vec2(a_linesofar * scaleB / floorwidth, (-normal.y * heightB + dash_to.x + 0.5) / u_texsize.y);
 
     v_width2 = vec2(outset, inset);
 


### PR DESCRIPTION
Fixes a potentially issue on mobile GPUs + zero-value dashes. We didn't handle this case in JS before anyway (so this isn't necessary to cherry-pick to release branch), but due to changing the way we pass uniforms to line-sdf shaders, there's a failing test on Android in the GL Native port of the shader changes. This change should fix it.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] tagged @astojilj for corresponding native update
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
