### PR TITLE
[Docs] Update customAttribution code example and parameter description

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -18,11 +18,11 @@ type Options = {
  * @implements {IControl}
  * @param {Object} [options]
  * @param {boolean} [options.compact] If `true`, force a compact attribution that shows the full attribution on mouse hover. If `false`, force the full attribution control. The default is a responsive attribution that collapses when the map is less than 640 pixels wide. **Attribution should not be collapsed if it can comfortably fit on the map. `compact` should only be used to modify default attribution when map size makes it impossible to fit [default attribution](https://docs.mapbox.com/help/how-mapbox-works/attribution/) and when the automatic compact resizing for default settings are not sufficient.**
- * @param {string | Array<string>} [options.customAttribution] String or strings to show in addition to any other attributions.
+ * @param {string | Array<string>} [options.customAttribution] String or strings to show in addition to any other attributions. You can also set a custom attribution when initializing your map with {@link https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters the customAttribution option}.
  * @example
  * var map = new mapboxgl.Map({attributionControl: false})
  *     .addControl(new mapboxgl.AttributionControl({
- *         compact: true
+ *         customAttribution: 'Map design by me'
  *     }));
  */
 class AttributionControl {


### PR DESCRIPTION
fixes https://github.com/mapbox/mapbox-gl-js-docs/issues/345

## Launch Checklist

A small change to the `AttributionControl` JSDoc:

1. Swaps the inline code snippet from `options.compact` to `options.customAttribution`. `compact` wasn't a great example to use since the param description actively discourages using it. 
2. Adds a sentence to the `customAttribution` param description to note that you can save some steps by setting customAttribution in your `Map`'s options. 

<img width="766" alt="image" src="https://user-images.githubusercontent.com/2365503/119718700-bdf14700-be1c-11eb-90e8-b93dbf0186cc.png">

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
