### PR TITLE
Replace two broken images on GL JS README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img width="400" alt="Mapbox" src="https://raw.githubusercontent.com/mapbox/mapbox-gl-js-docs/publisher-production/docs/pages/assets/logo.png">](https://www.mapbox.com/)
+[<img width="300" alt="Mapbox" src="https://assets-global.website-files.com/5d3ef00c73102c436bc83996/5d3ef00c73102c893bc83a28_logo-regular.png">](https://www.mapbox.com/)
 
 **Mapbox GL JS** is a JavaScript library for interactive, customizable vector maps on the web. It takes map styles that conform to the
 [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/), applies them to vector tiles that
@@ -24,7 +24,7 @@ native SDKs. For code and issues specific to the native SDKs, see the
 - [Open source styles](https://github.com/mapbox/mapbox-gl-styles)
 - [Contributor documentation](./CONTRIBUTING.md)
 
-[<img width="981" alt="Mapbox GL gallery" src="https://raw.githubusercontent.com/mapbox/mapbox-gl-js-docs/publisher-production/docs/pages/assets/gallery.png">](https://www.mapbox.com/gallery/)
+[<img width="500" alt="Mapbox GL JS v2" src="https://assets.website-files.com/5e832e12eb7ca02ee9064d42/5fcfb4f93ec3c13395bc2a7c_Gl%20JS%20(1).png">](https://www.mapbox.com/mapbox-gljs)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img width="300" alt="Mapbox" src="https://assets-global.website-files.com/5d3ef00c73102c436bc83996/5d3ef00c73102c893bc83a28_logo-regular.png">](https://www.mapbox.com/)
+[<img width="300" alt="Mapbox logo" src="https://static-assets.mapbox.com/www/logos/mapbox-logo-black.png">](https://www.mapbox.com/)
 
 **Mapbox GL JS** is a JavaScript library for interactive, customizable vector maps on the web. It takes map styles that conform to the
 [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/), applies them to vector tiles that
@@ -24,7 +24,7 @@ native SDKs. For code and issues specific to the native SDKs, see the
 - [Open source styles](https://github.com/mapbox/mapbox-gl-styles)
 - [Contributor documentation](./CONTRIBUTING.md)
 
-[<img width="500" alt="Mapbox GL JS v2" src="https://assets.website-files.com/5e832e12eb7ca02ee9064d42/5fcfb4f93ec3c13395bc2a7c_Gl%20JS%20(1).png">](https://www.mapbox.com/mapbox-gljs)
+[<img width="500" alt="Mapbox GL JS gallery of map images" src="https://static-assets.mapbox.com/www/gallery.png">](https://www.mapbox.com/mapbox-gljs)
 
 ## License
 

--- a/src/shaders/skybox_gradient.fragment.glsl
+++ b/src/shaders/skybox_gradient.fragment.glsl
@@ -1,7 +1,7 @@
 varying highp vec3 v_uv;
 
 uniform lowp sampler2D u_color_ramp;
-uniform lowp vec3 u_center_direction;
+uniform highp vec3 u_center_direction;
 uniform lowp float u_radius;
 uniform lowp float u_opacity;
 uniform highp float u_temporal_offset;


### PR DESCRIPTION
- replaces 2 broken images with image assets from www

I think the original images may have been deleted because they appeared to be un-used in the gl-js-docs repo /cc: @colleenmcginnis 

<img width=300 alt="screenshot" src="https://user-images.githubusercontent.com/6026447/119554729-bb1d2600-bd38-11eb-97f1-6642acddfaa8.jpg">