### PR TITLE
Disable fog tile culling with low horizon-blend

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -181,7 +181,7 @@ class Painter {
 
     _updateFog(style: Style) {
         const fog = style.fog;
-        if (!fog || (fog && fog.getOpacity(this.transform.pitch) !== 1.0)) {
+        if (!fog || fog.getOpacity(this.transform.pitch) < 1 || fog.properties.get('horizon-blend') < 0.03) {
             this.transform.fogCullDistSq = null;
             return;
         }


### PR DESCRIPTION
See: #10677

Addresses sky showing through culled high elevation terrain by simply disabling fog tile culling when `horizon-blend` < 0.03.

I don't necessarily think I caught the worst spot in the world, so 0.03 is a little forgiving. I think as little as 0.02 *might* be safe but probably cuts it a little close.

Original:

![hb-0-big copy](https://user-images.githubusercontent.com/572717/118045820-49eb7500-b32d-11eb-9b4c-eef96a30caea.jpg)

Threshold < 0.01:

![hb-01 copy](https://user-images.githubusercontent.com/572717/118045844-52dc4680-b32d-11eb-926d-2fc06c24e818.jpg)

Threshold < 0.02:

![hb-02 copy](https://user-images.githubusercontent.com/572717/118045856-57086400-b32d-11eb-938d-bbfe3f6bff1d.jpg)

Threshold < 0.03:

![hb-03 copy](https://user-images.githubusercontent.com/572717/118045862-5a9beb00-b32d-11eb-88b4-8ad0ba97a89d.jpg)

The look of the overall map with 0.03:

![hb-03-big copy](https://user-images.githubusercontent.com/572717/118045895-625b8f80-b32d-11eb-861f-703846c66f93.jpg)

Here's the worst case I could find where it's not *fully* patched over by the 0.03 threshold, but it's so slight that I think it might be permissible:

![Screen Shot 2021-05-12 at 2 22 56 PM copy](https://user-images.githubusercontent.com/572717/118046127-bc5c5500-b32d-11eb-813d-f162f98afe7e.jpg)

If not we could simply bump it up to 0.04.

I mainly just want to be sure that we don't sacrifice useful tile culling for a range of parameters people are likely to spend a lot of time in, but I think this is probably acceptable.