### PR TITLE
Run terrain elevation average unit tests without initial load

### DIFF
--- a/test/unit/terrain/terrain.test.js
+++ b/test/unit/terrain/terrain.test.js
@@ -300,6 +300,7 @@ test('Elevation', (t) => {
 
             map.once('render', () => {
                 map._updateTerrain();
+                map._isInitialLoad = false;
 
                 t.false(map.painter.averageElevationNeedsEasing());
 


### PR DESCRIPTION
Small fix post #10809 due to missing rebase on main.