### PR TITLE
Remove some unnecessary transforms

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -249,10 +249,10 @@ class Painter {
         this.rasterBoundsSegments = SegmentVector.simpleSegment(0, 0, 4, 2);
 
         const viewportArray = new PosArray();
-        viewportArray.emplaceBack(0, 0);
-        viewportArray.emplaceBack(1, 0);
-        viewportArray.emplaceBack(0, 1);
-        viewportArray.emplaceBack(1, 1);
+        viewportArray.emplaceBack(-1, -1);
+        viewportArray.emplaceBack( 1, -1);
+        viewportArray.emplaceBack(-1,  1);
+        viewportArray.emplaceBack( 1,  1);
         this.viewportBuffer = context.createVertexBuffer(viewportArray, posAttributes.members);
         this.viewportSegments = SegmentVector.simpleSegment(0, 0, 4, 2);
 

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -250,9 +250,9 @@ class Painter {
 
         const viewportArray = new PosArray();
         viewportArray.emplaceBack(-1, -1);
-        viewportArray.emplaceBack( 1, -1);
-        viewportArray.emplaceBack(-1,  1);
-        viewportArray.emplaceBack( 1,  1);
+        viewportArray.emplaceBack(1, -1);
+        viewportArray.emplaceBack(-1, 1);
+        viewportArray.emplaceBack(1, 1);
         this.viewportBuffer = context.createVertexBuffer(viewportArray, posAttributes.members);
         this.viewportSegments = SegmentVector.simpleSegment(0, 0, 4, 2);
 
@@ -287,12 +287,9 @@ class Painter {
      * new tiles at the same location, while retaining previously drawn pixels.
      */
     clearStencil() {
-        const context = this.context;
-        const gl = context.gl;
-
         this.nextStencilID = 1;
         this.currentStencilSource = undefined;
-        this.context.clear({ stencil: 0x0 });
+        this.context.clear({stencil: 0x0});
     }
 
     _renderTileClippingMasks(layer: StyleLayer, sourceCache?: SourceCache, tileIDs?: Array<OverscaledTileID>) {

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -292,21 +292,7 @@ class Painter {
 
         this.nextStencilID = 1;
         this.currentStencilSource = undefined;
-
-        // As a temporary workaround for https://github.com/mapbox/mapbox-gl-js/issues/5490,
-        // pending an upstream fix, we draw a fullscreen stencil=0 clipping mask here,
-        // effectively clearing the stencil buffer: once an upstream patch lands, remove
-        // this function in favor of context.clear({ stencil: 0x0 })
-
-        const matrix = mat4.create();
-        mat4.ortho(matrix, 0, this.width, this.height, 0, 0, 1);
-        mat4.scale(matrix, matrix, [gl.drawingBufferWidth, gl.drawingBufferHeight, 0]);
-
-        this.useProgram('clippingMask').draw(context, gl.TRIANGLES,
-            DepthMode.disabled, this.stencilClearMode, ColorMode.disabled, CullFaceMode.disabled,
-            clippingMaskUniformValues(matrix),
-            '$clipping', this.viewportBuffer,
-            this.quadTriangleIndexBuffer, this.viewportSegments);
+        this.context.clear({ stencil: 0x0 });
     }
 
     _renderTileClippingMasks(layer: StyleLayer, sourceCache?: SourceCache, tileIDs?: Array<OverscaledTileID>) {

--- a/src/render/program/heatmap_program.js
+++ b/src/render/program/heatmap_program.js
@@ -1,11 +1,8 @@
 // @flow
 
-import {mat4} from 'gl-matrix';
-
 import {
     Uniform1i,
     Uniform1f,
-    Uniform2f,
     UniformMatrix4f
 } from '../uniform_binding.js';
 import pixelsToTileUnits from '../../source/pixels_to_tile_units.js';

--- a/src/render/program/heatmap_program.js
+++ b/src/render/program/heatmap_program.js
@@ -23,8 +23,6 @@ export type HeatmapUniformsType = {|
 |};
 
 export type HeatmapTextureUniformsType = {|
-    'u_matrix': UniformMatrix4f,
-    'u_world': Uniform2f,
     'u_image': Uniform1i,
     'u_color_ramp': Uniform1i,
     'u_opacity': Uniform1f
@@ -37,8 +35,6 @@ const heatmapUniforms = (context: Context, locations: UniformLocations): Heatmap
 });
 
 const heatmapTextureUniforms = (context: Context, locations: UniformLocations): HeatmapTextureUniformsType => ({
-    'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
-    'u_world': new Uniform2f(context, locations.u_world),
     'u_image': new Uniform1i(context, locations.u_image),
     'u_color_ramp': new Uniform1i(context, locations.u_color_ramp),
     'u_opacity': new Uniform1f(context, locations.u_opacity)
@@ -61,14 +57,7 @@ const heatmapTextureUniformValues = (
     textureUnit: number,
     colorRampUnit: number
 ): UniformValues<HeatmapTextureUniformsType> => {
-    const matrix = mat4.create();
-    mat4.ortho(matrix, 0, painter.width, painter.height, 0, 0, 1);
-
-    const gl = painter.context.gl;
-
     return {
-        'u_matrix': matrix,
-        'u_world': [gl.drawingBufferWidth, gl.drawingBufferHeight],
         'u_image': textureUnit,
         'u_color_ramp': colorRampUnit,
         'u_opacity': layer.paint.get('heatmap-opacity')

--- a/src/shaders/heatmap_texture.vertex.glsl
+++ b/src/shaders/heatmap_texture.vertex.glsl
@@ -1,11 +1,8 @@
-uniform mat4 u_matrix;
-uniform vec2 u_world;
 attribute vec2 a_pos;
 varying vec2 v_pos;
 
 void main() {
-    gl_Position = u_matrix * vec4(a_pos * u_world, 0, 1);
+    gl_Position = vec4(a_pos, 0, 1);
 
-    v_pos.x = a_pos.x;
-    v_pos.y = 1.0 - a_pos.y;
+    v_pos = a_pos * 0.5 + 0.5;
 }


### PR DESCRIPTION
Remove some extraneous transforms and uniform uploads for transforms that could directly be in gl coordinates ([-1,-1][1, 1]).

cc @mapbox/gl-native . This PR includes shader changes with a small update to uniforms for the heatmap, they are fairly minimal to port.