### PR TITLE
Fix linter docs warnings

### DIFF
--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -41,7 +41,7 @@ export class Elevation {
      * Altitude above sea level in meters at specified point.
      * @param {MercatorCoordinate} point Mercator coordinate of the point.
      * @param {number} defaultIfNotLoaded Value that is returned if the dem tile of the provided point is not loaded
-     * @param {boolean} `true` if styling exaggeration should be applied to the resulting elevation.
+     * @param {boolean} exaggerated `true` if styling exaggeration should be applied to the resulting elevation.
      * @returns {number} Altitude in meters.
      * If there is no loaded tile that carries information for the requested
      * point elevation, returns `defaultIfNotLoaded`.

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -30,7 +30,7 @@ export class Elevation {
     /**
      * Helper around `getAtPoint` that guarantees that a numeric value is returned.
      * @param {MercatorCoordinate} point Mercator coordinate of the point.
-     * @param {number} defaultIfNotLoaded Value that is returned if the dem tile of the provided point is not loaded
+     * @param {number} defaultIfNotLoaded Value that is returned if the dem tile of the provided point is not loaded.
      * @returns {number} Altitude in meters.
      */
     getAtPointOrZero(point: MercatorCoordinate, defaultIfNotLoaded: number = 0): number {

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -29,8 +29,9 @@ export type ElevationQueryOptions = {
 export class Elevation {
     /**
      * Helper around `getAtPoint` that guarantees that a numeric value is returned.
-     * @param point
-     * @param defaultIfNotLoaded
+     * @param {MercatorCoordinate} point Mercator coordinate of the point.
+     * @param {number} defaultIfNotLoaded Value that is returned if the dem tile of the provided point is not loaded
+     * @returns {number} Altitude in meters.
      */
     getAtPointOrZero(point: MercatorCoordinate, defaultIfNotLoaded: number = 0): number {
         return this.getAtPoint(point, defaultIfNotLoaded) || 0;
@@ -40,7 +41,7 @@ export class Elevation {
      * Altitude above sea level in meters at specified point.
      * @param {MercatorCoordinate} point Mercator coordinate of the point.
      * @param {number} defaultIfNotLoaded Value that is returned if the dem tile of the provided point is not loaded
-     * @param exaggerated
+     * @param exaggerated Whether to apply the styling exaggeration to the resulting elevation
      * @returns {number} Altitude in meters.
      * If there is no loaded tile that carries information for the requested
      * point elevation, returns `defaultIfNotLoaded`.

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -41,7 +41,7 @@ export class Elevation {
      * Altitude above sea level in meters at specified point.
      * @param {MercatorCoordinate} point Mercator coordinate of the point.
      * @param {number} defaultIfNotLoaded Value that is returned if the dem tile of the provided point is not loaded
-     * @param exaggerated Whether to apply the styling exaggeration to the resulting elevation
+     * @param {boolean} `true` if styling exaggeration should be applied to the resulting elevation.
      * @returns {number} Altitude in meters.
      * If there is no loaded tile that carries information for the requested
      * point elevation, returns `defaultIfNotLoaded`.

--- a/src/ui/handler/shim/touch_zoom_rotate.js
+++ b/src/ui/handler/shim/touch_zoom_rotate.js
@@ -77,7 +77,7 @@ export default class TouchZoomRotateHandler {
     /**
      * Returns true if the handler is enabled and has detected the start of a zoom/rotate gesture.
      *
-     * @returns {boolean}
+     * @returns {boolean} `true` if enabled a zoom/rotate gesture was detected.
      */
     isActive() {
         return this._touchZoom.isActive() || this._touchRotate.isActive() || this._tapDragZoom.isActive();

--- a/src/ui/handler/shim/touch_zoom_rotate.js
+++ b/src/ui/handler/shim/touch_zoom_rotate.js
@@ -77,7 +77,7 @@ export default class TouchZoomRotateHandler {
     /**
      * Returns true if the handler is enabled and has detected the start of a zoom/rotate gesture.
      *
-     * @returns {boolean} `true` if enabled a zoom/rotate gesture was detected.
+     * @returns {boolean} `true` if enabled and a zoom/rotate gesture was detected.
      */
     isActive() {
         return this._touchZoom.isActive() || this._touchRotate.isActive() || this._tapDragZoom.isActive();

--- a/src/ui/handler/touch_zoom_rotate.js
+++ b/src/ui/handler/touch_zoom_rotate.js
@@ -265,42 +265,4 @@ export class TouchPitchHandler extends TwoTouchHandler {
         const isSameDirection = vectorA.y > 0 === vectorB.y > 0;
         return isVertical(vectorA) && isVertical(vectorB) && isSameDirection;
     }
-
-    /**
-     * Returns a Boolean indicating whether the "drag to pitch" interaction is enabled.
-     *
-     * @memberof TouchPitchHandler
-     * @name isEnabled
-     * @instance
-     * @returns {boolean} `true` if the "drag to pitch" interaction is enabled.
-     */
-
-    /**
-     * Returns a Boolean indicating whether the "drag to pitch" interaction is active, i.e. currently being used.
-     *
-     * @memberof TouchPitchHandler
-     * @name isActive
-     * @instance
-     * @returns {boolean} `true` if the "drag to pitch" interaction is active.
-     */
-
-    /**
-     * Enables the "drag to pitch" interaction.
-     *
-     * @memberof TouchPitchHandler
-     * @name enable
-     * @instance
-     * @example
-     * map.touchPitch.enable();
-     */
-
-    /**
-     * Disables the "drag to pitch" interaction.
-     *
-     * @memberof TouchPitchHandler
-     * @name disable
-     * @instance
-     * @example
-     * map.touchPitch.disable();
-     */
 }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1971,13 +1971,13 @@ class Map extends Camera {
         return this._update(true);
     }
 
-    // eslint-disable-next-line jsdoc/require-returns
     /**
      * Removes the layer with the given ID from the map's style.
      *
      * If no such layer exists, an `error` event is fired.
      *
      * @param {string} id id of the layer to remove
+     * @returns {Map} `this`
      * @fires error
      *
      * @example

--- a/src/util/eased_variable.js
+++ b/src/util/eased_variable.js
@@ -22,7 +22,7 @@ class EasedVariable {
      *
      * @param timeStamp {number} time at which to evaluate
      *
-     * @return {number} evaluated value
+     * @returns {number} evaluated value
      */
     getValue(timeStamp: number): number {
         if (timeStamp <= this._startTime) return this._start;


### PR DESCRIPTION
- Allow to run the linter without warning, housekeeping step prior to introducing more docs changes during this sprint
- Add a few missing `@returns` tags from both internal and public facing docs
- Cleanup some obsolete and leftover docs not associated to any code