### PR TITLE
Remove unnecessary sorting when getting rendered tiles before symbol placement

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -445,7 +445,7 @@ class Painter {
             const sourceCache = sourceCaches[id];
             coordsAscending[id] = sourceCache.getVisibleCoordinates();
             coordsDescending[id] = coordsAscending[id].slice().reverse();
-            coordsDescendingSymbol[id] = sourceCache.getVisibleCoordinates(true).reverse();
+            coordsDescendingSymbol[id] = sourceCache.getVisibleCoordinates(true);
         }
 
         this.opaquePassCutoff = Infinity;

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -173,10 +173,10 @@ class SourceCache extends Evented {
         return values((this._tiles: any)).map((tile: Tile) => tile.tileID).sort(compareTileId).map(id => id.key);
     }
 
-    getRenderableIds(symbolLayer?: boolean): Array<number> {
+    getRenderableIds(allLayers?: boolean): Array<number> {
         const renderables: Array<Tile> = [];
         for (const id in this._tiles) {
-            if (this._isIdRenderable(+id, symbolLayer)) renderables.push(this._tiles[id]);
+            if (this._isIdRenderable(+id, allLayers)) renderables.push(this._tiles[id]);
         }
         return renderables.map(tile => tile.tileID).sort(compareTileId).map(id => id.key);
     }
@@ -831,8 +831,8 @@ class SourceCache extends Evented {
         return tileResults;
     }
 
-    getVisibleCoordinates(symbolLayer?: boolean): Array<OverscaledTileID> {
-        const coords = this.getRenderableIds(symbolLayer).map((id) => this._tiles[id].tileID);
+    getVisibleCoordinates(includeAllLayers?: boolean): Array<OverscaledTileID> {
+        const coords = this.getRenderableIds(includeAllLayers).map((id) => this._tiles[id].tileID);
         for (const coord of coords) {
             coord.projMatrix = this.transform.calculateProjMatrix(coord.toUnwrapped());
         }

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -5,7 +5,6 @@ import {Event, ErrorEvent, Evented} from '../util/evented.js';
 import TileCache from './tile_cache.js';
 import {keysDifference, values} from '../util/util.js';
 import Context from '../gl/context.js';
-import Point from '@mapbox/point-geometry';
 import browser from '../util/browser.js';
 import {OverscaledTileID} from './tile_id.js';
 import assert from 'assert';
@@ -178,15 +177,6 @@ class SourceCache extends Evented {
         const renderables: Array<Tile> = [];
         for (const id in this._tiles) {
             if (this._isIdRenderable(+id, symbolLayer)) renderables.push(this._tiles[id]);
-        }
-        if (symbolLayer) {
-            return renderables.sort((a_: Tile, b_: Tile) => {
-                const a = a_.tileID;
-                const b = b_.tileID;
-                const rotatedA = (new Point(a.canonical.x, a.canonical.y))._rotate(this.transform.angle);
-                const rotatedB = (new Point(b.canonical.x, b.canonical.y))._rotate(this.transform.angle);
-                return a.overscaledZ - b.overscaledZ || rotatedB.y - rotatedA.y || rotatedB.x - rotatedA.x;
-            }).map(tile => tile.tileID.key);
         }
         return renderables.map(tile => tile.tileID).sort(compareTileId).map(id => id.key);
     }


### PR DESCRIPTION


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Two times of sorting are performed when getting the rendered tiles, however, the first sorting result will anyway be overridden by the second sorting, thus remove it from the code.

The second sorting is done right after the first sorting:
https://github.com/mapbox/mapbox-gl-js/blob/63bd2945940e77749dad2797009b84353abefe6e/src/style/style.js#L1630-L1636

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
