### PR TITLE
Fix line atlas not caching dashes properly

### DIFF
--- a/src/render/line_atlas.js
+++ b/src/render/line_atlas.js
@@ -155,6 +155,8 @@ class LineAtlas {
 
     addDash(dasharray: Array<number>, lineCap: string) {
         const key = this.getKey(dasharray, lineCap);
+        if (this.positions[key]) return this.positions[key];
+
         const round = lineCap === 'round';
         const n = round ? 7 : 0;
         const height = 2 * n + 1;

--- a/test/unit/render/line_atlas.test.js
+++ b/test/unit/render/line_atlas.test.js
@@ -4,44 +4,50 @@ import LineAtlas from '../../../src/render/line_atlas.js';
 test('LineAtlas', (t) => {
     const lineAtlas = new LineAtlas(64, 64);
     t.test('round [0, 0]', (t) => {
-        const entry = lineAtlas.addDash([0, 0], true);
+        const entry = lineAtlas.addDash([0, 0], 'round');
         t.equal(entry.br[0], 0);
         t.end();
     });
     t.test('round [1, 0]', (t) => {
-        const entry = lineAtlas.addDash([1, 0], true);
+        const entry = lineAtlas.addDash([1, 0], 'round');
         t.equal(entry.br[0], 1);
         t.end();
     });
     t.test('round [0, 1]', (t) => {
-        const entry = lineAtlas.addDash([0, 1], true);
+        const entry = lineAtlas.addDash([0, 1], 'round');
         t.equal(entry.br[0], 1);
         t.end();
     });
     t.test('odd round [1, 2, 1]', (t) => {
-        const entry = lineAtlas.addDash([1, 2, 1], true);
+        const entry = lineAtlas.addDash([1, 2, 1], 'round');
         t.equal(entry.br[0], 4);
         t.end();
     });
 
     t.test('regular [0, 0]', (t) => {
-        const entry = lineAtlas.addDash([0, 0], false);
+        const entry = lineAtlas.addDash([0, 0], 'butt');
         t.equal(entry.br[0], 0);
         t.end();
     });
     t.test('regular [1, 0]', (t) => {
-        const entry = lineAtlas.addDash([1, 0], false);
+        const entry = lineAtlas.addDash([1, 0], 'butt');
         t.equal(entry.br[0], 1);
         t.end();
     });
     t.test('regular [0, 1]', (t) => {
-        const entry = lineAtlas.addDash([0, 1], false);
+        const entry = lineAtlas.addDash([0, 1], 'butt');
         t.equal(entry.br[0], 1);
         t.end();
     });
     t.test('odd regular [1, 2, 1]', (t) => {
-        const entry = lineAtlas.addDash([1, 2, 1], false);
+        const entry = lineAtlas.addDash([1, 2, 1], 'butt');
         t.equal(entry.br[0], 4);
+        t.end();
+    });
+    t.test('trims & uses cached positions', (t) => {
+        lineAtlas.trim();
+        t.ok(lineAtlas.addDash([0, 0], 'butt'));
+        t.ok(lineAtlas.addDash([0, 0], 'round'));
         t.end();
     });
     t.end();


### PR DESCRIPTION
While fixing the "Line atlas out of space" warning in a different case, I inadvertently made a huge blunder that made line atlas stop caching properly, and it slipped through because it wasn't covered by tests and didn't affect anything visually.

This fixes the blunder and adds a test for it. We should cherry-pick this into the beta.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
