### PR TITLE
Improve character spacing for text offsets

### DIFF
--- a/debug/text.html
+++ b/debug/text.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+<div id='checkboxes'>
+    <label><input id='show-tile-boundaries-checkbox' type='checkbox'> tile debug</label><br />
+    <label><input id='show-symbol-collision-boxes-checkbox' type='checkbox'> collision debug</label><br />
+    <label><input id='show-overdraw-checkbox' type='checkbox'> overdraw debug</label><br />
+    <label><input id='pitch-checkbox' type='checkbox' checked> pitch with rotate</label><br />
+</div>
+
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+<script>
+
+var map = window.map = new mapboxgl.Map({
+    container: 'map',
+    hash: true,
+    style: {
+        version: 8,
+        sources: {},
+        layers: [],
+        glyphs: 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf'
+    }
+});
+
+const n = 101;
+
+map.on('load', function () {
+    map.addSource('maine', {
+        'type': 'geojson',
+        'data': {
+            'type': 'Feature',
+            'properties': {'title': 'Valley View Road Northeast'},
+            'geometry': {
+                'type': 'LineString',
+                'coordinates':
+                    [...Array(n).keys()].map((_, i) => [
+                        90 * (i / (n - 1) - 0.5),
+                        5 * Math.sin(i / (n - 1) * 10.0 * Math.PI)
+                    ])
+
+            }
+        }
+    });
+
+    map.addLayer({
+        'id': 'path',
+        'type': 'line',
+        'source': 'maine',
+        'layout': {},
+        'paint': {
+            'line-color': '#000',
+            'line-width': 3
+        }
+    });
+
+    map.addLayer({
+        'id': 'path-label',
+        'type': 'symbol',
+        'source': 'maine',
+        'minzoom': 1,
+        'maxzoom': 20,
+        'layout': {
+            'symbol-placement': 'line',
+            'text-offset': [0, 0.5],
+            'text-font': ['Open Sans Regular'],
+            'text-field': '{title}',
+            'text-pitch-alignment': 'viewport',
+            'text-size': 24
+        },
+        'paint': {
+        }
+    });
+});
+
+</script>
+</body>
+</html>

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -588,7 +588,7 @@ class SymbolBucket implements Bucket {
         if (anchor.segment !== undefined) {
             let sumForwardLength = anchor.dist(line[anchor.segment + 1]);
             let sumBackwardLength = anchor.dist(line[anchor.segment]);
-            const vertices = {};
+            const vertices = [];
             for (let i = anchor.segment + 1; i < line.length; i++) {
                 vertices[i] = {x: line[i].x, y: line[i].y, tileUnitDistanceFromAnchor: sumForwardLength};
                 if (i < line.length - 1) {

--- a/src/symbol/collision_index.js
+++ b/src/symbol/collision_index.js
@@ -131,12 +131,14 @@ class CollisionIndex {
         const projectionCache = {};
         const lineOffsetX = symbol.lineOffsetX * labelPlaneFontScale;
         const lineOffsetY = symbol.lineOffsetY * labelPlaneFontScale;
+        const roundRadius = fontSize;
 
         const firstAndLastGlyph = screenAnchorPoint.signedDistanceFromCamera > 0 ? projection.placeFirstAndLastGlyph(
             labelPlaneFontScale,
             glyphOffsetArray,
             lineOffsetX,
             lineOffsetY,
+            roundRadius,
             /*flip*/ false,
             labelPlaneAnchorPoint,
             tileUnitAnchorPoint,

--- a/src/symbol/text_offsetting.js
+++ b/src/symbol/text_offsetting.js
@@ -1,0 +1,107 @@
+export { placeGlyph, planSegment };
+
+import {vec2} from 'gl-matrix';
+
+function vec2quad(out, a, b, c, t) {
+    const q = t * t - 2 * t + 1;
+    const r = 2 * t * (1 - t);
+    const s = t * t;
+    out[0] = a[0] * q + b[0] * r + c[0] * s;
+    out[1] = a[1] * q + b[1] * r + c[1] * s;
+    return out;
+}
+
+function vec2quadDeriv(out, a, b, c, t) {
+    const q = t - 1;
+    const r = 1 - 2 * t;
+    out[0] = 2 * (a[0] * q + b[0] * r + c[0] * t);
+    out[1] = 2 * (a[1] * q + b[1] * r + c[1] * t);
+    return out;
+}
+
+function vec2angle(a) {
+    return Math.atan2(a[1], a[0]);
+}
+
+function vec2cross(a, b) {
+    return a[0] * b[1] - a[1] * b[0];
+}
+
+function vec2perp(out, a) {
+    out[0] = -a[1];
+    out[1] = a[0];
+    return out;
+}
+
+function planSegment(r01, r12, offset, radius) {
+    // Compute cachable information. This could be cached. Some sections can
+    // be omitted if there is no text offset. Function calls can be inlined.
+
+    // Current segment
+    const l01 = vec2.length(r01);
+    const t01 = vec2.scale([], r01, 1 / l01);
+
+    if (!r12) {
+        // Termination criteria to finish out the current segment and then halt
+        return { s0: l01, s1: l01, t01, t12: t01, currentSegmentDistance: NaN };
+    }
+
+    // Tangent of next segment
+    const t12 = vec2.normalize([], r12);
+
+    // Extension past the end of the segment, due to the miter
+    const cosTheta = vec2.dot(t01, t12);
+    const sinTheta = vec2cross(t12, t01);
+    const c = 1 / (1 + cosTheta);
+    const extension = sinTheta * c * offset;
+
+    // Miter vector (point relative to corner where offset segments meet)
+    const miter = vec2perp([], vec2.scale([], vec2.add([], t01, t12), c));
+
+    // Length of rounding (does not depend on text offset!)
+    const round = Math.max(
+        //Math.abs(extension), // dependence on text offset when radius is large??
+        Math.abs(vec2.dot(t01, miter) * radius)
+    );
+
+    // Stop, relative to p0, at which to start the quadratic arc
+    const s0 = l01 + extension - round;
+
+    // Parameterization scale factor of arc, to keep kerning roughly constant. Approximate
+    // and plucked out of the sky. Over-stretches a bit, which is nice so characters don't
+    // run into each other. It's not a very good estimate, but we already avoid paths with
+    // sharp corners, so why overthink it?
+    const tScale = Math.max(0.7, 1 / vec2.length(miter));
+
+    // Stop, relative to p0, at which to end quadratic arc
+    const s1 = s0 + 2 * round * tScale;
+
+    // Offset, after passing stop1, so that we end up at the correct position on the next arc
+    const currentSegmentDistance = s1 + extension - round;
+
+    return { r01, r12, s0, s1, round, t01, t12, currentSegmentDistance, miter, offset };
+}
+
+function placeGlyph(plan, arcPosition) {
+    const { r01, r12, s0, s1, round, t01, t12, currentSegmentDistance, miter, offset } = plan;
+
+    if (arcPosition < s0) {
+        // Simply offset and place along the line segment
+        const out = vec2.scale([], [-t01[1], t01[0]], offset);
+        vec2.scaleAndAdd(out, out, t01, arcPosition);
+        const angle = Math.atan2(t01[1], t01[0]);
+        return { x: out[0], y: out[1], angle };
+    } else {//if (arcPosition < s1) {
+        // Compute three quadratic arc control points
+        const pb = vec2.scaleAndAdd([], r01, miter, offset);
+        const pa = vec2.scaleAndAdd([], pb, t01, -round);
+        const pc = vec2.scaleAndAdd([], pb, t12, round);
+
+        // Arc parameter, using the
+        const t = (arcPosition - s0) / (s1 - s0);
+
+        const pos = vec2quad([], pa, pb, pc, t);
+        const angle = vec2angle(vec2quadDeriv([], pa, pb, pc, t));
+        return { x: pos[0], y: pos[1], angle };
+    }
+}


### PR DESCRIPTION
This PR uses the technique in [this notebook](https://observablehq.com/d/59bfd1df9c222880) to improve text offsets. It's mostly an exercise in bookkeeping as it uses simple math to account for miters and rounded corners via lines and quadratic splines:

<img width="525" alt="Screen Shot 2021-06-07 at 7 27 45 PM" src="https://user-images.githubusercontent.com/572717/121113195-78426000-c7c6-11eb-9c28-3b7c26021524.png">

The situation is still pretty bad on pitched maps and will need some additional work. This will also need some light optimization (mostly due to n^2 evaluations, which are already taking place, just with simpler math).

**NOTE**: I only just realized that text-anchor is *not* implemented via offset, so that I will need to adjust my strategy.

Before:

<img width="777" alt="current" src="https://user-images.githubusercontent.com/572717/121112878-f3574680-c7c5-11eb-8818-13eea4a517dd.png">

After:

<img width="789" alt="text-paths" src="https://user-images.githubusercontent.com/572717/121112884-f5b9a080-c7c5-11eb-93a9-5e0dca5818ac.png">

cc @ChrisLoer @zmiao


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
