### PR TITLE
Forbid param optional prefix in jsdoc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,8 @@
   "plugins": [
     "flowtype",
     "import",
-    "jsdoc"
+    "jsdoc",
+    "jsdoc-custom"
   ],
   "rules": {
     // no-duplicate-imports doesn't play well with Flow
@@ -86,7 +87,8 @@
     "jsdoc/require-param-description": "warn",
     "jsdoc/require-param-name": "warn",
     "jsdoc/require-returns": "warn",
-    "jsdoc/require-returns-description": "warn"
+    "jsdoc/require-returns-description": "warn",
+    "jsdoc-custom/no-param-optional-prefix": "warn"
   },
   "settings": {
     "jsdoc":{
@@ -104,6 +106,12 @@
         "jsdoc/require-param-name": "off",
         "jsdoc/require-returns": "off",
         "jsdoc/require-returns-description": "off"
+      }
+    },
+    {
+      "files": ["test/lint/**"],
+      "rules": {
+        "import/no-commonjs": "off"
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "start-release": "run-s build-token build-prod-min build-css print-release-url start-server",
     "diff-tarball": "build/run-node build/diff-tarball && echo \"Please confirm the above is correct [y/n]? \"; read answer; if [ \"$answer\" = \"${answer#[Yy]}\" ]; then false; fi",
     "prepare-publish": "git clean -fdx && yarn install",
-    "lint": "eslint --cache --ignore-path .gitignore src test bench debug/*.html",
+    "lint": "eslint --ignore-path .gitignore src test bench debug/*.html",
     "lint-docs": "documentation lint src/index.js",
     "lint-css": "stylelint 'src/css/mapbox-gl.css'",
     "test": "run-s lint lint-css lint-docs test-flow test-unit",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.0.0",
+    "eslint-plugin-jsdoc-custom": "file:./test/lint",
     "flow-bin": "^0.100.0",
     "gl": "^4.9.0",
     "glob": "^7.1.6",

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1061,12 +1061,7 @@ class Map extends Camera {
      * | [`sourcedataloading`](#map.event:sourcedataloading)       |                           |
      * | [`styleimagemissing`](#map.event:styleimagemissing)       |                           |
      *
-     * @param {string} [layerId] The ID of a style layer. If you provide a `layerId`,
-the listener will be triggered only if its location is within a visible feature in this layer,
-and the event will have a `features` property containing an array of the matching features.
-If you do not provide a `layerId`, the listener will be triggered by a corresponding event
-happening anywhere on the map, and the event will not have a `features` property.
-Note that many event types are not compatible with the optional `layerId` parameter.
+     * @param {string} layerId (optional) The ID of a style layer. If you provide a `layerId`,
      * the listener will be triggered only if its location is within a visible feature in this layer,
      * and the event will have a `features` property containing an array of the matching features.
      * If you do not provide a `layerId`, the listener will be triggered by a corresponding event
@@ -1138,12 +1133,7 @@ Note that many event types are not compatible with the optional `layerId` parame
      * a visible portion of the specified layer from outside that layer or outside the map canvas. `mouseleave`
      * and `mouseout` events are triggered when the cursor leaves a visible portion of the specified layer, or leaves
      * the map canvas.
-     * @param {string} [layerId] The ID of a style layer. If you provide a `layerId`,
-the listener will be triggered only if its location is within a visible feature in this layer,
-and the event will have a `features` property containing an array of the matching features.
-If you do not provide a `layerId`, the listener will be triggered by a corresponding event
-happening anywhere on the map, and the event will not have a `features` property.
-Note that many event types are not compatible with the optional `layerId` parameter.
+     * @param {string} layerId (optional) The ID of a style layer. If you provide a `layerId`,
      * the listener will be triggered only if its location is within a visible feature in this layer,
      * and the event will have a `features` property containing an array of the matching features.
      * If you do not provide a `layerId`, the listener will be triggered by a corresponding event
@@ -1186,7 +1176,7 @@ Note that many event types are not compatible with the optional `layerId` parame
      * optionally limited to layer-specific events.
      *
      * @param {string} type The event type previously used to install the listener.
-     * @param {string} [layerId] The layer ID previously used to install the listener.
+     * @param {string} layerId (optional) The layer ID previously used to install the listener.
      * @param {Function} listener The function previously installed as a listener.
      * @returns {Map} `this`
      * @example
@@ -1869,47 +1859,30 @@ Note that many event types are not compatible with the optional `layerId` parame
      * Reference a source that has _already been defined_ using the source's unique id.
      * Reference a _new source_ using a source object (as defined in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)) directly.
      * This is **required** for all `layer.type` options _except_ for `custom` and `background`.
-     * @param {string} layer.sourceLayer The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
-This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.
+     * @param {string} [layer.sourceLayer] (optional) The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
      * This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.
-     * @param {array} layer.filter An expression specifying conditions on source features.
-Only features that match the filter are displayed.
-The Mapbox Style Specification includes more information on the limitations of the [`filter`](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter) parameter
-and a complete list of available [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).
-If no filter is provided, all features in the source (or source layer for vector tilesets) will be displayed.
+     * @param {array} [layer.filter] (optional) An expression specifying conditions on source features.
      * Only features that match the filter are displayed.
      * The Mapbox Style Specification includes more information on the limitations of the [`filter`](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter) parameter
      * and a complete list of available [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).
      * If no filter is provided, all features in the source (or source layer for vector tilesets) will be displayed.
-     * @param {Object} layer.paint Paint properties for the layer.
-Available paint properties vary by `layer.type`.
-A full list of paint properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
-If no paint properties are specified, default values will be used.
+     * @param {Object} [layer.paint] (optional) Paint properties for the layer.
      * Available paint properties vary by `layer.type`.
      * A full list of paint properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
      * If no paint properties are specified, default values will be used.
-     * @param {Object} layer.layout Layout properties for the layer.
-Available layout properties vary by `layer.type`.
-A full list of layout properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
-If no layout properties are specified, default values will be used.
+     * @param {Object} [layer.layout] (optional) Layout properties for the layer.
      * Available layout properties vary by `layer.type`.
      * A full list of layout properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
      * If no layout properties are specified, default values will be used.
-     * @param {number} layer.maxzoom The maximum zoom level for the layer.
-At zoom levels equal to or greater than the maxzoom, the layer will be hidden.
-The value can be any number between `0` and `24` (inclusive).
-If no maxzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
+     * @param {number} [layer.maxzoom] (optional) The maximum zoom level for the layer.
      * At zoom levels equal to or greater than the maxzoom, the layer will be hidden.
      * The value can be any number between `0` and `24` (inclusive).
      * If no maxzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
-     * @param {number} layer.minzoom The minimum zoom level for the layer.
-At zoom levels less than the minzoom, the layer will be hidden.
-The value can be any number between `0` and `24` (inclusive).
-If no minzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
+     * @param {number} [layer.minzoom] (optional) The minimum zoom level for the layer.
      * At zoom levels less than the minzoom, the layer will be hidden.
      * The value can be any number between `0` and `24` (inclusive).
      * If no minzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
-     * @param {Object} layer.metadata Arbitrary properties useful to track with the layer, but do not influence rendering.
+     * @param {Object} [layer.metadata] (optional) Arbitrary properties useful to track with the layer, but do not influence rendering.
      * @param {string} [layer.renderingMode] This is only applicable for layers with the type `custom`.
      * See {@link CustomLayerInterface} for more information.
      * @param {string} [beforeId] The ID of an existing layer to insert the new layer before,
@@ -2312,7 +2285,7 @@ If no minzoom is provided, the layer will be visible at all zoom levels for whic
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} feature.sourceLayer *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
      * @param {Object} state A set of key-value pairs. The values should be valid JSON types.
      * @returns {Map} The map object.
      * @example
@@ -2350,9 +2323,8 @@ If no minzoom is provided, the layer will be visible at all zoom levels for whic
      * Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} feature.sourceLayer *For vector tile sources, `sourceLayer` is required.*
-     * @param {string} [key] The key in the feature state to reset.
-
+     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} key (optional) The key in the feature state to reset.
      *
      * @example
      * // Reset the entire state object for all features
@@ -2402,8 +2374,7 @@ If no minzoom is provided, the layer will be visible at all zoom levels for whic
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} feature.sourceLayer *For vector tile sources, `sourceLayer` is required.*
-
+     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
      *
      * @returns {Object} The state of the feature: a set of key-value pairs that was assigned to the feature at runtime.
      *

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1061,7 +1061,12 @@ class Map extends Camera {
      * | [`sourcedataloading`](#map.event:sourcedataloading)       |                           |
      * | [`styleimagemissing`](#map.event:styleimagemissing)       |                           |
      *
-     * @param {string} layerId (optional) The ID of a style layer. If you provide a `layerId`,
+     * @param {string} [layerId] The ID of a style layer. If you provide a `layerId`,
+the listener will be triggered only if its location is within a visible feature in this layer,
+and the event will have a `features` property containing an array of the matching features.
+If you do not provide a `layerId`, the listener will be triggered by a corresponding event
+happening anywhere on the map, and the event will not have a `features` property.
+Note that many event types are not compatible with the optional `layerId` parameter.
      * the listener will be triggered only if its location is within a visible feature in this layer,
      * and the event will have a `features` property containing an array of the matching features.
      * If you do not provide a `layerId`, the listener will be triggered by a corresponding event
@@ -1133,7 +1138,12 @@ class Map extends Camera {
      * a visible portion of the specified layer from outside that layer or outside the map canvas. `mouseleave`
      * and `mouseout` events are triggered when the cursor leaves a visible portion of the specified layer, or leaves
      * the map canvas.
-     * @param {string} layerId (optional) The ID of a style layer. If you provide a `layerId`,
+     * @param {string} [layerId] The ID of a style layer. If you provide a `layerId`,
+the listener will be triggered only if its location is within a visible feature in this layer,
+and the event will have a `features` property containing an array of the matching features.
+If you do not provide a `layerId`, the listener will be triggered by a corresponding event
+happening anywhere on the map, and the event will not have a `features` property.
+Note that many event types are not compatible with the optional `layerId` parameter.
      * the listener will be triggered only if its location is within a visible feature in this layer,
      * and the event will have a `features` property containing an array of the matching features.
      * If you do not provide a `layerId`, the listener will be triggered by a corresponding event
@@ -1176,7 +1186,7 @@ class Map extends Camera {
      * optionally limited to layer-specific events.
      *
      * @param {string} type The event type previously used to install the listener.
-     * @param {string} layerId (optional) The layer ID previously used to install the listener.
+     * @param {string} [layerId] The layer ID previously used to install the listener.
      * @param {Function} listener The function previously installed as a listener.
      * @returns {Map} `this`
      * @example
@@ -1859,30 +1869,47 @@ class Map extends Camera {
      * Reference a source that has _already been defined_ using the source's unique id.
      * Reference a _new source_ using a source object (as defined in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)) directly.
      * This is **required** for all `layer.type` options _except_ for `custom` and `background`.
-     * @param {string} [layer.sourceLayer] (optional) The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
+     * @param {string} layer.sourceLayer The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
+This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.
      * This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.
-     * @param {array} [layer.filter] (optional) An expression specifying conditions on source features.
+     * @param {array} layer.filter An expression specifying conditions on source features.
+Only features that match the filter are displayed.
+The Mapbox Style Specification includes more information on the limitations of the [`filter`](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter) parameter
+and a complete list of available [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).
+If no filter is provided, all features in the source (or source layer for vector tilesets) will be displayed.
      * Only features that match the filter are displayed.
      * The Mapbox Style Specification includes more information on the limitations of the [`filter`](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter) parameter
      * and a complete list of available [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).
      * If no filter is provided, all features in the source (or source layer for vector tilesets) will be displayed.
-     * @param {Object} [layer.paint] (optional) Paint properties for the layer.
+     * @param {Object} layer.paint Paint properties for the layer.
+Available paint properties vary by `layer.type`.
+A full list of paint properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
+If no paint properties are specified, default values will be used.
      * Available paint properties vary by `layer.type`.
      * A full list of paint properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
      * If no paint properties are specified, default values will be used.
-     * @param {Object} [layer.layout] (optional) Layout properties for the layer.
+     * @param {Object} layer.layout Layout properties for the layer.
+Available layout properties vary by `layer.type`.
+A full list of layout properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
+If no layout properties are specified, default values will be used.
      * Available layout properties vary by `layer.type`.
      * A full list of layout properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
      * If no layout properties are specified, default values will be used.
-     * @param {number} [layer.maxzoom] (optional) The maximum zoom level for the layer.
+     * @param {number} layer.maxzoom The maximum zoom level for the layer.
+At zoom levels equal to or greater than the maxzoom, the layer will be hidden.
+The value can be any number between `0` and `24` (inclusive).
+If no maxzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
      * At zoom levels equal to or greater than the maxzoom, the layer will be hidden.
      * The value can be any number between `0` and `24` (inclusive).
      * If no maxzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
-     * @param {number} [layer.minzoom] (optional) The minimum zoom level for the layer.
+     * @param {number} layer.minzoom The minimum zoom level for the layer.
+At zoom levels less than the minzoom, the layer will be hidden.
+The value can be any number between `0` and `24` (inclusive).
+If no minzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
      * At zoom levels less than the minzoom, the layer will be hidden.
      * The value can be any number between `0` and `24` (inclusive).
      * If no minzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
-     * @param {Object} [layer.metadata] (optional) Arbitrary properties useful to track with the layer, but do not influence rendering.
+     * @param {Object} layer.metadata Arbitrary properties useful to track with the layer, but do not influence rendering.
      * @param {string} [layer.renderingMode] This is only applicable for layers with the type `custom`.
      * See {@link CustomLayerInterface} for more information.
      * @param {string} [beforeId] The ID of an existing layer to insert the new layer before,
@@ -2285,7 +2312,7 @@ class Map extends Camera {
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} feature.sourceLayer *For vector tile sources, `sourceLayer` is required.*
      * @param {Object} state A set of key-value pairs. The values should be valid JSON types.
      * @returns {Map} The map object.
      * @example
@@ -2323,8 +2350,9 @@ class Map extends Camera {
      * Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
-     * @param {string} key (optional) The key in the feature state to reset.
+     * @param {string} feature.sourceLayer *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} [key] The key in the feature state to reset.
+
      *
      * @example
      * // Reset the entire state object for all features
@@ -2374,7 +2402,8 @@ class Map extends Camera {
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} feature.sourceLayer *For vector tile sources, `sourceLayer` is required.*
+
      *
      * @returns {Object} The state of the feature: a set of key-value pairs that was assigned to the feature at runtime.
      *

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1061,7 +1061,7 @@ class Map extends Camera {
      * | [`sourcedataloading`](#map.event:sourcedataloading)       |                           |
      * | [`styleimagemissing`](#map.event:styleimagemissing)       |                           |
      *
-     * @param {string} layerId (optional) The ID of a style layer. If you provide a `layerId`,
+     * @param {string} [layerId] The ID of a style layer. If you provide a `layerId`,
      * the listener will be triggered only if its location is within a visible feature in this layer,
      * and the event will have a `features` property containing an array of the matching features.
      * If you do not provide a `layerId`, the listener will be triggered by a corresponding event
@@ -1133,7 +1133,7 @@ class Map extends Camera {
      * a visible portion of the specified layer from outside that layer or outside the map canvas. `mouseleave`
      * and `mouseout` events are triggered when the cursor leaves a visible portion of the specified layer, or leaves
      * the map canvas.
-     * @param {string} layerId (optional) The ID of a style layer. If you provide a `layerId`,
+     * @param {string} [layerId] The ID of a style layer. If you provide a `layerId`,
      * the listener will be triggered only if its location is within a visible feature in this layer,
      * and the event will have a `features` property containing an array of the matching features.
      * If you do not provide a `layerId`, the listener will be triggered by a corresponding event
@@ -1176,7 +1176,7 @@ class Map extends Camera {
      * optionally limited to layer-specific events.
      *
      * @param {string} type The event type previously used to install the listener.
-     * @param {string} layerId (optional) The layer ID previously used to install the listener.
+     * @param {string} [layerId] The layer ID previously used to install the listener.
      * @param {Function} listener The function previously installed as a listener.
      * @returns {Map} `this`
      * @example
@@ -1859,30 +1859,30 @@ class Map extends Camera {
      * Reference a source that has _already been defined_ using the source's unique id.
      * Reference a _new source_ using a source object (as defined in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)) directly.
      * This is **required** for all `layer.type` options _except_ for `custom` and `background`.
-     * @param {string} [layer.sourceLayer] (optional) The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
+     * @param {string} [layer.sourceLayer] The name of the [source layer](https://docs.mapbox.com/help/glossary/source-layer/) within the specified `layer.source` to use for this style layer.
      * This is only applicable for vector tile sources and is **required** when `layer.source` is of the type `vector`.
-     * @param {array} [layer.filter] (optional) An expression specifying conditions on source features.
+     * @param {array} [layer.filter] An expression specifying conditions on source features.
      * Only features that match the filter are displayed.
      * The Mapbox Style Specification includes more information on the limitations of the [`filter`](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter) parameter
      * and a complete list of available [expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).
      * If no filter is provided, all features in the source (or source layer for vector tilesets) will be displayed.
-     * @param {Object} [layer.paint] (optional) Paint properties for the layer.
+     * @param {Object} [layer.paint] Paint properties for the layer.
      * Available paint properties vary by `layer.type`.
      * A full list of paint properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
      * If no paint properties are specified, default values will be used.
-     * @param {Object} [layer.layout] (optional) Layout properties for the layer.
+     * @param {Object} [layer.layout] Layout properties for the layer.
      * Available layout properties vary by `layer.type`.
      * A full list of layout properties for each layer type is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/).
      * If no layout properties are specified, default values will be used.
-     * @param {number} [layer.maxzoom] (optional) The maximum zoom level for the layer.
+     * @param {number} [layer.maxzoom] The maximum zoom level for the layer.
      * At zoom levels equal to or greater than the maxzoom, the layer will be hidden.
      * The value can be any number between `0` and `24` (inclusive).
      * If no maxzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
-     * @param {number} [layer.minzoom] (optional) The minimum zoom level for the layer.
+     * @param {number} [layer.minzoom] The minimum zoom level for the layer.
      * At zoom levels less than the minzoom, the layer will be hidden.
      * The value can be any number between `0` and `24` (inclusive).
      * If no minzoom is provided, the layer will be visible at all zoom levels for which there are tiles available.
-     * @param {Object} [layer.metadata] (optional) Arbitrary properties useful to track with the layer, but do not influence rendering.
+     * @param {Object} [layer.metadata] Arbitrary properties useful to track with the layer, but do not influence rendering.
      * @param {string} [layer.renderingMode] This is only applicable for layers with the type `custom`.
      * See {@link CustomLayerInterface} for more information.
      * @param {string} [beforeId] The ID of an existing layer to insert the new layer before,
@@ -2285,7 +2285,7 @@ class Map extends Camera {
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} [feature.sourceLayer] *For vector tile sources, `sourceLayer` is required.*
      * @param {Object} state A set of key-value pairs. The values should be valid JSON types.
      * @returns {Map} The map object.
      * @example
@@ -2323,8 +2323,8 @@ class Map extends Camera {
      * Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
-     * @param {string} key (optional) The key in the feature state to reset.
+     * @param {string} [feature.sourceLayer] *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} [key] The key in the feature state to reset.
      *
      * @example
      * // Reset the entire state object for all features
@@ -2374,7 +2374,7 @@ class Map extends Camera {
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} [feature.sourceLayer] *For vector tile sources, `sourceLayer` is required.*
      *
      * @returns {Object} The state of the feature: a set of key-value pairs that was assigned to the feature at runtime.
      *

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -94,7 +94,8 @@ export class Evented {
      * The listener will be called first time the event fires after the listener is registered.
      *
      * @param {string} type The event type to listen for.
-     * @param {Function} listener (optional) The function to be called when the event is fired once.
+     * @param {Function} [listener] The function to be called when the event is fired once.
+  If not provided, returns a Promise that will be resolved when the event is fired once.
      *   If not provided, returns a Promise that will be resolved when the event is fired once.
      * @returns {Object} `this` | Promise
      */

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -94,7 +94,7 @@ export class Evented {
      * The listener will be called first time the event fires after the listener is registered.
      *
      * @param {string} type The event type to listen for.
-     * @param {Function} listener (optional) The function to be called when the event is fired once.
+     * @param {Function} [listener] The function to be called when the event is fired once.
      *   If not provided, returns a Promise that will be resolved when the event is fired once.
      * @returns {Object} `this` | Promise
      */

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -94,8 +94,7 @@ export class Evented {
      * The listener will be called first time the event fires after the listener is registered.
      *
      * @param {string} type The event type to listen for.
-     * @param {Function} [listener] The function to be called when the event is fired once.
-  If not provided, returns a Promise that will be resolved when the event is fired once.
+     * @param {Function} listener (optional) The function to be called when the event is fired once.
      *   If not provided, returns a Promise that will be resolved when the event is fired once.
      * @returns {Object} `this` | Promise
      */

--- a/test/lint/index.js
+++ b/test/lint/index.js
@@ -1,0 +1,15 @@
+const noParamOptionalPrefix = require('./rules/no-param-optional-prefix.js');
+
+module.exports = {
+    configs: {
+        recommended: {
+            plugins: ['jsdoc-custom'],
+            rules: {
+                'jsdoc-custom/no-param-optional-prefix': 'warn'
+            },
+        },
+    },
+    rules: {
+        'no-param-optional-prefix': noParamOptionalPrefix
+    },
+};

--- a/test/lint/package.json
+++ b/test/lint/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "eslint-plugin-jsdoc-custom",
+  "version": "1.0.0",
+  "description": "Custom JSDoc rules for Mapbox GL JS",
+  "main": "index.js"
+}

--- a/test/lint/rules/no-param-optional-prefix.js
+++ b/test/lint/rules/no-param-optional-prefix.js
@@ -1,0 +1,57 @@
+const iterateJsdoc = require('eslint-plugin-jsdoc/dist/iterateJsdoc.js').default;
+
+const OPTIONAL_PREFIX_REGEX = /^(\s*\(optional\)\s*)/;
+
+module.exports = iterateJsdoc(({
+    utils,
+}) => {
+    utils.forEachPreferredTag('param', (tag) => {
+        if (OPTIONAL_PREFIX_REGEX.test(tag.description)) {
+            utils.reportJSDoc(`"(optional)" prefix not permitted on @${tag.tag}.`, tag, () => {
+                utils.changeTag(tag, {
+                    name: tag.optional ? tag.name : `[${tag.name}]`,
+                    description: tag.description.replace(OPTIONAL_PREFIX_REGEX, ''),
+                });
+            });
+        }
+    });
+}, {
+    contextDefaults: true,
+    meta: {
+        docs: {
+            description: 'Forbids usage of "(optional)" in param descriptions in favor of square brackets around the param name.',
+        },
+        fixable: 'code',
+        schema: [
+            {
+                additionalProperties: false,
+                properties: {
+                    contexts: {
+                        items: {
+                            anyOf: [
+                                {
+                                    type: 'string',
+                                },
+                                {
+                                    additionalProperties: false,
+                                    properties: {
+                                        comment: {
+                                            type: 'string',
+                                        },
+                                        context: {
+                                            type: 'string',
+                                        },
+                                    },
+                                    type: 'object',
+                                },
+                            ],
+                        },
+                        type: 'array',
+                    },
+                },
+                type: 'object',
+            },
+        ],
+        type: 'suggestion',
+    },
+});

--- a/test/lint/rules/no-param-optional-prefix.js
+++ b/test/lint/rules/no-param-optional-prefix.js
@@ -1,18 +1,14 @@
 const iterateJsdoc = require('eslint-plugin-jsdoc/dist/iterateJsdoc.js').default;
 
-const OPTIONAL_PREFIX_REGEX = /^(\s*\(optional\)\s*)/;
+const OPTIONAL_PREFIX_REGEX = /^(\s*\(optional\)\s*)/g;
 
 module.exports = iterateJsdoc(({
     utils,
+    report,
 }) => {
     utils.forEachPreferredTag('param', (tag) => {
         if (OPTIONAL_PREFIX_REGEX.test(tag.description)) {
-            utils.reportJSDoc(`"(optional)" prefix not permitted on @${tag.tag}.`, tag, () => {
-                utils.changeTag(tag, {
-                    name: tag.optional ? tag.name : `[${tag.name}]`,
-                    description: tag.description.replace(OPTIONAL_PREFIX_REGEX, ''),
-                });
-            });
+            report(`use square brackets around @${tag.tag} name instead of "(optional)" in description`, null, tag);
         }
     });
 }, {
@@ -21,7 +17,6 @@ module.exports = iterateJsdoc(({
         docs: {
             description: 'Forbids usage of "(optional)" in param descriptions in favor of square brackets around the param name.',
         },
-        fixable: 'code',
         schema: [
             {
                 additionalProperties: false,


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
