### PR TITLE
Fix test release page state management

### DIFF
--- a/build/print-release-url.js
+++ b/build/print-release-url.js
@@ -1,5 +1,5 @@
-const address = require('address');
-const qrcode = require('qrcode-terminal');
+import address from 'address';
+import qrcode from 'qrcode-terminal'
 
 const url = `http://${address.ip()}:9966/test/release/index.html`;
 console.warn(`Scan this QR code or enter ${url}`);

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -165,7 +165,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     const params = {
-        page: pages[0].page,
+        page: pages[0].key,
         version: 'latest',
         index: 0
     };
@@ -188,10 +188,15 @@ document.addEventListener('DOMContentLoaded', function() {
         titleItem.classList[titleItem.classList.contains('active') ? 'remove' : 'add']('active');
     });
 
-    let pageIndex = params.index;
-    if (pageIndex < 0) pageIndex = 0;
-    params.page = pages[pageIndex];
+    let pageIndex = 0;
+    for (let i = 0; i < pages.length; i++) {
+        if(params.page === pages[i].key) {
+            pageIndex = i;
+            break;
+        }
+    }
     params.index = pageIndex;
+    params.page = pages[pageIndex].key;
 
     for (let i = 0; i < pages.length; ++i) {
         const page = pages[i];
@@ -201,10 +206,9 @@ document.addEventListener('DOMContentLoaded', function() {
         item.dataset.page = page;
         item.dataset.index = i;
         item.addEventListener('click', function() {
-            params.page = this.dataset.page;
             pageIndex = this.dataset.index;
             if (pageIndex < 0) pageIndex = 0;
-            params.page = pages[pageIndex];
+            params.page = pages[pageIndex].key;
             params.index = pageIndex;
             titleItem.classList.remove('active');
             load();
@@ -249,7 +253,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         while (container.firstChild) container.removeChild(container.firstChild);
 
-        params.page = pages[pageIndex].page;
+        params.page = pages[pageIndex].key;
         const version = params.version;
 
         const page = pages[pageIndex];
@@ -309,7 +313,7 @@ document.addEventListener('DOMContentLoaded', function() {
         prevButton.classList[(pageIndex === 0) ? 'add' : 'remove']('disabled');
         nextButton.classList[(pageIndex + 1 === pages.length) ? 'add' : 'remove']('disabled');
 
-        let hash = 'page=' + page;
+        let hash = 'page=' + page.key;
         if (version !== 'latest') {
             hash += '&version=' + version;
         }
@@ -327,7 +331,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     nextButton.addEventListener('click', function() {
-        if (pageIndex + 1 <= pages.length) {
+        if (pageIndex + 1 < pages.length) {
             pageIndex++;
             load();
         }

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -190,7 +190,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     let pageIndex = 0;
     for (let i = 0; i < pages.length; i++) {
-        if(params.page === pages[i].key) {
+        if (params.page === pages[i].key) {
             pageIndex = i;
             break;
         }


### PR DESCRIPTION
This PR fixes a couple small bugs regarding the test release page.

First, you currently always end up with `?page=[Object object]` in the url since it is incorrectly stringifying the whole page metadata object. This PR adds logic to load a page by key, if specified (so that you can reload or send direct links) and also assigns it correctly from the key.

Second, the final page had an off-by-one error and would display a blank screen if you hit the disabled "next" button when there is no next page.

Finally, the `print-release-url` node script is broken and needed replacement with import syntax to run correctly.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
