### PR TITLE
document `features` for `MapMouseEvent` and `MapTouchEvent`

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -79,15 +79,15 @@ export class MapMouseEvent extends Event {
      *
      * @example
      * // logging features for a specific layer (with `e.features`)
-     * map.on('click', 'myLayerId', function(e) {
-     *     console.log('There are', e.features.length, 'features at point', e.point');
+     * map.on('click', 'myLayerId', (e) => {
+     *     console.log(`There are ${e.features.length} features at point ${e.point}`);
      * });
      *
      * @example
      * // logging all features for all layers (without `e.features`)
-     * map.on('click', function(e) {
+     * map.on('click', (e) => {
      *     var features = map.queryRenderedFeatures(e.point);
-     *     console.log('There are', features.length, 'features at point', e.point');
+     *     console.log(`There are ${e.features.length} features at point ${e.point}`);
      * });
      */
     features: Array<Object> | void;

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -69,6 +69,30 @@ export class MapMouseEvent extends Event {
     lngLat: LngLat;
 
     /**
+     * If a `layerId` was specified when adding the event listener with {@link Map#on}, `features` will be an array of
+     * [GeoJSON](http://geojson.org/) [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
+     * The array will contain all features from that layer that are rendered at the event's point.
+     * The `features` are identical to those returned by {@link Map#queryRenderedFeatures}.
+     *
+     * If no `layerId` was specified when adding the event listener, `features` will be `undefined`.
+     * You can get the features at the point with `map.queryRenderedFeatures(e.point)`.
+     *
+     * @example
+     * // logging features for a specific layer (with `e.features`)
+     * map.on('click', 'myLayerId', function(e) {
+     *     console.log('There are', e.features.length, 'features at point', e.point');
+     * });
+     *
+     * @example
+     * // logging all features for all layers (without `e.features`)
+     * map.on('click', function(e) {
+     *     var features = map.queryRenderedFeatures(e.point);
+     *     console.log('There are', features.length, 'features at point', e.point');
+     * });
+     */
+    features: Array<Object> | void;
+
+    /**
      * Prevents subsequent default processing of the event by the map.
      *
      * Calling this method will prevent the following default map behaviors:
@@ -181,6 +205,30 @@ export class MapTouchEvent extends Event {
      * [touch event's `touches`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches) property.
      */
     lngLats: Array<LngLat>;
+
+    /**
+     * If a `layerId` was specified when adding the event listener with {@link Map#on}, `features` will be an array of
+     * [GeoJSON](http://geojson.org/) [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
+     * The array will contain all features from that layer that are rendered at the event's point.
+     * The `features` are identical to those returned by {@link Map#queryRenderedFeatures}.
+     *
+     * If no `layerId` was specified when adding the event listener, `features` will be `undefined`.
+     * You can get the features at the point with `map.queryRenderedFeatures(e.point)`.
+     *
+     * @example
+     * // logging features for a specific layer (with `e.features`)
+     * map.on('touchstart', 'myLayerId', function(e) {
+     *     console.log('There are', e.features.length, 'features at point', e.point');
+     * });
+     *
+     * @example
+     * // logging all features for all layers (without `e.features`)
+     * map.on('touchstart', function(e) {
+     *     var features = map.queryRenderedFeatures(e.point);
+     *     console.log('There are', features.length, 'features at point', e.point');
+     * });
+     */
+    features: Array<Object> | void;
 
     /**
      * Prevents subsequent default processing of the event by the map.


### PR DESCRIPTION
`features` has been an undocumented property of `MapMouseEvent` and `MapTouchEvent`. This documents it.

 It is only set when `layerId` is specified for the listener. I'm not sure that having this property is ideal, but I don't think we can remove it at this point. It has existed for long enough (and has been used in docs examples) that we can't remove it without breaking things. I think the underlying logic for this property was: we need to query features internally when `layerId` is set to know if the event occurs on that layer so we might as well give them to the user. 

We could always set `features` but I don't think we should do this because of the performance cost.

![Screen Shot 2021-07-07 at 11 28 24 AM](https://user-images.githubusercontent.com/1421652/124787417-79c28d80-df16-11eb-8986-e6bac78d8174.png)
