### PR TITLE
Add code comments and examples to `Map` inline example in API docs

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -272,7 +272,7 @@ const defaultOptions = {
  *   center: [-122.420679, 37.772537], // starting position [lng, lat]
  *   zoom: 13, // starting zoom
  *   style: 'mapbox://styles/mapbox/streets-v11', // style URL or style object
- *   hash: true, // Sync `center`, `zoom`, `pitch`, and `bearing` with URL
+ *   hash: true, // sync `center`, `zoom`, `pitch`, and `bearing` with URL
  *   // Use `transformRequest` to modify requests that begin with `http://myHost`.
  *   transformRequest: (url, resourceType)=> {
  *     if(resourceType === 'Source' && url.startsWith('http://myHost')) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -267,18 +267,6 @@ const defaultOptions = {
  *  see `src/ui/default_locale.js` for an example with all supported string IDs. The object may specify all UI strings (thereby adding support for a new translation) or only a subset of strings (thereby patching the default translation table).
  * @param {boolean} [options.testMode=false] Silences errors and warnings generated due to an invalid accessToken, useful when using the library to write unit tests.
  * @example
- * <html>
- * <head>
- * <link href="https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.css" rel="stylesheet">
- * <script src="https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.js"></script>
- * <style>
- * body { margin: 0; padding: 0; }
- * #map { position: absolute; top: 0; bottom: 0; width: 100%; }
- * </style>
- * </head>
- * <body>
- * <div id="map"></div>
- * <script>
  * var map = new mapboxgl.Map({
  *   container: 'map', // container ID
  *   center: [-122.420679, 37.772537], // starting position [lng, lat]
@@ -296,9 +284,6 @@ const defaultOptions = {
  *     }
  *   }
  * });
- * </script>
- * </body>
- * </html>
  * @see [Display a map on a webpage](https://docs.mapbox.com/mapbox-gl-js/example/simple-map/)
  * @see [Display a map with a custom style](https://docs.mapbox.com/mapbox-gl-js/example/custom-style-id/)
  * @see [Check if Mapbox GL JS is supported](https://docs.mapbox.com/mapbox-gl-js/example/check-for-support/)

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -272,7 +272,7 @@ const defaultOptions = {
  *   center: [-122.420679, 37.772537], // starting position [lng, lat]
  *   zoom: 13, // starting zoom
  *   style: 'mapbox://styles/mapbox/streets-v11', // style URL or style object
- *   hash: true, // sync options to URL
+ *   hash: true, // Sync `center`, `zoom`, `pitch`, and `bearing` with URL
  *   // Use `transformRequest` to modify requests that begin with `http://myHost`.
  *   transformRequest: (url, resourceType)=> {
  *     if(resourceType === 'Source' && url.startsWith('http://myHost')) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -267,12 +267,25 @@ const defaultOptions = {
  *  see `src/ui/default_locale.js` for an example with all supported string IDs. The object may specify all UI strings (thereby adding support for a new translation) or only a subset of strings (thereby patching the default translation table).
  * @param {boolean} [options.testMode=false] Silences errors and warnings generated due to an invalid accessToken, useful when using the library to write unit tests.
  * @example
+ * <html>
+ * <head>
+ * <link href="https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.css" rel="stylesheet">
+ * <script src="https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.js"></script>
+ * <style>
+ * body { margin: 0; padding: 0; }
+ * #map { position: absolute; top: 0; bottom: 0; width: 100%; }
+ * </style>
+ * </head>
+ * <body>
+ * <div id="map"></div>
+ * <script>
  * var map = new mapboxgl.Map({
- *   container: 'map',
- *   center: [-122.420679, 37.772537],
- *   zoom: 13,
- *   style: style_object,
- *   hash: true,
+ *   container: 'map', // container ID
+ *   center: [-122.420679, 37.772537], // starting position [lng, lat]
+ *   zoom: 13, // starting zoom
+ *   style: 'mapbox://styles/mapbox/streets-v11', // style URL or style object
+ *   hash: true, // sync options to URL
+ *   // Use `transformRequest` to modify requests that begin with `http://myHost`.
  *   transformRequest: (url, resourceType)=> {
  *     if(resourceType === 'Source' && url.startsWith('http://myHost')) {
  *       return {
@@ -283,6 +296,12 @@ const defaultOptions = {
  *     }
  *   }
  * });
+ * </script>
+ * </body>
+ * </html>
+ * @see [Display a map on a webpage](https://docs.mapbox.com/mapbox-gl-js/example/simple-map/)
+ * @see [Display a map with a custom style](https://docs.mapbox.com/mapbox-gl-js/example/custom-style-id/)
+ * @see [Check if Mapbox GL JS is supported](https://docs.mapbox.com/mapbox-gl-js/example/check-for-support/)
  */
 class Map extends Camera {
     style: Style;

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -44,15 +44,13 @@ if (typeof Object.freeze == 'function') {
  * @property {string} credentials `'same-origin'|'include'` Use 'include' to send cookies with cross-origin requests.
  * @property {boolean} collectResourceTiming If true, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
  * @example
- * // Use transformRequest to modify requests
- * // that begin with `http://myHost`.
+ * // use transformRequest to modify requests that begin with `http://myHost`
  * transformRequest: function(url, resourceType) {
  *  if (resourceType === 'Source' && url.indexOf('http://myHost') > -1) {
  *    return {
  *      url: url.replace('http', 'https'),
  *      headers: { 'my-custom-header': true },
- *      // Include cookies for cross-origin requests.
- *      credentials: 'include'
+ *      credentials: 'include'  // Include cookies for cross-origin requests
  *    }
  *   }
  *  }

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -44,13 +44,15 @@ if (typeof Object.freeze == 'function') {
  * @property {string} credentials `'same-origin'|'include'` Use 'include' to send cookies with cross-origin requests.
  * @property {boolean} collectResourceTiming If true, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
  * @example
- * // use transformRequest to modify requests that begin with `http://myHost`
+ * // Use transformRequest to modify requests
+ * // that begin with `http://myHost`.
  * transformRequest: function(url, resourceType) {
  *  if (resourceType === 'Source' && url.indexOf('http://myHost') > -1) {
  *    return {
  *      url: url.replace('http', 'https'),
  *      headers: { 'my-custom-header': true },
- *      credentials: 'include'  // Include cookies for cross-origin requests
+ *      // Include cookies for cross-origin requests.
+ *      credentials: 'include'
  *    }
  *   }
  *  }


### PR DESCRIPTION
- adds code comments
- adds 3 related examples

Note: the related examples should not appear at the bottom of the page – ideally they should appear after `examples` and before `instance members`. I will work on a `mapbox-gl-js-docs` PR to implement that change.

Tagging @HeyStenson @ryanhamley for review.

## Launch Checklist
 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
