### PR TITLE
[WIP] Reformats `@fires` events in API docs to enable rendering

### DIFF
--- a/src/source/source.js
+++ b/src/source/source.js
@@ -11,8 +11,8 @@ import type {Callback} from '../types/callback.js';
 import {CanonicalTileID} from './tile_id.js';
 
 /**
- * The `Source` interface must be implemented by each source type, including "core" types (`vector`, `raster`,
- * `video`, etc.) and all custom, third-party types.
+ * The `Source` interface must be implemented by each source type, including "core" types like `vector`, `raster`,
+ * or `video`) and all custom, third-party types.
  *
  * @private
  *

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -22,8 +22,9 @@ import {CanonicalTileID} from './tile_id.js';
  * @param {string} options.type The source type, matching the value of `name` used in {@link Style#addSourceType}.
  * @param {Dispatcher} dispatcher A {@link Dispatcher} instance, which can be used to send messages to the workers.
  *
- * @fires data with `{dataType: 'source', sourceDataType: 'metadata'}` to indicate that any necessary metadata
- * has been loaded so that it's okay to call `loadTile`; and with `{dataType: 'source', sourceDataType: 'content'}`
+ * @fires Map.event:data Fires `data` with `{dataType: 'source', sourceDataType: 'metadata'}`
+ * to indicate that any necessary metadata has been loaded so that it's okay to call `loadTile`;
+ * fires `data` with `{dataType: 'source', sourceDataType: 'content'}`
  * to indicate that the source data has changed, so that any current caches should be flushed.
  * @property {string} id The id for the source.  Must match the id passed to the constructor.
  * @property {number} minzoom

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -891,7 +891,7 @@ class Style extends Evented {
      * If no such layer exists, an `error` event is fired.
      *
      * @param {string} id ID of the layer to remove.
-     * @fires error
+     * @fires Map.event:error
      */
     removeLayer(id: string) {
         this._checkLoaded();

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -183,8 +183,8 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {LngLatLike} center The centerpoint to set.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setCenter([-74, 38]);
@@ -200,8 +200,8 @@ class Camera extends Evented {
      * @param {PointLike} offset The `x` and `y` coordinates by which to pan the map.
      * @param {AnimationOptions | null} options An options object describing the destination and animation of the transition. We do not recommend using `options.offset` since this value will override the value of the `offset` parameter.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} `this` Returns itself to allow for method chaining.
      * @example
      * map.panBy([-74, 38]);
@@ -222,8 +222,8 @@ class Camera extends Evented {
      * @param {LngLatLike} lnglat The location to pan the map to.
      * @param {AnimationOptions | null} options Options describing the destination and animation of the transition.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.panTo([-74, 38]);
@@ -254,12 +254,12 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {number} zoom The zoom level to set (0-20).
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires zoomstart
-     * @fires move
-     * @fires zoom
-     * @fires moveend
-     * @fires zoomend
+     * @fires Map.event:movestart
+     * @fires Map.event:zoomstart
+     * @fires Map.event:move
+     * @fires Map.event:zoom
+     * @fires Map.event:moveend
+     * @fires Map.event:zoomend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Zoom to the zoom level 5 without an animated transition
@@ -277,12 +277,12 @@ class Camera extends Evented {
      * @param {number} zoom The zoom level to transition to.
      * @param {AnimationOptions | null} options Options object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires zoomstart
-     * @fires move
-     * @fires zoom
-     * @fires moveend
-     * @fires zoomend
+     * @fires Map.event:movestart
+     * @fires Map.event:zoomstart
+     * @fires Map.event:move
+     * @fires Map.event:zoom
+     * @fires Map.event:moveend
+     * @fires Map.event:zoomend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Zoom to the zoom level 5 without an animated transition
@@ -305,12 +305,12 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {AnimationOptions | null} options Options object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires zoomstart
-     * @fires move
-     * @fires zoom
-     * @fires moveend
-     * @fires zoomend
+     * @fires Map.event:movestart
+     * @fires Map.event:zoomstart
+     * @fires Map.event:move
+     * @fires Map.event:zoom
+     * @fires Map.event:moveend
+     * @fires Map.event:zoomend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // zoom the map in one level with a custom animation duration
@@ -327,12 +327,12 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {AnimationOptions | null} options Options object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires zoomstart
-     * @fires move
-     * @fires zoom
-     * @fires moveend
-     * @fires zoomend
+     * @fires Map.event:movestart
+     * @fires Map.event:zoomstart
+     * @fires Map.event:move
+     * @fires Map.event:zoom
+     * @fires Map.event:moveend
+     * @fires Map.event:zoomend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // zoom the map out one level with a custom animation offset
@@ -364,8 +364,8 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {number} bearing The desired bearing.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Rotate the map to 90 degrees.
@@ -394,8 +394,8 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {PaddingOptions} padding The desired padding. Format: {left: number, right: number, top: number, bottom: number}.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // Sets a left padding of 300px, and a top padding of 50px
@@ -414,8 +414,8 @@ class Camera extends Evented {
      * @param {number} bearing The desired bearing.
      * @param {AnimationOptions | null} options Options object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.rotateTo(30);
@@ -435,8 +435,8 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {AnimationOptions | null} options Options object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // resetNorth with an animation of 2 seconds.
@@ -453,8 +453,8 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {AnimationOptions | null} options Options object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // resetNorthPitch with an animation of 2 seconds.
@@ -476,8 +476,8 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {AnimationOptions | null} options Options object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // snapToNorth with an animation of 2 seconds.
@@ -506,9 +506,9 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {number} pitch The pitch to set, measured in degrees away from the plane of the screen (0-60).
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires pitchstart
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:pitchstart
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // setPitch with an animation of 2 seconds.
@@ -757,8 +757,8 @@ class Camera extends Evented {
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the map view transitions to the specified bounds.
      * @param {Object} [eventData] Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
 	 * @example
      * const bbox = [[-79, 43], [-73, 45]];
@@ -829,8 +829,8 @@ class Camera extends Evented {
      * @param {PointLike} [options.offset=[0, 0]] The center of the given bounds relative to the map's center, measured in pixels.
      * @param {number} [options.maxZoom] The maximum zoom level to allow when the map view transitions to the specified bounds.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires moveend
+     * @fires Map.event:movestart
+     * @fires Map.event:moveend
      * @returns {Map} Returns itself to allow for method chaining.
 	 * @example
      * const p0 = [220, 400];
@@ -903,16 +903,16 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {CameraOptions} options Options object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires zoomstart
-     * @fires pitchstart
-     * @fires rotate
-     * @fires move
-     * @fires zoom
-     * @fires pitch
-     * @fires moveend
-     * @fires zoomend
-     * @fires pitchend
+     * @fires Map.event:movestart
+     * @fires Map.event:zoomstart
+     * @fires Map.event:pitchstart
+     * @fires Map.event:rotate
+     * @fires Map.event:move
+     * @fires Map.event:zoom
+     * @fires Map.event:pitch
+     * @fires Map.event:moveend
+     * @fires Map.event:zoomend
+     * @fires Map.event:pitchend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // jump to coordinates at current zoom
@@ -1013,16 +1013,16 @@ class Camera extends Evented {
      * @memberof Map#
      * @param {FreeCameraOptions} options `FreeCameraOptions` object.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires zoomstart
-     * @fires pitchstart
-     * @fires rotate
-     * @fires move
-     * @fires zoom
-     * @fires pitch
-     * @fires moveend
-     * @fires zoomend
-     * @fires pitchend
+     * @fires Map.event:movestart
+     * @fires Map.event:zoomstart
+     * @fires Map.event:pitchstart
+     * @fires Map.event:rotate
+     * @fires Map.event:move
+     * @fires Map.event:zoom
+     * @fires Map.event:pitch
+     * @fires Map.event:moveend
+     * @fires Map.event:zoomend
+     * @fires Map.event:pitchend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * const camera = map.getFreeCameraOptions();
@@ -1087,16 +1087,16 @@ class Camera extends Evented {
      * @param {CameraOptions & AnimationOptions} options Options describing the destination and animation of the transition.
      *            Accepts {@link CameraOptions} and {@link AnimationOptions}.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires zoomstart
-     * @fires pitchstart
-     * @fires rotate
-     * @fires move
-     * @fires zoom
-     * @fires pitch
-     * @fires moveend
-     * @fires zoomend
-     * @fires pitchend
+     * @fires Map.event:movestart
+     * @fires Map.event:zoomstart
+     * @fires Map.event:pitchstart
+     * @fires Map.event:rotate
+     * @fires Map.event:move
+     * @fires Map.event:zoom
+     * @fires Map.event:pitch
+     * @fires Map.event:moveend
+     * @fires Map.event:zoomend
+     * @fires Map.event:pitchend
      * @returns {Map} `this` Returns itself to allow for method chaining.
      * @example
      * // Ease with default options to null island for 5 seconds.
@@ -1300,16 +1300,16 @@ class Camera extends Evented {
      * @param {number} [options.maxDuration] The animation's maximum duration, measured in milliseconds.
      *     If duration exceeds maximum duration, it resets to 0.
      * @param {Object | null} eventData Additional properties to be added to event objects of events triggered by this method.
-     * @fires movestart
-     * @fires zoomstart
-     * @fires pitchstart
-     * @fires move
-     * @fires zoom
-     * @fires rotate
-     * @fires pitch
-     * @fires moveend
-     * @fires zoomend
-     * @fires pitchend
+     * @fires Map.event:movestart
+     * @fires Map.event:zoomstart
+     * @fires Map.event:pitchstart
+     * @fires Map.event:move
+     * @fires Map.event:zoom
+     * @fires Map.event:rotate
+     * @fires Map.event:pitch
+     * @fires Map.event:moveend
+     * @fires Map.event:zoomend
+     * @fires Map.event:pitchend
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * // fly with default options to null island

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1613,7 +1613,7 @@ class Map extends Camera {
      * @param {Object} source The source object, conforming to the
      * Mapbox Style Specification's [source definition](https://www.mapbox.com/mapbox-gl-style-spec/#sources) or
      * {@link CanvasSourceOptions}.
-     * @fires source.add
+     * @fires Map.event:source.add
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.addSource('my-data', {
@@ -2080,7 +2080,7 @@ class Map extends Camera {
      *
      * @param {string} id ID of the layer to remove.
      * @returns {Map} Returns itself to allow for method chaining.
-     * @fires error
+     * @fires Map.event:error
      *
      * @example
      * // If a layer with ID 'state-data' exists, remove it.


### PR DESCRIPTION
Related to https://github.com/mapbox/mapbox-gl-js-docs/issues/641
Pairs with https://github.com/mapbox/mapbox-gl-js-docs/pull/665

This PR adds code to enable `@fires` events to render in GL JS API docs as linked items.

- adds `Map.event:` prefix to events in `camera.js`
- adds `Map.event:` prefix to events in `style.js` and `map.js`
- adds `Map.event:` prefix to events in `source.js` in an experimental way 
- copyedits one description

## Work in progress: 

The `source.js` file contains one instance that breaks format with the rest.

Instead of something like:

```
* @fires Map.event:movestart
```

It has descriptive text as well, that should also be rendered in the API docs:

```
 * @fires Map.event:data Fires `data` with `{dataType: 'source', sourceDataType: 'metadata'}`
 * to indicate that any necessary metadata has been loaded so that it's okay to call `loadTile`;
 * fires `data` with `{dataType: 'source', sourceDataType: 'content'}`
 * to indicate that the source data has changed, so that any current caches should be flushed.
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
