### PR TITLE
Add support for a boolean Line layout property called line-collapse. 

### DIFF
--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -14,6 +14,7 @@ import {register} from '../../util/web_worker_transfer.js';
 import {hasPattern, addPatternDependencies} from './pattern_bucket_features.js';
 import loadGeometry from '../load_geometry.js';
 import toEvaluationFeature from '../evaluation_feature.js';
+import Point from '@mapbox/point-geometry';
 import EvaluationParameters from '../../style/evaluation_parameters.js';
 
 import type {CanonicalTileID} from '../../source/tile_id.js';
@@ -25,7 +26,6 @@ import type {
     PopulateParameters
 } from '../bucket.js';
 import type LineStyleLayer from '../../style/style_layer/line_style_layer.js';
-import type Point from '@mapbox/point-geometry';
 import type {Segment} from '../segment.js';
 import {RGBAImage} from '../../util/image.js';
 import type Context from '../../gl/context.js';
@@ -317,18 +317,19 @@ class LineBucket implements Bucket {
         const layout = this.layers[0].layout;
         const join = layout.get('line-join').evaluate(feature, {});
         const cap = layout.get('line-cap').evaluate(feature, {});
+        const collapse = layout.get('line-collapse') || false;
         const miterLimit = layout.get('line-miter-limit');
         const roundLimit = layout.get('line-round-limit');
         this.lineClips = this.lineFeatureClips(feature);
 
         for (const line of geometry) {
-            this.addLine(line, feature, join, cap, miterLimit, roundLimit);
+            this.addLine(line, feature, join, cap, collapse, miterLimit, roundLimit);
         }
 
         this.programConfigurations.populatePaintArrays(this.layoutVertexArray.length, feature, index, imagePositions, canonical);
     }
 
-    addLine(vertices: Array<Point>, feature: BucketFeature, join: string, cap: string, miterLimit: number, roundLimit: number) {
+    addLine(vertices: Array<Point>, feature: BucketFeature, join: string, cap: string, collapse: boolean, miterLimit: number, roundLimit: number) {
         this.distance = 0;
         this.scaledDistance = 0;
         this.totalDistance = 0;
@@ -344,7 +345,7 @@ class LineBucket implements Bucket {
             this.maxLineLength = Math.max(this.maxLineLength, this.totalDistance);
         }
 
-        const isPolygon = vectorTileFeatureTypes[feature.type] === 'Polygon';
+        let isPolygon = vectorTileFeatureTypes[feature.type] === 'Polygon';
 
         // If the line has duplicate vertices at the ends, adjust start/length to remove them.
         let len = vertices.length;
@@ -357,7 +358,21 @@ class LineBucket implements Bucket {
         }
 
         // Ignore invalid geometry.
-        if (len < (isPolygon ? 3 : 2)) return;
+        const count = len - first;
+        if (count < (isPolygon ? 3 : 2)) {
+            if (count === 0 || !collapse) {
+                return;
+            }
+            //Allow lines/polygons to collapse to points
+            if (count === 1) {
+                if (len < vertices.length) {
+                    len++;
+                } else if (first > 0) {
+                    first--;
+                }
+                isPolygon = false;
+            }
+        }
 
         if (join === 'bevel') miterLimit = 1.05;
 
@@ -383,14 +398,18 @@ class LineBucket implements Bucket {
         }
 
         for (let i = first; i < len; i++) {
-
             nextVertex = i === len - 1 ?
                 (isPolygon ? vertices[first + 1] : (undefined: any)) : // if it's a polygon, treat the last vertex like the first
                 vertices[i + 1]; // just the next vertex
 
-            // if two consecutive vertices exist, skip the current one
-            if (nextVertex && vertices[i].equals(nextVertex)) continue;
-
+            // if two consecutive vertices exist,
+            // skip the current one if collapse to point is not allowed the line has more than 2 vertices.
+            const nextEqualsCurrent = nextVertex && vertices[i].equals(nextVertex);
+            if (nextEqualsCurrent) {
+                if (!collapse || len > 2) {
+                    continue;
+                }
+            }
             if (nextNormal) prevNormal = nextNormal;
             if (currentVertex) prevVertex = currentVertex;
 
@@ -399,7 +418,13 @@ class LineBucket implements Bucket {
             // Calculate the normal towards the next vertex in this line. In case
             // there is no next vertex, pretend that the line is continuing straight,
             // meaning that we are just using the previous normal.
-            nextNormal = nextVertex ? nextVertex.sub(currentVertex)._unit()._perp() : prevNormal;
+            // Fallback to a horizontal vector if there is no previous normal,
+            // (i.e. when a single line is collapsing to a point)
+            if (nextEqualsCurrent || !nextVertex) {
+                nextNormal = prevNormal || new Point(1, 0);
+            } else {
+                nextNormal = nextVertex.sub(currentVertex)._unit()._perp();
+            }
 
             // If we still don't have a previous normal, this is the beginning of a
             // non-closed line, so we're doing a straight "join".

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -906,6 +906,27 @@
       },
       "property-type": "data-driven"
     },
+    "line-collapse": {
+      "type": "boolean",
+      "default": false,
+      "doc": "If true, consecutive identical vertices may collapse to a point.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "N/A yet",
+          "android": "N/A",
+          "ios": "N/A",
+          "macos": "N/A"
+        },
+        "data-driven styling": {}
+      },
+      "expression": {
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      },
+      "property-type": "data-constant"
+    },
     "line-join": {
       "type": "enum",
       "values": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -920,7 +920,7 @@
         "data-driven styling": {}
       },
       "expression": {
-        "interpolated": true,
+        "interpolated": false,
         "parameters": [
           "zoom"
         ]

--- a/src/style/style_layer/line_style_layer_properties.js
+++ b/src/style/style_layer/line_style_layer_properties.js
@@ -21,6 +21,7 @@ import type ResolvedImage from '../../style-spec/expression/types/resolved_image
 
 export type LayoutProps = {|
     "line-cap": DataDrivenProperty<"butt" | "round" | "square">,
+    "line-collapse": DataConstantProperty<boolean>,
     "line-join": DataDrivenProperty<"bevel" | "round" | "miter">,
     "line-miter-limit": DataConstantProperty<number>,
     "line-round-limit": DataConstantProperty<number>,
@@ -29,6 +30,7 @@ export type LayoutProps = {|
 
 const layout: Properties<LayoutProps> = new Properties({
     "line-cap": new DataDrivenProperty(styleSpec["layout_line"]["line-cap"]),
+    "line-collapse": new DataConstantProperty(styleSpec["layout_line"]["line-collapse"]),
     "line-join": new DataDrivenProperty(styleSpec["layout_line"]["line-join"]),
     "line-miter-limit": new DataConstantProperty(styleSpec["layout_line"]["line-miter-limit"]),
     "line-round-limit": new DataConstantProperty(styleSpec["layout_line"]["line-round-limit"]),


### PR DESCRIPTION
Add support for a boolean Line layout property called line-collapse.
When true, lines or polygons will collapse to points if they have
equal vertices instead of being considered "invalid geometry" and not rendering.

Default value of `line-collapse` is false.

Re: https://github.com/mapbox/mapbox-gl-js/issues/8635
I'm opening this PR to "resurface the discussion" as requested in the issue above, but I still need to look into how to create a render test for the changes, and how to address the other bullets in the checklist.

> I did a little more digging. Tolerance did get past the issue with geojson-vt, but then the layer rendering itself was dropping the feature if the vertices of the line were the same.
> 
> I played around with it and tried adding a layout property for line-collapse where it would let the line render even if both vertices were the same. This fixed the issue I was having with single line segments and round endcaps.
> 
> Issues:
> 
> Didn't try much to make things work for polygons since I'm not too familiar with them and this is just a proof of concept
> Collapsed lines with multiple segments can get chopped in half when they cross tile borders
> Square endcaps on diagonal lines lose their orientation when the vertices are equal, as I just defaulted to using a horizontal normal vector instead of trying to find a way to compute the actual angle.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
