### PR TITLE
[docs] Add parenthesis around JSDoc param `data` for addImage and updateImage

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1750,7 +1750,7 @@ class Map extends Camera {
      * A {@link Map.event:error} event will be fired if there is not enough space in the sprite to add this image.
      *
      * @param {string} id The ID of the image.
-     * @param {HTMLImageElement | ImageBitmap | ImageData | {width: number, height: number, data: Uint8Array | Uint8ClampedArray} | StyleImageInterface} image The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
+     * @param {HTMLImageElement | ImageBitmap | ImageData | {width: number, height: number, data: (Uint8Array | Uint8ClampedArray)} | StyleImageInterface} image The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
      * properties with the same format as `ImageData`.
      * @param {Object | null} options Options object.
      * @param {number} options.pixelRatio The ratio of pixels in the image to physical pixels on the screen.
@@ -1828,7 +1828,7 @@ class Map extends Camera {
      * or [`line-pattern`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-line-line-pattern).
      *
      * @param {string} id The ID of the image.
-     * @param {HTMLImageElement | ImageBitmap | ImageData | {width: number, height: number, data: Uint8Array | Uint8ClampedArray} | StyleImageInterface} image The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
+     * @param {HTMLImageElement | ImageBitmap | ImageData | {width: number, height: number, data: (Uint8Array | Uint8ClampedArray)} | StyleImageInterface} image The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
      * properties with the same format as `ImageData`.
      *
      * @example


### PR DESCRIPTION
This PR applies a small fix to addImage and updateImage, where the `image` param value `data` needs parenthesis to be rendered correctly.


Current | Proposed
---|---
<img width="976" alt="2021-08-05 at 10 04 AM" src="https://user-images.githubusercontent.com/2180540/128363555-0ac568c2-2e83-4ba0-86b5-f2340bd9619c.png"> | <img width="974" alt="2021-08-05 at 10 04 AM" src="https://user-images.githubusercontent.com/2180540/128363584-b862faf6-1bff-4fad-b182-f0926497ff0a.png">




## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
