### PR TITLE
Terrain render loop: Prioritize large batches and lazy framebuffer switches

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -565,6 +565,7 @@ class Painter {
                 const terrain = (((this.terrain): any): Terrain);
                 const prevLayer = this.currentLayer;
                 this.currentLayer = terrain.renderBatch(this.currentLayer);
+                assert(this.context.bindFramebuffer.current === null);
                 assert(this.currentLayer > prevLayer);
                 continue;
             }

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -1013,22 +1013,21 @@ export class Terrain extends Elevation {
         });
 
         for (const batch of sortedRenderBatches) {
-            for (let i = coords.length - 1; i >= 0; i--) {
-                const proxy = coords[i];
-                if (psc.proxyCachedFBO[proxy.key] === undefined) {
-                    // Assign renderCache FBO if there are available FBOs in pool.
-                    let index = psc.renderCachePool.pop();
-                    if (index === undefined && psc.renderCache.length < RENDER_CACHE_MAX_SIZE) {
-                        index = psc.renderCache.length;
-                        psc.renderCache.push(this._createFBO());
-                        // assert(psc.renderCache.length <= coords.length);
-                    }
-                    if (index !== undefined) {
-                        if (psc.proxyCachedFBO[proxy.key] === undefined)
-                            psc.proxyCachedFBO[proxy.key] = {};
-                        psc.proxyCachedFBO[proxy.key][batch.start] = index;
-                        psc.renderCache[index].dirty = true; // needs to be rendered to.
-                    }
+            for (const id of coords) {
+                if (psc.proxyCachedFBO[id.key]) {
+                    continue;
+                }
+
+                // Assign renderCache FBO if there are available FBOs in pool.
+                let index = psc.renderCachePool.pop();
+                if (index === undefined && psc.renderCache.length < RENDER_CACHE_MAX_SIZE) {
+                    index = psc.renderCache.length;
+                    psc.renderCache.push(this._createFBO());
+                }
+                if (index !== undefined) {
+                    psc.proxyCachedFBO[id.key] = {};
+                    psc.proxyCachedFBO[id.key][batch.start] = index;
+                    psc.renderCache[index].dirty = true; // needs to be rendered to.
                 }
             }
         }

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -967,6 +967,13 @@ export class Terrain extends Elevation {
 
         this._clearRasterFadeFromRenderCache();
 
+        const sortedRenderBatch = [...this._drapedRenderBatches];
+        sortedRenderBatch.sort((batchA, batchB) => {
+            const batchASize = batchA.end - batchA.start
+            const batchBSize = batchB.end - batchB.start;
+            return batchBSize - batchASize;
+        });
+
         const coords = this.proxyCoords;
         const dirty = this._tilesDirty;
         for (let i = coords.length - 1; i >= 0; i--) {
@@ -996,8 +1003,8 @@ export class Terrain extends Elevation {
                     psc.renderCache[psc.proxyCachedFBO[proxy.key][proxyFBO]].dirty = equal < 0 || equal !== Object.values(prev).length;
                 }
             } else {
-                for (let j = 0; j < this._drapedRenderBatches.length; ++j) {
-                    const batch = this._drapedRenderBatches[j];
+                for (let j = 0; j < sortedRenderBatch.length; ++j) {
+                    const batch = sortedRenderBatch[j];
                     // Assign renderCache FBO if there are available FBOs in pool.
                     let index = psc.renderCachePool.pop();
                     if (index === undefined && psc.renderCache.length < RENDER_CACHE_MAX_SIZE) {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -641,7 +641,7 @@ export class Terrain extends Elevation {
         const drapedLayerBatch = this._drapedRenderBatches.shift();
         assert(drapedLayerBatch.start === startLayerIndex);
 
-        let accumulatedDrapes = [];
+        const accumulatedDrapes = [];
         const layerIds = painter.style.order;
 
         let poolIndex = 0;

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -1000,15 +1000,14 @@ export class Terrain extends Elevation {
             }
         }
 
-        const sortedRenderBatch = [...this._drapedRenderBatches];
-        sortedRenderBatch.sort((batchA, batchB) => {
+        const sortedRenderBatches = [...this._drapedRenderBatches];
+        sortedRenderBatches.sort((batchA, batchB) => {
             const batchASize = batchA.end - batchA.start;
             const batchBSize = batchB.end - batchB.start;
             return batchBSize - batchASize;
         });
 
-        for (let j = 0; j < sortedRenderBatch.length; ++j) {
-            const batch = sortedRenderBatch[j];
+        for (const batch of sortedRenderBatches) {
             for (let i = coords.length - 1; i >= 0; i--) {
                 const proxy = coords[i];
                 if (psc.proxyCachedFBO[proxy.key] === undefined) {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -967,13 +967,6 @@ export class Terrain extends Elevation {
 
         this._clearRasterFadeFromRenderCache();
 
-        const sortedRenderBatch = [...this._drapedRenderBatches];
-        sortedRenderBatch.sort((batchA, batchB) => {
-            const batchASize = batchA.end - batchA.start
-            const batchBSize = batchB.end - batchB.start;
-            return batchBSize - batchASize;
-        });
-
         const coords = this.proxyCoords;
         const dirty = this._tilesDirty;
         for (let i = coords.length - 1; i >= 0; i--) {
@@ -1002,9 +995,21 @@ export class Terrain extends Elevation {
                 for (const proxyFBO in psc.proxyCachedFBO[proxy.key]) {
                     psc.renderCache[psc.proxyCachedFBO[proxy.key][proxyFBO]].dirty = equal < 0 || equal !== Object.values(prev).length;
                 }
-            } else {
-                for (let j = 0; j < sortedRenderBatch.length; ++j) {
-                    const batch = sortedRenderBatch[j];
+            }
+        }
+
+        const sortedRenderBatch = [...this._drapedRenderBatches];
+        sortedRenderBatch.sort((batchA, batchB) => {
+            const batchASize = batchA.end - batchA.start
+            const batchBSize = batchB.end - batchB.start;
+            return batchBSize - batchASize;
+        });
+
+        for (let j = 0; j < sortedRenderBatch.length; ++j) {
+            const batch = sortedRenderBatch[j];
+            for (let i = coords.length - 1; i >= 0; i--) {
+                const proxy = coords[i];
+                if (psc.proxyCachedFBO[proxy.key] === undefined) {
                     // Assign renderCache FBO if there are available FBOs in pool.
                     let index = psc.renderCachePool.pop();
                     if (index === undefined && psc.renderCache.length < RENDER_CACHE_MAX_SIZE) {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -1356,9 +1356,7 @@ export class Terrain extends Elevation {
      * Bookkeeping if something gets rendered to the tile.
      */
     prepareDrawTile(coord: OverscaledTileID) {
-        if (!this.renderedToTile) {
-            this.renderedToTile = true;
-        }
+        this.renderedToTile = true;
     }
 
     _clearRenderCacheForTile(source: string, coord: OverscaledTileID) {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -603,11 +603,12 @@ export class Terrain extends Elevation {
     }
 
     renderToBackBuffer(accumulatedDrapes: Array<OverscaledTileID>) {
+        const painter = this.painter;
+        const context = this.painter.context;
+
         if (accumulatedDrapes.length === 0) {
             return;
         }
-        const painter = this.painter;
-        const context = this.painter.context;
 
         context.bindFramebuffer.set(null);
         context.viewport.set([0, 0, painter.width, painter.height]);
@@ -700,8 +701,12 @@ export class Terrain extends Elevation {
             }
         }
 
+        // Reset states and render last drapes
         this.renderToBackBuffer(accumulatedDrapes);
         this.renderingToTexture = false;
+
+        context.bindFramebuffer.set(null);
+        context.viewport.set([0, 0, painter.width, painter.height]);
 
         return drapedLayerBatch.end + 1;
     }


### PR DESCRIPTION
Ports two different optimizations to the render cache from native.

- (1) In terrain render cache prioritize large render batches first, this prevents allocating pool entry to small layer groups, which eventually leads to more draw call when the render cache pool is fully used. In an example location this changed FPS from 44 to 55.
- (2) In the terrain render loop, prevent overly binding/clearing framebuffers when nothing was drawn in a render batch. Unnecessary binding/clears are expensive gl calls. The full stats are attached in the before/after below. In an example frame this reduced the number of framebuffer bindings from 228 to 88 and number of clears from 103 to 71. This prevents such sequence of unnecessary bindFramebuffer:

<img width="599" alt="Screen Shot 2021-05-19 at 8 23 04 PM" src="https://user-images.githubusercontent.com/7061573/119201588-1357dd80-ba44-11eb-9cfa-5577a480e3ad.png">

<details>

**before/after (1)**

<img width="882" alt="Screen Shot 2021-05-19 at 6 04 52 PM" src="https://user-images.githubusercontent.com/7061573/119200229-5b293580-ba41-11eb-8a21-251ce3031e71.png">
<img width="880" alt="Screen Shot 2021-05-19 at 6 04 03 PM" src="https://user-images.githubusercontent.com/7061573/119200232-5c5a6280-ba41-11eb-9718-1c70532461d8.png">

**before/after (2)**

<img width="270" alt="Screen Shot 2021-05-21 at 2 06 24 PM" src="https://user-images.githubusercontent.com/7061573/119200271-73995000-ba41-11eb-950a-7c29140cbfc0.png">
<img width="267" alt="Screen Shot 2021-05-21 at 2 06 16 PM" src="https://user-images.githubusercontent.com/7061573/119200278-76944080-ba41-11eb-877a-1c02c160d449.png">

</details>

- `<changelog>Improve terrain performance by reducing number of framebuffer switches during draping</changelog>`
- `<changelog>Improve terrain performance by prioritizing allocation of large render cache batches</changelog>`