### PR TITLE
Supporting multiple layers in map events; unit-tests added

### DIFF
--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -73,18 +73,32 @@ export class MapMouseEvent extends Event {
      */
     lngLat: LngLat;
 
-    /**
+    /**.
      * If a `layerId` was specified when adding the event listener with {@link Map#on}, `features` will be an array of
      * [GeoJSON](http://geojson.org/) [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
      * The array will contain all features from that layer that are rendered at the event's point.
      * The `features` are identical to those returned by {@link Map#queryRenderedFeatures}.
      *
+     *
+     * If [`layerId1`, `layerId2`] were specified when adding the event listener with {@link Map#on}, `features` will be an array of
+     * [GeoJSON](http://geojson.org/) [Feature objects](https://tools.ietf.org/html/rfc7946#section-3.2).
+     * The array will contain all features from these layers that are rendered at the event's point.
+     * The `features` are identical to those returned by {@link Map#queryRenderedFeatures}.
+     *
+     *
      * If no `layerId` was specified when adding the event listener, `features` will be `undefined`.
      * You can get the features at the point with `map.queryRenderedFeatures(e.point)`.
+     *
      *
      * @example
      * // logging features for a specific layer (with `e.features`)
      * map.on('click', 'myLayerId', (e) => {
+     *     console.log(`There are ${e.features.length} features at point ${e.point}`);
+     * });
+     *
+     * @example
+     * // logging features for a specific layer (with `e.features`)
+     * map.on('click', ['layer1', 'layer2'] , (e) => {
      *     console.log(`There are ${e.features.length} features at point ${e.point}`);
      * });
      *

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1022,11 +1022,12 @@ class Map extends Camera {
         return this._rotating || this.handlers && this.handlers.isRotating();
     }
 
-    _createDelegatedListener(type: MapEvent, layerId: any, listener: any) {
+    _createDelegatedListener(type: MapEvent, layers: Array<any>, listener: any) {
         if (type === 'mouseenter' || type === 'mouseover') {
             let mousein = false;
             const mousemove = (e) => {
-                const features = this.getLayer(layerId) ? this.queryRenderedFeatures(e.point, {layers: [layerId]}) : [];
+                const filteredLayers = layers.filter(layerId => this.getLayer(layerId));
+                const features = filteredLayers.length ? this.queryRenderedFeatures(e.point, {layers: filteredLayers}) : [];
                 if (!features.length) {
                     mousein = false;
                 } else if (!mousein) {
@@ -1037,11 +1038,13 @@ class Map extends Camera {
             const mouseout = () => {
                 mousein = false;
             };
-            return {layer: layerId, listener, delegates: {mousemove, mouseout}};
+
+            return {layers, listener, delegates: {mousemove, mouseout}};
         } else if (type === 'mouseleave' || type === 'mouseout') {
             let mousein = false;
             const mousemove = (e) => {
-                const features = this.getLayer(layerId) ? this.queryRenderedFeatures(e.point, {layers: [layerId]}) : [];
+                const filteredLayers = layers.filter(layerId => this.getLayer(layerId));
+                const features = filteredLayers.length ? this.queryRenderedFeatures(e.point, {layers: filteredLayers}) : [];
                 if (features.length) {
                     mousein = true;
                 } else if (mousein) {
@@ -1055,10 +1058,12 @@ class Map extends Camera {
                     listener.call(this, new MapMouseEvent(type, this, e.originalEvent));
                 }
             };
-            return {layer: layerId, listener, delegates: {mousemove, mouseout}};
+
+            return {layers, listener, delegates: {mousemove, mouseout}};
         } else {
             const delegate = (e) => {
-                const features = this.getLayer(layerId) ? this.queryRenderedFeatures(e.point, {layers: [layerId]}) : [];
+                const filteredLayers = layers.filter(layerId => this.getLayer(layerId));
+                const features = filteredLayers.length ? this.queryRenderedFeatures(e.point, {layers: filteredLayers}) : [];
                 if (features.length) {
                     // Here we need to mutate the original event, so that preventDefault works as expected.
                     e.features = features;
@@ -1066,7 +1071,8 @@ class Map extends Camera {
                     delete e.features;
                 }
             };
-            return {layer: layerId, listener, delegates: {[type]: delegate}};
+
+            return {layers, listener, delegates: {[type]: delegate}};
         }
     }
 
@@ -1131,12 +1137,12 @@ class Map extends Camera {
      * | [`sourcedataloading`](#map.event:sourcedataloading)       |                           |
      * | [`styleimagemissing`](#map.event:styleimagemissing)       |                           |
      *
-     * @param {string} layerId (optional) The ID of a style layer. If you provide a `layerId`,
-     * the listener will be triggered only if its location is within a visible feature in this layer,
+     * @param {string | Array<string>} layerIds (optional) The ID(s) of a style layer(s). If you provide a `layerId`,
+     * the listener will be triggered only if its location is within a visible feature in these layers,
      * and the event will have a `features` property containing an array of the matching features.
-     * If you do not provide a `layerId`, the listener will be triggered by a corresponding event
+     * If you do not provide `layerIds`, the listener will be triggered by a corresponding event
      * happening anywhere on the map, and the event will not have a `features` property.
-     * Note that many event types are not compatible with the optional `layerId` parameter.
+     * Note that many event types are not compatible with the optional `layerIds` parameter.
      * @param {Function} listener The function to be called when the event is fired.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
@@ -1169,18 +1175,30 @@ class Map extends Camera {
      *         .setHTML(`Country name: ${e.features[0].properties.name}`)
      *         .addTo(map);
      * });
+     * @example
+     * // Set an event listener that will fire
+     * // when a feature on the countries or background layers of the map is clicked.
+     * map.on('click', ['countries', 'background'], (e) => {
+     *     new mapboxgl.Popup()
+     *         .setLngLat(e.lngLat)
+     *         .setHTML(`Country name: ${e.features[0].properties.name}`)
+     *         .addTo(map);
+     * });
      * @see [Example: Add 3D terrain to a map](https://docs.mapbox.com/mapbox-gl-js/example/add-terrain/)
      * @see [Example: Center the map on a clicked symbol](https://docs.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
      * @see [Example: Create a draggable marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      * @see [Example: Create a hover effect](https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/)
      * @see [Example: Display popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
      */
-    on(type: MapEvent, layerId: any, listener: any) {
+    on(type: MapEvent, layerIds: any, listener: any) {
         if (listener === undefined) {
-            return super.on(type, layerId);
+            return super.on(type, layerIds);
         }
 
-        const delegatedListener = this._createDelegatedListener(type, layerId, listener);
+        if (!Array.isArray(layerIds)) {
+            layerIds = [layerIds];
+        }
+        const delegatedListener = this._createDelegatedListener(type, layerIds, listener);
 
         this._delegatedListeners = this._delegatedListeners || {};
         this._delegatedListeners[type] = this._delegatedListeners[type] || [];
@@ -1203,12 +1221,12 @@ class Map extends Camera {
      * a visible portion of the specified layer from outside that layer or outside the map canvas. `mouseleave`
      * and `mouseout` events are triggered when the cursor leaves a visible portion of the specified layer, or leaves
      * the map canvas.
-     * @param {string} layerId (optional) The ID of a style layer. If you provide a `layerId`,
-     * the listener will be triggered only if its location is within a visible feature in this layer,
+     * @param {string | Array<string>} layerIds (optional) The ID(s) of a style layer(s). If you provide a `layerIds`,
+     * the listener will be triggered only if its location is within a visible feature in these layers,
      * and the event will have a `features` property containing an array of the matching features.
-     * If you do not provide a `layerId`, the listener will be triggered by a corresponding event
+     * If you do not provide a `layerIds`, the listener will be triggered by a corresponding event
      * happening anywhere on the map, and the event will not have a `features` property.
-     * Note that many event types are not compatible with the optional `layerId` parameter.
+     * Note that many event types are not compatible with the optional `layerIds` parameter.
      * @param {Function} listener The function to be called when the event is fired.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
@@ -1222,17 +1240,26 @@ class Map extends Camera {
      * map.once('touchstart', 'my-point-layer', (e) => {
      *     console.log(`The first map touch on the point layer was at: ${e.lnglat}`);
      * });
+     * @example
+     * // Log the coordinates of a user's first map touch
+     * // on specific layers.
+     * map.once('touchstart', ['my-point-layer', 'my-point-layer-2'], (e) => {
+     *     console.log(`The first map touch on the point layer was at: ${e.lnglat}`);
+     * });
      * @see [Example: Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      * @see [Example: Animate the camera around a point with 3D terrain](https://docs.mapbox.com/mapbox-gl-js/example/free-camera-point/)
      * @see [Example: Play map locations as a slideshow](https://docs.mapbox.com/mapbox-gl-js/example/playback-locations/)
      */
-    once(type: MapEvent, layerId: any, listener: any) {
+    once(type: MapEvent, layerIds: any, listener: any) {
 
         if (listener === undefined) {
-            return super.once(type, layerId);
+            return super.once(type, layerIds);
         }
 
-        const delegatedListener = this._createDelegatedListener(type, layerId, listener);
+        if (!Array.isArray(layerIds)) {
+            layerIds = [layerIds];
+        }
+        const delegatedListener = this._createDelegatedListener(type, layerIds, listener);
 
         for (const event in delegatedListener.delegates) {
             this.once((event: any), delegatedListener.delegates[event]);
@@ -1246,7 +1273,7 @@ class Map extends Camera {
      * optionally limited to layer-specific events.
      *
      * @param {string} type The event type previously used to install the listener.
-     * @param {string} layerId (optional) The layer ID previously used to install the listener.
+     * @param {string | Array<string>} layerIds (optional) The layer ID(s) previously used to install the listener.
      * @param {Function} listener The function previously installed as a listener.
      * @returns {Map} Returns itself to allow for method chaining.
      * @example
@@ -1266,16 +1293,33 @@ class Map extends Camera {
      * });
      * @see [Example: Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
-    off(type: MapEvent, layerId: any, listener: any) {
+    off(type: MapEvent, layerIds: any, listener: any) {
         if (listener === undefined) {
-            return super.off(type, layerId);
+            return super.off(type, layerIds);
         }
+
+        if (!Array.isArray(layerIds)) {
+            layerIds = [layerIds];
+        }
+
+        const areLayerArraysEqual = (arr1, arr2) => {
+            if (arr1.length !== arr2.length) return false;
+            const a1Hash = new Set(arr1); // creating a set: o(n)
+            const a2Hash = new Set(arr2); // creating a set: o(n)
+            if (a2Hash.size !== a1Hash.size) return false; // at-least 1 arr has duplicate value(s)
+
+            // comparing values
+            for (let i = 0; i < arr1.length; ++i) {
+                if (!a2Hash.has(arr1[i])) return false;
+            }
+            return true;
+        };
 
         const removeDelegatedListener = (delegatedListeners) => {
             const listeners = delegatedListeners[type];
             for (let i = 0; i < listeners.length; i++) {
                 const delegatedListener = listeners[i];
-                if (delegatedListener.layer === layerId && delegatedListener.listener === listener) {
+                if (delegatedListener.listener === listener && areLayerArraysEqual(delegatedListener.layers, layerIds)) {
                     for (const event in delegatedListener.delegates) {
                         this.off((event: any), delegatedListener.delegates[event]);
                     }

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -657,3 +657,474 @@ test("Map#on click should fire preclick before click", (t) => {
     map.remove();
     t.end();
 });
+
+// omer start
+test('Map#on adds a listener for an event on multiple layers which do not exist', (t) => {
+    const map = createMap(t);
+    const features = [{}];
+
+    t.stub(map, 'getLayer').returns(undefined);
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        t.deepEqual(options, {layers: []});
+        return features;
+    });
+
+    const spy = t.spy();
+
+    map.on('click', ['layer1', 'layer2'], spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.notCalled);
+    t.end();
+});
+
+test('Map#on adds a listener for an event on multiple layers which some do not exist', (t) => {
+    const map = createMap(t);
+    const features = [{}];
+
+    const getLayerCB = t.stub(map, 'getLayer');
+    getLayerCB.onCall(0).returns(undefined);
+    getLayerCB.onCall(1).returns({});
+    getLayerCB.returns({});
+
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        t.deepEqual(options, {layers: ['background']});
+        return features;
+    });
+
+    const spy = t.spy(function (e) {
+        t.equal(this, map);
+        t.equal(e.type, 'click');
+        t.equal(e.features, features);
+    });
+
+    map.on('click', ['layer', 'background'], spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.calledOnce);
+    t.end();
+});
+
+test('Map#on distinguishes distinct event types - multiple layers', (t) => {
+    const map = createMap(t);
+
+    t.stub(map, 'getLayer').returns({});
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        t.deepEqual(options, {layers: ['layer1', 'layer2']});
+        return [{}];
+    });
+
+    const spyDown = t.spy((e) => {
+        t.equal(e.type, 'mousedown');
+    });
+
+    const spyUp = t.spy((e) => {
+        t.equal(e.type, 'mouseup');
+    });
+
+    map.on('mousedown', ['layer1', 'layer2'], spyDown);
+    map.on('mouseup', ['layer1', 'layer2'], spyUp);
+    simulate.click(map.getCanvas());
+
+    t.ok(spyDown.calledOnce);
+    t.ok(spyUp.calledOnce);
+    t.end();
+});
+
+test('Map#on distinguishes distinct multiple layers', (t) => {
+    const map = createMap(t);
+    const featuresA = [{}];
+    const featuresB = [{}];
+
+    t.stub(map, 'getLayer').returns({});
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        return options.layers[0] === 'A' ? featuresA : featuresB;
+    });
+
+    const spyA = t.spy((e) => {
+        t.equal(e.features, featuresA);
+    });
+
+    const spyB = t.spy((e) => {
+        t.equal(e.features, featuresB);
+    });
+
+    map.on('click', ['A', 'A2'], spyA);
+    map.on('click', ['B', 'B2'], spyB);
+    simulate.click(map.getCanvas());
+
+    t.ok(spyA.calledOnce);
+    t.ok(spyB.calledOnce);
+    t.end();
+});
+
+test('Map#off removes a delegated event listener -  multiple layers', (t) => {
+    const map = createMap(t);
+
+    t.stub(map, 'getLayer').returns({});
+    t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+    const spy = t.spy();
+
+    map.on('click', ['layer1', 'layer2'], spy);
+    map.off('click', ['layer2', 'layer1'], spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.notCalled);
+    t.end();
+});
+
+test('Map#off distinguishes distinct event types -  multiple layers', (t) => {
+    const map = createMap(t);
+
+    t.stub(map, 'getLayer').returns({});
+    t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+    const spy = t.spy((e) => {
+        t.equal(e.type, 'mousedown');
+    });
+
+    map.on('mousedown', ['layer1', 'layer2'], spy);
+    map.on('mouseup', ['layer1', 'layer2'], spy);
+    map.off('mouseup', ['layer1', 'layer2'], spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.calledOnce);
+    t.end();
+});
+
+test('Map#off distinguishes distinct layers -  multiple layers', (t) => {
+    const map = createMap(t);
+    const featuresA = [{}];
+
+    t.stub(map, 'getLayer').returns({});
+    t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+        t.deepEqual(options, {layers: ['A', 'B']});
+        return featuresA;
+    });
+
+    const spy = t.spy((e) => {
+        t.equal(e.features, featuresA);
+    });
+
+    map.on('click', ['A', 'B'], spy);
+    map.on('click', ['C', 'D'], spy);
+    map.off('click', ['C', 'D'], spy);
+    simulate.click(map.getCanvas());
+
+    t.ok(spy.calledOnce);
+    t.end();
+});
+
+test('Map#off distinguishes distinct listeners -  multiple layers', (t) => {
+    const map = createMap(t);
+
+    t.stub(map, 'getLayer').returns({});
+    t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+    const spyA = t.spy();
+    const spyB = t.spy();
+
+    map.on('click', ['layer1', 'layer2'], spyA);
+    map.on('click', ['layer1', 'layer2'], spyB);
+    map.off('click', ['layer1', 'layer2'], spyB);
+    simulate.click(map.getCanvas());
+
+    t.ok(spyA.calledOnce);
+    t.ok(spyB.notCalled);
+    t.end();
+});
+
+['mouseenter', 'mouseover'].forEach((event) => {
+    test(`Map#on ${event} does not fire if the specified layer does not exist -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns(null);
+
+        const spy = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.notCalled);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when entering the specified layer -  multiple layers`, (t) => {
+        const map = createMap(t);
+        const features = [{}];
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+            t.deepEqual(options, {layers: ['layer1', 'layer2']});
+            return features;
+        });
+
+        const spy = t.spy(function (e) {
+            t.equal(this, map);
+            t.equal(e.type, event);
+            t.equal(e.target, map);
+            t.equal(e.features, features);
+        });
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#on ${event} does not fire on mousemove within the specified layer -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when reentering the specified layer -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures')
+            .onFirstCall().returns([{}])
+            .onSecondCall().returns([])
+            .onThirdCall().returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledTwice);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when reentering the specified layer after leaving the canvas -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mouseout(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledTwice);
+        t.end();
+    });
+
+    test(`Map#on ${event} distinguishes distinct layers -  multiple layers`, (t) => {
+        const map = createMap(t);
+        const featuresA = [{}];
+        const featuresB = [{}];
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+            return options.layers[0] === 'A' ? featuresA : featuresB;
+        });
+
+        const spyA = t.spy((e) => {
+            t.equal(e.features, featuresA);
+        });
+
+        const spyB = t.spy((e) => {
+            t.equal(e.features, featuresB);
+        });
+
+        map.on(event, ['A', 'A2'], spyA);
+        map.on(event, ['B', 'B2'], spyB);
+
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spyA.calledOnce);
+        t.ok(spyB.calledOnce);
+        t.end();
+    });
+
+    test(`Map#on ${event} distinguishes distinct listeners -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spyA = t.spy();
+        const spyB = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spyA);
+        map.on(event, ['layer1', 'layer2'], spyB);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spyA.calledOnce);
+        t.ok(spyB.calledOnce);
+        t.end();
+    });
+
+    test(`Map#off ${event} removes a delegated event listener -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        map.off(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.notCalled);
+        t.end();
+    });
+
+    test(`Map#off ${event} distinguishes distinct layers -  multiple layers`, (t) => {
+        const map = createMap(t);
+        const featuresA = [{}];
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').callsFake((point, options) => {
+            t.deepEqual(options, {layers: ['A', 'A2']});
+            return featuresA;
+        });
+
+        const spy = t.spy((e) => {
+            t.equal(e.features, featuresA);
+        });
+
+        map.on(event, ['A', 'A2'], spy);
+        map.on(event, ['B', 'B2'], spy);
+        map.off(event, ['B', 'B2'], spy);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#off ${event} distinguishes distinct listeners -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spyA = t.spy();
+        const spyB = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spyA);
+        map.on(event, ['layer1', 'layer2'], spyB);
+        map.off(event, ['layer1', 'layer2'], spyB);
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spyA.calledOnce);
+        t.ok(spyB.notCalled);
+        t.end();
+    });
+});
+
+['mouseleave', 'mouseout'].forEach((event) => {
+    test(`Map#on ${event} does not fire if the specified layer does not exist -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns(null);
+
+        const spy = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.notCalled);
+        t.end();
+    });
+
+    test(`Map#on ${event} does not fire on mousemove when entering or within the specified layer -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.notCalled);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when exiting the specified layer -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures')
+            .onFirstCall().returns([{}])
+            .onSecondCall().returns([]);
+
+        const spy = t.spy(function (e) {
+            t.equal(this, map);
+            t.equal(e.type, event);
+            t.equal(e.features, undefined);
+        });
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#on ${event} fires when exiting the canvas -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures').returns([{}]);
+
+        const spy = t.spy(function (e) {
+            t.equal(this, map);
+            t.equal(e.type, event);
+            t.equal(e.features, undefined);
+        });
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mouseout(map.getCanvas());
+
+        t.ok(spy.calledOnce);
+        t.end();
+    });
+
+    test(`Map#off ${event} removes a delegated event listener -  multiple layers`, (t) => {
+        const map = createMap(t);
+
+        t.stub(map, 'getLayer').returns({});
+        t.stub(map, 'queryRenderedFeatures')
+            .onFirstCall().returns([{}])
+            .onSecondCall().returns([]);
+
+        const spy = t.spy();
+
+        map.on(event, ['layer1', 'layer2'], spy);
+        map.off(event, ['layer1', 'layer2'], spy);
+        simulate.mousemove(map.getCanvas());
+        simulate.mousemove(map.getCanvas());
+        simulate.mouseout(map.getCanvas());
+
+        t.ok(spy.notCalled);
+        t.end();
+    });
+});


### PR DESCRIPTION
 - Briefly describe the changes in this PR
1. src/map.js   `on`,`once`,`off` methods supports getting either a string layerId or an array of layers. `_createDelegatedListener` handles given array, filters and calls `map.queryRenderedFeatures ` accordingly.
2. Unit-test added

 - write tests for all new functionality
Done

 - document any changes to public APIs
Done

 - [ ] post benchmark scores
Failed to run benchmark in windows (tried via cmd, gitbash and powershell):
```
yarn run v1.22.11
$ run-p build-token watch-css watch-dev watch-benchmarks start-server
$ node build/generate-access-token-script.js
$ postcss --watch -o dist/mapbox-gl.css src/css/mapbox-gl.css
$ rollup -c --environment BUILD:dev --watch
$ BENCHMARK_VERSION=${BENCHMARK_VERSION:-"$(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short=7 HEAD)"} rollup -c bench/rollup_config_benchmarks.js -w
$ st --no-cache -H 0.0.0.0 --port 9966 --index index.html .
'BENCHMARK_VERSION' is not recognized as an internal or external command,
operable program or batch file.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
listening at http://0.0.0.0:9966
ERROR: "watch-benchmarks" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

 - [ ] manually test the debug page
Done


 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
