### PR TITLE
Use adaptive resampling with MARTINI & Earcut for non-Mercator tiles

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -20,13 +20,11 @@
 
 var map = window.map = new mapboxgl.Map({
     container: 'map',
-    zoom: 3,
-    center: [-100, 40],
+    zoom: 12.5,
+    center: [-122.4194, 37.7749],
     style: 'mapbox://styles/mapbox/streets-v11',
-    // projection: 'winkel'
+    hash: true
 });
-
-map.showTileBoundaries = true;
 
 </script>
 </body>

--- a/debug/index.html
+++ b/debug/index.html
@@ -20,11 +20,13 @@
 
 var map = window.map = new mapboxgl.Map({
     container: 'map',
-    zoom: 12.5,
-    center: [-122.4194, 37.7749],
-    style: 'mapbox://styles/mapbox/streets-v10',
-    hash: true
+    zoom: 3,
+    center: [-100, 40],
+    style: 'mapbox://styles/mapbox/streets-v11',
+    // projection: 'winkel'
 });
+
+map.showTileBoundaries = true;
 
 </script>
 </body>

--- a/src/render/draw_debug.js
+++ b/src/render/draw_debug.js
@@ -136,9 +136,13 @@ function drawDebugTile(painter, sourceCache, coord: OverscaledTileID) {
     // Bind the empty texture for drawing outlines
     painter.emptyTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
 
+    const debugBuffer = tile._tileDebugBuffer || painter.debugBuffer;
+    const debugIndexBuffer = tile._tileDebugIndexBuffer || painter.debugIndexBuffer;
+    const debugSegments = tile._tileDebugSegments || painter.debugSegments;
+
     program.draw(context, gl.LINE_STRIP, depthMode, stencilMode, colorMode, CullFaceMode.disabled,
         debugUniformValues(posMatrix, Color.red), id,
-        tile._tileDebugBoundsBuffer, painter.tileDebugIndexBuffer, painter.tileDebugSegments);
+        debugBuffer, debugIndexBuffer, debugSegments);
 
     const tileRawData = tile.latestRawTileData;
     const tileByteLength = (tileRawData && tileRawData.byteLength) || 0;

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -738,7 +738,7 @@ class SourceCache extends Evented {
         const cached = Boolean(tile);
         if (!cached) {
             const painter = this.map ? this.map.painter : null;
-            tile = new Tile(tileID, this._source.tileSize * tileID.overscaleFactor(), this.transform.tileZoom, painter);
+            tile = new Tile(tileID, this._source.tileSize * tileID.overscaleFactor(), this.transform.tileZoom, painter, this._source.type === 'raster');
             this._loadTile(tile, this._tileLoaded.bind(this, tile, tileID.key, tile.state));
         }
 

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -1,12 +1,12 @@
 // @flow
 
-import {uniqueId, parseCacheControl, NUM_OF_SEGMENTS} from '../util/util.js';
+import {uniqueId, parseCacheControl} from '../util/util.js';
 import {deserialize as deserializeBucket} from '../data/bucket.js';
 import FeatureIndex from '../data/feature_index.js';
 import GeoJSONFeature from '../util/vectortile_to_geojson.js';
 import featureFilter from '../style-spec/feature_filter/index.js';
 import SymbolBucket from '../data/bucket/symbol_bucket.js';
-import {CollisionBoxArray, TileBoundsArray, PosArray, TriangleIndexArray} from '../data/array_types.js';
+import {CollisionBoxArray, TileBoundsArray, PosArray, TriangleIndexArray, LineStripIndexArray} from '../data/array_types.js';
 import Texture from '../render/texture.js';
 import browser from '../util/browser.js';
 import {Debug} from '../util/debug.js';
@@ -16,11 +16,13 @@ import SourceFeatureState from '../source/source_state.js';
 import {lazyLoadRTLTextPlugin} from './rtl_text_plugin.js';
 import {TileSpaceDebugBuffer} from '../data/debug_viz.js';
 import Color from '../style-spec/util/color.js';
+import loadGeometry, {setProjection} from '../data/load_geometry.js';
+import earcut from 'earcut';
 
 import boundsAttributes from '../data/bounds_attributes.js';
 import EXTENT from '../data/extent.js';
-import MercatorCoordinate from '../geo/mercator_coordinate.js';
-import tileTransform from '../geo/projection/tile_transform.js';
+import Point from '@mapbox/point-geometry';
+import SegmentVector from '../data/segment.js';
 
 const CLOCK_SKEW_RETRY_TIMEOUT = 30000;
 
@@ -53,6 +55,20 @@ export type TileState =
     | 'errored'   // Tile data was not loaded because of an error.
     | 'expired';  /* Tile data was previously loaded, but has expired per its
                    * HTTP headers and is in the process of refreshing. */
+
+// a tile bounds outline used for getting reprojected tile geometry in non-mercator projections
+const BOUNDS_FEATURE = (() => {
+    const c0 = new Point(0, 0);
+    const c1 = new Point(EXTENT, 0);
+    const c2 = new Point(EXTENT, EXTENT);
+    const c3 = new Point(0, EXTENT);
+    const coords = [[c0, c1, c2, c3, c0]];
+    return {
+        type: 2,
+        extent: EXTENT,
+        loadGeometry() { return coords.slice(); }
+    };
+})();
 
 /**
  * A tile object is the combination of a Coordinate, which defines
@@ -110,9 +126,12 @@ class Tile {
     queryGeometryDebugViz: TileSpaceDebugBuffer;
     queryBoundsDebugViz: TileSpaceDebugBuffer;
 
-    _tileDebugBoundsBuffer: VertexBuffer;
+    _tileDebugBuffer: VertexBuffer;
     _tileBoundsBuffer: VertexBuffer;
+    _tileDebugIndexBuffer: IndexBuffer;
     _tileBoundsIndexBuffer: IndexBuffer;
+    _tileDebugSegments: SegmentVector;
+    _tileBoundsSegments: SegmentVector;
 
     /**
      * @param {OverscaledTileID} tileID
@@ -141,8 +160,8 @@ class Tile {
         this.state = 'loading';
 
         if (painter) {
-            const projection = painter && painter.transform && painter.transform.projection;
-            this._makeTileDebugBuffer(painter.context, projection);
+            const {projection, projectionOptions} = painter.transform;
+            setProjection(projectionOptions);
             this._makeTileBoundsBuffers(painter.context, projection);
         }
     }
@@ -531,75 +550,39 @@ class Tile {
         });
     }
 
-    _add(x: number, y: number, denominator: number, projection: Projection) {
-        const s = Math.pow(2, -this.tileID.canonical.z);
-        const x1 = (this.tileID.canonical.x) * s;
-        const y1 = (this.tileID.canonical.y) * s;
-        const cs = tileTransform(this.tileID.canonical, projection);
-        const increment = s / denominator;
-        const x2 = x1 + x * increment;
-        const y2 = y1 + y * increment;
-        const l = new MercatorCoordinate(x2, y2).toLngLat();
-        const xy = ((projection.project(l.lng, l.lat)));
-        const x_ = (xy.x * cs.scale - cs.x) * EXTENT;
-        const y_ = (xy.y * cs.scale - cs.y) * EXTENT;
-        const a = x / denominator * EXTENT;
-        const b = y / denominator * EXTENT;
-        return {x_, y_, a, b};
-    }
-
-    _makeTileDebugBuffer(context: Context, projection: Projection) {
-        if (this._tileDebugBoundsBuffer || !projection) return;
-
-        const debugBoundsArray = new PosArray();
-
-        const add = (x, y) => {
-            const {x_, y_} = this._add(x, y, EXTENT, projection);
-            debugBoundsArray.emplaceBack(x_, y_);
-        };
-
-        const stride = EXTENT / NUM_OF_SEGMENTS;
-        const SIDES = [
-            {start: [0, 0], step: [stride, 0]},
-            {start: [EXTENT, 0], step: [0, stride]},
-            {start: [EXTENT, EXTENT], step: [-stride, 0]},
-            {start: [0, EXTENT], step: [0, -stride]}
-        ];
-
-        for (const {start, step} of SIDES) {
-            for (let i = 0; i < NUM_OF_SEGMENTS; i++) {
-                add(start[0] + (i * step[0]), start[1] + (i * step[1]));
-            }
-        }
-
-        this._tileDebugBoundsBuffer = context.createVertexBuffer(debugBoundsArray, boundsAttributes.members);
-    }
-
     _makeTileBoundsBuffers(context: Context, projection: Projection) {
         if (this._tileBoundsBuffer || !projection || projection.name === 'mercator') return;
 
-        const tileBoundsArray = new TileBoundsArray();
-        const quadTriangleIndices = new TriangleIndexArray();
+        const boundsVertices = new TileBoundsArray();
+        const boundsIndices = new TriangleIndexArray();
 
-        const add = (x, y) => {
-            const {x_, y_, a, b} = this._add(x, y, NUM_OF_SEGMENTS, projection);
-            tileBoundsArray.emplaceBack(x_, y_, a, b);
-        };
+        const debugVertices = new PosArray();
+        const debugIndices = new LineStripIndexArray();
 
-        for (let xi = 0; xi < NUM_OF_SEGMENTS; xi++) {
-            for (let yi = 0; yi < NUM_OF_SEGMENTS; yi++) {
-                const offset = tileBoundsArray.length;
-                add(xi, yi);
-                add(xi + 1, yi);
-                add(xi, yi + 1);
-                add(xi + 1, yi + 1);
-                quadTriangleIndices.emplaceBack(offset + 0, offset + 1, offset + 2);
-                quadTriangleIndices.emplaceBack(offset + 2, offset + 1, offset + 3);
-            }
+        const boundsLine = loadGeometry(BOUNDS_FEATURE, this.tileID.canonical)[0];
+        const flattened = [];
+
+        for (let i = 0; i < boundsLine.length; i++) {
+            const {x, y} = boundsLine[i];
+            boundsVertices.emplaceBack(x, y, x, y);
+            debugVertices.emplaceBack(x, y);
+            debugIndices.emplaceBack(i);
+            flattened.push(x, y);
+        }
+        debugIndices.emplaceBack(0);
+
+        const indices = earcut(flattened);
+        for (let i = 0; i < indices.length; i += 3) {
+            boundsIndices.emplaceBack(indices[i], indices[i + 1], indices[i + 2]);
         }
 
-        this._tileBoundsBuffer = context.createVertexBuffer(tileBoundsArray, boundsAttributes.members);
-        this._tileBoundsIndexBuffer = context.createIndexBuffer(quadTriangleIndices);
+        this._tileDebugIndexBuffer = context.createIndexBuffer(debugIndices);
+        this._tileDebugBuffer = context.createVertexBuffer(debugVertices, boundsAttributes.members);
+        this._tileDebugSegments = SegmentVector.simpleSegment(0, 0, debugVertices.length, debugIndices.length);
+
+        this._tileBoundsBuffer = context.createVertexBuffer(boundsVertices, boundsAttributes.members);
+        this._tileBoundsIndexBuffer = context.createIndexBuffer(boundsIndices);
+        this._tileBoundsSegments = SegmentVector.simpleSegment(0, 0, boundsVertices.length, boundsIndices.length);
     }
 }
 

--- a/src/source/tile_mesh.js
+++ b/src/source/tile_mesh.js
@@ -1,0 +1,162 @@
+// @flow
+// logic for generating non-Mercator adaptive raster tile reprojection meshes with MARTINI
+
+import tileTransform from '../geo/projection/tile_transform.js';
+import EXTENT from '../data/extent.js';
+import {lngFromMercatorX, latFromMercatorY} from '../geo/mercator_coordinate.js';
+import {TileBoundsArray, TriangleIndexArray} from '../data/array_types.js';
+
+import type {CanonicalTileID} from './tile_id.js';
+import type {Projection} from '../geo/projection/index.js';
+
+const meshSize = 32;
+const gridSize = meshSize + 1;
+
+const numTriangles = meshSize * meshSize * 2 - 2;
+const numParentTriangles = numTriangles - meshSize * meshSize;
+
+const coords = new Uint16Array(numTriangles * 4);
+
+// precalculate RTIN triangle coordinates
+for (let i = 0; i < numTriangles; i++) {
+    let id = i + 2;
+    let ax = 0, ay = 0, bx = 0, by = 0, cx = 0, cy = 0;
+
+    if (id & 1) {
+        bx = by = cx = meshSize; // bottom-left triangle
+
+    } else {
+        ax = ay = cy = meshSize; // top-right triangle
+    }
+
+    while ((id >>= 1) > 1) {
+        const mx = (ax + bx) >> 1;
+        const my = (ay + by) >> 1;
+
+        if (id & 1) { // left half
+            bx = ax; by = ay;
+            ax = cx; ay = cy;
+
+        } else { // right half
+            ax = bx; ay = by;
+            bx = cx; by = cy;
+        }
+
+        cx = mx; cy = my;
+    }
+
+    const k = i * 4;
+    coords[k + 0] = ax;
+    coords[k + 1] = ay;
+    coords[k + 2] = bx;
+    coords[k + 3] = by;
+}
+
+// temporary arrays we'll reuse for MARTINI mesh code
+const reprojectedCoords = new Uint16Array(gridSize * gridSize * 2);
+const used = new Uint8Array(gridSize * gridSize);
+const indexMap = new Uint16Array(gridSize * gridSize);
+
+type TileMesh = {
+    vertices: TileBoundsArray,
+    indices: TriangleIndexArray
+};
+
+export default function getTileMesh(canonical: CanonicalTileID, projection: Projection): TileMesh {
+    const cs = tileTransform(canonical, projection);
+    const z2 = Math.pow(2, canonical.z);
+
+    for (let y = 0; y < gridSize; y++) {
+        for (let x = 0; x < gridSize; x++) {
+            const lng = lngFromMercatorX((canonical.x + x / meshSize) / z2);
+            const lat = latFromMercatorY((canonical.y + y / meshSize) / z2);
+            const p = projection.project(lng, lat);
+            const k = y * gridSize + x;
+            reprojectedCoords[2 * k + 0] = Math.round((p.x * cs.scale - cs.x) * EXTENT);
+            reprojectedCoords[2 * k + 1] = Math.round((p.y * cs.scale - cs.y) * EXTENT);
+        }
+    }
+
+    used.fill(0);
+    indexMap.fill(0);
+
+    // iterate over all possible triangles, starting from the smallest level
+    for (let i = numTriangles - 1; i >= 0; i--) {
+        const k = i * 4;
+        const ax = coords[k + 0];
+        const ay = coords[k + 1];
+        const bx = coords[k + 2];
+        const by = coords[k + 3];
+        const mx = (ax + bx) >> 1;
+        const my = (ay + by) >> 1;
+        const cx = mx + my - ay;
+        const cy = my + ax - mx;
+
+        const aIndex = ay * gridSize + ax;
+        const bIndex = by * gridSize + bx;
+        const mIndex = my * gridSize + mx;
+
+        // calculate error in the middle of the long edge of the triangle
+        const rax = reprojectedCoords[2 * aIndex + 0];
+        const ray = reprojectedCoords[2 * aIndex + 1];
+        const rbx = reprojectedCoords[2 * bIndex + 0];
+        const rby = reprojectedCoords[2 * bIndex + 1];
+        const rmx = reprojectedCoords[2 * mIndex + 0];
+        const rmy = reprojectedCoords[2 * mIndex + 1];
+
+        // raster tiles are typically 512px, and we use 1px as an error threshold; 8192 / 512 = 16
+        const isUsed = Math.hypot((rax + rbx) / 2 - rmx, (ray + rby) / 2 - rmy) >= 16;
+
+        used[mIndex] = used[mIndex] || (isUsed ? 1 : 0);
+
+        if (i < numParentTriangles) { // bigger triangles; accumulate error with children
+            const leftChildIndex = ((ay + cy) >> 1) * gridSize + ((ax + cx) >> 1);
+            const rightChildIndex = ((by + cy) >> 1) * gridSize + ((bx + cx) >> 1);
+            used[mIndex] = used[mIndex] || used[leftChildIndex] || used[rightChildIndex];
+        }
+    }
+
+    const vertices = new TileBoundsArray();
+    const indices = new TriangleIndexArray();
+
+    let numVertices = 0;
+
+    function addVertex(x, y) {
+        const k = y * gridSize + x;
+
+        if (indexMap[k] === 0) {
+            vertices.emplaceBack(
+                reprojectedCoords[2 * k + 0],
+                reprojectedCoords[2 * k + 1],
+                x * EXTENT / meshSize,
+                y * EXTENT / meshSize);
+
+            // save new vertex index so that we can reuse it
+            indexMap[k] = ++numVertices;
+        }
+
+        return indexMap[k] - 1;
+    }
+
+    function addTriangles(ax, ay, bx, by, cx, cy) {
+        const mx = (ax + bx) >> 1;
+        const my = (ay + by) >> 1;
+
+        if (Math.abs(ax - cx) + Math.abs(ay - cy) > 1 && used[my * gridSize + mx]) {
+            // triangle doesn't approximate the surface well enough; drill down further
+            addTriangles(cx, cy, ax, ay, mx, my);
+            addTriangles(bx, by, cx, cy, mx, my);
+
+        } else {
+            const ai = addVertex(ax, ay);
+            const bi = addVertex(bx, by);
+            const ci = addVertex(cx, cy);
+            indices.emplaceBack(ai, bi, ci);
+        }
+    }
+
+    addTriangles(0, 0, meshSize, meshSize, meshSize, 0);
+    addTriangles(meshSize, meshSize, 0, 0, 0, meshSize);
+
+    return {vertices, indices};
+}

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -11,10 +11,6 @@ import type {Callback} from '../types/callback.js';
 // Number.MAX_SAFE_INTEGER not available in IE
 export const MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
 
-// the number of segments created to reproject tiles from Mercator
-// to another projection
-export const NUM_OF_SEGMENTS = 32;
-
 const DEG_TO_RAD = Math.PI / 180;
 const RAD_TO_DEG = 180 / Math.PI;
 

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -334,7 +334,7 @@ test('SourceCache#removeTile', (t) => {
                 callback();
             }
         });
-        sourceCache.map = {painter: {crossTileSymbolIndex: "", tileExtentVAO: {}, context: {
+        sourceCache.map = {painter: {transform: new Transform(), crossTileSymbolIndex: "", tileExtentVAO: {}, context: {
             createIndexBuffer: () => {},
             createVertexBuffer: () => {}
         }}};


### PR DESCRIPTION
This PR switches out tile bounds meshes for vector tiles from grid-based to adaptively resampled (using the same pathway as for geometry) combined with Earcut triangulation. This seems to completely eliminate stuttering I encountered in the `projections` branch when panning and zooming the map — previously it would spent too much time reprojecting 1k points for each tile (with a subtle bug that actually made it 4k) and making a 2k-triangle mesh, whereas the new code generates ~30–140 vertices/triangles per tile and doesn't show up noticeably in the profiler. 

Additionally, the new bounds are much more precise due to adaptive resampling — points are added on a tile side until there's sub-1px precision for the curve.

It also fixes a rounding issue in reprojection code that apparently caused subtle seams between tiles in certain situations.

**Update:** the PR now adopts MARTINI algorithm for reprojecting raster tiles, generating adaptive RTIN meshes for a good compromise between performance and correct raster reprojection.

### Reprojected vector tile triangulation example

<img width=600 src=https://user-images.githubusercontent.com/25395/131622426-291191ed-321d-45a0-82ab-8f4aef2b347e.png>

### MARTINI raster reprojection mesh example

<img width=600 src=https://user-images.githubusercontent.com/25395/132041759-9932bc46-8c1b-4f72-983e-2f16000c0d18.png>
