### PR TITLE
v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.4.1
+
+### 🐞 Bug fixes
+
+* Fix a bug where Safari didn't properly resize the map when entering full screen mode. [#10905](https://github.com/mapbox/mapbox-gl-js/pull/10905)
+* Remove `engines` field from `package.json` to allow installing `mapbox-gl` with Yarn on Node v12 and earlier. [#10904](https://github.com/mapbox/mapbox-gl-js/issues/10914)
+
 ## 2.4.0
 
 ### ✨ Features and improvements

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",
@@ -9,9 +9,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/mapbox/mapbox-gl-js.git"
-  },
-  "engines": {
-    "node": ">=14.15.4"
   },
   "dependencies": {
     "@mapbox/geojson-rewind": "^0.5.0",

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -486,6 +486,7 @@ class Map extends Camera {
             window.addEventListener('online', this._onWindowOnline, false);
             window.addEventListener('resize', this._onWindowResize, false);
             window.addEventListener('orientationchange', this._onWindowResize, false);
+            window.addEventListener('webkitfullscreenchange', this._onWindowResize, false);
         }
 
         this.handlers = new HandlerManager(this, options);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -3043,6 +3043,7 @@ class Map extends Camera {
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);
             window.removeEventListener('orientationchange', this._onWindowResize, false);
+            window.removeEventListener('webkitfullscreenchange', this._onWindowResize, false);
             window.removeEventListener('online', this._onWindowOnline, false);
         }
 


### PR DESCRIPTION
Closes #10914. Cherry-picks the Safari fullscreen fix and removes  `engines`, bringing v2.4.1 changes to the `v2.4` release branch for release and showing what the changes are specifically.