### PR TITLE
Wrapping longitudes returned by getBounds()

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1152,7 +1152,7 @@ class Transform {
             .extend(this.pointLocation(new Point(this.width - this._edgeInsets.right, this._edgeInsets.top)))
             .extend(this.pointLocation(new Point(this.width - this._edgeInsets.right, this.height - this._edgeInsets.bottom)))
             .extend(this.pointLocation(new Point(this._edgeInsets.left, this.height - this._edgeInsets.bottom)));
-        return new LngLatBounds(bounds.getSouthWest(), bounds.getNorthEast());
+        return new LngLatBounds(bounds.getSouthWest().wrap(), bounds.getNorthEast().wrap());
     }
 
     _getBounds3D(): LngLatBounds {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1147,11 +1147,12 @@ class Transform {
      */
     getBounds(): LngLatBounds {
         if (this._terrainEnabled()) return this._getBounds3D();
-        return new LngLatBounds()
+        const bounds = new LngLatBounds()
             .extend(this.pointLocation(new Point(this._edgeInsets.left, this._edgeInsets.top)))
             .extend(this.pointLocation(new Point(this.width - this._edgeInsets.right, this._edgeInsets.top)))
             .extend(this.pointLocation(new Point(this.width - this._edgeInsets.right, this.height - this._edgeInsets.bottom)))
             .extend(this.pointLocation(new Point(this._edgeInsets.left, this.height - this._edgeInsets.bottom)));
+        return new LngLatBounds(bounds.getSouthWest(), bounds.getNorthEast());
     }
 
     _getBounds3D(): LngLatBounds {

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -117,6 +117,17 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test('getBounds() returns valid longitudes across the 180th meridian', (t) => {
+        const transform = new Transform();
+        transform.center = new LngLat(180, 0);
+        transform.zoom = 0;
+        transform.resize(500, 500);
+        const bounds = transform.getBounds();
+        t.ok(bounds.getEast() > -180 && bounds.getEast() <= 180);
+        t.ok(bounds.getWest() > -180 && bounds.getWest() <= 180);
+        t.end();
+    });
+
     t.test('_minZoomForBounds respects latRange and lngRange', (t) => {
         t.test('it returns 0 when latRange and lngRange are undefined', (t) => {
             const transform = new Transform();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -862,6 +862,14 @@ test('Map', (t) => {
             t.end();
         });
 
+        t.test('returns valid longitudes across the 180th meridian', (t) => {
+            const map = createMap(t, {zoom: 1, center: [180, 0], bearing: 45, skipCSSStub: true});
+            const bounds = map.getBounds();
+            t.ok(bounds.getEast() > -180 && bounds.getEast() <= 180);
+            t.ok(bounds.getWest() > -180 && bounds.getWest() <= 180);
+            t.end();
+        });
+
         t.end();
 
         function toFixed(bounds) {


### PR DESCRIPTION
When the map is at very low zoom levels or clossing the 180th meridian, `map.getBounds()` returns coordinates with longitudes greater than 180 or less than -180. This fixes that by applying `lng_lat.wrap()` to the return values.

Depending on use cases, this could be a breaking change. If the user uses the returned boundaries to draw shapes on the map. I doubt that this is a common use case, but I'm not sure what other side effects this change might have.

Also, when the map is zoomed out slightly more than the world he boundaries might return something like NorthEast: [90, -170], SouthWest: [-90, 170]. Here while in fact the map is covering the whole world, the returned boundaries could just as well be interpreted as just a narrow slice around the 180th meridian. I'm not sure what side effects this might have.
## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
