### PR TITLE
Include dist/package.json in npm published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "build/",
     "dist/mapbox-gl*",
     "dist/style-spec/",
+    "dist/package.json",
     "flow-typed/*.js",
     "src/",
     ".flowconfig",


### PR DESCRIPTION
There's a little code mystery about how `dist/package.json` *was* published in the `2.2.0` release when it seems like it was configured *not* to explicitly include it via `package.json` `files`. There is context about the inclusion here: https://github.com/mapbox/mapbox-gl-js/pull/10367.

See `package.json` here:

https://unpkg.com/browse/mapbox-gl@2.2.0/dist/

Despite this uncertainty about how it got included, it seems like the right move is to indeed include it, which means adding it to `files`.