### PR TITLE
Add coments to transform instance variables

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -38,7 +38,7 @@ class Transform {
     // 2^zoom (worldSize = tileSize * scale)
     scale: number;
 
-    // Map dimensions (not including the pixel ratio)
+    // Map viewport size (not including the pixel ratio)
     width: number;
     height: number;
 
@@ -69,10 +69,10 @@ class Transform {
     projMatrix: Float64Array;
     invProjMatrix: Float64Array;
 
-    // Same projection matrix as above, pixel-aligned to avoid fractional pixels for raster tiles
+    // Same as projMatrix, pixel-aligned to avoid fractional pixels for raster tiles
     alignedProjMatrix: Float64Array;
 
-    // From tile coordinates to screen coordinates (projMatrix premultiplied by labelPlaneMatrix)
+    // From world coordinates to screen pixel coordinates (projMatrix premultiplied by labelPlaneMatrix)
     pixelMatrix: Float64Array;
     pixelMatrixInverse: Float64Array;
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -34,25 +34,58 @@ class Transform {
     lngRange: ?[number, number];
     latRange: ?[number, number];
     maxValidLatitude: number;
+
+    // 2^zoom (worldSize = tileSize * scale)
     scale: number;
+
+    // Map dimensions (not including the pixel ratio)
     width: number;
     height: number;
+
+    // Bearing, radians, in [-pi, pi]
     angle: number;
+
+    // 2D rotation matrix in the horizontal plane, as a function of bearing
     rotationMatrix: Float64Array;
+
+    // Zoom, modulo 1
     zoomFraction: number;
+
+    // The scale factor component of the conversion from pixels ([0, w] x [h, 0]) to GL
+    // NDC ([1, -1] x [1, -1]) (note flipped y)
     pixelsToGLUnits: [number, number];
+
+    // Distance from camera to the center, in screen pixel units, independent of zoom
     cameraToCenterDistance: number;
+
+    // Projection from mercator coordinates ([0, 0] nw, [1, 1] se) to GL clip coordinates
     mercatorMatrix: Array<number>;
+
+    // Translate points in mercator coordinates to be centered about the camera, with units chosen
+    // for screen-height-dependent scaling of fog. Not affected by orientation of camera.
     mercatorFogMatrix: Array<number>;
+
+    // Projection from world coordinates (mercator scaled by worldSize) to clip coordinates
     projMatrix: Float64Array;
     invProjMatrix: Float64Array;
+
+    // Same projection matrix as above, pixel-aligned to avoid fractional pixels for raster tiles
     alignedProjMatrix: Float64Array;
+
+    // From tile coordinates to screen coordinates (projMatrix premultiplied by labelPlaneMatrix)
     pixelMatrix: Float64Array;
     pixelMatrixInverse: Float64Array;
+
     worldToFogMatrix: Float64Array;
     skyboxMatrix: Float32Array;
+
+    // Transform from screen coordinates to GL NDC, [0, w] x [h, 0] --> [-1, 1] x [-1, 1]
+    // Roughly speaking, applies pixelsToGLUnits scaling with a translation
     glCoordMatrix: Float32Array;
+
+    // Inverse of glCoordMatrix, from NDC to screen coordinates, [-1, 1] x [-1, 1] --> [0, w] x [h, 0]
     labelPlaneMatrix: Float32Array;
+
     freezeTileCoverage: boolean;
     cameraElevationReference: ElevationReference;
     fogCullDistSq: ?number;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -62,7 +62,7 @@ class Transform {
     mercatorMatrix: Array<number>;
 
     // Translate points in mercator coordinates to be centered about the camera, with units chosen
-    // for screen-height-dependent scaling of fog. Not affected by orientation of camera.
+    // for screen-height-independent scaling of fog. Not affected by orientation of camera.
     mercatorFogMatrix: Array<number>;
 
     // Projection from world coordinates (mercator scaled by worldSize) to clip coordinates


### PR DESCRIPTION
Instance variables in the transform class are currently documented, to varying degrees, where _assigned_ a value. I've found this to be a source of difficulty since I constantly have to search and reverse-engineer their meaning in order to keep things straight in my head.

This PR adds strictly internal comments to the transform class to help give an overview of the meaning of most of the instance members of `transform`.

Broken out from draft PR #10673

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
