### PR TITLE
correct zoom, bearing and shear for projections

### DIFF
--- a/src/geo/projection/adjustments.js
+++ b/src/geo/projection/adjustments.js
@@ -67,8 +67,7 @@ function getShearAdjustment(projection, zoom, loc, interpT) {
     const pdx = p2.x - p1.x;
     const pdy = p2.y - p1.y;
 
-    const angleAdjust = - Math.atan(pdy / pdx) / Math.PI * 180;
-
+    const angleAdjust = -Math.atan(pdy / pdx) / Math.PI * 180;
 
     const mc3 = MercatorCoordinate.fromLngLat(loc);
     const offset = 1 / 40000;
@@ -86,7 +85,6 @@ function getShearAdjustment(projection, zoom, loc, interpT) {
     const pdx4 = p4.x - p1.x;
     const pdy4 = p4.y - p1.y;
     const delta4 = rotate(pdx4, pdy4, angleAdjust);
-
 
     const scale = Math.abs(delta3.x) / Math.abs(delta4.y);
 

--- a/src/geo/projection/adjustments.js
+++ b/src/geo/projection/adjustments.js
@@ -1,0 +1,103 @@
+// @flow
+
+import LngLat from '../lng_lat.js';
+import MercatorCoordinate from '../mercator_coordinate.js';
+import {mat4} from 'gl-matrix';
+import type {Projection} from './index.js';
+
+export default function getProjectionAdjustments(projection: Projection, zoom: number, center: LngLat) {
+
+    const width = 1024;
+    const adjust = Math.log(width / 1024) / Math.LN2;
+    const zoomA = 4 + adjust;
+    const zoomB = 7 + adjust;
+    const t = Math.max(0, Math.min(1, (zoom - zoomA) / (zoomB - zoomA)));
+
+    const zoomAdjustment = getZoomAdjustment(projection, center);
+    const zoomAdjustmentOrigin = getZoomAdjustment(projection, LngLat.convert(projection.center));
+    const scaleAdjustment = Math.pow(2, zoomAdjustment * t + (1 - t) * zoomAdjustmentOrigin);
+
+    return {
+        shear: getShearAdjustment(projection, zoom, center, t),
+        scale: scaleAdjustment
+    };
+}
+
+/*
+ * Calculates the scale difference between Mercator and the given projection at a certain location.
+ */
+function getZoomAdjustment(projection: Projection, loc: LngLat) {
+    const loc2 = new LngLat(loc.lng + 360 / 40000, loc.lat);
+    const p1 = projection.project(loc.lng, loc.lat);
+    const p2 = projection.project(loc2.lng, loc2.lat);
+
+    const m1 = MercatorCoordinate.fromLngLat(loc);
+    const m2 = MercatorCoordinate.fromLngLat(loc2);
+
+    const pdx = p2.x - p1.x;
+    const pdy = p2.y - p1.y;
+    const mdx = m2.x - m1.x;
+    const mdy = m2.y - m1.y;
+
+    const scale = Math.sqrt((mdx * mdx + mdy * mdy) / (pdx * pdx + pdy * pdy));
+
+    return Math.log(scale) / Math.LN2;
+}
+
+function getShearAdjustment(projection, zoom, loc, interpT) {
+
+    const loc2 = new LngLat(loc.lng + 360 / 40000, loc.lat);
+
+    const p1 = projection.project(loc.lng, loc.lat);
+    const p2 = projection.project(loc2.lng, loc2.lat);
+
+    const pdx = p2.x - p1.x;
+    const pdy = p2.y - p1.y;
+
+    const angleAdjust = - Math.atan(pdy / pdx) / Math.PI * 180;
+
+
+    const mc3 = MercatorCoordinate.fromLngLat(loc);
+    const offset = 1 / 40000;
+    mc3.x += offset;
+    const loc3 = mc3.toLngLat();
+    const p3 = projection.project(loc3.lng, loc3.lat);
+    const pdx3 = p3.x - p1.x;
+    const pdy3 = p3.y - p1.y;
+    const delta3 = rotate(pdx3, pdy3, angleAdjust);
+
+    const mc4 = MercatorCoordinate.fromLngLat(loc);
+    mc4.y += offset;
+    const loc4 = mc4.toLngLat();
+    const p4 = projection.project(loc4.lng, loc4.lat);
+    const pdx4 = p4.x - p1.x;
+    const pdy4 = p4.y - p1.y;
+    const delta4 = rotate(pdx4, pdy4, angleAdjust);
+
+
+    const scale = Math.abs(delta3.x) / Math.abs(delta4.y);
+
+    const unrotate = mat4.identity([]);
+    mat4.rotateZ(unrotate, unrotate, -angleAdjust / 180 * Math.PI * (1 - interpT));
+
+    // unskew
+    const shear = mat4.identity([]);
+    mat4.scale(shear, shear, [1, 1 - (1 - scale) * interpT, 1]);
+    shear[4] = -delta4.x / delta4.y * interpT;
+
+    // unrotate
+    mat4.rotateZ(shear, shear, angleAdjust / 180 * Math.PI);
+
+    mat4.multiply(shear, unrotate, shear);
+
+    return shear;
+}
+
+function rotate(x, y, angle) {
+    const cos = Math.cos(angle / 180 * Math.PI);
+    const sin = Math.sin(angle / 180 * Math.PI);
+    return {
+        x: x * cos - y * sin,
+        y: x * sin + y * cos
+    };
+}

--- a/src/geo/projection/adjustments.js
+++ b/src/geo/projection/adjustments.js
@@ -59,6 +59,7 @@ function getZoomAdjustment(projection: Projection, loc: LngLat) {
 
 function getShearAdjustment(projection, zoom, loc, interpT) {
 
+    // create a location a tiny amount (~1km) east of the given location
     const loc2 = new LngLat(loc.lng + 360 / 40000, loc.lat);
 
     const p1 = projection.project(loc.lng, loc.lat);
@@ -67,8 +68,17 @@ function getShearAdjustment(projection, zoom, loc, interpT) {
     const pdx = p2.x - p1.x;
     const pdy = p2.y - p1.y;
 
+    // Calculate how much the map would need to be rotated to make east-west in
+    // projected coordinates be left-right
     const angleAdjust = -Math.atan(pdy / pdx) / Math.PI * 180;
 
+    // Find the projected coordinates of two locations, one slightly north and one slightly east.
+    // Then calculate the transform that would make the projected coordinates of the two locations be:
+    // - equal distances from the original location
+    // - perpendicular to one another
+    //
+    // Only the position of the coordinate to the north is adjusted.
+    // The coordinate to the east stays where it is.
     const mc3 = MercatorCoordinate.fromLngLat(loc);
     const offset = 1 / 40000;
     mc3.x += offset;

--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -3,7 +3,7 @@ import LngLat from '../lng_lat.js';
 
 export const albers = {
     name: 'albers',
-    range: [3.5, 7],
+    range: [4, 7],
 
     center: [-96, 37.5],
     parallels: [29.5, 45.5],
@@ -42,7 +42,7 @@ export const albers = {
 export const alaska = {
     ...albers,
     name: 'alaska',
-    range: [4, 7],
+    range: [4.5, 7],
     center: [-154, 50],
     parallels: [55, 65]
 };

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -266,25 +266,12 @@ class Transform {
         return new Point(this.width, this.height);
     }
 
-    // calculates the angle between a vector pointing north in
-    // Mercator and a vector pointing north in the projection
-    // and converts the angle from radians to degrees
-    _getBearingOffset(lngLat?: LngLat): number {
-        if (this.projection.name === 'mercator') return 0;
-        const {lng, lat} = lngLat || this.center;
-        const north = {lng, lat: lat + 0.0001};
-        const projectedCenter = this.projection.project(lng, lat);
-        const projectedNorth = this.projection.project(north.lng, north.lat);
-        const northVector = {x: projectedNorth.x - projectedCenter.x, y: projectedNorth.y - projectedCenter.y};
-        return (Math.atan2(northVector.x, northVector.y) * 180 / Math.PI) + 180;
-    }
-
     get bearing(): number {
-        return wrap(this._getBearingOffset() + this.rotation, -180, 180);
+        return wrap(this.rotation, -180, 180);
     }
 
     set bearing(bearing: number) {
-        this.rotation = bearing - this._getBearingOffset();
+        this.rotation = bearing;
     }
 
     get rotation(): number {
@@ -1573,7 +1560,7 @@ class Transform {
         // seems to solve z-fighting issues in deckgl while not clipping buildings too close to the camera.
         const nearZ = this.height / 50;
 
-        const worldToCamera = this._camera.getWorldToCamera(this.worldSize, pixelsPerMeter);
+        const worldToCamera = this._camera.getWorldToCamera(this.worldSize, pixelsPerMeter, this);
         const cameraToClip = this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, nearZ, farZ);
 
         // Apply center of perspective offset

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -283,12 +283,9 @@ class FreeCamera {
         mat4.fromQuat(matrix, invOrientation);
 
 
-        const adjustments = getProjectionAdjustments(transform.projection, transform.zoom, transform.center);
+        const adjustments = getProjectionAdjustments(transform);
 
-        mat4.multiply(matrix, matrix, adjustments.shear);
-
-        const sa = adjustments.scale;
-        mat4.scale(matrix, matrix, [sa, sa, 1]);
+        mat4.multiply(matrix, matrix, adjustments);
 
         mat4.translate(matrix, matrix, invPosition);
 

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -282,9 +282,7 @@ class FreeCamera {
 
         mat4.fromQuat(matrix, invOrientation);
 
-
         const adjustments = getProjectionAdjustments(transform);
-
         mat4.multiply(matrix, matrix, adjustments);
 
         mat4.translate(matrix, matrix, invPosition);


### PR DESCRIPTION
fix #10715

Corrects scale, bearing and shear for projections. It does this by applying corrections to the worldToCamera matrix. 

Corrections are applied gradually as you zoom based on a hardcoded zoom range. My attempts to automatically derive a good range from each projection didn't work out. The range needs to consider both the amount of distortion at that zoom and how the change feels while zooming. The latter is somewhat subjective.

There is no external configuration for this. Each projection has it's own hardcoded settings.