### PR TITLE
Updates `geometry-type` description 

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3112,7 +3112,7 @@
         }
       },
       "geometry-type": {
-        "doc": "Gets the feature's geometry type: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`.",
+        "doc": "Gets the feature's geometry type: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`. `Multi*` feature types are only returned in GeoJSON sources. When working with vector tile sources, use the singular forms.",
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
fixes https://github.com/mapbox/mapbox-gl-js/issues/7699

This PR updates the wording for `geometry-type` in the style spec according to @samanpwbb's suggestions. @mapbox/gl-js, is there anything you'd like to add or change here?    