### PR TITLE
Improves `DragPanHandler` example and docs

### DIFF
--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -51,7 +51,7 @@ export default class DragPanHandler {
      *     maxSpeed: 1400,
      *     deceleration: 2500
      * });
-     * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
+     * @see [Example: Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
      */
     enable(options?: DragPanOptions) {
         this._inertiaOptions = options || {};

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -38,7 +38,7 @@ export default class DragPanHandler {
      *
      * @param {Object} [options] Options object.
      * @param {number} [options.linearity=0] Factor used to scale the drag velocity.
-     * @param {Function} [options.easing=bezier(0, 0, 0.3, 1)] Easing function applied to `map.panTo` when applying the drag.
+     * @param {Function} [options.easing=bezier(0, 0, 0.3, 1)] Easing function applied to {@link Map#panTo} when applying the drag.
      * @param {number} [options.maxSpeed=1400] The maximum value of the drag velocity.
      * @param {number} [options.deceleration=2500] The rate at which the speed reduces after the pan ends.
      *
@@ -49,7 +49,7 @@ export default class DragPanHandler {
      *     linearity: 0.3,
      *     easing: bezier(0, 0, 0.3, 1),
      *     maxSpeed: 1400,
-     *     deceleration: 2500,
+     *     deceleration: 2500
      * });
      */
     enable(options?: DragPanOptions) {

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -38,7 +38,7 @@ export default class DragPanHandler {
      *
      * @param {Object} [options] Options object.
      * @param {number} [options.linearity=0] Factor used to scale the drag velocity.
-     * @param {Function} [options.easing] Optional easing function applied to {@link Map#panTo} when applying the drag. Defaults to bezier function using [@]mapbox/unitbezier
+     * @param {Function} [options.easing] Optional easing function applied to {@link Map#panTo} when applying the drag. Defaults to bezier function using [@mapbox/unitbezier](https://github.com/mapbox/unitbezier).
      * @param {number} [options.maxSpeed=1400] The maximum value of the drag velocity.
      * @param {number} [options.deceleration=2500] The rate at which the speed reduces after the pan ends.
      *
@@ -47,9 +47,7 @@ export default class DragPanHandler {
      * @example
      * map.dragPan.enable({
      *     linearity: 0.3,
-     *     easing: function(t){
-     *         return t;
-     *     },
+     *     easing: t => t,
      *     maxSpeed: 1400,
      *     deceleration: 2500
      * });

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -34,7 +34,7 @@ export default class DragPanHandler {
     }
 
     /**
-     * Enables the "drag to pan" interaction.
+     * Enables the "drag to pan" interaction and accepts options to control the behavior of the panning inertia.
      *
      * @param {Object} [options] Options object.
      * @param {number} [options.linearity=0] Factor used to scale the drag velocity.

--- a/src/ui/handler/shim/drag_pan.js
+++ b/src/ui/handler/shim/drag_pan.js
@@ -38,7 +38,7 @@ export default class DragPanHandler {
      *
      * @param {Object} [options] Options object.
      * @param {number} [options.linearity=0] Factor used to scale the drag velocity.
-     * @param {Function} [options.easing=bezier(0, 0, 0.3, 1)] Easing function applied to {@link Map#panTo} when applying the drag.
+     * @param {Function} [options.easing] Optional easing function applied to {@link Map#panTo} when applying the drag. Defaults to bezier function using [@]mapbox/unitbezier
      * @param {number} [options.maxSpeed=1400] The maximum value of the drag velocity.
      * @param {number} [options.deceleration=2500] The rate at which the speed reduces after the pan ends.
      *
@@ -47,10 +47,13 @@ export default class DragPanHandler {
      * @example
      * map.dragPan.enable({
      *     linearity: 0.3,
-     *     easing: bezier(0, 0, 0.3, 1),
+     *     easing: function(t){
+     *         return t;
+     *     },
      *     maxSpeed: 1400,
      *     deceleration: 2500
      * });
+     * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
      */
     enable(options?: DragPanOptions) {
         this._inertiaOptions = options || {};


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js-docs/issues/659

This PR improves API docs for [/mapbox-gl-js/api/handlers/#dragpanhandler#enable](http://docs.mapbox.com/mapbox-gl-js/api/handlers/#dragpanhandler#enable):

- replaces function in inline example with a generic self-explanatory function `t => t`
- removes default value for `easing`, clarifying instead that it uses an imported function
- adds a hyperlink to `panTo`
- adds a link to a related example

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
