### PR TITLE
Update doc comments to conform to eslint-complete-sentences rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,10 +22,10 @@
     // no-duplicate-imports doesn't play well with Flow
     // https://github.com/babel/eslint-plugin-babel/issues/59
     "no-duplicate-imports": "off",
-    "import/no-duplicates": "error",
+    "import/no-duplicates": "off",
 
     // ensure compatibility with Node's native ESM
-    "import/extensions": ["error", {
+    "import/extensions": ["off", {
       "js": "always",
       "json": "always"
     }],
@@ -52,22 +52,22 @@
       }
     ],
     "global-require": "off",
-    "import/no-commonjs": "error",
+    "import/no-commonjs": "off",
     "key-spacing": "off",
     "no-eq-null": "off",
     "no-lonely-if": "off",
     "no-new": "off",
-    "no-unused-vars": ["error", {"argsIgnorePattern": "^_$"}],
-    "no-warning-comments": "error",
-    "object-curly-spacing": ["error", "never"],
-    "prefer-arrow-callback": "error",
-    "prefer-const": ["error", {"destructuring": "all"}],
-    "prefer-template": "error",
+    "no-unused-vars": ["off", {"argsIgnorePattern": "^_$"}],
+    "no-offing-comments": "off",
+    "object-curly-spacing": ["off", "never"],
+    "prefer-arrow-callback": "off",
+    "prefer-const": ["off", {"destructuring": "all"}],
+    "prefer-template": "off",
     "quotes": "off",
     "space-before-function-paren": "off",
-    "template-curly-spacing": "error",
+    "template-curly-spacing": "off",
     "no-useless-escape": "off",
-    "indent": ["error", 4, {
+    "indent": ["off", 4, {
       "flatTernaryExpressions": true,
       "CallExpression": {
         "arguments": "off"
@@ -79,7 +79,7 @@
         "parameters": "off"
       }
     }],
-    "no-multiple-empty-lines": [ "error", {
+    "no-multiple-empty-lines": [ "off", {
         "max": 1
     }],
     "jsdoc/check-param-names": "warn",
@@ -87,7 +87,31 @@
     "jsdoc/require-param-description": "warn",
     "jsdoc/require-param-name": "warn",
     "jsdoc/require-returns": "warn",
-    "jsdoc/require-returns-description": "warn"
+    "jsdoc/require-returns-description": "warn",
+    "jsdoc/require-property": "off",
+    "jsdoc/require-description-complete-sentence": "warn",
+    "jsdoc/check-access": "off",
+    "jsdoc/check-alignment": "off",
+    "jsdoc/check-examples": ["off", {
+        "matchingFileName": "src/fake_filename_for_jsdoc_examples",
+        "rejectExampleCodeRegex": "<script>"
+    }],
+    "jsdoc/check-indentation": "off",
+    "jsdoc/check-line-alignment": "off",
+    "jsdoc/check-property-names": "off",
+    "jsdoc/check-tag-names": "off",
+    "jsdoc/check-types": "off",
+    "jsdoc/newline-after-description": "off",
+    "jsdoc/no-bad-blocks": "off",
+    "jsdoc/require-description": "off",
+    "jsdoc/require-example": "off",
+    "jsdoc/require-param-type": "off",
+    "jsdoc/require-property-description": "off",
+    "jsdoc/require-property-name": "off",
+    "jsdoc/require-property-type": "off",
+    "jsdoc/require-returns-type": "off",
+    "jsdoc/require-throws": "off",
+    "jsdoc/valid-types": "off"
   },
   "settings": {
     "jsdoc":{
@@ -115,7 +139,7 @@
         "jsdoc/require-returns": "off",
         "jsdoc/require-returns-description": "off",
         "jsdoc/require-property": "off",
-        "jsdoc/require-description-complete-sentence": "off",
+        "jsdoc/require-description-complete-sentence": "warn",
         "jsdoc/check-access": "off",
         "jsdoc/check-alignment": "off",
         "jsdoc/check-examples": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -87,31 +87,7 @@
     "jsdoc/require-param-description": "warn",
     "jsdoc/require-param-name": "warn",
     "jsdoc/require-returns": "warn",
-    "jsdoc/require-returns-description": "warn",
-    "jsdoc/require-property": "off",
-    "jsdoc/require-description-complete-sentence": "warn",
-    "jsdoc/check-access": "off",
-    "jsdoc/check-alignment": "off",
-    "jsdoc/check-examples": ["error", {
-        "matchingFileName": "src/fake_filename_for_jsdoc_examples",
-        "rejectExampleCodeRegex": "<script>"
-    }],
-    "jsdoc/check-indentation": "warn",
-    "jsdoc/check-line-alignment": "warn",
-    "jsdoc/check-property-names": "warn",
-    "jsdoc/check-tag-names": "warn",
-    "jsdoc/check-types": "warn",
-    "jsdoc/newline-after-description": "warn",
-    "jsdoc/no-bad-blocks": "warn",
-    "jsdoc/require-description": "warn",
-    "jsdoc/require-example": "warn",
-    "jsdoc/require-param-type": "warn",
-    "jsdoc/require-property-description": "warn",
-    "jsdoc/require-property-name": "warn",
-    "jsdoc/require-property-type": "warn",
-    "jsdoc/require-returns-type": "warn",
-    "jsdoc/require-throws": "warn",
-    "jsdoc/valid-types": "warn"
+    "jsdoc/require-returns-description": "warn"
   },
   "settings": {
     "jsdoc":{
@@ -184,7 +160,7 @@
         "jsdoc/require-returns": "error",
         "jsdoc/require-returns-description": "error",
         "jsdoc/require-property": "warn",
-        "jsdoc/require-description-complete-sentence": "warn",
+        "jsdoc/require-description-complete-sentence": "error",
         "jsdoc/check-access": "warn",
         "jsdoc/check-alignment": "warn",
         "jsdoc/check-examples": ["error", {

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,10 +22,10 @@
     // no-duplicate-imports doesn't play well with Flow
     // https://github.com/babel/eslint-plugin-babel/issues/59
     "no-duplicate-imports": "off",
-    "import/no-duplicates": "off",
+    "import/no-duplicates": "error",
 
     // ensure compatibility with Node's native ESM
-    "import/extensions": ["off", {
+    "import/extensions": ["error", {
       "js": "always",
       "json": "always"
     }],
@@ -52,22 +52,22 @@
       }
     ],
     "global-require": "off",
-    "import/no-commonjs": "off",
+    "import/no-commonjs": "error",
     "key-spacing": "off",
     "no-eq-null": "off",
     "no-lonely-if": "off",
     "no-new": "off",
-    "no-unused-vars": ["off", {"argsIgnorePattern": "^_$"}],
-    "no-offing-comments": "off",
-    "object-curly-spacing": ["off", "never"],
-    "prefer-arrow-callback": "off",
-    "prefer-const": ["off", {"destructuring": "all"}],
-    "prefer-template": "off",
+    "no-unused-vars": ["error", {"argsIgnorePattern": "^_$"}],
+    "no-warning-comments": "error",
+    "object-curly-spacing": ["error", "never"],
+    "prefer-arrow-callback": "error",
+    "prefer-const": ["error", {"destructuring": "all"}],
+    "prefer-template": "error",
     "quotes": "off",
     "space-before-function-paren": "off",
-    "template-curly-spacing": "off",
+    "template-curly-spacing": "error",
     "no-useless-escape": "off",
-    "indent": ["off", 4, {
+    "indent": ["error", 4, {
       "flatTernaryExpressions": true,
       "CallExpression": {
         "arguments": "off"
@@ -79,7 +79,7 @@
         "parameters": "off"
       }
     }],
-    "no-multiple-empty-lines": [ "off", {
+    "no-multiple-empty-lines": [ "error", {
         "max": 1
     }],
     "jsdoc/check-param-names": "warn",
@@ -92,26 +92,26 @@
     "jsdoc/require-description-complete-sentence": "warn",
     "jsdoc/check-access": "off",
     "jsdoc/check-alignment": "off",
-    "jsdoc/check-examples": ["off", {
+    "jsdoc/check-examples": ["error", {
         "matchingFileName": "src/fake_filename_for_jsdoc_examples",
         "rejectExampleCodeRegex": "<script>"
     }],
-    "jsdoc/check-indentation": "off",
-    "jsdoc/check-line-alignment": "off",
-    "jsdoc/check-property-names": "off",
-    "jsdoc/check-tag-names": "off",
-    "jsdoc/check-types": "off",
-    "jsdoc/newline-after-description": "off",
-    "jsdoc/no-bad-blocks": "off",
-    "jsdoc/require-description": "off",
-    "jsdoc/require-example": "off",
-    "jsdoc/require-param-type": "off",
-    "jsdoc/require-property-description": "off",
-    "jsdoc/require-property-name": "off",
-    "jsdoc/require-property-type": "off",
-    "jsdoc/require-returns-type": "off",
-    "jsdoc/require-throws": "off",
-    "jsdoc/valid-types": "off"
+    "jsdoc/check-indentation": "warn",
+    "jsdoc/check-line-alignment": "warn",
+    "jsdoc/check-property-names": "warn",
+    "jsdoc/check-tag-names": "warn",
+    "jsdoc/check-types": "warn",
+    "jsdoc/newline-after-description": "warn",
+    "jsdoc/no-bad-blocks": "warn",
+    "jsdoc/require-description": "warn",
+    "jsdoc/require-example": "warn",
+    "jsdoc/require-param-type": "warn",
+    "jsdoc/require-property-description": "warn",
+    "jsdoc/require-property-name": "warn",
+    "jsdoc/require-property-type": "warn",
+    "jsdoc/require-returns-type": "warn",
+    "jsdoc/require-throws": "warn",
+    "jsdoc/valid-types": "warn"
   },
   "settings": {
     "jsdoc":{
@@ -139,7 +139,7 @@
         "jsdoc/require-returns": "off",
         "jsdoc/require-returns-description": "off",
         "jsdoc/require-property": "off",
-        "jsdoc/require-description-complete-sentence": "warn",
+        "jsdoc/require-description-complete-sentence": "off",
         "jsdoc/check-access": "off",
         "jsdoc/check-alignment": "off",
         "jsdoc/check-examples": "off",

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -84,10 +84,10 @@ class LngLat {
     }
 
     /**
-     * Returns the approximate distance between a pair of coordinates in meters
-     * Uses the Haversine Formula (from R.W. Sinnott, "Virtues of the Haversine", Sky and Telescope, vol. 68, no. 2, 1984, p. 159)
+     * Returns the approximate distance between a pair of coordinates in meters.
+     * Uses the Haversine Formula (from R.W. Sinnott, "Virtues of the Haversine", Sky and Telescope, vol. 68, no. 2, 1984, p. 159).
      *
-     * @param {LngLat} lngLat coordinates to compute the distance to
+     * @param {LngLat} lngLat Coordinates to compute the distance to.
      * @returns {number} Distance in meters between the two coordinates.
      * @example
      * const newYork = new mapboxgl.LngLat(-74.0060, 40.7128);

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -39,10 +39,10 @@ class LngLatBounds {
     }
 
     /**
-     * Set the northeast corner of the bounding box
+     * Set the northeast corner of the bounding box.
      *
-     * @param {LngLatLike} ne a {@link LngLatLike} object describing the northeast corner of the bounding box.
-     * @returns {LngLatBounds} `this`
+     * @param {LngLatLike} ne A {@link LngLatLike} object describing the northeast corner of the bounding box.
+     * @returns {LngLatBounds} Returns `this`.
      * @example
      * const sw = new mapboxgl.LngLat(-73.9876, 40.7661);
      * const ne = new mapboxgl.LngLat(-73.9397, 40.8002);
@@ -55,10 +55,10 @@ class LngLatBounds {
     }
 
     /**
-     * Set the southwest corner of the bounding box
+     * Set the southwest corner of the bounding box.
      *
-     * @param {LngLatLike} sw a {@link LngLatLike} object describing the southwest corner of the bounding box.
-     * @returns {LngLatBounds} `this`
+     * @param {LngLatLike} sw A {@link LngLatLike} object describing the southwest corner of the bounding box.
+     * @returns {LngLatBounds} Returns `this`.
      * @example
      * const sw = new mapboxgl.LngLat(-73.9876, 40.7661);
      * const ne = new mapboxgl.LngLat(-73.9397, 40.8002);
@@ -73,8 +73,8 @@ class LngLatBounds {
     /**
      * Extend the bounds to include a given LngLatLike or LngLatBoundsLike.
      *
-     * @param {LngLatLike|LngLatBoundsLike} obj object to extend to
-     * @returns {LngLatBounds} `this`
+     * @param {LngLatLike|LngLatBoundsLike} obj Object to extend to.
+     * @returns {LngLatBounds} Returns `this`.
      * @example
      * const sw = new mapboxgl.LngLat(-73.9876, 40.7661);
      * const ne = new mapboxgl.LngLat(-73.9397, 40.8002);
@@ -259,7 +259,7 @@ class LngLatBounds {
     /**
     * Check if the point is within the bounding box.
     *
-    * @param {LngLatLike} lnglat geographic point to check against.
+    * @param {LngLatLike} lnglat Geographic point to check against.
     * @returns {boolean} True if the point is within the bounding box.
     * @example
     * const llb = new mapboxgl.LngLatBounds(

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -42,7 +42,7 @@ class LngLatBounds {
      * Set the northeast corner of the bounding box.
      *
      * @param {LngLatLike} ne A {@link LngLatLike} object describing the northeast corner of the bounding box.
-     * @returns {LngLatBounds} Returns `this`.
+     * @returns {LngLatBounds} Returns itself to allow for method chaining.
      * @example
      * const sw = new mapboxgl.LngLat(-73.9876, 40.7661);
      * const ne = new mapboxgl.LngLat(-73.9397, 40.8002);
@@ -58,7 +58,7 @@ class LngLatBounds {
      * Set the southwest corner of the bounding box.
      *
      * @param {LngLatLike} sw A {@link LngLatLike} object describing the southwest corner of the bounding box.
-     * @returns {LngLatBounds} Returns `this`.
+     * @returns {LngLatBounds} Returns itself to allow for method chaining.
      * @example
      * const sw = new mapboxgl.LngLat(-73.9876, 40.7661);
      * const ne = new mapboxgl.LngLat(-73.9397, 40.8002);
@@ -74,7 +74,7 @@ class LngLatBounds {
      * Extend the bounds to include a given LngLatLike or LngLatBoundsLike.
      *
      * @param {LngLatLike|LngLatBoundsLike} obj Object to extend to.
-     * @returns {LngLatBounds} Returns `this`.
+     * @returns {LngLatBounds} Returns itself to allow for method chaining.
      * @example
      * const sw = new mapboxgl.LngLat(-73.9876, 40.7661);
      * const ne = new mapboxgl.LngLat(-73.9397, 40.8002);

--- a/src/geo/mercator_coordinate.js
+++ b/src/geo/mercator_coordinate.js
@@ -59,7 +59,7 @@ export function mercatorScale(lat: number) {
  *
  * `MercatorCoordinate` uses the web mercator projection ([EPSG:3857](https://epsg.io/3857)) with slightly different units:
  * - the size of 1 unit is the width of the projected world instead of the "mercator meter"
- * - the origin of the coordinate space is at the north-west corner instead of the middle
+ * - the origin of the coordinate space is at the north-west corner instead of the middle.
  *
  * For example, `MercatorCoordinate(0, 0, 0)` is the north-west corner of the mercator world and
  * `MercatorCoordinate(1, 1, 0)` is the south-east corner. If you are familiar with

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -575,12 +575,11 @@ class Transform {
     }
 
     /**
-     * Return a zoom level that will cover all tiles the transform
-     *
-     * @param {Object} options options
+     * Return a zoom level that will cover all tiles the transform.
+     * @param {Object} options Options.
      * @param {number} options.tileSize Tile size, expressed in screen pixels.
      * @param {boolean} options.roundZoom Target zoom level. If true, the value will be rounded to the closest integer. Otherwise the value will be floored.
-     * @returns {number} zoom level An integer zoom level at which all tiles will be visible.
+     * @returns {number} An integer zoom level at which all tiles will be visible.
      */
     coveringZoomLevel(options: {roundZoom?: boolean, tileSize: number}) {
         const z = (options.roundZoom ? Math.round : Math.floor)(
@@ -1198,8 +1197,7 @@ class Transform {
 
     /**
      * Returns the maximum geographical bounds the map is constrained to, or `null` if none set.
-     *
-     * @returns {LngLatBounds} {@link LngLatBounds}
+     * @returns {LngLatBounds} {@link LngLatBounds}.
      */
     getMaxBounds(): LngLatBounds | null {
         if (!this.latRange || this.latRange.length !== 2 ||

--- a/src/gl/vertex_buffer.js
+++ b/src/gl/vertex_buffer.js
@@ -81,10 +81,10 @@ class VertexBuffer {
     }
 
     /**
-     * Set the attribute pointers in a WebGL context
-     * @param gl The WebGL context
-     * @param program The active WebGL program
-     * @param vertexOffset Index of the starting vertex of the segment
+     * Set the attribute pointers in a WebGL context.
+     * @param gl The WebGL context.
+     * @param program The active WebGL program.
+     * @param vertexOffset Index of the starting vertex of the segment.
      */
     setVertexAttribPointers(gl: WebGLRenderingContext, program: Program<*>, vertexOffset: ?number) {
         for (let j = 0; j < this.attributes.length; j++) {
@@ -105,7 +105,7 @@ class VertexBuffer {
     }
 
     /**
-     * Destroy the GL buffer bound to the given WebGL context
+     * Destroy the GL buffer bound to the given WebGL context.
      */
     destroy() {
         const gl = this.context.gl;

--- a/src/index.js
+++ b/src/index.js
@@ -239,8 +239,8 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  * @function supported
  * @param {Object} [options]
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`,
- *   the function will return `false` if the performance of Mapbox GL JS would
- *   be dramatically worse than expected (a software WebGL renderer would be used).
+ *  the function will return `false` if the performance of Mapbox GL JS would
+ *  be dramatically worse than expected (a software WebGL renderer would be used).
  * @return {boolean}
  * @example
  * // Show an alert if the browser does not support Mapbox GL

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ const exported = {
     },
 
     /**
-     * Gets and sets the map's default API URL for requesting tiles, styles, sprites, and glyphs
+     * Gets and sets the map's default API URL for requesting tiles, styles, sprites, and glyphs.
      *
      * @var {string} baseApiUrl
      * @returns {string} The current base API URL.
@@ -199,7 +199,7 @@ const exported = {
      * Takes precedence over `mapboxgl.workerUrl`.
      *
      * @var {Object} workerClass
-     * @returns {Object|null} a Class object, an instance of which exposes the `Worker` interface.
+     * @returns {Object|null} Class object, an instance of which exposes the `Worker` interface.
      * @example
      * import mapboxgl from 'mapbox-gl/dist/mapbox-gl-csp.js';
      * import MapboxGLWorker from 'mapbox-gl/dist/mapbox-gl-csp-worker.js';
@@ -240,7 +240,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  * @param {Object} [options]
  * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`,
  *   the function will return `false` if the performance of Mapbox GL JS would
- *   be dramatically worse than expected (e.g. a software WebGL renderer would be used).
+ *   be dramatically worse than expected (a software WebGL renderer would be used).
  * @return {boolean}
  * @example
  * // Show an alert if the browser does not support Mapbox GL
@@ -266,7 +266,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
 
 /**
   * Gets the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text) status.
-  * The status can be `unavailable` (i.e. not requested or removed), `loading`, `loaded` or `error`.
+  * The status can be `unavailable` (not requested or removed), `loading`, `loaded` or `error`.
   * If the status is `loaded` and the plugin is requested again, an error will be thrown.
   *
   * @function getRTLTextPluginStatus

--- a/src/index.js
+++ b/src/index.js
@@ -199,7 +199,7 @@ const exported = {
      * Takes precedence over `mapboxgl.workerUrl`.
      *
      * @var {Object} workerClass
-     * @returns {Object|null} Class object, an instance of which exposes the `Worker` interface.
+     * @returns {Object|null} A class that implements the `Worker` interface.
      * @example
      * import mapboxgl from 'mapbox-gl/dist/mapbox-gl-csp.js';
      * import MapboxGLWorker from 'mapbox-gl/dist/mapbox-gl-csp-worker.js';

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -27,7 +27,7 @@ export type CanvasSourceSpecification = {|
  * @property {string} type Source type. Must be `"canvas"`.
  * @property {string|HTMLCanvasElement} canvas Canvas source from which to read pixels. Can be a string representing the ID of the canvas element, or the `HTMLCanvasElement` itself.
  * @property {Array<Array<number>>} coordinates Four geographical coordinates denoting where to place the corners of the canvas, specified in `[longitude, latitude]` pairs.
- * @property {boolean} [animate=true] Whether the canvas source is animated. If the canvas is static (i.e. pixels do not need to be re-read on every frame), `animate` should be set to `false` to improve performance.
+ * @property {boolean} [animate=true] Whether the canvas source is animated. If the canvas is static (pixels do not need to be re-read on every frame), `animate` should be set to `false` to improve performance.
  */
 
 /**
@@ -188,7 +188,7 @@ class CanvasSource extends ImageSource {
      *   represented as arrays of longitude and latitude numbers, which define the corners of the canvas.
      *   The coordinates start at the top left corner of the canvas and proceed in clockwise order.
      *   They do not have to represent a rectangle.
-     * @returns {CanvasSource} this
+     * @returns {CanvasSource} Returns `this`.
      */
 
     // setCoordinates inherited from ImageSource

--- a/src/source/canvas_source.js
+++ b/src/source/canvas_source.js
@@ -188,7 +188,7 @@ class CanvasSource extends ImageSource {
      *   represented as arrays of longitude and latitude numbers, which define the corners of the canvas.
      *   The coordinates start at the top left corner of the canvas and proceed in clockwise order.
      *   They do not have to represent a rectangle.
-     * @returns {CanvasSource} Returns `this`.
+     * @returns {CanvasSource} Returns itself to allow for method chaining.
      */
 
     // setCoordinates inherited from ImageSource

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -156,7 +156,7 @@ class GeoJSONSource extends Evented implements Source {
      * Sets the GeoJSON data and re-renders the map.
      *
      * @param {Object|string} data A GeoJSON data object or a URL to one. The latter is preferable in the case of large GeoJSON files.
-     * @returns {GeoJSONSource} Returns `this`.
+     * @returns {GeoJSONSource} Returns itself to allow for method chaining.
      * @example
      * map.addSource('source_id', {
      *     type: 'geojson',
@@ -187,7 +187,7 @@ class GeoJSONSource extends Evented implements Source {
      *
      * @param clusterId The value of the cluster's `cluster_id` property.
      * @param callback A callback to be called when the zoom value is retrieved (`(error, zoom) => { ... }`).
-     * @returns {GeoJSONSource} Returns `this`.
+     * @returns {GeoJSONSource} Returns itself to allow for method chaining.
      * @example
      * // Assuming the map has a layer named 'clusters' and a source 'earthquakes'
      * // The following creates a camera animation on cluster feature click
@@ -222,7 +222,7 @@ class GeoJSONSource extends Evented implements Source {
      *
      * @param clusterId The value of the cluster's `cluster_id` property.
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
-     * @returns {GeoJSONSource} Returns `this`.
+     * @returns {GeoJSONSource} Returns itself to allow for method chaining.
      * @example
      * // Retrieve cluster children on click
      * map.on('click', 'clusters', (e) => {
@@ -252,7 +252,7 @@ class GeoJSONSource extends Evented implements Source {
      * @param limit The maximum number of features to return. (Defaults to `10` if a falsy value is given).
      * @param offset The number of features to skip (for use with pagination, for example). (Defaults to `0` if a falsy value is given).
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
-     * @returns {GeoJSONSource} Returns `this`.
+     * @returns {GeoJSONSource} Returns itself to allow for method chaining.
      * @example
      * // Retrieve cluster leaves on click
      * map.on('click', 'clusters', (e) => {

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -19,7 +19,7 @@ import type {Cancelable} from '../types/cancelable.js';
 
 /**
  * A source containing GeoJSON.
- * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson) for detailed documentation of options.)
+ * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson) for detailed documentation of options).
  *
  * @example
  * map.addSource('some id', {
@@ -156,7 +156,7 @@ class GeoJSONSource extends Evented implements Source {
      * Sets the GeoJSON data and re-renders the map.
      *
      * @param {Object|string} data A GeoJSON data object or a URL to one. The latter is preferable in the case of large GeoJSON files.
-     * @returns {GeoJSONSource} this
+     * @returns {GeoJSONSource} Returns `this`.
      * @example
      * map.addSource('source_id', {
      *     type: 'geojson',
@@ -187,7 +187,7 @@ class GeoJSONSource extends Evented implements Source {
      *
      * @param clusterId The value of the cluster's `cluster_id` property.
      * @param callback A callback to be called when the zoom value is retrieved (`(error, zoom) => { ... }`).
-     * @returns {GeoJSONSource} this
+     * @returns {GeoJSONSource} Returns `this`.
      * @example
      * // Assuming the map has a layer named 'clusters' and a source 'earthquakes'
      * // The following creates a camera animation on cluster feature click
@@ -222,7 +222,7 @@ class GeoJSONSource extends Evented implements Source {
      *
      * @param clusterId The value of the cluster's `cluster_id` property.
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
-     * @returns {GeoJSONSource} this
+     * @returns {GeoJSONSource} Returns `this`.
      * @example
      * // Retrieve cluster children on click
      * map.on('click', 'clusters', (e) => {
@@ -249,10 +249,10 @@ class GeoJSONSource extends Evented implements Source {
      * For clustered sources, fetches the original points that belong to the cluster (as an array of GeoJSON features).
      *
      * @param clusterId The value of the cluster's `cluster_id` property.
-     * @param limit The maximum number of features to return. (Defaults to `10` if a falsy value is given.)
-     * @param offset The number of features to skip (e.g. for pagination). (Defaults to `0` if a falsy value is given.)
+     * @param limit The maximum number of features to return. (Defaults to `10` if a falsy value is given).
+     * @param offset The number of features to skip (for use with pagination, for example). (Defaults to `0` if a falsy value is given).
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
-     * @returns {GeoJSONSource} this
+     * @returns {GeoJSONSource} Returns `this`.
      * @example
      * // Retrieve cluster leaves on click
      * map.on('click', 'clusters', (e) => {

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -250,7 +250,7 @@ class GeoJSONSource extends Evented implements Source {
      *
      * @param clusterId The value of the cluster's `cluster_id` property.
      * @param limit The maximum number of features to return. (Defaults to `10` if a falsy value is given).
-     * @param offset The number of features to skip (for use with pagination, for example). (Defaults to `0` if a falsy value is given).
+     * @param offset The number of features to skip. This is useful for paginating results. Defaults to `0` if a falsy value is given.
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
      * @returns {GeoJSONSource} Returns itself to allow for method chaining.
      * @example

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -144,7 +144,7 @@ class ImageSource extends Evented implements Source {
      *   represented as arrays of longitude and latitude numbers, which define the corners of the image.
      *   The coordinates start at the top left corner of the image and proceed in clockwise order.
      *   They do not have to represent a rectangle.
-     * @returns {ImageSource} Returns `this`.
+     * @returns {ImageSource} Returns itself to allow for method chaining.
      * @example
      * // Add to an image source to the map with some initial URL and coordinates
      * map.addSource('image_source_id', {
@@ -196,7 +196,7 @@ class ImageSource extends Evented implements Source {
      *   represented as arrays of longitude and latitude numbers, which define the corners of the image.
      *   The coordinates start at the top left corner of the image and proceed in clockwise order.
      *   They do not have to represent a rectangle.
-     * @returns {ImageSource} Returns `this`.
+     * @returns {ImageSource} Returns itself to allow for method chaining.
      * @example
      * // Add an image source to the map with some initial coordinates
      * map.addSource('image_source_id', {

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -27,7 +27,7 @@ type Coordinates = [[number, number], [number, number], [number, number], [numbe
 
 /**
  * A data source containing an image.
- * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-image) for detailed documentation of options.)
+ * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-image) for detailed documentation of options).
  *
  * @example
  * // add to map
@@ -144,7 +144,7 @@ class ImageSource extends Evented implements Source {
      *   represented as arrays of longitude and latitude numbers, which define the corners of the image.
      *   The coordinates start at the top left corner of the image and proceed in clockwise order.
      *   They do not have to represent a rectangle.
-     * @returns {ImageSource} this
+     * @returns {ImageSource} Returns `this`.
      * @example
      * // Add to an image source to the map with some initial URL and coordinates
      * map.addSource('image_source_id', {
@@ -196,7 +196,7 @@ class ImageSource extends Evented implements Source {
      *   represented as arrays of longitude and latitude numbers, which define the corners of the image.
      *   The coordinates start at the top left corner of the image and proceed in clockwise order.
      *   They do not have to represent a rectangle.
-     * @returns {ImageSource} this
+     * @returns {ImageSource} Returns `this`.
      * @example
      * // Add an image source to the map with some initial coordinates
      * map.addSource('image_source_id', {

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -795,7 +795,7 @@ class SourceCache extends Evented {
     }
 
     /**
-     * Remove all tiles from this pyramid
+     * Remove all tiles from this pyramid.
      * @private
      */
     clearTiles() {

--- a/src/source/tile_cache.js
+++ b/src/source/tile_cache.js
@@ -16,9 +16,9 @@ class TileCache {
     order: Array<number>;
     onRemove: (element: Tile) => void;
     /**
-     * @param {number} max number of permitted values
+     * @param {number} max The max number of permitted values.
      * @private
-     * @param {Function} onRemove callback called with items when they expire
+     * @param {Function} onRemove The callback called with items when they expire.
      */
     constructor(max: number, onRemove: (element: Tile) => void) {
         this.max = max;
@@ -27,9 +27,9 @@ class TileCache {
     }
 
     /**
-     * Clear the cache
+     * Clear the cache.
      *
-     * @returns {TileCache} this cache
+     * @returns {TileCache} Return `this`.
      * @private
      */
     reset() {
@@ -53,7 +53,7 @@ class TileCache {
      * @param {OverscaledTileID} tileID lookup key for the item
      * @param {*} data any value
      *
-     * @returns {TileCache} this cache
+     * @returns {TileCache} Returns `this`.
      * @private
      */
     add(tileID: OverscaledTileID, data: Tile, expiryTimeout: number | void) {

--- a/src/source/tile_cache.js
+++ b/src/source/tile_cache.js
@@ -53,7 +53,7 @@ class TileCache {
      * @param {OverscaledTileID} tileID lookup key for the item
      * @param {*} data any value
      *
-     * @returns {TileCache} Returns `this`.
+     * @returns {TileCache} Returns itself to allow for method chaining.
      * @private
      */
     add(tileID: OverscaledTileID, data: Tile, expiryTimeout: number | void) {

--- a/src/source/tile_cache.js
+++ b/src/source/tile_cache.js
@@ -29,7 +29,7 @@ class TileCache {
     /**
      * Clear the cache.
      *
-     * @returns {TileCache} Return `this`.
+     * @returns {TileCache} Returns itself to allow for method chaining.
      * @private
      */
     reset() {

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -24,7 +24,7 @@ import type {LoadVectorTileResult} from './vector_tile_worker_source.js';
 
 /**
  * A source containing vector tiles in [Mapbox Vector Tile format](https://docs.mapbox.com/vector-tiles/reference/).
- * (See the [Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector) for detailed documentation of options.)
+ * (See the [Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector) for detailed documentation of options).
  *
  * @example
  * map.addSource('some id', {
@@ -154,7 +154,7 @@ class VectorTileSource extends Evented implements Source {
      * Sets the source `tiles` property and re-renders the map.
      *
      * @param {string[]} tiles An array of one or more tile source URLs, as in the TileJSON spec.
-     * @returns {VectorTileSource} this
+     * @returns {VectorTileSource} Returns `this`.
      * @example
      * map.addSource('vector_source_id', {
      *     type: 'vector',
@@ -180,7 +180,7 @@ class VectorTileSource extends Evented implements Source {
      * Sets the source `url` property and re-renders the map.
      *
      * @param {string} url A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-     * @returns {VectorTileSource} this
+     * @returns {VectorTileSource} Returns `this`.
      * @example
      * map.addSource('vector_source_id', {
      *     type: 'vector',

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -154,7 +154,7 @@ class VectorTileSource extends Evented implements Source {
      * Sets the source `tiles` property and re-renders the map.
      *
      * @param {string[]} tiles An array of one or more tile source URLs, as in the TileJSON spec.
-     * @returns {VectorTileSource} Returns `this`.
+     * @returns {VectorTileSource} Returns itself to allow for method chaining.
      * @example
      * map.addSource('vector_source_id', {
      *     type: 'vector',
@@ -180,7 +180,7 @@ class VectorTileSource extends Evented implements Source {
      * Sets the source `url` property and re-renders the map.
      *
      * @param {string} url A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-     * @returns {VectorTileSource} Returns `this`.
+     * @returns {VectorTileSource} Returns itself to allow for method chaining.
      * @example
      * map.addSource('vector_source_id', {
      *     type: 'vector',

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -169,7 +169,7 @@ class VideoSource extends ImageSource {
      * @method setCoordinates
      * @instance
      * @memberof VideoSource
-     * @returns {VideoSource} Returns `this`.
+     * @returns {VideoSource} Returns itself to allow for method chaining.
      * @example
      * // Add a video source to the map to map
      * map.addSource('video_source_id', {

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -16,7 +16,7 @@ import type {VideoSourceSpecification} from '../style-spec/types.js';
 
 /**
  * A data source containing video.
- * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-video) for detailed documentation of options.)
+ * (See the [Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#sources-video) for detailed documentation of options).
  *
  * @example
  * // add to map
@@ -169,7 +169,7 @@ class VideoSource extends ImageSource {
      * @method setCoordinates
      * @instance
      * @memberof VideoSource
-     * @returns {VideoSource} this
+     * @returns {VideoSource} Returns `this`.
      * @example
      * // Add a video source to the map to map
      * map.addSource('video_source_id', {

--- a/src/style/query_geometry.js
+++ b/src/style/query_geometry.js
@@ -70,9 +70,9 @@ export class QueryGeometry {
     }
 
     /**
-     * Returns true if the initial query by the user was a single point
+     * Returns true if the initial query by the user was a single point.
      *
-     * @returns {boolean} True if the initial query geometry was a single point
+     * @returns {boolean} Returns `true` if the initial query geometry was a single point.
      */
     isPointQuery(): boolean {
         return this.screenBounds.length === 1;
@@ -80,7 +80,7 @@ export class QueryGeometry {
 
     /**
      * Due to data-driven styling features do not uniform size(eg `circle-radius`) and can be offset differntly
-     * from their original location(for eg. with `*-translate`). This means we have to expand our query region for
+     * from their original location(for example with `*-translate`). This means we have to expand our query region for
      * each tile to account for variation in these properties.
      * Each tile calculates a tile level max padding value (in screenspace pixels) when its parsed, this function
      * lets us calculate a buffered version of the screenspace query geometry for each tile.
@@ -101,9 +101,8 @@ export class QueryGeometry {
      * the query at the surface of the earth. Instead the feature may be closer and only intersect
      * the query because it extrudes into the air.
      *
-     * This returns a geometry thats a convex polygon that encomapasses the query frustum and the point underneath the camera.
+     * This returns a geometry that is a convex polygon that encompasses the query frustum and the point underneath the camera.
      * Similar to `bufferedScreenGeometry`, buffering is added to account for variation in paint properties.
-     *
      *
      * Case 1: point underneath camera is exactly behind query volume
      *              +----------+
@@ -115,10 +114,7 @@ export class QueryGeometry {
      *                X      X
      *                 X    X
      *                  X  X
-     *                   XX
-     *
-     *
-     *
+     *                   XX.
      *
      * Case 2: point is behind and to the right
      *              +----------+
@@ -130,9 +126,7 @@ export class QueryGeometry {
      *                 XXXX       X
      *                    XXX     XX
      *                        XX   X
-     *                           XXX
-     *
-     *
+     *                           XXX.
      *
      * Case 3: point is behind and to the left
      *              +----------+
@@ -144,9 +138,7 @@ export class QueryGeometry {
      *          XX       XXX
      *          X    XXXX
      *         X XXXX
-     *         XXX
-     *
-     *
+     *         XXX.
      *
      * @param {number} buffer The tile padding in screenspace pixels.
      * @returns {Point[]} The buffered query geometry.
@@ -179,7 +171,7 @@ export class QueryGeometry {
      * @param {Tile} tile The tile to check.
      * @param {Transform} transform The current map transform.
      * @param {boolean} use3D A boolean indicating whether to query 3D features.
-     * @returns {?TilespaceQueryGeometry} Returns undefined if the tile does not intersect
+     * @returns {?TilespaceQueryGeometry} Returns `undefined` if the tile does not intersect.
      */
     containsTile(tile: Tile, transform: Transform, use3D: boolean): ?TilespaceQueryGeometry {
         // The buffer around the query geometry is applied in screen-space.

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -703,9 +703,9 @@ class Style extends Evented {
     }
 
     /**
-     * Remove a source from this stylesheet, given its id.
-     * @param {string} id id of the source to remove
-     * @throws {Error} if no source is found with the given ID
+     * Remove a source from this stylesheet, given its ID.
+     * @param {string} id ID of the source to remove.
+     * @throws {Error} If no source is found with the given ID.
      * @returns {Map} The {@link Map} object.
      */
     removeSource(id: string) {
@@ -743,9 +743,9 @@ class Style extends Evented {
     }
 
     /**
-    * Set the data of a GeoJSON source, given its id.
-    * @param {string} id id of the source
-    * @param {GeoJSON|string} data GeoJSON source
+    * Set the data of a GeoJSON source, given its ID.
+    * @param {string} id ID of the source.
+    * @param {GeoJSON|string} data GeoJSON source.
     */
     setGeoJSONSourceData(id: string, data: GeoJSON | string) {
         this._checkLoaded();
@@ -759,9 +759,9 @@ class Style extends Evented {
     }
 
     /**
-     * Get a source by id.
-     * @param {string} id id of the desired source
-     * @returns {Object} source
+     * Get a source by ID.
+     * @param {string} id ID of the desired source.
+     * @returns {Object} The source object.
      */
     getSource(id: string): Object {
         const sourceCache = this._getSourceCache(id);
@@ -772,7 +772,7 @@ class Style extends Evented {
      * Add a layer to the map style. The layer will be inserted before the layer with
      * ID `before`, or appended if `before` is omitted.
      * @param {Object | CustomLayerInterface} layerObject The style layer to add.
-     * @param {string} [before] ID of an existing layer to insert before
+     * @param {string} [before] ID of an existing layer to insert before.
      * @param {Object} options Style setter options.
      * @returns {Map} The {@link Map} object.
      */
@@ -853,8 +853,8 @@ class Style extends Evented {
     /**
      * Moves a layer to a different z-position. The layer will be inserted before the layer with
      * ID `before`, or appended if `before` is omitted.
-     * @param {string} id  ID of the layer to move
-     * @param {string} [before] ID of an existing layer to insert before
+     * @param {string} id  ID of the layer to move.
+     * @param {string} [before] ID of an existing layer to insert before.
      */
     moveLayer(id: string, before?: string) {
         this._checkLoaded();
@@ -890,7 +890,7 @@ class Style extends Evented {
      *
      * If no such layer exists, an `error` event is fired.
      *
-     * @param {string} id id of the layer to remove
+     * @param {string} id ID of the layer to remove.
      * @fires error
      */
     removeLayer(id: string) {
@@ -927,28 +927,28 @@ class Style extends Evented {
     /**
      * Return the style layer object with the given `id`.
      *
-     * @param {string} id - id of the desired layer
-     * @returns {?Object} a layer, if one with the given `id` exists
+     * @param {string} id ID of the desired layer.
+     * @returns {?Object} A layer, if one with the given `id` exists.
      */
     getLayer(id: string): Object {
         return this._layers[id];
     }
 
     /**
-     * checks if a specific layer is present within the style.
+     * Checks if a specific layer is present within the style.
      *
-     * @param {string} id - id of the desired layer
-     * @returns {boolean} a boolean specifying if the given layer is present
+     * @param {string} id ID of the desired layer.
+     * @returns {boolean} A boolean specifying if the given layer is present.
      */
     hasLayer(id: string): boolean {
         return id in this._layers;
     }
 
     /**
-     * checks if a specific layer type is present within the style.
+     * Checks if a specific layer type is present within the style.
      *
-     * @param {string} type - type of the desired layer
-     * @returns {boolean} a boolean specifying if the given layer type is present
+     * @param {string} type Type of the desired layer.
+     * @returns {boolean} A boolean specifying if the given layer type is present.
      */
     hasLayerType(type: string): boolean {
         for (const layerId in this._layers) {
@@ -1008,9 +1008,9 @@ class Style extends Evented {
     }
 
     /**
-     * Get a layer's filter object
-     * @param {string} layer the layer to inspect
-     * @returns {*} the layer's filter, if any
+     * Get a layer's filter object.
+     * @param {string} layer The layer to inspect.
+     * @returns {*} The layer's filter, if any.
      */
     getFilter(layer: string) {
         return clone(this.getLayer(layer).filter);
@@ -1032,10 +1032,10 @@ class Style extends Evented {
     }
 
     /**
-     * Get a layout property's value from a given layer
-     * @param {string} layerId the layer to inspect
-     * @param {string} name the name of the layout property
-     * @returns {*} the property value
+     * Get a layout property's value from a given layer.
+     * @param {string} layerId The layer to inspect.
+     * @param {string} name The name of the layout property.
+     * @returns {*} The property value.
      */
     getLayoutProperty(layerId: string, name: string) {
         const layer = this.getLayer(layerId);

--- a/src/style/style_layer/custom_style_layer.js
+++ b/src/style/style_layer/custom_style_layer.js
@@ -22,7 +22,7 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => 
  * The `renderingMode` property controls whether the layer is treated as a `"2d"` or `"3d"` map layer. Use:
  * - `"renderingMode": "3d"` to use the depth buffer and share it with other layers
  * - `"renderingMode": "2d"` to add a layer with no depth. If you need to use the depth buffer for a `"2d"` layer you must use an offscreen
- *   framebuffer and {@link CustomLayerInterface#prerender}
+ *   framebuffer and {@link CustomLayerInterface#prerender}.
  *
  * @interface CustomLayerInterface
  * @property {string} id A unique layer id.

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -40,7 +40,7 @@ export class Elevation {
     /**
      * Altitude above sea level in meters at specified point.
      * @param {MercatorCoordinate} point Mercator coordinate of the point.
-     * @param {number} defaultIfNotLoaded Value that is returned if the dem tile of the provided point is not loaded
+     * @param {number} defaultIfNotLoaded Value that is returned if the dem tile of the provided point is not loaded.
      * @param {boolean} exaggerated `true` if styling exaggeration should be applied to the resulting elevation.
      * @returns {number} Altitude in meters.
      * If there is no loaded tile that carries information for the requested
@@ -107,7 +107,7 @@ export class Elevation {
 
     /**
      * Get elevation minimum and maximum for tile identified by `tileID`.
-     * @param {OverscaledTileID} tileID is a sub tile (or covers the same space) of the DEM tile we read the information from.
+     * @param {OverscaledTileID} The `tileID` is a sub tile (or covers the same space) of the DEM tile we read the information from.
      * @returns {?{min: number, max: number}} The min and max elevation.
      */
     getMinMaxForTile(tileID: OverscaledTileID): ?{min: number, max: number} {
@@ -145,7 +145,7 @@ export class Elevation {
 
     /**
      * Performs raycast against visible DEM tiles on the screen and returns the distance travelled along the ray.
-     * x & y components of the position are expected to be in normalized mercator coordinates [0, 1] and z in meters.
+     * `x` & `y` components of the position are expected to be in normalized mercator coordinates [0, 1] and z in meters.
      * @param {vec3} position The ray origin.
      * @param {vec3} dir The ray direction.
      * @param {number} exaggeration The terrain exaggeration.

--- a/src/terrain/elevation.js
+++ b/src/terrain/elevation.js
@@ -107,7 +107,7 @@ export class Elevation {
 
     /**
      * Get elevation minimum and maximum for tile identified by `tileID`.
-     * @param {OverscaledTileID} The `tileID` is a sub tile (or covers the same space) of the DEM tile we read the information from.
+     * @param {OverscaledTileID} tileID The `tileId` is a sub tile (or covers the same space) of the DEM tile we read the information from.
      * @returns {?{min: number, max: number}} The min and max elevation.
      */
     getMinMaxForTile(tileID: OverscaledTileID): ?{min: number, max: number} {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -146,7 +146,7 @@ class ProxySourceCache extends SourceCache {
 /**
  * Canonical, wrap and overscaledZ contain information of original source cache tile.
  * This tile gets ortho-rendered to proxy tile (defined by proxyTileKey).
- * posMatrix holds orthographic, scaling and translation information that is used
+ * `posMatrix` holds orthographic, scaling and translation information that is used
  * for rendering original tile content to a proxy tile. Proxy tile covers whole
  * or sub-rectangle of the original tile.
  */

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -180,7 +180,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setCenter([-74, 38]);
      */
@@ -197,7 +197,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.panBy([-74, 38]);
      * @example
@@ -219,7 +219,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.panTo([-74, 38]);
      * @example
@@ -255,7 +255,7 @@ class Camera extends Evented {
      * @fires zoom
      * @fires moveend
      * @fires zoomend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Zoom to the zoom level 5 without an animated transition
      * map.setZoom(5);
@@ -278,7 +278,7 @@ class Camera extends Evented {
      * @fires zoom
      * @fires moveend
      * @fires zoomend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Zoom to the zoom level 5 without an animated transition
      * map.zoomTo(5);
@@ -306,7 +306,7 @@ class Camera extends Evented {
      * @fires zoom
      * @fires moveend
      * @fires zoomend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // zoom the map in one level with a custom animation duration
      * map.zoomIn({duration: 1000});
@@ -328,7 +328,7 @@ class Camera extends Evented {
      * @fires zoom
      * @fires moveend
      * @fires zoomend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // zoom the map out one level with a custom animation offset
      * map.zoomOut({offset: [80, 60]});
@@ -361,7 +361,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // rotate the map to 90 degrees
      * map.setBearing(90);
@@ -391,7 +391,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Sets a left padding of 300px, and a top padding of 50px
      * map.setPadding({left: 300, top: 50});
@@ -411,7 +411,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.rotateTo(30);
      * @example
@@ -432,7 +432,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // resetNorth with an animation of 2 seconds.
      * map.resetNorth({duration: 2000});
@@ -450,7 +450,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // resetNorthPitch with an animation of 2 seconds.
      * map.resetNorthPitch({duration: 2000});
@@ -473,7 +473,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // snapToNorth with an animation of 2 seconds.
      * map.snapToNorth({duration: 2000});
@@ -504,7 +504,7 @@ class Camera extends Evented {
      * @fires pitchstart
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // setPitch with an animation of 2 seconds.
      * map.setPitch(80, {duration: 2000});
@@ -750,7 +750,7 @@ class Camera extends Evented {
      * @param {Object} [eventData] Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
 	 * @example
      * const bbox = [[-79, 43], [-73, 45]];
      * map.fitBounds(bbox, {
@@ -822,7 +822,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
 	 * @example
      * const p0 = [220, 400];
      * const p1 = [500, 900];
@@ -904,7 +904,7 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @fires pitchend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // jump to coordinates at current zoom
      * map.jumpTo({center: [0, 0]});
@@ -1014,7 +1014,7 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @fires pitchend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * const camera = map.getFreeCameraOptions();
      *
@@ -1088,7 +1088,7 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @fires pitchend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @see [Navigate the map with game-like controls](https://www.mapbox.com/mapbox-gl-js/example/game-controls/)
      * @example
      * // Ease with default options to null island for 5 seconds
@@ -1301,7 +1301,7 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @fires pitchend
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // fly with default options to null island
      * map.flyTo({center: [0, 0], zoom: 9});
@@ -1486,7 +1486,7 @@ class Camera extends Evented {
      * Stops any animated transition underway.
      *
      * @memberof Map#
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.stop();
      */

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -78,7 +78,7 @@ export type CameraOptions = {
  * @property {number} duration The animation's duration, measured in milliseconds.
  * @property {Function} easing A function taking a time in the range 0..1 and returning a number where 0 is
  *   the initial state and 1 is the final state.
- * @property {PointLike} offset of the target center relative to real map container center at the end of animation.
+ * @property {PointLike} offset The target center's offset relative to real map container center at the end of animation.
  * @property {boolean} animate If `false`, no animation will occur.
  * @property {boolean} essential If `true`, then the animation is considered essential and will not be affected by
  *   [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
@@ -180,7 +180,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.setCenter([-74, 38]);
      */
@@ -197,7 +197,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.panBy([-74, 38]);
      * @example
@@ -219,7 +219,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.panTo([-74, 38]);
      * @example
@@ -255,7 +255,7 @@ class Camera extends Evented {
      * @fires zoom
      * @fires moveend
      * @fires zoomend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Zoom to the zoom level 5 without an animated transition
      * map.setZoom(5);
@@ -278,7 +278,7 @@ class Camera extends Evented {
      * @fires zoom
      * @fires moveend
      * @fires zoomend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Zoom to the zoom level 5 without an animated transition
      * map.zoomTo(5);
@@ -306,7 +306,7 @@ class Camera extends Evented {
      * @fires zoom
      * @fires moveend
      * @fires zoomend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // zoom the map in one level with a custom animation duration
      * map.zoomIn({duration: 1000});
@@ -328,7 +328,7 @@ class Camera extends Evented {
      * @fires zoom
      * @fires moveend
      * @fires zoomend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // zoom the map out one level with a custom animation offset
      * map.zoomOut({offset: [80, 60]});
@@ -361,7 +361,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // rotate the map to 90 degrees
      * map.setBearing(90);
@@ -387,11 +387,11 @@ class Camera extends Evented {
      * Equivalent to `jumpTo({padding: padding})`.
      *
      * @memberof Map#
-     * @param padding The desired padding. Format: { left: number, right: number, top: number, bottom: number }
+     * @param padding The desired padding. Format: {left: number, right: number, top: number, bottom: number}.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Sets a left padding of 300px, and a top padding of 50px
      * map.setPadding({left: 300, top: 50});
@@ -411,7 +411,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.rotateTo(30);
      * @example
@@ -432,7 +432,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // resetNorth with an animation of 2 seconds.
      * map.resetNorth({duration: 2000});
@@ -450,7 +450,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // resetNorthPitch with an animation of 2 seconds.
      * map.resetNorthPitch({duration: 2000});
@@ -465,7 +465,7 @@ class Camera extends Evented {
     }
 
     /**
-     * Snaps the map so that north is up (0° bearing), if the current bearing is close enough to it (i.e. within the
+     * Snaps the map so that north is up (0° bearing), if the current bearing is close enough to it (within the
      * `bearingSnap` threshold).
      *
      * @memberof Map#
@@ -473,7 +473,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // snapToNorth with an animation of 2 seconds.
      * map.snapToNorth({duration: 2000});
@@ -504,7 +504,7 @@ class Camera extends Evented {
      * @fires pitchstart
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // setPitch with an animation of 2 seconds.
      * map.setPitch(80, {duration: 2000});
@@ -750,7 +750,7 @@ class Camera extends Evented {
      * @param {Object} [eventData] Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
 	 * @example
      * const bbox = [[-79, 43], [-73, 45]];
      * map.fitBounds(bbox, {
@@ -808,8 +808,8 @@ class Camera extends Evented {
      * pass in the current map bearing.
      *
      * @memberof Map#
-     * @param p0 First point on screen, in pixel coordinates
-     * @param p1 Second point on screen, in pixel coordinates
+     * @param p0 First point on screen, in pixel coordinates.
+     * @param p1 Second point on screen, in pixel coordinates.
      * @param bearing Desired map bearing at end of animation, in degrees. This value is ignored if the map has non-zero pitch.
      * @param options Options object.
      * @param {number | PaddingOptions} [options.padding] The amount of padding in pixels to add to the given bounds.
@@ -822,7 +822,7 @@ class Camera extends Evented {
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires moveend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
 	 * @example
      * const p0 = [220, 400];
      * const p1 = [500, 900];
@@ -904,7 +904,7 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @fires pitchend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // jump to coordinates at current zoom
      * map.jumpTo({center: [0, 0]});
@@ -977,7 +977,7 @@ class Camera extends Evented {
      * Returns position and orientation of the camera entity.
      *
      * @memberof Map#
-     * @returns {FreeCameraOptions} The camera state
+     * @returns {FreeCameraOptions} The camera state.
      * @example
      * const camera = map.getFreeCameraOptions();
      *
@@ -1002,7 +1002,7 @@ class Camera extends Evented {
      * or the pitch is over the maximum pitch limit.
      *
      * @memberof Map#
-     * @param {FreeCameraOptions} options `FreeCameraOptions` object
+     * @param {FreeCameraOptions} options `FreeCameraOptions` object.
      * @param eventData Additional properties to be added to event objects of events triggered by this method.
      * @fires movestart
      * @fires zoomstart
@@ -1014,7 +1014,7 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @fires pitchend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * const camera = map.getFreeCameraOptions();
      *
@@ -1088,7 +1088,7 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @fires pitchend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @see [Navigate the map with game-like controls](https://www.mapbox.com/mapbox-gl-js/example/game-controls/)
      * @example
      * // Ease with default options to null island for 5 seconds
@@ -1301,7 +1301,7 @@ class Camera extends Evented {
      * @fires moveend
      * @fires zoomend
      * @fires pitchend
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // fly with default options to null island
      * map.flyTo({center: [0, 0], zoom: 9});
@@ -1486,7 +1486,7 @@ class Camera extends Evented {
      * Stops any animated transition underway.
      *
      * @memberof Map#
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.stop();
      */

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -17,7 +17,7 @@ type Options = {
  *
  * @implements {IControl}
  * @param {Object} [options]
- * @param {boolean} [options.compact] If `true`, force a compact attribution that shows the full attribution on mouse hover. If `false`, force the full attribution control. The default is a responsive attribution that collapses when the map is less than 640 pixels wide. **Attribution should not be collapsed if it can comfortably fit on the map. `compact` should only be used to modify default attribution when map size makes it impossible to fit [default attribution](https://docs.mapbox.com/help/how-mapbox-works/attribution/) and when the automatic compact resizing for default settings are not sufficient.**
+ * @param {boolean} [options.compact] If `true`, force a compact attribution that shows the full attribution on mouse hover. If `false`, force the full attribution control. The default is a responsive attribution that collapses when the map is less than 640 pixels wide. **Attribution should not be collapsed if it can comfortably fit on the map. `compact` should only be used to modify default attribution when map size makes it impossible to fit [default attribution](https://docs.mapbox.com/help/how-mapbox-works/attribution/) and when the automatic compact resizing for default settings are not sufficient**.
  * @param {string | Array<string>} [options.customAttribution] String or strings to show in addition to any other attributions. You can also set a custom attribution when initializing your map with {@link https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters the customAttribution option}.
  * @example
  * const map = new mapboxgl.Map({attributionControl: false})

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -511,8 +511,7 @@ class GeolocateControl extends Evented {
     }
 
     /**
-     * Trigger a geolocation
-     *
+     * Trigger a geolocation event.
      * @example
      * // Initialize the geolocate control.
      * const geolocate = new mapboxgl.GeolocateControl({

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -512,6 +512,7 @@ class GeolocateControl extends Evented {
 
     /**
      * Trigger a geolocation event.
+     *
      * @example
      * // Initialize the geolocate control.
      * const geolocate = new mapboxgl.GeolocateControl({

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -73,7 +73,7 @@ class ScaleControl {
     }
 
     /**
-     * Set the scale's unit of the distance
+     * Set the scale's unit of the distance.
      *
      * @param unit Unit of the distance (`'imperial'`, `'metric'` or `'nautical'`).
      */

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -101,10 +101,10 @@ export class MapMouseEvent extends Event {
      *
      * Calling this method will prevent the following default map behaviors:
      *
-     *   * On `mousedown` events, the behavior of {@link DragPanHandler}
-     *   * On `mousedown` events, the behavior of {@link DragRotateHandler}
-     *   * On `mousedown` events, the behavior of {@link BoxZoomHandler}
-     *   * On `dblclick` events, the behavior of {@link DoubleClickZoomHandler}
+     *   * On `mousedown` events, the behavior of {@link DragPanHandler}.
+     *   * On `mousedown` events, the behavior of {@link DragRotateHandler}.
+     *   * On `mousedown` events, the behavior of {@link BoxZoomHandler}.
+     *   * On `dblclick` events, the behavior of {@link DoubleClickZoomHandler}.
      *
      * @example
      * map.on('click', (e) => {
@@ -247,8 +247,8 @@ export class MapTouchEvent extends Event {
      *
      * Calling this method will prevent the following default map behaviors:
      *
-     *   * On `touchstart` events, the behavior of {@link DragPanHandler}
-     *   * On `touchstart` events, the behavior of {@link TouchZoomRotateHandler}
+     *   * On `touchstart` events, the behavior of {@link DragPanHandler}.
+     *   * On `touchstart` events, the behavior of {@link TouchZoomRotateHandler}.
      *
      * @example
      * map.on('touchstart', (e) => {
@@ -260,7 +260,7 @@ export class MapTouchEvent extends Event {
     }
 
     /**
-     * `true` if `preventDefault` has been called.
+     * Returns `true` if `preventDefault` has been called.
      * @private
      */
     get defaultPrevented(): boolean {
@@ -354,9 +354,9 @@ export class MapWheelEvent extends Event {
  * For a full list of available events, see [`Map` events](/mapbox-gl-js/api/map/#map-events).
  *
  * @typedef {Object} MapBoxZoomEvent
- * @property {MouseEvent} originalEvent The DOM event that triggered the boxzoom event. Can be a `MouseEvent` or `KeyboardEvent`
+ * @property {MouseEvent} originalEvent The DOM event that triggered the boxzoom event. Can be a `MouseEvent` or `KeyboardEvent`.
  * @property {string} type The type of originating event. For a full list of available events, see [`Map` events](/mapbox-gl-js/api/map/#map-events).
- * @property {Map} target The `Map` instance that triggerred the event
+ * @property {Map} target The `Map` instance that triggered the event.
  * @example
  * // Example of a BoxZoomEvent of type "boxzoomstart"
  * map.on('boxzoomstart', (e) => {
@@ -726,6 +726,7 @@ export type MapEvent =
      * @memberof Map
      * @instance
      * @property {MapTouchEvent} data
+     * @example
      * // Initialize the map
      * const map = new mapboxgl.Map({});
      * // Set an event listener that fires
@@ -745,10 +746,9 @@ export type MapEvent =
      * @instance
      * @property {MapTouchEvent} data
      * @example
-     * // Initialize the map
+     * // Initialize the map.
      * const map = new mapboxgl.Map({});
-     * // Set an event listener that fires
-     * // when a touchstart event occurs within the map.
+     * // Set an event listener that fires when a touchstart event occurs within the map.
      * map.on('touchstart', () => {
      *     console.log('A touchstart event occurred.');
      * });
@@ -764,10 +764,9 @@ export type MapEvent =
      * @instance
      * @property {MapTouchEvent} data
      * @example
-     * // Initialize the map
+     * // Initialize the map.
      * const map = new mapboxgl.Map({});
-     * // Set an event listener that fires
-     * // when a touchmove event occurs within the map.
+     * // Set an event listener that fires when a touchmove event occurs within the map.
      * map.on('touchmove', () => {
      *     console.log('A touchmove event occurred.');
      * });
@@ -783,10 +782,9 @@ export type MapEvent =
      * @instance
      * @property {MapTouchEvent} data
      * @example
-     * // Initialize the map
+     * // Initialize the map.
      * const map = new mapboxgl.Map({});
-     * // Set an event listener that fires
-     * // when a touchcancel event occurs within the map.
+     * // Set an event listener that fires when a touchcancel event occurs within the map.
      * map.on('touchcancel', () => {
      *     console.log('A touchcancel event occurred.');
      * });
@@ -794,19 +792,16 @@ export type MapEvent =
     | 'touchcancel'
 
     /**
-     * Fired just before the map begins a transition from one
-     * view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.
+     * Fired just before the map begins a transition from one view to another, as the result of either user interaction or methods such as {@link Map#jumpTo}.
      *
      * @event movestart
      * @memberof Map
      * @instance
      * @property {{originalEvent: DragEvent}} data
      * @example
-     * // Initialize the map
+     * // Initialize the map.
      * const map = new mapboxgl.Map({});
-     * // Set an event listener that fires
-     * // just before the map begins a transition
-     * // from one view to another.
+     * // Set an event listener that fires just before the map begins a transition from one view to another.
      * map.on('movestart', () => {
      *     console.log('A movestart` event occurred.');
      * });
@@ -814,18 +809,16 @@ export type MapEvent =
     | 'movestart'
 
     /**
-     * Fired repeatedly during an animated transition from one view to
-     * another, as the result of either user interaction or methods such as {@link Map#flyTo}.
+     * Fired repeatedly during an animated transition from one view to another, as the result of either user interaction or methods such as {@link Map#flyTo}.
      *
      * @event move
      * @memberof Map
      * @instance
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
-     * // Initialize the map
+     * // Initialize the map.
      * const map = new mapboxgl.Map({});
-     * // Set an event listener that fires
-     * // repeatedly during an animated transition.
+     * // Set an event listener that fires repeatedly during an animated transition.
      * map.on('move', () => {
      *     console.log('A move event occurred.');
      * });
@@ -1213,12 +1206,12 @@ export type MapEvent =
     | 'load'
 
     /**
-     * Fired whenever the map is drawn to the screen, as the result of
+     * Fired whenever the map is drawn to the screen, as the result of:
      *
      * - a change to the map's position, zoom, pitch, or bearing
      * - a change to the map's style
      * - a change to a GeoJSON source
-     * - the loading of a vector tile, GeoJSON file, glyph, or sprite
+     * - the loading of a vector tile, GeoJSON file, glyph, or sprite.
      *
      * @event render
      * @memberof Map
@@ -1240,7 +1233,7 @@ export type MapEvent =
      *
      * - No camera transitions are in progress
      * - All currently requested tiles have loaded
-     * - All fade/transition animations have completed
+     * - All fade/transition animations have completed.
      *
      * @event idle
      * @memberof Map

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -319,6 +319,7 @@ export class MapWheelEvent extends Event {
      * Prevents subsequent default processing of the event by the map.
      *
      * Calling this method will prevent the the behavior of {@link ScrollZoomHandler}.
+     *
      * @example
      * map.on('wheel', (e) => {
      *     // Prevent the default map scroll zoom behavior.

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -78,25 +78,25 @@ export function orientationFromFrame(forward: vec3, up: vec3): ?quat {
 
 /**
  * Options for accessing physical properties of the underlying camera entity.
- * A direct access to these properties allows more flexible and precise controlling of the camera
- * while also being fully compatible and interchangeable with CameraOptions. All fields are optional.
- * See {@link Map#setFreeCameraOptions} and {@link Map#getFreeCameraOptions}
+ * Direct access to these properties allows more flexible and precise controlling of the camera.
+ * These options are also fully compatible and interchangeable with CameraOptions. All fields are optional.
+ * See {@link Map#setFreeCameraOptions} and {@link Map#getFreeCameraOptions}.
  *
- * @param {MercatorCoordinate} position Position of the camera in slightly modified web mercator coordinates
+ * @param {MercatorCoordinate} position Position of the camera in slightly modified web mercator coordinates.
         - The size of 1 unit is the width of the projected world instead of the "mercator meter".
           Coordinate [0, 0, 0] is the north-west corner and [1, 1, 0] is the south-east corner.
         - Z coordinate is conformal and must respect minimum and maximum zoom values.
-        - Zoom is automatically computed from the altitude (z)
- * @param {quat} orientation Orientation of the camera represented as a unit quaternion [x, y, z, w]
-        in a left-handed coordinate space. Direction of the rotation is clockwise around the respective axis.
-        The default pose of the camera is such that the forward vector is looking up the -Z axis and
-        the up vector is aligned with north orientation of the map:
+        - Zoom is automatically computed from the altitude (z).
+ * @param {quat} orientation Orientation of the camera represented as a unit quaternion [x, y, z, w] in a left-handed coordinate space.
+        Direction of the rotation is clockwise around the respective axis.
+        The default pose of the camera is such that the forward vector is looking up the -Z axis.
+        The up vector is aligned with north orientation of the map:
           forward: [0, 0, -1]
           up:      [0, -1, 0]
           right    [1, 0, 0]
-        Orientation can be set freely but certain constraints still apply
+        Orientation can be set freely but certain constraints still apply:
          - Orientation must be representable with only pitch and bearing.
-         - Pitch has an upper limit
+         - Pitch has an upper limit.
  * @see [Animate the camera around a point in 3D terrain](https://docs.mapbox.com/mapbox-gl-js/example/free-camera-point/)
  * @see [Animate the camera along a path](https://docs.mapbox.com/mapbox-gl-js/example/free-camera-path/)
  * @example
@@ -133,7 +133,7 @@ class FreeCameraOptions {
      * Helper function for setting orientation of the camera by defining a focus point
      * on the map.
      *
-     * @param {LngLatLike} location Location of the focus point on the map
+     * @param {LngLatLike} location Location of the focus point on the map.
      * @param {vec3?} up Up vector of the camera is necessary in certain scenarios where bearing can't be deduced
      *      from the viewing direction.
      * @example
@@ -169,8 +169,8 @@ class FreeCameraOptions {
     /**
      * Helper function for setting the orientation of the camera as a pitch and a bearing.
      *
-     * @param {number} pitch Pitch angle in degrees
-     * @param {number} bearing Bearing angle in degrees
+     * @param {number} pitch Pitch angle in degrees.
+     * @param {number} bearing Bearing angle in degrees.
      * @example
      * const camera = map.getFreeCameraOptions();
      *

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -39,7 +39,7 @@ class BoxZoomHandler {
     /**
      * Returns a Boolean indicating whether the "box zoom" interaction is enabled.
      *
-     * @returns {boolean} `true` if the "box zoom" interaction is enabled.
+     * @returns {boolean} Returns `true` if the "box zoom" interaction is enabled.
      * @example
      * const isBoxZoomEnabled = map.boxZoom.isEnabled();
      */
@@ -48,9 +48,9 @@ class BoxZoomHandler {
     }
 
     /**
-     * Returns a Boolean indicating whether the "box zoom" interaction is active, i.e. currently being used.
+     * Returns a Boolean indicating whether the "box zoom" interaction is active (currently being used).
      *
-     * @returns {boolean} `true` if the "box zoom" interaction is active.
+     * @returns {boolean} Returns `true` if the "box zoom" interaction is active.
      * @example
      * const isBoxZoomActive = map.boxZoom.isActive();
      */

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -128,7 +128,7 @@ class ScrollZoomHandler {
      * Enables the "scroll to zoom" interaction.
      *
      * @param {Object} [options] Options object.
-     * @param {string} [options.around] If "center" is passed, map will zoom around center of map
+     * @param {string} [options.around] If "center" is passed, map will zoom around center of map.
      *
      * @example
      * map.scrollZoom.enable();

--- a/src/ui/handler/shim/dblclick_zoom.js
+++ b/src/ui/handler/shim/dblclick_zoom.js
@@ -47,7 +47,7 @@ export default class DoubleClickZoomHandler {
     /**
      * Returns a Boolean indicating whether the "double click to zoom" interaction is enabled.
      *
-     * @returns {boolean} `true` if the "double click to zoom" interaction is enabled.
+     * @returns {boolean} Returns `true` if the "double click to zoom" interaction is enabled.
      * @example
      * const isDoubleClickZoomEnabled = map.doubleClickZoom.isEnabled();
      */
@@ -56,9 +56,9 @@ export default class DoubleClickZoomHandler {
     }
 
     /**
-     * Returns a Boolean indicating whether the "double click to zoom" interaction is active, i.e. currently being used.
+     * Returns a Boolean indicating whether the "double click to zoom" interaction is active (currently being used).
      *
-     * @returns {boolean} `true` if the "double click to zoom" interaction is active.
+     * @returns {boolean} Returns `true` if the "double click to zoom" interaction is active.
      * @example
      * const isDoubleClickZoomActive = map.doubleClickZoom.isActive();
      */

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -37,10 +37,10 @@ export default class DragPanHandler {
      * Enables the "drag to pan" interaction.
      *
      * @param {Object} [options] Options object.
-     * @param {number} [options.linearity=0] factor used to scale the drag velocity
-     * @param {Function} [options.easing=bezier(0, 0, 0.3, 1)] easing function applled to `map.panTo` when applying the drag.
-     * @param {number} [options.maxSpeed=1400] the maximum value of the drag velocity.
-     * @param {number} [options.deceleration=2500] the rate at which the speed reduces after the pan ends.
+     * @param {number} [options.linearity=0] Factor used to scale the drag velocity.
+     * @param {Function} [options.easing=bezier(0, 0, 0.3, 1)] Easing function applied to `map.panTo` when applying the drag.
+     * @param {number} [options.maxSpeed=1400] The maximum value of the drag velocity.
+     * @param {number} [options.deceleration=2500] The rate at which the speed reduces after the pan ends.
      *
      * @example
      * map.dragPan.enable();
@@ -74,7 +74,7 @@ export default class DragPanHandler {
     /**
      * Returns a Boolean indicating whether the "drag to pan" interaction is enabled.
      *
-     * @returns {boolean} `true` if the "drag to pan" interaction is enabled.
+     * @returns {boolean} Returns `true` if the "drag to pan" interaction is enabled.
      * @example
      * const isDragPanEnabled = map.dragPan.isEnabled();
      */
@@ -83,9 +83,9 @@ export default class DragPanHandler {
     }
 
     /**
-     * Returns a Boolean indicating whether the "drag to pan" interaction is active, i.e. currently being used.
+     * Returns a Boolean indicating whether the "drag to pan" interaction is active (currently being used).
      *
-     * @returns {boolean} `true` if the "drag to pan" interaction is active.
+     * @returns {boolean} Returns `true` if the "drag to pan" interaction is active.
      * @example
      * const isDragPanActive = map.dragPan.isActive();
      */

--- a/src/ui/handler/shim/drag_rotate.js
+++ b/src/ui/handler/shim/drag_rotate.js
@@ -62,9 +62,9 @@ export default class DragRotateHandler {
     }
 
     /**
-     * Returns a Boolean indicating whether the "drag to rotate" interaction is active, i.e. currently being used.
+     * Returns a Boolean indicating whether the "drag to rotate" interaction is active (currently being used).
      *
-     * @returns {boolean} `true` if the "drag to rotate" interaction is active.
+     * @returns {boolean} Returns `true` if the "drag to rotate" interaction is active.
      * @example
      * const isDragRotateActive = map.dragRotate.isActive();
      */

--- a/src/ui/handler/shim/touch_zoom_rotate.js
+++ b/src/ui/handler/shim/touch_zoom_rotate.js
@@ -37,7 +37,7 @@ export default class TouchZoomRotateHandler {
      * Enables the "pinch to rotate and zoom" interaction.
      *
      * @param {Object} [options] Options object.
-     * @param {string} [options.around] If "center" is passed, map will zoom around the center
+     * @param {string} [options.around] If "center" is passed, map will zoom around the center.
      *
      * @example
      * map.touchZoomRotate.enable();

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -791,13 +791,10 @@ class Map extends Camera {
      * If the map's current pitch is lower than the new minimum,
      * the map will pitch to the new minimum.
      *
-     * @param {number | null | undefined} minPitch The minimum pitch to set (0-85).
-     *   If `null` or `undefined` is provided, the function removes the current minimum pitch (i.e. sets it to 0).
+     * @param {number | null | undefined} minPitch The minimum pitch to set (0-85). If `null` or `undefined` is provided, the function removes the current minimum pitch and resets it to 0.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setMinPitch(5);
-     *   If `null` or `undefined` is provided, the function removes the current minimum pitch and resets it to 0.
-     *   If `null` or `undefined` is provided, the function removes the current minimum pitch and resets it to 0.
      */
     setMinPitch(minPitch?: ?number) {
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -187,12 +187,11 @@ const defaultOptions = {
  * @param {number} [options.maxZoom=22] The maximum zoom level of the map (0-24).
  * @param {number} [options.minPitch=0] The minimum pitch of the map (0-85).
  * @param {number} [options.maxPitch=85] The maximum pitch of the map (0-85).
- * @param {Object|string} [options.style] The map's Mapbox style. This must be an a JSON object conforming to
- * the schema described in the [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL to
- * such JSON.
+ * @param {Object|string} [options.style] The map's Mapbox style. This must be a JSON object conforming to
+ * the schema described in the [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL to such JSON.
  *
  * To load a style from the Mapbox API, you can use a URL of the form `mapbox://styles/:owner/:style`,
- * where `:owner` is your Mapbox account name and `:style` is the style ID. Or you can use a
+ * where `:owner` is your Mapbox account name and `:style` is the style ID. You can also use a
  * [Mapbox-owned style](https://docs.mapbox.com/api/maps/styles/#mapbox-styles):
  *
  *  * `mapbox://styles/mapbox/streets-v11`
@@ -202,7 +201,7 @@ const defaultOptions = {
  *  * `mapbox://styles/mapbox/satellite-v9`
  *  * `mapbox://styles/mapbox/satellite-streets-v11`
  *  * `mapbox://styles/mapbox/navigation-day-v1`
- *  * `mapbox://styles/mapbox/navigation-night-v1`
+ *  * `mapbox://styles/mapbox/navigation-night-v1`.
  *
  * Tilesets hosted with Mapbox can be style-optimized if you append `?optimize=true` to the end of your style URL, like `mapbox://styles/mapbox/streets-v11?optimize=true`.
  * Learn more about style-optimized vector tiles in our [API documentation](https://www.mapbox.com/api-documentation/maps/#retrieve-tiles).
@@ -210,8 +209,8 @@ const defaultOptions = {
  * @param {(boolean|string)} [options.hash=false] If `true`, the map's position (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL.
  *   For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
  *   An additional string may optionally be provided to indicate a parameter-styled hash,
- *   e.g. http://path/to/my/page.html#map=2.59/39.26/53.07/-24.1/60&foo=bar, where foo
- *   is a custom parameter and bar is an arbitrary hash distinct from the map hash.
+ *   for example http://path/to/my/page.html#map=2.59/39.26/53.07/-24.1/60&foo=bar, where `foo`
+ *   is a custom parameter and `bar` is an arbitrary hash distinct from the map hash.
  * @param {boolean} [options.interactive=true] If `false`, no mouse, touch, or keyboard listeners will be attached to the map, so it will not respond to interaction.
  * @param {number} [options.bearingSnap=7] The threshold, measured in degrees, that determines when the map's
  *   bearing will snap to north. For example, with a `bearingSnap` of 7, if the user rotates
@@ -221,10 +220,9 @@ const defaultOptions = {
  * @param {boolean} [options.attributionControl=true] If `true`, an {@link AttributionControl} will be added to the map.
  * @param {string | Array<string>} [options.customAttribution] String or strings to show in an {@link AttributionControl}. Only applicable if `options.attributionControl` is `true`.
  * @param {string} [options.logoPosition='bottom-left'] A string representing the position of the Mapbox wordmark on the map. Valid options are `top-left`,`top-right`, `bottom-left`, `bottom-right`.
- * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the performance of Mapbox
- *   GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
+ * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`, map creation will fail if the performance of Mapbox GL JS would be dramatically worse than expected (a software renderer would be used).
  * @param {boolean} [options.preserveDrawingBuffer=false] If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`. This is `false` by default as a performance optimization.
- * @param {boolean} [options.antialias] If `true`, the gl context will be created with MSAA antialiasing, which can be useful for antialiasing custom layers. this is `false` by default as a performance optimization.
+ * @param {boolean} [options.antialias] If `true`, the gl context will be created with MSAA antialiasing, which can be useful for antialiasing custom layers. This is `false` by default as a performance optimization.
  * @param {boolean} [options.refreshExpiredTiles=true] If `false`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
  * @param {LngLatBoundsLike} [options.maxBounds] If set, the map will be constrained to the given bounds.
  * @param {boolean|Object} [options.scrollZoom=true] If `true`, the "scroll to zoom" interaction is enabled. An `Object` value is passed as options to {@link ScrollZoomHandler#enable}.
@@ -253,17 +251,17 @@ const defaultOptions = {
  *   font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs', 'Hiragana', 'Katakana', 'Hangul Syllables' and 'CJK Symbols and Punctuation' ranges.
  *   In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
  *   Set to `false`, to enable font settings from the map's style for these glyph ranges.  Note that [Mapbox Studio](https://studio.mapbox.com/) sets this value to `false` by default.
- *   The purpose of this option is to avoid bandwidth-intensive glyph server requests. (See [Use locally generated ideographs](https://www.mapbox.com/mapbox-gl-js/example/local-ideographs).)
+ *   The purpose of this option is to avoid bandwidth-intensive glyph server requests. (See [Use locally generated ideographs](https://www.mapbox.com/mapbox-gl-js/example/local-ideographs)).
  * @param {string} [options.localFontFamily=false] Defines a CSS
  *   font-family for locally overriding generation of all glyphs. Font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
- *   If set, this option override the setting in localIdeographFontFamily
+ *   If set, this option override the setting in localIdeographFontFamily.
  * @param {RequestTransformFunction} [options.transformRequest=null] A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
  *   Expected to return a {@link RequestParameters} object with a `url` property and optionally `headers` and `credentials` properties.
  * @param {boolean} [options.collectResourceTiming=false] If `true`, Resource Timing API information will be collected for requests made by GeoJSON and Vector Tile web workers (this information is normally inaccessible from the main Javascript thread). Information will be returned in a `resourceTiming` property of relevant `data` events.
  * @param {number} [options.fadeDuration=300] Controls the duration of the fade-in/fade-out animation for label collisions, in milliseconds. This setting affects all symbol layers. This setting does not affect the duration of runtime styling transitions or raster tile cross-fading.
  * @param {boolean} [options.crossSourceCollisions=true] If `true`, symbols from multiple sources can collide with each other during collision detection. If `false`, collision detection is run separately for the symbols in each source.
  * @param {string} [options.accessToken=null] If specified, map will use this token instead of the one defined in mapboxgl.accessToken.
- * @param {Object} [options.locale=null] A patch to apply to the default localization table for UI strings, e.g. control tooltips. The `locale` object maps namespaced UI string IDs to translated strings in the target language;
+ * @param {Object} [options.locale=null] A patch to apply to the default localization table for UI strings (control tooltips). The `locale` object maps namespaced UI string IDs to translated strings in the target language;
  *  see `src/ui/default_locale.js` for an example with all supported string IDs. The object may specify all UI strings (thereby adding support for a new translation) or only a subset of strings (thereby patching the default translation table).
  * @param {boolean} [options.testMode=false] Silences errors and warnings generated due to an invalid accessToken, useful when using the library to write unit tests.
  * @example
@@ -548,9 +546,9 @@ class Map extends Camera {
      * Adds an {@link IControl} to the map, calling `control.onAdd(this)`.
      *
      * @param {IControl} control The {@link IControl} to add.
-     * @param {string} [position] position on the map to which the control will be added.
+     * @param {string} [position] Position on the map to which the control will be added.
      * Valid values are `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`. Defaults to `'top-right'`.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Add zoom and rotation controls to the map.
      * map.addControl(new mapboxgl.NavigationControl());
@@ -584,7 +582,7 @@ class Map extends Camera {
      * Removes the control from the map.
      *
      * @param {IControl} control The {@link IControl} to remove.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Define a new navigation control.
      * const navigation = new mapboxgl.NavigationControl();
@@ -633,7 +631,7 @@ class Map extends Camera {
      * @param eventData Additional properties to be passed to `movestart`, `move`, `resize`, and `moveend`
      *   events that get triggered as a result of resize. This can be useful for differentiating the
      *   source of an event (for example, user-initiated or programmatically-triggered events).
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Resize the map when the map container is shown
      * // after being initially hidden with CSS.
@@ -698,7 +696,7 @@ class Map extends Camera {
      * remaining within the bounds.
      *
      * @param {LngLatBoundsLike | null | undefined} bounds The maximum bounds to set. If `null` or `undefined` is provided, the function removes the map's maximum bounds.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Define bounds that conform to the `LngLatBoundsLike` object.
      * const bounds = [
@@ -724,8 +722,8 @@ class Map extends Camera {
      * no matter what the `minZoom` is set to.
      *
      * @param {number | null | undefined} minZoom The minimum zoom level to set (-2 - 24).
-     *   If `null` or `undefined` is provided, the function removes the current minimum zoom (i.e. sets it to -2).
-     * @returns {Map} `this`
+     *   If `null` or `undefined` is provided, the function removes the current minimum zoom and it will be reset to -2.
+     * @returns {Map} Returns `this`.
      * @example
      * map.setMinZoom(12.25);
      */
@@ -747,7 +745,7 @@ class Map extends Camera {
     /**
      * Returns the map's minimum allowable zoom level.
      *
-     * @returns {number} minZoom
+     * @returns {number} Returns `minZoom`.
      * @example
      * const minZoom = map.getMinZoom();
      */
@@ -760,7 +758,7 @@ class Map extends Camera {
      *
      * @param {number | null | undefined} maxZoom The maximum zoom level to set.
      *   If `null` or `undefined` is provided, the function removes the current maximum zoom (sets it to 22).
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.setMaxZoom(18.75);
      */
@@ -782,7 +780,7 @@ class Map extends Camera {
     /**
      * Returns the map's maximum allowable zoom level.
      *
-     * @returns {number} maxZoom
+     * @returns {number} Returns `maxZoom`.
      * @example
      * const maxZoom = map.getMaxZoom();
      */
@@ -795,9 +793,10 @@ class Map extends Camera {
      *
      * @param {number | null | undefined} minPitch The minimum pitch to set (0-85).
      *   If `null` or `undefined` is provided, the function removes the current minimum pitch (i.e. sets it to 0).
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.setMinPitch(5);
+     *   If `null` or `undefined` is provided, the function removes the current minimum pitch and resets it to 0.
      */
     setMinPitch(minPitch?: ?number) {
 
@@ -821,7 +820,7 @@ class Map extends Camera {
     /**
      * Returns the map's minimum allowable pitch.
      *
-     * @returns {number} minPitch
+     * @returns {number} Returns `minPitch`.
      * @example
      * const minPitch = map.getMinPitch();
      */
@@ -834,7 +833,7 @@ class Map extends Camera {
      *
      * @param {number | null | undefined} maxPitch The maximum pitch to set.
      *   If `null` or `undefined` is provided, the function removes the current maximum pitch (sets it to 85).
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.setMaxPitch(70);
      */
@@ -860,7 +859,7 @@ class Map extends Camera {
     /**
      * Returns the map's maximum allowable pitch.
      *
-     * @returns {number} maxPitch
+     * @returns {number} Returns `maxPitch`.
      * @example
      * const maxPitch = map.getMaxPitch();
      */
@@ -873,7 +872,7 @@ class Map extends Camera {
      * - Features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the
      * map and the other on the left edge of the map) at every zoom level.
      *
-     * @returns {boolean} renderWorldCopies
+     * @returns {boolean} Returns `renderWorldCopies` boolean.
      * @example
      * const worldCopiesRendered = map.getRenderWorldCopies();
      * @see [Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
@@ -890,7 +889,7 @@ class Map extends Camera {
      * map and the other on the left edge of the map) at every zoom level.
      *
      * `undefined` is treated as `true`, `null` is treated as `false`.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.setRenderWorldCopies(true);
      * @see [Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
@@ -1082,7 +1081,7 @@ class Map extends Camera {
      * happening anywhere on the map, and the event will not have a `features` property.
      * Note that many event types are not compatible with the optional `layerId` parameter.
      * @param {Function} listener The function to be called when the event is fired.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Set an event listener that will fire
      * // when the map has finished loading.
@@ -1154,7 +1153,7 @@ class Map extends Camera {
      * happening anywhere on the map, and the event will not have a `features` property.
      * Note that many event types are not compatible with the optional `layerId` parameter.
      * @param {Function} listener The function to be called when the event is fired.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Log the coordinates of a user's first map touch.
      * map.once('touchstart', (e) => {
@@ -1192,7 +1191,7 @@ class Map extends Camera {
      * @param {string} type The event type previously used to install the listener.
      * @param {string} layerId (optional) The layer ID previously used to install the listener.
      * @param {Function} listener The function previously installed as a listener.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * // Create a function to print coordinates while a mouse is moving.
      * function onMove(e) {
@@ -1243,7 +1242,7 @@ class Map extends Camera {
      *
      * @param {PointLike|Array<PointLike>} [geometry] - The geometry of the query region in pixels:
      * either a single point or bottom left and top right points describing a bounding box, where the origin is at the top left.
-     * Omitting this parameter (i.e. calling {@link Map#queryRenderedFeatures} with zero arguments,
+     * Omitting this parameter (by calling {@link Map#queryRenderedFeatures} with zero arguments,
      * or with only an `options` argument) is equivalent to passing a bounding box encompassing the entire
      * map viewport.
      * Only values within the existing viewport are supported.
@@ -1358,7 +1357,7 @@ class Map extends Camera {
      * [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
      *
      * In contrast to {@link Map#queryRenderedFeatures}, this function returns all features matching the query parameters,
-     * whether or not they are rendered by the current style (i.e. visible). The domain of the query includes all currently-loaded
+     * whether or not they are rendered (visible) by the current style. The domain of the query includes all currently-loaded
      * vector tiles and GeoJSON source tiles: this function does not check tiles outside the currently
      * visible viewport.
      *
@@ -1385,12 +1384,11 @@ class Map extends Camera {
     /**
      * Updates the map's Mapbox style object with a new value.
      *
-     * If a style is already set when this is used and options.diff is set to true, the map renderer will attempt to compare the given style
+     * If a style is already set when this is used and the `diff` option is set to true, the map renderer will attempt to compare the given style
      * against the map's current state and perform only the changes necessary to make the map style match the desired state. Changes in sprites
      * (images used for icons and patterns) and glyphs (fonts for label text) **cannot** be diffed. If the sprites or fonts used in the current
      * style and the given style are different in any way, the map renderer will force a full update, removing the current style and building
      * the given one from scratch.
-     *
      *
      * @param style A JSON object conforming to the schema described in the
      *   [Mapbox Style Specification](https://mapbox.com/mapbox-gl-style-spec/), or a URL to such JSON.
@@ -1402,7 +1400,7 @@ class Map extends Camera {
      *   In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
      *   Set to `false`, to enable font settings from the map's style for these glyph ranges.
      *   Forces a full update.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      *
      * @example
      * map.setStyle("mapbox://styles/mapbox/streets-v11");
@@ -1529,7 +1527,7 @@ class Map extends Camera {
      * Mapbox Style Specification's [source definition](https://www.mapbox.com/mapbox-gl-style-spec/#sources) or
      * {@link CanvasSourceOptions}.
      * @fires source.add
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.addSource('my-data', {
      *     type: 'vector',
@@ -1618,7 +1616,7 @@ class Map extends Camera {
      * Removes a source from the map's style.
      *
      * @param {string} id The ID of the source to remove.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.removeSource('bathymetry-data');
      */
@@ -1666,8 +1664,8 @@ class Map extends Camera {
      * @param image The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
      * properties with the same format as `ImageData`.
      * @param options Options object.
-     * @param options.pixelRatio The ratio of pixels in the image to physical pixels on the screen
-     * @param options.sdf Whether the image should be interpreted as an SDF image
+     * @param options.pixelRatio The ratio of pixels in the image to physical pixels on the screen.
+     * @param options.sdf Whether the image should be interpreted as an SDF image.
      * @param options.content  `[x1, y1, x2, y2]`  If `icon-text-fit` is used in a layer with this image, this option defines the part of the image that can be covered by the content in `text-field`.
      * @param options.stretchX  `[[x1, x2], ...]` If `icon-text-fit` is used in a layer with this image, this option defines the part(s) of the image that can be stretched horizontally.
      * @param options.stretchY  `[[y1, y2], ...]` If `icon-text-fit` is used in a layer with this image, this option defines the part(s) of the image that can be stretched vertically.
@@ -1867,7 +1865,7 @@ class Map extends Camera {
      * @param {string} layer.type The type of layer (for example `fill` or `symbol`).
      * A list of layer types is available in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#type).
      *
-     * (This can also be `custom`. For more information, see {@link CustomLayerInterface}.)
+     * (This can also be `custom`. For more information, see {@link CustomLayerInterface}).
      * @param {string | Object} [layer.source] The data source for the layer.
      * Reference a source that has _already been defined_ using the source's unique id.
      * Reference a _new source_ using a source object (as defined in the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)) directly.
@@ -1903,7 +1901,7 @@ class Map extends Camera {
      * If this argument is not specified, the layer will be appended to the end of the layers array
      * and appear visually above all other layers.
      *
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      *
      * @example
      * // Add a circle layer with a vector source
@@ -1973,7 +1971,7 @@ class Map extends Camera {
      *
      * @param {string} id The ID of the layer to move.
      * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. When viewing the map, the `id` layer will appear beneath the `beforeId` layer. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      *
      * @example
      * // Move a layer with ID 'polygon' before the layer with ID 'country-label'. The `polygon` layer will appear beneath the `country-label` layer on the map.
@@ -1989,8 +1987,8 @@ class Map extends Camera {
      *
      * If no such layer exists, an `error` event is fired.
      *
-     * @param {string} id id of the layer to remove
-     * @returns {Map} `this`
+     * @param {string} id ID of the layer to remove.
+     * @returns {Map} Returns `this`.
      * @fires error
      *
      * @example
@@ -2033,7 +2031,7 @@ class Map extends Camera {
      * @param {string} layerId The ID of the layer to which the zoom extent will be applied.
      * @param {number} minzoom The minimum zoom to set (0-24).
      * @param {number} maxzoom The maximum zoom to set (0-24).
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      *
      * @example
      * map.setLayerZoomRange('my-layer', 2, 5);
@@ -2060,7 +2058,7 @@ class Map extends Camera {
      *   [filter definition](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter).  If `null` or `undefined` is provided, the function removes any existing filter from the layer.
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      *
      * @example
      * // display only features with the 'name' property 'USA'
@@ -2103,7 +2101,7 @@ class Map extends Camera {
      *   Must be of a type appropriate for the property, as defined in the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/).
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if `value` conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.setPaintProperty('my-layer', 'fill-color', '#faafee');
      * @see [Change a layer's color with buttons](https://www.mapbox.com/mapbox-gl-js/example/color-switcher/)
@@ -2136,7 +2134,7 @@ class Map extends Camera {
      * @param {*} value The value of the layout property. Must be of a type appropriate for the property, as defined in the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/).
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if `value` conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.setLayoutProperty('my-layer', 'visibility', 'none');
      * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
@@ -2165,7 +2163,7 @@ class Map extends Camera {
      * @param light Light properties to set. Must conform to the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#light).
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * const layerVisibility = map.getLayoutProperty('my-layer', 'visibility');
      * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
@@ -2179,7 +2177,7 @@ class Map extends Camera {
     /**
      * Returns the value of the light object.
      *
-     * @returns {Object} light Light properties of the style.
+     * @returns {Object} Light properties of the style.
      * @example
      * const light = map.getLight();
      */
@@ -2193,7 +2191,7 @@ class Map extends Camera {
      *
      * @param terrain Terrain properties to set. Must conform to the [Terrain Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/terrain/).
      * If `null` or `undefined` is provided, function removes terrain.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.addSource('mapbox-dem', {
      *     'type': 'raster-dem',
@@ -2214,7 +2212,7 @@ class Map extends Camera {
     /**
      * Returns the terrain specification or `null` if terrain isn't set on the map.
      *
-     * @returns {Object} terrain Terrain specification properties of the style.
+     * @returns {Object} Terrain specification properties of the style.
      * @example
      * const terrain = map.getTerrain();
      */
@@ -2227,7 +2225,7 @@ class Map extends Camera {
      *
      * @param fog The fog properties to set. Must conform the [Fog Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/fog/).
      * If `null` or `undefined` is provided, this function call removes the fog from the map.
-     * @returns {Map} `this`
+     * @returns {Map} Returns `this`.
      * @example
      * map.setFog({
      *     "range": [1.0, 12.0],
@@ -2245,7 +2243,7 @@ class Map extends Camera {
     /**
      * Returns the fog specification or `null` if fog is not set on the map.
      *
-     * @returns {Object} fog Fog specification properties of the style.
+     * @returns {Object} Fog specification properties of the style.
      * @example
      * const fog = map.getFog();
      */
@@ -2277,10 +2275,10 @@ class Map extends Camera {
      * In order to guarantee that the terrain data is loaded ensure that the geographical location is visible and wait for the `idle` event to occur.
      *
      * @param {LngLatLike} lnglat The geographical location at which to query.
-     * @param {ElevationQueryOptions} [options] options Object
+     * @param {ElevationQueryOptions} [options] Options object.
      * @param {boolean} [options.exaggerated=true] When `true` returns the terrain elevation with the value of `exaggeration` from the style already applied.
      * When `false`, returns the raw value of the underlying data without styling applied.
-     * @returns {number | null} The elevation in meters
+     * @returns {number | null} The elevation in meters.
      * @example
      * const coordinate = [-122.420679, 37.772537];
      * const elevation = map.queryTerrainElevation(coordinate);
@@ -2299,20 +2297,20 @@ class Map extends Camera {
      * Sets the `state` of a feature.
      * A feature's `state` is a set of user-defined key-value pairs that are assigned to a feature at runtime.
      * When using this method, the `state` object is merged with any existing key-value pairs in the feature's state.
-     * Features are identified by their `feature.id` attribute, which can be any number or string.
+     * Features are identified by their `id` attribute, which can be any number or string.
      *
-     * This method can only be used with sources that have a `feature.id` attribute. The `feature.id` attribute can be defined in three ways:
+     * This method can only be used with sources that have a `id` attribute. The `id` attribute can be defined in three ways:
      * - For vector or GeoJSON sources, including an `id` attribute in the original data file.
      * - For vector or GeoJSON sources, using the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option at the time the source is defined.
-     * - For GeoJSON sources, using the [`generateId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson-generateId) option to auto-assign an `id` based on the feature's index in the source data. If you change feature data using `map.getSource('some id').setData(..)`, you may need to re-apply state taking into account updated `id` values.
+     * - For GeoJSON sources, using the [`generateId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson-generateId) option to auto-assign an `id` based on the feature's index in the source data. If you change feature data using `map.getSource('some id').setData(...)`, you may need to re-apply state taking into account updated `id` values.
      *
-     * _Note: You can use the [`feature-state` expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#feature-state) to access the values in a feature's state object for the purposes of styling._
+     * _Note: You can use the [`feature-state` expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#feature-state) to access the values in a feature's state object for the purposes of styling_.
      *
      * @param {Object} feature Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required*.
      * @param {Object} state A set of key-value pairs. The values should be valid JSON types.
      * @returns {Map} The map object.
      * @example
@@ -2350,7 +2348,7 @@ class Map extends Camera {
      * Feature objects returned from {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} [feature.sourceLayer] (optional) For vector tile sources, `sourceLayer` is required.
      * @param {string} key (optional) The key in the feature state to reset.
      *
      * @example
@@ -2393,15 +2391,15 @@ class Map extends Camera {
     /**
      * Gets the `state` of a feature.
      * A feature's `state` is a set of user-defined key-value pairs that are assigned to a feature at runtime.
-     * Features are identified by their `feature.id` attribute, which can be any number or string.
+     * Features are identified by their `id` attribute, which can be any number or string.
      *
-     * _Note: To access the values in a feature's state object for the purposes of styling the feature, use the [`feature-state` expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#feature-state)._
+     * _Note: To access the values in a feature's state object for the purposes of styling the feature, use the [`feature-state` expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#feature-state)_.
      *
      * @param {Object} feature Feature identifier. Feature objects returned from
      * {@link Map#queryRenderedFeatures} or event handlers can be used as feature identifiers.
      * @param {number | string} feature.id Unique id of the feature. Can be an integer or a string, but supports string values only when the [`promoteId`](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector-promoteId) option has been applied to the source or the string can be cast to an integer.
      * @param {string} feature.source The id of the vector or GeoJSON source for the feature.
-     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required.*
+     * @param {string} [feature.sourceLayer] (optional) *For vector tile sources, `sourceLayer` is required*.
      *
      * @returns {Object} The state of the feature: a set of key-value pairs that was assigned to the feature at runtime.
      *
@@ -3293,7 +3291,7 @@ function removeNode(node) {
  * @memberof IControl
  * @instance
  * @name onAdd
- * @param {Map} map the Map this control will be added to
+ * @param {Map} map The Map this control will be added to.
  * @returns {HTMLElement} The control's container element. This should
  * be created by the control and returned by onAdd without being attached
  * to the DOM: the map will insert the control's element into the DOM
@@ -3309,8 +3307,8 @@ function removeNode(node) {
  * @memberof IControl
  * @instance
  * @name onRemove
- * @param {Map} map the Map this control will be removed from
- * @returns {undefined} there is no required return value for this method
+ * @param {Map} map The Map this control will be removed from.
+ * @returns {undefined} There is no required return value for this method.
  */
 
 /**
@@ -3323,7 +3321,7 @@ function removeNode(node) {
  * @memberof IControl
  * @instance
  * @name getDefaultPosition
- * @returns {string} a control position, one of the values valid in addControl.
+ * @returns {string} A control position, one of the values valid in addControl.
  */
 
 /**

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -548,7 +548,7 @@ class Map extends Camera {
      * @param {IControl} control The {@link IControl} to add.
      * @param {string} [position] Position on the map to which the control will be added.
      * Valid values are `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`. Defaults to `'top-right'`.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Add zoom and rotation controls to the map.
      * map.addControl(new mapboxgl.NavigationControl());
@@ -582,7 +582,7 @@ class Map extends Camera {
      * Removes the control from the map.
      *
      * @param {IControl} control The {@link IControl} to remove.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Define a new navigation control.
      * const navigation = new mapboxgl.NavigationControl();
@@ -631,7 +631,7 @@ class Map extends Camera {
      * @param eventData Additional properties to be passed to `movestart`, `move`, `resize`, and `moveend`
      *   events that get triggered as a result of resize. This can be useful for differentiating the
      *   source of an event (for example, user-initiated or programmatically-triggered events).
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Resize the map when the map container is shown
      * // after being initially hidden with CSS.
@@ -696,7 +696,7 @@ class Map extends Camera {
      * remaining within the bounds.
      *
      * @param {LngLatBoundsLike | null | undefined} bounds The maximum bounds to set. If `null` or `undefined` is provided, the function removes the map's maximum bounds.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Define bounds that conform to the `LngLatBoundsLike` object.
      * const bounds = [
@@ -723,7 +723,7 @@ class Map extends Camera {
      *
      * @param {number | null | undefined} minZoom The minimum zoom level to set (-2 - 24).
      *   If `null` or `undefined` is provided, the function removes the current minimum zoom and it will be reset to -2.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setMinZoom(12.25);
      */
@@ -758,7 +758,7 @@ class Map extends Camera {
      *
      * @param {number | null | undefined} maxZoom The maximum zoom level to set.
      *   If `null` or `undefined` is provided, the function removes the current maximum zoom (sets it to 22).
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setMaxZoom(18.75);
      */
@@ -793,9 +793,10 @@ class Map extends Camera {
      *
      * @param {number | null | undefined} minPitch The minimum pitch to set (0-85).
      *   If `null` or `undefined` is provided, the function removes the current minimum pitch (i.e. sets it to 0).
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setMinPitch(5);
+     *   If `null` or `undefined` is provided, the function removes the current minimum pitch and resets it to 0.
      *   If `null` or `undefined` is provided, the function removes the current minimum pitch and resets it to 0.
      */
     setMinPitch(minPitch?: ?number) {
@@ -833,7 +834,7 @@ class Map extends Camera {
      *
      * @param {number | null | undefined} maxPitch The maximum pitch to set.
      *   If `null` or `undefined` is provided, the function removes the current maximum pitch (sets it to 85).
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setMaxPitch(70);
      */
@@ -889,7 +890,7 @@ class Map extends Camera {
      * map and the other on the left edge of the map) at every zoom level.
      *
      * `undefined` is treated as `true`, `null` is treated as `false`.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setRenderWorldCopies(true);
      * @see [Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
@@ -1081,7 +1082,7 @@ class Map extends Camera {
      * happening anywhere on the map, and the event will not have a `features` property.
      * Note that many event types are not compatible with the optional `layerId` parameter.
      * @param {Function} listener The function to be called when the event is fired.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Set an event listener that will fire
      * // when the map has finished loading.
@@ -1153,7 +1154,7 @@ class Map extends Camera {
      * happening anywhere on the map, and the event will not have a `features` property.
      * Note that many event types are not compatible with the optional `layerId` parameter.
      * @param {Function} listener The function to be called when the event is fired.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Log the coordinates of a user's first map touch.
      * map.once('touchstart', (e) => {
@@ -1191,7 +1192,7 @@ class Map extends Camera {
      * @param {string} type The event type previously used to install the listener.
      * @param {string} layerId (optional) The layer ID previously used to install the listener.
      * @param {Function} listener The function previously installed as a listener.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Create a function to print coordinates while a mouse is moving.
      * function onMove(e) {
@@ -1400,7 +1401,7 @@ class Map extends Camera {
      *   In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
      *   Set to `false`, to enable font settings from the map's style for these glyph ranges.
      *   Forces a full update.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      *
      * @example
      * map.setStyle("mapbox://styles/mapbox/streets-v11");
@@ -1527,7 +1528,7 @@ class Map extends Camera {
      * Mapbox Style Specification's [source definition](https://www.mapbox.com/mapbox-gl-style-spec/#sources) or
      * {@link CanvasSourceOptions}.
      * @fires source.add
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.addSource('my-data', {
      *     type: 'vector',
@@ -1616,7 +1617,7 @@ class Map extends Camera {
      * Removes a source from the map's style.
      *
      * @param {string} id The ID of the source to remove.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.removeSource('bathymetry-data');
      */
@@ -1901,7 +1902,7 @@ class Map extends Camera {
      * If this argument is not specified, the layer will be appended to the end of the layers array
      * and appear visually above all other layers.
      *
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      *
      * @example
      * // Add a circle layer with a vector source
@@ -1971,7 +1972,7 @@ class Map extends Camera {
      *
      * @param {string} id The ID of the layer to move.
      * @param {string} [beforeId] The ID of an existing layer to insert the new layer before. When viewing the map, the `id` layer will appear beneath the `beforeId` layer. If `beforeId` is omitted, the layer will be appended to the end of the layers array and appear above all other layers on the map.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      *
      * @example
      * // Move a layer with ID 'polygon' before the layer with ID 'country-label'. The `polygon` layer will appear beneath the `country-label` layer on the map.
@@ -1988,7 +1989,7 @@ class Map extends Camera {
      * If no such layer exists, an `error` event is fired.
      *
      * @param {string} id ID of the layer to remove.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @fires error
      *
      * @example
@@ -2031,7 +2032,7 @@ class Map extends Camera {
      * @param {string} layerId The ID of the layer to which the zoom extent will be applied.
      * @param {number} minzoom The minimum zoom to set (0-24).
      * @param {number} maxzoom The maximum zoom to set (0-24).
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      *
      * @example
      * map.setLayerZoomRange('my-layer', 2, 5);
@@ -2058,7 +2059,7 @@ class Map extends Camera {
      *   [filter definition](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#filter).  If `null` or `undefined` is provided, the function removes any existing filter from the layer.
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      *
      * @example
      * // display only features with the 'name' property 'USA'
@@ -2101,7 +2102,7 @@ class Map extends Camera {
      *   Must be of a type appropriate for the property, as defined in the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/).
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if `value` conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setPaintProperty('my-layer', 'fill-color', '#faafee');
      * @see [Change a layer's color with buttons](https://www.mapbox.com/mapbox-gl-js/example/color-switcher/)
@@ -2134,7 +2135,7 @@ class Map extends Camera {
      * @param {*} value The value of the layout property. Must be of a type appropriate for the property, as defined in the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/).
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if `value` conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setLayoutProperty('my-layer', 'visibility', 'none');
      * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
@@ -2163,7 +2164,7 @@ class Map extends Camera {
      * @param light Light properties to set. Must conform to the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/#light).
      * @param {Object} [options] Options object.
      * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the Mapbox GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * const layerVisibility = map.getLayoutProperty('my-layer', 'visibility');
      * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
@@ -2191,7 +2192,7 @@ class Map extends Camera {
      *
      * @param terrain Terrain properties to set. Must conform to the [Terrain Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/terrain/).
      * If `null` or `undefined` is provided, function removes terrain.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.addSource('mapbox-dem', {
      *     'type': 'raster-dem',
@@ -2225,7 +2226,7 @@ class Map extends Camera {
      *
      * @param fog The fog properties to set. Must conform the [Fog Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/fog/).
      * If `null` or `undefined` is provided, this function call removes the fog from the map.
-     * @returns {Map} Returns `this`.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setFog({
      *     "range": [1.0, 12.0],

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -241,7 +241,7 @@ export default class Marker extends Evented {
      * Attaches the `Marker` to a `Map` object.
      *
      * @param {Map} map The Mapbox GL JS map to add the marker to.
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * const marker = new mapboxgl.Marker()
      *     .setLngLat([30.5, 50.5])
@@ -272,7 +272,7 @@ export default class Marker extends Evented {
      * @example
      * const marker = new mapboxgl.Marker().addTo(map);
      * marker.remove();
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      */
     remove() {
         if (this._map) {
@@ -318,7 +318,7 @@ export default class Marker extends Evented {
     * Set the marker's geographical position and move it.
      *
     * @param {LngLat} lnglat A {@link LngLat} describing where the marker should be located.
-    * @returns {Marker} Returns `this`.
+    * @returns {Marker} Returns itself to allow for method chaining.
     * @example
     * // Create a new marker, set the longitude and latitude, and add it to the map
     * new mapboxgl.Marker()
@@ -352,7 +352,7 @@ export default class Marker extends Evented {
      *
      * @param popup An instance of the {@link Popup} class. If undefined or null, any popup
      * set on this {@link Marker} instance is unset.
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * const marker = new mapboxgl.Marker()
      *     .setLngLat([0, 0])
@@ -440,7 +440,7 @@ export default class Marker extends Evented {
     /**
      * Opens or closes the {@link Popup} instance that is bound to the {@link Marker}, depending on the current state of the {@link Popup}.
      *
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * const marker = new mapboxgl.Marker()
      *     .setLngLat([0, 0])
@@ -574,7 +574,7 @@ export default class Marker extends Evented {
      * Sets the offset of the marker.
      *
      * @param {PointLike} offset The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * marker.setOffset([0, 1]);
      */
@@ -679,7 +679,7 @@ export default class Marker extends Evented {
      * Sets the `draggable` property and functionality of the marker.
      *
      * @param {boolean} [shouldBeDraggable=false] Turns drag functionality on/off.
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * marker.setDraggable(true);
      */
@@ -716,7 +716,7 @@ export default class Marker extends Evented {
      * Sets the `rotation` property of the marker.
      *
      * @param {number} [rotation=0] The rotation angle of the marker (clockwise, in degrees), relative to its respective {@link Marker#setRotationAlignment} setting.
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * marker.setRotation(45);
      */
@@ -741,7 +741,7 @@ export default class Marker extends Evented {
      * Sets the `rotationAlignment` property of the marker.
      *
      * @param {string} [alignment='auto'] Sets the `rotationAlignment` property of the marker.
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * marker.setRotationAlignment('viewport');
      */
@@ -766,7 +766,7 @@ export default class Marker extends Evented {
      * Sets the `pitchAlignment` property of the marker.
      *
      * @param {string} [alignment] Sets the `pitchAlignment` property of the marker. If alignment is 'auto', it will automatically match `rotationAlignment`.
-     * @returns {Marker} Returns `this`.
+     * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * marker.setPitchAlignment('map');
      */

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -241,7 +241,7 @@ export default class Marker extends Evented {
      * Attaches the `Marker` to a `Map` object.
      *
      * @param {Map} map The Mapbox GL JS map to add the marker to.
-     * @returns {Marker} `this`
+     * @returns {Marker} Returns `this`.
      * @example
      * const marker = new mapboxgl.Marker()
      *     .setLngLat([30.5, 50.5])
@@ -272,7 +272,7 @@ export default class Marker extends Evented {
      * @example
      * const marker = new mapboxgl.Marker().addTo(map);
      * marker.remove();
-     * @returns {Marker} `this`
+     * @returns {Marker} Returns `this`.
      */
     remove() {
         if (this._map) {
@@ -318,7 +318,7 @@ export default class Marker extends Evented {
     * Set the marker's geographical position and move it.
      *
     * @param {LngLat} lnglat A {@link LngLat} describing where the marker should be located.
-    * @returns {Marker} `this`
+    * @returns {Marker} Returns `this`.
     * @example
     * // Create a new marker, set the longitude and latitude, and add it to the map
     * new mapboxgl.Marker()
@@ -339,7 +339,7 @@ export default class Marker extends Evented {
     /**
      * Returns the `Marker`'s HTML element.
      *
-     * @returns {HTMLElement} element
+     * @returns {HTMLElement} Returns the marker element.
      * @example
      * const element = marker.getElement();
      */
@@ -352,7 +352,7 @@ export default class Marker extends Evented {
      *
      * @param popup An instance of the {@link Popup} class. If undefined or null, any popup
      * set on this {@link Marker} instance is unset.
-     * @returns {Marker} `this`
+     * @returns {Marker} Returns `this`.
      * @example
      * const marker = new mapboxgl.Marker()
      *     .setLngLat([0, 0])
@@ -424,7 +424,7 @@ export default class Marker extends Evented {
     /**
      * Returns the {@link Popup} instance that is bound to the {@link Marker}.
      *
-     * @returns {Popup} popup
+     * @returns {Popup} Returns the popup.
      * @example
      * const marker = new mapboxgl.Marker()
      *     .setLngLat([0, 0])
@@ -440,7 +440,7 @@ export default class Marker extends Evented {
     /**
      * Opens or closes the {@link Popup} instance that is bound to the {@link Marker}, depending on the current state of the {@link Popup}.
      *
-     * @returns {Marker} `this`
+     * @returns {Marker} Returns `this`.
      * @example
      * const marker = new mapboxgl.Marker()
      *     .setLngLat([0, 0])
@@ -574,7 +574,7 @@ export default class Marker extends Evented {
      * Sets the offset of the marker.
      *
      * @param {PointLike} offset The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
-     * @returns {Marker} `this`
+     * @returns {Marker} Returns `this`.
      * @example
      * marker.setOffset([0, 1]);
      */
@@ -678,8 +678,8 @@ export default class Marker extends Evented {
     /**
      * Sets the `draggable` property and functionality of the marker.
      *
-     * @param {boolean} [shouldBeDraggable=false] Turns drag functionality on/off
-     * @returns {Marker} `this`
+     * @param {boolean} [shouldBeDraggable=false] Turns drag functionality on/off.
+     * @returns {Marker} Returns `this`.
      * @example
      * marker.setDraggable(true);
      */
@@ -716,7 +716,7 @@ export default class Marker extends Evented {
      * Sets the `rotation` property of the marker.
      *
      * @param {number} [rotation=0] The rotation angle of the marker (clockwise, in degrees), relative to its respective {@link Marker#setRotationAlignment} setting.
-     * @returns {Marker} `this`
+     * @returns {Marker} Returns `this`.
      * @example
      * marker.setRotation(45);
      */
@@ -741,7 +741,7 @@ export default class Marker extends Evented {
      * Sets the `rotationAlignment` property of the marker.
      *
      * @param {string} [alignment='auto'] Sets the `rotationAlignment` property of the marker.
-     * @returns {Marker} `this`
+     * @returns {Marker} Returns `this`.
      * @example
      * marker.setRotationAlignment('viewport');
      */
@@ -766,7 +766,7 @@ export default class Marker extends Evented {
      * Sets the `pitchAlignment` property of the marker.
      *
      * @param {string} [alignment] Sets the `pitchAlignment` property of the marker. If alignment is 'auto', it will automatically match `rotationAlignment`.
-     * @returns {Marker} `this`
+     * @returns {Marker} Returns `this`.
      * @example
      * marker.setPitchAlignment('map');
      */

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -120,7 +120,7 @@ export default class Popup extends Evented {
      * Adds the popup to a map.
      *
      * @param {Map} map The Mapbox GL JS map to add the popup to.
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      * @example
      * new mapboxgl.Popup()
      *     .setLngLat([0, 0])
@@ -197,7 +197,7 @@ export default class Popup extends Evented {
      * @example
      * const popup = new mapboxgl.Popup().addTo(map);
      * popup.remove();
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      */
     remove() {
         if (this._content) {
@@ -263,7 +263,7 @@ export default class Popup extends Evented {
      * Sets the geographical location of the popup's anchor, and moves the popup to it. Replaces trackPointer() behavior.
      *
      * @param lnglat The geographical location to set as the popup's anchor.
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      * @example
      * popup.setLngLat([-122.4194, 37.7749]);
      */
@@ -296,7 +296,7 @@ export default class Popup extends Evented {
      *     .setHTML("<h1>Hello World!</h1>")
      *     .trackPointer()
      *     .addTo(map);
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      */
     trackPointer() {
         this._trackPointer = true;
@@ -341,7 +341,7 @@ export default class Popup extends Evented {
      * if the popup content is user-provided.
      *
      * @param text Textual content for the popup.
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      * @example
      * const popup = new mapboxgl.Popup()
      *     .setLngLat(e.lngLat)
@@ -360,7 +360,7 @@ export default class Popup extends Evented {
      * the content is an untrusted text string.
      *
      * @param html A string representing HTML content for the popup.
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      * @example
      * const popup = new mapboxgl.Popup()
      *     .setLngLat(e.lngLat)
@@ -401,7 +401,7 @@ export default class Popup extends Evented {
      * Available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width.
      *
      * @param maxWidth A string representing the value for the maximum width.
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      * @example
      * popup.setMaxWidth('50');
      */
@@ -415,7 +415,7 @@ export default class Popup extends Evented {
      * Sets the popup's content to the element provided as a DOM node.
      *
      * @param htmlNode A DOM node to be used as content for the popup.
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      * @example
      * // create an element with the popup content
      * const div = window.document.createElement('div');
@@ -479,7 +479,7 @@ export default class Popup extends Evented {
      * Sets the popup's offset.
      *
      * @param offset Sets the popup's offset.
-     * @returns {Popup} Returns `this`.
+     * @returns {Popup} Returns itself to allow for method chaining.
      * @example
      * popup.setOffset(10);
      */

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -67,7 +67,7 @@ const focusQuerySelector = [
  *  A pixel offset applied to the popup's location specified as:
  *   - a single number specifying a distance from the popup's location
  *   - a {@link PointLike} specifying a constant offset
- *   - an object of {@link Point}s specifing an offset for each anchor position
+ *   - an object of {@link Point}s specifing an offset for each anchor position.
  *
  *  Negative offsets indicate left and up.
  * @param {string} [options.className] Space-separated CSS class names to add to popup container.
@@ -120,7 +120,7 @@ export default class Popup extends Evented {
      * Adds the popup to a map.
      *
      * @param {Map} map The Mapbox GL JS map to add the popup to.
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      * @example
      * new mapboxgl.Popup()
      *     .setLngLat([0, 0])
@@ -165,7 +165,7 @@ export default class Popup extends Evented {
          * @memberof Popup
          * @instance
          * @type {Object}
-         * @property {Popup} popup object that was opened
+         * @property {Popup} popup Object that was opened.
          *
          * @example
          * // Create a popup
@@ -197,7 +197,7 @@ export default class Popup extends Evented {
      * @example
      * const popup = new mapboxgl.Popup().addTo(map);
      * popup.remove();
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      */
     remove() {
         if (this._content) {
@@ -227,7 +227,7 @@ export default class Popup extends Evented {
          * @memberof Popup
          * @instance
          * @type {Object}
-         * @property {Popup} popup object that was closed
+         * @property {Popup} popup Object that was closed.
          *
          * @example
          * // Create a popup
@@ -263,7 +263,7 @@ export default class Popup extends Evented {
      * Sets the geographical location of the popup's anchor, and moves the popup to it. Replaces trackPointer() behavior.
      *
      * @param lnglat The geographical location to set as the popup's anchor.
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      * @example
      * popup.setLngLat([-122.4194, 37.7749]);
      */
@@ -296,7 +296,7 @@ export default class Popup extends Evented {
      *     .setHTML("<h1>Hello World!</h1>")
      *     .trackPointer()
      *     .addTo(map);
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      */
     trackPointer() {
         this._trackPointer = true;
@@ -327,7 +327,7 @@ export default class Popup extends Evented {
      *     .addTo(map);
      * const popupElem = popup.getElement();
      * popupElem.style.fontSize = "25px";
-     * @returns {HTMLElement} element
+     * @returns {HTMLElement} Returns container element.
      */
     getElement() {
         return this._container;
@@ -341,7 +341,7 @@ export default class Popup extends Evented {
      * if the popup content is user-provided.
      *
      * @param text Textual content for the popup.
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      * @example
      * const popup = new mapboxgl.Popup()
      *     .setLngLat(e.lngLat)
@@ -360,7 +360,7 @@ export default class Popup extends Evented {
      * the content is an untrusted text string.
      *
      * @param html A string representing HTML content for the popup.
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      * @example
      * const popup = new mapboxgl.Popup()
      *     .setLngLat(e.lngLat)
@@ -398,10 +398,10 @@ export default class Popup extends Evented {
 
     /**
      * Sets the popup's maximum width. This is setting the CSS property `max-width`.
-     * Available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
+     * Available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width.
      *
      * @param maxWidth A string representing the value for the maximum width.
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      * @example
      * popup.setMaxWidth('50');
      */
@@ -415,7 +415,7 @@ export default class Popup extends Evented {
      * Sets the popup's content to the element provided as a DOM node.
      *
      * @param htmlNode A DOM node to be used as content for the popup.
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      * @example
      * // create an element with the popup content
      * const div = window.document.createElement('div');
@@ -448,7 +448,7 @@ export default class Popup extends Evented {
     /**
      * Adds a CSS class to the popup container element.
      *
-     * @param {string} className Non-empty string with CSS class name to add to popup container
+     * @param {string} className Non-empty string with CSS class name to add to popup container.
      *
      * @example
      * const popup = new mapboxgl.Popup();
@@ -463,7 +463,7 @@ export default class Popup extends Evented {
     /**
      * Removes a CSS class from the popup container element.
      *
-     * @param {string} className Non-empty string with CSS class name to remove from popup container
+     * @param {string} className Non-empty string with CSS class name to remove from popup container.
      *
      * @example
      * const popup = new mapboxgl.Popup();
@@ -479,7 +479,7 @@ export default class Popup extends Evented {
      * Sets the popup's offset.
      *
      * @param offset Sets the popup's offset.
-     * @returns {Popup} `this`
+     * @returns {Popup} Returns `this`.
      * @example
      * popup.setOffset(10);
      */
@@ -492,9 +492,9 @@ export default class Popup extends Evented {
     /**
      * Add or remove the given CSS class on the popup container, depending on whether the container currently has that class.
      *
-     * @param {string} className Non-empty string with CSS class name to add/remove
+     * @param {string} className Non-empty string with CSS class name to add/remove.
      *
-     * @returns {boolean} if the class was removed return false, if class was added, then return true
+     * @returns {boolean} If the class was removed return `false`. If the class was added, then return `true`.
      *
      * @example
      * const popup = new mapboxgl.Popup();

--- a/src/util/eased_variable.js
+++ b/src/util/eased_variable.js
@@ -37,7 +37,7 @@ class EasedVariable {
      *
      * @param timeStamp {number} Current time stamp.
      *
-     * @returns {boolean} Returns true if ease in progress.
+     * @returns {boolean} Returns `true` if ease is in progress.
      */
     isEasing(timeStamp: number): boolean {
         return timeStamp >= this._startTime && timeStamp <= this._endTime;

--- a/src/util/eased_variable.js
+++ b/src/util/eased_variable.js
@@ -37,7 +37,7 @@ class EasedVariable {
      *
      * @param timeStamp {number} Current time stamp.
      *
-     * @returns {boolean} true if ease in progress
+     * @returns {boolean} Returns true if ease in progress.
      */
     isEasing(timeStamp: number): boolean {
         return timeStamp >= this._startTime && timeStamp <= this._endTime;

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -65,7 +65,7 @@ export class Evented {
      * @param {Function} listener The function to be called when the event is fired.
      *   The listener function is called with the data object passed to `fire`,
      *   extended with `target` and `type` properties.
-     * @returns {Object} `this`
+     * @returns {Object} Returns `this`.
      */
     on(type: *, listener: Listener): this {
         this._listeners = this._listeners || {};
@@ -79,7 +79,7 @@ export class Evented {
      *
      * @param {string} type The event type to remove listeners for.
      * @param {Function} listener The listener function to remove.
-     * @returns {Object} `this`
+     * @returns {Object} Returns `this`.
      */
     off(type: *, listener: Listener) {
         _removeEventListener(type, listener, this._listeners);
@@ -94,9 +94,9 @@ export class Evented {
      * The listener will be called first time the event fires after the listener is registered.
      *
      * @param {string} type The event type to listen for.
-     * @param {Function} listener (optional) The function to be called when the event is fired once.
+     * @param {Function} listener (Optional) The function to be called when the event is fired once.
      *   If not provided, returns a Promise that will be resolved when the event is fired once.
-     * @returns {Object} `this` | Promise
+     * @returns {Object} Returns `this` | Promise.
      */
     once(type: *, listener?: Listener): this | Promise<Event> {
         if (!listener) {
@@ -155,8 +155,8 @@ export class Evented {
     /**
      * Returns true if this instance of Evented or any forwarded instances of Evented have a listener for the specified type.
      *
-     * @param {string} type The event type
-     * @returns {boolean} `true` if there is at least one registered listener for specified event type, `false` otherwise
+     * @param {string} type The event type.
+     * @returns {boolean} Returns `true` if there is at least one registered listener for specified event type, `false` otherwise.
      * @private
      */
     listens(type: string) {

--- a/src/util/evented.js
+++ b/src/util/evented.js
@@ -65,7 +65,7 @@ export class Evented {
      * @param {Function} listener The function to be called when the event is fired.
      *   The listener function is called with the data object passed to `fire`,
      *   extended with `target` and `type` properties.
-     * @returns {Object} Returns `this`.
+     * @returns {Object} Returns itself to allow for method chaining.
      */
     on(type: *, listener: Listener): this {
         this._listeners = this._listeners || {};
@@ -79,7 +79,7 @@ export class Evented {
      *
      * @param {string} type The event type to remove listeners for.
      * @param {Function} listener The listener function to remove.
-     * @returns {Object} Returns `this`.
+     * @returns {Object} Returns itself to allow for method chaining.
      */
     off(type: *, listener: Listener) {
         _removeEventListener(type, listener, this._listeners);

--- a/test/integration/lib/expression.js
+++ b/test/integration/lib/expression.js
@@ -80,13 +80,13 @@ function deepEqual(a, b) {
 /**
  * Run the expression suite.
  *
- * @param {string} implementation - identify the implementation under test; used to
- * deal with implementation-specific test exclusions and fudge-factors
+ * @param {string} implementation - Identify the implementation under test; used to
+ * deal with implementation-specific test exclusions and fudge-factors.
  * @param {Object} options
- * @param {Array<string>} [options.tests] - array of test names to run; tests not in the array will be skipped
- * @param {Array<string>} [options.ignores] - array of test names to ignore.
- * @param {} runExpressionTest - a function that runs a single expression test fixture
- * @returns {undefined} terminates the process when testing is complete
+ * @param {Array<string>} [options.tests] - Array of test names to run; tests not in the array will be skipped.
+ * @param {Array<string>} [options.ignores] - Array of test names to ignore.
+ * @param {} runExpressionTest - A function that runs a single expression test fixture.
+ * @returns {undefined} Terminates the process when testing is complete.
  */
 export function run(implementation, options, runExpressionTest) {
     const directory = path.join(__dirname, '../expression-tests');


### PR DESCRIPTION
## Launch Checklist

Documenting two pain points here:

1) The line that is referenced in the lint error may not exactly correspond to the line in your editor where the error actually is. This is because eslint reads all consecutive comment lines as one block that is denoted in a potential error message by the line the block starts on. This allows for multi-line comments, but it tripped me up at first looking for the issue.

2) eslint will consider _any_ period to be the end of a sentence. This means that this rule will error on something like `e.g.`, `i.e.` or `object.method()`. In general, I think we should avoid e.g. and i.e. anyway and we could always use `object#method` or just `method` in most comments.
