### PR TITLE
Documentation and tests to clarify ['image'] and ['coalesce']

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2959,7 +2959,7 @@
         }
       },
       "image": {
-        "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the `format` expression. If set, the `image` argument will check that the requested image exists in the style and will return either the resolved image name or `null`, depending on whether or not the image is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `image` argument.",
+        "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the `format` expression. A `coalesce` expression containing `image` expressions will evaluate to the first listed image that is currently in the style. the `image` argument will check that the requested image exists in the style and will return either the resolved image name or `null`, depending on whether or not the image is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `image` argument.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -2983,7 +2983,7 @@
         }
       },
       "to-string": {
-        "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a boolean, the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a color, it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
+        "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a boolean, the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a color, it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. If the input is an image, `to-string` returns the image name. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2761,7 +2761,7 @@
         }
       },
       "coalesce": {
-        "doc": "Evaluates each expression in turn until the first valid value is obtained. Invalid values are `null` and images that are unavailable in the style. If all values are invalid, coalesce returns the first value listed.",
+        "doc": "Evaluates each expression in turn until the first valid value is obtained. Invalid values are `null` and [`image`](#types-image) expressions that are unavailable in the style. If all values are invalid, coalesce returns the first value listed.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2959,7 +2959,7 @@
         }
       },
       "image": {
-        "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the `format` expression. A `coalesce` expression containing `image` expressions will evaluate to the first listed image that is currently in the style. the `image` argument will check that the requested image exists in the style and will return either the resolved image name or `null`, depending on whether or not the image is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `image` argument.",
+        "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the `format` expression. A [`'coalesce'`](#decision-coalesce) expression containing `image` expressions will evaluate to the first listed image that is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `image` argument.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -2983,7 +2983,7 @@
         }
       },
       "to-string": {
-        "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a boolean, the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a color, it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. If the input is an image, `to-string` returns the image name. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
+        "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a [boolean](#types-boolean), the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a [`'color'`](#types-color), it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. If the input is an [`'image'`](#types-image), `to-string` returns the image name. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2761,7 +2761,7 @@
         }
       },
       "coalesce": {
-        "doc": "Evaluates each expression in turn until the first valid value is obtained. Invalid values are `null` and [`'image'`](#types-image) expressions that are unavailable in the style. If all values are invalid, coalesce returns the first value listed.",
+        "doc": "Evaluates each expression in turn until the first valid value is obtained. Invalid values are `null` and [`'image'`](#types-image) expressions that are unavailable in the style. If all values are invalid, `coalesce` returns the first value listed.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2959,7 +2959,7 @@
         }
       },
       "image": {
-        "doc": "Returns a [`ResolvedImage`](../types/#resolvedimage) for use in [`icon-image`](../layers/#layout-symbol-icon-image), `*-pattern` entries and as a section in the [`'format'`](#types-format) expression. A [`'coalesce'`](#coalesce) expression containing `image` expressions will evaluate to the first listed image that is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `'image'` argument.",
+        "doc": "Returns a [`ResolvedImage`](/mapbox-gl-js/style-spec/types/#resolvedimage) for use in [`icon-image`](/mapbox-gl-js/style-spec/layers/#layout-symbol-icon-image), `*-pattern` entries, and as a section in the [`'format'`](#types-format) expression. A [`'coalesce'`](#coalesce) expression containing `image` expressions will evaluate to the first listed image that is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `'image'` argument.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2959,7 +2959,7 @@
         }
       },
       "image": {
-        "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the [`'format'`](#types-format) expression. A [`'coalesce'`](#coalesce) expression containing `image` expressions will evaluate to the first listed image that is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `'image'` argument.",
+        "doc": "Returns a [`ResolvedImage`](../types/#resolvedimage) for use in [`icon-image`](../layers/#layout-symbol-icon-image), `*-pattern` entries and as a section in the [`'format'`](#types-format) expression. A [`'coalesce'`](#coalesce) expression containing `image` expressions will evaluate to the first listed image that is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `'image'` argument.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2761,7 +2761,7 @@
         }
       },
       "coalesce": {
-        "doc": "Evaluates each expression in turn until the first non-null value is obtained, and returns that value.",
+        "doc": "Evaluates each expression in turn until the first valid value is obtained. Invalid values are `null` and images that are unavailable in the style. If all values are invalid, coalesce returns the first value listed.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2761,7 +2761,7 @@
         }
       },
       "coalesce": {
-        "doc": "Evaluates each expression in turn until the first valid value is obtained. Invalid values are `null` and [`image`](#types-image) expressions that are unavailable in the style. If all values are invalid, coalesce returns the first value listed.",
+        "doc": "Evaluates each expression in turn until the first valid value is obtained. Invalid values are `null` and [`'image'`](#types-image) expressions that are unavailable in the style. If all values are invalid, coalesce returns the first value listed.",
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2959,7 +2959,7 @@
         }
       },
       "image": {
-        "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the `format` expression. A [`'coalesce'`](#decision-coalesce) expression containing `image` expressions will evaluate to the first listed image that is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `image` argument.",
+        "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the [`'format'`](#types-format) expression. A [`'coalesce'`](#coalesce) expression containing `image` expressions will evaluate to the first listed image that is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `'image'` argument.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -2983,7 +2983,7 @@
         }
       },
       "to-string": {
-        "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a [boolean](#types-boolean), the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a [`'color'`](#types-color), it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. If the input is an [`'image'`](#types-image), `to-string` returns the image name. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
+        "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a [`boolean`](#types-boolean), the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a [`color`](#color), it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. If the input is an [`'image'`](#types-image) expression, `'to-string'` returns the image name. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.",
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3067,7 +3067,7 @@
         }
       },
       "get": {
-        "doc": "Retrieves a property value from the current feature's properties, or from another object if a second argument is provided. Returns null if the requested property is missing.",
+        "doc": "Retrieves a property value from the current feature's properties, or from another object if a second argument is provided. Returns `null` if the requested property is missing.",
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -3115,7 +3115,7 @@
         }
       },
       "feature-state": {
-        "doc": "Retrieves a property value from the current feature's state. Returns null if the requested property is not present on the feature's state. A feature's state is not part of the GeoJSON or vector tile data, and must be set programmatically on each feature. Features are identified by their `id` attribute, which must be an integer or a string that can be cast to an integer. Note that [\"feature-state\"] can only be used with paint properties that support data-driven styling.",
+        "doc": "Retrieves a property value from the current feature's state. Returns `null` if the requested property is not present on the feature's state. A feature's state is not part of the GeoJSON or vector tile data, and must be set programmatically on each feature. Features are identified by their `id` attribute, which must be an integer or a string that can be cast to an integer. Note that [\"feature-state\"] can only be used with paint properties that support data-driven styling.",
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {

--- a/test/integration/expression-tests/image/basic/test.json
+++ b/test/integration/expression-tests/image/basic/test.json
@@ -7,6 +7,10 @@
     [
         {"availableImages": ["monument-15"]},
         {}
+    ],
+    [
+      {},
+      {}
     ]
   ],
   "expected": {
@@ -17,7 +21,8 @@
       "type": "resolvedImage"
     },
     "outputs": [
-      {"name":"monument-15","available":true}
+      {"name":"monument-15","available":true},
+      {"name":"monument-15","available":false}
     ],
     "serialized": [
       "image",

--- a/test/integration/expression-tests/image/coalesce/compare/test.json
+++ b/test/integration/expression-tests/image/coalesce/compare/test.json
@@ -1,0 +1,40 @@
+{
+  "expression":
+  ["==", "missing",
+    ["to-string", ["coalesce",
+      ["image", "monument-15"],
+      "missing"
+      ]
+    ]
+  ],
+  "propertySpec": {
+    "type": "boolean"
+  },
+  "inputs": [
+    [
+      {"availableImages": ["monument-15"]},
+      {}
+    ],
+    [{}, {}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [
+      false,
+      true
+    ],
+    "serialized":
+      ["==", "missing",
+      ["to-string", ["coalesce",
+        ["image", "monument-15"],
+        "missing"
+        ]
+      ]
+    ]
+  }
+}

--- a/test/integration/expression-tests/image/coalesce/get/test.json
+++ b/test/integration/expression-tests/image/coalesce/get/test.json
@@ -1,0 +1,40 @@
+{
+  "expression":
+  ["==", "missing",
+    ["to-string", ["coalesce",
+      ["image", ["get", "x"]],
+      "missing"
+      ]
+    ]
+  ],
+  "propertySpec": {
+    "type": "boolean"
+  },
+  "inputs": [
+    [
+      {"availableImages": ["monument-15"]},
+      {"properties": {"x": "monument-15"}}
+    ],
+    [{}, {"properties": {"x": "monument-15"}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [
+      false,
+      true
+    ],
+    "serialized":
+    ["==", "missing",
+      ["to-string", ["coalesce",
+        ["image", ["string", ["get", "x"]]],
+        "missing"
+        ]
+      ]
+    ]
+  }
+}

--- a/test/integration/expression-tests/image/coalesce/to-string/test.json
+++ b/test/integration/expression-tests/image/coalesce/to-string/test.json
@@ -1,0 +1,24 @@
+{
+  "expression": ["to-string", ["coalesce", ["image", "foo"], ["image", "bar"], ["image", "monument-15"], "no image found"]],
+  "propertySpec": {
+    "type": "string"
+  },
+  "inputs": [
+    [{"availableImages": ["monument-15"]},{}],
+    [{"availableImages": []},{}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "string"
+    },
+    "outputs": [
+      "monument-15",
+      "no image found"
+
+    ],
+    "serialized": ["to-string", ["coalesce", ["image", "foo"], ["image", "bar"], ["image", "monument-15"], "no image found"]]
+  }
+}

--- a/test/integration/expression-tests/image/coalesce/to-string/test.json
+++ b/test/integration/expression-tests/image/coalesce/to-string/test.json
@@ -17,7 +17,6 @@
     "outputs": [
       "monument-15",
       "no image found"
-
     ],
     "serialized": ["to-string", ["coalesce", ["image", "foo"], ["image", "bar"], ["image", "monument-15"], "no image found"]]
   }

--- a/test/integration/lib/harness.js
+++ b/test/integration/lib/harness.js
@@ -194,7 +194,10 @@ export default function (directory, implementation, options, run) {
         const q = queue(1);
         q.defer(write, out, resultsShell[0]);
         for (const test of tests) {
-            q.defer(write, out, itemTemplate({r: test, hasFailedTests: unsuccessful.length > 0}));
+            const escaped = itemTemplate({r: test, hasFailedTests: unsuccessful.length > 0});
+            // Undo lodash.template's escape characters to correctly render "<" and ">" as html.
+            const fixed = escaped.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+            q.defer(write, out, fixed);
         }
         q.defer(write, out, resultsShell[1]);
         q.await(() => {


### PR DESCRIPTION
Closes #10466

- Clarifications documentation about ['image'] and ['coalesce'] and adding links.
- Adding style tests to ensure that the behavior works as described.
- A change to the style tester to fix broken HTML rendering.
Pairs with [mapbox-gl-js-docs#693](https://github.com/mapbox/mapbox-gl-js-docs/pull/693)

## Launch Checklist

 - [x] write tests for all new functionality
 - [x] manually test the debug page
