### PR TITLE
add map.on with two arguments to instance members

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1000,6 +1000,43 @@ class Map extends Camera {
     }
 
     /**
+     * Adds a listener for events of a specified type.
+     *
+     * @method
+     * @name on
+     * @memberof Map
+     * @instance
+     * @param {string} type The event type to listen for.
+     * @param {Function} listener The function to be called when the event is fired.
+     * @returns {Map} `this`
+     * @example
+     * // Set an event listener that will fire
+     * // when the map has finished loading.
+     * map.on('load', function() {
+     *   // Once the map has finished loading,
+     *   // add a new layer.
+     *   map.addLayer({
+     *     id: 'points-of-interest',
+     *     source: {
+     *       type: 'vector',
+     *       url: 'mapbox://mapbox.mapbox-streets-v8'
+     *     },
+     *     'source-layer': 'poi_label',
+     *     type: 'circle',
+     *     paint: {
+     *       // Mapbox Style Specification paint properties
+     *     },
+     *     layout: {
+     *       // Mapbox Style Specification layout properties
+     *     }
+     *   });
+     * });
+     * @see [Add 3D buildings](https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/)
+     * @see [Add terrain](https://docs.mapbox.com/mapbox-gl-js/example/add-terrain/)
+     * @see [Get coordinates of the mouse pointer](https://docs.mapbox.com/mapbox-gl-js/example/mouse-position/)
+     */
+
+    /**
      * Adds a listener for events of a specified type, optionally limited to features in a specified style layer.
      *
      * @param {string} type The event type to listen for. Events compatible with the optional `layerId` parameter are triggered


### PR DESCRIPTION
closes https://github.com/mapbox/mapbox-gl-js-docs/issues/431

* adds the two-argument version of `map.on` to instance members, which extends the pattern use for `map.once` and `map.off`.

Screenshot:

<img width=400 alt="screenshot" src="https://user-images.githubusercontent.com/6026447/119142991-d4de0680-b9e2-11eb-8826-bf01aa38ca01.jpg"> 

## Question

- Should the argument order be reversed from `listener, type` to `type, listener`?

Tagging @mapbox/gl-js and @HeyStenson for review. 

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] include after visuals or gifs if this PR includes visual changes
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
