### PR TITLE
Remove event listener for Safari resize

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3043,7 +3043,7 @@ class Map extends Camera {
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);
             window.removeEventListener('orientationchange', this._onWindowResize, false);
-            window.addEventListener('webkitfullscreenchange', this._onWindowResize, false);
+            window.removeEventListener('webkitfullscreenchange', this._onWindowResize, false);
             window.removeEventListener('online', this._onWindowOnline, false);
         }
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3043,6 +3043,7 @@ class Map extends Camera {
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);
             window.removeEventListener('orientationchange', this._onWindowResize, false);
+            window.addEventListener('webkitfullscreenchange', this._onWindowResize, false);
             window.removeEventListener('online', this._onWindowOnline, false);
         }
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
- https://github.com/mapbox/mapbox-gl-js/pull/10905 added an event listener for Safari resize events but neglected to remove the listener in `map.remove` so this PR fixes that
