### PR TITLE
Fix transform type error

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -66,7 +66,7 @@ class Transform {
     mercatorFogMatrix: Array<number>;
 
     // Projection from world coordinates (mercator scaled by worldSize) to clip coordinates
-    projMatrix: Float64Array;
+    projMatrix: Array<number>;
     invProjMatrix: Float64Array;
 
     // Same as projMatrix, pixel-aligned to avoid fractional pixels for raster tiles


### PR DESCRIPTION
Another fix broken out from #10673

It appears that incorrect assignment of an `Array<number>` to `Float64Array` variable `transform.projMatrix` has escaped flow's type checking.

I'm quite interested in changing all(ish) instances of `Float32Array` and `Float64Array` matrices and vectors to `Array<number>` since double precision will be maintained while the WebGL API will still accept them.

To that end, this PR opts for changing the type to match the data rather than changing the data to match the type.

Assignment occurs here, and I've confirmed that `transform.projMatrix` is indeed just an `Array<number>`:

https://github.com/mapbox/mapbox-gl-js/blob/85ce4d4bc781d184b85b87f97d1a9cb2c9be22d3/src/geo/transform.js#L1477-L1483