### PR TITLE
Fix `"output": "terrainDepth"` render test option

### DIFF
--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -192,10 +192,10 @@ async function runTest(t) {
         // 1. get pixel data from test canvas as Uint8Array
         if (options.output === "terrainDepth") {
             const pixels = drawTerrainDepth(map, w, h);
-            actualImageData = Uint8ClampedArray.from(pixels);
-            if (!actualImageData) {
+            if (!pixels) {
                 throw new Error('Failed to render terrain depth, make sure that terrain is enabled on the render test');
             }
+            actualImageData = Uint8ClampedArray.from(pixels);
         } else {
             actualImageData = new Uint8Array(gl.drawingBufferWidth * gl.drawingBufferHeight * 4);
             gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, actualImageData);

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -41,6 +41,7 @@ setupHTML();
 
 const {canvas: expectedCanvas, ctx: expectedCtx} = createCanvas();
 const {canvas: diffCanvas, ctx: diffCtx} = createCanvas();
+const {canvas: terrainDepthCanvas, ctx: terrainDepthCtx} = createCanvas();
 let map;
 
 tape.onFinish(() => {
@@ -191,10 +192,11 @@ async function runTest(t) {
         // 1. get pixel data from test canvas as Uint8Array
         if (options.output === "terrainDepth") {
             const pixels = drawTerrainDepth(map, w, h);
-            actualImageData = Uint8Array.from(pixels);
-        }
-
-        if (!actualImageData) {
+            actualImageData = Uint8ClampedArray.from(pixels);
+            if (!actualImageData) {
+                throw new Error('Failed to render terrain depth, make sure that terrain is enabled on the render test');
+            }
+        } else {
             actualImageData = new Uint8Array(gl.drawingBufferWidth * gl.drawingBufferHeight * 4);
             gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, actualImageData);
 
@@ -230,7 +232,17 @@ async function runTest(t) {
         }
 
         let fileInfo;
-        const actual = map.getCanvas().toDataURL();
+        let actual;
+
+        if (options.output === "terrainDepth") {
+            terrainDepthCanvas.width = w;
+            terrainDepthCanvas.height = h;
+            const terrainDepthData = new ImageData(actualImageData, w, h);
+            terrainDepthCtx.putImageData(terrainDepthData, 0, 0);
+            actual = terrainDepthCanvas.toDataURL();
+        } else {
+            actual = map.getCanvas().toDataURL();
+        }
 
         if (process.env.UPDATE) {
             fileInfo = [


### PR DESCRIPTION
- Fix render tests using option `"output": "terrainDepth"` which prevents regenerating some render tests when running commands such as `UPDATE=1 yarn run test-render tests=terrain/raycast/depth-buffer-1`.
- Add error check when using this option without the use of terrain