### PR TITLE
[docs] Fix link to idle event

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -883,7 +883,7 @@ export type MapEvent =
      * Fired just after the map completes a transition from one zoom level to another
      * as the result of either user interaction or methods such as {@link Map#flyTo}.
      * The zoom transition will usually end before rendering is finished, so if you
-     * need to wait for rendering to finish, use the {@link Map#idle} event instead.
+     * need to wait for rendering to finish, use the {@link Map.event:idle} event instead.
      *
      * @event zoomend
      * @memberof Map


### PR DESCRIPTION
This PR fixes the link to the idle event to use the event syntax. This link appears under https://docs.mapbox.com/mapbox-gl-js/api/map/#map.event:zoomend and is currently returning a 404.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
