### PR TITLE
Increase strictness of style API validation.

### DIFF
--- a/src/style-spec/validate_mapbox_api_supported.js
+++ b/src/style-spec/validate_mapbox_api_supported.js
@@ -45,13 +45,21 @@ function getSourceErrors(source: Object, i: number): Array<?ValidationError> {
     errors.push(...getAllowedKeyErrors(source, sourceKeys, 'source'));
 
     /*
+     * "type" is required and must be one of "vector", "raster", "raster-dem"
+     */
+    const typePattern = /^(vector|raster|raster-dem)$/;
+    if (!source.type || !isValid(source.type, typePattern)) {
+        errors.push(new ValidationError(`sources[${i}]`, source.type, "Source type must be vector, raster, or raster-dem"));
+    }
+    
+    /*
      * "source" is required. Valid examples:
      * mapbox://mapbox.abcd1234
      * mapbox://penny.abcd1234
      * mapbox://mapbox.abcd1234,penny.abcd1234
      */
     const sourceUrlPattern = /^mapbox:\/\/([^/]*)$/;
-    if (!isValid(source.url, sourceUrlPattern)) {
+    if (!source.url || !isValid(source.url, sourceUrlPattern)) {
         errors.push(new ValidationError(`sources[${i}]`, source.url, 'Source url must be a valid Mapbox tileset url'));
     }
 

--- a/src/style-spec/validate_mapbox_api_supported.js
+++ b/src/style-spec/validate_mapbox_api_supported.js
@@ -34,6 +34,7 @@ function getAllowedKeyErrors(obj: Object, keys: Array<*>, path: ?string): Array<
     return errors;
 }
 
+const acceptedSourceTypes = new Set(["vector", "raster", "raster-dem"]);
 function getSourceErrors(source: Object, i: number): Array<?ValidationError> {
     const errors = [];
 
@@ -47,9 +48,8 @@ function getSourceErrors(source: Object, i: number): Array<?ValidationError> {
     /*
      * "type" is required and must be one of "vector", "raster", "raster-dem"
      */
-    const typePattern = /^(vector|raster|raster-dem)$/;
-    if (!source.type || !isValid(source.type, typePattern)) {
-        errors.push(new ValidationError(`sources[${i}]`, source.type, "Source type must be vector, raster, or raster-dem"));
+    if (!acceptedSourceTypes.has(String(source.type))) {
+        errors.push(new ValidationError(`sources[${i}].type`, source.type, `Expected one of [${Array.from(acceptedSourceTypes).join(", ")}]`));
     }
 
     /*
@@ -60,7 +60,7 @@ function getSourceErrors(source: Object, i: number): Array<?ValidationError> {
      */
     const sourceUrlPattern = /^mapbox:\/\/([^/]*)$/;
     if (!source.url || !isValid(source.url, sourceUrlPattern)) {
-        errors.push(new ValidationError(`sources[${i}]`, source.url, 'Source url must be a valid Mapbox tileset url'));
+        errors.push(new ValidationError(`sources[${i}].url`, source.url, 'Expected a valid Mapbox tileset url'));
     }
 
     return errors;

--- a/src/style-spec/validate_mapbox_api_supported.js
+++ b/src/style-spec/validate_mapbox_api_supported.js
@@ -51,7 +51,7 @@ function getSourceErrors(source: Object, i: number): Array<?ValidationError> {
     if (!source.type || !isValid(source.type, typePattern)) {
         errors.push(new ValidationError(`sources[${i}]`, source.type, "Source type must be vector, raster, or raster-dem"));
     }
-    
+
     /*
      * "source" is required. Valid examples:
      * mapbox://mapbox.abcd1234

--- a/test/unit/style-spec/fixture/bad-dasharray.output-api-supported.json
+++ b/test/unit/style-spec/fixture/bad-dasharray.output-api-supported.json
@@ -1,10 +1,10 @@
 [
   {
-    "line": 16,
-    "message": "layers[0].paint.line-dasharray[1]: -2 is less than the minimum value 0"
+    "message": "layers[0].paint.line-dasharray[1]: -2 is less than the minimum value 0",
+    "line": 16
   },
   {
-    "line": 16,
-    "message": "layers[0].paint.line-dasharray[2]: -1 is less than the minimum value 0"
+    "message": "layers[0].paint.line-dasharray[2]: -1 is less than the minimum value 0",
+    "line": 16
   }
 ]

--- a/test/unit/style-spec/fixture/bad-sky.output-api-supported.json
+++ b/test/unit/style-spec/fixture/bad-sky.output-api-supported.json
@@ -1,18 +1,18 @@
 [
   {
-    "line": 23,
-    "message": "layers[1].paint.sky-atmosphere-sun[0]: -1 is less than the minimum value 0"
+    "message": "layers[1].paint.sky-atmosphere-sun[0]: -1 is less than the minimum value 0",
+    "line": 23
   },
   {
-    "line": 23,
-    "message": "layers[1].paint.sky-atmosphere-sun[1]: 181 is greater than the maximum value 180"
+    "message": "layers[1].paint.sky-atmosphere-sun[1]: 181 is greater than the maximum value 180",
+    "line": 23
   },
   {
-    "line": 39,
-    "message": "layers[3].paint.sky-gradient-center[0]: 361 is greater than the maximum value 360"
+    "message": "layers[3].paint.sky-gradient-center[0]: 361 is greater than the maximum value 360",
+    "line": 39
   },
   {
-    "line": 39,
-    "message": "layers[3].paint.sky-gradient-center[1]: -1 is less than the minimum value 0"
+    "message": "layers[3].paint.sky-gradient-center[1]: -1 is less than the minimum value 0",
+    "line": 39
   }
 ]

--- a/test/unit/style-spec/fixture/fog-invalid-input.output-api-supported.json
+++ b/test/unit/style-spec/fixture/fog-invalid-input.output-api-supported.json
@@ -1,14 +1,14 @@
 [
   {
-    "line": 11,
-    "message": "range[0]: -100 is less than the minimum value -20"
+    "message": "range[0]: -100 is less than the minimum value -20",
+    "line": 11
   },
   {
-    "line": 11,
-    "message": "range[1]: -80 is less than the minimum value -20"
+    "message": "range[1]: -80 is less than the minimum value -20",
+    "line": 11
   },
   {
-    "line": 12,
-    "message": "horizon-blend: -4 is less than the minimum value 0"
+    "message": "horizon-blend: -4 is less than the minimum value 0",
+    "line": 12
   }
 ]

--- a/test/unit/style-spec/fixture/layers.output-api-supported.json
+++ b/test/unit/style-spec/fixture/layers.output-api-supported.json
@@ -76,11 +76,11 @@
     "line": 14
   },
   {
-    "message": "sources[2]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[2].type: Expected one of [vector, raster, raster-dem]",
     "line": 13
   },
   {
-    "message": "sources[2]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[2].url: Expected a valid Mapbox tileset url"
   },
   {
     "message": "source.data: Unsupported property \"data\"",
@@ -91,10 +91,10 @@
     "line": 19
   },
   {
-    "message": "sources[3]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[3].type: Expected one of [vector, raster, raster-dem]",
     "line": 17
   },
   {
-    "message": "sources[3]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[3].url: Expected a valid Mapbox tileset url"
   }
 ]

--- a/test/unit/style-spec/fixture/layers.output-api-supported.json
+++ b/test/unit/style-spec/fixture/layers.output-api-supported.json
@@ -76,11 +76,25 @@
     "line": 14
   },
   {
+    "message": "sources[2]: Source type must be vector, raster, or raster-dem",
+    "line": 13
+  },
+  {
+    "message": "sources[2]: Source url must be a valid Mapbox tileset url"
+  },
+  {
     "message": "source.data: Unsupported property \"data\"",
     "line": 18
   },
   {
     "message": "source.lineMetrics: Unsupported property \"lineMetrics\"",
     "line": 19
+  },
+  {
+    "message": "sources[3]: Source type must be vector, raster, or raster-dem",
+    "line": 17
+  },
+  {
+    "message": "sources[3]: Source url must be a valid Mapbox tileset url"
   }
 ]

--- a/test/unit/style-spec/fixture/non-mapbox-references.output-api-supported.json
+++ b/test/unit/style-spec/fixture/non-mapbox-references.output-api-supported.json
@@ -8,11 +8,11 @@
     "line": 4
   },
   {
-    "message": "sources[0]: Source url must be a valid Mapbox tileset url",
+    "message": "sources[0].url: Expected a valid Mapbox tileset url",
     "line": 8
   },
   {
-    "message": "sources[1]: Source url must be a valid Mapbox tileset url",
+    "message": "sources[1].url: Expected a valid Mapbox tileset url",
     "line": 12
   }
 ]

--- a/test/unit/style-spec/fixture/numbers.output-api-supported.json
+++ b/test/unit/style-spec/fixture/numbers.output-api-supported.json
@@ -1,25 +1,32 @@
 [
-    {
-      "line": 42,
-      "message": "layers[2].paint.circle-radius: -1 is less than the minimum value 0"
-    },
-    {
-      "message": "layers[3].paint.circle-radius: number expected, null found"
-    },
-    {
-      "line": 58,
-      "message": "layers[4].paint.circle-radius: missing required property \"stops\""
-    },
-    {
-      "line": 66,
-      "message": "layers[5].paint.circle-radius: number expected, array found"
-    },
-    {
-      "line": 74,
-      "message": "layers[6].paint.circle-radius: number expected, boolean found"
-    },
-    {
-      "line": 6,
-      "message": "source.data: Unsupported property \"data\""
-    }
-  ]
+  {
+    "message": "layers[2].paint.circle-radius: -1 is less than the minimum value 0",
+    "line": 42
+  },
+  {
+    "message": "layers[3].paint.circle-radius: number expected, null found"
+  },
+  {
+    "message": "layers[4].paint.circle-radius: missing required property \"stops\"",
+    "line": 58
+  },
+  {
+    "message": "layers[5].paint.circle-radius: number expected, array found",
+    "line": 66
+  },
+  {
+    "message": "layers[6].paint.circle-radius: number expected, boolean found",
+    "line": 74
+  },
+  {
+    "message": "source.data: Unsupported property \"data\"",
+    "line": 6
+  },
+  {
+    "message": "sources[0]: Source type must be vector, raster, or raster-dem",
+    "line": 5
+  },
+  {
+    "message": "sources[0]: Source url must be a valid Mapbox tileset url"
+  }
+]

--- a/test/unit/style-spec/fixture/numbers.output-api-supported.json
+++ b/test/unit/style-spec/fixture/numbers.output-api-supported.json
@@ -23,10 +23,10 @@
     "line": 6
   },
   {
-    "message": "sources[0]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[0].type: Expected one of [vector, raster, raster-dem]",
     "line": 5
   },
   {
-    "message": "sources[0]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[0].url: Expected a valid Mapbox tileset url"
   }
 ]

--- a/test/unit/style-spec/fixture/sources.input.json
+++ b/test/unit/style-spec/fixture/sources.input.json
@@ -49,6 +49,9 @@
         "zoom": ["+", ["zoom"]],
         "state": ["+", ["feature-state", "foo"]]
       }
+    },
+    "missing-url": {
+      "type": "vector"
     }
   },
   "layers": []

--- a/test/unit/style-spec/fixture/sources.output-api-supported.json
+++ b/test/unit/style-spec/fixture/sources.output-api-supported.json
@@ -40,24 +40,24 @@
     "line": 50
   },
   {
-    "message": "sources[0]: Source type must be vector, raster, or raster-dem"
+    "message": "sources[0].type: Expected one of [vector, raster, raster-dem]"
   },
   {
-    "message": "sources[0]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[0].url: Expected a valid Mapbox tileset url"
   },
   {
-    "message": "sources[1]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[1].type: Expected one of [vector, raster, raster-dem]",
     "line": 7
   },
   {
-    "message": "sources[1]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[1].url: Expected a valid Mapbox tileset url"
   },
   {
     "message": "source.tiles: Unsupported property \"tiles\"",
     "line": 12
   },
   {
-    "message": "sources[2]: Source url must be a valid Mapbox tileset url",
+    "message": "sources[2].url: Expected a valid Mapbox tileset url",
     "line": 11
   },
   {
@@ -65,7 +65,7 @@
     "line": 17
   },
   {
-    "message": "sources[3]: Source url must be a valid Mapbox tileset url",
+    "message": "sources[3].url: Expected a valid Mapbox tileset url",
     "line": 16
   },
   {
@@ -77,22 +77,22 @@
     "line": 22
   },
   {
-    "message": "sources[4]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[4].type: Expected one of [vector, raster, raster-dem]",
     "line": 20
   },
   {
-    "message": "sources[4]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[4].url: Expected a valid Mapbox tileset url"
   },
   {
     "message": "source.urls: Unsupported property \"urls\"",
     "line": 28
   },
   {
-    "message": "sources[5]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[5].type: Expected one of [vector, raster, raster-dem]",
     "line": 27
   },
   {
-    "message": "sources[5]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[5].url: Expected a valid Mapbox tileset url"
   },
   {
     "message": "source.urls: Unsupported property \"urls\"",
@@ -103,11 +103,11 @@
     "line": 33
   },
   {
-    "message": "sources[6]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[6].type: Expected one of [vector, raster, raster-dem]",
     "line": 31
   },
   {
-    "message": "sources[6]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[6].url: Expected a valid Mapbox tileset url"
   },
   {
     "message": "source.canvas: Unsupported property \"canvas\"",
@@ -118,11 +118,11 @@
     "line": 40
   },
   {
-    "message": "sources[7]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[7].type: Expected one of [vector, raster, raster-dem]",
     "line": 38
   },
   {
-    "message": "sources[7]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[7].url: Expected a valid Mapbox tileset url"
   },
   {
     "message": "source.data: Unsupported property \"data\"",
@@ -137,10 +137,13 @@
     "line": 48
   },
   {
-    "message": "sources[8]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[8].type: Expected one of [vector, raster, raster-dem]",
     "line": 45
   },
   {
-    "message": "sources[8]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[8].url: Expected a valid Mapbox tileset url"
+  },
+  {
+    "message": "sources[9].url: Expected a valid Mapbox tileset url"
   }
 ]

--- a/test/unit/style-spec/fixture/sources.output-api-supported.json
+++ b/test/unit/style-spec/fixture/sources.output-api-supported.json
@@ -40,6 +40,19 @@
     "line": 50
   },
   {
+    "message": "sources[0]: Source type must be vector, raster, or raster-dem"
+  },
+  {
+    "message": "sources[0]: Source url must be a valid Mapbox tileset url"
+  },
+  {
+    "message": "sources[1]: Source type must be vector, raster, or raster-dem",
+    "line": 7
+  },
+  {
+    "message": "sources[1]: Source url must be a valid Mapbox tileset url"
+  },
+  {
     "message": "source.tiles: Unsupported property \"tiles\"",
     "line": 12
   },
@@ -64,8 +77,22 @@
     "line": 22
   },
   {
+    "message": "sources[4]: Source type must be vector, raster, or raster-dem",
+    "line": 20
+  },
+  {
+    "message": "sources[4]: Source url must be a valid Mapbox tileset url"
+  },
+  {
     "message": "source.urls: Unsupported property \"urls\"",
     "line": 28
+  },
+  {
+    "message": "sources[5]: Source type must be vector, raster, or raster-dem",
+    "line": 27
+  },
+  {
+    "message": "sources[5]: Source url must be a valid Mapbox tileset url"
   },
   {
     "message": "source.urls: Unsupported property \"urls\"",
@@ -76,12 +103,26 @@
     "line": 33
   },
   {
+    "message": "sources[6]: Source type must be vector, raster, or raster-dem",
+    "line": 31
+  },
+  {
+    "message": "sources[6]: Source url must be a valid Mapbox tileset url"
+  },
+  {
     "message": "source.canvas: Unsupported property \"canvas\"",
     "line": 39
   },
   {
     "message": "source.coordinates: Unsupported property \"coordinates\"",
     "line": 40
+  },
+  {
+    "message": "sources[7]: Source type must be vector, raster, or raster-dem",
+    "line": 38
+  },
+  {
+    "message": "sources[7]: Source url must be a valid Mapbox tileset url"
   },
   {
     "message": "source.data: Unsupported property \"data\"",
@@ -94,5 +135,12 @@
   {
     "message": "source.clusterProperties: Unsupported property \"clusterProperties\"",
     "line": 48
+  },
+  {
+    "message": "sources[8]: Source type must be vector, raster, or raster-dem",
+    "line": 45
+  },
+  {
+    "message": "sources[8]: Source url must be a valid Mapbox tileset url"
   }
 ]

--- a/test/unit/style-spec/fixture/text-field-format.output-api-supported.json
+++ b/test/unit/style-spec/fixture/text-field-format.output-api-supported.json
@@ -28,10 +28,10 @@
     "line": 6
   },
   {
-    "message": "sources[0]: Source type must be vector, raster, or raster-dem",
+    "message": "sources[0].type: Expected one of [vector, raster, raster-dem]",
     "line": 5
   },
   {
-    "message": "sources[0]: Source url must be a valid Mapbox tileset url"
+    "message": "sources[0].url: Expected a valid Mapbox tileset url"
   }
 ]

--- a/test/unit/style-spec/fixture/text-field-format.output-api-supported.json
+++ b/test/unit/style-spec/fixture/text-field-format.output-api-supported.json
@@ -26,5 +26,12 @@
   {
     "message": "source.data: Unsupported property \"data\"",
     "line": 6
+  },
+  {
+    "message": "sources[0]: Source type must be vector, raster, or raster-dem",
+    "line": 5
+  },
+  {
+    "message": "sources[0]: Source url must be a valid Mapbox tileset url"
   }
 ]


### PR DESCRIPTION
## Launch Checklist

This PR makes mapbox-api-supported  documentation more strict. Require 'type' and 'url' keys, and require that type is one of 'vector', 'raster', or 'raster-dem'. Styles with sources that have no type or url do not work, but it is possible to upload them to the style API.

<changelog>In mapbox-api-supported spec validation, require 'type' and 'url' keys, and require that type is one of 'vector', 'raster', or 'raster-dem'.</changelog>

cc: @mapbox/map-design-team @mapbox/static-apis

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [x] write tests for all new functionality
 - [ ] ~~document any changes to public APIs~~
 - [ ] ~~post benchmark scores~~
 - [ ] ~~manually test the debug page~~
 - [x] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] ~~tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port~~
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
