### PR TITLE
Pin chrome to version 91

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          chrome-version: 91.0.4472.164
       - run: yarn run build-dev
       - run: yarn run build-token
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: 91.0.4472.164
       - run: yarn run test-render
       - store_test_results:
           path: test/integration/render-tests
@@ -221,7 +222,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: 91.0.4472.164
       - run: yarn run test-render-prod
       - store_test_results:
           path: test/integration/render-tests
@@ -233,7 +235,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: 91.0.4472.164
       - run: yarn run test-query
       - store_test_results:
           path: test/integration/query-tests
@@ -260,7 +263,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: 91.0.4472.164
       - run:
           name: Collect performance stats
           command: node bench/gl-stats.js


### PR DESCRIPTION
Chrome version 92 seems to not want to launch and is causing tests to time out this PR pins it to version 91.