### PR TITLE
[projections] Simplify and optimize tile transform code

### DIFF
--- a/debug/projections.html
+++ b/debug/projections.html
@@ -48,7 +48,7 @@
                 <option value="sinusoidal">Sinusoidal</option>
                 <option value="wgs84">WGS84</option>
                 <option value="albers" selected>Albers USA</option>
-                <option value="albersAlaska">Albers Alaska</option>
+                <option value="alaska">Albers Alaska</option>
             </select>
         </fieldset>
         <fieldset>
@@ -85,7 +85,7 @@ function makeMap() {
     const el = document.getElementById('projName');
     const zooms = {
         albers: 3,
-        albersAlaska: 4,
+        alaska: 4,
         winkel: 1.2,
         mercator: 1.0,
         sinusoidal: 1.0,
@@ -93,7 +93,7 @@ function makeMap() {
     };
     const centers = {
         albers: [-122.414, 37.776],
-        albersAlaska: [-154, 63],
+        alaska: [-154, 63],
         winkel: [0, 0],
         mercator: [0, 0],
         sinusoidal: [0, 0],

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -58,8 +58,7 @@ export default function loadGeometry(feature: VectorTileFeature, canonical?: Can
 
     function reproject(p) {
         if (projection && projection.name === 'mercator' || !canonical) {
-            const p_ = new Point(Math.round(p.x * scale), Math.round(p.y * scale));
-            return clampPoint(p_);
+            return new Point(Math.round(p.x * scale), Math.round(p.y * scale));
         } else {
             const lng = lngFromMercatorX((canonical.x + p.x / featureExtent) / z2);
             const lat = latFromMercatorY((canonical.y + p.y / featureExtent) / z2);
@@ -96,7 +95,7 @@ export default function loadGeometry(feature: VectorTileFeature, canonical?: Can
             const pointMerc = ring[i];
             const pointProj = reproject(ring[i]);
 
-            if (prevMerc && prevProj && feature.type !== 1) {
+            if (projection && projection.name !== 'mercator' && prevMerc && prevProj && feature.type !== 1) {
                 addResampled(resampled, prevMerc, pointMerc, prevProj, pointProj);
             } else {
                 resampled.push(clampPoint(pointProj));

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -5,6 +5,7 @@ import {warnOnce, clamp} from '../util/util.js';
 import EXTENT from './extent.js';
 import {lngFromMercatorX, latFromMercatorY} from '../geo/mercator_coordinate.js';
 import projections from '../geo/projection/index.js';
+import tileTransform from '../geo/projection/tile_transform.js';
 import Point from '@mapbox/point-geometry';
 import type {CanonicalTileID} from '../source/tile_id.js';
 
@@ -51,7 +52,7 @@ export default function loadGeometry(feature: VectorTileFeature, canonical?: Can
     const scale = EXTENT / featureExtent;
     let cs, z2;
     if (canonical) {
-        cs = projection.tileTransform(canonical);
+        cs = tileTransform(canonical, projection.project);
         z2 = Math.pow(2, canonical.z);
     }
 

--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -1,6 +1,5 @@
 // @flow
 import LngLat from '../lng_lat.js';
-import makeTileTransform from './tile_transform.js';
 
 const albersConstants = {
     refLng: -96,
@@ -52,30 +51,24 @@ function unproject(x, y, constants) {
     return new LngLat(lng, lat);
 }
 
-function albersProject(lng: number, lat: number) {
-    return project(lng, lat, albersConstants);
-}
-
-function alaskaProject(lng: number, lat: number) {
-    return project(lng, lat, alaskaConstants);
-}
-
 export const albers = {
     name: 'albers',
     range: [3.5, 7],
-    project: albersProject,
+    project(lng: number, lat: number) {
+        return project(lng, lat, albersConstants);
+    },
     unproject: (x: number, y: number) => {
         return unproject(x, y, albersConstants);
-    },
-    tileTransform: makeTileTransform(albersProject)
+    }
 };
 
 export const alaska = {
     name: 'alaska',
     range: [4, 7],
-    project: alaskaProject,
+    project(lng: number, lat: number) {
+        return project(lng, lat, alaskaConstants);
+    },
     unproject: (x: number, y: number) => {
         return unproject(x, y, alaskaConstants);
-    },
-    tileTransform: makeTileTransform(alaskaProject)
+    }
 };

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -10,8 +10,7 @@ export type Projection = {
     name: string,
     range: Array<number>,
     project: (lng: number, lat: number, options?: Object) => {x: number, y: number},
-    unproject: (x: number, y: number) => LngLat,
-    tileTransform: (id: Object) => {scale: number, x: number, y: number, x2: number, y2: number}
+    unproject: (x: number, y: number) => LngLat
 };
 
 export default {

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -1,18 +1,13 @@
 // @flow
 import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat} from '../mercator_coordinate.js';
-import makeTileTransform from './tile_transform.js';
-
-function project(lng: number, lat: number) {
-    const x = mercatorXfromLng(lng);
-    const y = mercatorYfromLat(lat);
-
-    return {x, y};
-}
 
 export default {
     name: 'mercator',
     range: [],
-    project,
-    unproject: (x: number, y: number) => new MercatorCoordinate(x, y).toLngLat(),
-    tileTransform: makeTileTransform(project)
+    project(lng: number, lat: number) {
+        const x = mercatorXfromLng(lng);
+        const y = mercatorYfromLat(lat);
+        return {x, y};
+    },
+    unproject: (x: number, y: number) => new MercatorCoordinate(x, y).toLngLat()
 };

--- a/src/geo/projection/sinusoidal.js
+++ b/src/geo/projection/sinusoidal.js
@@ -1,21 +1,17 @@
 // @flow
 import LngLat from '../lng_lat.js';
-import makeTileTransform from './tile_transform.js';
-
-function project(lng: number, lat: number) {
-    const x = 0.5 + lng * Math.cos(lat / 180 * Math.PI) / 360 * 2;
-    const y = 0.5 - lat / 360 * 2;
-    return {x, y};
-}
 
 export default {
     name: 'sinusoidal',
     range: [],
-    project,
+    project(lng: number, lat: number) {
+        const x = 0.5 + lng * Math.cos(lat / 180 * Math.PI) / 360 * 2;
+        const y = 0.5 - lat / 360 * 2;
+        return {x, y};
+    },
     unproject: (x: number, y: number) => {
         const lat = (0.5 - y) / 2 * 360;
         const lng = (x - 0.5) / Math.cos(lat / 180 * Math.PI) / 2 * 360;
         return new LngLat(lng, lat);
-    },
-    tileTransform: makeTileTransform(project)
+    }
 };

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -1,50 +1,45 @@
 // @flow
-import MercatorCoordinate from '../mercator_coordinate.js';
+import {lngFromMercatorX, latFromMercatorY} from '../mercator_coordinate.js';
+import {number as interpolate} from '../../style-spec/util/interpolate.js';
 
-function idBounds(id) {
+export default function tileTransform(id: Object, project: function) {
     const s = Math.pow(2, -id.z);
     const x1 = (id.x) * s;
     const x2 = (id.x + 1) * s;
     const y1 = (id.y) * s;
     const y2 = (id.y + 1) * s;
-
-    const interp = (a, b, t) => a * (1 - t) + b * t;
+    const lng1 = lngFromMercatorX(x1);
+    const lng2 = lngFromMercatorX(x2);
+    const lat1 = latFromMercatorY(y1);
+    const lat2 = latFromMercatorY(y2);
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
 
     const n = 2;
-    const locs = [];
     for (let i = 0; i <= n; i++) {
-        const f = i / n;
-        locs.push(new MercatorCoordinate(interp(x1, x2, f), y1).toLngLat());
-        locs.push(new MercatorCoordinate(interp(x1, x2, f), y2).toLngLat());
-        locs.push(new MercatorCoordinate(x1, interp(y1, y2, f)).toLngLat());
-        locs.push(new MercatorCoordinate(x2, interp(y1, y2, f)).toLngLat());
+        const lng = lngFromMercatorX(interpolate(x1, x2, i / n));
+        const lat = latFromMercatorY(interpolate(y1, y2, i / n));
+
+        const p0 = project(lng, lat1);
+        const p1 = project(lng, lat2);
+        const p2 = project(lng1, lat);
+        const p3 = project(lng2, lat);
+
+        minX = Math.min(minX, p0.x, p1.x, p2.x, p3.x);
+        maxX = Math.max(maxX, p0.x, p1.x, p2.x, p3.x);
+        minY = Math.min(minY, p0.y, p1.y, p2.y, p3.y);
+        maxY = Math.max(maxY, p0.y, p1.y, p2.y, p3.y);
     }
-    return locs;
-}
 
-export default function (project: function) {
-    return (id: Object) => {
-        const locs = idBounds(id);
-        let minX = Infinity;
-        let minY = Infinity;
-        let maxX = -Infinity;
-        let maxY = -Infinity;
-        for (const l of locs) {
-            const {x, y} = project(l.lng, l.lat);
-            minX = Math.min(minX, x);
-            maxX = Math.max(maxX, x);
-            minY = Math.min(minY, y);
-            maxY = Math.max(maxY, y);
-        }
-
-        const max = Math.max(maxX - minX, maxY - minY);
-        const scale = 1 / max;
-        return {
-            scale,
-            x: minX * scale,
-            y: minY * scale,
-            x2: maxX * scale,
-            y2: maxY * scale
-        };
+    const max = Math.max(maxX - minX, maxY - minY);
+    const scale = 1 / max;
+    return {
+        scale,
+        x: minX * scale,
+        y: minY * scale,
+        x2: maxX * scale,
+        y2: maxY * scale
     };
 }

--- a/src/geo/projection/wgs84.js
+++ b/src/geo/projection/wgs84.js
@@ -1,17 +1,12 @@
 // @flow
-import makeTileTransform from './tile_transform.js';
-
-function project(lng: number, lat: number) {
-    const x = 0.5 + lng / 360;
-    const y = 0.5 - lat / 360;
-
-    return {x, y};
-}
 
 export default {
     name: 'wgs84',
     range: [],
-    project,
-    unproject: () => {},
-    tileTransform: makeTileTransform(project)
+    project(lng: number, lat: number) {
+        const x = 0.5 + lng / 360;
+        const y = 0.5 - lat / 360;
+        return {x, y};
+    },
+    unproject: () => {}
 };

--- a/src/geo/projection/winkelTripel.js
+++ b/src/geo/projection/winkelTripel.js
@@ -4,6 +4,5 @@ export default {
     name: 'winkel',
     range: [3.5, 7],
     project: () => {},
-    unproject: () => {},
-    tileTransform: () => {}
+    unproject: () => {}
 };

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -4,6 +4,7 @@ import LngLat from './lng_lat.js';
 import LngLatBounds from './lng_lat_bounds.js';
 import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude, latFromMercatorY} from './mercator_coordinate.js';
 import projections from './projection/index.js';
+import tileTransform from '../geo/projection/tile_transform.js';
 import Point from '@mapbox/point-geometry';
 import {wrap, clamp, radToDeg, degToRad, getAABBPointSquareDist, furthestTileCorner} from '../util/util.js';
 import {number as interpolate} from '../style-spec/util/interpolate.js';
@@ -677,7 +678,7 @@ class Transform {
         const minRange = options.isTerrainDEM ? -maxRange : this._elevation ? this._elevation.getMinElevationBelowMSL() : 0;
 
         const aabbForTile = (z, x, y, wrap, min, max) => {
-            const tt = this.projection.tileTransform({z, x, y});
+            const tt = tileTransform({z, x, y}, this.projection.project);
             const tx = tt.x / tt.scale;
             const ty = tt.y / tt.scale;
             const tx2 = tt.x2 / tt.scale;
@@ -1264,7 +1265,7 @@ class Transform {
             scaledX = unwrappedX * scale;
             scaledY = canonical.y * scale;
         } else {
-            const cs = this.projection.tileTransform(canonical);
+            const cs = tileTransform(canonical, this.projection.project);
             scale = 1;
             scaledX = cs.x;
             scaledY = cs.y;

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -20,6 +20,7 @@ import Color from '../style-spec/util/color.js';
 import boundsAttributes from '../data/bounds_attributes.js';
 import EXTENT from '../data/extent.js';
 import MercatorCoordinate from '../geo/mercator_coordinate.js';
+import tileTransform from '../geo/projection/tile_transform.js';
 
 const CLOCK_SKEW_RETRY_TIMEOUT = 30000;
 
@@ -534,7 +535,7 @@ class Tile {
         const s = Math.pow(2, -this.tileID.canonical.z);
         const x1 = (this.tileID.canonical.x) * s;
         const y1 = (this.tileID.canonical.y) * s;
-        const cs = projection.tileTransform(this.tileID.canonical);
+        const cs = tileTransform(this.tileID.canonical, projection.project);
         const increment = s / denominator;
         const x2 = x1 + x * increment;
         const y2 = y1 + y * increment;


### PR DESCRIPTION
- Remove `tileTransform` closure from `Projection` in favor of a pure function to avoid duplication (we have to calculate it from scratch for every tile ID anyway)
- Optimize `tileTransform` code for less intermediary object allocations.
- Turn off resampling for Mercator projection to avoid redundant midpoint calculations.
- Fix Albers Alaska in the debug page (misnamed)
