### PR TITLE
Change `sprite` link from glossary --> style spec

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1741,7 +1741,7 @@ class Map extends Camera {
     // eslint-disable-next-line jsdoc/require-returns
     /**
      * Add an image to the style. This image can be displayed on the map like any other icon in the style's
-     * [sprite](https://docs.mapbox.com/help/glossary/sprite/) using the image's ID with
+     * [sprite](https://docs.mapbox.com/mapbox-gl-js/style-spec/sprite/) using the image's ID with
      * [`icon-image`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-image),
      * [`background-pattern`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-background-background-pattern),
      * [`fill-pattern`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-fill-fill-pattern),


### PR DESCRIPTION
Addresses https://github.com/mapbox/mapbox-gl-js/issues/9879

Pairs with https://github.com/mapbox/mapbox-gl-js-docs/pull/664

* Change `sprite` link from glossary --> style spec

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
