### PR TITLE
Fix to  map jumping when bounds cross longitude 180

### DIFF
--- a/debug/antimeridian.html
+++ b/debug/antimeridian.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>The Zealand conspiracy</title>
+    <title>Mapbox GL JS debug page</title>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel='stylesheet' href='../dist/mapbox-gl.css' />
@@ -24,7 +24,7 @@ var map = new mapboxgl.Map({
     style: 'mapbox://styles/mapbox/streets-v11',
     zoom: 6,
     center: [179.012, -18.124],
-    maxBounds: [[175, -21.943], [360 - 175, -12.261]]
+    maxBounds: [[175, -25], [-175, -10]]
 });
 map.transform.center = new mapboxgl.LngLat(190, -40);
 

--- a/debug/antimeridian.html
+++ b/debug/antimeridian.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>The Zealand conspiracy</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='../dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='../dist/mapbox-gl-dev.js'></script>
+<script src='../debug/access_token_generated.js'></script>
+
+<script>
+
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v11',
+    zoom: 6,
+    center: [179.012, -18.124],
+    maxBounds: [[175, -21.943], [360 - 175, -12.261]]
+});
+map.transform.center = new mapboxgl.LngLat(190, -40);
+
+document.addEventListener('keypress', (e) => {
+    console.log(e.key);
+    if (e.key === " ") {
+        console.log(map.transform.center);
+        console.log(map.transform.point);
+    }
+});
+
+</script>
+</body>
+</html>

--- a/debug/antimeridian.html
+++ b/debug/antimeridian.html
@@ -19,7 +19,7 @@
 
 <script>
 
-var map = new mapboxgl.Map({
+var map = window.map = new mapboxgl.Map({
     container: 'map',
     style: 'mapbox://styles/mapbox/streets-v11',
     zoom: 6,
@@ -31,8 +31,8 @@ map.transform.center = new mapboxgl.LngLat(190, -40);
 document.addEventListener('keypress', (e) => {
     console.log(e.key);
     if (e.key === " ") {
-        console.log(map.transform.center);
-        console.log(map.transform.point);
+        console.log('map.transform.center:', map.transform.center);
+        console.log('map.transform.point:', map.transform.point);
     }
 });
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -887,7 +887,7 @@ class Transform {
     zoomScale(zoom: number) { return Math.pow(2, zoom); }
     scaleZoom(scale: number) { return Math.log(scale) / Math.LN2; }
 
-    // World coordinates from LngLat
+    // Transform from LngLat to Point in world coordinates [-180, 180] x [90, -90] --> [0, this.worldSize] x [0, this.worldSize]
     project(lnglat: LngLat) {
         const lat = clamp(lnglat.lat, -this.maxValidLatitude, this.maxValidLatitude);
         return new Point(
@@ -895,7 +895,7 @@ class Transform {
                 mercatorYfromLat(lat) * this.worldSize);
     }
 
-    // LngLat from world coordinates
+    // Transform from Point in world coordinates to LngLat [0, this.worldSize] x [0, this.worldSize] --> [-180, 180] x [90, -90]
     unproject(point: Point): LngLat {
         return new MercatorCoordinate(point.x / this.worldSize, point.y / this.worldSize).toLngLat();
     }
@@ -1361,8 +1361,8 @@ class Transform {
 
         this._constraining = true;
 
-        let minY = 0;
-        let maxY = 0;
+        let minY = Infinity;
+        let maxY = -Infinity;
         let minX, maxX, sy, sx, y2;
         const size = this.size,
             unmodified = this._unmodified;

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1361,11 +1361,9 @@ class Transform {
 
         this._constraining = true;
 
-        let minY;
-        let maxY;
-        let minX = -180;
-        let maxX = 180;
-        let sy, sx, y2;
+        let minY = 0;
+        let maxY = 0;
+        let minX, maxX, sy, sx, y2;
         const size = this.size,
             unmodified = this._unmodified;
 

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1362,7 +1362,7 @@ class Transform {
         let maxY = 90;
         let minX = -180;
         let maxX = 180;
-        let sy, sx, x2, y2;
+        let sy, sx, y2;
         const size = this.size,
             unmodified = this._unmodified;
 
@@ -1403,24 +1403,23 @@ class Transform {
             if (y + h2 > maxY) y2 = maxY - h2;
         }
 
+        let x = point.x;
+
         if (this.lngRange) {
-            let x = point.x;
             const w2 = size.x / 2;
 
-            // If the left edge is more than 180 degrees below the minimum boundary, add 360 degrees to the value.
-            if (x - w2 - minX < -this.worldSize / 2) x += this.worldSize;
+            // Wrapping.
+            if (x < minX) x += this.worldSize;
+            if (x > maxX) x -= this.worldSize;
 
-            // If the right edge is more than 180 degrees beyond the max boundary, add 360 degrees to the value.
-            if (x + w2 - maxX > this.worldSize / 2) x -= this.worldSize;
-
-            if (x - w2 < minX) x2 = minX + w2;
-            if (x + w2 > maxX) x2 = maxX - w2;
+            if (x - w2 < minX) x = minX + w2;
+            if (x + w2 > maxX) x = maxX - w2;
         }
 
         // pan the map if the screen goes off the range
-        if (x2 !== undefined || y2 !== undefined) {
+        if (x !== point.x || y2 !== undefined) {
             this.center = this.unproject(new Point(
-                x2 !== undefined ? x2 : point.x,
+                x,
                 y2 !== undefined ? y2 : point.y));
         }
 

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -117,6 +117,42 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test('maxBounds snaps to correct side when crossing 180th meridian (#10447)', (t) => {
+        console.log("start snap test");
+        const transform = new Transform();
+        transform.zoom = 6;
+        transform.resize(500, 500);
+
+        transform.lngRange = [160, 190];
+        transform.latRange = [-55, -23];
+
+        transform.center = new LngLat(-170, -40);
+
+        t.ok(transform.center.lng < 190);
+        t.ok(transform.center.lng > 175);
+
+        t.end();
+    });
+
+    t.test('maxBounds snaps to correct side when crossing 180th meridian on the West', (t) => {
+        console.log("start snap test");
+        const transform = new Transform();
+        transform.zoom = 6;
+        transform.resize(500, 500);
+
+        transform.lngRange = [-190, -160];
+        transform.latRange = [-55, -23];
+
+        transform.center = new LngLat(190, -40);
+
+        console.log("transform center lng");
+        console.log(transform.center);
+        t.ok(transform.center.lng > -190);
+        t.ok(transform.center.lng < -175);
+
+        t.end();
+    });
+
     t.test('_minZoomForBounds respects latRange and lngRange', (t) => {
         t.test('it returns 0 when latRange and lngRange are undefined', (t) => {
             const transform = new Transform();

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -201,7 +201,6 @@ test('transform', (t) => {
         transform.zoom = 6;
         transform.resize(500, 500);
         transform.setMaxBounds(new LngLatBounds([160, -20], [-160, 20]));  //East bound is "smaller"
-        console.log(transform.getMaxBounds());
 
         const wrap = val => ((val + 360) % 360);
 

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -117,40 +117,66 @@ test('transform', (t) => {
         t.end();
     });
 
-    t.test('maxBounds snaps to correct side when crossing 180th meridian (#10447)', (t) => {
-        console.log("start snap test");
-        const transform = new Transform();
-        transform.zoom = 6;
-        transform.resize(500, 500);
+    t.test('maxBounds should not jump to the wrong side when crossing 180th meridian (#10447)', (t) => {
+        t.test(' to the East', (t) => {
+            const transform = new Transform();
+            transform.zoom = 6;
+            transform.resize(500, 500);
+            transform.lngRange = [160, 190];
+            transform.latRange = [-55, -23];
 
-        transform.lngRange = [160, 190];
-        transform.latRange = [-55, -23];
+            transform.center = new LngLat(-170, -40);
 
-        transform.center = new LngLat(-170, -40);
+            t.ok(transform.center.lng < 190);
+            t.ok(transform.center.lng > 175);
 
-        t.ok(transform.center.lng < 190);
-        t.ok(transform.center.lng > 175);
+            t.end();
+        });
+
+        t.test('to the West', (t) => {
+            const transform = new Transform();
+            transform.zoom = 6;
+            transform.resize(500, 500);
+            transform.lngRange = [-190, -160];
+            transform.latRange = [-55, -23];
+
+            transform.center = new LngLat(170, -40);
+
+            t.ok(transform.center.lng > -190);
+            t.ok(transform.center.lng < -175);
+
+            t.end();
+        });
+
+        t.test('longitude 0 - 360', (t) => {
+            const transform = new Transform();
+            transform.zoom = 6;
+            transform.resize(500, 500);
+            transform.lngRange = [0, 360];
+            transform.latRange = [-90, 90];
+
+            transform.center = new LngLat(-155, 0);
+
+            t.same(transform.center, new LngLat(205, 0));
+
+            t.end();
+        });
+
+        t.test('longitude -360 - 0', (t) => {
+            const transform = new Transform();
+            transform.zoom = 6;
+            transform.resize(500, 500);
+            transform.lngRange = [-360, 0];
+            transform.latRange = [-90, 90];
+
+            transform.center = new LngLat(160, 0);
+            t.same(transform.center, new LngLat(-200, 0));
+
+            t.end();
+        });
 
         t.end();
-    });
 
-    t.test('maxBounds snaps to correct side when crossing 180th meridian on the West', (t) => {
-        console.log("start snap test");
-        const transform = new Transform();
-        transform.zoom = 6;
-        transform.resize(500, 500);
-
-        transform.lngRange = [-190, -160];
-        transform.latRange = [-55, -23];
-
-        transform.center = new LngLat(170, -40);
-
-        console.log("transform center lng");
-        console.log(transform.center);
-        t.ok(transform.center.lng > -190);
-        t.ok(transform.center.lng < -175);
-
-        t.end();
     });
 
     t.test('_minZoomForBounds respects latRange and lngRange', (t) => {

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -143,7 +143,7 @@ test('transform', (t) => {
         transform.lngRange = [-190, -160];
         transform.latRange = [-55, -23];
 
-        transform.center = new LngLat(190, -40);
+        transform.center = new LngLat(170, -40);
 
         console.log("transform center lng");
         console.log(transform.center);


### PR DESCRIPTION
## Launch Checklist
Closes #10447.
Closes #6985.

These two issues arise from the same cause: when maxBounds crossed the 180th Meridian, the view would be adjusted incorrectly, snapping to the other edge of the map and preventing the user from crossing the Meridian in either direction.

This PR provides a fix by wrapping and normalizing the bounds and position before applying the update.

To allow maps across the 180th meridian to work with correct (unwrapped) longitude, I added a check in setMaxBounds to unwrap them.

Two minor issues unsolved by this fix:

- The bounds span 360 degrees AND The map is moved quickly against the edge so that the center passes beyond the edge. The user can effectively "force" the map to the other side. (Previously this wouldn't have happened, but the only working case was bounds from -180 to 180.)
- Bounds spanning over 360 degrees are treated at higher zoom levels as effectively no bounds. (I think this isn't really a valid use case, and I'm not seeing any Github issues about it.  If I'm wrong, I think it's still an improvement over previous/current behavior which is sudden snapping to an unrelated point on the map.)

These both happen because the map center is now "wrapped" before checking maxBounds. This prevents issues with the 180th meridian, but it also means that the map position has no reference for where it is on the map separate from its world position.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Fix crossing the antimeridian from west to east
 - [x] Fix crossing the antimeridian from east to west
 - [x] write tests for all new functionality
 - [x] Check edge cases
 - [x] Add support for entering bounds without unwrapping longitudes (As described in #6985)
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>'maxBounds' property across the 180th meridian work correctly.</changelog>`
