### PR TITLE
add geolocate bearing

### DIFF
--- a/debug/debug.html
+++ b/debug/debug.html
@@ -47,6 +47,7 @@ map.addControl(new mapboxgl.GeolocateControl({
     },
     trackUserLocation: true,
     showUserLocation: true,
+    showUserHeading: true,
     fitBoundsOptions: {
         maxZoom: 20
     }

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -702,6 +702,42 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.35);
 }
 
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading {
+    width: 0;
+    height: 0;
+}
+
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-left: 7.5px solid transparent;
+    border-bottom: 7.5px solid #1da1f2;
+    transform: translate(0px, -28px) skewY(-20deg);
+    position: absolute;
+}
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::after {
+    content: "";
+    width: 0;
+    height: 0;
+    border-right: 7.5px solid transparent;
+    border-bottom: 7.5px solid #1da1f2;
+    transform: translate(7.5px, -28px) skewY(20deg);
+    position: absolute;
+}
+
+@-webkit-keyframes mapboxgl-user-location-dot-pulse {
+    0%   { -webkit-transform: scale(1); opacity: 1; }
+    70%  { -webkit-transform: scale(3); opacity: 0; }
+    100% { -webkit-transform: scale(1); opacity: 0; }
+}
+
+@-ms-keyframes mapboxgl-user-location-dot-pulse {
+    0%   { -ms-transform: scale(1); opacity: 1; }
+    70%  { -ms-transform: scale(3); opacity: 0; }
+    100% { -ms-transform: scale(1); opacity: 0; }
+}
+
 @keyframes mapboxgl-user-location-dot-pulse {
     0%   { transform: scale(1); opacity: 1; }
     70%  { transform: scale(3); opacity: 0; }

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -707,20 +707,21 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     height: 0;
 }
 
-.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::before {
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::before,
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::after {
     content: "";
-    border-left: 7.5px solid transparent;
     border-bottom: 7.5px solid #4aa1eb;
-    transform: translate(0, -28px) skewY(-20deg);
     position: absolute;
 }
 
+.mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::before {
+    border-left: 7.5px solid transparent;
+    transform: translate(0, -28px) skewY(-20deg);
+}
+
 .mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::after {
-    content: "";
     border-right: 7.5px solid transparent;
-    border-bottom: 7.5px solid #4aa1eb;
     transform: translate(7.5px, -28px) skewY(20deg);
-    position: absolute;
 }
 
 @keyframes mapboxgl-user-location-dot-pulse {

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -709,20 +709,20 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
 .mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::before {
     content: "";
-    width: 0;
-    height: 0;
+    width: 1;
+    height: 1;
     border-left: 7.5px solid transparent;
-    border-bottom: 7.5px solid #1da1f2;
+    border-bottom: 7.5px solid #4aa1eb;
     transform: translate(0, -28px) skewY(-20deg);
     position: absolute;
 }
 
 .mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::after {
     content: "";
-    width: 0;
-    height: 0;
+    width: 1;
+    height: 1;
     border-right: 7.5px solid transparent;
-    border-bottom: 7.5px solid #1da1f2;
+    border-bottom: 7.5px solid #4aa1eb;
     transform: translate(7.5px, -28px) skewY(20deg);
     position: absolute;
 }

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -709,8 +709,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
 .mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::before {
     content: "";
-    width: 1;
-    height: 1;
     border-left: 7.5px solid transparent;
     border-bottom: 7.5px solid #4aa1eb;
     transform: translate(0, -28px) skewY(-20deg);
@@ -719,8 +717,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
 .mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::after {
     content: "";
-    width: 1;
-    height: 1;
     border-right: 7.5px solid transparent;
     border-bottom: 7.5px solid #4aa1eb;
     transform: translate(7.5px, -28px) skewY(20deg);

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -713,9 +713,10 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     height: 0;
     border-left: 7.5px solid transparent;
     border-bottom: 7.5px solid #1da1f2;
-    transform: translate(0px, -28px) skewY(-20deg);
+    transform: translate(0, -28px) skewY(-20deg);
     position: absolute;
 }
+
 .mapboxgl-user-location-show-heading .mapboxgl-user-location-heading::after {
     content: "";
     width: 0;

--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -727,18 +727,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     position: absolute;
 }
 
-@-webkit-keyframes mapboxgl-user-location-dot-pulse {
-    0%   { -webkit-transform: scale(1); opacity: 1; }
-    70%  { -webkit-transform: scale(3); opacity: 0; }
-    100% { -webkit-transform: scale(1); opacity: 0; }
-}
-
-@-ms-keyframes mapboxgl-user-location-dot-pulse {
-    0%   { -ms-transform: scale(1); opacity: 1; }
-    70%  { -ms-transform: scale(3); opacity: 0; }
-    100% { -ms-transform: scale(1); opacity: 0; }
-}
-
 @keyframes mapboxgl-user-location-dot-pulse {
     0%   { transform: scale(1); opacity: 1; }
     70%  { transform: scale(3); opacity: 0; }

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -486,7 +486,7 @@ class GeolocateControl extends Evented {
     * map.on('load', function() {
     *   geolocate.trigger();
     * });
-    * Called on a deviceorientationabsolute or deviceorientation event.
+    * Called on a deviceorientation event.
     *
     * @param deviceOrientationEvent {DeviceOrientationEvent}
     * @private

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -598,7 +598,7 @@ class GeolocateControl extends Evented {
                     this._onSuccess, this._onError, positionOptions);
 
                 if (this.options.showUserHeading) {
-                    window.addEventListener('deviceorientation', this._onDeviceOrientationListener);
+                    this._addDeviceOrientationListener()
                 }
             }
         } else {
@@ -611,6 +611,21 @@ class GeolocateControl extends Evented {
         }
 
         return true;
+    }
+
+    _addDeviceOrientationListener() {
+        if (typeof DeviceMotionEvent !== "undefined" &&
+            typeof DeviceMotionEvent.requestPermission === 'function') {
+            DeviceOrientationEvent.requestPermission()
+                .then(response => {
+                    if (response == 'granted') {
+                        window.addEventListener('deviceorientation', this._onDeviceOrientationListener);
+                    }
+                })
+                .catch(console.error)
+        } else {
+            window.addEventListener('deviceorientation', this._onDeviceOrientationListener);
+        }
     }
 
     _clearWatch() {

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -614,7 +614,6 @@ class GeolocateControl extends Evented {
     _clearWatch() {
         window.navigator.geolocation.clearWatch(this._geolocationWatchID);
 
-        window.removeEventListener('deviceorientationabsolute', this._onDeviceOrientation);
         window.removeEventListener('deviceorientation', this._onDeviceOrientation);
 
         this._geolocationWatchID = (undefined: any);

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -341,7 +341,7 @@ class GeolocateControl extends Evented {
      */
     _updateMarkerRotation() {
         if (this._userLocationDotMarker && this._heading) {
-            this._userLocationDotMarker.setRotation(this._heading)
+            this._userLocationDotMarker.setRotation(this._heading);
             this._dotElement.classList.add('mapboxgl-user-location-show-heading');
         } else {
             this._dotElement.classList.remove('mapboxgl-user-location-show-heading');

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -349,8 +349,8 @@ class GeolocateControl extends Evented {
      */
     _updateMarkerRotation() {
         if (this._userLocationDotMarker && typeof this._heading === 'number') {
-            this._dotElement.classList.add('mapboxgl-user-location-show-heading');
             this._userLocationDotMarker.setRotation(this._heading);
+            this._dotElement.classList.add('mapboxgl-user-location-show-heading');
         } else {
             this._dotElement.classList.remove('mapboxgl-user-location-show-heading');
             this._userLocationDotMarker.setRotation(0);
@@ -493,7 +493,8 @@ class GeolocateControl extends Evented {
     */
     _onDeviceOrientation(deviceOrientationEvent: DeviceOrientationEvent) {
         if (this._userLocationDotMarker) {
-            this._heading = deviceOrientationEvent.alpha;
+            // alpha increases counter clockwise around the z axis
+            this._heading = deviceOrientationEvent.alpha * -1;
             this._updateMarkerRotationThrottled();
         }
     }

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -340,7 +340,7 @@ class GeolocateControl extends Evented {
      * @private
      */
     _updateMarkerRotation() {
-        if (this._userLocationDotMarker && this._heading) {
+        if (this._userLocationDotMarker && typeof this._heading === 'number') {
             this._userLocationDotMarker.setRotation(this._heading);
             this._dotElement.classList.add('mapboxgl-user-location-show-heading');
         } else {
@@ -484,16 +484,6 @@ class GeolocateControl extends Evented {
     * @private
     */
     _onDeviceOrientation(deviceOrientationEvent: DeviceOrientationEvent) {
-        if (!deviceOrientationEvent.absolute && !deviceOrientationEvent.webkitCompassHeading) {
-            // an absolute orientation or a webkitCompassHeading is required
-
-            // disable the listeners since we assume future triggers will be the same
-            window.removeEventListener('deviceorientationabsolute', this._onDeviceOrientation);
-            window.removeEventListener('deviceorientation', this._onDeviceOrientation);
-
-            return;
-        }
-
         if (this._userLocationDotMarker) {
             this._heading = deviceOrientationEvent.webkitCompassHeading || deviceOrientationEvent.alpha;
             this._updateMarkerRotationThrottled();
@@ -596,14 +586,9 @@ class GeolocateControl extends Evented {
                 this._geolocationWatchID = window.navigator.geolocation.watchPosition(
                     this._onSuccess, this._onError, positionOptions);
 
-                if (this.options.showUserHeading) {
-                    if ('ondeviceorientationabsolute' in window) {
-                        window.addEventListener('deviceorientationabsolute', this._onDeviceOrientation.bind(this));
-                    } else if ('ondeviceorientation' in window) {
-                        window.addEventListener('deviceorientation', this._onDeviceOrientation.bind(this));
-                    }
+                if (this.options.showUserHeading && 'ondeviceorientation' in window) {
+                    window.addEventListener('deviceorientation', this._onDeviceOrientation.bind(this));
                 }
-
             }
         } else {
             window.navigator.geolocation.getCurrentPosition(

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -142,7 +142,7 @@ class GeolocateControl extends Evented {
         ], this);
 
         // by referencing the function with .bind(), we can correctly remove from window's event listeners
-        this._onDeviceOrientationListener = this._onDeviceOrientation.bind(this)
+        this._onDeviceOrientationListener = this._onDeviceOrientation.bind(this);
         this._updateMarkerRotationThrottled = throttle(this._updateMarkerRotation, 20);
     }
 

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -473,19 +473,6 @@ class GeolocateControl extends Evented {
     * Programmatically request and move the map to the user's location.
     *
     * @returns {boolean} Returns `false` if called before control was added to a map, otherwise returns `true`.
-    * @example
-    * // Initialize the geolocate control.
-    * var geolocate = new mapboxgl.GeolocateControl({
-    *  positionOptions: {
-    *    enableHighAccuracy: true
-    *  },
-    *  trackUserLocation: true
-    * });
-    * // Add the control to the map.
-    * map.addControl(geolocate);
-    * map.on('load', function() {
-    *   geolocate.trigger();
-    * });
     * Called on a deviceorientation event.
     *
     * @param deviceOrientationEvent {DeviceOrientationEvent}
@@ -501,7 +488,19 @@ class GeolocateControl extends Evented {
 
     /**
      * Trigger a geolocation
-     *
+     * @example
+     * // Initialize the geolocate control.
+     * var geolocate = new mapboxgl.GeolocateControl({
+     *  positionOptions: {
+     *    enableHighAccuracy: true
+     *  },
+     *  trackUserLocation: true
+     * });
+     * // Add the control to the map.
+     * map.addControl(geolocate);
+     * map.on('load', function() {
+     *   geolocate.trigger();
+     * });
      * @returns {boolean} Returns `false` if called before control was added to a map, otherwise returns `true`.
      */
     trigger() {

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -124,6 +124,7 @@ class GeolocateControl extends Evented {
     _setup: boolean; // set to true once the control has been setup
     _heading: ?number;
     _updateMarkerRotationThrottled: Function;
+    _onDeviceOrientationListener: Function;
 
     constructor(options: Options) {
         super();
@@ -140,6 +141,8 @@ class GeolocateControl extends Evented {
             '_updateMarkerRotation'
         ], this);
 
+        // by referencing the function with .bind(), we can correctly remove from window's event listeners
+        this._onDeviceOrientationListener = this._onDeviceOrientation.bind(this)
         this._updateMarkerRotationThrottled = throttle(this._updateMarkerRotation, 20);
     }
 
@@ -595,7 +598,7 @@ class GeolocateControl extends Evented {
                     this._onSuccess, this._onError, positionOptions);
 
                 if (this.options.showUserHeading) {
-                    window.addEventListener('deviceorientation', this._onDeviceOrientation.bind(this));
+                    window.addEventListener('deviceorientation', this._onDeviceOrientationListener);
                 }
             }
         } else {
@@ -613,7 +616,7 @@ class GeolocateControl extends Evented {
     _clearWatch() {
         window.navigator.geolocation.clearWatch(this._geolocationWatchID);
 
-        window.removeEventListener('deviceorientation', this._onDeviceOrientation);
+        window.removeEventListener('deviceorientation', this._onDeviceOrientationListener);
 
         this._geolocationWatchID = (undefined: any);
         this._geolocateButton.classList.remove('mapboxgl-ctrl-geolocate-waiting');

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -22,10 +22,12 @@ type Options = {
 };
 
 type DeviceOrientationEvent = {
-    absolute: Boolean,
+    absolute: boolean,
     alpha: number,
     beta: number,
-    gamma: number
+    gamma: number,
+    requestPermission: Promise<String>,
+    webkitCompassHeading?: number,
 }
 
 const defaultOptions: Options = {
@@ -630,6 +632,7 @@ class GeolocateControl extends Evented {
 
         if (typeof window.DeviceMotionEvent !== "undefined" &&
             typeof window.DeviceMotionEvent.requestPermission === 'function') {
+            //$FlowFixMe[incompatible-type]
             DeviceOrientationEvent.requestPermission()
                 .then(response => {
                     if (response === 'granted') {

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -598,7 +598,7 @@ class GeolocateControl extends Evented {
                     this._onSuccess, this._onError, positionOptions);
 
                 if (this.options.showUserHeading) {
-                    this._addDeviceOrientationListener()
+                    this._addDeviceOrientationListener();
                 }
             }
         } else {
@@ -614,15 +614,15 @@ class GeolocateControl extends Evented {
     }
 
     _addDeviceOrientationListener() {
-        if (typeof DeviceMotionEvent !== "undefined" &&
-            typeof DeviceMotionEvent.requestPermission === 'function') {
+        if (typeof window.DeviceMotionEvent !== "undefined" &&
+            typeof window.DeviceMotionEvent.requestPermission === 'function') {
             DeviceOrientationEvent.requestPermission()
                 .then(response => {
-                    if (response == 'granted') {
+                    if (response === 'granted') {
                         window.addEventListener('deviceorientation', this._onDeviceOrientationListener);
                     }
                 })
-                .catch(console.error)
+                .catch(console.error);
         } else {
             window.addEventListener('deviceorientation', this._onDeviceOrientationListener);
         }

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -572,11 +572,12 @@ test('GeolocateControl watching device orientation event', (t) => {
 
     const click = new window.Event('click');
 
-    const DeviceOrientationEventLike = (alpha) => {
+    // since DeviceOrientationEvent is not supported: https://developer.mozilla.org/en-US/docs/Web/API/DeviceOrientationEvent
+    const deviceOrientationEventLike = (alpha) => {
         const instance = new window.Event('deviceorientation');
         instance.alpha = alpha;
         return instance;
-    }
+    };
 
     t.notOk(geolocate._dotElement.classList.contains('mapboxgl-user-location-show-heading'), 'userLocation should not have heading');
 
@@ -589,16 +590,16 @@ test('GeolocateControl watching device orientation event', (t) => {
         t.ok(geolocate._userLocationDotMarker._map, 'userLocation dot marker on map');
         t.notOk(geolocate._userLocationDotMarker._element.classList.contains('mapboxgl-user-location-dot-stale'), 'userLocation does not have stale class');
         geolocate.once('trackuserlocationend', () => {
-            const event = DeviceOrientationEventLike(359)
+            const event = deviceOrientationEventLike(359);
             window.dispatchEvent(event);
             setImmediate(() => {
                 t.ok(geolocate._dotElement.classList.contains('mapboxgl-user-location-show-heading'), 'userLocation should have heading');
-                t.equal(geolocate._userLocationDotMarker._rotation, 359, 'userLocation rotation is not rotated by 359 degrees')
+                t.equal(geolocate._userLocationDotMarker._rotation, 359, 'userLocation rotation is not rotated by 359 degrees');
 
-                const event = DeviceOrientationEventLike(15)
+                const event = deviceOrientationEventLike(15);
                 window.dispatchEvent(event);
                 setImmediate(() => {
-                    t.equal(geolocate._userLocationDotMarker._rotation, 15, 'userLocation rotation is not rotated by 15 degrees')
+                    t.equal(geolocate._userLocationDotMarker._rotation, 15, 'userLocation rotation is not rotated by 15 degrees');
                     t.end();
                 });
             });

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -576,6 +576,7 @@ test('GeolocateControl watching device orientation event', (t) => {
     const deviceOrientationEventLike = (alpha) => {
         const instance = new window.Event('deviceorientation');
         instance.alpha = alpha;
+        instance.absolute = true;
         return instance;
     };
 

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -590,13 +590,13 @@ test('GeolocateControl watching device orientation event', (t) => {
         t.ok(geolocate._userLocationDotMarker._map, 'userLocation dot marker on map');
         t.notOk(geolocate._userLocationDotMarker._element.classList.contains('mapboxgl-user-location-dot-stale'), 'userLocation does not have stale class');
         geolocate.once('trackuserlocationend', () => {
-            const event = deviceOrientationEventLike(359);
+            const event = deviceOrientationEventLike(-359);
             window.dispatchEvent(event);
             setImmediate(() => {
                 t.ok(geolocate._dotElement.classList.contains('mapboxgl-user-location-show-heading'), 'userLocation should have heading');
                 t.equal(geolocate._userLocationDotMarker._rotation, 359, 'userLocation rotation is not rotated by 359 degrees');
 
-                const event = deviceOrientationEventLike(15);
+                const event = deviceOrientationEventLike(-15);
                 window.dispatchEvent(event);
                 setImmediate(() => {
                     t.equal(geolocate._userLocationDotMarker._rotation, 15, 'userLocation rotation is not rotated by 15 degrees');

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -288,6 +288,59 @@ test('GeolocateControl watching map updates recenter on location with dot', (t) 
     geolocation.send({latitude: 10, longitude: 20, accuracy: 30});
 });
 
+test('GeolocateControl watching device orientation event', (t) => {
+    t.plan(6);
+
+    const map = createMap(t);
+    const geolocate = new GeolocateControl({
+        fitBoundsOptions: {
+            linear: true,
+            duration: 0
+        },
+        showUserHeading: true,
+        showUserLocation: true,
+        trackUserLocation: true,
+    });
+    map.addControl(geolocate);
+
+    const click = new window.Event('click');
+
+    let moveendCount = 0;
+    map.once('moveend', () => {
+        // moveend was being called a second time, this ensures that we don't run the tests a second time
+        if (moveendCount > 0) return;
+        moveendCount++;
+
+        t.deepEqual(lngLatAsFixed(map.getCenter(), 4), {lat: 10, lng: 20}, 'map centered on location after 1st update');
+        t.ok(geolocate._userLocationDotMarker._map, 'userLocation dot marker on map');
+        t.false(geolocate._userLocationDotMarker._element.classList.contains('mapboxgl-user-location-dot-stale'), 'userLocation does not have stale class');
+        map.once('moveend', () => {
+            t.deepEqual(lngLatAsFixed(map.getCenter(), 4), {lat: 40, lng: 50}, 'map centered on location after 2nd update');
+            geolocate.once('error', () => {
+                t.ok(geolocate._userLocationDotMarker._map, 'userLocation dot  marker on map');
+                t.ok(geolocate._userLocationDotMarker._element.classList.contains('mapboxgl-user-location-dot-stale'), 'userLocation has stale class');
+                // t.end();
+            });
+            geolocation.changeError({code: 2, message: 'position unavailable'});
+
+            window.dispatchEvent(new window.Event('deviceorientation', {
+                absolute: false,
+                alpha: 1,
+                beta: 0,
+                gamma: 0,
+            }));
+
+            geolocate.on('trackuserlocationend', () => {
+                console.log('trackuserlocationend');
+                t.end();
+            });
+        });
+        geolocation.change({latitude: 40, longitude: 50, accuracy: 60});
+    });
+    geolocate._geolocateButton.dispatchEvent(click);
+    geolocation.send({latitude: 10, longitude: 20, accuracy: 30});
+});
+
 test('GeolocateControl watching map background event', (t) => {
     const map = createMap(t);
     t.plan(0);

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -557,7 +557,7 @@ test('GeolocateControl shown even if trackUserLocation = false', (t) => {
 });
 
 test('GeolocateControl watching device orientation event', (t) => {
-    t.plan(7);
+    t.plan(8);
     const map = createMap(t);
     const geolocate = new GeolocateControl({
         fitBoundsOptions: {
@@ -581,6 +581,8 @@ test('GeolocateControl watching device orientation event', (t) => {
 
     t.notOk(geolocate._dotElement.classList.contains('mapboxgl-user-location-show-heading'), 'userLocation should not have heading');
 
+    const eventListenerSpy = t.spy(window, 'addEventListener')
+
     let moveendCount = 0;
     map.once('moveend', () => {
         // moveend was being called a second time, this ensures that we don't run the tests a second time
@@ -590,6 +592,8 @@ test('GeolocateControl watching device orientation event', (t) => {
         t.ok(geolocate._userLocationDotMarker._map, 'userLocation dot marker on map');
         t.notOk(geolocate._userLocationDotMarker._element.classList.contains('mapboxgl-user-location-dot-stale'), 'userLocation does not have stale class');
         geolocate.once('trackuserlocationend', () => {
+            t.equal(eventListenerSpy.getCall(0).args[0], 'deviceorientation');
+
             const event = deviceOrientationEventLike(-359);
             window.dispatchEvent(event);
             setImmediate(() => {

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -581,7 +581,7 @@ test('GeolocateControl watching device orientation event', (t) => {
 
     t.notOk(geolocate._dotElement.classList.contains('mapboxgl-user-location-show-heading'), 'userLocation should not have heading');
 
-    const eventListenerSpy = t.spy(window, 'addEventListener')
+    const eventListenerSpy = t.spy(window, 'addEventListener');
 
     let moveendCount = 0;
     map.once('moveend', () => {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Fixes https://github.com/mapbox/mapbox-gl-js/issues/8329 https://github.com/mapbox/mapbox-gl-js/issues/8034

 - [x] briefly describe the changes in this PR

This PR adds a heading to the current location if the data is available via Geolocate.


https://user-images.githubusercontent.com/6927131/124303846-e4ce3600-db9d-11eb-89a0-4b3b4c153de5.mov



**include before/after visuals or gifs if this PR includes visual changes**

| Before | After |
|--|--|
| <img width="1269" alt="Screen Shot 2021-07-03 at 1 28 56" src="https://user-images.githubusercontent.com/6927131/124304065-2ced5880-db9e-11eb-8bea-ced778b5aa01.png"> |  <img width="1296" alt="Screen Shot 2021-07-03 at 1 29 21" src="https://user-images.githubusercontent.com/6927131/124304077-2fe84900-db9e-11eb-843f-a2bc450843f2.png"> |


**Which browser is this compatible with?**

This event listener is compatible with all modern browsers. I was only able to test in Chrome's simulated mode, so I cannot guarantee this would work in other browsers (TODO create a debug page that can simulate these events)

https://developer.mozilla.org/en-US/docs/Web/API/Window/deviceorientation_event

**Does this support landscape?**

This supports portrait mode only, and that is because there is no way to confidently know that the device is in landscape mode. If there are good solutions to this, I am open to including it in this or subsequent PRs.


**What to include in the changelog**

I was not sure where to add as the changelog seems to be generated at releases, but I'd like to add this to the changelog.

```
Add user location tracking capability to `GeolocateControl` #4479, 
  * New option `showUserHeading` to draw a "hat" around the `Marker` "dot" on the map at the user's location
```

 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs -> Should I update the changelog now?
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`

cc: @mapbox/map-design-team @mapbox/static-apis