### PR TITLE
fix eslint errors for jsdoc examples

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -93,7 +93,8 @@
     "jsdoc/check-access": "warn",
     "jsdoc/check-alignment": "warn",
     "jsdoc/check-examples": ["error", {
-        "matchingFileName": "src/fake_filename_for_jsdoc_examples"
+        "matchingFileName": "src/fake_filename_for_jsdoc_examples",
+        "rejectExampleCodeRegex": "<script>"
     }],
     "jsdoc/check-indentation": "warn",
     "jsdoc/check-line-alignment": "warn",

--- a/.eslintrc
+++ b/.eslintrc
@@ -82,9 +82,35 @@
     "no-multiple-empty-lines": [ "error", {
         "max": 1
     }],
+    "jsdoc/check-param-names": "warn",
+    "jsdoc/require-param": "error",
+    "jsdoc/require-param-description": "error",
+    "jsdoc/require-param-name": "error",
+    "jsdoc/require-returns": "error",
+    "jsdoc/require-returns-description": "error",
+    "jsdoc/require-property": "warn",
+    "jsdoc/require-description-complete-sentence": "warn",
+    "jsdoc/check-access": "warn",
+    "jsdoc/check-alignment": "warn",
     "jsdoc/check-examples": ["error", {
         "matchingFileName": "src/fake_filename_for_jsdoc_examples"
-    }]
+    }],
+    "jsdoc/check-indentation": "warn",
+    "jsdoc/check-line-alignment": "warn",
+    "jsdoc/check-property-names": "warn",
+    "jsdoc/check-tag-names": "warn",
+    "jsdoc/check-types": "warn",
+    "jsdoc/newline-after-description": "warn",
+    "jsdoc/no-bad-blocks": "warn",
+    "jsdoc/require-description": "warn",
+    "jsdoc/require-example": "warn",
+    "jsdoc/require-param-type": "warn",
+    "jsdoc/require-property-description": "warn",
+    "jsdoc/require-property-name": "warn",
+    "jsdoc/require-property-type": "warn",
+    "jsdoc/require-returns-type": "warn",
+    "jsdoc/require-throws": "warn",
+    "jsdoc/valid-types": "warn"
   },
   "settings": {
     "jsdoc":{

--- a/.eslintrc
+++ b/.eslintrc
@@ -82,33 +82,9 @@
     "no-multiple-empty-lines": [ "error", {
         "max": 1
     }],
-    "jsdoc/check-param-names": "warn",
-    "jsdoc/require-param": "error",
-    "jsdoc/require-param-description": "error",
-    "jsdoc/require-param-name": "error",
-    "jsdoc/require-returns": "error",
-    "jsdoc/require-returns-description": "error",
-    "jsdoc/require-property": "warn",
-    "jsdoc/require-description-complete-sentence": "warn",
-    "jsdoc/check-access": "warn",
-    "jsdoc/check-alignment": "warn",
-    "jsdoc/check-examples": "warn",
-    "jsdoc/check-indentation": "warn",
-    "jsdoc/check-line-alignment": "warn",
-    "jsdoc/check-property-names": "warn",
-    "jsdoc/check-tag-names": "warn",
-    "jsdoc/check-types": "warn",
-    "jsdoc/newline-after-description": "warn",
-    "jsdoc/no-bad-blocks": "warn",
-    "jsdoc/require-description": "warn",
-    "jsdoc/require-example": "warn",
-    "jsdoc/require-param-type": "warn",
-    "jsdoc/require-property-description": "warn",
-    "jsdoc/require-property-name": "warn",
-    "jsdoc/require-property-type": "warn",
-    "jsdoc/require-returns-type": "warn",
-    "jsdoc/require-throws": "warn",
-    "jsdoc/valid-types": "warn"
+    "jsdoc/check-examples": ["error", {
+        "matchingFileName": "src/fake_filename_for_jsdoc_examples"
+    }]
   },
   "settings": {
     "jsdoc":{
@@ -116,6 +92,15 @@
     }
   },
   "overrides": [
+    {
+      "files": ["src/fake_filename_for_jsdoc_examples"],
+      "rules": {
+        "flowtype/require-valid-file-annotation": "off"
+      },
+      "globals": {
+        "map": true
+      }
+    },
     {
       "files": ["debug/**", "bench/**", "test/**", "src/style-spec/**"],
       "rules": {

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -24,8 +24,8 @@ export const earthRadius = 6371008.8;
  * @param {number} lng Longitude, measured in degrees.
  * @param {number} lat Latitude, measured in degrees.
  * @example
- * var ll = new mapboxgl.LngLat(-123.9749, 40.7736);
- * ll.lng; // = -123.9749
+ * const ll = new mapboxgl.LngLat(-123.9749, 40.7736);
+ * console.log(ll.lng); // = -123.9749
  * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
  * @see [Display a popup](https://www.mapbox.com/mapbox-gl-js/example/popup/)
  * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
@@ -51,9 +51,9 @@ class LngLat {
      *
      * @returns {LngLat} The wrapped `LngLat` object.
      * @example
-     * var ll = new mapboxgl.LngLat(286.0251, 40.7736);
-     * var wrapped = ll.wrap();
-     * wrapped.lng; // = -73.9749
+     * const ll = new mapboxgl.LngLat(286.0251, 40.7736);
+     * const wrapped = ll.wrap();
+     * console.log(wrapped.lng); // = -73.9749
      */
     wrap() {
         return new LngLat(wrap(this.lng, -180, 180), this.lat);
@@ -64,7 +64,7 @@ class LngLat {
      *
      * @returns {Array<number>} The coordinates represeted as an array of longitude and latitude.
      * @example
-     * var ll = new mapboxgl.LngLat(-73.9749, 40.7736);
+     * const ll = new mapboxgl.LngLat(-73.9749, 40.7736);
      * ll.toArray(); // = [-73.9749, 40.7736]
      */
     toArray() {
@@ -76,7 +76,7 @@ class LngLat {
      *
      * @returns {string} The coordinates represented as a string of the format `'LngLat(lng, lat)'`.
      * @example
-     * var ll = new mapboxgl.LngLat(-73.9749, 40.7736);
+     * const ll = new mapboxgl.LngLat(-73.9749, 40.7736);
      * ll.toString(); // = "LngLat(-73.9749, 40.7736)"
      */
     toString() {
@@ -90,9 +90,9 @@ class LngLat {
      * @param {LngLat} lngLat coordinates to compute the distance to
      * @returns {number} Distance in meters between the two coordinates.
      * @example
-     * var new_york = new mapboxgl.LngLat(-74.0060, 40.7128);
-     * var los_angeles = new mapboxgl.LngLat(-118.2437, 34.0522);
-     * new_york.distanceTo(los_angeles); // = 3935751.690893987, "true distance" using a non-spherical approximation is ~3966km
+     * const newYork = new mapboxgl.LngLat(-74.0060, 40.7128);
+     * const losAngeles = new mapboxgl.LngLat(-118.2437, 34.0522);
+     * newYork.distanceTo(losAngeles); // = 3935751.690893987, "true distance" using a non-spherical approximation is ~3966km
      */
     distanceTo(lngLat: LngLat) {
         const rad = Math.PI / 180;
@@ -110,7 +110,7 @@ class LngLat {
      * @param {number} [radius=0] Distance in meters from the coordinates to extend the bounds.
      * @returns {LngLatBounds} A new `LngLatBounds` object representing the coordinates extended by the `radius`.
      * @example
-     * var ll = new mapboxgl.LngLat(-73.9749, 40.7736);
+     * const ll = new mapboxgl.LngLat(-73.9749, 40.7736);
      * ll.toBounds(100).toArray(); // = [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
      */
     toBounds(radius?: number = 0) {
@@ -131,9 +131,9 @@ class LngLat {
      * @param {LngLatLike} input An array of two numbers or object to convert, or a `LngLat` object to return.
      * @returns {LngLat} A new `LngLat` object, if a conversion occurred, or the original `LngLat` object.
      * @example
-     * var arr = [-73.9749, 40.7736];
-     * var ll = mapboxgl.LngLat.convert(arr);
-     * ll;   // = LngLat {lng: -73.9749, lat: 40.7736}
+     * const arr = [-73.9749, 40.7736];
+     * const ll = mapboxgl.LngLat.convert(arr);
+     * console.log(ll);   // = LngLat {lng: -73.9749, lat: 40.7736}
      */
     static convert(input: LngLatLike): LngLat {
         if (input instanceof LngLat) {
@@ -159,9 +159,9 @@ class LngLat {
  *
  * @typedef {LngLat | {lng: number, lat: number} | {lon: number, lat: number} | [number, number]} LngLatLike
  * @example
- * var v1 = new mapboxgl.LngLat(-122.420679, 37.772537);
- * var v2 = [-122.420679, 37.772537];
- * var v3 = {lon: -122.420679, lat: 37.772537};
+ * const v1 = new mapboxgl.LngLat(-122.420679, 37.772537);
+ * const v2 = [-122.420679, 37.772537];
+ * const v3 = {lon: -122.420679, lat: 37.772537};
  */
 export type LngLatLike = LngLat | {lng: number, lat: number} | {lon: number, lat: number} | [number, number];
 

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -17,9 +17,9 @@ import type {LngLatLike} from './lng_lat.js';
  * @param {LngLatLike} [sw] The southwest corner of the bounding box.
  * @param {LngLatLike} [ne] The northeast corner of the bounding box.
  * @example
- * var sw = new mapboxgl.LngLat(-73.9876, 40.7661);
- * var ne = new mapboxgl.LngLat(-73.9397, 40.8002);
- * var llb = new mapboxgl.LngLatBounds(sw, ne);
+ * const sw = new mapboxgl.LngLat(-73.9876, 40.7661);
+ * const ne = new mapboxgl.LngLat(-73.9397, 40.8002);
+ * const llb = new mapboxgl.LngLatBounds(sw, ne);
  */
 class LngLatBounds {
     _ne: LngLat;
@@ -113,7 +113,7 @@ class LngLatBounds {
      *
      * @returns {LngLat} The bounding box's center.
      * @example
-     * var llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.getCenter(); // = LngLat {lng: -73.96365, lat: 40.78315}
      */
     getCenter(): LngLat {
@@ -182,7 +182,7 @@ class LngLatBounds {
      * @returns {Array<Array<number>>} The bounding box represented as an array, consisting of the
      *   southwest and northeast coordinates of the bounding represented as arrays of numbers.
      * @example
-     * var llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toArray(); // = [[-73.9876, 40.7661], [-73.9397, 40.8002]]
      */
     toArray() {
@@ -195,7 +195,7 @@ class LngLatBounds {
      * @returns {string} The bounding box represents as a string of the format
      *   `'LngLatBounds(LngLat(lng, lat), LngLat(lng, lat))'`.
      * @example
-     * var llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * const llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toString(); // = "LngLatBounds(LngLat(-73.9876, 40.7661), LngLat(-73.9397, 40.8002))"
      */
     toString() {
@@ -217,12 +217,12 @@ class LngLatBounds {
     * @param {LngLatLike} lnglat geographic point to check against.
     * @returns {boolean} True if the point is within the bounding box.
     * @example
-    * var llb = new mapboxgl.LngLatBounds(
+    * const llb = new mapboxgl.LngLatBounds(
     *   new mapboxgl.LngLat(-73.9876, 40.7661),
     *   new mapboxgl.LngLat(-73.9397, 40.8002)
     * );
     *
-    * var ll = new mapboxgl.LngLat(-73.9567, 40.7789);
+    * const ll = new mapboxgl.LngLat(-73.9567, 40.7789);
     *
     * console.log(llb.contains(ll)); // = true
     */
@@ -248,9 +248,9 @@ class LngLatBounds {
      * @param {LngLatBoundsLike} input An array of two coordinates to convert, or a `LngLatBounds` object to return.
      * @returns {LngLatBounds} A new `LngLatBounds` object, if a conversion occurred, or the original `LngLatBounds` object.
      * @example
-     * var arr = [[-73.9876, 40.7661], [-73.9397, 40.8002]];
-     * var llb = mapboxgl.LngLatBounds.convert(arr);
-     * llb;   // = LngLatBounds {_sw: LngLat {lng: -73.9876, lat: 40.7661}, _ne: LngLat {lng: -73.9397, lat: 40.8002}}
+     * const arr = [[-73.9876, 40.7661], [-73.9397, 40.8002]];
+     * const llb = mapboxgl.LngLatBounds.convert(arr);
+     * console.log(llb);   // = LngLatBounds {_sw: LngLat {lng: -73.9876, lat: 40.7661}, _ne: LngLat {lng: -73.9397, lat: 40.8002}}
      */
     static convert(input: LngLatBoundsLike): LngLatBounds {
         if (!input || input instanceof LngLatBounds) return input;
@@ -264,12 +264,12 @@ class LngLatBounds {
  *
  * @typedef {LngLatBounds | [LngLatLike, LngLatLike] | [number, number, number, number]} LngLatBoundsLike
  * @example
- * var v1 = new mapboxgl.LngLatBounds(
+ * const v1 = new mapboxgl.LngLatBounds(
  *   new mapboxgl.LngLat(-73.9876, 40.7661),
  *   new mapboxgl.LngLat(-73.9397, 40.8002)
  * );
- * var v2 = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002])
- * var v3 = [[-73.9876, 40.7661], [-73.9397, 40.8002]];
+ * const v2 = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+ * const v3 = [[-73.9876, 40.7661], [-73.9397, 40.8002]];
  */
 export type LngLatBoundsLike = LngLatBounds | [LngLatLike, LngLatLike] | [number, number, number, number];
 

--- a/src/geo/mercator_coordinate.js
+++ b/src/geo/mercator_coordinate.js
@@ -72,7 +72,7 @@ export function mercatorScale(lat: number) {
  * @param {number} y The y component of the position.
  * @param {number} z The z component of the position.
  * @example
- * var nullIsland = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
+ * const nullIsland = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
  *
  * @see [Add a custom style layer](https://www.mapbox.com/mapbox-gl-js/example/custom-style-layer/)
  */
@@ -94,8 +94,8 @@ class MercatorCoordinate {
      * @param {number} altitude The altitude in meters of the position.
      * @returns {MercatorCoordinate} The projected mercator coordinate.
      * @example
-     * var coord = mapboxgl.MercatorCoordinate.fromLngLat({ lng: 0, lat: 0}, 0);
-     * coord; // MercatorCoordinate(0.5, 0.5, 0)
+     * const coord = mapboxgl.MercatorCoordinate.fromLngLat({lng: 0, lat: 0}, 0);
+     * console.log(coord); // MercatorCoordinate(0.5, 0.5, 0)
      */
     static fromLngLat(lngLatLike: LngLatLike, altitude: number = 0) {
         const lngLat = LngLat.convert(lngLatLike);
@@ -111,8 +111,8 @@ class MercatorCoordinate {
      *
      * @returns {LngLat} The `LngLat` object.
      * @example
-     * var coord = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
-     * var lngLat = coord.toLngLat(); // LngLat(0, 0)
+     * const coord = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
+     * const lngLat = coord.toLngLat(); // LngLat(0, 0)
      */
     toLngLat() {
         return new LngLat(
@@ -125,7 +125,7 @@ class MercatorCoordinate {
      *
      * @returns {number} The altitude in meters.
      * @example
-     * var coord = new mapboxgl.MercatorCoordinate(0, 0, 0.02);
+     * const coord = new mapboxgl.MercatorCoordinate(0, 0, 0.02);
      * coord.toAltitude(); // 6914.281956295339
      */
     toAltitude() {

--- a/src/index.js
+++ b/src/index.js
@@ -184,10 +184,11 @@ const exported = {
      * @var {string} workerUrl
      * @returns {string} A URL hosting a JavaScript bundle for mapbox-gl's WebWorker.
      * @example
-     * // <script src='https://api.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl-csp.js'></script>
-     * // <script>
+     * <script src='https://api.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl-csp.js'></script>
+     * <script>
      * mapboxgl.workerUrl = "https://api.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl-csp-worker.js";
-     * // </script>
+     * ...
+     * </script>
      */
     workerUrl: '',
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const exported = {
      *
      * @function prewarm
      * @example
-     * mapboxgl.prewarm()
+     * mapboxgl.prewarm();
      */
     prewarm,
     /**
@@ -81,7 +81,7 @@ const exported = {
      *
      * @function clearPrewarmedResources
      * @example
-     * mapboxgl.clearPrewarmedResources()
+     * mapboxgl.clearPrewarmedResources();
      */
     clearPrewarmedResources,
 
@@ -184,11 +184,10 @@ const exported = {
      * @var {string} workerUrl
      * @returns {string} A URL hosting a JavaScript bundle for mapbox-gl's WebWorker.
      * @example
-     * <script src='https://api.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl-csp.js'></script>
-     * <script>
+     * // <script src='https://api.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl-csp.js'></script>
+     * // <script>
      * mapboxgl.workerUrl = "https://api.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl-csp-worker.js";
-     * ...
-     * </script>
+     * // </script>
      */
     workerUrl: '',
 
@@ -201,8 +200,8 @@ const exported = {
      * @var {Object} workerClass
      * @returns {Object|null} a Class object, an instance of which exposes the `Worker` interface.
      * @example
-     * import mapboxgl from 'mapbox-gl/dist/mapbox-gl-csp.js'
-     * import MapboxGLWorker from 'mapbox-gl/dist/mapbox-gl-csp-worker.js'
+     * import mapboxgl from 'mapbox-gl/dist/mapbox-gl-csp.js';
+     * import MapboxGLWorker from 'mapbox-gl/dist/mapbox-gl-csp-worker.js';
      *
      * mapboxgl.workerClass = MapboxGLWorker;
      */
@@ -243,7 +242,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  * @example
  * // Show an alert if the browser does not support Mapbox GL
  * if (!mapboxgl.supported()) {
- *   alert('Your browser does not support Mapbox GL');
+ *     alert('Your browser does not support Mapbox GL');
  * }
  * @see [Check for browser support](https://www.mapbox.com/mapbox-gl-js/example/check-for-support/)
  */

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -36,19 +36,19 @@ export type CanvasSourceSpecification = {|
  * @example
  * // add to map
  * map.addSource('some id', {
- *    type: 'canvas',
- *    canvas: 'idOfMyHTMLCanvas',
- *    animate: true,
- *    coordinates: [
- *        [-76.54, 39.18],
- *        [-76.52, 39.18],
- *        [-76.52, 39.17],
- *        [-76.54, 39.17]
- *    ]
+ *     type: 'canvas',
+ *     canvas: 'idOfMyHTMLCanvas',
+ *     animate: true,
+ *     coordinates: [
+ *         [-76.54, 39.18],
+ *         [-76.52, 39.18],
+ *         [-76.52, 39.17],
+ *         [-76.54, 39.17]
+ *     ]
  * });
  *
  * // update
- * var mySource = map.getSource('some id');
+ * const mySource = map.getSource('some id');
  * mySource.setCoordinates([
  *     [-76.54335737228394, 39.18579907229748],
  *     [-76.52803659439087, 39.1838364847587],

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -29,34 +29,34 @@ import type {Cancelable} from '../types/cancelable.js';
  *
  * @example
  * map.addSource('some id', {
- *    type: 'geojson',
- *    data: {
- *        "type": "FeatureCollection",
- *        "features": [{
- *            "type": "Feature",
- *            "properties": {},
- *            "geometry": {
- *                "type": "Point",
- *                "coordinates": [
- *                    -76.53063297271729,
- *                    39.18174077994108
- *                ]
- *            }
- *        }]
- *    }
+ *     type: 'geojson',
+ *     data: {
+ *         "type": "FeatureCollection",
+ *         "features": [{
+ *             "type": "Feature",
+ *             "properties": {},
+ *             "geometry": {
+ *                 "type": "Point",
+ *                 "coordinates": [
+ *                     -76.53063297271729,
+ *                     39.18174077994108
+ *                 ]
+ *             }
+ *         }]
+ *     }
  * });
  *
  * @example
  * map.getSource('some id').setData({
- *   "type": "FeatureCollection",
- *   "features": [{
- *       "type": "Feature",
- *       "properties": { "name": "Null Island" },
- *       "geometry": {
- *           "type": "Point",
- *           "coordinates": [ 0, 0 ]
- *       }
- *   }]
+ *     "type": "FeatureCollection",
+ *     "features": [{
+ *         "type": "Feature",
+ *         "properties": {"name": "Null Island"},
+ *         "geometry": {
+ *             "type": "Point",
+ *             "coordinates": [ 0, 0 ]
+ *         }
+ *     }]
  * });
  * @see [Draw GeoJSON points](https://www.mapbox.com/mapbox-gl-js/example/geojson-markers/)
  * @see [Add a GeoJSON line](https://www.mapbox.com/mapbox-gl-js/example/geojson-line/)
@@ -198,19 +198,19 @@ class GeoJSONSource extends Evented implements Source {
      * @returns {GeoJSONSource} this
      * @example
      * // Retrieve cluster leaves on click
-     * map.on('click', 'clusters', function(e) {
-     *   var features = map.queryRenderedFeatures(e.point, {
-     *     layers: ['clusters']
-     *   });
+     * map.on('click', 'clusters', (e) => {
+     *     const features = map.queryRenderedFeatures(e.point, {
+     *         layers: ['clusters']
+     *     });
      *
-     *   var clusterId = features[0].properties.cluster_id;
-     *   var pointCount = features[0].properties.point_count;
-     *   var clusterSource = map.getSource('clusters');
+     *     const clusterId = features[0].properties.cluster_id;
+     *     const pointCount = features[0].properties.point_count;
+     *     const clusterSource = map.getSource('clusters');
      *
-     *   clusterSource.getClusterLeaves(clusterId, pointCount, 0, function(error, features) {
+     *     clusterSource.getClusterLeaves(clusterId, pointCount, 0, (error, features) => {
      *     // Print cluster leaves in the console
-     *     console.log('Cluster leaves:', error, features);
-     *   })
+     *         console.log('Cluster leaves:', error, features);
+     *     });
      * });
      */
     getClusterLeaves(clusterId: number, limit: number, offset: number, callback: Callback<Array<GeoJSONFeature>>) {

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -32,18 +32,18 @@ type Coordinates = [[number, number], [number, number], [number, number], [numbe
  * @example
  * // add to map
  * map.addSource('some id', {
- *    type: 'image',
- *    url: 'https://www.mapbox.com/images/foo.png',
- *    coordinates: [
- *        [-76.54, 39.18],
- *        [-76.52, 39.18],
- *        [-76.52, 39.17],
- *        [-76.54, 39.17]
- *    ]
+ *     type: 'image',
+ *     url: 'https://www.mapbox.com/images/foo.png',
+ *     coordinates: [
+ *         [-76.54, 39.18],
+ *         [-76.52, 39.18],
+ *         [-76.52, 39.17],
+ *         [-76.54, 39.17]
+ *     ]
  * });
  *
  * // update coordinates
- * var mySource = map.getSource('some id');
+ * const mySource = map.getSource('some id');
  * mySource.setCoordinates([
  *     [-76.54335737228394, 39.18579907229748],
  *     [-76.52803659439087, 39.1838364847587],
@@ -53,14 +53,14 @@ type Coordinates = [[number, number], [number, number], [number, number], [numbe
  *
  * // update url and coordinates simultaneously
  * mySource.updateImage({
- *    url: 'https://www.mapbox.com/images/bar.png',
- *    coordinates: [
- *        [-76.54335737228394, 39.18579907229748],
- *        [-76.52803659439087, 39.1838364847587],
- *        [-76.5295386314392, 39.17683392507606],
- *        [-76.54520273208618, 39.17876344106642]
- *    ]
- * })
+ *     url: 'https://www.mapbox.com/images/bar.png',
+ *     coordinates: [
+ *         [-76.54335737228394, 39.18579907229748],
+ *         [-76.52803659439087, 39.1838364847587],
+ *         [-76.5295386314392, 39.17683392507606],
+ *         [-76.54520273208618, 39.17876344106642]
+ *     ]
+ * });
  *
  * map.removeSource('some id');  // remove
  * @see [Add an image](https://www.mapbox.com/mapbox-gl-js/example/image-on-a-map/)

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -21,21 +21,21 @@ import type {VideoSourceSpecification} from '../style-spec/types.js';
  * @example
  * // add to map
  * map.addSource('some id', {
- *    type: 'video',
- *    url: [
- *        'https://www.mapbox.com/blog/assets/baltimore-smoke.mp4',
- *        'https://www.mapbox.com/blog/assets/baltimore-smoke.webm'
- *    ],
- *    coordinates: [
- *        [-76.54, 39.18],
- *        [-76.52, 39.18],
- *        [-76.52, 39.17],
- *        [-76.54, 39.17]
- *    ]
+ *     type: 'video',
+ *     url: [
+ *         'https://www.mapbox.com/blog/assets/baltimore-smoke.mp4',
+ *         'https://www.mapbox.com/blog/assets/baltimore-smoke.webm'
+ *     ],
+ *     coordinates: [
+ *         [-76.54, 39.18],
+ *         [-76.52, 39.18],
+ *         [-76.52, 39.17],
+ *         [-76.54, 39.17]
+ *     ]
  * });
  *
  * // update
- * var mySource = map.getSource('some id');
+ * const mySource = map.getSource('some id');
  * mySource.setCoordinates([
  *     [-76.54335737228394, 39.18579907229748],
  *     [-76.52803659439087, 39.1838364847587],

--- a/src/style/style_image.js
+++ b/src/style/style_image.js
@@ -59,30 +59,30 @@ export function renderStyleImage(image: StyleImage) {
  * @see [Add an animated icon to the map.](https://docs.mapbox.com/mapbox-gl-js/example/add-image-animated/)
  *
  * @example
- * var flashingSquare = {
+ * const flashingSquare = {
  *     width: 64,
  *     height: 64,
  *     data: new Uint8Array(64 * 64 * 4),
  *
- *     onAdd: function(map) {
+ *     onAdd(map) {
  *         this.map = map;
  *     },
  *
- *     render: function() {
+ *     render() {
  *         // keep repainting while the icon is on the map
  *         this.map.triggerRepaint();
  *
  *         // alternate between black and white based on the time
- *         var value = Math.round(Date.now() / 1000) % 2 === 0  ? 255 : 0;
+ *         const value = Math.round(Date.now() / 1000) % 2 === 0  ? 255 : 0;
  *
  *         // check if image needs to be changed
  *         if (value !== this.previousValue) {
  *             this.previousValue = value;
  *
- *             var bytesPerPixel = 4;
- *             for (var x = 0; x < this.width; x++) {
- *                 for (var y = 0; y < this.height; y++) {
- *                     var offset = (y * this.width + x) * bytesPerPixel;
+ *             const bytesPerPixel = 4;
+ *             for (let x = 0; x < this.width; x++) {
+ *                 for (let y = 0; y < this.height; y++) {
+ *                     const offset = (y * this.width + x) * bytesPerPixel;
  *                     this.data[offset + 0] = value;
  *                     this.data[offset + 1] = value;
  *                     this.data[offset + 2] = value;
@@ -94,9 +94,9 @@ export function renderStyleImage(image: StyleImage) {
  *             return true;
  *         }
  *     }
- *  }
+ * };
  *
- *  map.addImage('flashing_square', flashingSquare);
+ * map.addImage('flashing_square', flashingSquare);
  */
 
 /**

--- a/src/style/style_layer/custom_style_layer.js
+++ b/src/style/style_layer/custom_style_layer.js
@@ -70,7 +70,7 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => 
  *     }
  * }
  *
- * map.on('load', function() {
+ * map.on('load', () => {
  *     map.addLayer(new NullIslandLayer());
  * });
  * @see [Add a custom style layer](https://docs.mapbox.com/mapbox-gl-js/example/custom-style-layer/)

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -47,13 +47,13 @@ import type {PaddingOptions} from '../geo/edge_insets.js';
  * @property {PaddingOptions} padding Dimensions in pixels applied on each side of the viewport for shifting the vanishing point.
  * @example
  * // set the map's initial perspective with CameraOptions
- * var map = new mapboxgl.Map({
- *   container: 'map',
- *   style: 'mapbox://styles/mapbox/streets-v11',
- *   center: [-73.5804, 45.53483],
- *   pitch: 60,
- *   bearing: -60,
- *   zoom: 10
+ * const map = new mapboxgl.Map({
+ *     container: 'map',
+ *     style: 'mapbox://styles/mapbox/streets-v11',
+ *     center: [-73.5804, 45.53483],
+ *     pitch: 60,
+ *     bearing: -60,
+ *     zoom: 10
  * });
  * @see [Set pitch and bearing](https://docs.mapbox.com/mapbox-gl-js/example/set-perspective/)
  * @see [Jump to a series of locations](https://docs.mapbox.com/mapbox-gl-js/example/jump-to/)
@@ -112,15 +112,15 @@ export type ElevationBoxRaycast = {
  * @property {number} right Padding in pixels from the right of the map canvas.
  *
  * @example
- * var bbox = [[-79, 43], [-73, 45]];
+ * const bbox = [[-79, 43], [-73, 45]];
  * map.fitBounds(bbox, {
- *   padding: {top: 10, bottom:25, left: 15, right: 5}
+ *     padding: {top: 10, bottom:25, left: 15, right: 5}
  * });
  *
  * @example
- * var bbox = [[-79, 43], [-73, 45]];
+ * const bbox = [[-79, 43], [-73, 45]];
  * map.fitBounds(bbox, {
- *   padding: 20
+ *     padding: 20
  * });
  * @see [Fit to the bounds of a LineString](https://docs.mapbox.com/mapbox-gl-js/example/zoomto-linestring/)
  * @see [Fit a map to a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/fitbounds/)
@@ -165,9 +165,9 @@ class Camera extends Evented {
      * @returns The map's geographical centerpoint.
      * @example
      * // return a LngLat object such as {lng: 0, lat: 0}
-     * var center = map.getCenter();
+     * const center = map.getCenter();
      * // access longitude and latitude values directly
-     * var {longitude, latitude} = map.getCenter();
+     * const {longitude, latitude} = map.getCenter();
      * @see Tutorial: [Use Mapbox GL JS in a React app](https://docs.mapbox.com/help/tutorials/use-mapbox-gl-js-with-react/#store-the-new-coordinates)
      */
     getCenter(): LngLat { return new LngLat(this.transform.center.lng, this.transform.center.lat); }
@@ -279,8 +279,8 @@ class Camera extends Evented {
      * map.zoomTo(5);
      * // Zoom to the zoom level 8 with an animated transition
      * map.zoomTo(8, {
-     *   duration: 2000,
-     *   offset: [100, 50]
+     *     duration: 2000,
+     *     offset: [100, 50]
      * });
      */
     zoomTo(zoom: number, options: ? AnimationOptions, eventData?: Object) {
@@ -385,7 +385,7 @@ class Camera extends Evented {
      * @returns {Map} `this`
      * @example
      * // Sets a left padding of 300px, and a top padding of 50px
-     * map.setPadding({ left: 300, top: 50 });
+     * map.setPadding({left: 300, top: 50});
      */
     setPadding(padding: PaddingOptions, eventData?: Object) {
         this.jumpTo({padding}, eventData);
@@ -499,9 +499,9 @@ class Camera extends Evented {
      * @returns {CameraOptions | void} If map is able to fit to provided bounds, returns `CameraOptions` with
      *      `center`, `zoom`, and `bearing`. If map is unable to fit, method will warn and return undefined.
      * @example
-     * var bbox = [[-79, 43], [-73, 45]];
-     * var newCameraTransform = map.cameraForBounds(bbox, {
-     *   padding: {top: 10, bottom:25, left: 15, right: 5}
+     * const bbox = [[-79, 43], [-73, 45]];
+     * const newCameraTransform = map.cameraForBounds(bbox, {
+     *     padding: {top: 10, bottom:25, left: 15, right: 5}
      * });
      */
     cameraForBounds(bounds: LngLatBoundsLike, options?: CameraOptions): void | CameraOptions & AnimationOptions {
@@ -724,9 +724,9 @@ class Camera extends Evented {
      * @fires moveend
      * @returns {Map} `this`
 	 * @example
-     * var bbox = [[-79, 43], [-73, 45]];
+     * const bbox = [[-79, 43], [-73, 45]];
      * map.fitBounds(bbox, {
-     *   padding: {top: 10, bottom:25, left: 15, right: 5}
+     *     padding: {top: 10, bottom:25, left: 15, right: 5}
      * });
      * @see [Fit a map to a bounding box](https://www.mapbox.com/mapbox-gl-js/example/fitbounds/)
      */
@@ -796,10 +796,10 @@ class Camera extends Evented {
      * @fires moveend
      * @returns {Map} `this`
 	 * @example
-     * var p0 = [220, 400];
-     * var p1 = [500, 900];
+     * const p0 = [220, 400];
+     * const p1 = [500, 900];
      * map.fitScreenCoordinates(p0, p1, map.getBearing(), {
-     *   padding: {top: 10, bottom:25, left: 15, right: 5}
+     *     padding: {top: 10, bottom:25, left: 15, right: 5}
      * });
      * @see Used by {@link BoxZoomHandler}
      */
@@ -882,10 +882,10 @@ class Camera extends Evented {
      * map.jumpTo({center: [0, 0]});
      * // jump with zoom, pitch, and bearing options
      * map.jumpTo({
-     *   center: [0, 0],
-     *   zoom: 8,
-     *   pitch: 45,
-     *   bearing: 90
+     *     center: [0, 0],
+     *     zoom: 8,
+     *     pitch: 45,
+     *     bearing: 90
      * });
      * @see [Jump to a series of locations](https://docs.mapbox.com/mapbox-gl-js/example/jump-to/)
      * @see [Update a feature in realtime](https://docs.mapbox.com/mapbox-gl-js/example/live-update-feature/)
@@ -1244,13 +1244,13 @@ class Camera extends Evented {
      * map.flyTo({center: [0, 0], zoom: 9});
      * // using flyTo options
      * map.flyTo({
-     *   center: [0, 0],
-     *   zoom: 9,
-     *   speed: 0.2,
-     *   curve: 1,
-     *   easing(t) {
-     *     return t;
-     *   }
+     *     center: [0, 0],
+     *     zoom: 9,
+     *     speed: 0.2,
+     *     curve: 1,
+     *     easing(t) {
+     *         return t;
+     *     }
      * });
      * @see [Fly to a location](https://www.mapbox.com/mapbox-gl-js/example/flyto/)
      * @see [Slowly fly to a location](https://www.mapbox.com/mapbox-gl-js/example/flyto-options/)

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -20,7 +20,7 @@ type Options = {
  * @param {boolean} [options.compact] If `true`, force a compact attribution that shows the full attribution on mouse hover. If `false`, force the full attribution control. The default is a responsive attribution that collapses when the map is less than 640 pixels wide. **Attribution should not be collapsed if it can comfortably fit on the map. `compact` should only be used to modify default attribution when map size makes it impossible to fit [default attribution](https://docs.mapbox.com/help/how-mapbox-works/attribution/) and when the automatic compact resizing for default settings are not sufficient.**
  * @param {string | Array<string>} [options.customAttribution] String or strings to show in addition to any other attributions. You can also set a custom attribution when initializing your map with {@link https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters the customAttribution option}.
  * @example
- * var map = new mapboxgl.Map({attributionControl: false})
+ * const map = new mapboxgl.Map({attributionControl: false})
  *     .addControl(new mapboxgl.AttributionControl({
  *         customAttribution: 'Map design by me'
  *     }));

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -514,16 +514,16 @@ class GeolocateControl extends Evented {
      * Trigger a geolocation
      * @example
      * // Initialize the geolocate control.
-     * var geolocate = new mapboxgl.GeolocateControl({
-     *  positionOptions: {
-     *    enableHighAccuracy: true
-     *  },
-     *  trackUserLocation: true
+     * const geolocate = new mapboxgl.GeolocateControl({
+     *     positionOptions: {
+     *         enableHighAccuracy: true
+     *     },
+     *     trackUserLocation: true
      * });
      * // Add the control to the map.
      * map.addControl(geolocate);
-     * map.on('load', function() {
-     *   geolocate.trigger();
+     * map.on('load', () => {
+     *     geolocate.trigger();
      * });
      * @returns {boolean} Returns `false` if called before control was added to a map, otherwise returns `true`.
      */
@@ -702,18 +702,18 @@ export default GeolocateControl;
  * @property {Position} data The returned [Position](https://developer.mozilla.org/en-US/docs/Web/API/Position) object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or [Geolocation.watchPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
  * @example
  * // Initialize the GeolocateControl.
- * var geolocate = new mapboxgl.GeolocateControl({
- *   positionOptions: {
- *       enableHighAccuracy: true
- *   },
- *   trackUserLocation: true
+ * const geolocate = new mapboxgl.GeolocateControl({
+ *     positionOptions: {
+ *         enableHighAccuracy: true
+ *     },
+ *     trackUserLocation: true
  * });
  * // Add the control to the map.
  * map.addControl(geolocate);
  * // Set an event listener that fires
  * // when a geolocate event occurs.
- * geolocate.on('geolocate', function() {
- *   console.log('A geolocate event has occurred.')
+ * geolocate.on('geolocate', () => {
+ *     console.log('A geolocate event has occurred.');
  * });
  *
  */
@@ -727,18 +727,18 @@ export default GeolocateControl;
  * @property {PositionError} data The returned [PositionError](https://developer.mozilla.org/en-US/docs/Web/API/PositionError) object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or [Geolocation.watchPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
  * @example
  * // Initialize the GeolocateControl.
- * var geolocate = new mapboxgl.GeolocateControl({
- *   positionOptions: {
- *       enableHighAccuracy: true
- *   },
- *   trackUserLocation: true
+ * const geolocate = new mapboxgl.GeolocateControl({
+ *     positionOptions: {
+ *         enableHighAccuracy: true
+ *     },
+ *     trackUserLocation: true
  * });
  * // Add the control to the map.
  * map.addControl(geolocate);
  * // Set an event listener that fires
  * // when an error event occurs.
- * geolocate.on('error', function() {
- *   console.log('An error event has occurred.')
+ * geolocate.on('error', () => {
+ *     console.log('An error event has occurred.');
  * });
  *
  */
@@ -752,18 +752,18 @@ export default GeolocateControl;
  * @property {Position} data The returned [Position](https://developer.mozilla.org/en-US/docs/Web/API/Position) object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or [Geolocation.watchPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
  * @example
  * // Initialize the GeolocateControl.
- * var geolocate = new mapboxgl.GeolocateControl({
- *   positionOptions: {
- *       enableHighAccuracy: true
- *   },
- *   trackUserLocation: true
+ * const geolocate = new mapboxgl.GeolocateControl({
+ *     positionOptions: {
+ *         enableHighAccuracy: true
+ *     },
+ *     trackUserLocation: true
  * });
  * // Add the control to the map.
  * map.addControl(geolocate);
  * // Set an event listener that fires
  * // when an outofmaxbounds event occurs.
- * geolocate.on('outofmaxbounds', function() {
- *   console.log('An outofmaxbounds event has occurred.')
+ * geolocate.on('outofmaxbounds', () => {
+ *     console.log('An outofmaxbounds event has occurred.');
  * });
  *
  */
@@ -776,18 +776,18 @@ export default GeolocateControl;
  * @instance
  * @example
  * // Initialize the GeolocateControl.
- * var geolocate = new mapboxgl.GeolocateControl({
- *   positionOptions: {
- *       enableHighAccuracy: true
- *   },
- *   trackUserLocation: true
+ * const geolocate = new mapboxgl.GeolocateControl({
+ *     positionOptions: {
+ *         enableHighAccuracy: true
+ *     },
+ *     trackUserLocation: true
  * });
  * // Add the control to the map.
  * map.addControl(geolocate);
  * // Set an event listener that fires
  * // when a trackuserlocationstart event occurs.
- * geolocate.on('trackuserlocationstart', function() {
- *   console.log('A trackuserlocationstart event has occurred.')
+ * geolocate.on('trackuserlocationstart', () => {
+ *     console.log('A trackuserlocationstart event has occurred.');
  * });
  *
  */
@@ -800,18 +800,18 @@ export default GeolocateControl;
  * @instance
  * @example
  * // Initialize the GeolocateControl.
- * var geolocate = new mapboxgl.GeolocateControl({
- *   positionOptions: {
- *       enableHighAccuracy: true
- *   },
- *   trackUserLocation: true
+ * const geolocate = new mapboxgl.GeolocateControl({
+ *     positionOptions: {
+ *         enableHighAccuracy: true
+ *     },
+ *     trackUserLocation: true
  * });
  * // Add the control to the map.
  * map.addControl(geolocate);
  * // Set an event listener that fires
  * // when a trackuserlocationend event occurs.
- * geolocate.on('trackuserlocationend', function() {
- *   console.log('A trackuserlocationend event has occurred.')
+ * geolocate.on('trackuserlocationend', () => {
+ *     console.log('A trackuserlocationend event has occurred.');
  * });
  *
  */

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -29,11 +29,11 @@ const defaultOptions: Options = {
  * @param {Boolean} [options.showZoom=true] If `true` the zoom-in and zoom-out buttons are included.
  * @param {Boolean} [options.visualizePitch=false] If `true` the pitch is visualized by rotating X-axis of compass.
  * @example
- * var nav = new mapboxgl.NavigationControl();
+ * const nav = new mapboxgl.NavigationControl();
  * map.addControl(nav, 'top-left');
  * @example
- * var nav = new mapboxgl.NavigationControl({
- *   visualizePitch: true
+ * const nav = new mapboxgl.NavigationControl({
+ *     visualizePitch: true
  * });
  * map.addControl(nav, 'bottom-right');
  * @see [Display map navigation controls](https://www.mapbox.com/mapbox-gl-js/example/navigation/)

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -26,7 +26,7 @@ const defaultOptions: Options = {
  * @param {number} [options.maxWidth='100'] The maximum length of the scale control in pixels.
  * @param {string} [options.unit='metric'] Unit of the distance (`'imperial'`, `'metric'` or `'nautical'`).
  * @example
- * var scale = new mapboxgl.ScaleControl({
+ * const scale = new mapboxgl.ScaleControl({
  *     maxWidth: 80,
  *     unit: 'imperial'
  * });

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -90,7 +90,7 @@ export class MapMouseEvent extends Event {
      * // logging all features for all layers (without `e.features`)
      * map.on('click', (e) => {
      *     const features = map.queryRenderedFeatures(e.point);
-     *     console.log(`There are ${e.features.length} features at point ${e.point}`);
+     *     console.log(`There are ${features.length} features at point ${e.point}`);
      * });
      */
     features: Array<Object> | void;
@@ -224,14 +224,14 @@ export class MapTouchEvent extends Event {
      * @example
      * // logging features for a specific layer (with `e.features`)
      * map.on('touchstart', 'myLayerId', (e) => {
-     *     console.log('There are', e.features.length, 'features at point', e.point);
+     *     console.log(`There are ${e.features.length} features at point ${e.point}`);
      * });
      *
      * @example
      * // logging all features for all layers (without `e.features`)
      * map.on('touchstart', (e) => {
      *     const features = map.queryRenderedFeatures(e.point);
-     *     console.log('There are', features.length, 'features at point', e.point);
+     *     console.log(`There are ${features.length} features at point ${e.point}`);
      * });
      */
     features: Array<Object> | void;

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -16,19 +16,22 @@ import type LngLat from '../geo/lng_lat.js';
  * @extends {Object}
  * @example
  * // Example of a MapMouseEvent of type "click"
- * {
- *     lngLat: {
- *         lng: 40.203,
- *         lat: -74.451
- *     },
- *     originalEvent: {...},
- *     point: {
- *         x: 266,
- *         y: 464
- *     },
- *      target: {...},
- *      type: "click"
- * }
+ * map.on('click', (e) => {
+ *     console.log(e);
+ *     // {
+ *     //     lngLat: {
+ *     //         lng: 40.203,
+ *     //         lat: -74.451
+ *     //     },
+ *     //     originalEvent: {...},
+ *     //     point: {
+ *     //         x: 266,
+ *     //         y: 464
+ *     //     },
+ *     //      target: {...},
+ *     //      type: "click"
+ *     // }
+ * });
  * @see [`Map` events documentation](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-events)
  * @see [Display popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
  * @see [Display popup on hover](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
@@ -86,7 +89,7 @@ export class MapMouseEvent extends Event {
      * @example
      * // logging all features for all layers (without `e.features`)
      * map.on('click', (e) => {
-     *     var features = map.queryRenderedFeatures(e.point);
+     *     const features = map.queryRenderedFeatures(e.point);
      *     console.log(`There are ${e.features.length} features at point ${e.point}`);
      * });
      */
@@ -136,32 +139,35 @@ export class MapMouseEvent extends Event {
  * @extends {Object}
  * @example
  * // Example of a MapTouchEvent of type "touch"
-  * {
- *   lngLat: {
- *      lng: 40.203,
- *      lat: -74.451
- *   },
- *   lngLats: [
- *      {
- *         lng: 40.203,
- *         lat: -74.451
- *      }
- *   ],
- *   originalEvent: {...},
- *   point: {
- *      x: 266,
- *      y: 464
- *   },
- *   points: [
- *      {
- *         x: 266,
- *         y: 464
- *      }
- *   ]
- *   preventDefault(),
- *   target: {...},
- *   type: "touchstart"
- * }
+ * map.on('touchstart', (e) => {
+ *     console.log(e);
+ *     // {
+ *     //   lngLat: {
+ *     //      lng: 40.203,
+ *     //      lat: -74.451
+ *     //   },
+ *     //   lngLats: [
+ *     //      {
+ *     //         lng: 40.203,
+ *     //         lat: -74.451
+ *     //      }
+ *     //   ],
+ *     //   originalEvent: {...},
+ *     //   point: {
+ *     //      x: 266,
+ *     //      y: 464
+ *     //   },
+ *     //   points: [
+ *     //      {
+ *     //         x: 266,
+ *     //         y: 464
+ *     //      }
+ *     //   ]
+ *     //   preventDefault(),
+ *     //   target: {...},
+ *     //   type: "touchstart"
+ *     // }
+ * });
  * @see [`Map` events documentation](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-events)
  * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
 */
@@ -217,15 +223,15 @@ export class MapTouchEvent extends Event {
      *
      * @example
      * // logging features for a specific layer (with `e.features`)
-     * map.on('touchstart', 'myLayerId', function(e) {
-     *     console.log('There are', e.features.length, 'features at point', e.point');
+     * map.on('touchstart', 'myLayerId', (e) => {
+     *     console.log('There are', e.features.length, 'features at point', e.point);
      * });
      *
      * @example
      * // logging all features for all layers (without `e.features`)
-     * map.on('touchstart', function(e) {
-     *     var features = map.queryRenderedFeatures(e.point);
-     *     console.log('There are', features.length, 'features at point', e.point');
+     * map.on('touchstart', (e) => {
+     *     const features = map.queryRenderedFeatures(e.point);
+     *     console.log('There are', features.length, 'features at point', e.point);
      * });
      */
     features: Array<Object> | void;
@@ -276,11 +282,10 @@ export class MapTouchEvent extends Event {
  * @extends {Object}
  * @example
  * // Example of a MapWheelEvent of type "wheel"
- * {
- *   originalEvent: WheelEvent {...},
- * 	 target: Map {...},
- * 	 type: "wheel"
- * }
+ * map.on('wheel', (e) => {
+ *     console.log('event type:', e.type);
+ *     // event type: wheel
+ * });
 * @see [`Map` events documentation](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-events)
  */
 export class MapWheelEvent extends Event {
@@ -338,11 +343,10 @@ export class MapWheelEvent extends Event {
  * @property {Map} target The `Map` instance that triggerred the event
  * @example
  * // Example of a BoxZoomEvent of type "boxzoomstart"
- * {
- *   originalEvent: {...},
- *   type: "boxzoomstart",
- *   target: {...}
- * }
+ * map.on('boxzoomstart', (e) => {
+ *     console.log('event type:', e.type);
+ *     // event type: boxzoomstart
+ * });
  * @see [`Map` events documentation](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-events)
  * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
  */
@@ -372,19 +376,22 @@ export type MapBoxZoomEvent = {
  * the event is related to loading of a tile.
  * @example
  * // Example of a MapDataEvent of type "sourcedata"
- * {
- *   dataType: "source",
- *   isSourceLoaded: false,
- *   source: {
- *     type: "vector",
- *     url: "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2"
- *   },
- *   sourceDataType: "visibility",
- *   sourceId: "composite",
- *   style: {...},
- *   target: {...},
- *   type: "sourcedata"
- * }
+ * map.on('sourcedata', (e) => {
+ *     console.log(e);
+ *     // {
+ *     //   dataType: "source",
+ *     //   isSourceLoaded: false,
+ *     //   source: {
+ *     //     type: "vector",
+ *     //     url: "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2"
+ *     //   },
+ *     //   sourceDataType: "visibility",
+ *     //   sourceId: "composite",
+ *     //   style: {...},
+ *     //   target: {...},
+ *     //   type: "sourcedata"
+ *     // }
+ * });
  * @see [`Map` events documentation](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-events)
  * @see [Change a map's style](https://docs.mapbox.com/mapbox-gl-js/example/setstyle/)
  * @see [Add a GeoJSON line](https://docs.mapbox.com/mapbox-gl-js/example/geojson-line/)
@@ -419,17 +426,17 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener
-     * map.on('mousedown', function() {
-     *   console.log('A mousedown event has occurred.');
+     * map.on('mousedown', () => {
+     *     console.log('A mousedown event has occurred.');
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener for a specific layer
-     * map.on('mousedown', 'poi-label', function() {
-     *   console.log('A mousedown event has occurred on a visible portion of the poi-label layer.');
+     * map.on('mousedown', 'poi-label', () => {
+     *     console.log('A mousedown event has occurred on a visible portion of the poi-label layer.');
      * });
      * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
      * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
@@ -449,17 +456,17 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener
-     * map.on('mouseup', function() {
-     *   console.log('A mouseup event has occurred.');
+     * map.on('mouseup', () => {
+     *     console.log('A mouseup event has occurred.');
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener for a specific layer
-     * map.on('mouseup', 'poi-label', function() {
-     *   console.log('A mouseup event has occurred on a visible portion of the poi-label layer.');
+     * map.on('mouseup', 'poi-label', () => {
+     *     console.log('A mouseup event has occurred on a visible portion of the poi-label layer.');
      * });
      * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
      * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
@@ -481,17 +488,17 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener
-     * map.on('mouseover', function() {
-     *   console.log('A mouseover event has occurred.');
+     * map.on('mouseover', () => {
+     *     console.log('A mouseover event has occurred.');
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener for a specific layer
-     * map.on('mouseover', 'poi-label', function() {
-     *   console.log('A mouseover event has occurred on a visible portion of the poi-label layer.');
+     * map.on('mouseover', 'poi-label', () => {
+     *     console.log('A mouseover event has occurred on a visible portion of the poi-label layer.');
      * });
      * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
      * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
@@ -513,17 +520,17 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener
-     * map.on('mousemove', function() {
-     *   console.log('A mousemove event has occurred.');
+     * map.on('mousemove', () => {
+     *     console.log('A mousemove event has occurred.');
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener for a specific layer
-     * map.on('mousemove', 'poi-label', function() {
-     *   console.log('A mousemove event has occurred on a visible portion of the poi-label layer.');
+     * map.on('mousemove', 'poi-label', () => {
+     *     console.log('A mousemove event has occurred on a visible portion of the poi-label layer.');
      * });
      * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
      * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
@@ -544,17 +551,17 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener
-     * map.on('click', function(e) {
-     *   console.log('A click event has occurred at ' + e.lngLat);
+     * map.on('click', (e) => {
+     *     console.log(`A click event has occurred at ${e.lngLat}`);
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener for a specific layer
-     * map.on('click', 'poi-label', function(e) {
-     *   console.log('A click event has occurred on a visible portion of the poi-label layer at ' + e.lngLat);
+     * map.on('click', 'poi-label', (e) => {
+     *     console.log(`A click event has occurred on a visible portion of the poi-label layer at ${e.lngLat}`);
      * });
      * @see [Measure distances](https://www.mapbox.com/mapbox-gl-js/example/measure/)
      * @see [Center the map on a clicked symbol](https://www.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
@@ -575,17 +582,17 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener
-     * map.on('dblclick', function(e) {
-     *   console.log('A dblclick event has occurred at ' + e.lngLat);
+     * map.on('dblclick', (e) => {
+     *     console.log(`A dblclick event has occurred at ${e.lngLat}`);
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener for a specific layer
-     * map.on('dblclick', 'poi-label', function(e) {
-     *   console.log('A dblclick event has occurred on a visible portion of the poi-label layer at ' + e.lngLat);
+     * map.on('dblclick', 'poi-label', (e) => {
+     *     console.log(`A dblclick event has occurred on a visible portion of the poi-label layer at ${e.lngLat}`);
      * });
      */
     | 'dblclick'
@@ -603,10 +610,10 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener
-     * map.on('mouseenter', 'water', function() {
-     *   console.log('A mouseenter event occurred on a visible portion of the water layer.');
+     * map.on('mouseenter', 'water', () => {
+     *     console.log('A mouseenter event occurred on a visible portion of the water layer.');
      * });
      * @see [Center the map on a clicked symbol](https://docs.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
      * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
@@ -628,12 +635,12 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when the pointing device leaves
      * // a visible portion of the specified layer.
-     * map.on('mouseleave', 'water', function() {
-     *   console.log('A mouseleave event occurred.');
+     * map.on('mouseleave', 'water', () => {
+     *     console.log('A mouseleave event occurred.');
      * });
      * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
      * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
@@ -649,12 +656,12 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when the pointing device leave's
      * // the map's canvas.
-     * map.on('mouseout', function() {
-     *   console.log('A mouseout event occurred.');
+     * map.on('mouseout', () => {
+     *     console.log('A mouseout event occurred.');
      * });
      */
     | 'mouseout'
@@ -668,12 +675,12 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when the right mouse button is
      * // pressed within the map.
-     * map.on('contextmenu', function() {
-     *   console.log('A contextmenu event occurred.');
+     * map.on('contextmenu', () => {
+     *     console.log('A contextmenu event occurred.');
      * });
      */
     | 'contextmenu'
@@ -687,11 +694,11 @@ export type MapEvent =
      * @property {MapWheelEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when a wheel event occurs within the map.
-     * map.on('wheel', function() {
-     *   console.log('A wheel event occurred.');
+     * map.on('wheel', () => {
+     *     console.log('A wheel event occurred.');
      * });
      */
     | 'wheel'
@@ -704,11 +711,11 @@ export type MapEvent =
      * @instance
      * @property {MapTouchEvent} data
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when a touchstart event occurs within the map.
-     * map.on('touchstart', function() {
-     *   console.log('A touchstart event occurred.');
+     * map.on('touchstart', () => {
+     *     console.log('A touchstart event occurred.');
      * });
      * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
@@ -723,11 +730,11 @@ export type MapEvent =
      * @property {MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when a touchstart event occurs within the map.
-     * map.on('touchstart', function() {
-     *   console.log('A touchstart event occurred.');
+     * map.on('touchstart', () => {
+     *     console.log('A touchstart event occurred.');
      * });
      * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
@@ -742,11 +749,11 @@ export type MapEvent =
      * @property {MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when a touchmove event occurs within the map.
-     * map.on('touchmove', function() {
-     *   console.log('A touchmove event occurred.');
+     * map.on('touchmove', () => {
+     *     console.log('A touchmove event occurred.');
      * });
      * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
@@ -761,11 +768,11 @@ export type MapEvent =
      * @property {MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when a touchcancel event occurs within the map.
-     * map.on('touchcancel', function() {
-     *   console.log('A touchcancel event occurred.');
+     * map.on('touchcancel', () => {
+     *     console.log('A touchcancel event occurred.');
      * });
      */
     | 'touchcancel'
@@ -780,12 +787,12 @@ export type MapEvent =
      * @property {{originalEvent: DragEvent}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just before the map begins a transition
      * // from one view to another.
-     * map.on('movestart', function() {
-     *   console.log('A movestart` event occurred.');
+     * map.on('movestart', () => {
+     *     console.log('A movestart` event occurred.');
      * });
      */
     | 'movestart'
@@ -800,11 +807,11 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // repeatedly during an animated transition.
-     * map.on('move', function() {
-     *   console.log('A move event occurred.');
+     * map.on('move', () => {
+     *     console.log('A move event occurred.');
      * });
      * @see [Display HTML clusters with custom properties](https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/)
      * @see [Filter features within map view](https://docs.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
@@ -821,11 +828,11 @@ export type MapEvent =
      * @property {{originalEvent: DragEvent}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just after the map completes a transition.
-     * map.on('moveend', function() {
-     *   console.log('A moveend event occurred.');
+     * map.on('moveend', () => {
+     *     console.log('A moveend event occurred.');
      * });
      * @see [Play map locations as a slideshow](https://www.mapbox.com/mapbox-gl-js/example/playback-locations/)
      * @see [Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
@@ -842,11 +849,11 @@ export type MapEvent =
      * @property {{originalEvent: DragEvent}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when a "drag to pan" interaction starts.
-     * map.on('dragstart', function() {
-     *   console.log('A dragstart event occurred.');
+     * map.on('dragstart', () => {
+     *     console.log('A dragstart event occurred.');
      * });
      */
     | 'dragstart'
@@ -860,11 +867,11 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // repeatedly  during a "drag to pan" interaction.
-     * map.on('drag', function() {
-     *   console.log('A drag event occurred.');
+     * map.on('drag', () => {
+     *     console.log('A drag event occurred.');
      * });
      */
     | 'drag'
@@ -878,11 +885,11 @@ export type MapEvent =
      * @property {{originalEvent: DragEvent}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when a "drag to pan" interaction ends.
-     * map.on('dragend', function() {
-     *   console.log('A dragend event occurred.');
+     * map.on('dragend', () => {
+     *     console.log('A dragend event occurred.');
      * });
      * @see [Create a draggable marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
      */
@@ -898,11 +905,11 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just before a zoom transition starts.
-     * map.on('zoomstart', function() {
-     *   console.log('A zoomstart event occurred.');
+     * map.on('zoomstart', () => {
+     *     console.log('A zoomstart event occurred.');
      * });
      */
     | 'zoomstart'
@@ -917,11 +924,11 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // repeatedly during a zoom transition.
-     * map.on('zoom', function() {
-     *   console.log('A zoom event occurred.');
+     * map.on('zoom', () => {
+     *     console.log('A zoom event occurred.');
      * });
      * @see [Update a choropleth layer by zoom level](https://www.mapbox.com/mapbox-gl-js/example/updating-choropleth/)
      */
@@ -939,11 +946,11 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just after a zoom transition finishes.
-     * map.on('zoomend', function() {
-     *   console.log('A zoomend event occurred.');
+     * map.on('zoomend', () => {
+     *     console.log('A zoomend event occurred.');
      * });
      */
     | 'zoomend'
@@ -957,11 +964,11 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just before a "drag to rotate" interaction starts.
-     * map.on('rotatestart', function() {
-     *   console.log('A rotatestart event occurred.');
+     * map.on('rotatestart', () => {
+     *     console.log('A rotatestart event occurred.');
      * });
      */
     | 'rotatestart'
@@ -975,11 +982,11 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // repeatedly during "drag to rotate" interaction.
-     * map.on('rotate', function() {
-     *   console.log('A rotate event occurred.');
+     * map.on('rotate', () => {
+     *     console.log('A rotate event occurred.');
      * });
      */
     | 'rotate'
@@ -993,11 +1000,11 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just after a "drag to rotate" interaction ends.
-     * map.on('rotateend', function() {
-     *   console.log('A rotateend event occurred.');
+     * map.on('rotateend', () => {
+     *     console.log('A rotateend event occurred.');
      * });
      */
     | 'rotateend'
@@ -1012,11 +1019,11 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just before a pitch (tilt) transition starts.
-     * map.on('pitchstart', function() {
-     *   console.log('A pitchstart event occurred.');
+     * map.on('pitchstart', () => {
+     *     console.log('A pitchstart event occurred.');
      * });
      */
     | 'pitchstart'
@@ -1032,11 +1039,11 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // repeatedly during a pitch (tilt) transition.
-     * map.on('pitch', function() {
-     *   console.log('A pitch event occurred.');
+     * map.on('pitch', () => {
+     *     console.log('A pitch event occurred.');
      * });
      */
     | 'pitch'
@@ -1051,11 +1058,11 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just after a pitch (tilt) transition ends.
-     * map.on('pitchend', function() {
-     *   console.log('A pitchend event occurred.');
+     * map.on('pitchend', () => {
+     *     console.log('A pitchend event occurred.');
      * });
      */
     | 'pitchend'
@@ -1069,11 +1076,11 @@ export type MapEvent =
      * @property {MapBoxZoomEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just before a "box zoom" interaction starts.
-     * map.on('boxzoomstart', function() {
-     *   console.log('A boxzoomstart event occurred.');
+     * map.on('boxzoomstart', () => {
+     *     console.log('A boxzoomstart event occurred.');
      * });
      */
     | 'boxzoomstart'
@@ -1088,11 +1095,11 @@ export type MapEvent =
      * @property {MapBoxZoomEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just after a "box zoom" interaction ends.
-     * map.on('boxzoomend', function() {
-     *   console.log('A boxzoomend event occurred.');
+     * map.on('boxzoomend', () => {
+     *     console.log('A boxzoomend event occurred.');
      * });
      */
     | 'boxzoomend'
@@ -1107,11 +1114,11 @@ export type MapEvent =
      * @property {MapBoxZoomEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // the user cancels a "box zoom" interaction.
-     * map.on('boxzoomcancel', function() {
-     *   console.log('A boxzoomcancel event occurred.');
+     * map.on('boxzoomcancel', () => {
+     *     console.log('A boxzoomcancel event occurred.');
      * });
      */
     | 'boxzoomcancel'
@@ -1124,11 +1131,11 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // immediately after the map has been resized.
-     * map.on('resize', function() {
-     *   console.log('A resize event occurred.');
+     * map.on('resize', () => {
+     *     console.log('A resize event occurred.');
      * });
      */
     | 'resize'
@@ -1141,11 +1148,11 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when the WebGL context is lost.
-     * map.on('webglcontextlost', function() {
-     *   console.log('A webglcontextlost event occurred.');
+     * map.on('webglcontextlost', () => {
+     *     console.log('A webglcontextlost event occurred.');
      * });
      */
     | 'webglcontextlost'
@@ -1158,11 +1165,11 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when the WebGL context is restored.
-     * map.on('webglcontextrestored', function() {
-     *   console.log('A webglcontextrestored event occurred.');
+     * map.on('webglcontextrestored', () => {
+     *     console.log('A webglcontextrestored event occurred.');
      * });
      */
     | 'webglcontextrestored'
@@ -1177,11 +1184,11 @@ export type MapEvent =
      * @type {Object}
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when the map has finished loading.
-     * map.on('load', function() {
-     *   console.log('A load event occurred.');
+     * map.on('load', () => {
+     *     console.log('A load event occurred.');
      * });
      * @see [Draw GeoJSON points](https://www.mapbox.com/mapbox-gl-js/example/geojson-markers/)
      * @see [Add live realtime data](https://www.mapbox.com/mapbox-gl-js/example/live-geojson/)
@@ -1202,11 +1209,11 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // whenever the map is drawn to the screen.
-     * map.on('render', function() {
-     *   console.log('A render event occurred.');
+     * map.on('render', () => {
+     *     console.log('A render event occurred.');
      * });
      */
     | 'render'
@@ -1224,11 +1231,11 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just before the map enters an "idle" state.
-     * map.on('idle', function() {
-     *   console.log('A idle event occurred.');
+     * map.on('idle', () => {
+     *     console.log('A idle event occurred.');
      * });
      */
     | 'idle'
@@ -1241,11 +1248,11 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // just after the map is removed.
-     * map.on('remove', function() {
-     *   console.log('A remove event occurred.');
+     * map.on('remove', () => {
+     *     console.log('A remove event occurred.');
      * });
      */
     | 'remove'
@@ -1262,11 +1269,11 @@ export type MapEvent =
      * @property {{error: {message: string}}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when an error occurs.
-     * map.on('error', function() {
-     *   console.log('A error event occurred.');
+     * map.on('error', () => {
+     *     console.log('A error event occurred.');
      * });
      */
     | 'error'
@@ -1281,11 +1288,11 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when map data loads or changes.
-     * map.on('data', function() {
-     *   console.log('A data event occurred.');
+     * map.on('data', () => {
+     *     console.log('A data event occurred.');
      * });
      * @see [Display HTML clusters with custom properties](https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/)
      */
@@ -1301,11 +1308,11 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when the map's style loads or changes.
-     * map.on('styledata', function() {
-     *   console.log('A styledata event occurred.');
+     * map.on('styledata', () => {
+     *     console.log('A styledata event occurred.');
      * });
      */
     | 'styledata'
@@ -1320,11 +1327,11 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when one of the map's sources loads or changes.
-     * map.on('sourcedata', function() {
-     *   console.log('A sourcedata event occurred.');
+     * map.on('sourcedata', () => {
+     *     console.log('A sourcedata event occurred.');
      * });
      */
     | 'sourcedata'
@@ -1340,12 +1347,12 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // when any map data begins loading
      * // or changing asynchronously.
-     * map.on('dataloading', function() {
-     *   console.log('A dataloading event occurred.');
+     * map.on('dataloading', () => {
+     *     console.log('A dataloading event occurred.');
      * });
      */
     | 'dataloading'
@@ -1361,12 +1368,12 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // map's style begins loading or
      * // changing asyncronously.
-     * map.on('styledataloading', function() {
-     *   console.log('A styledataloading event occurred.');
+     * map.on('styledataloading', () => {
+     *     console.log('A styledataloading event occurred.');
      * });
      */
     | 'styledataloading'
@@ -1382,12 +1389,12 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // map's sources begin loading or
      * // changing asyncronously.
-     * map.on('sourcedataloading', function() {
-     *   console.log('A sourcedataloading event occurred.');
+     * map.on('sourcedataloading', () => {
+     *     console.log('A sourcedataloading event occurred.');
      * });
      */
     | 'sourcedataloading'
@@ -1403,11 +1410,11 @@ export type MapEvent =
      * @property {string} id The id of the missing image.
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
      * // an icon or pattern is missing.
-     * map.on('styleimagemissing', function() {
-     *   console.log('A styleimagemissing event occurred.');
+     * map.on('styleimagemissing', () => {
+     *     console.log('A styleimagemissing event occurred.');
      * });
      * @see [Generate and add a missing icon to the map](https://mapbox.com/mapbox-gl-js/example/add-image-missing-generated/)
      */
@@ -1430,7 +1437,7 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new mapboxgl.Map({});
      * map.speedIndexTiming = true;
      * // Set an event listener that fires
      * map.on('speedindexcompleted', function() {

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -57,7 +57,7 @@ class BoxZoomHandler {
      * Enables the "box zoom" interaction.
      *
      * @example
-     *   map.boxZoom.enable();
+     * map.boxZoom.enable();
      */
     enable() {
         if (this.isEnabled()) return;
@@ -68,7 +68,7 @@ class BoxZoomHandler {
      * Disables the "box zoom" interaction.
      *
      * @example
-     *   map.boxZoom.disable();
+     * map.boxZoom.disable();
      */
     disable() {
         if (!this.isEnabled()) return;

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -138,7 +138,7 @@ class KeyboardHandler {
      * Enables the "keyboard rotate and zoom" interaction.
      *
      * @example
-     *   map.keyboard.enable();
+     * map.keyboard.enable();
      */
     enable() {
         this._enabled = true;
@@ -148,7 +148,7 @@ class KeyboardHandler {
      * Disables the "keyboard rotate and zoom" interaction.
      *
      * @example
-     *   map.keyboard.disable();
+     * map.keyboard.disable();
      */
     disable() {
         this._enabled = false;
@@ -182,7 +182,7 @@ class KeyboardHandler {
      * "keyboard zoom" interaction enabled.
      *
      * @example
-     *   map.keyboard.disableRotation();
+     * map.keyboard.disableRotation();
      */
     disableRotation() {
         this._rotationDisabled = true;
@@ -192,8 +192,8 @@ class KeyboardHandler {
      * Enables the "keyboard pan/rotate" interaction.
      *
      * @example
-     *   map.keyboard.enable();
-     *   map.keyboard.enableRotation();
+     * map.keyboard.enable();
+     * map.keyboard.enableRotation();
      */
     enableRotation() {
         this._rotationDisabled = false;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -80,7 +80,7 @@ class ScrollZoomHandler {
      * @param {number} [zoomRate=1/100] The rate used to scale trackpad movement to a zoom value.
      * @example
      * // Speed up trackpad zoom
-     * map.scrollZoom.setZoomRate(1/25);
+     * map.scrollZoom.setZoomRate(1 / 25);
      */
     setZoomRate(zoomRate: number) {
         this._defaultZoomRate = zoomRate;
@@ -91,7 +91,7 @@ class ScrollZoomHandler {
     * @param {number} [wheelZoomRate=1/450] The rate used to scale mouse wheel movement to a zoom value.
     * @example
     * // Slow down zoom of mouse wheel
-    * map.scrollZoom.setWheelZoomRate(1/600);
+    * map.scrollZoom.setWheelZoomRate(1 / 600);
     */
     setWheelZoomRate(wheelZoomRate: number) {
         this._wheelZoomRate = wheelZoomRate;
@@ -126,9 +126,9 @@ class ScrollZoomHandler {
      * @param {string} [options.around] If "center" is passed, map will zoom around center of map
      *
      * @example
-     *   map.scrollZoom.enable();
+     * map.scrollZoom.enable();
      * @example
-     *  map.scrollZoom.enable({ around: 'center' })
+     * map.scrollZoom.enable({around: 'center'});
      */
     enable(options: any) {
         if (this.isEnabled()) return;
@@ -140,7 +140,7 @@ class ScrollZoomHandler {
      * Disables the "scroll to zoom" interaction.
      *
      * @example
-     *   map.scrollZoom.disable();
+     * map.scrollZoom.disable();
      */
     disable() {
         if (!this.isEnabled()) return;

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -42,14 +42,14 @@ export default class DragPanHandler {
      * @param {number} [options.deceleration=2500] the rate at which the speed reduces after the pan ends.
      *
      * @example
-     *   map.dragPan.enable();
+     * map.dragPan.enable();
      * @example
-     *   map.dragPan.enable({
-     *      linearity: 0.3,
-     *      easing: bezier(0, 0, 0.3, 1),
-     *      maxSpeed: 1400,
-     *      deceleration: 2500,
-     *   });
+     * map.dragPan.enable({
+     *     linearity: 0.3,
+     *     easing: bezier(0, 0, 0.3, 1),
+     *     maxSpeed: 1400,
+     *     deceleration: 2500,
+     * });
      */
     enable(options?: DragPanOptions) {
         this._inertiaOptions = options || {};

--- a/src/ui/handler/shim/touch_zoom_rotate.js
+++ b/src/ui/handler/shim/touch_zoom_rotate.js
@@ -39,9 +39,9 @@ export default class TouchZoomRotateHandler {
      * @param {string} [options.around] If "center" is passed, map will zoom around the center
      *
      * @example
-     *   map.touchZoomRotate.enable();
+     * map.touchZoomRotate.enable();
      * @example
-     *   map.touchZoomRotate.enable({ around: 'center' });
+     * map.touchZoomRotate.enable({around: 'center'});
      */
     enable(options: ?{around?: 'center'}) {
         this._touchZoom.enable(options);
@@ -54,7 +54,7 @@ export default class TouchZoomRotateHandler {
      * Disables the "pinch to rotate and zoom" interaction.
      *
      * @example
-     *   map.touchZoomRotate.disable();
+     * map.touchZoomRotate.disable();
      */
     disable() {
         this._touchZoom.disable();
@@ -88,7 +88,7 @@ export default class TouchZoomRotateHandler {
      * interaction enabled.
      *
      * @example
-     *   map.touchZoomRotate.disableRotation();
+     * map.touchZoomRotate.disableRotation();
      */
     disableRotation() {
         this._rotationDisabled = true;
@@ -99,8 +99,8 @@ export default class TouchZoomRotateHandler {
      * Enables the "pinch to rotate" interaction.
      *
      * @example
-     *   map.touchZoomRotate.enable();
-     *   map.touchZoomRotate.enableRotation();
+     * map.touchZoomRotate.enable();
+     * map.touchZoomRotate.enableRotation();
      */
     enableRotation() {
         this._rotationDisabled = false;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -267,22 +267,22 @@ const defaultOptions = {
  *  see `src/ui/default_locale.js` for an example with all supported string IDs. The object may specify all UI strings (thereby adding support for a new translation) or only a subset of strings (thereby patching the default translation table).
  * @param {boolean} [options.testMode=false] Silences errors and warnings generated due to an invalid accessToken, useful when using the library to write unit tests.
  * @example
- * var map = new mapboxgl.Map({
- *   container: 'map', // container ID
- *   center: [-122.420679, 37.772537], // starting position [lng, lat]
- *   zoom: 13, // starting zoom
- *   style: 'mapbox://styles/mapbox/streets-v11', // style URL or style object
- *   hash: true, // sync `center`, `zoom`, `pitch`, and `bearing` with URL
- *   // Use `transformRequest` to modify requests that begin with `http://myHost`.
- *   transformRequest: (url, resourceType)=> {
- *     if(resourceType === 'Source' && url.startsWith('http://myHost')) {
- *       return {
- *        url: url.replace('http', 'https'),
- *        headers: { 'my-custom-header': true},
- *        credentials: 'include'  // Include cookies for cross-origin requests
- *      }
+ * const map = new mapboxgl.Map({
+ *     container: 'map', // container ID
+ *     center: [-122.420679, 37.772537], // starting position [lng, lat]
+ *     zoom: 13, // starting zoom
+ *     style: 'mapbox://styles/mapbox/streets-v11', // style URL or style object
+ *     hash: true, // sync `center`, `zoom`, `pitch`, and `bearing` with URL
+ *     // Use `transformRequest` to modify requests that begin with `http://myHost`.
+ *     transformRequest: (url, resourceType) => {
+ *         if (resourceType === 'Source' && url.startsWith('http://myHost')) {
+ *             return {
+ *                 url: url.replace('http', 'https'),
+ *                 headers: {'my-custom-header': true},
+ *                 credentials: 'include'  // Include cookies for cross-origin requests
+ *             };
+ *         }
  *     }
- *   }
  * });
  * @see [Display a map on a webpage](https://docs.mapbox.com/mapbox-gl-js/example/simple-map/)
  * @see [Display a map with a custom style](https://docs.mapbox.com/mapbox-gl-js/example/custom-style-id/)
@@ -587,7 +587,7 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * // Define a new navigation control.
-     * var navigation = new mapboxgl.NavigationControl();
+     * const navigation = new mapboxgl.NavigationControl();
      * // Add zoom and rotation controls to the map.
      * map.addControl(navigation);
      * // Remove zoom and rotation controls from the map.
@@ -611,7 +611,7 @@ class Map extends Camera {
      * @returns {boolean} True if map contains control.
      * @example
      * // Define a new navigation control.
-     * var navigation = new mapboxgl.NavigationControl();
+     * const navigation = new mapboxgl.NavigationControl();
      * // Add zoom and rotation controls to the map.
      * map.addControl(navigation);
      * // Check that the navigation control exists on the map.
@@ -637,7 +637,7 @@ class Map extends Camera {
      * @example
      * // Resize the map when the map container is shown
      * // after being initially hidden with CSS.
-     * var mapDiv = document.getElementById('map');
+     * const mapDiv = document.getElementById('map');
      * if (mapDiv.style.visibility === true) map.resize();
      */
     resize(eventData?: Object) {
@@ -669,7 +669,7 @@ class Map extends Camera {
      * If a padding is set on the map, the bounds returned are for the inset.
      * @returns {LngLatBounds} The geographical bounds of the map as {@link LngLatBounds}.
      * @example
-     * var bounds = map.getBounds();
+     * const bounds = map.getBounds();
      */
     getBounds(): LngLatBounds {
         return this.transform.getBounds();
@@ -679,7 +679,7 @@ class Map extends Camera {
      * Returns the maximum geographical bounds the map is constrained to, or `null` if none set.
      * @returns The map object.
      * @example
-     * var maxBounds = map.getMaxBounds();
+     * const maxBounds = map.getMaxBounds();
      */
     getMaxBounds(): LngLatBounds | null {
         return this.transform.getMaxBounds();
@@ -699,9 +699,9 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * // Define bounds that conform to the `LngLatBoundsLike` object.
-     * var bounds = [
-     *   [-74.04728, 40.68392], // [west, south]
-     *   [-73.91058, 40.87764]  // [east, north]
+     * const bounds = [
+     *     [-74.04728, 40.68392], // [west, south]
+     *     [-73.91058, 40.87764]  // [east, north]
      * ];
      * // Set the map's max bounds.
      * map.setMaxBounds(bounds);
@@ -747,7 +747,7 @@ class Map extends Camera {
      *
      * @returns {number} minZoom
      * @example
-     * var minZoom = map.getMinZoom();
+     * const minZoom = map.getMinZoom();
      */
     getMinZoom() { return this.transform.minZoom; }
 
@@ -782,7 +782,7 @@ class Map extends Camera {
      *
      * @returns {number} maxZoom
      * @example
-     * var maxZoom = map.getMaxZoom();
+     * const maxZoom = map.getMaxZoom();
      */
     getMaxZoom() { return this.transform.maxZoom; }
 
@@ -864,7 +864,7 @@ class Map extends Camera {
      * map and the other on the left edge of the map) at every zoom level.
      * @returns {boolean} renderWorldCopies
      * @example
-     * var worldCopiesRendered = map.getRenderWorldCopies();
+     * const worldCopiesRendered = map.getRenderWorldCopies();
      * @see [Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
      */
     getRenderWorldCopies() { return this.transform.renderWorldCopies; }
@@ -900,8 +900,8 @@ class Map extends Camera {
      * @param {LngLatLike} lnglat The geographical location to project.
      * @returns {Point} The {@link Point} corresponding to `lnglat`, relative to the map's `container`.
      * @example
-     * var coordinate = [-122.420679, 37.772537];
-     * var point = map.project(coordinate);
+     * const coordinate = [-122.420679, 37.772537];
+     * const point = map.project(coordinate);
      */
     project(lnglat: LngLatLike) {
         return this.transform.locationPoint3D(LngLat.convert(lnglat));
@@ -916,9 +916,9 @@ class Map extends Camera {
      * @param {PointLike} point The pixel coordinates to unproject.
      * @returns {LngLat} The {@link LngLat} corresponding to `point`.
      * @example
-     * map.on('click', function(e) {
-     *   // When the map is clicked, get the geographic coordinate.
-     *   var coordinate = map.unproject(e.point);
+     * map.on('click', (e) => {
+     *     // When the map is clicked, get the geographic coordinate.
+     *     const coordinate = map.unproject(e.point);
      * });
      */
     unproject(point: PointLike) {
@@ -929,7 +929,7 @@ class Map extends Camera {
      * Returns true if the map is panning, zooming, rotating, or pitching due to a camera animation or user gesture.
      * @returns {boolean} True if the map is moving.
      * @example
-     * var isMoving = map.isMoving();
+     * const isMoving = map.isMoving();
      */
     isMoving(): boolean {
         return this._moving || this.handlers && this.handlers.isMoving();
@@ -939,7 +939,7 @@ class Map extends Camera {
      * Returns true if the map is zooming due to a camera animation or user gesture.
      * @returns {boolean} True if the map is zooming.
      * @example
-     * var isZooming = map.isZooming();
+     * const isZooming = map.isZooming();
      */
     isZooming(): boolean {
         return this._zooming || this.handlers && this.handlers.isZooming();
@@ -1072,32 +1072,32 @@ class Map extends Camera {
      * @example
      * // Set an event listener that will fire
      * // when the map has finished loading.
-     * map.on('load', function() {
-     *   // Add a new layer.
-     *   map.addLayer({
-     *     id: 'points-of-interest',
-     *     source: {
-     *       type: 'vector',
-     *       url: 'mapbox://mapbox.mapbox-streets-v8'
-     *     },
-     *     'source-layer': 'poi_label',
-     *     type: 'circle',
-     *     paint: {
-     *       // Mapbox Style Specification paint properties
-     *     },
-     *     layout: {
-     *       // Mapbox Style Specification layout properties
-     *     }
-     *   });
+     * map.on('load', () => {
+     *     // Add a new layer.
+     *     map.addLayer({
+     *         id: 'points-of-interest',
+     *         source: {
+     *             type: 'vector',
+     *             url: 'mapbox://mapbox.mapbox-streets-v8'
+     *         },
+     *         'source-layer': 'poi_label',
+     *         type: 'circle',
+     *         paint: {
+     *             // Mapbox Style Specification paint properties
+     *         },
+     *         layout: {
+     *             // Mapbox Style Specification layout properties
+     *         }
+     *     });
      * });
      * @example
      * // Set an event listener that will fire
      * // when a feature on the countries layer of the map is clicked.
-     * map.on('click', 'countries', function(e) {
-     *   new mapboxgl.Popup()
-     *     .setLngLat(e.lngLat)
-     *     .setHTML(`Country name: ${e.features[0].properties.name}`)
-     *     .addTo(map);
+     * map.on('click', 'countries', (e) => {
+     *     new mapboxgl.Popup()
+     *         .setLngLat(e.lngLat)
+     *         .setHTML(`Country name: ${e.features[0].properties.name}`)
+     *         .addTo(map);
      * });
      * @see [Add 3D terrain to a map](https://docs.mapbox.com/mapbox-gl-js/example/add-terrain/)
      * @see [Center the map on a clicked symbol](https://docs.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
@@ -1143,14 +1143,14 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * // Log the coordinates of a user's first map touch.
-     * map.once('touchstart', function (e) {
-     *   console.log('The first map touch was at: ' + e.lnglat)
+     * map.once('touchstart', (e) => {
+     *     console.log(`The first map touch was at: ${e.lnglat}`);
      * });
      * @example
      * // Log the coordinates of a user's first map touch
      * // on a specific layer.
-     * map.once('touchstart', 'my-point-layer', function (e) {
-     *   console.log('The first map touch on the point layer was at: ' + e.lnglat)
+     * map.once('touchstart', 'my-point-layer', (e) => {
+     *     console.log(`The first map touch on the point layer was at: ${e.lnglat}`);
      * });
      * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      * @see [Animate the camera around a point with 3D terrain](https://docs.mapbox.com/mapbox-gl-js/example/free-camera-point/)
@@ -1182,17 +1182,17 @@ class Map extends Camera {
      * @example
      * // Create a function to print coordinates while a mouse is moving.
      * function onMove(e) {
-     *   console.log('The mouse is moving: ' + e.lngLat)
+     *     console.log(`The mouse is moving: ${e.lngLat}`);
      * }
      * // Create a function to unbind the `mousemove` event.
      * function onUp(e) {
-     *   console.log('The final coordinates are: ' + e.lngLat)
-     *   map.off('mousemove', onMove);
+     *     console.log(`The final coordinates are: ${e.lngLat}`);
+     *     map.off('mousemove', onMove);
      * }
      * // When a click occurs, bind both functions to mouse events.
-     * map.on('mousedown', function (e) {
-     *   map.on('mousemove', onMove);
-     *   map.once('mouseup', onUp);
+     * map.on('mousedown', (e) => {
+     *     map.on('mousemove', onMove);
+     *     map.once('mouseup', onUp);
      * });
      * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
@@ -1274,30 +1274,30 @@ class Map extends Camera {
      *
      * @example
      * // Find all features at a point
-     * var features = map.queryRenderedFeatures(
+     * const features = map.queryRenderedFeatures(
      *   [20, 35],
-     *   { layers: ['my-layer-name'] }
+     *   {layers: ['my-layer-name']}
      * );
      *
      * @example
      * // Find all features within a static bounding box
-     * var features = map.queryRenderedFeatures(
+     * const features = map.queryRenderedFeatures(
      *   [[10, 20], [30, 50]],
-     *   { layers: ['my-layer-name'] }
+     *   {layers: ['my-layer-name']}
      * );
      *
      * @example
      * // Find all features within a bounding box around a point
-     * var width = 10;
-     * var height = 20;
-     * var features = map.queryRenderedFeatures([
-     *   [point.x - width / 2, point.y - height / 2],
-     *   [point.x + width / 2, point.y + height / 2]
-     * ], { layers: ['my-layer-name'] });
+     * const width = 10;
+     * const height = 20;
+     * const features = map.queryRenderedFeatures([
+     *     [point.x - width / 2, point.y - height / 2],
+     *     [point.x + width / 2, point.y + height / 2]
+     * ], {layers: ['my-layer-name']});
      *
      * @example
      * // Query all rendered features from a single layer
-     * var features = map.queryRenderedFeatures({ layers: ['my-layer-name'] });
+     * const features = map.queryRenderedFeatures({layers: ['my-layer-name']});
      * @see [Get features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/queryrenderedfeatures/)
      * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
      * @see [Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
@@ -1358,8 +1358,8 @@ class Map extends Camera {
      *
      * @example
      * // Find all features in one source layer in a vector source
-     * var features = map.querySourceFeatures('your-source-id', {
-     *   sourceLayer: 'your-source-layer'
+     * const features = map.querySourceFeatures('your-source-id', {
+     *     sourceLayer: 'your-source-layer'
      * });
      *
      * @see [Highlight features containing similar data](https://www.mapbox.com/mapbox-gl-js/example/query-similar-features/)
@@ -1483,8 +1483,8 @@ class Map extends Camera {
      * @returns {Object} The map's style JSON object.
      *
      * @example
-     * map.on('load', function() {
-     *   var styleJson = map.getStyle();
+     * map.on('load', () => {
+     *     const styleJson = map.getStyle();
      * });
      *
      */
@@ -1500,7 +1500,7 @@ class Map extends Camera {
      * @returns {boolean} A Boolean indicating whether the style is fully loaded.
      *
      * @example
-     * var styleLoadStatus = map.isStyleLoaded();
+     * const styleLoadStatus = map.isStyleLoaded();
      */
     isStyleLoaded() {
         if (!this.style) return warnOnce('There is no style added to the map.');
@@ -1518,23 +1518,23 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * map.addSource('my-data', {
-     *   type: 'vector',
-     *   url: 'mapbox://myusername.tilesetid'
+     *     type: 'vector',
+     *     url: 'mapbox://myusername.tilesetid'
      * });
      * @example
      * map.addSource('my-data', {
-     *   "type": "geojson",
-     *   "data": {
-     *     "type": "Feature",
-     *     "geometry": {
-     *       "type": "Point",
-     *       "coordinates": [-77.0323, 38.9131]
-     *     },
-     *     "properties": {
-     *       "title": "Mapbox DC",
-     *       "marker-symbol": "monument"
+     *     "type": "geojson",
+     *     "data": {
+     *         "type": "Feature",
+     *         "geometry": {
+     *             "type": "Point",
+     *             "coordinates": [-77.0323, 38.9131]
+     *         },
+     *         "properties": {
+     *             "title": "Mapbox DC",
+     *             "marker-symbol": "monument"
+     *         }
      *     }
-     *   }
      * });
      * @see Vector source: [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
      * @see GeoJSON source: [Add live realtime data](https://docs.mapbox.com/mapbox-gl-js/example/live-geojson/)
@@ -1553,7 +1553,7 @@ class Map extends Camera {
      * @param {string} id The ID of the source to be checked.
      * @returns {boolean} A Boolean indicating whether the source is loaded.
      * @example
-     * var sourceLoaded = map.isSourceLoaded('bathymetry-data');
+     * const sourceLoaded = map.isSourceLoaded('bathymetry-data');
      */
     isSourceLoaded(id: string) {
         const sourceCaches = this.style && this.style._getSourceCaches(id);
@@ -1571,7 +1571,7 @@ class Map extends Camera {
      *
      * @returns {boolean} A Boolean indicating whether all tiles are loaded.
      * @example
-     * var tilesLoaded = map.areTilesLoaded();
+     * const tilesLoaded = map.areTilesLoaded();
      */
 
     areTilesLoaded() {
@@ -1629,7 +1629,7 @@ class Map extends Camera {
      * A list of options for each source type is available on the Mapbox Style Specification's
      * [Sources](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) page.
      * @example
-     * var sourceObject = map.getSource('points');
+     * const sourceObject = map.getSource('points');
      * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      * @see [Animate a point](https://docs.mapbox.com/mapbox-gl-js/example/animate-point-along-line/)
      * @see [Add live realtime data](https://docs.mapbox.com/mapbox-gl-js/example/live-geojson/)
@@ -1661,23 +1661,22 @@ class Map extends Camera {
      * @example
      * // If the style's sprite does not already contain an image with ID 'cat',
      * // add the image 'cat-icon.png' to the style's sprite with the ID 'cat'.
-     * map.loadImage('https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Cat_silhouette.svg/400px-Cat_silhouette.svg.png', function(error, image) {
-     *    if (error) throw error;
-     *    if (!map.hasImage('cat')) map.addImage('cat', image);
+     * map.loadImage('https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Cat_silhouette.svg/400px-Cat_silhouette.svg.png', (error, image) => {
+     *     if (error) throw error;
+     *     if (!map.hasImage('cat')) map.addImage('cat', image);
      * });
-     *
      *
      * // Add a stretchable image that can be used with `icon-text-fit`
      * // In this example, the image is 600px wide by 400px high.
-     * map.loadImage('https://upload.wikimedia.org/wikipedia/commons/8/89/Black_and_White_Boxed_%28bordered%29.png', function(error, image) {
-     *    if (error) throw error;
-     *    if (!map.hasImage('border-image')) {
-     *      map.addImage('border-image', image, {
-     *          content: [16, 16, 300, 384], // place text over left half of image, avoiding the 16px border
-     *          stretchX: [[16, 584]], // stretch everything horizontally except the 16px border
-     *          stretchY: [[16, 384]], // stretch everything vertically except the 16px border
-     *      });
-     *    }
+     * map.loadImage('https://upload.wikimedia.org/wikipedia/commons/8/89/Black_and_White_Boxed_%28bordered%29.png', (error, image) => {
+     *     if (error) throw error;
+     *     if (!map.hasImage('border-image')) {
+     *         map.addImage('border-image', image, {
+     *             content: [16, 16, 300, 384], // place text over left half of image, avoiding the 16px border
+     *             stretchX: [[16, 584]], // stretch everything horizontally except the 16px border
+     *             stretchY: [[16, 384]], // stretch everything vertically except the 16px border
+     *         });
+     *     }
      * });
      *
      *
@@ -1775,7 +1774,7 @@ class Map extends Camera {
      * @example
      * // Check if an image with the ID 'cat' exists in
      * // the style's sprite.
-     * var catIconExists = map.hasImage('cat');
+     * const catIconExists = map.hasImage('cat');
      */
     hasImage(id: string): boolean {
         if (!id) {
@@ -1811,10 +1810,10 @@ class Map extends Camera {
      *
      * @example
      * // Load an image from an external URL.
-     * map.loadImage('http://placekitten.com/50/50', function(error, image) {
-     *   if (error) throw error;
-     *   // Add the loaded image to the style's sprite with the ID 'kitten'.
-     *   map.addImage('kitten', image);
+     * map.loadImage('http://placekitten.com/50/50', (error, image) => {
+     *     if (error) throw error;
+     *     // Add the loaded image to the style's sprite with the ID 'kitten'.
+     *     map.addImage('kitten', image);
      * });
      *
      * @see [Add an icon to the map](https://www.mapbox.com/mapbox-gl-js/example/add-image/)
@@ -1833,7 +1832,7 @@ class Map extends Camera {
     * @returns {Array<string>} An Array of strings containing the names of all sprites/images currently available in the map.
     *
     * @example
-    * var allImages = map.listImages();
+    * const allImages = map.listImages();
     *
     */
     listImages() {
@@ -1895,53 +1894,53 @@ class Map extends Camera {
      * @example
      * // Add a circle layer with a vector source
      * map.addLayer({
-     *   id: 'points-of-interest',
-     *   source: {
-     *     type: 'vector',
-     *     url: 'mapbox://mapbox.mapbox-streets-v8'
-     *   },
-     *   'source-layer': 'poi_label',
-     *   type: 'circle',
-     *   paint: {
+     *     id: 'points-of-interest',
+     *     source: {
+     *         type: 'vector',
+     *         url: 'mapbox://mapbox.mapbox-streets-v8'
+     *     },
+     *     'source-layer': 'poi_label',
+     *     type: 'circle',
+     *     paint: {
      *     // Mapbox Style Specification paint properties
-     *   },
-     *   layout: {
+     *     },
+     *     layout: {
      *     // Mapbox Style Specification layout properties
-     *   }
+     *     }
      * });
      *
      * @example
      * // Define a source before using it to create a new layer
      * map.addSource('state-data', {
-     *   type: 'geojson',
-     *   data: 'path/to/data.geojson'
+     *     type: 'geojson',
+     *     data: 'path/to/data.geojson'
      * });
      *
      * map.addLayer({
-     *   id: 'states',
-     *   // References the GeoJSON source defined above
-     *   // and does not require a `source-layer`
-     *   source: 'state-data',
-     *   type: 'symbol',
-     *   layout: {
-     *     // Set the label content to the
-     *     // feature's `name` property
-     *     text-field: ['get', 'name']
-     *   }
+     *     id: 'states',
+     *     // References the GeoJSON source defined above
+     *     // and does not require a `source-layer`
+     *     source: 'state-data',
+     *     type: 'symbol',
+     *     layout: {
+     *         // Set the label content to the
+     *         // feature's `name` property
+     *         'text-field': ['get', 'name']
+     *     }
      * });
      *
      * @example
      * // Add a new symbol layer before an existing layer
      * map.addLayer({
-     *   id: 'states',
-     *   // References a source that's already been defined
-     *   source: 'state-data',
-     *   type: 'symbol',
-     *   layout: {
-     *     // Set the label content to the
-     *     // feature's `name` property
-     *     text-field: ['get', 'name']
-     *   }
+     *     id: 'states',
+     *     // References a source that's already been defined
+     *     source: 'state-data',
+     *     type: 'symbol',
+     *     layout: {
+     *         // Set the label content to the
+     *         // feature's `name` property
+     *         'text-field': ['get', 'name']
+     *     }
      * // Add the layer before the existing `cities` layer
      * }, 'cities');
      *
@@ -1997,7 +1996,7 @@ class Map extends Camera {
      *   if the ID corresponds to no existing layers.
      *
      * @example
-     * var stateDataLayer = map.getLayer('state-data');
+     * const stateDataLayer = map.getLayer('state-data');
      *
      * @see [Filter symbols by toggling a list](https://www.mapbox.com/mapbox-gl-js/example/filter-markers/)
      * @see [Filter symbols by text input](https://www.mapbox.com/mapbox-gl-js/example/filter-markers-by-input/)
@@ -2148,7 +2147,7 @@ class Map extends Camera {
      * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      * @returns {Map} `this`
      * @example
-     * var layerVisibility = map.getLayoutProperty('my-layer', 'visibility');
+     * const layerVisibility = map.getLayoutProperty('my-layer', 'visibility');
      * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
      */
     setLight(light: LightSpecification, options: StyleSetterOptions = {}) {
@@ -2181,7 +2180,7 @@ class Map extends Camera {
      *     'maxzoom': 14
      * });
      * // add the DEM source as a terrain layer with exaggerated height
-     * map.setTerrain({ 'source': 'mapbox-dem', 'exaggeration': 1.5 });
+     * map.setTerrain({'source': 'mapbox-dem', 'exaggeration': 1.5});
      */
     setTerrain(terrain: TerrainSpecification) {
         this._lazyInitEmptyStyle();
@@ -2206,9 +2205,9 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * map.setFog({
-     *  "range": [1.0, 12.0],
-     *  "color": 'white',
-     *  "horizon-blend": 0.1
+     *     "range": [1.0, 12.0],
+     *     "color": 'white',
+     *     "horizon-blend": 0.1
      * });
      * @see [Add fog to a map](https://docs.mapbox.com/mapbox-gl-js/example/add-fog/)
      */
@@ -2255,8 +2254,8 @@ class Map extends Camera {
      * When `false`, returns the raw value of the underlying data without styling applied.
      * @returns {number | null} The elevation in meters
      * @example
-     * var coordinate = [-122.420679, 37.772537];
-     * var elevation = map.queryTerrainElevation(coordinate);
+     * const coordinate = [-122.420679, 37.772537];
+     * const elevation = map.queryTerrainElevation(coordinate);
      * @see [Query terrain elevation](https://docs.mapbox.com/mapbox-gl-js/example/query-terrain-elevation/)
      */
     queryTerrainElevation(lnglat: LngLatLike, options: ElevationQueryOptions): number | null {
@@ -2291,16 +2290,16 @@ class Map extends Camera {
      * @example
      * // When the mouse moves over the `my-layer` layer, update
      * // the feature state for the feature under the mouse
-     * map.on('mousemove', 'my-layer', function(e) {
-     *   if (e.features.length > 0) {
-     *     map.setFeatureState({
-     *       source: 'my-source',
-     *       sourceLayer: 'my-source-layer',
-     *       id: e.features[0].id,
-     *     }, {
-     *       hover: true
-     *     });
-     *   }
+     * map.on('mousemove', 'my-layer', (e) => {
+     *     if (e.features.length > 0) {
+     *         map.setFeatureState({
+     *             source: 'my-source',
+     *             sourceLayer: 'my-source-layer',
+     *             id: e.features[0].id,
+     *         }, {
+     *             hover: true
+     *         });
+     *     }
      * });
      *
      * @see [Create a hover effect](https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/)
@@ -2330,31 +2329,31 @@ class Map extends Camera {
      * // Reset the entire state object for all features
      * // in the `my-source` source
      * map.removeFeatureState({
-     *   source: 'my-source'
+     *     source: 'my-source'
      * });
      *
      * @example
      * // When the mouse leaves the `my-layer` layer,
      * // reset the entire state object for the
      * // feature under the mouse
-     * map.on('mouseleave', 'my-layer', function(e) {
-     *   map.removeFeatureState({
-     *     source: 'my-source',
-     *     sourceLayer: 'my-source-layer',
-     *     id: e.features[0].id
-     *   });
+     * map.on('mouseleave', 'my-layer', (e) => {
+     *     map.removeFeatureState({
+     *         source: 'my-source',
+     *         sourceLayer: 'my-source-layer',
+     *         id: e.features[0].id
+     *     });
      * });
      *
      * @example
      * // When the mouse leaves the `my-layer` layer,
      * // reset only the `hover` key-value pair in the
      * // state for the feature under the mouse
-     * map.on('mouseleave', 'my-layer', function(e) {
-     *   map.removeFeatureState({
-     *     source: 'my-source',
-     *     sourceLayer: 'my-source-layer',
-     *     id: e.features[0].id
-     *   }, 'hover');
+     * map.on('mouseleave', 'my-layer', (e) => {
+     *     map.removeFeatureState({
+     *         source: 'my-source',
+     *         sourceLayer: 'my-source-layer',
+     *         id: e.features[0].id
+     *     }, 'hover');
      * });
      *
     */
@@ -2381,14 +2380,14 @@ class Map extends Camera {
      * @example
      * // When the mouse moves over the `my-layer` layer,
      * // get the feature state for the feature under the mouse
-     * map.on('mousemove', 'my-layer', function(e) {
-     *   if (e.features.length > 0) {
-     *     map.getFeatureState({
-     *       source: 'my-source',
-     *       sourceLayer: 'my-source-layer',
-     *       id: e.features[0].id
-     *     });
-     *   }
+     * map.on('mousemove', 'my-layer', (e) => {
+     *     if (e.features.length > 0) {
+     *         map.getFeatureState({
+     *             source: 'my-source',
+     *             sourceLayer: 'my-source-layer',
+     *             id: e.features[0].id
+     *         });
+     *     }
      * });
      *
      */
@@ -3227,6 +3226,7 @@ function removeNode(node) {
  *     }
  * }
  *
+ * @example
  * // Control implemented as ES5 prototypical class
  * function HelloWorldControl() { }
  *
@@ -3239,8 +3239,8 @@ function removeNode(node) {
  * };
  *
  * HelloWorldControl.prototype.onRemove = function () {
- *      this._container.parentNode.removeChild(this._container);
- *      this._map = undefined;
+ *     this._container.parentNode.removeChild(this._container);
+ *     this._map = undefined;
  * };
  */
 
@@ -3292,7 +3292,7 @@ function removeNode(node) {
  *
  * @typedef {Object} Point
  * @example
- * var point = new mapboxgl.Point(-77, 38);
+ * const point = new mapboxgl.Point(-77, 38);
  */
 
 /**
@@ -3300,6 +3300,6 @@ function removeNode(node) {
  *
  * @typedef {(Point | Array<number>)} PointLike
  * @example
- * var p1 = new mapboxgl.Point(-77, 38); // a PointLike which is a Point
- * var p2 = [-77, 38]; // a PointLike which is an array of two numbers
+ * const p1 = new mapboxgl.Point(-77, 38); // a PointLike which is a Point
+ * const p2 = [-77, 38]; // a PointLike which is an array of two numbers
  */

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -44,16 +44,16 @@ export const TERRAIN_OCCLUDED_OPACITY = 0.2;
  * @param {string} [options.pitchAlignment='auto'] `map` aligns the `Marker` to the plane of the map. `viewport` aligns the `Marker` to the plane of the viewport. `auto` automatically matches the value of `rotationAlignment`.
  * @param {string} [options.rotationAlignment='auto'] `map` aligns the `Marker`'s rotation relative to the map, maintaining a bearing as the map rotates. `viewport` aligns the `Marker`'s rotation relative to the viewport, agnostic to map rotations. `auto` is equivalent to `viewport`.
  * @example
- * var marker = new mapboxgl.Marker()
- *   .setLngLat([30.5, 50.5])
- *   .addTo(map);
+ * const marker = new mapboxgl.Marker()
+ *     .setLngLat([30.5, 50.5])
+ *     .addTo(map);
  * @example
  * // Set options
- * var marker = new mapboxgl.Marker({
+ * const marker = new mapboxgl.Marker({
  *     color: "#FFFFFF",
  *     draggable: true
- *   }).setLngLat([30.5, 50.5])
- *   .addTo(map);
+ * }).setLngLat([30.5, 50.5])
+ *     .addTo(map);
  * @see [Add custom icons with Markers](https://www.mapbox.com/mapbox-gl-js/example/custom-marker-icons/)
  * @see [Create a draggable Marker](https://www.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
  */
@@ -241,9 +241,9 @@ export default class Marker extends Evented {
      * @param {Map} map The Mapbox GL JS map to add the marker to.
      * @returns {Marker} `this`
      * @example
-     * var marker = new mapboxgl.Marker()
-     *   .setLngLat([30.5, 50.5])
-     *   .addTo(map); // add the marker to the map
+     * const marker = new mapboxgl.Marker()
+     *     .setLngLat([30.5, 50.5])
+     *     .addTo(map); // add the marker to the map
      */
     addTo(map: Map) {
         this.remove();
@@ -267,7 +267,7 @@ export default class Marker extends Evented {
     /**
      * Removes the marker from a map.
      * @example
-     * var marker = new mapboxgl.Marker().addTo(map);
+     * const marker = new mapboxgl.Marker().addTo(map);
      * marker.remove();
      * @returns {Marker} `this`
      */
@@ -302,9 +302,9 @@ export default class Marker extends Evented {
      * @returns {LngLat} A {@link LngLat} describing the marker's location.
     * @example
     * // Store the marker's longitude and latitude coordinates in a variable
-    * var lngLat = marker.getLngLat();
+    * const lngLat = marker.getLngLat();
     * // Print the marker's longitude and latitude values in the console
-    * console.log('Longitude: ' + lngLat.lng + ', Latitude: ' + lngLat.lat )
+    * console.log(`Longitude: ${lngLat.lng}, Latitude: ${lngLat.lat}`);
     * @see [Create a draggable Marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
     */
     getLngLat() {
@@ -318,8 +318,8 @@ export default class Marker extends Evented {
     * @example
     * // Create a new marker, set the longitude and latitude, and add it to the map
     * new mapboxgl.Marker()
-    *   .setLngLat([-65.017, -16.457])
-    *   .addTo(map);
+    *     .setLngLat([-65.017, -16.457])
+    *     .addTo(map);
     * @see [Add custom icons with Markers](https://docs.mapbox.com/mapbox-gl-js/example/custom-marker-icons/)
     * @see [Create a draggable Marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
     * @see [Add a marker using a place name](https://docs.mapbox.com/mapbox-gl-js/example/marker-from-geocode/)
@@ -346,10 +346,10 @@ export default class Marker extends Evented {
      * set on this {@link Marker} instance is unset.
      * @returns {Marker} `this`
      * @example
-     * var marker = new mapboxgl.Marker()
-     *  .setLngLat([0, 0])
-     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>")) // add popup
-     *  .addTo(map);
+     * const marker = new mapboxgl.Marker()
+     *     .setLngLat([0, 0])
+     *     .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>")) // add popup
+     *     .addTo(map);
      * @see [Attach a popup to a marker instance](https://docs.mapbox.com/mapbox-gl-js/example/set-popup/)
      */
     setPopup(popup: ?Popup) {
@@ -417,10 +417,10 @@ export default class Marker extends Evented {
      * Returns the {@link Popup} instance that is bound to the {@link Marker}.
      * @returns {Popup} popup
      * @example
-     * var marker = new mapboxgl.Marker()
-     *  .setLngLat([0, 0])
-     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
-     *  .addTo(map);
+     * const marker = new mapboxgl.Marker()
+     *     .setLngLat([0, 0])
+     *     .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
+     *     .addTo(map);
      *
      * console.log(marker.getPopup()); // return the popup instance
      */
@@ -432,10 +432,10 @@ export default class Marker extends Evented {
      * Opens or closes the {@link Popup} instance that is bound to the {@link Marker}, depending on the current state of the {@link Popup}.
      * @returns {Marker} `this`
      * @example
-     * var marker = new mapboxgl.Marker()
-     *  .setLngLat([0, 0])
-     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
-     *  .addTo(map);
+     * const marker = new mapboxgl.Marker()
+     *     .setLngLat([0, 0])
+     *     .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
+     *     .addTo(map);
      *
      * marker.togglePopup(); // toggle popup open or closed
      */

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -76,22 +76,24 @@ const focusQuerySelector = [
  *  To ensure the popup resizes to fit its content, set this property to `'none'`.
  *  See the MDN documentation for the list of [available values](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width).
  * @example
- * var markerHeight = 50, markerRadius = 10, linearOffset = 25;
- * var popupOffsets = {
- *  'top': [0, 0],
- *  'top-left': [0,0],
- *  'top-right': [0,0],
- *  'bottom': [0, -markerHeight],
- *  'bottom-left': [linearOffset, (markerHeight - markerRadius + linearOffset) * -1],
- *  'bottom-right': [-linearOffset, (markerHeight - markerRadius + linearOffset) * -1],
- *  'left': [markerRadius, (markerHeight - markerRadius) * -1],
- *  'right': [-markerRadius, (markerHeight - markerRadius) * -1]
- *  };
- * var popup = new mapboxgl.Popup({offset: popupOffsets, className: 'my-class'})
- *   .setLngLat(e.lngLat)
- *   .setHTML("<h1>Hello World!</h1>")
- *   .setMaxWidth("300px")
- *   .addTo(map);
+ * const markerHeight = 50;
+ * const markerRadius = 10;
+ * const linearOffset = 25;
+ * const popupOffsets = {
+ *     'top': [0, 0],
+ *     'top-left': [0, 0],
+ *     'top-right': [0, 0],
+ *     'bottom': [0, -markerHeight],
+ *     'bottom-left': [linearOffset, (markerHeight - markerRadius + linearOffset) * -1],
+ *     'bottom-right': [-linearOffset, (markerHeight - markerRadius + linearOffset) * -1],
+ *     'left': [markerRadius, (markerHeight - markerRadius) * -1],
+ *     'right': [-markerRadius, (markerHeight - markerRadius) * -1]
+ * };
+ * const popup = new mapboxgl.Popup({offset: popupOffsets, className: 'my-class'})
+ *     .setLngLat(e.lngLat)
+ *     .setHTML("<h1>Hello World!</h1>")
+ *     .setMaxWidth("300px")
+ *     .addTo(map);
  * @see [Display a popup](https://www.mapbox.com/mapbox-gl-js/example/popup/)
  * @see [Display a popup on hover](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
  * @see [Display a popup on click](https://www.mapbox.com/mapbox-gl-js/example/popup-on-click/)
@@ -121,9 +123,9 @@ export default class Popup extends Evented {
      * @returns {Popup} `this`
      * @example
      * new mapboxgl.Popup()
-     *   .setLngLat([0, 0])
-     *   .setHTML("<h1>Null Island</h1>")
-     *   .addTo(map);
+     *     .setLngLat([0, 0])
+     *     .setHTML("<h1>Null Island</h1>")
+     *     .addTo(map);
      * @see [Display a popup](https://docs.mapbox.com/mapbox-gl-js/example/popup/)
      * @see [Display a popup on hover](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
      * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
@@ -167,11 +169,11 @@ export default class Popup extends Evented {
          *
          * @example
          * // Create a popup
-         * var popup = new mapboxgl.Popup();
+         * const popup = new mapboxgl.Popup();
          * // Set an event listener that will fire
          * // any time the popup is opened
-         * popup.on('open', function(){
-         *   console.log('popup was opened');
+         * popup.on('open', () => {
+         *     console.log('popup was opened');
          * });
          *
          */
@@ -191,7 +193,7 @@ export default class Popup extends Evented {
      * Removes the popup from the map it has been added to.
      *
      * @example
-     * var popup = new mapboxgl.Popup().addTo(map);
+     * const popup = new mapboxgl.Popup().addTo(map);
      * popup.remove();
      * @returns {Popup} `this`
      */
@@ -227,11 +229,11 @@ export default class Popup extends Evented {
          *
          * @example
          * // Create a popup
-         * var popup = new mapboxgl.Popup();
+         * const popup = new mapboxgl.Popup();
          * // Set an event listener that will fire
          * // any time the popup is closed
-         * popup.on('close', function(){
-         *   console.log('popup was closed');
+         * popup.on('close', () => {
+         *     console.log('popup was closed');
          * });
          *
          */
@@ -283,10 +285,10 @@ export default class Popup extends Evented {
      * Tracks the popup anchor to the cursor position on screens with a pointer device (it will be hidden on touchscreens). Replaces the `setLngLat` behavior.
      * For most use cases, set `closeOnClick` and `closeButton` to `false`.
      * @example
-     * var popup = new mapboxgl.Popup({ closeOnClick: false, closeButton: false })
-     *   .setHTML("<h1>Hello World!</h1>")
-     *   .trackPointer()
-     *   .addTo(map);
+     * const popup = new mapboxgl.Popup({closeOnClick: false, closeButton: false})
+     *     .setHTML("<h1>Hello World!</h1>")
+     *     .trackPointer()
+     *     .addTo(map);
      * @returns {Popup} `this`
      */
     trackPointer() {
@@ -311,11 +313,11 @@ export default class Popup extends Evented {
      * Returns the `Popup`'s HTML element.
      * @example
      * // Change the `Popup` element's font size
-     * var popup = new mapboxgl.Popup()
-     *   .setLngLat([-96, 37.8])
-     *   .setHTML("<p>Hello World!</p>")
-     *   .addTo(map);
-     * var popupElem = popup.getElement();
+     * const popup = new mapboxgl.Popup()
+     *     .setLngLat([-96, 37.8])
+     *     .setHTML("<p>Hello World!</p>")
+     *     .addTo(map);
+     * const popupElem = popup.getElement();
      * popupElem.style.fontSize = "25px";
      * @returns {HTMLElement} element
      */
@@ -333,10 +335,10 @@ export default class Popup extends Evented {
      * @param text Textual content for the popup.
      * @returns {Popup} `this`
      * @example
-     * var popup = new mapboxgl.Popup()
-     *   .setLngLat(e.lngLat)
-     *   .setText('Hello, world!')
-     *   .addTo(map);
+     * const popup = new mapboxgl.Popup()
+     *     .setLngLat(e.lngLat)
+     *     .setText('Hello, world!')
+     *     .addTo(map);
      */
     setText(text: string) {
         return this.setDOMContent(window.document.createTextNode(text));
@@ -352,10 +354,10 @@ export default class Popup extends Evented {
      * @param html A string representing HTML content for the popup.
      * @returns {Popup} `this`
      * @example
-     * var popup = new mapboxgl.Popup()
-     *   .setLngLat(e.lngLat)
-     *   .setHTML("<h1>Hello World!</h1>")
-     *   .addTo(map);
+     * const popup = new mapboxgl.Popup()
+     *     .setLngLat(e.lngLat)
+     *     .setHTML("<h1>Hello World!</h1>")
+     *     .addTo(map);
      * @see [Display a popup](https://docs.mapbox.com/mapbox-gl-js/example/popup/)
      * @see [Display a popup on hover](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
      * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
@@ -404,12 +406,12 @@ export default class Popup extends Evented {
      * @returns {Popup} `this`
      * @example
      * // create an element with the popup content
-     * var div = window.document.createElement('div');
+     * const div = window.document.createElement('div');
      * div.innerHTML = 'Hello, world!';
-     * var popup = new mapboxgl.Popup()
-     *   .setLngLat(e.lngLat)
-     *   .setDOMContent(div)
-     *   .addTo(map);
+     * const popup = new mapboxgl.Popup()
+     *     .setLngLat(e.lngLat)
+     *     .setDOMContent(div)
+     *     .addTo(map);
      */
     setDOMContent(htmlNode: Node) {
         if (this._content) {
@@ -437,8 +439,8 @@ export default class Popup extends Evented {
      * @param {string} className Non-empty string with CSS class name to add to popup container
      *
      * @example
-     * let popup = new mapboxgl.Popup()
-     * popup.addClassName('some-class')
+     * const popup = new mapboxgl.Popup();
+     * popup.addClassName('some-class');
      */
     addClassName(className: string) {
         if (this._container) {
@@ -452,8 +454,8 @@ export default class Popup extends Evented {
      * @param {string} className Non-empty string with CSS class name to remove from popup container
      *
      * @example
-     * let popup = new mapboxgl.Popup()
-     * popup.removeClassName('some-class')
+     * const popup = new mapboxgl.Popup();
+     * popup.removeClassName('some-class');
      */
     removeClassName(className: string) {
         if (this._container) {
@@ -481,8 +483,8 @@ export default class Popup extends Evented {
      * @returns {boolean} if the class was removed return false, if class was added, then return true
      *
      * @example
-     * let popup = new mapboxgl.Popup()
-     * popup.toggleClassName('toggleClass')
+     * const popup = new mapboxgl.Popup();
+     * popup.toggleClassName('toggleClass');
      */
     toggleClassName(className: string) {
         if (this._container) {

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -45,15 +45,19 @@ if (typeof Object.freeze == 'function') {
  * @property {boolean} collectResourceTiming If true, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
  * @example
  * // use transformRequest to modify requests that begin with `http://myHost`
- * transformRequest: function(url, resourceType) {
- *  if (resourceType === 'Source' && url.indexOf('http://myHost') > -1) {
- *    return {
- *      url: url.replace('http', 'https'),
- *      headers: { 'my-custom-header': true },
- *      credentials: 'include'  // Include cookies for cross-origin requests
- *    }
- *   }
- *  }
+ * const map = new Map({
+ *     container: 'map',
+ *     style: 'mapbox://styles/mapbox/streets-v11',
+ *     transformRequest: (url, resourceType) => {
+ *         if (resourceType === 'Source' && url.indexOf('http://myHost') > -1) {
+ *             return {
+ *                 url: url.replace('http', 'https'),
+ *                 headers: {'my-custom-header': true},
+ *                 credentials: 'include'  // Include cookies for cross-origin requests
+ *             };
+ *         }
+ *     }
+ * });
  *
  */
 export type RequestParameters = {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/9616

This fixes all eslint errors for "jsdoc/check-examples".

I didn't review whether we want any differences between our internal eslint config and the config for examples. But changes required with the current config look fine. I added two exceptions:
- allowing a global `map` variable to avoid needing to add a `new Map(...)` to every example
- no flow header required
