### PR TITLE
Fix precision issue in gradient skybox shader

### DIFF
--- a/src/shaders/skybox_gradient.fragment.glsl
+++ b/src/shaders/skybox_gradient.fragment.glsl
@@ -1,7 +1,7 @@
 varying highp vec3 v_uv;
 
 uniform lowp sampler2D u_color_ramp;
-uniform lowp vec3 u_center_direction;
+uniform highp vec3 u_center_direction;
 uniform lowp float u_radius;
 uniform lowp float u_opacity;
 uniform highp float u_temporal_offset;


### PR DESCRIPTION
Gradient skybox is suffering from precision issues on some of the ARM Mali gpus resulting in "wobbly"/jittery movement of the gradient effect on both gl-js and gl-native. This is caused by the uniform `u_center_direction` in `skybox_gradient.fragment.glsl` shader being defined as `lowp`. Increasing the precision to `highp` fixes the issue.

https://user-images.githubusercontent.com/55925868/119485249-87092b80-bd5f-11eb-8012-559457864b9b.mp4


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix gradient skybox rendering issue on some ARM Mali gpus</changelog>`
