### PR TITLE
Mark precision of pack_depth function

### DIFF
--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -31,11 +31,11 @@ vec3 dither(vec3 color, highp vec2 seed) {
 
 // Pack depth to RGBA. A piece of code copied in various libraries and WebGL
 // shadow mapping examples.
-vec4 pack_depth(float ndc_z) {
-    float depth = ndc_z * 0.5 + 0.5;
-    const vec4 bit_shift = vec4(256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0);
-    const vec4 bit_mask  = vec4(0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);
-    vec4 res = fract(depth * bit_shift);
+highp vec4 pack_depth(highp float ndc_z) {
+    highp float depth = ndc_z * 0.5 + 0.5;
+    const highp vec4 bit_shift = vec4(256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0);
+    const highp vec4 bit_mask  = vec4(0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);
+    highp vec4 res = fract(depth * bit_shift);
     res -= res.xxyz * bit_mask;
     return res;
 }


### PR DESCRIPTION
This small PR fixes an issue on the gl-native side when we use OpenGL ES, as we need to call the `pack_depth` function using a high precision float.