### PR TITLE
Add `protected` field to API supported validation

### DIFF
--- a/src/style-spec/validate_mapbox_api_supported.js
+++ b/src/style-spec/validate_mapbox_api_supported.js
@@ -106,7 +106,8 @@ function getRootErrors(style: Object, specKeys: Array<any>): Array<?ValidationEr
         'draft',
         'created',
         'modified',
-        'visibility'
+        'visibility',
+        'protected'
     ];
 
     const allowedKeyErrors = getAllowedKeyErrors(style, [...specKeys, ...optionalRootProperties]);
@@ -145,6 +146,10 @@ function getRootErrors(style: Object, specKeys: Array<any>): Array<?ValidationEr
     const visibilityPattern = /^(public|private)$/;
     if (!isValid(style.visibility, visibilityPattern)) {
         errors.push(new ValidationError('visibility', style.visibility, 'Style visibility must be public or private'));
+    }
+
+    if (style.protected !== undefined && getType(style.protected) !== 'boolean') {
+        errors.push(new ValidationError('protected', style.protected, 'Style protection must be true or false'));
     }
 
     return errors;

--- a/test/unit/style-spec/fixture/style-api.input.json
+++ b/test/unit/style-spec/fixture/style-api.input.json
@@ -56,5 +56,6 @@
     "owner": "Cyrus",
     "visibility": "private",
     "cacheControl": "s-max-age=200",
-    "draft": true
+    "draft": true,
+    "protected": true
 }


### PR DESCRIPTION
## Launch Checklist

This PR adds `protected` validation to mapbox-api-supported. Will make sure it's either not defined or a boolean.

cc: @mapbox/map-design-team

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
