### PR TITLE
Cherry-pick v2.3.1 and style-spec@13.20.1 changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.1
+
+### 🐞 Bug fixes
+
+* Fix fog flickering when the map option `optimizeForTerrain` is set to false ([#10763](https://github.com/mapbox/mapbox-gl-js/pull/10767))
+* Fix collision boxes which were not correctly updated for symbols with `text-variable-anchor` ([#10709](https://github.com/mapbox/mapbox-gl-js/pull/10709))
+
 ## 2.3.0
 
 ### ✨ Features and improvements

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 13.20.1
+
+### 🐞 Bug fixes
+
+* Increase strictness of the style API validation for source types ([#10779](https://github.com/mapbox/mapbox-gl-js/pull/10779))
+* Remove strictly-increasing requirement for fog range validation ([#10772](https://github.com/mapbox/mapbox-gl-js/pull/10772))
+
 ## 13.20.0
 
 ### ✨ Features and improvements


### PR DESCRIPTION
Cherry-picks 2.3.1 and 13.20.1 changelogs back into `main`.