### PR TITLE
Globe View: Prevent dynamic buffer updates

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -40,6 +40,7 @@ import background from './draw_background.js';
 import debug, {drawDebugPadding, drawDebugQueryGeometry} from './draw_debug.js';
 import custom from './draw_custom.js';
 import sky from './draw_sky.js';
+import {GlobeSharedBuffers} from '../geo/projection/globe.js';
 import {Terrain} from '../terrain/terrain.js';
 import {Debug} from '../util/debug.js';
 
@@ -144,6 +145,7 @@ class Painter {
     debugOverlayTexture: Texture;
     debugOverlayCanvas: HTMLCanvasElement;
     _terrain: ?Terrain;
+    globeSharedBuffers: ?GlobeSharedBuffers;
     tileLoaded: boolean;
     frameCopies: Array<WebGLTexture>;
     loadTimeStamps: Array<number>;
@@ -824,6 +826,9 @@ class Painter {
     destroy() {
         if (this._terrain) {
             this._terrain.destroy();
+        }
+        if (this.globeSharedBuffers) {
+            this.globeSharedBuffers.destroy();
         }
         this.emptyTexture.destroy();
         if (this.debugOverlayTexture) {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -89,6 +89,8 @@ class Tile {
     texture: any;
     fbo: ?Framebuffer;
     demTexture: ?Texture;
+    globeGridBuffer: ?VertexBuffer;
+    globePoleBuffer: ?VertexBuffer;
     refreshedUponExpiration: boolean;
     reloadCallback: any;
     resourceTiming: ?Array<PerformanceResourceTiming>;
@@ -252,6 +254,14 @@ class Tile {
 
         if (this.lineAtlasTexture) {
             this.lineAtlasTexture.destroy();
+        }
+
+        if (this.globeGridBuffer) {
+            this.globeGridBuffer.destroy();
+        }
+
+        if (this.globePoleBuffer) {
+            this.globePoleBuffer.destroy();
         }
 
         Debug.run(() => {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -37,7 +37,6 @@ import browser from '../util/browser.js';
 import DEMData from '../data/dem_data.js';
 import rasterFade from '../render/raster_fade.js';
 import {create as createSource} from '../source/source.js';
-import { GlobeTile } from '../geo/projection/globe.js';
 
 import type Map from '../ui/map.js';
 import type Painter from '../render/painter.js';
@@ -121,7 +120,7 @@ class ProxySourceCache extends SourceCache {
         for (const id in this._tiles) {
             if (!(id in incoming)) {
                 this.freeFBO(id);
-                this._tiles[id].state = 'unloaded';
+                this._tiles[id].unloadVectorData();
                 delete this._tiles[id];
             }
         }
@@ -565,7 +564,7 @@ export class Terrain extends Elevation {
             if (options && options.elevationTileID) {
                 id = options.elevationTileID;
             }
-    
+
             uniforms['u_tile_tl_up'] = tileTransform.upVector(id, 0, 0);
             uniforms['u_tile_tr_up'] = tileTransform.upVector(id, EXTENT, 0);
             uniforms['u_tile_br_up'] = tileTransform.upVector(id, EXTENT, EXTENT);


### PR DESCRIPTION
Prevent updating buffers using GL_DYNAMIC_DRAW which costs about half of the frame time. This change replaces it with a different buffer management scheme to initialize the shared data once and store the tile buffer data per tile (Profiling shows that moving away from this cuts about 17ms of frame time spent and updates the FPS from 30 to 60 as this is the biggest frame drain at the moment).

<img width="1428" alt="Screen Shot 2021-08-17 at 4 17 24 PM" src="https://user-images.githubusercontent.com/7061573/129987074-2c6147b7-ed19-4f90-af9a-a578991a4c7c.png">
