### PR TITLE
Add custom JSDoc linter rule to enforce style convention

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,8 @@
   "plugins": [
     "flowtype",
     "import",
-    "jsdoc"
+    "jsdoc",
+    "jsdoc-custom"
   ],
   "rules": {
     // no-duplicate-imports doesn't play well with Flow
@@ -86,7 +87,8 @@
     "jsdoc/require-param-description": "warn",
     "jsdoc/require-param-name": "warn",
     "jsdoc/require-returns": "warn",
-    "jsdoc/require-returns-description": "warn"
+    "jsdoc/require-returns-description": "warn",
+    "jsdoc-custom/format-mapbox-gl-js": "warn"
   },
   "settings": {
     "jsdoc":{
@@ -104,6 +106,12 @@
         "jsdoc/require-param-name": "off",
         "jsdoc/require-returns": "off",
         "jsdoc/require-returns-description": "off"
+      }
+    },
+    {
+      "files": ["test/lint/**"],
+      "rules": {
+        "import/no-commonjs": "off"
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.0.0",
+    "eslint-plugin-jsdoc-custom": "file:./test/lint",
     "flow-bin": "^0.100.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",

--- a/src/index.js
+++ b/src/index.js
@@ -64,9 +64,9 @@ const exported = {
      * `mapboxgl.clearPrewarmedResources()`. This is only necessary if your web page remains
      * active but stops using maps altogether.
      *
-     * This is primarily useful when using GL-JS maps in a single page app, wherein a user
-     * would navigate between various views that can cause Map instances to constantly be
-     * created and destroyed.
+     * This is primarily useful when using Mapbox GL JS maps in a single page app, wherein
+     * a user would navigate between various views that can cause Map instances to constantly
+     * be created and destroyed.
      *
      * @function prewarm
      * @example
@@ -119,7 +119,7 @@ const exported = {
     },
 
     /**
-     * Gets and sets the number of web workers instantiated on a page with GL JS maps.
+     * Gets and sets the number of web workers instantiated on a page with Mapbox GL JS maps.
      * By default, it is set to 2.
      * Make sure to set this property before creating any map instances for it to have effect.
      *
@@ -193,7 +193,7 @@ const exported = {
     workerClass: null,
 
     /**
-     * Sets the time used by GL JS internally for all animations. Useful for generating videos from GL JS.
+     * Sets the time used by Mapbox GL JS internally for all animations. Useful for generating videos from Mapbox GL JS.
      * @var {number} time
      */
     setNow: browser.setNow,

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -1203,7 +1203,7 @@ export type MapEvent =
     | 'remove'
 
     /**
-     * Fired when an error occurs. This is GL JS's primary error reporting
+     * Fired when an error occurs. This is Mapbox GL JS's primary error reporting
      * mechanism. We use an event instead of `throw` to better accommodate
      * asyncronous operations. If no listeners are bound to the `error` event, the
      * error will be printed to the console.

--- a/test/lint/index.js
+++ b/test/lint/index.js
@@ -1,0 +1,15 @@
+const formatMapboxGLJS = require('./rules/format-mapbox-gl-js.js');
+
+module.exports = {
+    configs: {
+        recommended: {
+            plugins: ['jsdoc-custom'],
+            rules: {
+                'jsdoc-custom/require-defaults': 'warn'
+            },
+        },
+    },
+    rules: {
+        'format-mapbox-gl-js': formatMapboxGLJS
+    },
+};

--- a/test/lint/package.json
+++ b/test/lint/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "eslint-plugin-jsdoc-custom",
+  "version": "1.0.0",
+  "description": "Custom JSDoc rules for Mapbox GL JS",
+  "main": "index.js"
+}

--- a/test/lint/rules/format-mapbox-gl-js.js
+++ b/test/lint/rules/format-mapbox-gl-js.js
@@ -1,0 +1,46 @@
+const iterateJsdoc = require('eslint-plugin-jsdoc/dist/iterateJsdoc.js').default;
+const iterateDescriptiveTags = require('../util/iterate-descriptive-tags.js');
+const lineNumberByIndex = require('../util/line-number-by-index');
+
+const FORBIDDEN_GL_JS_REGEX = /(GL-JS|[^x][\s\r\g]+GL JS)/g;
+
+function createDescriptionValidator(utils) {
+    return function ({description, tag}) {
+        if (!description) return;
+
+        const text = description.description;
+        const joinedText = text.split(/\n/).map(x => x.trim()).join(' ');
+
+        const forbiddenMatchIndex = joinedText.search(FORBIDDEN_GL_JS_REGEX);
+        if (forbiddenMatchIndex !== -1) {
+            const tagline = tag && tag.source ? tag.source[0].number : 0;
+            const line = tagline + lineNumberByIndex(text, forbiddenMatchIndex);
+
+            utils.reportJSDoc(`"Mapbox GL JS" should not be hyphenated or omit "Mapbox".`, {line});
+        }
+    };
+}
+
+module.exports = iterateJsdoc(({jsdoc, utils}) => {
+    const validator = createDescriptionValidator(utils);
+
+    iterateDescriptiveTags(utils, jsdoc, validator);
+}, {
+    contextDefaults: true,
+    iterateAllJsdocs: true,
+    meta: {
+        docs: {
+            description: 'This rule enforces consistent usage of the name "Mapbox GL JS" to refer to the project.',
+        },
+        fixable: 'code',
+        schema: [
+            {
+                additionalProperties: false,
+                properties: {
+                },
+                type: 'object',
+            },
+        ],
+        type: 'suggestion',
+    },
+});

--- a/test/lint/util/iterate-descriptive-tags.js
+++ b/test/lint/util/iterate-descriptive-tags.js
@@ -1,0 +1,29 @@
+const descriptiveTags = new Set([
+    'summary', 'file', 'fileoverview', 'overview', 'classdesc', 'todo',
+    'deprecated', 'throws', 'exception', 'yields', 'yield', 'param', 'returns'
+]);
+
+module.exports = function iterateDescriptiveTags(utils, jsdoc, callback) {
+    callback({
+        description: utils.getDescription(),
+        tag: {line: jsdoc.source[0].number + 1}
+    });
+
+    const {tagsWithNames} = utils.getTagsByType(jsdoc.tags);
+    const tagsWithoutNames = utils.filterTags(({tag: tagName}) => {
+        return descriptiveTags.has(tagName) ||
+            utils.hasOptionTag(tagName) && !tagsWithNames.some(({tag}) => tag === tagName);
+    });
+
+    tagsWithNames.forEach((tag) => {
+        const description = utils.getDescription(tag);
+        callback({description, tag});
+
+        callback({description: tag, tag});
+    });
+
+    tagsWithoutNames.forEach((tag) => {
+        const description = utils.getDescription(tag);
+        callback({description, tag});
+    });
+};

--- a/test/lint/util/line-number-by-index.js
+++ b/test/lint/util/line-number-by-index.js
@@ -1,0 +1,17 @@
+/**
+ * Return the line number in a string by character position.
+ * @param {string} str string of text analyzed.
+ * @param {number} index offset relative to start of string.
+ * @returns {number} line number at offset
+ * @private
+ */
+module.exports = function lineNumberByIndex(string, index) {
+    let match;
+    let line = 0;
+    const re = /(^)[\S\s]/gm;
+    while ((match = re.exec(string))) {
+        if (match.index > index) break;
+        line++;
+    }
+    return line;
+};


### PR DESCRIPTION
I started correcting some JSDoc annotations in https://github.com/mapbox/mapbox-gl-js/pull/10823 but felt that the underlying problem is that consistency is not actually enforced, so that manually fixing the annotations, though good, paves the way to repeat the same actions again in the future.

[eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc#readme) rules are used in Mapbox GL JS but aren't specific to the needs of this project in particular.

So I gave a shot at writing a rule to enforce referring to the project as "Mapbox GL JS" rather than "GL JS", "GL-JS", or "Mapbox GL-JS". The main problem at the moment is that it's a bit challenging to iterate over all nodes once, without any duplicates, and with correct line numbers. It doesn't return false positives currently, but it does duplicate some warnings. For example, src/index.js:128 shows up twice, and src/ui/events.js:1215 is spurious but goes away when you fix line 1206:

```
mapbox-gl-js/src/index.js
   67:0  warning  "Mapbox GL JS" should not be hyphenated or omit "Mapbox"  jsdoc-custom/format-mapbox-gl-js
  122:0  warning  "Mapbox GL JS" should not be hyphenated or omit "Mapbox"  jsdoc-custom/format-mapbox-gl-js
  128:0  warning  "Mapbox GL JS" should not be hyphenated or omit "Mapbox"  jsdoc-custom/format-mapbox-gl-js
  128:0  warning  "Mapbox GL JS" should not be hyphenated or omit "Mapbox"  jsdoc-custom/format-mapbox-gl-js
  196:0  warning  "Mapbox GL JS" should not be hyphenated or omit "Mapbox"  jsdoc-custom/format-mapbox-gl-js

mapbox-gl-js/src/ui/events.js
  1206:0  warning  "Mapbox GL JS" should not be hyphenated or omit "Mapbox"  jsdoc-custom/format-mapbox-gl-js
  1215:0  warning  "Mapbox GL JS" should not be hyphenated or omit "Mapbox"  jsdoc-custom/format-mapbox-gl-js
```

(Strings which trigger this are "Mapbox GL-JS" and "GL JS" without Mapbox.)

To expand on the problem, if you try to iterate over the minimal set of nodes just once, you tend to miss annotations. If you try to catch everything, you tend to iterate over the same node twice. I've opted at the moment to fall on the side of duplicates rather than false negatives.

cc @mapbox/docs @domlet 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
