### PR TITLE
Globe view to mercator transition

### DIFF
--- a/build/generate-struct-arrays.js
+++ b/build/generate-struct-arrays.js
@@ -175,6 +175,9 @@ createStructArrayType('symbol_instance', symbolInstance, true);
 createStructArrayType('glyph_offset', glyphOffset, true);
 createStructArrayType('symbol_line_vertex', lineVertex, true);
 
+import globeAttributes from '../src/terrain/globe_attributes.js';
+createStructArrayType('globe_vertex', globeAttributes);
+
 // feature index array
 createStructArrayType('feature_index', createLayout([
     // the index of the feature in the original vectortile
@@ -200,13 +203,6 @@ createStructArrayType('line_index', createLayout([
 // line strip index array
 createStructArrayType('line_strip_index', createLayout([
     { type: 'Uint16', name: 'vertices', components: 1 }
-]));
-
-// line strip index array
-createStructArrayType('globe_vertex', createLayout([
-    { type: 'Float32', name: 'a_pos', components: 3 },
-    { type: 'Float32', name: 'a_pos_merc', components: 3 },
-    { type: 'Float32', name: 'a_uv', components: 2 }
 ]));
 
 // skybox vertex array

--- a/build/generate-struct-arrays.js
+++ b/build/generate-struct-arrays.js
@@ -205,6 +205,7 @@ createStructArrayType('line_strip_index', createLayout([
 // line strip index array
 createStructArrayType('globe_vertex', createLayout([
     { type: 'Float32', name: 'a_pos', components: 3 },
+    { type: 'Float32', name: 'a_pos_merc', components: 3 },
     { type: 'Float32', name: 'a_uv', components: 2 }
 ]));
 

--- a/debug/globe-view.html
+++ b/debug/globe-view.html
@@ -26,7 +26,7 @@
     <label><input id='show-overdraw-checkbox' type='checkbox'> overdraw debug</label><br />
     <label><input id='freeze-tile-coverage-checkbox' type='checkbox'> freeze tile coverage </label><br />
     <label><input id='terrain-checkbox' type='checkbox'> terrain</label><br />
-    <label><input id='globe-checkbox' type='checkbox'> globe</label><br />
+    <label><input id='globe-checkbox' type='checkbox' checked> globe</label><br />
     <label><input id='show-terrain-wireframe-checkbox' type='checkbox'> terrain wireframe</label><br />
     <label><input id='satellite-checkbox' type='checkbox'> satellite</label><br />
     <label><input id='buildings-checkbox' type='checkbox'> buildings</label><br />

--- a/debug/globe-view.html
+++ b/debug/globe-view.html
@@ -67,7 +67,7 @@ const r = 255 * 0.75;
 
 let buildingsLayerId = '3d-buildings';
 const hillshadeId = 'mapbox-dem-hillshade';
-
+map.repaint = true;
 map.on('style.load', function() {
     map.addSource('mapbox-dem', {
         "type": "raster-dem",

--- a/debug/globe-view.html
+++ b/debug/globe-view.html
@@ -67,7 +67,7 @@ const r = 255 * 0.75;
 
 let buildingsLayerId = '3d-buildings';
 const hillshadeId = 'mapbox-dem-hillshade';
-map.repaint = true;
+
 map.on('style.load', function() {
     map.addSource('mapbox-dem', {
         "type": "raster-dem",

--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -817,11 +817,11 @@ register('StructArrayLayout1ui2', StructArrayLayout1ui2);
 
 /**
  * Implementation of the StructArray layout:
- * [0]: Float32[5]
+ * [0]: Float32[8]
  *
  * @private
  */
-class StructArrayLayout5f20 extends StructArray {
+class StructArrayLayout8f32 extends StructArray {
     uint8: Uint8Array;
     float32: Float32Array;
 
@@ -830,25 +830,28 @@ class StructArrayLayout5f20 extends StructArray {
         this.float32 = new Float32Array(this.arrayBuffer);
     }
 
-    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number) {
+    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
         const i = this.length;
         this.resize(i + 1);
-        return this.emplace(i, v0, v1, v2, v3, v4);
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
-    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number) {
-        const o4 = i * 5;
+    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
+        const o4 = i * 8;
         this.float32[o4 + 0] = v0;
         this.float32[o4 + 1] = v1;
         this.float32[o4 + 2] = v2;
         this.float32[o4 + 3] = v3;
         this.float32[o4 + 4] = v4;
+        this.float32[o4 + 5] = v5;
+        this.float32[o4 + 6] = v6;
+        this.float32[o4 + 7] = v7;
         return i;
     }
 }
 
-StructArrayLayout5f20.prototype.bytesPerElement = 20;
-register('StructArrayLayout5f20', StructArrayLayout5f20);
+StructArrayLayout8f32.prototype.bytesPerElement = 32;
+register('StructArrayLayout8f32', StructArrayLayout8f32);
 
 /**
  * Implementation of the StructArray layout:
@@ -1227,7 +1230,7 @@ export {
     StructArrayLayout1ul3ui12,
     StructArrayLayout2ui4,
     StructArrayLayout1ui2,
-    StructArrayLayout5f20,
+    StructArrayLayout8f32,
     StructArrayLayout2f8,
     StructArrayLayout4f16,
     StructArrayLayout2i4 as PosArray,
@@ -1251,6 +1254,6 @@ export {
     StructArrayLayout3ui6 as TriangleIndexArray,
     StructArrayLayout2ui4 as LineIndexArray,
     StructArrayLayout1ui2 as LineStripIndexArray,
-    StructArrayLayout5f20 as GlobeVertexArray,
+    StructArrayLayout8f32 as GlobeVertexArray,
     StructArrayLayout3f12 as SkyboxVertexArray
 };

--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -716,6 +716,43 @@ register('StructArrayLayout3i6', StructArrayLayout3i6);
 
 /**
  * Implementation of the StructArray layout:
+ * [0]: Float32[7]
+ *
+ * @private
+ */
+class StructArrayLayout7f28 extends StructArray {
+    uint8: Uint8Array;
+    float32: Float32Array;
+
+    _refreshViews() {
+        this.uint8 = new Uint8Array(this.arrayBuffer);
+        this.float32 = new Float32Array(this.arrayBuffer);
+    }
+
+    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number) {
+        const i = this.length;
+        this.resize(i + 1);
+        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6);
+    }
+
+    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number) {
+        const o4 = i * 7;
+        this.float32[o4 + 0] = v0;
+        this.float32[o4 + 1] = v1;
+        this.float32[o4 + 2] = v2;
+        this.float32[o4 + 3] = v3;
+        this.float32[o4 + 4] = v4;
+        this.float32[o4 + 5] = v5;
+        this.float32[o4 + 6] = v6;
+        return i;
+    }
+}
+
+StructArrayLayout7f28.prototype.bytesPerElement = 28;
+register('StructArrayLayout7f28', StructArrayLayout7f28);
+
+/**
+ * Implementation of the StructArray layout:
  * [0]: Uint32[1]
  * [4]: Uint16[3]
  *
@@ -814,44 +851,6 @@ class StructArrayLayout1ui2 extends StructArray {
 
 StructArrayLayout1ui2.prototype.bytesPerElement = 2;
 register('StructArrayLayout1ui2', StructArrayLayout1ui2);
-
-/**
- * Implementation of the StructArray layout:
- * [0]: Float32[8]
- *
- * @private
- */
-class StructArrayLayout8f32 extends StructArray {
-    uint8: Uint8Array;
-    float32: Float32Array;
-
-    _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
-        this.float32 = new Float32Array(this.arrayBuffer);
-    }
-
-    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
-        const i = this.length;
-        this.resize(i + 1);
-        return this.emplace(i, v0, v1, v2, v3, v4, v5, v6, v7);
-    }
-
-    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number, v5: number, v6: number, v7: number) {
-        const o4 = i * 8;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
-        this.float32[o4 + 3] = v3;
-        this.float32[o4 + 4] = v4;
-        this.float32[o4 + 5] = v5;
-        this.float32[o4 + 6] = v6;
-        this.float32[o4 + 7] = v7;
-        return i;
-    }
-}
-
-StructArrayLayout8f32.prototype.bytesPerElement = 32;
-register('StructArrayLayout8f32', StructArrayLayout8f32);
 
 /**
  * Implementation of the StructArray layout:
@@ -1227,10 +1226,10 @@ export {
     StructArrayLayout3i2f6i15ui1ul3f76,
     StructArrayLayout1f4,
     StructArrayLayout3i6,
+    StructArrayLayout7f28,
     StructArrayLayout1ul3ui12,
     StructArrayLayout2ui4,
     StructArrayLayout1ui2,
-    StructArrayLayout8f32,
     StructArrayLayout2f8,
     StructArrayLayout4f16,
     StructArrayLayout2i4 as PosArray,
@@ -1251,9 +1250,9 @@ export {
     StructArrayLayout2ub2f12 as CollisionVertexArray,
     StructArrayLayout3f12 as CollisionVertexExtArray,
     StructArrayLayout3ui6 as QuadTriangleArray,
+    StructArrayLayout7f28 as GlobeVertexArray,
     StructArrayLayout3ui6 as TriangleIndexArray,
     StructArrayLayout2ui4 as LineIndexArray,
     StructArrayLayout1ui2 as LineStripIndexArray,
-    StructArrayLayout8f32 as GlobeVertexArray,
     StructArrayLayout3f12 as SkyboxVertexArray
 };

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -206,28 +206,6 @@ export default {
     createTileTransform(tr: Transform, worldSize: number): TileTransform {
         return new GlobeTileTransform(tr, worldSize);
     },
-
-    tileAabb(id: UnwrappedTileID, z: number, min: number, max: number) {
-
-        // const aabb = tileBoundsOnGlobe(id);
-
-        // // Transform corners of the aabb to the correct space
-        // const corners = aabb.getCorners();
-
-        // const mx = Number.MAX_VALUE;
-        // const max = [-mx, -mx, -mx];
-        // const min = [mx, mx, mx];
-
-        // for (let i = 0; i < corners.length; i++) {
-        //     vec3.transformMat4(corners[i], corners[i], globeMatrix);
-        //     vec3.min(min, min, corners[i]);
-        //     vec3.max(max, max, corners[i]);
-        // }
-
-        // return new Aabb(min, max);
-
-        return null;
-    },
 }
 
 export const globeRefRadius = EXTENT / Math.PI / 2.0;
@@ -325,8 +303,8 @@ export function normalizeECEF(bounds: Aabb): Float64Array {
     return m;
 }
 
-export const GLOBE_ZOOM_THRESHOLD_MIN = 5;
-export const GLOBE_ZOOM_THRESHOLD_MAX = 6;
+export const GLOBE_ZOOM_THRESHOLD_MIN = 8;
+export const GLOBE_ZOOM_THRESHOLD_MAX = 9;
 
 export function globeToMercatorTransition(zoom: number): number {
     return smoothstep(GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_ZOOM_THRESHOLD_MAX, zoom);

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -303,8 +303,8 @@ export function normalizeECEF(bounds: Aabb): Float64Array {
     return m;
 }
 
-export const GLOBE_ZOOM_THRESHOLD_MIN = 8;
-export const GLOBE_ZOOM_THRESHOLD_MAX = 9;
+export const GLOBE_ZOOM_THRESHOLD_MIN = 7;
+export const GLOBE_ZOOM_THRESHOLD_MAX = 8;
 
 export function globeToMercatorTransition(zoom: number): number {
     return smoothstep(GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_ZOOM_THRESHOLD_MAX, zoom);

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -337,7 +337,7 @@ export function denormalizeECEF(bounds: Aabb): Float64Array {
     return m;
 }
 
-export const GLOBE_VERTEX_GRID_SIZE = 128;
+export const GLOBE_VERTEX_GRID_SIZE = 32;
 
 export class GlobeSharedBuffers {
     poleIndexBuffer: IndexBuffer;

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -326,7 +326,7 @@ export function denormalizeECEF(bounds: Aabb): Float64Array {
     return m;
 }
 
-export const GLOBE_VERTEX_GRID_SIZE = 32;
+export const GLOBE_VERTEX_GRID_SIZE = 128;
 
 export class GlobeSharedBuffers {
     poleIndexBuffer: IndexBuffer;

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -70,8 +70,8 @@ class MercatorTileTransform {
             [xMax, yMax, max]);
     }
 
-    cullTile(aabb: Aabb, id: CanonicalTileID, camera: FreeCamera): boolean {
-        return true;
+    cullTile(aabb: Aabb, id: CanonicalTileID, zoom: number, camera: FreeCamera): boolean {
+        return false;
     }
 
     upVector(id: CanonicalTileID, x: Number, y: number): vec3 {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1380,8 +1380,25 @@ class Transform {
         const posMatrix = mat4.identity(new Float64Array(16));
         mat4.translate(posMatrix, posMatrix, [point.x, point.y, -wsRadius]);
         mat4.scale(posMatrix, posMatrix, [s, s, s]);
-        // mat4.rotateX(posMatrix, posMatrix, degToRad(-this._center.lat));
-        // mat4.rotateY(posMatrix, posMatrix, degToRad(-this._center.lng));
+        mat4.rotateX(posMatrix, posMatrix, degToRad(-this._center.lat));
+        mat4.rotateY(posMatrix, posMatrix, degToRad(-this._center.lng));
+
+        return posMatrix;
+    }
+
+    calculateGlobeMercatorMatrix(worldSize: number): Float64Array {
+        const localRadius = EXTENT / (2.0 * Math.PI);
+        const wsRadius = worldSize / (2.0 * Math.PI);
+        const s = wsRadius / localRadius;
+
+        const lat = clamp(this.center.lat, -this.maxValidLatitude, this.maxValidLatitude);
+        const point = new Point(
+            mercatorXfromLng(this.center.lng) * worldSize,
+            mercatorYfromLat(lat) * worldSize);
+
+        const posMatrix = mat4.identity(new Float64Array(16));
+        mat4.translate(posMatrix, posMatrix, [point.x, point.y, -wsRadius]);
+        mat4.scale(posMatrix, posMatrix, [s, s, s]);
 
         return posMatrix;
     }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -845,7 +845,7 @@ class Transform {
             // For example the globe view could perform additional backface culling
             const id = new CanonicalTileID(it.zoom, x, y);
 
-            if (!tileTransform.cullTile(it.aabb, id, this._camera)) {
+            if (tileTransform.cullTile(it.aabb, id, this.zoom, this._camera)) {
                 continue;
             }
 
@@ -1387,18 +1387,14 @@ class Transform {
     }
 
     calculateGlobeMercatorMatrix(worldSize: number): Float64Array {
-        const localRadius = EXTENT / (2.0 * Math.PI);
-        const wsRadius = worldSize / (2.0 * Math.PI);
-        const s = wsRadius / localRadius;
-
         const lat = clamp(this.center.lat, -this.maxValidLatitude, this.maxValidLatitude);
         const point = new Point(
             mercatorXfromLng(this.center.lng) * worldSize,
             mercatorYfromLat(lat) * worldSize);
 
         const posMatrix = mat4.identity(new Float64Array(16));
-        mat4.translate(posMatrix, posMatrix, [point.x, point.y, -wsRadius]);
-        mat4.scale(posMatrix, posMatrix, [s, s, s]);
+        mat4.translate(posMatrix, posMatrix, [point.x, point.y, 0.0]);
+        mat4.scale(posMatrix, posMatrix, [worldSize, worldSize, worldSize]);
 
         return posMatrix;
     }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -682,7 +682,7 @@ class Transform {
 
         // No change of LOD behavior for pitch lower than 60 and when there is no top padding: return only tile ids from the requested zoom level
         const minZoom = this.pitch <= 60.0 && this._edgeInsets.top <= this._edgeInsets.bottom && !this._elevation ? z : 0;
-        
+
         const tileTransform = this._projection.createTileTransform(this, numTiles);
 
         // Compute size of the globe in tiles, ie. worldSize / tileSize
@@ -1380,8 +1380,8 @@ class Transform {
         const posMatrix = mat4.identity(new Float64Array(16));
         mat4.translate(posMatrix, posMatrix, [point.x, point.y, -wsRadius]);
         mat4.scale(posMatrix, posMatrix, [s, s, s]);
-        mat4.rotateX(posMatrix, posMatrix, degToRad(-this._center.lat));
-        mat4.rotateY(posMatrix, posMatrix, degToRad(-this._center.lng));
+        // mat4.rotateX(posMatrix, posMatrix, degToRad(-this._center.lat));
+        // mat4.rotateY(posMatrix, posMatrix, degToRad(-this._center.lng));
 
         return posMatrix;
     }
@@ -1414,7 +1414,7 @@ class Transform {
     //     mat4.scale(posMatrix, posMatrix, [s, s, s]);
     //     mat4.rotateX(posMatrix, posMatrix, degToRad(-this._center.lat));
     //     mat4.rotateY(posMatrix, posMatrix, degToRad(-this._center.lng));
-        
+
     //     return mat4.multiply([], posMatrix, denormalizeECEF(tileBoundsOnGlobe(unwrappedTileID.canonical)));
     // }
 
@@ -1711,7 +1711,7 @@ class Transform {
 
         // Z-axis uses pixel coordinates when globe mode is enabled
         const pixelsPerMeter = this.pixelsPerMeter;
-        
+
         this._projectionScaler = pixelsPerMeter / (mercatorZfromAltitude(1, this.center.lat) * this.worldSize);
         //this._projectionScaler = mercatorZfromAltitude(1, 0) / mercatorZfromAltitude(1, this.center.lat);
         this.cameraToCenterDistance = 0.5 / Math.tan(halfFov) * this.height * this._projectionScaler;

--- a/src/shaders/_prelude.glsl
+++ b/src/shaders/_prelude.glsl
@@ -4,6 +4,7 @@
 
 #define EPSILON 0.0000001
 #define PI 3.141592653589793
+#define EXTENT 8192.0
 
 #ifdef FOG
 

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -16,6 +16,12 @@ precision highp float;
 
 #endif
 
+float wrap(float n, float min, float max) {
+    float d = max - min;
+    float w = mod(mod(n - min, d) + d, d) + min;
+    return (w == min) ? max : w;
+}
+
 // Unpack a pair of values that have been packed into a single float.
 // The packed values are assumed to be 8-bit unsigned integers, and are
 // packed like so:

--- a/src/shaders/globe_depth.vertex.glsl
+++ b/src/shaders/globe_depth.vertex.glsl
@@ -1,15 +1,3 @@
-//uniform mat4 u_matrix;
-//attribute vec2 a_pos;
-//attribute vec2 a_texture_pos;
-//
-//varying float v_depth;
-//
-//void main() {
-//    float elevation = elevation(a_texture_pos);
-//    gl_Position = u_matrix * vec4(a_pos, elevation, 1.0);
-//    v_depth = gl_Position.z / gl_Position.w;
-//}
-
 uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
 uniform mat4 u_merc_matrix;
@@ -22,16 +10,9 @@ attribute vec2 a_uv;
 
 varying float v_depth;
 
-float wrap(float n, float min, float max) {
-    float d = max - min;
-    float w = mod(mod(n - min, d) + d, d) + min;
-    return (w == min) ? max : w;
-}
-
 void main() {
-    //vec3 elevation = elevationVector(a_texture_pos) * elevation(a_texture_pos);
-    //gl_Position = u_matrix * vec4(vec3(a_pos, 0) + elevation, 1.0);
-    vec3 height = elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0);
+    vec2 uv = a_uv * EXTENT;
+    vec3 height = elevationVector(uv) * elevation(uv);
 
     vec4 globe = u_globe_matrix * vec4(a_globe_pos + height, 1.0);
 

--- a/src/shaders/globe_depth.vertex.glsl
+++ b/src/shaders/globe_depth.vertex.glsl
@@ -10,8 +10,13 @@
 //    v_depth = gl_Position.z / gl_Position.w;
 //}
 
+uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
+uniform mat4 u_merc_matrix;
+uniform float u_zoom_transition;
+
 attribute vec3 a_globe_pos;
+attribute vec3 a_merc_pos;
 attribute vec2 a_uv;
 
 varying float v_depth;
@@ -19,6 +24,13 @@ varying float v_depth;
 void main() {
     //vec3 elevation = elevationVector(a_texture_pos) * elevation(a_texture_pos);
     //gl_Position = u_matrix * vec4(vec3(a_pos, 0) + elevation, 1.0);
-    gl_Position = u_globe_matrix * vec4(a_globe_pos + elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0), 1.0);
+    vec3 height = elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0);
+
+    vec4 globe =  u_globe_matrix * vec4(a_globe_pos + height, 1.0);
+    vec4 mercator = u_merc_matrix * vec4(a_merc_pos, 1.0);
+    vec3 position = mix(globe.xyz, mercator.xyz, vec3(u_zoom_transition));
+
+    gl_Position = u_proj_matrix * vec4(position, 1.0);
+
     v_depth = gl_Position.z / gl_Position.w;
 }

--- a/src/shaders/globe_depth.vertex.glsl
+++ b/src/shaders/globe_depth.vertex.glsl
@@ -14,6 +14,7 @@ uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
 uniform mat4 u_merc_matrix;
 uniform float u_zoom_transition;
+uniform vec2 u_merc_center;
 
 attribute vec3 a_globe_pos;
 attribute vec3 a_merc_pos;
@@ -21,14 +22,26 @@ attribute vec2 a_uv;
 
 varying float v_depth;
 
+float wrap(float n, float min, float max) {
+    float d = max - min;
+    float w = mod(mod(n - min, d) + d, d) + min;
+    return (w == min) ? max : w;
+}
+
 void main() {
     //vec3 elevation = elevationVector(a_texture_pos) * elevation(a_texture_pos);
     //gl_Position = u_matrix * vec4(vec3(a_pos, 0) + elevation, 1.0);
     vec3 height = elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0);
 
     vec4 globe =  u_globe_matrix * vec4(a_globe_pos + height, 1.0);
-    vec4 mercator = u_merc_matrix * vec4(a_merc_pos, 1.0);
-    vec3 position = mix(globe.xyz, mercator.xyz, vec3(u_zoom_transition));
+
+    vec4 mercator = vec4(a_merc_pos, 1.0);
+    mercator.xy -= u_merc_center;
+    mercator.x = wrap(mercator.x, -0.5, 0.5);
+    mercator = u_merc_matrix * mercator;
+
+    vec3 t = vec3(u_zoom_transition);
+    vec3 position = mix(globe.xyz, mercator.xyz, t);
 
     gl_Position = u_proj_matrix * vec4(position, 1.0);
 

--- a/src/shaders/globe_depth.vertex.glsl
+++ b/src/shaders/globe_depth.vertex.glsl
@@ -17,7 +17,7 @@ uniform float u_zoom_transition;
 uniform vec2 u_merc_center;
 
 attribute vec3 a_globe_pos;
-attribute vec3 a_merc_pos;
+attribute vec2 a_merc_pos;
 attribute vec2 a_uv;
 
 varying float v_depth;
@@ -33,9 +33,9 @@ void main() {
     //gl_Position = u_matrix * vec4(vec3(a_pos, 0) + elevation, 1.0);
     vec3 height = elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0);
 
-    vec4 globe =  u_globe_matrix * vec4(a_globe_pos + height, 1.0);
+    vec4 globe = u_globe_matrix * vec4(a_globe_pos + height, 1.0);
 
-    vec4 mercator = vec4(a_merc_pos, 1.0);
+    vec4 mercator = vec4(a_merc_pos, 0.0, 1.0);
     mercator.xy -= u_merc_center;
     mercator.x = wrap(mercator.x, -0.5, 0.5);
     mercator = u_merc_matrix * mercator;

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -5,7 +5,7 @@ uniform float u_zoom_transition;
 uniform vec2 u_merc_center;
 
 attribute vec3 a_globe_pos;
-attribute vec3 a_merc_pos;
+attribute vec2 a_merc_pos;
 attribute vec2 a_uv;
 
 varying vec2 v_pos0;
@@ -21,9 +21,9 @@ void main() {
 
     vec3 height = elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0);
 
-    vec4 globe =  u_globe_matrix * vec4(a_globe_pos + height, 1.0);
+    vec4 globe = u_globe_matrix * vec4(a_globe_pos + height, 1.0);
 
-    vec4 mercator = vec4(a_merc_pos, 1.0);
+    vec4 mercator = vec4(a_merc_pos, 0.0, 1.0);
     mercator.xy -= u_merc_center;
     mercator.x = wrap(mercator.x, -0.5, 0.5);
     mercator = u_merc_matrix * mercator;

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -28,7 +28,7 @@ void main() {
     mercator.x = wrap(mercator.x, -0.5, 0.5);
     mercator = u_merc_matrix * mercator;
 
-    vec3 t = vec3(pow(u_zoom_transition, 6.0));
+    vec3 t = vec3(u_zoom_transition);
     vec3 position = mix(globe.xyz, mercator.xyz, t);
 
     gl_Position = u_proj_matrix * vec4(position, 1.0);

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -1,6 +1,7 @@
 uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
 uniform mat4 u_merc_matrix;
+uniform float u_zoom_transition;
 
 attribute vec3 a_globe_pos;
 attribute vec3 a_merc_pos;
@@ -12,5 +13,5 @@ void main() {
     v_pos0 = a_uv;
     vec4 globe =  u_globe_matrix * vec4(a_globe_pos + elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0), 1.0);
     vec4 mercator = u_merc_matrix * vec4(a_merc_pos, 1.0);
-    gl_Position = u_proj_matrix * vec4(mix(globe.xyz, mercator.xyz, vec3(0.5)), 1.0);
+    gl_Position = u_proj_matrix * vec4(mix(globe.xyz, mercator.xyz, vec3(u_zoom_transition)), 1.0);
 }

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -11,7 +11,12 @@ varying vec2 v_pos0;
 
 void main() {
     v_pos0 = a_uv;
-    vec4 globe =  u_globe_matrix * vec4(a_globe_pos + elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0), 1.0);
+
+    vec3 height = elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0);
+
+    vec4 globe =  u_globe_matrix * vec4(a_globe_pos + height, 1.0);
     vec4 mercator = u_merc_matrix * vec4(a_merc_pos, 1.0);
-    gl_Position = u_proj_matrix * vec4(mix(globe.xyz, mercator.xyz, vec3(u_zoom_transition)), 1.0);
+    vec3 position = mix(globe.xyz, mercator.xyz, vec3(u_zoom_transition));
+
+    gl_Position = u_proj_matrix * vec4(position, 1.0);
 }

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -1,18 +1,16 @@
+uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
+uniform mat4 u_merc_matrix;
 
 attribute vec3 a_globe_pos;
+attribute vec3 a_merc_pos;
 attribute vec2 a_uv;
 
 varying vec2 v_pos0;
 
-#ifdef FOG
-varying float v_fog_opacity;
-#endif
-
-const float skirtOffset = 24575.0;
-const float wireframeOffset = 0.00015;
-
 void main() {
     v_pos0 = a_uv;
-    gl_Position = u_globe_matrix * vec4(a_globe_pos + elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0), 1.0);
+    vec4 globe =  u_globe_matrix * vec4(a_globe_pos + elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0), 1.0);
+    vec4 mercator = u_merc_matrix * vec4(a_merc_pos, 1.0);
+    gl_Position = u_proj_matrix * vec4(mix(globe.xyz, mercator.xyz, vec3(0.5)), 1.0);
 }

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -2,6 +2,7 @@ uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
 uniform mat4 u_merc_matrix;
 uniform float u_zoom_transition;
+uniform vec2 u_merc_center;
 
 attribute vec3 a_globe_pos;
 attribute vec3 a_merc_pos;
@@ -9,14 +10,26 @@ attribute vec2 a_uv;
 
 varying vec2 v_pos0;
 
+float wrap(float n, float min, float max) {
+    float d = max - min;
+    float w = mod(mod(n - min, d) + d, d) + min;
+    return (w == min) ? max : w;
+}
+
 void main() {
     v_pos0 = a_uv;
 
     vec3 height = elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0);
 
     vec4 globe =  u_globe_matrix * vec4(a_globe_pos + height, 1.0);
-    vec4 mercator = u_merc_matrix * vec4(a_merc_pos, 1.0);
-    vec3 position = mix(globe.xyz, mercator.xyz, vec3(u_zoom_transition));
+
+    vec4 mercator = vec4(a_merc_pos, 1.0);
+    mercator.xy -= u_merc_center;
+    mercator.x = wrap(mercator.x, -0.5, 0.5);
+    mercator = u_merc_matrix * mercator;
+
+    vec3 t = vec3(pow(u_zoom_transition, 6.0));
+    vec3 position = mix(globe.xyz, mercator.xyz, t);
 
     gl_Position = u_proj_matrix * vec4(position, 1.0);
 }

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -10,16 +10,11 @@ attribute vec2 a_uv;
 
 varying vec2 v_pos0;
 
-float wrap(float n, float min, float max) {
-    float d = max - min;
-    float w = mod(mod(n - min, d) + d, d) + min;
-    return (w == min) ? max : w;
-}
-
 void main() {
     v_pos0 = a_uv;
 
-    vec3 height = elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0);
+    vec2 uv = a_uv * EXTENT;
+    vec3 height = elevationVector(uv) * elevation(uv);
 
     vec4 globe = u_globe_matrix * vec4(a_globe_pos + height, 1.0);
 

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -188,16 +188,17 @@ function createPoleTriangleVertices(fanSize, tiles, ws, topCap) {
     const radius = ws / Math.PI / 2.0;
 
     // Place the tip
-    arr.emplaceBack(0, -radius, 0, 0.5, topCap ? 0.0 : 1.0);
+    arr.emplaceBack(0, -radius, 0, 0, 0, 0.5, topCap ? 0.0 : 1.0);
 
     const startAngle = 0;
     const endAngle = 360.0 / tiles;
 
     for (let i = 0; i <= fanSize; i++) {
-        const angle = lerp(startAngle, endAngle, i / fanSize);
+        const uvX = i / fanSize;
+        const angle = lerp(startAngle, endAngle, uvX);
         const p = latLngToECEF(85, angle, radius);
 
-        arr.emplaceBack(p[0], p[1], p[2], 0, 0, i / fanSize, topCap ? 0.0 : 1.0);
+        arr.emplaceBack(p[0], p[1], p[2], 0, 0, uvX, topCap ? 0.0 : 1.0);
     }
 
     return arr;

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -10,7 +10,7 @@ import {Terrain} from './terrain.js';
 import Tile from '../source/tile.js';
 import assert from 'assert';
 import EXTENT from '../data/extent.js';
-import {easeCubicInOut, warnOnce, wrap, clamp, degToRad} from '../util/util.js';
+import {easeCubicInOut, warnOnce, wrap, clamp, degToRad, smoothstep} from '../util/util.js';
 import {RasterBoundsArray, GlobeVertexArray, TriangleIndexArray} from '../data/array_types.js';
 import {lngFromMercatorX, mercatorXfromLng, latFromMercatorY, mercatorYfromLat, mercatorZfromAltitude} from '../geo/mercator_coordinate.js';
 import {createLayout} from '../util/struct_array.js';
@@ -142,6 +142,9 @@ const layout = createLayout([
 
 const lerp = (a, b, t) => a * (1 - t) + b * t;
 
+const GLOBE_ZOOM_THRESHOLD_MIN = 5;
+const GLOBE_ZOOM_THRESHOLD_MAX = 6;
+
 function createGridVertices(painter, count: number, sx, sy, sz): any {
     const counter = painter.frameCounter;
     const tr = painter.transform;
@@ -180,7 +183,7 @@ function createGridVertices(painter, count: number, sx, sy, sz): any {
                 radius
             ];
 
-            const t = Math.cos(counter/100.0) * 0.5 + 0.5;
+            const t = smoothstep(GLOBE_ZOOM_THRESHOLD_MIN, GLOBE_ZOOM_THRESHOLD_MAX, tr.zoom);
             const xx = lerp(p[0], pMercator[0], t);
             const yy = lerp(p[1], pMercator[1], t);
             const zz = lerp(p[2], pMercator[2], t);

--- a/src/terrain/globe_attributes.js
+++ b/src/terrain/globe_attributes.js
@@ -1,0 +1,11 @@
+// @flow
+import {createLayout} from '../util/struct_array.js';
+
+const layout = createLayout([
+    { type: 'Float32', name: 'a_globe_pos', components: 3 },
+    { type: 'Float32', name: 'a_merc_pos', components: 2 },
+    { type: 'Float32', name: 'a_uv', components: 2 }
+]);
+
+export default layout;
+export const {members, size, alignment} = layout;

--- a/src/terrain/globe_raster_program.js
+++ b/src/terrain/globe_raster_program.js
@@ -17,6 +17,7 @@ export type GlobeRasterUniformsType = {|
     'u_globe_matrix': UniformMatrix4f,
     'u_merc_matrix': UniformMatrix4f,
     'u_zoom_transition': Uniform1f,
+    'u_merc_center': Uniform2f,
     'u_image0': Uniform1i
 |};
 
@@ -36,6 +37,7 @@ const globeRasterUniforms = (context: Context, locations: UniformLocations): Glo
     'u_globe_matrix': new UniformMatrix4f(context, locations.u_globe_matrix),
     'u_merc_matrix': new UniformMatrix4f(context, locations.u_merc_matrix),
     'u_zoom_transition': new Uniform1f(context, locations.u_zoom_transition),
+    'u_merc_center': new Uniform2f(context, locations.u_merc_center),
     'u_image0': new Uniform1i(context, locations.u_image0)
 });
 
@@ -55,11 +57,13 @@ const globeRasterUniformValues = (
     globeMatrix: Float32Array,
     globeMercatorMatrix: Float32Array,
     zoomTransition: number,
+    mercCenter: [number, number],
 ): UniformValues<GlobeRasterUniformsType> => ({
     'u_proj_matrix': projMatrix,
     'u_globe_matrix': globeMatrix,
     'u_merc_matrix': globeMercatorMatrix,
     'u_zoom_transition': zoomTransition,
+    'u_merc_center': mercCenter,
     'u_image0': 0
 });
 

--- a/src/terrain/globe_raster_program.js
+++ b/src/terrain/globe_raster_program.js
@@ -16,6 +16,7 @@ export type GlobeRasterUniformsType = {|
     'u_proj_matrix': UniformMatrix4f,
     'u_globe_matrix': UniformMatrix4f,
     'u_merc_matrix': UniformMatrix4f,
+    'u_zoom_transition': Uniform1f,
     'u_image0': Uniform1i
 |};
 
@@ -34,6 +35,7 @@ const globeRasterUniforms = (context: Context, locations: UniformLocations): Glo
     'u_proj_matrix': new UniformMatrix4f(context, locations.u_proj_matrix),
     'u_globe_matrix': new UniformMatrix4f(context, locations.u_globe_matrix),
     'u_merc_matrix': new UniformMatrix4f(context, locations.u_merc_matrix),
+    'u_zoom_transition': new Uniform1f(context, locations.u_zoom_transition),
     'u_image0': new Uniform1i(context, locations.u_image0)
 });
 
@@ -51,11 +53,13 @@ const atmosphereUniforms = (context: Context, locations: UniformLocations): Atmo
 const globeRasterUniformValues = (
     projMatrix: Float32Array,
     globeMatrix: Float32Array,
-    globeMercatorMatrix: Float32Array
+    globeMercatorMatrix: Float32Array,
+    zoomTransition: number,
 ): UniformValues<GlobeRasterUniformsType> => ({
     'u_proj_matrix': projMatrix,
     'u_globe_matrix': globeMatrix,
     'u_merc_matrix': globeMercatorMatrix,
+    'u_zoom_transition': zoomTransition,
     'u_image0': 0
 });
 

--- a/src/terrain/globe_raster_program.js
+++ b/src/terrain/globe_raster_program.js
@@ -13,7 +13,9 @@ import type Context from '../gl/context.js';
 import type {UniformValues, UniformLocations} from '../render/uniform_binding.js';
 
 export type GlobeRasterUniformsType = {|
+    'u_proj_matrix': UniformMatrix4f,
     'u_globe_matrix': UniformMatrix4f,
+    'u_merc_matrix': UniformMatrix4f,
     'u_image0': Uniform1i
 |};
 
@@ -29,7 +31,9 @@ export type AtmosphereUniformsType = {|
 |};
 
 const globeRasterUniforms = (context: Context, locations: UniformLocations): GlobeRasterUniformsType => ({
+    'u_proj_matrix': new UniformMatrix4f(context, locations.u_proj_matrix),
     'u_globe_matrix': new UniformMatrix4f(context, locations.u_globe_matrix),
+    'u_merc_matrix': new UniformMatrix4f(context, locations.u_merc_matrix),
     'u_image0': new Uniform1i(context, locations.u_image0)
 });
 
@@ -45,9 +49,13 @@ const atmosphereUniforms = (context: Context, locations: UniformLocations): Atmo
 });
 
 const globeRasterUniformValues = (
-    globeMatrix: Float32Array
+    projMatrix: Float32Array,
+    globeMatrix: Float32Array,
+    globeMercatorMatrix: Float32Array
 ): UniformValues<GlobeRasterUniformsType> => ({
+    'u_proj_matrix': projMatrix,
     'u_globe_matrix': globeMatrix,
+    'u_merc_matrix': globeMercatorMatrix,
     'u_image0': 0
 });
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -30,6 +30,7 @@ import webpSupported from '../util/webp_supported.js';
 import {PerformanceMarkers, PerformanceUtils} from '../util/performance.js';
 import Marker from '../ui/marker.js';
 import EasedVariable from '../util/eased_variable.js';
+import {GLOBE_ZOOM_THRESHOLD_MAX} from '../geo/projection/globe.js';
 
 import {setCacheLimits} from '../util/tile_request_cache.js';
 
@@ -2760,6 +2761,14 @@ class Map extends Camera {
         this._domRenderTaskQueue.run(paintStartTimeStamp);
         // A task queue callback may have fired a user event which may have removed the map
         if (this._removed) return;
+
+        if (this.transform.zoom >= GLOBE_ZOOM_THRESHOLD_MAX - 0.01) {
+            this.transform.projection = null;
+            this.style.dispatcher.broadcast('setProjection', null);
+        } else {
+            this.transform.projection = 'globe';
+            this.style.dispatcher.broadcast('setProjection', this.transform.projection.name);
+        }
 
         let crossFading = false;
         const fadeDuration = this._isInitialLoad ? 0 : this._fadeDuration;


### PR DESCRIPTION
First pass at adding a globe view to mercator transition:
- Add a transition from globe view to mercator past a given zoom level threshold by morphing the globe sphere geometry into a plane. This switch allows to enable immediate support of layers that aren't yet supported by globe view (heatmap/circles/fill-extrusion/sky/fog). The transition switch is enabled from zoom 7 to 8. The transformation doesn't need to normalize/denormalize the positions similarly to the ECEF vertices (as we have enough precision for a switch up to zoom 14). The morphing is done on the vertex shader (A first approach on the CPU was done but I moved the process to the GPU as it didn't require updating the vertex buffers on every frame).
- Enable triangle backface culling for globe view rendering
- Consolidate vertex layout definition
- Remove some dead code and cleanup

https://user-images.githubusercontent.com/7061573/131902800-bd1b4a14-6645-45a7-bdcc-2ee04d926b6f.mov

https://user-images.githubusercontent.com/7061573/131901914-6a1504fc-0210-492d-9b40-829ce6372fff.mov

TODOs Following-up this PR:
- Better handling of symbols during the transition
- Support for transition from globe view when using terrain
- Optimizations to make the transition smoother and reduce the cost of rendering the globe. We could split the vertex buffer for globe vertices into two different buffers (One storing the mercator positions only bound during the zoom transition and disabled for every other zooms).
- Adjust zoom-in behavior to keep center of mouse as center of zoom prior and after the transition