### PR TITLE
Clamp unproject to mercator bounds in all projections

### DIFF
--- a/src/geo/mercator_coordinate.js
+++ b/src/geo/mercator_coordinate.js
@@ -40,6 +40,8 @@ export function altitudeFromMercatorZ(z: number, y: number) {
     return z * circumferenceAtLatitude(latFromMercatorY(y));
 }
 
+export const MAX_MERCATOR_LATITUDE = 85.051129;
+
 /**
  * Determine the Mercator scale factor for a given latitude, see
  * https://en.wikipedia.org/wiki/Mercator_projection#Scale_factor

--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -1,7 +1,6 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
-import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 export const albers = {
     name: 'albers',
@@ -37,7 +36,7 @@ export const albers = {
         const lng = clamp((theta / n * 180 / Math.PI) + this.center[0], -180, 180);
         const a = x_ / Math.sin(theta);
         const s = clamp((Math.pow(a / r * n, 2) - c) / (-2 * n), -1, 1);
-        const lat = clamp(Math.asin(s) * 180 / Math.PI, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+        const lat = clamp(Math.asin(s) * 180 / Math.PI, -90, 90);
         return new LngLat(lng, lat);
     }
 };

--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -1,5 +1,7 @@
 // @flow
 import LngLat from '../lng_lat.js';
+import {clamp} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 export const albers = {
     name: 'albers',
@@ -32,9 +34,10 @@ export const albers = {
         const y_ = (y - 1) * -2;
         const y2 = -(y_ - b);
         const theta = Math.atan2(x_, y2);
-        const lng = (theta / n * 180 / Math.PI) + this.center[0];
+        const lng = clamp((theta / n * 180 / Math.PI) + this.center[0], -180, 180);
         const a = x_ / Math.sin(theta);
-        const lat = Math.asin((Math.pow(a / r * n, 2) - c) / (-2 * n)) * 180 / Math.PI;
+        const s = clamp((Math.pow(a / r * n, 2) - c) / (-2 * n), -1, 1);
+        const lat = clamp(Math.asin(s) * 180 / Math.PI, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
         return new LngLat(lng, lat);
     }
 };

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -1,5 +1,6 @@
 // @flow
-import {mercatorXfromLng, mercatorYfromLat, lngFromMercatorX, latFromMercatorY} from '../mercator_coordinate.js';
+import {mercatorXfromLng, mercatorYfromLat, lngFromMercatorX, latFromMercatorY, MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+import {clamp} from '../../util/util.js';
 import LngLat from '../lng_lat.js';
 
 export default {
@@ -11,8 +12,8 @@ export default {
         return {x, y};
     },
     unproject(x: number, y: number) {
-        return new LngLat(
-            lngFromMercatorX(x),
-            latFromMercatorY(y));
+        const lng = lngFromMercatorX(x);
+        const lat = clamp(latFromMercatorY(y), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+        return new LngLat(lng, lat);
     }
 };

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -1,6 +1,5 @@
 // @flow
-import {mercatorXfromLng, mercatorYfromLat, lngFromMercatorX, latFromMercatorY, MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
-import {clamp} from '../../util/util.js';
+import {mercatorXfromLng, mercatorYfromLat, lngFromMercatorX, latFromMercatorY} from '../mercator_coordinate.js';
 import LngLat from '../lng_lat.js';
 
 export default {
@@ -13,7 +12,7 @@ export default {
     },
     unproject(x: number, y: number) {
         const lng = lngFromMercatorX(x);
-        const lat = clamp(latFromMercatorY(y), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+        const lat = latFromMercatorY(y);
         return new LngLat(lng, lat);
     }
 };

--- a/src/geo/projection/wgs84.js
+++ b/src/geo/projection/wgs84.js
@@ -1,5 +1,7 @@
 // @flow
 import LngLat from '../lng_lat.js';
+import {clamp} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 export default {
     name: 'wgs84',
@@ -10,8 +12,8 @@ export default {
         return {x, y};
     },
     unproject(x: number, y: number) {
-        return new LngLat(
-            (x - 0.5) * 360,
-            (0.5 - y) * 360);
+        const lng = (x - 0.5) * 360;
+        const lat = clamp((0.5 - y) * 360, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+        return new LngLat(lng, lat);
     }
 };

--- a/src/geo/projection/wgs84.js
+++ b/src/geo/projection/wgs84.js
@@ -1,7 +1,6 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
-import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 export default {
     name: 'wgs84',
@@ -13,7 +12,7 @@ export default {
     },
     unproject(x: number, y: number) {
         const lng = (x - 0.5) * 360;
-        const lat = clamp((0.5 - y) * 360, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+        const lat = clamp((0.5 - y) * 360, -90, 90);
         return new LngLat(lng, lat);
     }
 };

--- a/src/geo/projection/winkelTripel.js
+++ b/src/geo/projection/winkelTripel.js
@@ -1,7 +1,6 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
-import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 export default {
     name: 'winkel',
@@ -58,7 +57,7 @@ export default {
         } while ((Math.abs(dlambda) > epsilon || Math.abs(dphi) > epsilon) && --i > 0);
 
         const lng = clamp(lambda * 180 / Math.PI, -180, 180);
-        const lat = clamp(phi * 180 / Math.PI, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+        const lat = clamp(phi * 180 / Math.PI, -90, 90);
 
         return new LngLat(lng, lat);
     }

--- a/src/geo/projection/winkelTripel.js
+++ b/src/geo/projection/winkelTripel.js
@@ -1,5 +1,7 @@
 // @flow
 import LngLat from '../lng_lat.js';
+import {clamp} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 export default {
     name: 'winkel',
@@ -55,6 +57,9 @@ export default {
             phi -= dphi;
         } while ((Math.abs(dlambda) > epsilon || Math.abs(dphi) > epsilon) && --i > 0);
 
-        return new LngLat(lambda * 180 / Math.PI, phi * 180 / Math.PI);
+        const lng = clamp(lambda * 180 / Math.PI, -180, 180);
+        const lat = clamp(phi * 180 / Math.PI, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+
+        return new LngLat(lng, lat);
     }
 };

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -228,7 +228,9 @@ class Transform {
         this.pitch = Math.min(this.pitch, pitch);
     }
 
-    get renderWorldCopies(): boolean { return this._renderWorldCopies; }
+    get renderWorldCopies(): boolean {
+        return this.projection.name === 'mercator' && this._renderWorldCopies;
+    }
     set renderWorldCopies(renderWorldCopies?: ?boolean) {
         if (renderWorldCopies === undefined) {
             renderWorldCopies = true;
@@ -955,18 +957,14 @@ class Transform {
         const a = this.pointCoordinate(point);
         const b = this.pointCoordinate(this.centerPoint);
         const loc = this.locationCoordinate(lnglat);
-        const newCenter = new MercatorCoordinate(
-                loc.x - (a.x - b.x),
-                loc.y - (a.y - b.y));
-        this.center = this.coordinateLocation(newCenter);
-        if (this._renderWorldCopies) {
-            this.center = this.center.wrap();
-        }
+        this.setLocation(new MercatorCoordinate(
+            loc.x - (a.x - b.x),
+            loc.y - (a.y - b.y)));
     }
 
     setLocation(location: MercatorCoordinate) {
         this.center = this.coordinateLocation(location);
-        if (this._renderWorldCopies) {
+        if (this.renderWorldCopies) {
             this.center = this.center.wrap();
         }
     }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -2,7 +2,7 @@
 
 import LngLat from './lng_lat.js';
 import LngLatBounds from './lng_lat_bounds.js';
-import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude, latFromMercatorY} from './mercator_coordinate.js';
+import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude, latFromMercatorY, MAX_MERCATOR_LATITUDE} from './mercator_coordinate.js';
 import getProjection from './projection/index.js';
 import tileTransform from '../geo/projection/tile_transform.js';
 import Point from '@mapbox/point-geometry';
@@ -36,7 +36,6 @@ class Transform {
     tileZoom: number;
     lngRange: ?[number, number];
     latRange: ?[number, number];
-    maxValidLatitude: number;
 
     // 2^zoom (worldSize = tileSize * scale)
     scale: number;
@@ -118,7 +117,6 @@ class Transform {
 
     constructor(minZoom: ?number, maxZoom: ?number, minPitch: ?number, maxPitch: ?number, renderWorldCopies: boolean | void, projection: string) {
         this.tileSize = 512; // constant
-        this.maxValidLatitude = 85.051129; // constant
 
         this._renderWorldCopies = renderWorldCopies === undefined ? true : renderWorldCopies;
         this._minZoom = minZoom || DEFAULT_MIN_ZOOM;
@@ -940,7 +938,7 @@ class Transform {
     scaleZoom(scale: number) { return Math.log(scale) / Math.LN2; }
 
     project(lnglat: LngLat) {
-        const lat = clamp(lnglat.lat, -this.maxValidLatitude, this.maxValidLatitude);
+        const lat = clamp(lnglat.lat, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
         const projectedLngLat = this.projection.project(lnglat.lng, lat);
         return new Point(
                 projectedLngLat.x * this.worldSize,
@@ -1275,7 +1273,7 @@ class Transform {
             this._constrain();
         } else {
             this.lngRange = null;
-            this.latRange = [-this.maxValidLatitude, this.maxValidLatitude];
+            this.latRange = [-MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE];
         }
     }
 

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -5,7 +5,7 @@ import LngLat from '../../../src/geo/lng_lat.js';
 import {OverscaledTileID, CanonicalTileID} from '../../../src/source/tile_id.js';
 import {fixedNum, fixedLngLat, fixedCoord, fixedPoint, fixedVec3, fixedVec4} from '../../util/fixed.js';
 import {FreeCameraOptions} from '../../../src/ui/free_camera.js';
-import MercatorCoordinate, {mercatorZfromAltitude} from '../../../src/geo/mercator_coordinate.js';
+import MercatorCoordinate, {mercatorZfromAltitude, MAX_MERCATOR_LATITUDE} from '../../../src/geo/mercator_coordinate.js';
 import {vec3, quat} from 'gl-matrix';
 import LngLatBounds from '../../../src/geo/lng_lat_bounds.js';
 import {degToRad} from '../../../src/util/util.js';
@@ -16,7 +16,6 @@ test('transform', (t) => {
         const transform = new Transform();
         transform.resize(500, 500);
         t.equal(transform.unmodified, true);
-        t.equal(transform.maxValidLatitude, 85.051129);
         t.equal(transform.tileSize, 512, 'tileSize');
         t.equal(transform.worldSize, 512, 'worldSize');
         t.equal(transform.width, 500, 'width');
@@ -901,8 +900,8 @@ test('transform', (t) => {
     t.test('clamps latitude', (t) => {
         const transform = new Transform();
 
-        t.deepEqual(transform.project(new LngLat(0, -90)), transform.project(new LngLat(0, -transform.maxValidLatitude)));
-        t.deepEqual(transform.project(new LngLat(0, 90)), transform.project(new LngLat(0, transform.maxValidLatitude)));
+        t.deepEqual(transform.project(new LngLat(0, -90)), transform.project(new LngLat(0, -MAX_MERCATOR_LATITUDE)));
+        t.deepEqual(transform.project(new LngLat(0, 90)), transform.project(new LngLat(0, MAX_MERCATOR_LATITUDE)));
         t.end();
     });
 
@@ -1193,7 +1192,7 @@ test('transform', (t) => {
         t.test('clamp to bounds', (t) => {
             const transform = new Transform();
             transform.resize(100, 100);
-            transform.setMaxBounds(new LngLatBounds(new LngLat(-180, -transform.maxValidLatitude), new LngLat(180, transform.maxValidLatitude)));
+            transform.setMaxBounds(new LngLatBounds(new LngLat(-180, -MAX_MERCATOR_LATITUDE), new LngLat(180, MAX_MERCATOR_LATITUDE)));
             transform.zoom = 8.56;
             const options = new FreeCameraOptions();
 

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -824,7 +824,7 @@ test('Drag above horizon clamps', (t) => {
 });
 
 test('Drag below / behind camera', (t) => {
-    const map = createMap(t);
+    const map = createMap(t, {zoom: 3});
     map.setPitch(85);
     const marker = new Marker({draggable: true})
         .setLngLat(map.unproject([map.transform.width / 2, map.transform.height - 20]))


### PR DESCRIPTION
This PR fixes the issue where the map breaks when you pan outside the world in alternate projections — it does so by adding clamping logic to each individual projection so that `unproject` never produces `NaN` or values outside of the Web Mercator bounds (-180, -85.05.., 180, 85.05..), and you can't pan in a way that puts center of the map outside of valid geographic bounds. Notes:

- Clamping has to happen inside individual `unproject` (sometimes in the middle of calculations, e.g. in Albers) because you can't clamp once a value turns into `NaN`.
- Theoretically, some projections could be clamped beyond Web Mercator limits (e.g. 90 latitude and not 85.05+), but it might be better for consistency to clamp to the same range everywhere, especially since our vector and raster tiles only cover the Web Mercator range, and panning outside it might be counterintuitive.
- Projections that can have world copy rendering only clamp `lat`, not `lng`, to keep the current behavior of panning seamlessly through anti-meridian (which doesn't yet work for `wgs84` projection but keeps the default behavior of mercator).
- There's a known issue of the map going wild jumping chaotically during fast panning inertia. Not critical to address in this PR but we should ticket this and follow up.
- This approach feels pretty intuitive. You can't move the center of the map outside the rendered area, but you can still grab the map in empty areas for panning. `getCenter()`/etc. will always return valid results. And we avoid the issue of breaking the return type signature when porting this to native.
- In the future, we should introduce wrapping for Albers so that it could represent areas like western islands of Alaska & far eastern Russia seamlessly instead of having a hard cut (e.g. so that "anti-meridian" moves to a different vertical tile bound).