### PR TITLE
Update `layer.source` description for `addLayer`

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1843,8 +1843,7 @@ class Map extends Camera {
      * (This can also be `custom`. For more information, see {@link CustomLayerInterface}.)
      * @param {string | Object} [layer.source] The data source for the layer.
      * Reference a source that has _already been defined_ using the source's unique id.
-     * Reference a _new source_ using a source object (as defined in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)) directly.
-     * This is **required** for all `layer.type` options _except_ for `custom`.
+     * This is **required** for all `layer.type` options _except_ for `custom` and `background`.
      * @param {string} [layer.sourceLayer] (optional) The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
      * This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.
      * @param {array} [layer.filter] (optional) An expression specifying conditions on source features.

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1843,6 +1843,7 @@ class Map extends Camera {
      * (This can also be `custom`. For more information, see {@link CustomLayerInterface}.)
      * @param {string | Object} [layer.source] The data source for the layer.
      * Reference a source that has _already been defined_ using the source's unique id.
+     * Reference a _new source_ using a source object (as defined in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)) directly.
      * This is **required** for all `layer.type` options _except_ for `custom` and `background`.
      * @param {string} [layer.sourceLayer] (optional) The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
      * This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js-docs/issues/424

- notes that `background` layers do not require `source
- removes "Reference a new source using a source object (as defined in the Mapbox Style Specification ) directly." since this was deprecated

before/after

<img width=400 alt="screenshot" src="https://user-images.githubusercontent.com/6026447/119147715-8bdc8100-b9e7-11eb-853a-be9db6f86dc6.jpg"> 
<img width=400 alt="screenshot" src="https://user-images.githubusercontent.com/6026447/119147392-415b0480-b9e7-11eb-8c70-d646860f020f.jpg"> 

Tagging @mapbox/gl-js and @HeyStenson for review

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
