### PR TITLE
Changed animation duration from 0 to 100ms for reduced motion

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1124,7 +1124,9 @@ class Camera extends Evented {
             easing: defaultEasing
         }, options);
 
-        if (options.animate === false || (!options.essential && browser.prefersReducedMotion)) options.duration = 0;
+        if (options.animate === false || (!options.essential && browser.prefersReducedMotion)) {
+            options.duration = 100;
+        }
 
         const tr = this.transform,
             startZoom = this.getZoom(),


### PR DESCRIPTION
Changed animation duration from 0 to 100ms for reduced motion to fix issues in iOS where the map would overreact to pan or zoom swipes.

Bug: on iOS, with reduced motion enabled, when panning or zooming by swiping with your finger(s) (letting go of the screen before the destination is reached) you will sometimes find yourself in a situation where Mapbox panned/zoomed way too much.

For instance, at a relatively high zoom level, you end up from one country in another country. When reduced motion is disabled you would only be able to reach another city at most.

`<changelog>Changed animation duration from 0 to 100ms for reduced motion, to address iOS bugs.</changelog>`
