### PR TITLE
Fix ImageSource breaking in FF/Safari if it's not immediately displayed

### DIFF
--- a/debug/update_image.html
+++ b/debug/update_image.html
@@ -27,7 +27,7 @@ const map = new mapboxgl.Map({
     hash: false
 });
 
-const path = "/docs/pages/assets/";
+const path = "https://docs.mapbox.com/mapbox-gl-js/assets/";
 
 const frameCount = 5;
 

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -9,6 +9,7 @@ import rasterBoundsAttributes from '../data/raster_bounds_attributes.js';
 import SegmentVector from '../data/segment.js';
 import Texture from '../render/texture.js';
 import MercatorCoordinate from '../geo/mercator_coordinate.js';
+import browser from '../util/browser.js';
 
 import type {Source} from './source.js';
 import type {CanvasSourceSpecification} from './canvas_source.js';
@@ -78,7 +79,7 @@ class ImageSource extends Evented implements Source {
     dispatcher: Dispatcher;
     map: Map;
     texture: Texture | null;
-    image: HTMLImageElement | ImageBitmap;
+    image: ImageData;
     tileID: CanonicalTileID;
     _boundsArray: RasterBoundsArray;
     boundsBuffer: VertexBuffer;
@@ -117,7 +118,7 @@ class ImageSource extends Evented implements Source {
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (image) {
-                this.image = image;
+                this.image = browser.getImageData(image);
                 if (newCoordinates) {
                     this.coordinates = newCoordinates;
                 }


### PR DESCRIPTION
Closes #10685 by immediately decoding an image of an `ImageSource` on load for use later so that we don't hit a race condition where the memory for it is freed preemptively.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix ImageSource breaking in FF/Safari if it's not immediately visible.</changelog>`
