### PR TITLE
[projections] Fix performance regression in draw_background

### DIFF
--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -3,6 +3,7 @@
 import StencilMode from '../gl/stencil_mode.js';
 import DepthMode from '../gl/depth_mode.js';
 import CullFaceMode from '../gl/cull_face_mode.js';
+import Tile from '../source/tile.js';
 import {
     backgroundUniformValues,
     backgroundPatternUniformValues
@@ -55,8 +56,8 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
         const matrix = coords ? tileID.projMatrix : painter.transform.calculateProjMatrix(unwrappedTileID);
         painter.prepareDrawTile(tileID);
 
-        const tile = sourceCache ? sourceCache.getTile(tileID) : backgroundTiles ? backgroundTiles[tileID.key] : null;
-        if (!tile) continue;
+        const tile = sourceCache ? sourceCache.getTile(tileID) :
+            backgroundTiles ? backgroundTiles[tileID.key] : new Tile(tileID, tileSize, transform.zoom, painter);
 
         const uniformValues = image ?
             backgroundPatternUniformValues(matrix, opacity, painter, image, {tileID, tileSize}, crossfade) :

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -3,7 +3,6 @@
 import StencilMode from '../gl/stencil_mode.js';
 import DepthMode from '../gl/depth_mode.js';
 import CullFaceMode from '../gl/cull_face_mode.js';
-import Tile from '../source/tile.js';
 import {
     backgroundUniformValues,
     backgroundPatternUniformValues
@@ -42,7 +41,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
     let backgroundTiles;
     if (!tileIDs) {
         backgroundTiles = painter.getBackgroundTiles();
-        tileIDs = Object.values(backgroundTiles).map(tile => tile.tileID);
+        tileIDs = Object.values(backgroundTiles).map(tile => (tile: any).tileID);
     }
 
     if (image) {
@@ -56,7 +55,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
         const matrix = coords ? tileID.projMatrix : painter.transform.calculateProjMatrix(unwrappedTileID);
         painter.prepareDrawTile(tileID);
 
-        const tile = coords ? sourceCache.getTile(tileID) : backgroundTiles[tileID.key];
+        const tile = backgroundTiles ? backgroundTiles[tileID.key] : sourceCache.getTile(tileID);
 
         const uniformValues = image ?
             backgroundPatternUniformValues(matrix, opacity, painter, image, {tileID, tileSize}, crossfade) :

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -38,7 +38,12 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
 
     const program = painter.useProgram(image ? 'backgroundPattern' : 'background');
 
-    const tileIDs = coords ? coords : transform.coveringTiles({tileSize});
+    let tileIDs = coords;
+    let backgroundTiles;
+    if (!tileIDs) {
+        backgroundTiles = painter.getBackgroundTiles();
+        tileIDs = Object.values(backgroundTiles).map(tile => tile.tileID);
+    }
 
     if (image) {
         context.activeTexture.set(gl.TEXTURE0);
@@ -51,7 +56,7 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
         const matrix = coords ? tileID.projMatrix : painter.transform.calculateProjMatrix(unwrappedTileID);
         painter.prepareDrawTile(tileID);
 
-        const tile = new Tile(tileID, tileSize, transform.zoom, painter);
+        const tile = coords ? sourceCache.getTile(tileID) : backgroundTiles[tileID.key];
 
         const uniformValues = image ?
             backgroundPatternUniformValues(matrix, opacity, painter, image, {tileID, tileSize}, crossfade) :

--- a/src/render/draw_background.js
+++ b/src/render/draw_background.js
@@ -55,7 +55,8 @@ function drawBackground(painter: Painter, sourceCache: SourceCache, layer: Backg
         const matrix = coords ? tileID.projMatrix : painter.transform.calculateProjMatrix(unwrappedTileID);
         painter.prepareDrawTile(tileID);
 
-        const tile = backgroundTiles ? backgroundTiles[tileID.key] : sourceCache.getTile(tileID);
+        const tile = sourceCache ? sourceCache.getTile(tileID) : backgroundTiles ? backgroundTiles[tileID.key] : null;
+        if (!tile) continue;
 
         const uniformValues = image ?
             backgroundPatternUniformValues(matrix, opacity, painter, image, {tileID, tileSize}, crossfade) :

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -42,6 +42,7 @@ import custom from './draw_custom.js';
 import sky from './draw_sky.js';
 import {Terrain} from '../terrain/terrain.js';
 import {Debug} from '../util/debug.js';
+import Tile from '../source/tile.js';
 
 const draw = {
     symbol,
@@ -59,7 +60,6 @@ const draw = {
 };
 
 import type Transform from '../geo/transform.js';
-import type Tile from '../source/tile.js';
 import type {OverscaledTileID, UnwrappedTileID} from '../source/tile_id.js';
 import type Style from '../style/style.js';
 import type StyleLayer from '../style/style_layer.js';
@@ -149,6 +149,7 @@ class Painter {
     tileLoaded: boolean;
     frameCopies: Array<WebGLTexture>;
     loadTimeStamps: Array<number>;
+    _backgroundTiles: {[_: number | string]: Tile};
 
     constructor(gl: WebGLRenderingContext, transform: Transform) {
         this.context = new Context(gl);
@@ -168,6 +169,7 @@ class Painter {
 
         this.gpuTimers = {};
         this.frameCounter = 0;
+        this._backgroundTiles = {};
     }
 
     updateTerrain(style: Style, cameraChanging: boolean) {
@@ -909,6 +911,17 @@ class Painter {
         if (fogOpacity === 0) return false;
 
         return true;
+    }
+
+    getBackgroundTiles() {
+        const oldTiles = this._backgroundTiles;
+        const newTiles = this._backgroundTiles = {};
+
+        const tileIDs = this.transform.coveringTiles({tileSize: 512});
+        for (const tileID of tileIDs) {
+            newTiles[tileID.key] = oldTiles[tileID.key] || new Tile(tileID, null, null, this);
+        }
+        return newTiles;
     }
 }
 

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -917,9 +917,10 @@ class Painter {
         const oldTiles = this._backgroundTiles;
         const newTiles = this._backgroundTiles = {};
 
-        const tileIDs = this.transform.coveringTiles({tileSize: 512});
+        const tileSize = 512;
+        const tileIDs = this.transform.coveringTiles({tileSize});
         for (const tileID of tileIDs) {
-            newTiles[tileID.key] = oldTiles[tileID.key] || new Tile(tileID, null, null, this);
+            newTiles[tileID.key] = oldTiles[tileID.key] || new Tile(tileID, tileSize, this.transform.tileZoom, this);
         }
         return newTiles;
     }


### PR DESCRIPTION
An omission caused `draw_background` to regenerate raster/stencil buffers on every frame instead of reusing ones from cached tiles. This is a quick fix so that it takes any available source cache from the style and uses that for the background tiles, removing the bottleneck. It's likely not passing Flow tests now but we can fix that after consolidating with @ryanhamley's branch.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
