### PR TITLE
Add event listener for webkitfullscreenchange to resize maps when entering full screen in Safari

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -486,6 +486,7 @@ class Map extends Camera {
             window.addEventListener('online', this._onWindowOnline, false);
             window.addEventListener('resize', this._onWindowResize, false);
             window.addEventListener('orientationchange', this._onWindowResize, false);
+            window.addEventListener('webkitfullscreenchange', this._onWindowResize, false);
         }
 
         this.handlers = new HandlerManager(this, options);


### PR DESCRIPTION
## Launch Checklist

fixes https://github.com/mapbox/mapbox-gl-js/issues/7990

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
Adds `window.addEventListener('webkitfullscreenchange')` that resizes the map when Safari enters fullscreen mode
You can use [this JSBin](https://jsbin.com/tocamuw/11) as a basis for checking the change
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Force the map to fill its container when Safari enters fullscreen mode</changelog>`
