### PR TITLE
Added links to SDF image documentation for icon-color and icon-halo-color

### DIFF
--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -5215,7 +5215,7 @@
       "type": "color",
       "default": "#000000",
       "transition": true,
-      "doc": "The color of the icon. This can only be used with [SDF icons](/help/troubleshooting/using-recolorable-images-in-mapbox-maps).",
+      "doc": "The color of the icon. This can only be used with [SDF icons](/help/troubleshooting/using-recolorable-images-in-mapbox-maps/).",
       "requires": [
         "icon-image"
       ],
@@ -5247,7 +5247,7 @@
       "type": "color",
       "default": "rgba(0, 0, 0, 0)",
       "transition": true,
-      "doc": "The color of the icon's halo. Icon halos can only be used with [SDF icons](/help/troubleshooting/using-recolorable-images-in-mapbox-maps).",
+      "doc": "The color of the icon's halo. Icon halos can only be used with [SDF icons](/help/troubleshooting/using-recolorable-images-in-mapbox-maps/).",
       "requires": [
         "icon-image"
       ],

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -5215,7 +5215,7 @@
       "type": "color",
       "default": "#000000",
       "transition": true,
-      "doc": "The color of the icon. This can only be used with sdf icons.",
+      "doc": "The color of the icon. This can only be used with [SDF icons](/help/troubleshooting/using-recolorable-images-in-mapbox-maps).",
       "requires": [
         "icon-image"
       ],
@@ -5247,7 +5247,7 @@
       "type": "color",
       "default": "rgba(0, 0, 0, 0)",
       "transition": true,
-      "doc": "The color of the icon's halo. Icon halos can only be used with SDF icons.",
+      "doc": "The color of the icon's halo. Icon halos can only be used with [SDF icons](/help/troubleshooting/using-recolorable-images-in-mapbox-maps).",
       "requires": [
         "icon-image"
       ],


### PR DESCRIPTION
Response to #10975. Adding these links should help draw attention to the SDF requirement and prevent future confusion.
