### PR TITLE
Update sources and markers while fog transitioning

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2678,10 +2678,15 @@ class Map extends Camera {
         // updates during fog transitions
         const fogIsTransitioning = this.style && this.style.fog && this.style.fog.hasTransition();
 
+        if (fogIsTransitioning) {
+            this.style._markersNeedUpdate = true;
+            this._sourcesDirty = true;
+        }
+
         // If we are in _render for any reason other than an in-progress paint
         // transition, update source caches to check for and load any tiles we
         // need for the current transform
-        if (this.style && (this._sourcesDirty || fogIsTransitioning)) {
+        if (this.style && this._sourcesDirty) {
             this._sourcesDirty = false;
             this.painter._updateFog(this.style);
             this._updateTerrain(); // Terrain DEM source updates here and skips update in style._updateSources.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2674,10 +2674,14 @@ class Map extends Camera {
             this.style.update(parameters);
         }
 
+        // Fog affects tile culling, so we continuously check for necessary
+        // updates during fog transitions
+        const fogIsTransitioning = this.style && this.style.fog && this.style.fog.hasTransition();
+
         // If we are in _render for any reason other than an in-progress paint
         // transition, update source caches to check for and load any tiles we
         // need for the current transform
-        if (this.style && this._sourcesDirty) {
+        if (this.style && (this._sourcesDirty || fogIsTransitioning)) {
             this._sourcesDirty = false;
             this.painter._updateFog(this.style);
             this._updateTerrain(); // Terrain DEM source updates here and skips update in style._updateSources.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2674,8 +2674,6 @@ class Map extends Camera {
             this.style.update(parameters);
         }
 
-        // Fog affects tile culling, so we continuously check for necessary
-        // updates during fog transitions
         const fogIsTransitioning = this.style && this.style.fog && this.style.fog.hasTransition();
 
         if (fogIsTransitioning) {


### PR DESCRIPTION
Addresses #10686

Since fog affects tile culling and marker appearance, this PR checks whether fog is transitioning and updates sources and markers during the transition.

Before this fix (tiles do not load and marker reflects state at the *start* of the transition rather than during or after it):

![pre-fix](https://user-images.githubusercontent.com/572717/119041903-0a93d880-b96c-11eb-803d-29dd91896f27.gif)

After this fix (marker and sources update during transition):

![post-fix](https://user-images.githubusercontent.com/572717/119041916-0ff12300-b96c-11eb-9f3a-126061d1c447.gif)

Note: `_updateFog()` alone was not adequate to solve the problem since even if it computes an updated tile culling threshold, it does not *apply* it.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
