### PR TITLE
symbol-clip: splitting filter expressions into dynamic and static parts

### DIFF
--- a/build/run-tap
+++ b/build/run-tap
@@ -5,4 +5,4 @@ else
   arg="${@}"
 fi
 
-node_modules/.bin/tap --no-timeout --node-arg --inspect-brk --node-arg --no-warnings --node-arg --experimental-loader --node-arg ./build/node-loader.js $arg --node-arg
+node_modules/.bin/tap --node-arg --no-warnings --node-arg --experimental-loader --node-arg ./build/node-loader.js $arg --node-arg

--- a/build/run-tap
+++ b/build/run-tap
@@ -5,4 +5,4 @@ else
   arg="${@}"
 fi
 
-node_modules/.bin/tap --node-arg --no-warnings --node-arg --experimental-loader --node-arg ./build/node-loader.js $arg --node-arg
+node_modules/.bin/tap --no-timeout --node-arg --inspect-brk --node-arg --no-warnings --node-arg --experimental-loader --node-arg ./build/node-loader.js $arg --node-arg

--- a/debug/index.html
+++ b/debug/index.html
@@ -53,7 +53,7 @@ map.once('load', () => {
 
     map.once('idle', () => {
         map.panTo([-122.4199724, 37.7687162], {duration: 50000});
-    })
+    });
 });
 
 </script>

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -263,7 +263,7 @@ class FeatureIndex {
     }
 
     loadFeature(featureIndexData: FeatureIndices): VectorTileFeature {
-        const {featureIndex, bucketIndex, sourceLayerIndex, layoutVertexArrayOffset} = featureIndexData;
+        const {featureIndex, sourceLayerIndex} = featureIndexData;
 
         this.loadVTLayers();
         const sourceLayerName = this.sourceLayerCoder.decode(sourceLayerIndex);

--- a/src/source/tile_id.js
+++ b/src/source/tile_id.js
@@ -46,8 +46,8 @@ export class CanonicalTileID {
     getMercatorFromTilePoint(x: number, y: number): MercatorCoordinate {
         const tilesAtZoom = Math.pow(2, this.z);
         return new MercatorCoordinate(
-            (this.x * EXTENT + x ) / (tilesAtZoom * EXTENT),
-            (this.y * EXTENT + y ) / (tilesAtZoom * EXTENT)
+            (this.x * EXTENT + x) / (tilesAtZoom * EXTENT),
+            (this.y * EXTENT + y) / (tilesAtZoom * EXTENT)
         );
     }
 

--- a/src/style-spec/expression/evaluation_context.js
+++ b/src/style-spec/expression/evaluation_context.js
@@ -5,11 +5,9 @@ import {Color} from './values.js';
 import type MercatorCoordinate from '../../geo/mercator_coordinate.js';
 import type {FormattedSection} from './types/formatted.js';
 import type {GlobalProperties, Feature, FeatureState} from './index.js';
-import type {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id.js';
+import type {CanonicalTileID} from '../../source/tile_id.js';
 
 const geometryTypes = ['Unknown', 'Point', 'LineString', 'Polygon'];
-
-const tempArray = [0, 0, 0];
 
 class EvaluationContext {
     globals: GlobalProperties;
@@ -66,7 +64,7 @@ class EvaluationContext {
             const y1 = (m[1] * x + m[5] * y + m[9] * z + m[13]) / w;
             const z1 = (m[2] * x + m[6] * y + m[10] * z + m[14]) / w;
 
-            return Math.sqrt(x1*x1 + y1*y1  + z1*z1);
+            return Math.sqrt(x1 * x1 + y1 * y1  + z1 * z1);
         }
 
         return 0;

--- a/src/style-spec/expression/evaluation_context.js
+++ b/src/style-spec/expression/evaluation_context.js
@@ -1,7 +1,6 @@
 // @flow
 
 import {Color} from './values.js';
-import {vec3} from 'gl-matrix';
 
 import type MercatorCoordinate from '../../geo/mercator_coordinate.js';
 import type {FormattedSection} from './types/formatted.js';
@@ -56,10 +55,18 @@ class EvaluationContext {
 
     distanceFromCamera() {
         if (this.cameraDistanceReferencePoint && this.globals && this.globals.cameraDistanceMatrix) {
-            tempArray[0] = this.cameraDistanceReferencePoint.x;
-            tempArray[1] = this.cameraDistanceReferencePoint.y;
-            tempArray[2] = this.cameraDistanceReferencePoint.z;
-            return vec3.length(vec3.transformMat4(tempArray, tempArray, this.globals.cameraDistanceMatrix));
+
+            const m = this.globals.cameraDistanceMatrix;
+            const {x, y, z} = this.cameraDistanceReferencePoint;
+
+            //inlined vec3*mat4 multiplication to prevent importing gl-matrix as a dependency
+            let w = m[3] * x + m[7] * y + m[11] * z + m[15];
+            w = w || 1.0;
+            const x1 = (m[0] * x + m[4] * y + m[8] * z + m[12]) / w;
+            const y1 = (m[1] * x + m[5] * y + m[9] * z + m[13]) / w;
+            const z1 = (m[2] * x + m[6] * y + m[10] * z + m[14]) / w;
+
+            return Math.sqrt(x1*x1 + y1*y1  + z1*z1);
         }
 
         return 0;

--- a/src/style-spec/expression/index.js
+++ b/src/style-spec/expression/index.js
@@ -200,7 +200,7 @@ export class CameraDependentExpression<Kind: EvaluationKind> {
         this._styleExpression = expression;
     }
 
-    evaluateWithoutErrorHandling(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, canonical?: CanonicalTileID, availableImages?: Array<string>, formattedSection?: FormattedSection, ): any {
+    evaluateWithoutErrorHandling(globals: GlobalProperties, feature?: Feature, featureState?: FeatureState, canonical?: CanonicalTileID, availableImages?: Array<string>, formattedSection?: FormattedSection,): any {
         return this._styleExpression.evaluateWithoutErrorHandling(globals, feature, featureState, canonical, availableImages, formattedSection);
     }
 
@@ -275,8 +275,8 @@ export function createPropertyExpression(expression: mixed, propertySpec: StyleP
 
     if (supportsCameraStateExpression(propertySpec)) {
         return success(isFeatureConstant ?
-                (new CameraDependentExpression('composite', expression.value): CameraStateExpression) :
-                (new CameraDependentExpression('composite', expression.value): CompositeCameraStateExpression));
+            (new CameraDependentExpression('composite', expression.value): CameraStateExpression) :
+            (new CameraDependentExpression('composite', expression.value): CompositeCameraStateExpression));
     }
 
     const zoomCurve = findZoomCurve(parsed);

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -86,7 +86,14 @@ function createFilter(filter: any): FeatureFilter {
     try {
         staticFilter = extractStaticFilter(filter);
     } catch (e) {
-        console.warn(`Failed to extract static filter from ${JSON.stringify(filter)}. Falling back to using 'true' as a filter and evaluating entire filter dynamically`);
+        console.warn(
+`Failed to extract static filter. Filter will continue working, but at higher memory usage and slower framerate.
+This is most likely a bug, please report this via https://github.com/mapbox/mapbox-gl-js/issues/new?assignees=&labels=&template=Bug_report.md
+and paste the contents of this message in the report.
+Thank you!
+Filter Expression:
+${JSON.stringify(filter, null, 2)}
+        `);
     }
     const dynamicFilter = filter === staticFilter ? true : filter;
 
@@ -220,9 +227,6 @@ function unionDynamicBranches(filter: any) {
 
 function isDynamicFilter(filter: any): boolean {
     // Base Cases
-    if (typeof filter === 'boolean') {
-        return false;
-    }
     if (!Array.isArray(filter)) {
         return false;
     }

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -3,6 +3,7 @@
 import {createExpression} from '../expression/index.js';
 import type {GlobalProperties, Feature} from '../expression/index.js';
 import type {CanonicalTileID} from '../../source/tile_id.js';
+import type MercatorCoordinate from '../../geo/mercator_coordinate.js';
 
 type FilterExpression = (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID) => boolean;
 export type FeatureFilter = {filter: FilterExpression, dynamicFilter: FilterExpression, needGeometry: boolean};
@@ -111,7 +112,7 @@ function createFilter(filter: any): FeatureFilter {
         const needGeometry = geometryNeeded(staticFilter);
         return {
             filter: (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID) => compiledStaticFilter.value.evaluate(globalProperties, feature, {}, canonical),
-            dynamicFilter: (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID) => compiledDynamicFilter.value.evaluate(globalProperties, feature, {}, canonical),
+            dynamicFilter: (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID, refLocation: ?MercatorCoordinate) => compiledDynamicFilter.value.evaluate(globalProperties, feature, {}, canonical, null, null, refLocation),
             needGeometry
         };
     }

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -5,7 +5,7 @@ import type {GlobalProperties, Feature} from '../expression/index.js';
 import type {CanonicalTileID} from '../../source/tile_id.js';
 
 type FilterExpression = (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID) => boolean;
-export type FeatureFilter ={filter: FilterExpression, dynamicFilter: FilterExpression, needGeometry: boolean};
+export type FeatureFilter = {filter: FilterExpression, dynamicFilter: FilterExpression, needGeometry: boolean};
 
 export default createFilter;
 export {isExpressionFilter, isDynamicFilter, extractStaticFilter};
@@ -95,10 +95,10 @@ function createFilter(filter: any): FeatureFilter {
     if (compiledStaticFilter.result === 'error' || compiledDynamicFilter.result === 'error') {
         throw new Error(compiledStaticFilter.value.map(err => `${err.key}: ${err.message}`).join(', '));
     } else {
-        const needGeometry = geometryNeeded(filter);
+        const needGeometry = geometryNeeded(staticFilter);
         return {
             filter: (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID) => compiledStaticFilter.value.evaluate(globalProperties, feature, {}, canonical),
-            dynamicFilter: (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID) => compiledDynamicFilter.value.evaluate(globalProperties, feature, {}, canonical)
+            dynamicFilter: (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID) => compiledDynamicFilter.value.evaluate(globalProperties, feature, {}, canonical),
             needGeometry
         };
     }
@@ -210,11 +210,11 @@ function isDynamicFilter(filter: any): boolean {
     if (typeof filter === 'boolean') {
         return false;
     }
-    if (isRootExpressionDynamic(filter[0])) {
-        return true;
-    }
     if (!Array.isArray(filter)) {
         return false;
+    }
+    if (isRootExpressionDynamic(filter[0])) {
+        return true;
     }
 
     for(const child of filter.slice(1)) {

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -8,7 +8,7 @@ type FilterExpression = (globalProperties: GlobalProperties, feature: Feature, c
 export type FeatureFilter ={filter: FilterExpression, needGeometry: boolean};
 
 export default createFilter;
-export {isExpressionFilter};
+export {isExpressionFilter, isFilterDynamic};
 
 function isExpressionFilter(filter: any) {
     if (filter === true || filter === false) {
@@ -52,6 +52,27 @@ function isExpressionFilter(filter: any) {
     }
 }
 
+
+
+
+function isFilterDynamic(filter: any): boolean {
+    // Base Cases
+    if (filter === true || filter === false) {
+        return false;
+    }
+    if (isRootExpressionDynamic(filter[0])) {
+        return true;
+    }
+
+    // Recursively traverse expression and bubble up a base case.
+    return filter.slice(1).some((f) => isFilterDynamic(f));
+}
+
+function isRootExpressionDynamic(expression: string): boolean {
+    return expression === 'pitch' ||
+        expression === 'distance-from-center';
+}
+
 const filterSpec = {
     'type': 'boolean',
     'default': false,
@@ -59,7 +80,7 @@ const filterSpec = {
     'property-type': 'data-driven',
     'expression': {
         'interpolated': false,
-        'parameters': ['zoom', 'feature']
+        'parameters': ['zoom', 'feature', 'pitch', 'distance-from-center']
     }
 };
 
@@ -83,7 +104,7 @@ function createFilter(filter: any): FeatureFilter {
 
     const compiled = createExpression(filter, filterSpec);
     if (compiled.result === 'error') {
-        throw new Error(compiled.value.map(err => `${err.key}: ${err.message}`).join(', '));
+        throw new Error(compiled.value.map(err => `${err.key}: ${ermessage}`).join(', '));
     } else {
         const needGeometry = geometryNeeded(filter);
         return {filter: (globalProperties: GlobalProperties, feature: Feature, canonical?: CanonicalTileID) => compiled.value.evaluate(globalProperties, feature, {}, canonical),

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -8,7 +8,7 @@ type FilterExpression = (globalProperties: GlobalProperties, feature: Feature, c
 export type FeatureFilter ={filter: FilterExpression, needGeometry: boolean};
 
 export default createFilter;
-export {isExpressionFilter, isFilterDynamic};
+export {isExpressionFilter, isDynamicFilter};
 
 function isExpressionFilter(filter: any) {
     if (filter === true || filter === false) {
@@ -55,17 +55,25 @@ function isExpressionFilter(filter: any) {
 
 
 
-function isFilterDynamic(filter: any): boolean {
+function isDynamicFilter(filter: any): boolean {
     // Base Cases
-    if (filter === true || filter === false) {
+    if (typeof filter === 'boolean') {
         return false;
     }
     if (isRootExpressionDynamic(filter[0])) {
         return true;
     }
+    if (!Array.isArray(filter)) {
+        return false;
+    }
 
-    // Recursively traverse expression and bubble up a base case.
-    return filter.slice(1).some((f) => isFilterDynamic(f));
+    for(const child of filter.slice(1)) {
+        if (isDynamicFilter(child)){
+            return true;
+        }
+    }
+
+    return false;
 }
 
 function isRootExpressionDynamic(expression: string): boolean {

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -57,6 +57,10 @@ function extractStaticFilter(filter: any): any {
         return filter;
     }
 
+    // 1. Union branches
+
+    // 2. Collapse dynamic conditions to  `true`
+
     return true;
 }
 

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -8,7 +8,7 @@ type FilterExpression = (globalProperties: GlobalProperties, feature: Feature, c
 export type FeatureFilter ={filter: FilterExpression, needGeometry: boolean};
 
 export default createFilter;
-export {isExpressionFilter, isDynamicFilter};
+export {isExpressionFilter, isDynamicFilter, extractStaticFilter};
 
 function isExpressionFilter(filter: any) {
     if (filter === true || filter === false) {
@@ -52,7 +52,13 @@ function isExpressionFilter(filter: any) {
     }
 }
 
+function extractStaticFilter(filter: any): any {
+    if (!isDynamicFilter(filter)) {
+        return filter;
+    }
 
+    return true;
+}
 
 
 function isDynamicFilter(filter: any): boolean {

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -89,7 +89,6 @@ function createFilter(filter: any): FeatureFilter {
     }
     const dynamicFilter = filter === staticFilter ? true : filter;
 
-    // TODO: separate out static and dynamic filterSpec
     const compiledStaticFilter = createExpression(staticFilter, filterSpec);
     const compiledDynamicFilter = createExpression(dynamicFilter, filterSpec);
     if (compiledStaticFilter.result === 'error' || compiledDynamicFilter.result === 'error') {
@@ -148,7 +147,7 @@ const dynamicConditionExpressions = new Set([
 function collapsedExpression(expression: any): any {
     if (dynamicConditionExpressions.has(expression[0])) {
 
-        for(let i = 1; i < expression.length; i++) {
+        for (let i = 1; i < expression.length; i++) {
             const param = expression[i];
             if (isDynamicFilter(param)) {
                 return true;
@@ -181,14 +180,14 @@ function unionDynamicBranches(filter: any) {
     } else if (filter[0] === 'match') {
         isBranchingDynamically = isBranchingDynamically || isDynamicFilter(filter[1]);
 
-        for (let i = 2; i < filter.length - 1; i +=2) {
+        for (let i = 2; i < filter.length - 1; i += 2) {
             branches.push(filter[i + 1]);
         }
         branches.push(filter[filter.length - 1]);
     } else if (filter[0] === 'step') {
         isBranchingDynamically = isBranchingDynamically || isDynamicFilter(filter[1]);
 
-        for (let i = 1; i < filter.length - 1; i +=2) {
+        for (let i = 1; i < filter.length - 1; i += 2) {
             branches.push(filter[i + 1]);
         }
     }
@@ -204,7 +203,6 @@ function unionDynamicBranches(filter: any) {
     }
 }
 
-
 function isDynamicFilter(filter: any): boolean {
     // Base Cases
     if (typeof filter === 'boolean') {
@@ -217,9 +215,9 @@ function isDynamicFilter(filter: any): boolean {
         return true;
     }
 
-    for(let i = 1; i < filter.length; i++) {
+    for (let i = 1; i < filter.length; i++) {
         const child = filter[i];
-        if (isDynamicFilter(child)){
+        if (isDynamicFilter(child)) {
             return true;
         }
     }

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -88,8 +88,14 @@ function unionDynamicBranches(filter: any) {
         }
 
         branches.push(filter[filter.length - 1]);
+    } else if (filter[0] === 'match') {
+        tests.push(filter[1]);
+
+        for (let i = 2; i < filter.length - 1; i +=2) {
+            branches.push(filter[i + 1]);
+        }
+        branches.push(filter[filter.length - 1]);
     }
-    // TODO: add `match`
 
     const isBranchingDynamically = tests.some((test) => isDynamicFilter(test));
     if (isBranchingDynamically) {

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -92,7 +92,21 @@ function createFilter(filter: any): FeatureFilter {
     const compiledStaticFilter = createExpression(staticFilter, filterSpec);
     const compiledDynamicFilter = createExpression(dynamicFilter, filterSpec);
     if (compiledStaticFilter.result === 'error' || compiledDynamicFilter.result === 'error') {
-        throw new Error(compiledStaticFilter.value.map(err => `${err.key}: ${err.message}`).join(', '));
+        const staticFilterErrors = compiledStaticFilter.result === 'error' ?
+            compiledStaticFilter.value.map(err => `${err.key}: ${err.message}`).join(', ') :
+            'None';
+
+        const dynamicFilterErrors = compiledDynamicFilter.result === 'error' ?
+            compiledDynamicFilter.value.map(err => `${err.key}: ${err.message}`).join(', ') :
+            'None';
+
+        const errorMsg = `static-filter errors:
+            ${staticFilterErrors}
+
+            dynamic-filter errors:
+            ${dynamicFilterErrors}
+        `;
+        throw new Error(errorMsg);
     } else {
         const needGeometry = geometryNeeded(staticFilter);
         return {

--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -75,7 +75,7 @@ function extractStaticFilter(filter: any): any {
  * This ensures that all possible outcomes of a `dynamic` branch are considered
  * when evaluating the expression upfront during filtering.
  *
- * @param {Array<any>} filter the filter expression. Mutated in-place.
+ * @param {Array<any>} filter the filter expression mutated in-place.
  */
 function unionDynamicBranches(filter: any) {
     const tests = [];

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -1171,6 +1171,7 @@
         "parameters": [
           "zoom",
           "feature",
+          "feature-state",
           "pitch",
           "distance-from-center"
         ]

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -269,13 +269,13 @@ export class Placement {
         }
 
         let clippingData = null;
-        assert(!!tile.latestFeatureIndex)
+        assert(!!tile.latestFeatureIndex);
         if (needsDynamicClipping && tile.latestFeatureIndex) {
 
             clippingData = {
                 unwrappedTileID,
                 featureIndex: tile.latestFeatureIndex
-            }
+            };
         }
 
         // As long as this placement lives, we have to hold onto this bucket's
@@ -432,11 +432,9 @@ export class Placement {
             });
         };
 
-
         const placeSymbol = (symbolInstance: SymbolInstance, symbolIndex: number, collisionArrays: CollisionArrays) => {
             if (clippingData) {
                 const clipExpression = layout.get('symbol-clip');
-                // TODO: feature state support, image expression support
                 clipExpression.parameters.zoom = this.transform.zoom;
                 clipExpression.parameters.pitch = this.transform.pitch;
                 clipExpression.parameters.cameraDistanceMatrix = this.transform.mercatorFogMatrix;

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -270,7 +270,7 @@ export class Placement {
 
         let clippingData = null;
         assert(!!tile.latestFeatureIndex)
-        if (tile.latestFeatureIndex) {
+        if (needsDynamicClipping && tile.latestFeatureIndex) {
 
             clippingData = {
                 unwrappedTileID,

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -104,7 +104,85 @@ test('filter', t => {
             ],
             ["all", ["<", ["get", "filter_rank"], 2 ], [ "<" ,["pitch"], 60]],
             ["any", ["<", ["get", "filter_rank"], 2 ], [ "<" ,["pitch"], 60]],
-            ["<" ,["pitch"], 60]
+            ["<" ,["pitch"], 60],
+            ["all",
+                [
+                    "<=",
+                    ["get", "filterrank"],
+                    3
+                ],
+                [
+                    "match",
+                    ["get", "class"],
+                    "settlement",
+                    [
+                    "match",
+                    ["get", "worldview"],
+                    ["all", "US"],
+                    true,
+                    false
+                    ],
+                    "disputed_settlement",
+                    [
+                    "all",
+                    [
+                        "==",
+                        ["get", "disputed"],
+                        "true"
+                    ],
+                    [
+                        "match",
+                        ["get", "worldview"],
+                        ["all", "US"],
+                        true,
+                        false
+                    ],
+                    ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]]
+                    ],
+                    false
+                ],
+                [
+                    "step",
+                    ["zoom"],
+                    false,
+                    8,
+                    [
+                    "<",
+                    ["get", "symbolrank"],
+                    11
+                    ],
+                    10,
+                    [
+                    "<",
+                    ["get", "symbolrank"],
+                    12
+                    ],
+                    11,
+                    [
+                    "<",
+                    ["get", "symbolrank"],
+                    13
+                    ],
+                    12,
+                    [
+                    "<",
+                    ["get", "symbolrank"],
+                    15
+                    ],
+                    13,
+                    [
+                    ">=",
+                    ["get", "symbolrank"],
+                    11
+                    ],
+                    14,
+                    [
+                    ">=",
+                    ["get", "symbolrank"],
+                    13
+                    ]
+                ]
+            ]
         ];
 
         const STATIC_FILTERS = [
@@ -248,6 +326,22 @@ test('filter', t => {
                     ["get", "filterrank"],
                     4
                 ]
+            ],
+        ["<=",
+            ["get", "filterrank"],
+            [
+                "+",
+                [
+                "step",
+                ["zoom"],
+                0,
+                16,
+                1,
+                17,
+                2
+                ],
+                3
+            ]
             ]
         ]
 

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -1,5 +1,5 @@
 import {test} from '../../util/test.js';
-import {default as createFilter, isExpressionFilter} from '../../../src/style-spec/feature_filter/index.js';
+import {default as createFilter, isExpressionFilter, isDynamicFilter} from '../../../src/style-spec/feature_filter/index.js';
 
 import convertFilter from '../../../src/style-spec/feature_filter/convert.js';
 import Point from '@mapbox/point-geometry';
@@ -87,6 +87,17 @@ test('filter', t => {
         t.equal(withinFilter.filter({zoom: 3}, {type: 2, geometry: [[getPointFromLngLat(2, 2, canonical), getPointFromLngLat(3, 3, canonical)]]}, canonical), true);
         t.equal(withinFilter.filter({zoom: 3}, {type: 2, geometry: [[getPointFromLngLat(6, 6, canonical), getPointFromLngLat(2, 2, canonical)]]}, canonical), false);
         t.equal(withinFilter.filter({zoom: 3}, {type: 2, geometry: [[getPointFromLngLat(5, 5, canonical), getPointFromLngLat(2, 2, canonical)]]}, canonical), false);
+        t.end();
+    });
+
+    t.test('dynamic filters', (t) => {
+
+        t.test('isDynamicFilter', (t) => {
+
+
+            t.end();
+        });
+
         t.end();
     });
 

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -562,6 +562,105 @@ test('filter', t => {
                 t.end();
             });
 
+            t.test('it collapses dynamic match expressions to any expressions', (t) => {
+                const testCases = [
+                    {
+                        dynamic: ["match",
+                            ["pitch"],
+                            [10, 20 , 30], [ "<", ["get", "filterrank"], 2],
+                            [70, 80], [ ">", ["get", "filterrank"], 5],
+                            ["all", [ ">", ["get", "filterrank"], 2], [ "<", ["get", "filterrank"], 5]]
+                        ],
+                        static: ["any",
+                            [ "<", ["get", "filterrank"], 2],
+                            [ ">", ["get", "filterrank"], 5],
+                            ["all", [ ">", ["get", "filterrank"], 2], [ "<", ["get", "filterrank"], 5]]
+                        ]
+                    },
+                    {
+                        dynamic: ["all",
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement_subdivision",
+                                [
+                                "match",
+                                ["get", "worldview"],
+                                ["all", "US"],
+                                true,
+                                false
+                                ],
+                                "disputed_settlement_subdivision",
+                                [
+                                "all",
+                                [
+                                    "match",
+                                    ["distance-from-center"],
+                                    [1, 2], ["==", ["get", "worldview"], "US"],
+                                    [4, 5], ["==", ["get", "worldview"], "IND"],
+                                    ["==", ["get", "worldview"], "INTL"]
+                                ],
+                                [
+                                    "case",
+                                    ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
+                                    ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
+                                    ["==", ["get", "worldview"], "INTL"]
+                                ]
+                                ],
+                                false
+                            ],
+                            [
+                                "<=",
+                                ["get", "filterrank"],
+                                4
+                            ]
+                        ],
+                        static: ["all",
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement_subdivision",
+                                [
+                                "match",
+                                ["get", "worldview"],
+                                ["all", "US"],
+                                true,
+                                false
+                                ],
+                                "disputed_settlement_subdivision",
+                                [
+                                "all",
+                                [
+                                    "any",
+                                    ["==", ["get", "worldview"], "US"],
+                                    ["==", ["get", "worldview"], "IND"],
+                                    ["==", ["get", "worldview"], "INTL"]
+                                ],
+                                [
+                                    "any",
+                                    ["==", ["get", "worldview"], "US"],
+                                    ["==", ["get", "worldview"], "IND"],
+                                    ["==", ["get", "worldview"], "INTL"]
+                                ]
+                                ],
+                                false
+                            ],
+                            [
+                                "<=",
+                                ["get", "filterrank"],
+                                4
+                            ]
+                        ]
+                    }
+                ]
+
+                for(const testCase of testCases) {
+                    t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
+                }
+
+                t.end();
+            });
+
             t.end();
         });
 

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -1016,8 +1016,6 @@ test('filter', t => {
                 t.end();
             });
 
-
-
             t.end();
         });
 

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -372,6 +372,40 @@ test('filter', t => {
                 t.end();
             });
 
+            t.test('it collapses dynamic case expressions to any expressions', (t) => {
+                const testCases =[
+                    {
+                        dynamic: ["case",
+                            ["<", ["pitch"], 60], true,
+                            ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], true,
+                            false
+                        ],
+                        static: ["any", true, true, false]
+                    },
+                    {
+                        dynamic: ["case",
+                            ["<", ["pitch"], 60], ["<", ["get", "filter_rank"], 2],
+                            [">", ["get", "filter_rank"], 4],
+                        ],
+                        static: ["any", ["<", ["get", "filter_rank"], 2], [">", ["get", "filter_rank"], 4]]
+                    },
+                    {
+                        dynamic: ["case",
+                            ["<", ["pitch"], 60], ["<", ["get", "filter_rank"], 2],
+                            ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], [">", ["get", "filter_rank"], 4],
+                            false
+                        ],
+                        static: ["any", ["<", ["get", "filter_rank"], 2], [">", ["get", "filter_rank"], 4], false]
+                    }
+                ];
+
+                for(const testCase of testCases) {
+                    t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
+                }
+
+                t.end();
+            });
+
             t.end();
         });
 

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -102,9 +102,9 @@ test('filter', t => {
                 ["<", ["pitch"], 60], ["<", ["get", "filter_rank"], 2],
                 [">", ["get", "filter_rank"], 4],
             ],
-            ["all", ["<", ["get", "filter_rank"], 2 ], [ "<" ,["pitch"], 60]],
-            ["any", ["<", ["get", "filter_rank"], 2 ], [ "<" ,["pitch"], 60]],
-            ["<" ,["pitch"], 60],
+            ["all", ["<", ["get", "filter_rank"], 2 ], [ "<", ["pitch"], 60]],
+            ["any", ["<", ["get", "filter_rank"], 2 ], [ "<", ["pitch"], 60]],
+            ["<", ["pitch"], 60],
             ["all",
                 [
                     "<=",
@@ -116,28 +116,28 @@ test('filter', t => {
                     ["get", "class"],
                     "settlement",
                     [
-                    "match",
-                    ["get", "worldview"],
-                    ["all", "US"],
-                    true,
-                    false
-                    ],
-                    "disputed_settlement",
-                    [
-                    "all",
-                    [
-                        "==",
-                        ["get", "disputed"],
-                        "true"
-                    ],
-                    [
                         "match",
                         ["get", "worldview"],
                         ["all", "US"],
                         true,
                         false
                     ],
-                    ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]]
+                    "disputed_settlement",
+                    [
+                        "all",
+                        [
+                            "==",
+                            ["get", "disputed"],
+                            "true"
+                        ],
+                        [
+                            "match",
+                            ["get", "worldview"],
+                            ["all", "US"],
+                            true,
+                            false
+                        ],
+                        ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]]
                     ],
                     false
                 ],
@@ -147,39 +147,39 @@ test('filter', t => {
                     false,
                     8,
                     [
-                    "<",
-                    ["get", "symbolrank"],
-                    11
+                        "<",
+                        ["get", "symbolrank"],
+                        11
                     ],
                     10,
                     [
-                    "<",
-                    ["get", "symbolrank"],
-                    12
+                        "<",
+                        ["get", "symbolrank"],
+                        12
                     ],
                     11,
                     [
-                    "<",
-                    ["get", "symbolrank"],
-                    13
+                        "<",
+                        ["get", "symbolrank"],
+                        13
                     ],
                     12,
                     [
-                    "<",
-                    ["get", "symbolrank"],
-                    15
+                        "<",
+                        ["get", "symbolrank"],
+                        15
                     ],
                     13,
                     [
-                    ">=",
-                    ["get", "symbolrank"],
-                    11
+                        ">=",
+                        ["get", "symbolrank"],
+                        11
                     ],
                     14,
                     [
-                    ">=",
-                    ["get", "symbolrank"],
-                    13
+                        ">=",
+                        ["get", "symbolrank"],
+                        13
                     ]
                 ]
             ]
@@ -200,16 +200,16 @@ test('filter', t => {
                 [
                     "all",
                     [
-                    "==",
-                    ["get", "disputed"],
-                    "true"
+                        "==",
+                        ["get", "disputed"],
+                        "true"
                     ],
                     [
-                    "match",
-                    ["get", "worldview"],
-                    ["all", "US"],
-                    true,
-                    false
+                        "match",
+                        ["get", "worldview"],
+                        ["all", "US"],
+                        true,
+                        false
                     ]
                 ],
                 false
@@ -225,27 +225,27 @@ test('filter', t => {
                     ["get", "class"],
                     "settlement",
                     [
-                    "match",
-                    ["get", "worldview"],
-                    ["all", "US"],
-                    true,
-                    false
-                    ],
-                    "disputed_settlement",
-                    [
-                    "all",
-                    [
-                        "==",
-                        ["get", "disputed"],
-                        "true"
-                    ],
-                    [
                         "match",
                         ["get", "worldview"],
                         ["all", "US"],
                         true,
                         false
-                    ]
+                    ],
+                    "disputed_settlement",
+                    [
+                        "all",
+                        [
+                            "==",
+                            ["get", "disputed"],
+                            "true"
+                        ],
+                        [
+                            "match",
+                            ["get", "worldview"],
+                            ["all", "US"],
+                            true,
+                            false
+                        ]
                     ],
                     false
                 ],
@@ -255,39 +255,39 @@ test('filter', t => {
                     false,
                     8,
                     [
-                    "<",
-                    ["get", "symbolrank"],
-                    11
+                        "<",
+                        ["get", "symbolrank"],
+                        11
                     ],
                     10,
                     [
-                    "<",
-                    ["get", "symbolrank"],
-                    12
+                        "<",
+                        ["get", "symbolrank"],
+                        12
                     ],
                     11,
                     [
-                    "<",
-                    ["get", "symbolrank"],
-                    13
+                        "<",
+                        ["get", "symbolrank"],
+                        13
                     ],
                     12,
                     [
-                    "<",
-                    ["get", "symbolrank"],
-                    15
+                        "<",
+                        ["get", "symbolrank"],
+                        15
                     ],
                     13,
                     [
-                    ">=",
-                    ["get", "symbolrank"],
-                    11
+                        ">=",
+                        ["get", "symbolrank"],
+                        11
                     ],
                     14,
                     [
-                    ">=",
-                    ["get", "symbolrank"],
-                    13
+                        ">=",
+                        ["get", "symbolrank"],
+                        13
                     ]
                 ]
             ],
@@ -297,27 +297,27 @@ test('filter', t => {
                     ["get", "class"],
                     "settlement_subdivision",
                     [
-                    "match",
-                    ["get", "worldview"],
-                    ["all", "US"],
-                    true,
-                    false
-                    ],
-                    "disputed_settlement_subdivision",
-                    [
-                    "all",
-                    [
-                        "==",
-                        ["get", "disputed"],
-                        "true"
-                    ],
-                    [
                         "match",
                         ["get", "worldview"],
                         ["all", "US"],
                         true,
                         false
-                    ]
+                    ],
+                    "disputed_settlement_subdivision",
+                    [
+                        "all",
+                        [
+                            "==",
+                            ["get", "disputed"],
+                            "true"
+                        ],
+                        [
+                            "match",
+                            ["get", "worldview"],
+                            ["all", "US"],
+                            true,
+                            false
+                        ]
                     ],
                     false
                 ],
@@ -327,54 +327,53 @@ test('filter', t => {
                     4
                 ]
             ],
-        ["<=",
-            ["get", "filterrank"],
-            [
-                "+",
+            ["<=",
+                ["get", "filterrank"],
                 [
-                "step",
-                ["zoom"],
-                0,
-                16,
-                1,
-                17,
-                2
-                ],
-                3
-            ]
+                    "+",
+                    [
+                        "step",
+                        ["zoom"],
+                        0,
+                        16,
+                        1,
+                        17,
+                        2
+                    ],
+                    3
+                ]
             ],
             ["<=", ["get", "test_param"], null]
-        ]
+        ];
 
         t.test('isDynamicFilter', (t) => {
             t.test('true', (t) => {
-                for(const filter of DYNAMIC_FILTERS) {
+                for (const filter of DYNAMIC_FILTERS) {
                     t.ok(isDynamicFilter(filter), `Filter ${JSON.stringify(filter, null, 2)} should be classified as dynamic.`);
                 }
                 t.end();
             });
 
             t.test('false', (t) => {
-                for(const filter of STATIC_FILTERS) {
+                for (const filter of STATIC_FILTERS) {
                     t.notOk(isDynamicFilter(filter), `Filter ${JSON.stringify(filter, null, 2)} should be classified as static.`);
                 }
                 t.end();
             });
-
 
             t.end();
         });
 
         t.test('extractStaticFilter', (t) => {
             t.test('it lets static filters pass through', (t) => {
-                for(const filter of STATIC_FILTERS) {
+                for (const filter of STATIC_FILTERS) {
                     t.equal(extractStaticFilter(filter), filter);
                 }
                 t.end();
             });
 
             t.test('it collapses dynamic case expressions to any expressions', (t) => {
-                const testCases =[
+                const testCases = [
                     {
                         dynamic: ["case",
                             ["<", ["pitch"], 60], true,
@@ -417,26 +416,26 @@ test('filter', t => {
                                 ["get", "class"],
                                 "settlement_subdivision",
                                 [
-                                "match",
-                                ["get", "worldview"],
-                                ["all", "US"],
-                                true,
-                                false
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
                                 ],
                                 "disputed_settlement_subdivision",
                                 [
-                                "all",
-                                [
-                                    "==",
-                                    ["get", "disputed"],
-                                    "true"
-                                ],
-                                [
-                                    "case",
-                                    ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
-                                    ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
-                                    ["==", ["get", "worldview"], "INTL"]
-                                ]
+                                    "all",
+                                    [
+                                        "==",
+                                        ["get", "disputed"],
+                                        "true"
+                                    ],
+                                    [
+                                        "case",
+                                        ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
+                                        ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
+                                        ["==", ["get", "worldview"], "INTL"]
+                                    ]
                                 ],
                                 false
                             ],
@@ -452,26 +451,26 @@ test('filter', t => {
                                 ["get", "class"],
                                 "settlement_subdivision",
                                 [
-                                "match",
-                                ["get", "worldview"],
-                                ["all", "US"],
-                                true,
-                                false
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
                                 ],
                                 "disputed_settlement_subdivision",
                                 [
-                                "all",
-                                [
-                                    "==",
-                                    ["get", "disputed"],
-                                    "true"
-                                ],
-                                [
-                                    "any",
-                                    ["==", ["get", "worldview"], "US"],
-                                    ["==", ["get", "worldview"], "IND"],
-                                    ["==", ["get", "worldview"], "INTL"]
-                                ]
+                                    "all",
+                                    [
+                                        "==",
+                                        ["get", "disputed"],
+                                        "true"
+                                    ],
+                                    [
+                                        "any",
+                                        ["==", ["get", "worldview"], "US"],
+                                        ["==", ["get", "worldview"], "IND"],
+                                        ["==", ["get", "worldview"], "INTL"]
+                                    ]
                                 ],
                                 false
                             ],
@@ -489,26 +488,26 @@ test('filter', t => {
                                 ["get", "class"],
                                 "settlement_subdivision",
                                 [
-                                "match",
-                                ["get", "worldview"],
-                                ["all", "US"],
-                                true,
-                                false
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
                                 ],
                                 "disputed_settlement_subdivision",
                                 [
-                                "all",
-                                [
-                                    "==",
-                                    ["get", "disputed"],
-                                    "true"
-                                ],
-                                [
-                                    "case",
-                                    ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
-                                    ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
-                                    ["==", ["get", "worldview"], "INTL"]
-                                ]
+                                    "all",
+                                    [
+                                        "==",
+                                        ["get", "disputed"],
+                                        "true"
+                                    ],
+                                    [
+                                        "case",
+                                        ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
+                                        ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
+                                        ["==", ["get", "worldview"], "INTL"]
+                                    ]
                                 ],
                                 false
                             ],
@@ -524,26 +523,26 @@ test('filter', t => {
                                 ["get", "class"],
                                 "settlement_subdivision",
                                 [
-                                "match",
-                                ["get", "worldview"],
-                                ["all", "US"],
-                                true,
-                                false
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
                                 ],
                                 "disputed_settlement_subdivision",
                                 [
-                                "all",
-                                [
-                                    "==",
-                                    ["get", "disputed"],
-                                    "true"
-                                ],
-                                [
-                                    "any",
-                                    ["==", ["get", "worldview"], "US"],
-                                    ["==", ["get", "worldview"], "IND"],
-                                    ["==", ["get", "worldview"], "INTL"]
-                                ]
+                                    "all",
+                                    [
+                                        "==",
+                                        ["get", "disputed"],
+                                        "true"
+                                    ],
+                                    [
+                                        "any",
+                                        ["==", ["get", "worldview"], "US"],
+                                        ["==", ["get", "worldview"], "IND"],
+                                        ["==", ["get", "worldview"], "INTL"]
+                                    ]
                                 ],
                                 false
                             ],
@@ -556,7 +555,7 @@ test('filter', t => {
                     }
                 ];
 
-                for(const testCase of testCases) {
+                for (const testCase of testCases) {
                     t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
                 }
 
@@ -568,7 +567,7 @@ test('filter', t => {
                     {
                         dynamic: ["match",
                             ["pitch"],
-                            [10, 20 , 30], [ "<", ["get", "filterrank"], 2],
+                            [10, 20, 30], [ "<", ["get", "filterrank"], 2],
                             [70, 80], [ ">", ["get", "filterrank"], 5],
                             ["all", [ ">", ["get", "filterrank"], 2], [ "<", ["get", "filterrank"], 5]]
                         ],
@@ -585,28 +584,28 @@ test('filter', t => {
                                 ["get", "class"],
                                 "settlement_subdivision",
                                 [
-                                "match",
-                                ["get", "worldview"],
-                                ["all", "US"],
-                                true,
-                                false
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
                                 ],
                                 "disputed_settlement_subdivision",
                                 [
-                                "all",
-                                [
-                                    "match",
-                                    ["distance-from-center"],
-                                    [1, 2], ["==", ["get", "worldview"], "US"],
-                                    [4, 5], ["==", ["get", "worldview"], "IND"],
-                                    ["==", ["get", "worldview"], "INTL"]
-                                ],
-                                [
-                                    "case",
-                                    ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
-                                    ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
-                                    ["==", ["get", "worldview"], "INTL"]
-                                ]
+                                    "all",
+                                    [
+                                        "match",
+                                        ["distance-from-center"],
+                                        [1, 2], ["==", ["get", "worldview"], "US"],
+                                        [4, 5], ["==", ["get", "worldview"], "IND"],
+                                        ["==", ["get", "worldview"], "INTL"]
+                                    ],
+                                    [
+                                        "case",
+                                        ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
+                                        ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
+                                        ["==", ["get", "worldview"], "INTL"]
+                                    ]
                                 ],
                                 false
                             ],
@@ -622,27 +621,27 @@ test('filter', t => {
                                 ["get", "class"],
                                 "settlement_subdivision",
                                 [
-                                "match",
-                                ["get", "worldview"],
-                                ["all", "US"],
-                                true,
-                                false
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
                                 ],
                                 "disputed_settlement_subdivision",
                                 [
-                                "all",
-                                [
-                                    "any",
-                                    ["==", ["get", "worldview"], "US"],
-                                    ["==", ["get", "worldview"], "IND"],
-                                    ["==", ["get", "worldview"], "INTL"]
-                                ],
-                                [
-                                    "any",
-                                    ["==", ["get", "worldview"], "US"],
-                                    ["==", ["get", "worldview"], "IND"],
-                                    ["==", ["get", "worldview"], "INTL"]
-                                ]
+                                    "all",
+                                    [
+                                        "any",
+                                        ["==", ["get", "worldview"], "US"],
+                                        ["==", ["get", "worldview"], "IND"],
+                                        ["==", ["get", "worldview"], "INTL"]
+                                    ],
+                                    [
+                                        "any",
+                                        ["==", ["get", "worldview"], "US"],
+                                        ["==", ["get", "worldview"], "IND"],
+                                        ["==", ["get", "worldview"], "INTL"]
+                                    ]
                                 ],
                                 false
                             ],
@@ -653,9 +652,9 @@ test('filter', t => {
                             ]
                         ]
                     }
-                ]
+                ];
 
-                for(const testCase of testCases) {
+                for (const testCase of testCases) {
                     t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
                 }
 
@@ -666,153 +665,153 @@ test('filter', t => {
                 const testCases = [
                     {
                         dynamic: [
+                            "all",
+                            [
+                                "<=",
+                                ["get", "filterrank"],
+                                3
+                            ],
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement",
+                                [
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
+                                ],
+                                "disputed_settlement",
+                                [
                                     "all",
                                     [
-                                        "<=",
-                                        ["get", "filterrank"],
-                                        3
+                                        "==",
+                                        ["get", "disputed"],
+                                        "true"
                                     ],
                                     [
-                                        "match",
-                                        ["get", "class"],
-                                        "settlement",
-                                        [
                                         "match",
                                         ["get", "worldview"],
                                         ["all", "US"],
                                         true,
                                         false
-                                        ],
-                                        "disputed_settlement",
-                                        [
-                                        "all",
-                                        [
-                                            "==",
-                                            ["get", "disputed"],
-                                            "true"
-                                        ],
-                                        [
-                                            "match",
-                                            ["get", "worldview"],
-                                            ["all", "US"],
-                                            true,
-                                            false
-                                        ]
-                                        ],
-                                        false
-                                    ],
-                                    [
-                                        "step",
-                                        ["pitch"],
-                                        true,
-                                        10,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        10
-                                        ],
-                                        20,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        20
-                                        ],
-                                        30,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        30
-                                        ],
-                                        40,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        40
-                                        ],
-                                        50,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        50
-                                        ],
-                                        60,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        60
-                                        ]
                                     ]
+                                ],
+                                false
+                            ],
+                            [
+                                "step",
+                                ["pitch"],
+                                true,
+                                10,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    10
+                                ],
+                                20,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    20
+                                ],
+                                30,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    30
+                                ],
+                                40,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    40
+                                ],
+                                50,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    50
+                                ],
+                                60,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    60
+                                ]
+                            ]
                         ],
                         static: [
+                            "all",
+                            [
+                                "<=",
+                                ["get", "filterrank"],
+                                3
+                            ],
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement",
+                                [
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
+                                ],
+                                "disputed_settlement",
+                                [
                                     "all",
                                     [
-                                        "<=",
-                                        ["get", "filterrank"],
-                                        3
+                                        "==",
+                                        ["get", "disputed"],
+                                        "true"
                                     ],
                                     [
-                                        "match",
-                                        ["get", "class"],
-                                        "settlement",
-                                        [
                                         "match",
                                         ["get", "worldview"],
                                         ["all", "US"],
                                         true,
                                         false
-                                        ],
-                                        "disputed_settlement",
-                                        [
-                                        "all",
-                                        [
-                                            "==",
-                                            ["get", "disputed"],
-                                            "true"
-                                        ],
-                                        [
-                                            "match",
-                                            ["get", "worldview"],
-                                            ["all", "US"],
-                                            true,
-                                            false
-                                        ]
-                                        ],
-                                        false
-                                    ],
-                                    [
-                                        "any",
-                                        true,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        10
-                                        ],
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        20
-                                        ],
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        30
-                                        ],
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        40
-                                        ],
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        50
-                                        ],
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        60
-                                        ]
                                     ]
+                                ],
+                                false
+                            ],
+                            [
+                                "any",
+                                true,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    10
+                                ],
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    20
+                                ],
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    30
+                                ],
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    40
+                                ],
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    50
+                                ],
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    60
+                                ]
+                            ]
                         ]
                     }
                 ];
@@ -841,172 +840,172 @@ test('filter', t => {
                     },
                     {
                         dynamic: [
+                            "all",
+                            [
+                                "<=",
+                                ["get", "filterrank"],
+                                3
+                            ],
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement",
+                                [
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
+                                ],
+                                "disputed_settlement",
+                                [
                                     "all",
                                     [
-                                        "<=",
-                                        ["get", "filterrank"],
-                                        3
+                                        "==",
+                                        ["get", "disputed"],
+                                        "true"
                                     ],
                                     [
-                                        "match",
-                                        ["get", "class"],
-                                        "settlement",
-                                        [
                                         "match",
                                         ["get", "worldview"],
                                         ["all", "US"],
                                         true,
                                         false
-                                        ],
-                                        "disputed_settlement",
-                                        [
-                                        "all",
-                                        [
-                                            "==",
-                                            ["get", "disputed"],
-                                            "true"
-                                        ],
-                                        [
-                                            "match",
-                                            ["get", "worldview"],
-                                            ["all", "US"],
-                                            true,
-                                            false
-                                        ]
-                                        ],
-                                        false
-                                    ],
-                                    [
-                                        "step",
-                                        ["zoom"],
-                                        true,
-                                        8,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        11
-                                        ],
-                                        10,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        12
-                                        ],
-                                        11,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        13
-                                        ],
-                                        12,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        15
-                                        ],
-                                        13,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        11
-                                        ],
-                                        14,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        13
-                                        ]
-                                    ],
-                                    [
-                                        "<=",
-                                        ["pitch"],
-                                        60
-                                    ],
-                                    [
-                                        "<=",
-                                        ["distance-from-center"],
-                                        2
                                     ]
+                                ],
+                                false
+                            ],
+                            [
+                                "step",
+                                ["zoom"],
+                                true,
+                                8,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    11
+                                ],
+                                10,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    12
+                                ],
+                                11,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    13
+                                ],
+                                12,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    15
+                                ],
+                                13,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    11
+                                ],
+                                14,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    13
+                                ]
+                            ],
+                            [
+                                "<=",
+                                ["pitch"],
+                                60
+                            ],
+                            [
+                                "<=",
+                                ["distance-from-center"],
+                                2
+                            ]
                         ],
                         static: [
+                            "all",
+                            [
+                                "<=",
+                                ["get", "filterrank"],
+                                3
+                            ],
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement",
+                                [
+                                    "match",
+                                    ["get", "worldview"],
+                                    ["all", "US"],
+                                    true,
+                                    false
+                                ],
+                                "disputed_settlement",
+                                [
                                     "all",
                                     [
-                                        "<=",
-                                        ["get", "filterrank"],
-                                        3
+                                        "==",
+                                        ["get", "disputed"],
+                                        "true"
                                     ],
                                     [
-                                        "match",
-                                        ["get", "class"],
-                                        "settlement",
-                                        [
                                         "match",
                                         ["get", "worldview"],
                                         ["all", "US"],
                                         true,
                                         false
-                                        ],
-                                        "disputed_settlement",
-                                        [
-                                        "all",
-                                        [
-                                            "==",
-                                            ["get", "disputed"],
-                                            "true"
-                                        ],
-                                        [
-                                            "match",
-                                            ["get", "worldview"],
-                                            ["all", "US"],
-                                            true,
-                                            false
-                                        ]
-                                        ],
-                                        false
-                                    ],
-                                    [
-                                        "step",
-                                        ["zoom"],
-                                        true,
-                                        8,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        11
-                                        ],
-                                        10,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        12
-                                        ],
-                                        11,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        13
-                                        ],
-                                        12,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        15
-                                        ],
-                                        13,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        11
-                                        ],
-                                        14,
-                                        [
-                                        ">=",
-                                        ["get", "symbolrank"],
-                                        13
-                                        ]
-                                    ],
-                                    true,
-                                    true
+                                    ]
+                                ],
+                                false
+                            ],
+                            [
+                                "step",
+                                ["zoom"],
+                                true,
+                                8,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    11
+                                ],
+                                10,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    12
+                                ],
+                                11,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    13
+                                ],
+                                12,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    15
+                                ],
+                                13,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    11
+                                ],
+                                14,
+                                [
+                                    ">=",
+                                    ["get", "symbolrank"],
+                                    13
+                                ]
+                            ],
+                            true,
+                            true
                         ]
                     }
                 ];

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -1,5 +1,5 @@
 import {test} from '../../util/test.js';
-import {default as createFilter, isExpressionFilter, isDynamicFilter} from '../../../src/style-spec/feature_filter/index.js';
+import {default as createFilter, isExpressionFilter, isDynamicFilter, extractStaticFilter} from '../../../src/style-spec/feature_filter/index.js';
 
 import convertFilter from '../../../src/style-spec/feature_filter/convert.js';
 import Point from '@mapbox/point-geometry';
@@ -360,6 +360,17 @@ test('filter', t => {
                 t.end();
             });
 
+
+            t.end();
+        });
+
+        t.test('extractStaticFilter', (t) => {
+            t.test('it lets static filters pass through', (t) => {
+                for(const filter of STATIC_FILTERS) {
+                    t.equal(extractStaticFilter(filter), filter);
+                }
+                t.end();
+            });
 
             t.end();
         });

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -342,7 +342,8 @@ test('filter', t => {
                 ],
                 3
             ]
-            ]
+            ],
+            ["<=", ["get", "test_param"], null]
         ]
 
         t.test('isDynamicFilter', (t) => {

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -670,6 +670,180 @@ test('filter', t => {
                     {
                         dynamic: ["all", ["<", ["pitch"], 60], ["<", ["distance-from-center"], 4]],
                         static: ["all", true, true]
+                    },
+                    {
+                        dynamic: ["all", ["<", ["+", ["*", ["pitch"], 2], 5], 60], ["<", ["+", ["distance-from-center"], 1], 4]],
+                        static: ["all", true, true]
+                    },
+                    {
+                        dynamic: [
+                                    "all",
+                                    [
+                                        "<=",
+                                        ["get", "filterrank"],
+                                        3
+                                    ],
+                                    [
+                                        "match",
+                                        ["get", "class"],
+                                        "settlement",
+                                        [
+                                        "match",
+                                        ["get", "worldview"],
+                                        ["all", "US"],
+                                        true,
+                                        false
+                                        ],
+                                        "disputed_settlement",
+                                        [
+                                        "all",
+                                        [
+                                            "==",
+                                            ["get", "disputed"],
+                                            "true"
+                                        ],
+                                        [
+                                            "match",
+                                            ["get", "worldview"],
+                                            ["all", "US"],
+                                            true,
+                                            false
+                                        ]
+                                        ],
+                                        false
+                                    ],
+                                    [
+                                        "step",
+                                        ["zoom"],
+                                        true,
+                                        8,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        11
+                                        ],
+                                        10,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        12
+                                        ],
+                                        11,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        13
+                                        ],
+                                        12,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        15
+                                        ],
+                                        13,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        11
+                                        ],
+                                        14,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        13
+                                        ]
+                                    ],
+                                    [
+                                        "<=",
+                                        ["pitch"],
+                                        60
+                                    ],
+                                    [
+                                        "<=",
+                                        ["distance-from-center"],
+                                        2
+                                    ]
+                        ],
+                        static: [
+                                    "all",
+                                    [
+                                        "<=",
+                                        ["get", "filterrank"],
+                                        3
+                                    ],
+                                    [
+                                        "match",
+                                        ["get", "class"],
+                                        "settlement",
+                                        [
+                                        "match",
+                                        ["get", "worldview"],
+                                        ["all", "US"],
+                                        true,
+                                        false
+                                        ],
+                                        "disputed_settlement",
+                                        [
+                                        "all",
+                                        [
+                                            "==",
+                                            ["get", "disputed"],
+                                            "true"
+                                        ],
+                                        [
+                                            "match",
+                                            ["get", "worldview"],
+                                            ["all", "US"],
+                                            true,
+                                            false
+                                        ]
+                                        ],
+                                        false
+                                    ],
+                                    [
+                                        "step",
+                                        ["zoom"],
+                                        true,
+                                        8,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        11
+                                        ],
+                                        10,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        12
+                                        ],
+                                        11,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        13
+                                        ],
+                                        12,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        15
+                                        ],
+                                        13,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        11
+                                        ],
+                                        14,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        13
+                                        ]
+                                    ],
+                                    true,
+                                    true
+                        ]
                     }
                 ];
                 debugger;

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -661,6 +661,169 @@ test('filter', t => {
                 t.end();
             });
 
+            t.test('it collapses dynamic step expressions to any expressions', (t) => {
+                const testCases = [
+                    {
+                        dynamic: [
+                                    "all",
+                                    [
+                                        "<=",
+                                        ["get", "filterrank"],
+                                        3
+                                    ],
+                                    [
+                                        "match",
+                                        ["get", "class"],
+                                        "settlement",
+                                        [
+                                        "match",
+                                        ["get", "worldview"],
+                                        ["all", "US"],
+                                        true,
+                                        false
+                                        ],
+                                        "disputed_settlement",
+                                        [
+                                        "all",
+                                        [
+                                            "==",
+                                            ["get", "disputed"],
+                                            "true"
+                                        ],
+                                        [
+                                            "match",
+                                            ["get", "worldview"],
+                                            ["all", "US"],
+                                            true,
+                                            false
+                                        ]
+                                        ],
+                                        false
+                                    ],
+                                    [
+                                        "step",
+                                        ["pitch"],
+                                        true,
+                                        10,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        10
+                                        ],
+                                        20,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        20
+                                        ],
+                                        30,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        30
+                                        ],
+                                        40,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        40
+                                        ],
+                                        50,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        50
+                                        ],
+                                        60,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        60
+                                        ]
+                                    ]
+                        ],
+                        static: [
+                                    "all",
+                                    [
+                                        "<=",
+                                        ["get", "filterrank"],
+                                        3
+                                    ],
+                                    [
+                                        "match",
+                                        ["get", "class"],
+                                        "settlement",
+                                        [
+                                        "match",
+                                        ["get", "worldview"],
+                                        ["all", "US"],
+                                        true,
+                                        false
+                                        ],
+                                        "disputed_settlement",
+                                        [
+                                        "all",
+                                        [
+                                            "==",
+                                            ["get", "disputed"],
+                                            "true"
+                                        ],
+                                        [
+                                            "match",
+                                            ["get", "worldview"],
+                                            ["all", "US"],
+                                            true,
+                                            false
+                                        ]
+                                        ],
+                                        false
+                                    ],
+                                    [
+                                        "any",
+                                        true,
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        10
+                                        ],
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        20
+                                        ],
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        30
+                                        ],
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        40
+                                        ],
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        50
+                                        ],
+                                        [
+                                        ">=",
+                                        ["get", "symbolrank"],
+                                        60
+                                        ]
+                                    ]
+                        ]
+                    }
+                ];
+
+                for (const testCase of testCases) {
+                    t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
+                }
+
+                t.end();
+
+            });
+
             t.test('it collapses dynamic conditionals to true', (t) => {
                 const testCases = [
                     {
@@ -846,7 +1009,6 @@ test('filter', t => {
                         ]
                     }
                 ];
-                debugger;
                 for (const testCase of testCases) {
                     t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
                 }

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -661,6 +661,27 @@ test('filter', t => {
                 t.end();
             });
 
+            t.test('it collapses dynamic conditionals to true', (t) => {
+                const testCases = [
+                    {
+                        dynamic: ["<", ["pitch"], 60],
+                        static: true
+                    },
+                    {
+                        dynamic: ["all", ["<", ["pitch"], 60], ["<", ["distance-from-center"], 4]],
+                        static: ["all", true, true]
+                    }
+                ];
+                debugger;
+                for (const testCase of testCases) {
+                    t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
+                }
+
+                t.end();
+            });
+
+
+
             t.end();
         });
 

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -92,7 +92,179 @@ test('filter', t => {
 
     t.test('dynamic filters', (t) => {
 
+        const DYNAMIC_FILTERS = [
+            ["case",
+                ["<", ["pitch"], 60], true,
+                ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], true,
+                false
+            ],
+            ["case",
+                ["<", ["pitch"], 60], ["<", ["get", "filter_rank"], 2],
+                [">", ["get", "filter_rank"], 4],
+            ],
+            ["all", ["<", ["get", "filter_rank"], 2 ], [ "<" ,["pitch"], 60]],
+            ["any", ["<", ["get", "filter_rank"], 2 ], [ "<" ,["pitch"], 60]],
+            ["<" ,["pitch"], 60]
+        ];
+
+        const STATIC_FILTERS = [
+            ["match",
+                ["get", "class"],
+                "country",
+                [
+                    "match",
+                    ["get", "worldview"],
+                    ["all", "US"],
+                    true,
+                    false
+                ],
+                "disputed_country",
+                [
+                    "all",
+                    [
+                    "==",
+                    ["get", "disputed"],
+                    "true"
+                    ],
+                    [
+                    "match",
+                    ["get", "worldview"],
+                    ["all", "US"],
+                    true,
+                    false
+                    ]
+                ],
+                false
+            ],
+            ["all",
+                [
+                    "<=",
+                    ["get", "filterrank"],
+                    3
+                ],
+                [
+                    "match",
+                    ["get", "class"],
+                    "settlement",
+                    [
+                    "match",
+                    ["get", "worldview"],
+                    ["all", "US"],
+                    true,
+                    false
+                    ],
+                    "disputed_settlement",
+                    [
+                    "all",
+                    [
+                        "==",
+                        ["get", "disputed"],
+                        "true"
+                    ],
+                    [
+                        "match",
+                        ["get", "worldview"],
+                        ["all", "US"],
+                        true,
+                        false
+                    ]
+                    ],
+                    false
+                ],
+                [
+                    "step",
+                    ["zoom"],
+                    false,
+                    8,
+                    [
+                    "<",
+                    ["get", "symbolrank"],
+                    11
+                    ],
+                    10,
+                    [
+                    "<",
+                    ["get", "symbolrank"],
+                    12
+                    ],
+                    11,
+                    [
+                    "<",
+                    ["get", "symbolrank"],
+                    13
+                    ],
+                    12,
+                    [
+                    "<",
+                    ["get", "symbolrank"],
+                    15
+                    ],
+                    13,
+                    [
+                    ">=",
+                    ["get", "symbolrank"],
+                    11
+                    ],
+                    14,
+                    [
+                    ">=",
+                    ["get", "symbolrank"],
+                    13
+                    ]
+                ]
+            ],
+            ["all",
+                [
+                    "match",
+                    ["get", "class"],
+                    "settlement_subdivision",
+                    [
+                    "match",
+                    ["get", "worldview"],
+                    ["all", "US"],
+                    true,
+                    false
+                    ],
+                    "disputed_settlement_subdivision",
+                    [
+                    "all",
+                    [
+                        "==",
+                        ["get", "disputed"],
+                        "true"
+                    ],
+                    [
+                        "match",
+                        ["get", "worldview"],
+                        ["all", "US"],
+                        true,
+                        false
+                    ]
+                    ],
+                    false
+                ],
+                [
+                    "<=",
+                    ["get", "filterrank"],
+                    4
+                ]
+            ]
+        ]
+
         t.test('isDynamicFilter', (t) => {
+            t.test('true', (t) => {
+                for(const filter of DYNAMIC_FILTERS) {
+                    t.ok(isDynamicFilter(filter), `Filter ${JSON.stringify(filter, null, 2)} should be classified as dynamic.`);
+                }
+                t.end();
+            });
+
+            t.test('false', (t) => {
+                for(const filter of STATIC_FILTERS) {
+                    t.notOk(isDynamicFilter(filter), `Filter ${JSON.stringify(filter, null, 2)} should be classified as static.`);
+                }
+                t.end();
+            });
 
 
             t.end();

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -396,6 +396,162 @@ test('filter', t => {
                             false
                         ],
                         static: ["any", ["<", ["get", "filter_rank"], 2], [">", ["get", "filter_rank"], 4], false]
+                    },
+                    {
+                        dynamic: ["case",
+                            ["<", ["pitch"], 60], ["<", ["get", "filter_rank"], 2],
+                            ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], [">", ["get", "filter_rank"], 4],
+                            ["any", ["==", ["get", "filter_rank"], 2], ["==", ["get", "filter_rank"], 3]]
+                        ],
+                        static: ["any",
+                            ["<", ["get", "filter_rank"], 2],
+                            [">", ["get", "filter_rank"], 4],
+                            ["any", ["==", ["get", "filter_rank"], 2], ["==", ["get", "filter_rank"], 3]]
+                        ]
+                    },
+                    {
+                        dynamic: ["all",
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement_subdivision",
+                                [
+                                "match",
+                                ["get", "worldview"],
+                                ["all", "US"],
+                                true,
+                                false
+                                ],
+                                "disputed_settlement_subdivision",
+                                [
+                                "all",
+                                [
+                                    "==",
+                                    ["get", "disputed"],
+                                    "true"
+                                ],
+                                [
+                                    "case",
+                                    ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
+                                    ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
+                                    ["==", ["get", "worldview"], "INTL"]
+                                ]
+                                ],
+                                false
+                            ],
+                            [
+                                "<=",
+                                ["get", "filterrank"],
+                                4
+                            ]
+                        ],
+                        static: ["all",
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement_subdivision",
+                                [
+                                "match",
+                                ["get", "worldview"],
+                                ["all", "US"],
+                                true,
+                                false
+                                ],
+                                "disputed_settlement_subdivision",
+                                [
+                                "all",
+                                [
+                                    "==",
+                                    ["get", "disputed"],
+                                    "true"
+                                ],
+                                [
+                                    "any",
+                                    ["==", ["get", "worldview"], "US"],
+                                    ["==", ["get", "worldview"], "IND"],
+                                    ["==", ["get", "worldview"], "INTL"]
+                                ]
+                                ],
+                                false
+                            ],
+                            [
+                                "<=",
+                                ["get", "filterrank"],
+                                4
+                            ]
+                        ]
+                    },
+                    {
+                        dynamic: ["all",
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement_subdivision",
+                                [
+                                "match",
+                                ["get", "worldview"],
+                                ["all", "US"],
+                                true,
+                                false
+                                ],
+                                "disputed_settlement_subdivision",
+                                [
+                                "all",
+                                [
+                                    "==",
+                                    ["get", "disputed"],
+                                    "true"
+                                ],
+                                [
+                                    "case",
+                                    ["<", ["pitch"], 60], ["==", ["get", "worldview"], "US"],
+                                    ["all", [">=", ["pitch"], 60], ["<", ["distance-from-center"], 2]], ["==", ["get", "worldview"], "IND"],
+                                    ["==", ["get", "worldview"], "INTL"]
+                                ]
+                                ],
+                                false
+                            ],
+                            [
+                                "case",
+                                ["<", ["pitch"], 60], ["<", ["get", "filterrank"], 4],
+                                [">=", ["get", "filterrank"], 5]
+                            ]
+                        ],
+                        static: ["all",
+                            [
+                                "match",
+                                ["get", "class"],
+                                "settlement_subdivision",
+                                [
+                                "match",
+                                ["get", "worldview"],
+                                ["all", "US"],
+                                true,
+                                false
+                                ],
+                                "disputed_settlement_subdivision",
+                                [
+                                "all",
+                                [
+                                    "==",
+                                    ["get", "disputed"],
+                                    "true"
+                                ],
+                                [
+                                    "any",
+                                    ["==", ["get", "worldview"], "US"],
+                                    ["==", ["get", "worldview"], "IND"],
+                                    ["==", ["get", "worldview"], "INTL"]
+                                ]
+                                ],
+                                false
+                            ],
+                            [
+                                "any",
+                                ["<", ["get", "filterrank"], 4],
+                                [">=", ["get", "filterrank"], 5]
+                            ]
+                        ]
                     }
                 ];
 

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -163,7 +163,16 @@ function validSchema(k, t, obj, ref, version, kind) {
             t.ok(ref['property-type'][obj['property-type']], `${k}.expression: property-type: ${obj['property-type']}`);
             t.equal('boolean', typeof expression.interpolated, `${k}.expression.interpolated.required (boolean)`);
             t.equal(true, Array.isArray(expression.parameters), `${k}.expression.parameters array`);
-            if (obj['property-type'] !== 'color-ramp') t.equal(true, expression.parameters.every(k => k === 'zoom' || k === 'feature' || k === 'feature-state'));
+            if (obj['property-type'] !== 'color-ramp'){
+                t.equal(true, expression.parameters.every(k => {
+                    return k === 'zoom' ||
+                        k === 'feature' ||
+                        k === 'feature-state' ||
+                        k === 'pitch' ||
+                        k == 'distance-from-center';
+                    })
+                );
+            }
         }
 
         // schema key required checks

--- a/test/unit/style-spec/spec.test.js
+++ b/test/unit/style-spec/spec.test.js
@@ -163,14 +163,14 @@ function validSchema(k, t, obj, ref, version, kind) {
             t.ok(ref['property-type'][obj['property-type']], `${k}.expression: property-type: ${obj['property-type']}`);
             t.equal('boolean', typeof expression.interpolated, `${k}.expression.interpolated.required (boolean)`);
             t.equal(true, Array.isArray(expression.parameters), `${k}.expression.parameters array`);
-            if (obj['property-type'] !== 'color-ramp'){
+            if (obj['property-type'] !== 'color-ramp') {
                 t.equal(true, expression.parameters.every(k => {
                     return k === 'zoom' ||
                         k === 'feature' ||
                         k === 'feature-state' ||
                         k === 'pitch' ||
-                        k == 'distance-from-center';
-                    })
+                        k === 'distance-from-center';
+                })
                 );
             }
         }


### PR DESCRIPTION
I'm opening this as a separate PR so its easier to review and understand whats going on with the filter splitting.

### Goal

The goal with this is to let the designer define everything in the `filter` itself, and the expression compiler separates out what it it can do upfront in filtering, and what it should do later in the clipping stages.
It does this by transforming the filter expression upfront to ensure that all possible dynamic branches get taken during the filtering stage.

### Current State:

This PR adds a step to the filter expression parsing, wherein, if an expression contains `dynamic` params ( i.e `["pitch"] or `["distance-from-center"]`) it transforms the expression  such that all possible branches of those conditions get considered in the initial `filtering` stage and the clipping decision based on the `dynamic` params can be taken later.

It does this in two phases:

### 1. Unioning all possible `dynamic` branches 

`case`, `match` and `step` expressions can all cause the expression evaluation to do down a specific path. This however cannot be decided upfront if the branching conditions involve `["pitch"]` or `["distance-from-center"]` so it transforms this expression into an `any` expression with all the possible branches as parameters of the any expression

### 2. Replace dynamic compound boolean logic expressions to true

Now the expression should be free of any dynamic branches, but it can still contain compound boolean logic expressions (i.e `all` or `any`) with dynamic parameters in them. For eg 
```
["all",
    ["<", ["get", "filter_rank"], 3],
    ["<", ["distance-from-center"], 2]
]
```
In these cases, it replaces the dynamic boolean (["<", ["distance-from-center"], 2]) with `true`. This lets the static part `["<", ["get", "filter_rank"], 3]` still be evaluated and considered , but lets us decide on the dynamic part later.