### PR TITLE
Minor improvements to transform class

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -836,7 +836,7 @@ class Transform {
                 let overHorizonLine = false;
                 const horizonLineFromTop = this.horizonLineFromTop();
                 if (sqDist > fogCullDistSq && horizonLineFromTop !== 0) {
-                    const projMatrix = this.calculateProjMatrix([], entry.tileID.toUnwrapped());
+                    const projMatrix = this.calculateProjMatrix(entry.tileID.toUnwrapped());
 
                     let minmax;
                     if (useElevationData && this._elevation) {
@@ -1259,14 +1259,14 @@ class Transform {
      * @param {UnwrappedTileID} unwrappedTileID;
      * @private
      */
-    calculateProjMatrix(output: Array<number>, unwrappedTileID: UnwrappedTileID, aligned: boolean = false) {
+    calculateProjMatrix(unwrappedTileID: UnwrappedTileID, aligned: boolean = false) {
         const projMatrixKey = unwrappedTileID.key;
         const cache = aligned ? this._alignedProjMatrixCache : this._projMatrixCache;
         if (cache[projMatrixKey]) {
             return cache[projMatrixKey];
         }
 
-        const posMatrix = this.calculatePosMatrix(unwrappedTileID, this.worldSize);
+        const posMatrix = this.calculatePosMatrix([], unwrappedTileID, this.worldSize);
         mat4.multiply(posMatrix, aligned ? this.alignedProjMatrix : this.projMatrix, posMatrix);
 
         cache[projMatrixKey] = posMatrix;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -836,7 +836,7 @@ class Transform {
                 let overHorizonLine = false;
                 const horizonLineFromTop = this.horizonLineFromTop();
                 if (sqDist > fogCullDistSq && horizonLineFromTop !== 0) {
-                    const projMatrix = this.calculateProjMatrix(entry.tileID.toUnwrapped());
+                    const projMatrix = this.calculateProjMatrix([], entry.tileID.toUnwrapped());
 
                     let minmax;
                     if (useElevationData && this._elevation) {
@@ -1220,7 +1220,7 @@ class Transform {
         }
     }
 
-    calculatePosMatrix(unwrappedTileID: UnwrappedTileID, worldSize: number): Array<number> {
+    calculatePosMatrix(output: Array<number>, unwrappedTileID: UnwrappedTileID, worldSize: number): Array<number> {
         const canonical = unwrappedTileID.canonical;
         const scale = worldSize / this.zoomScale(canonical.z);
         const unwrappedX = canonical.x + Math.pow(2, canonical.z) * unwrappedTileID.wrap;
@@ -1247,7 +1247,7 @@ class Transform {
             return cache[fogTileMatrixKey];
         }
 
-        const posMatrix = this.calculatePosMatrix(unwrappedTileID, this.cameraWorldSize);
+        const posMatrix = this.calculatePosMatrix([], unwrappedTileID, this.cameraWorldSize);
         mat4.multiply(posMatrix, this.worldToFogMatrix, posMatrix);
 
         cache[fogTileMatrixKey] = posMatrix;
@@ -1259,7 +1259,7 @@ class Transform {
      * @param {UnwrappedTileID} unwrappedTileID;
      * @private
      */
-    calculateProjMatrix(unwrappedTileID: UnwrappedTileID, aligned: boolean = false): Array<number> {
+    calculateProjMatrix(Array<number> output, unwrappedTileID: UnwrappedTileID, aligned: boolean = false) {
         const projMatrixKey = unwrappedTileID.key;
         const cache = aligned ? this._alignedProjMatrixCache : this._projMatrixCache;
         if (cache[projMatrixKey]) {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1259,7 +1259,7 @@ class Transform {
      * @param {UnwrappedTileID} unwrappedTileID;
      * @private
      */
-    calculateProjMatrix(Array<number> output, unwrappedTileID: UnwrappedTileID, aligned: boolean = false) {
+    calculateProjMatrix(output: Array<number>, unwrappedTileID: UnwrappedTileID, aligned: boolean = false) {
         const projMatrixKey = unwrappedTileID.key;
         const cache = aligned ? this._alignedProjMatrixCache : this._projMatrixCache;
         if (cache[projMatrixKey]) {

--- a/src/render/draw_sky.js
+++ b/src/render/draw_sky.js
@@ -151,30 +151,25 @@ function captureSkybox(painter: Painter, layer: SkyLayer, width: number, height:
 
     const sunDirection = layer.getCenter(painter, true);
     const program = painter.useProgram('skyboxCapture');
-    const faceRotate = new Float64Array(16);
+    const faceRotate = [];
 
     // +x;
-    mat4.identity(faceRotate);
-    mat4.rotateY(faceRotate, faceRotate, -Math.PI * 0.5);
+    mat4.fromYRotation(faceRotate, -Math.PI * 0.5);
     drawSkyboxFace(context, layer, program, faceRotate, sunDirection, 0);
     // -x
-    mat4.identity(faceRotate);
-    mat4.rotateY(faceRotate, faceRotate, Math.PI * 0.5);
+    mat4.fromYRotation(faceRotate, Math.PI * 0.5);
     drawSkyboxFace(context, layer, program, faceRotate, sunDirection, 1);
     // +y
-    mat4.identity(faceRotate);
-    mat4.rotateX(faceRotate, faceRotate, -Math.PI * 0.5);
+    mat4.fromXRotation(faceRotate, -Math.PI * 0.5);
     drawSkyboxFace(context, layer, program, faceRotate, sunDirection, 2);
     // -y
-    mat4.identity(faceRotate);
-    mat4.rotateX(faceRotate, faceRotate, Math.PI * 0.5);
+    mat4.fromXRotation(faceRotate, Math.PI * 0.5);
     drawSkyboxFace(context, layer, program, faceRotate, sunDirection, 3);
     // +z
     mat4.identity(faceRotate);
     drawSkyboxFace(context, layer, program, faceRotate, sunDirection, 4);
     // -z
-    mat4.identity(faceRotate);
-    mat4.rotateY(faceRotate, faceRotate, Math.PI);
+    mat4.fromYRotation(faceRotate, Math.PI);
     drawSkyboxFace(context, layer, program, faceRotate, sunDirection, 5);
 
     context.viewport.set([0, 0, painter.width, painter.height]);

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -8,7 +8,7 @@ import pixelsToTileUnits from '../source/pixels_to_tile_units.js';
 import * as symbolProjection from '../symbol/projection.js';
 import * as symbolSize from '../symbol/symbol_size.js';
 import {mat4} from 'gl-matrix';
-const identityMat4 = mat4.identity(new Float32Array(16));
+const identityMat4 = mat4.identity([]);
 import StencilMode from '../gl/stencil_mode.js';
 import DepthMode from '../gl/depth_mode.js';
 import CullFaceMode from '../gl/cull_face_mode.js';
@@ -50,7 +50,7 @@ type SymbolTileRenderState = {
         isSDF: boolean,
         hasHalo: boolean,
         tile: Tile,
-        labelPlaneMatrixInv: ?Float32Array
+        labelPlaneMatrixInv: ?Array<number>
     }
 };
 
@@ -294,7 +294,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         const s = pixelsToTileUnits(tile, 1, painter.transform.zoom);
         const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.projMatrix, pitchWithMap, rotateWithMap, painter.transform, s);
         // labelPlaneMatrixInv is used for converting vertex pos to tile coordinates needed for sampling elevation.
-        const labelPlaneMatrixInv = painter.terrain && pitchWithMap && alongLine ? mat4.invert(new Float32Array(16), labelPlaneMatrix) : identityMat4;
+        const labelPlaneMatrixInv = painter.terrain && pitchWithMap && alongLine ? mat4.invert([], labelPlaneMatrix) : identityMat4;
         const glCoordMatrix = symbolProjection.getGlCoordMatrix(coord.projMatrix, pitchWithMap, rotateWithMap, painter.transform, s);
 
         const hasVariableAnchors = variablePlacement && bucket.hasTextData();

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -682,10 +682,10 @@ class Painter {
     /**
      * Transform a matrix to incorporate the *-translate and *-translate-anchor properties into it.
      * @param inViewportPixelUnitsUnits True when the units accepted by the matrix are in viewport pixels instead of tile units.
-     * @returns {Float32Array} matrix
+     * @returns {Array<number>} matrix
      * @private
      */
-    translatePosMatrix(matrix: Float32Array, tile: Tile, translate: [number, number], translateAnchor: 'map' | 'viewport', inViewportPixelUnitsUnits?: boolean) {
+    translatePosMatrix(matrix: Array<number>, tile: Tile, translate: [number, number], translateAnchor: 'map' | 'viewport', inViewportPixelUnitsUnits?: boolean) {
         if (!translate[0] && !translate[1]) return matrix;
 
         const angle = inViewportPixelUnitsUnits ?
@@ -707,9 +707,7 @@ class Painter {
             0
         ];
 
-        const translatedMatrix = new Float32Array(16);
-        mat4.translate(translatedMatrix, matrix, translation);
-        return translatedMatrix;
+        return mat4.translate([], matrix, translation);
     }
 
     saveTileTexture(texture: Texture) {

--- a/src/render/program/background_program.js
+++ b/src/render/program/background_program.js
@@ -71,7 +71,7 @@ const backgroundPatternUniforms = (context: Context, locations: UniformLocations
 });
 
 const backgroundUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     opacity: number,
     color: Color
 ): UniformValues<BackgroundUniformsType> => ({
@@ -81,7 +81,7 @@ const backgroundUniformValues = (
 });
 
 const backgroundPatternUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     opacity: number,
     painter: Painter,
     image: CrossFaded<ResolvedImage>,

--- a/src/render/program/clipping_mask_program.js
+++ b/src/render/program/clipping_mask_program.js
@@ -13,7 +13,7 @@ const clippingMaskUniforms = (context: Context, locations: UniformLocations): Cl
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix)
 });
 
-const clippingMaskUniformValues = (matrix: Float32Array): UniformValues<ClippingMaskUniformsType> => ({
+const clippingMaskUniformValues = (matrix: Array<number>): UniformValues<ClippingMaskUniformsType> => ({
     'u_matrix': matrix
 });
 

--- a/src/render/program/collision_program.js
+++ b/src/render/program/collision_program.js
@@ -38,7 +38,7 @@ const collisionCircleUniforms = (context: Context, locations: UniformLocations):
 });
 
 const collisionUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     transform: Transform,
     tile: Tile
 ): UniformValues<CollisionUniformsType> => {
@@ -52,8 +52,8 @@ const collisionUniformValues = (
 };
 
 const collisionCircleUniformValues = (
-    matrix: Float32Array,
-    invMatrix: Float32Array,
+    matrix: Array<number>,
+    invMatrix: Array<number>,
     transform: Transform
 ): UniformValues<CollisionCircleUniformsType> => {
     return {

--- a/src/render/program/debug_program.js
+++ b/src/render/program/debug_program.js
@@ -25,7 +25,7 @@ const debugUniforms = (context: Context, locations: UniformLocations): DebugUnif
     'u_overlay_scale':  new Uniform1f(context, locations.u_overlay_scale),
 });
 
-const debugUniformValues = (matrix: Float32Array, color: Color, scaleRatio: number = 1): UniformValues<DebugUniformsType> => ({
+const debugUniformValues = (matrix: Array<number>, color: Color, scaleRatio: number = 1): UniformValues<DebugUniformsType> => ({
     'u_matrix': matrix,
     'u_color': color,
     'u_overlay': 0,

--- a/src/render/program/fill_extrusion_program.js
+++ b/src/render/program/fill_extrusion_program.js
@@ -72,7 +72,7 @@ const fillExtrusionPatternUniforms = (context: Context, locations: UniformLocati
 });
 
 const fillExtrusionUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     painter: Painter,
     shouldUseVerticalGradient: boolean,
     opacity: number
@@ -100,7 +100,7 @@ const fillExtrusionUniformValues = (
 };
 
 const fillExtrusionPatternUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     painter: Painter,
     shouldUseVerticalGradient: boolean,
     opacity: number,

--- a/src/render/program/fill_program.js
+++ b/src/render/program/fill_program.js
@@ -79,12 +79,12 @@ const fillOutlinePatternUniforms = (context: Context, locations: UniformLocation
     'u_fade': new Uniform1f(context, locations.u_fade)
 });
 
-const fillUniformValues = (matrix: Float32Array): UniformValues<FillUniformsType> => ({
+const fillUniformValues = (matrix: Array<number>): UniformValues<FillUniformsType> => ({
     'u_matrix': matrix
 });
 
 const fillPatternUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     painter: Painter,
     crossfade: CrossfadeParameters,
     tile: Tile
@@ -94,7 +94,7 @@ const fillPatternUniformValues = (
 );
 
 const fillOutlineUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     drawingBufferSize: [number, number]
 ): UniformValues<FillOutlineUniformsType> => ({
     'u_matrix': matrix,
@@ -102,7 +102,7 @@ const fillOutlineUniformValues = (
 });
 
 const fillOutlinePatternUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     painter: Painter,
     crossfade: CrossfadeParameters,
     tile: Tile,

--- a/src/render/program/heatmap_program.js
+++ b/src/render/program/heatmap_program.js
@@ -45,7 +45,7 @@ const heatmapTextureUniforms = (context: Context, locations: UniformLocations): 
 });
 
 const heatmapUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     tile: Tile,
     zoom: number,
     intensity: number

--- a/src/render/program/hillshade_program.js
+++ b/src/render/program/hillshade_program.js
@@ -61,7 +61,7 @@ const hillshadeUniformValues = (
     painter: Painter,
     tile: Tile,
     layer: HillshadeStyleLayer,
-    matrix: ?Float32Array
+    matrix: ?Array<number>
 ): UniformValues<HillshadeUniformsType> => {
     const shadow = layer.paint.get("hillshade-shadow-color");
     const highlight = layer.paint.get("hillshade-highlight-color");

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -99,7 +99,7 @@ const lineUniformValues = (
     painter: Painter,
     tile: Tile,
     layer: LineStyleLayer,
-    matrix: ?Float32Array
+    matrix: ?Array<number>
 ): UniformValues<LineUniformsType> => {
     const transform = painter.transform;
 
@@ -118,7 +118,7 @@ const lineGradientUniformValues = (
     painter: Painter,
     tile: Tile,
     layer: LineStyleLayer,
-    matrix: ?Float32Array,
+    matrix: ?Array<number>,
     imageHeight: number
 ): UniformValues<LineGradientUniformsType> => {
     return extend(lineUniformValues(painter, tile, layer, matrix), {
@@ -132,7 +132,7 @@ const linePatternUniformValues = (
     tile: Tile,
     layer: LineStyleLayer,
     crossfade: CrossfadeParameters,
-    matrix: ?Float32Array
+    matrix: ?Array<number>
 ): UniformValues<LinePatternUniformsType> => {
     const transform = painter.transform;
     const tileZoomRatio = calculateTileRatio(tile, transform);
@@ -157,7 +157,7 @@ const lineSDFUniformValues = (
     tile: Tile,
     layer: LineStyleLayer,
     crossfade: CrossfadeParameters,
-    matrix: ?Float32Array
+    matrix: ?Array<number>
 ): UniformValues<LineSDFUniformsType> => {
     const tileZoomRatio = calculateTileRatio(tile, painter.transform);
     return extend(lineUniformValues(painter, tile, layer, matrix), {

--- a/src/render/program/raster_program.js
+++ b/src/render/program/raster_program.js
@@ -45,7 +45,7 @@ const rasterUniforms = (context: Context, locations: UniformLocations): RasterUn
 });
 
 const rasterUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     parentTL: [number, number],
     parentScaleBy: number,
     fade: {mix: number, opacity: number},

--- a/src/render/program/skybox_capture_program.js
+++ b/src/render/program/skybox_capture_program.js
@@ -34,7 +34,7 @@ const skyboxCaptureUniforms = (context: Context, locations: UniformLocations): S
 });
 
 const skyboxCaptureUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     sunDirection: vec3,
     sunIntensity: number,
     atmosphereColor: Color,

--- a/src/render/program/skybox_program.js
+++ b/src/render/program/skybox_program.js
@@ -39,7 +39,7 @@ const skyboxUniforms = (context: Context, locations: UniformLocations): SkyboxUn
 });
 
 const skyboxUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     sunDirection: vec3,
     cubemap: number,
     opacity: number,
@@ -63,7 +63,7 @@ const skyboxGradientUniforms = (context: Context, locations: UniformLocations): 
 });
 
 const skyboxGradientUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     centerDirection: vec3,
     radius: number, //degrees
     opacity: number,

--- a/src/render/program/symbol_program.js
+++ b/src/render/program/symbol_program.js
@@ -151,9 +151,9 @@ const symbolIconUniformValues = (
     rotateInShader: boolean,
     pitchWithMap: boolean,
     painter: Painter,
-    matrix: Float32Array,
-    labelPlaneMatrix: Float32Array,
-    glCoordMatrix: Float32Array,
+    matrix: Array<number>,
+    labelPlaneMatrix: Array<number>,
+    glCoordMatrix: Array<number>,
     isText: boolean,
     texSize: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {
@@ -185,9 +185,9 @@ const symbolSDFUniformValues = (
     rotateInShader: boolean,
     pitchWithMap: boolean,
     painter: Painter,
-    matrix: Float32Array,
-    labelPlaneMatrix: Float32Array,
-    glCoordMatrix: Float32Array,
+    matrix: Array<number>,
+    labelPlaneMatrix: Array<number>,
+    glCoordMatrix: Array<number>,
     isText: boolean,
     texSize: [number, number],
     isHalo: boolean
@@ -209,9 +209,9 @@ const symbolTextAndIconUniformValues = (
     rotateInShader: boolean,
     pitchWithMap: boolean,
     painter: Painter,
-    matrix: Float32Array,
-    labelPlaneMatrix: Float32Array,
-    glCoordMatrix: Float32Array,
+    matrix: Array<number>,
+    labelPlaneMatrix: Array<number>,
+    glCoordMatrix: Array<number>,
     texSizeSDF: [number, number],
     texSizeIcon: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {

--- a/src/render/uniform_binding.js
+++ b/src/render/uniform_binding.js
@@ -107,14 +107,14 @@ class UniformColor extends Uniform<Color> {
     }
 }
 
-const emptyMat4 = new Float32Array(16);
-class UniformMatrix4f extends Uniform<Float32Array> {
+const emptyMat4 = new Array(16);
+class UniformMatrix4f extends Uniform<Array<number>> {
     constructor(context: Context, location: WebGLUniformLocation) {
         super(context, location);
         this.current = emptyMat4;
     }
 
-    set(v: Float32Array): void {
+    set(v: Array<number>): void {
         // The vast majority of matrix comparisons that will trip this set
         // happen at i=12 or i=0, so we check those first to avoid lots of
         // unnecessary iteration:
@@ -133,14 +133,14 @@ class UniformMatrix4f extends Uniform<Float32Array> {
     }
 }
 
-const emptyMat3 = new Float32Array(9);
-class UniformMatrix3f extends Uniform<Float32Array> {
+const emptyMat3 = new Array(9);
+class UniformMatrix3f extends Uniform<Array<number>> {
     constructor(context: Context, location: WebGLUniformLocation) {
         super(context, location);
         this.current = emptyMat3;
     }
 
-    set(v: Float32Array): void {
+    set(v: Array<number>): void {
         for (let i = 0; i < 9; i++) {
             if (v[i] !== this.current[i]) {
                 this.current = v;

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -843,7 +843,7 @@ class SourceCache extends Evented {
     getVisibleCoordinates(symbolLayer?: boolean): Array<OverscaledTileID> {
         const coords = this.getRenderableIds(symbolLayer).map((id) => this._tiles[id].tileID);
         for (const coord of coords) {
-            coord.projMatrix = this.transform.calculateProjMatrix(coord.projMatrix, coord.toUnwrapped());
+            coord.projMatrix = this.transform.calculateProjMatrix(coord.toUnwrapped());
         }
         return coords;
     }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -843,7 +843,7 @@ class SourceCache extends Evented {
     getVisibleCoordinates(symbolLayer?: boolean): Array<OverscaledTileID> {
         const coords = this.getRenderableIds(symbolLayer).map((id) => this._tiles[id].tileID);
         for (const coord of coords) {
-            coord.projMatrix = this.transform.calculateProjMatrix(coord.toUnwrapped());
+            coord.projMatrix = this.transform.calculateProjMatrix(coord.projMatrix, coord.toUnwrapped());
         }
         return coords;
     }

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -79,7 +79,7 @@ export class OverscaledTileID {
     wrap: number;
     canonical: CanonicalTileID;
     key: number;
-    projMatrix: Float32Array;
+    projMatrix: Array<number>;
 
     constructor(overscaledZ: number, wrap: number, z: number, x: number, y: number) {
         assert(overscaledZ >= z);

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -87,7 +87,6 @@ export class OverscaledTileID {
         this.wrap = wrap;
         this.canonical = new CanonicalTileID(z, +x, +y);
         this.key = wrap === 0 && overscaledZ === z ? this.canonical.key : calculateKey(wrap, overscaledZ, z, x, y);
-        this.projMatrix = [];
     }
 
     equals(id: OverscaledTileID) {

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -87,6 +87,7 @@ export class OverscaledTileID {
         this.wrap = wrap;
         this.canonical = new CanonicalTileID(z, +x, +y);
         this.key = wrap === 0 && overscaledZ === z ? this.canonical.key : calculateKey(wrap, overscaledZ, z, x, y);
+        this.projMatrix = [];
     }
 
     equals(id: OverscaledTileID) {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -153,7 +153,7 @@ class ProxySourceCache extends SourceCache {
 class ProxiedTileID extends OverscaledTileID {
     proxyTileKey: number;
 
-    constructor(tileID: OverscaledTileID, proxyTileKey: number, projMatrix: Float32Array) {
+    constructor(tileID: OverscaledTileID, proxyTileKey: number, projMatrix: Array<number>) {
         super(tileID.overscaledZ, tileID.wrap, tileID.canonical.z, tileID.canonical.x, tileID.canonical.y);
         this.proxyTileKey = proxyTileKey;
         this.projMatrix = projMatrix;
@@ -546,7 +546,7 @@ export class Terrain extends Elevation {
         options?: {
             useDepthForOcclusion?: boolean,
             useMeterToDem?: boolean,
-            labelPlaneMatrixInv?: ?Float32Array,
+            labelPlaneMatrixInv?: ?Array<number>,
             morphing?: { srcDemTile: Tile, dstDemTile: Tile, phase: number }
         }) {
         const context = this.painter.context;

--- a/src/terrain/terrain_raster_program.js
+++ b/src/terrain/terrain_raster_program.js
@@ -22,7 +22,7 @@ const terrainRasterUniforms = (context: Context, locations: UniformLocations): T
 });
 
 const terrainRasterUniformValues = (
-    matrix: Float32Array,
+    matrix: Array<number>,
     skirtHeight: number
 ): UniformValues<TerrainRasterUniformsType> => ({
     'u_matrix': matrix,

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -241,18 +241,16 @@ class FreeCamera {
         return [col[0], col[1], col[2]];
     }
 
-    getCameraToWorld(worldSize: number, pixelsPerMeter: number): Float64Array {
-        const cameraToWorld = new Float64Array(16);
-        mat4.invert(cameraToWorld, this.getWorldToCamera(worldSize, pixelsPerMeter));
+    getCameraToWorld(worldSize: number, pixelsPerMeter: number): Array<number> {
+        const cameraToWorld = mat4.invert([], this.getWorldToCamera(worldSize, pixelsPerMeter));
         return cameraToWorld;
     }
 
-    getWorldToCameraPosition(worldSize: number, pixelsPerMeter: number, uniformScale: number): Float64Array {
+    getWorldToCameraPosition(worldSize: number, pixelsPerMeter: number, uniformScale: number): Array<number> {
         const invPosition = this.position;
 
         vec3.scale(invPosition, invPosition, -worldSize);
-        const matrix = new Float64Array(16);
-        mat4.fromScaling(matrix, [uniformScale, uniformScale, uniformScale]);
+        const matrix = mat4.fromScaling([], [uniformScale, uniformScale, uniformScale]);
         mat4.translate(matrix, matrix, invPosition);
 
         // Adjust scale on z (3rd column 3rd row)
@@ -261,7 +259,7 @@ class FreeCamera {
         return matrix;
     }
 
-    getWorldToCamera(worldSize: number, pixelsPerMeter: number): Float64Array {
+    getWorldToCamera(worldSize: number, pixelsPerMeter: number): Array<number> {
         // transformation chain from world space to camera space:
         // 1. Height value (z) of renderables is in meters. Scale z coordinate by pixelsPerMeter
         // 2. Transform from pixel coordinates to camera space with cameraMatrix^-1
@@ -269,16 +267,14 @@ class FreeCamera {
 
         // worldToCamera: flip * cam^-1 * zScale
         // cameraToWorld: (flip * cam^-1 * zScale)^-1 => (zScale^-1 * cam * flip^-1)
-        const matrix = new Float64Array(16);
 
         // Compute inverse of camera matrix and post-multiply negated translation
-        const invOrientation = new Float64Array(4);
         const invPosition = this.position;
 
-        quat.conjugate(invOrientation, this._orientation);
+        const invOrientation = quat.conjugate([], this._orientation);
         vec3.scale(invPosition, invPosition, -worldSize);
 
-        mat4.fromQuat(matrix, invOrientation);
+        const matrix = mat4.fromQuat([], invOrientation);
         mat4.translate(matrix, matrix, invPosition);
 
         // Pre-multiply y (2nd row)
@@ -296,10 +292,8 @@ class FreeCamera {
         return matrix;
     }
 
-    getCameraToClipPerspective(fovy: number, aspectRatio: number, nearZ: number, farZ: number): Float64Array {
-        const matrix = new Float64Array(16);
-        mat4.perspective(matrix, fovy, aspectRatio, nearZ, farZ);
-        return matrix;
+    getCameraToClipPerspective(fovy: number, aspectRatio: number, nearZ: number, farZ: number): Array<number> {
+        return mat4.perspective([], fovy, aspectRatio, nearZ, farZ);
     }
 
     getDistanceToElevation(elevationMeters: number): number {

--- a/src/util/primitives.js
+++ b/src/util/primitives.js
@@ -33,7 +33,7 @@ class Frustum {
         this.planes = planes_;
     }
 
-    static fromInvProjectionMatrix(invProj: Float64Array, worldSize: number, zoom: number): Frustum {
+    static fromInvProjectionMatrix(invProj: Array<number>, worldSize: number, zoom: number): Frustum {
         const clipSpaceCorners = [
             [-1, 1, -1, 1],
             [ 1, 1, -1, 1],


### PR DESCRIPTION
I spent some time last night carefully stepping through `geo/transform.js` to kick the tires a bit and really familiarize myself with the details. I've made a few changes, only some of which I think are worth merging.

- 👍  Add comments to `geo/transform.js` instance variables (they are often described where computed, which can be a burden to track down over and over and over)
- 👍  Fix type errors which slip past flow. `transform.projMatrix`, for example, is [specified as a `Float64Array`](https://github.com/mapbox/mapbox-gl-js/blob/2441ec134bb368465d85f36bde5d6ffeb6bbf834/src/geo/transform.js#L47) but [assigned a `Array<number>`](https://github.com/mapbox/mapbox-gl-js/blob/2441ec134bb368465d85f36bde5d6ffeb6bbf834/src/geo/transform.js#L1477-L1483)
- 👍  Simplify matrix initialization. There are a number of places where we have things like `mat4.create()` followed by `mat4.rotateX()`. This can be simplified via `mat4.fromXRotation()`. The benefit is minuscule, but results in less code and fewer multiplications so it's probably fine to clean up.
- 🤷  Switch from `Float64Array` to `Array`. To the best of my knowledge, `Float32Array` is used in various places because the WebGL API accepts it, even though the additional precision of `Float64Array` may have value. The WebGL API also [accepts `Array<number>`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/uniform#parameters), which would allow delaying the loss of precision until the last possible moment. See: https://github.com/mapbox/gl-js-team/issues/57

  Because of flow, this change had moderately far-reaching effects but seemed manageable. Using `Float64Array` feels very precise and correct, but it's not clear to me that there's a real advantage, compared to the disadvantage of early loss of precision just to satisfy the WebGL API's requirements.
- 🤷  ~~Reuse tile projection matrices. By instantiating tiles with an empty projection matrix and then writing into it rather than re-assigning every time, this could cut down on GC. I briefly talked to @arindam1993 about this, who probably has additional thoughts about how to address this more meaningfully than I have here.~~ Could do this, but I didn't carry it all the way through and introduced type errors which aren't currently worth ironing out.

I'm leaving this in draft state at the moment because I'm a bit ambivalent about simply merging this without first picking and choosing the good parts.

cc @mpulkki-mapbox re: https://github.com/mapbox/gl-js-team/issues/57, in case you have knowledge about whether the impact of float32 precision justifies a switch to `Array<number>`.