### PR TITLE
Globe view to mercator transition: Symbols

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -361,6 +361,7 @@ class SymbolBucket implements Bucket {
     writingModes: Array<number>;
     allowVerticalPlacement: boolean;
     hasRTLText: boolean;
+    projection: string;
 
     constructor(options: BucketParameters<SymbolStyleLayer>) {
         this.collisionBoxArray = options.collisionBoxArray;

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -68,8 +68,9 @@ class GlobeTileTransform {
 
         const decode = denormalizeECEF(tileBoundsOnGlobe(id.canonical));
 
-        mat4.multiply(matrix, matrix, decode)
+        mat4.multiply(matrix, matrix, decode);
 
+        // TODO: Optimize this function to prevent the inversion step
         return mat4.invert(matrix, matrix);
     }
 
@@ -349,7 +350,7 @@ export function denormalizeECEF(bounds: Aabb): Float64Array {
     return m;
 }
 
-export const GLOBE_VERTEX_GRID_SIZE = 16;
+export const GLOBE_VERTEX_GRID_SIZE = 128;
 
 export class GlobeSharedBuffers {
     poleIndexBuffer: IndexBuffer;

--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -217,7 +217,7 @@ export default {
     zAxisUnit: "pixels",
 
     pixelsPerMeter(lat: number, worldSize: number) {
-        return mercatorZfromAltitude(1, lat) * worldSize;
+        return mercatorZfromAltitude(1, 0) * worldSize;
     },
 
     createTileTransform(tr: Transform, worldSize: number): TileTransform {

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -16,6 +16,8 @@ export type TileTransform = {
 
     createTileMatrix: (id: UnwrappedTileID) => Float64Array,
 
+    createInversionMatrix: (id: UnwrappedTileID) => Float64Array,
+
     tileAabb: (id: UnwrappedTileID, z: number, min: number, max: number) => Aabb,
 
     upVector: (id: CanonicalTileID, x: Number, y: number) => vec3,

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -9,10 +9,13 @@ import {Aabb} from '../../util/primitives.js';
 class MercatorTileTransform {
     _tr: Transform;
     _worldSize: number;
+    _identity: Float64Array;
 
     constructor(tr: Transform, worldSize: number) {
         this._tr = tr;
         this._worldSize = worldSize;
+        // TODO: Cache this elsewhere?
+        this._identity = mat4.identity(new Float64Array(16));
     }
 
     createLabelPlaneMatrix(posMatrix: mat4, tileID: CanonicalTileID, pitchWithMap: boolean, rotateWithMap: boolean, pixelsToTileUnits): mat4 {
@@ -39,6 +42,10 @@ class MercatorTileTransform {
         } else {
             return this._tr.glCoordMatrix;
         }
+    }
+
+    createInversionMatrix(id: UnwrappedTileID): Float64Array {
+         return this._identity;
     }
 
     createTileMatrix(id: UnwrappedTileID): Float64Array {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1392,12 +1392,15 @@ class Transform {
             mercatorXfromLng(this.center.lng) * worldSize,
             mercatorYfromLat(lat) * worldSize);
 
+        const mercatorZ = mercatorZfromAltitude(1, this.center.lat) * worldSize;
+        const projectionScaler = mercatorZ / this.pixelsPerMeter;
         const tileTransform = this.projection.createTileTransform(this, worldSize);
-        const zScale = tileTransform.tileSpaceUpVectorScale();
+        const zScale = tileTransform.tileSpaceUpVectorScale() / projectionScaler;
+        const ws = worldSize / projectionScaler;
 
         const posMatrix = mat4.identity(new Float64Array(16));
         mat4.translate(posMatrix, posMatrix, [point.x, point.y, 0.0]);
-        mat4.scale(posMatrix, posMatrix, [worldSize, worldSize, zScale]);
+        mat4.scale(posMatrix, posMatrix, [ws, ws, zScale]);
 
         return posMatrix;
     }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1392,9 +1392,12 @@ class Transform {
             mercatorXfromLng(this.center.lng) * worldSize,
             mercatorYfromLat(lat) * worldSize);
 
+        const tileTransform = this.projection.createTileTransform(this, worldSize);
+        const zScale = tileTransform.tileSpaceUpVectorScale();
+
         const posMatrix = mat4.identity(new Float64Array(16));
         mat4.translate(posMatrix, posMatrix, [point.x, point.y, 0.0]);
-        mat4.scale(posMatrix, posMatrix, [worldSize, worldSize, worldSize]);
+        mat4.scale(posMatrix, posMatrix, [worldSize, worldSize, zScale]);
 
         return posMatrix;
     }

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -132,7 +132,9 @@ function updateVariableAnchors(coords, painter, layer, sourceCache, rotationAlig
     for (const coord of coords) {
         const tile = sourceCache.getTile(coord);
         const bucket: SymbolBucket = (tile.getBucket(layer): any);
-        if (!bucket || !bucket.text || !bucket.text.segments.get().length) continue;
+        if (!bucket || bucket.projection !== tr.projection.name || !bucket.text || !bucket.text.segments.get().length) {
+            continue;
+        }
 
         const sizeData = bucket.textSizeData;
         const size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
@@ -271,21 +273,26 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         mercatorYfromLat(tr.center.lat)
     ];
     const variablePlacement = layer.layout.get('text-variable-anchor');
-
+    const isGlobeProjection = tr.projection.name === 'globe';
+    const globeToMercator = isGlobeProjection ?
+        globeToMercatorTransition(tr.zoom) : 0.0;
     const tileRenderState: Array<SymbolTileRenderState> = [];
-    let defines = painter.terrain && pitchWithMap ? ['PITCH_WITH_MAP_TERRAIN'] : null;
 
+    let defines = [];
+    if (painter.terrain && pitchWithMap) {
+        defines.push('PITCH_WITH_MAP_TERRAIN');
+    }
+    if (isGlobeProjection) {
+        defines.push('PROJECTION_GLOBE_VIEW');
+    }
     if (alongLine) {
-        if (defines)
-            defines.push('PROJECTED_POS_ON_VIEWPORT');
-        else
-            defines = ['PROJECTED_POS_ON_VIEWPORT'];
+        defines.push('PROJECTED_POS_ON_VIEWPORT');
     }
 
     for (const coord of coords) {
         const tile = sourceCache.getTile(coord);
         const bucket: SymbolBucket = (tile.getBucket(layer): any);
-        if (!bucket) continue;
+        if (!bucket || bucket.projection !== tr.projection.name) continue;
         const buffers = isText ? bucket.text : bucket.icon;
         if (!buffers || !buffers.segments.get().length) continue;
         const programConfiguration = buffers.programConfigurations.get(layer.id);
@@ -357,8 +364,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         let uniformValues;
         const invMatrix = tileTransform.createInversionMatrix(coord.toUnwrapped());
-        const globeToMercator = tr.projection.name === 'globe'
-            ? globeToMercatorTransition(tr.zoom) : 0.0;
+
         if (isSDF) {
             if (!bucket.iconsInText) {
                 uniformValues = symbolSDFUniformValues(sizeData.kind,

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -374,7 +374,8 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
             } else {
                 uniformValues = symbolTextAndIconUniformValues(sizeData.kind,
                 size, rotateInShader, pitchWithMap, painter, matrix,
-                uLabelPlaneMatrix, uglCoordMatrix, texSize, texSizeIcon);
+                uLabelPlaneMatrix, uglCoordMatrix, texSize, texSizeIcon,
+                coordId, globeToMercator, invMatrix, mercCenter);
             }
         } else {
             uniformValues = symbolIconUniformValues(sizeData.kind,

--- a/src/render/program/symbol_program.js
+++ b/src/render/program/symbol_program.js
@@ -4,6 +4,7 @@ import {
     Uniform1i,
     Uniform1f,
     Uniform2f,
+    Uniform3f,
     UniformMatrix4f
 } from '../uniform_binding.js';
 import {extend} from '../../util/util.js';
@@ -30,6 +31,10 @@ export type SymbolIconUniformsType = {|
     'u_is_text': Uniform1i,
     'u_pitch_with_map': Uniform1i,
     'u_texsize': Uniform2f,
+    'u_tile_id': Uniform3f,
+    'u_zoom_transition': Uniform1f,
+    'u_inv_rot_matrix': UniformMatrix4f,
+    'u_merc_center': Uniform2f,
     'u_texture': Uniform1i
 |};
 
@@ -52,6 +57,10 @@ export type SymbolSDFUniformsType = {|
     'u_texture': Uniform1i,
     'u_gamma_scale': Uniform1f,
     'u_device_pixel_ratio': Uniform1f,
+    'u_tile_id': Uniform3f,
+    'u_zoom_transition': Uniform1f,
+    'u_inv_rot_matrix': UniformMatrix4f,
+    'u_merc_center': Uniform2f,
     'u_is_halo': Uniform1i
 |};
 
@@ -97,6 +106,10 @@ const symbolIconUniforms = (context: Context, locations: UniformLocations): Symb
     'u_is_text': new Uniform1i(context, locations.u_is_text),
     'u_pitch_with_map': new Uniform1i(context, locations.u_pitch_with_map),
     'u_texsize': new Uniform2f(context, locations.u_texsize),
+    'u_tile_id': new Uniform3f(context, locations.u_tile_id),
+    'u_zoom_transition': new Uniform1f(context, locations.u_zoom_transition),
+    'u_inv_rot_matrix': new UniformMatrix4f(context, locations.u_inv_rot_matrix),
+    'u_merc_center': new Uniform2f(context, locations.u_merc_center),
     'u_texture': new Uniform1i(context, locations.u_texture)
 });
 
@@ -119,6 +132,10 @@ const symbolSDFUniforms = (context: Context, locations: UniformLocations): Symbo
     'u_texture': new Uniform1i(context, locations.u_texture),
     'u_gamma_scale': new Uniform1f(context, locations.u_gamma_scale),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
+    'u_tile_id': new Uniform3f(context, locations.u_tile_id),
+    'u_zoom_transition': new Uniform1f(context, locations.u_zoom_transition),
+    'u_inv_rot_matrix': new UniformMatrix4f(context, locations.u_inv_rot_matrix),
+    'u_merc_center': new Uniform2f(context, locations.u_merc_center),
     'u_is_halo': new Uniform1i(context, locations.u_is_halo)
 });
 
@@ -156,7 +173,11 @@ const symbolIconUniformValues = (
     labelPlaneMatrix: Float32Array,
     glCoordMatrix: Float32Array,
     isText: boolean,
-    texSize: [number, number]
+    texSize: [number, number],
+    tileID: [number, number, number],
+    zoomTransition: number,
+    invRotMatrix: Float32Array,
+    mercCenter: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {
     const transform = painter.transform;
 
@@ -176,6 +197,10 @@ const symbolIconUniformValues = (
         'u_is_text': +isText,
         'u_pitch_with_map': +pitchWithMap,
         'u_texsize': texSize,
+        'u_tile_id': tileID,
+        'u_zoom_transition': zoomTransition,
+        'u_inv_rot_matrix': invRotMatrix,
+        'u_merc_center': mercCenter,
         'u_texture': 0
     };
 };
@@ -191,7 +216,11 @@ const symbolSDFUniformValues = (
     glCoordMatrix: Float32Array,
     isText: boolean,
     texSize: [number, number],
-    isHalo: boolean
+    isHalo: boolean,
+    tileID: [number, number, number],
+    zoomTransition: number,
+    invRotMatrix: Float32Array,
+    mercCenter: [number, number]
 ): UniformValues<SymbolSDFUniformsType> => {
     const {cameraToCenterDistance, _pitch} = painter.transform;
 
@@ -200,6 +229,10 @@ const symbolSDFUniformValues = (
         glCoordMatrix, isText, texSize), {
         'u_gamma_scale': pitchWithMap ? cameraToCenterDistance * Math.cos(painter.terrain ? 0 : _pitch) : 1,
         'u_device_pixel_ratio': browser.devicePixelRatio,
+        'u_tile_id': tileID,
+        'u_zoom_transition': zoomTransition,
+        'u_inv_rot_matrix': invRotMatrix,
+        'u_merc_center': mercCenter,
         'u_is_halo': +isHalo
     });
 };

--- a/src/render/program/symbol_program.js
+++ b/src/render/program/symbol_program.js
@@ -226,13 +226,10 @@ const symbolSDFUniformValues = (
 
     return extend(symbolIconUniformValues(functionType, size,
         rotateInShader, pitchWithMap, painter, matrix, labelPlaneMatrix,
-        glCoordMatrix, isText, texSize), {
+        glCoordMatrix, isText, texSize, tileID, zoomTransition,
+        invRotMatrix, mercCenter), {
         'u_gamma_scale': pitchWithMap ? cameraToCenterDistance * Math.cos(painter.terrain ? 0 : _pitch) : 1,
         'u_device_pixel_ratio': browser.devicePixelRatio,
-        'u_tile_id': tileID,
-        'u_zoom_transition': zoomTransition,
-        'u_inv_rot_matrix': invRotMatrix,
-        'u_merc_center': mercCenter,
         'u_is_halo': +isHalo
     });
 };
@@ -247,11 +244,16 @@ const symbolTextAndIconUniformValues = (
     labelPlaneMatrix: Float32Array,
     glCoordMatrix: Float32Array,
     texSizeSDF: [number, number],
-    texSizeIcon: [number, number]
+    texSizeIcon: [number, number],
+    tileID: [number, number, number],
+    zoomTransition: number,
+    invRotMatrix: Float32Array,
+    mercCenter: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {
     return extend(symbolSDFUniformValues(functionType, size,
         rotateInShader, pitchWithMap, painter, matrix, labelPlaneMatrix,
-        glCoordMatrix, true, texSizeSDF, true), {
+        glCoordMatrix, true, texSizeSDF, true, tileID, zoomTransition,
+        invRotMatrix, mercCenter), {
         'u_texsize_icon': texSizeIcon,
         'u_texture_icon': 1
     });

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -16,10 +16,33 @@ precision highp float;
 
 #endif
 
+#ifndef EXTENT
+#define EXTENT 8192.0
+#endif
+
+#ifndef PI
+#define PI 3.141592653589793
+#endif
+
 float wrap(float n, float min, float max) {
     float d = max - min;
     float w = mod(mod(n - min, d) + d, d) + min;
     return (w == min) ? max : w;
+}
+
+vec3 mix_globe_mercator(mat4 matrix, vec2 tile_anchor, vec3 position, vec3 tile_id, vec2 mercator_center, float t) {
+    if (t >= 1.0) { return position; }
+
+    float tiles = pow(2.0, tile_id.z);
+
+    vec2 mercator = (tile_anchor / EXTENT + tile_id.xy) / tiles;
+    mercator -= mercator_center;
+    mercator.x = wrap(mercator.x, -0.5, 0.5);
+
+    vec4 mercator_tile = vec4(mercator.xy * EXTENT, EXTENT / (2.0 * PI), 1.0);
+    mercator_tile = matrix * mercator_tile;
+
+    return mix(position, mercator_tile.xyz, vec3(t));
 }
 
 // Unpack a pair of values that have been packed into a single float.

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -31,7 +31,7 @@ float wrap(float n, float min, float max) {
 }
 
 vec3 mix_globe_mercator(mat4 matrix, vec2 tile_anchor, vec3 position, vec3 tile_id, vec2 mercator_center, float t) {
-#ifdef PROJECTION_GLOBE_VIEW
+#if defined(PROJECTION_GLOBE_VIEW) && !defined(PROJECTED_POS_ON_VIEWPORT)
     float tiles = pow(2.0, tile_id.z);
 
     vec2 mercator = (tile_anchor / EXTENT + tile_id.xy) / tiles;

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -31,8 +31,7 @@ float wrap(float n, float min, float max) {
 }
 
 vec3 mix_globe_mercator(mat4 matrix, vec2 tile_anchor, vec3 position, vec3 tile_id, vec2 mercator_center, float t) {
-    if (t >= 1.0) { return position; }
-
+#ifdef PROJECTION_GLOBE_VIEW
     float tiles = pow(2.0, tile_id.z);
 
     vec2 mercator = (tile_anchor / EXTENT + tile_id.xy) / tiles;
@@ -43,6 +42,9 @@ vec3 mix_globe_mercator(mat4 matrix, vec2 tile_anchor, vec3 position, vec3 tile_
     mercator_tile = matrix * mercator_tile;
 
     return mix(position, mercator_tile.xyz, vec3(t));
+#else
+    return position;
+#endif
 }
 
 // Unpack a pair of values that have been packed into a single float.

--- a/src/shaders/_prelude_terrain.vertex.glsl
+++ b/src/shaders/_prelude_terrain.vertex.glsl
@@ -33,7 +33,7 @@ uniform sampler2D u_depth;
 uniform vec2 u_depth_size_inv;
 
 vec3 elevationVector(vec2 pos) {
-    vec2 uv = pos / 8192.0;
+    vec2 uv = pos / EXTENT;
     vec3 up = normalize(mix(
         mix(u_tile_tl_up, u_tile_tr_up, uv.xxx),
         mix(u_tile_bl_up, u_tile_br_up, uv.xxx),

--- a/src/shaders/globe_depth.vertex.glsl
+++ b/src/shaders/globe_depth.vertex.glsl
@@ -1,6 +1,7 @@
 uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
 uniform mat4 u_merc_matrix;
+uniform mat4 u_up_vector_matrix;
 uniform float u_zoom_transition;
 uniform vec2 u_merc_center;
 
@@ -12,11 +13,12 @@ varying float v_depth;
 
 void main() {
     vec2 uv = a_uv * EXTENT;
-    vec3 height = elevationVector(uv) * elevation(uv);
+    vec4 up_vector = u_up_vector_matrix * vec4(elevationVector(uv), 1.0);
+    float height = elevation(uv);
 
-    vec4 globe = u_globe_matrix * vec4(a_globe_pos + height, 1.0);
+    vec4 globe = u_globe_matrix * vec4(a_globe_pos + up_vector.xyz * height, 1.0);
 
-    vec4 mercator = vec4(a_merc_pos, 0.0, 1.0);
+    vec4 mercator = vec4(a_merc_pos, height, 1.0);
     mercator.xy -= u_merc_center;
     mercator.x = wrap(mercator.x, -0.5, 0.5);
     mercator = u_merc_matrix * mercator;

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -1,6 +1,7 @@
 uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
 uniform mat4 u_merc_matrix;
+uniform mat4 u_up_vector_matrix;
 uniform float u_zoom_transition;
 uniform vec2 u_merc_center;
 
@@ -14,11 +15,12 @@ void main() {
     v_pos0 = a_uv;
 
     vec2 uv = a_uv * EXTENT;
-    vec3 height = elevationVector(uv) * elevation(uv);
+    vec4 up_vector = u_up_vector_matrix * vec4(elevationVector(uv), 1.0);
+    float height = elevation(uv);
 
-    vec4 globe = u_globe_matrix * vec4(a_globe_pos + height, 1.0);
+    vec4 globe = u_globe_matrix * vec4(a_globe_pos + up_vector.xyz * height, 1.0);
 
-    vec4 mercator = vec4(a_merc_pos, 0.0, 1.0);
+    vec4 mercator = vec4(a_merc_pos, height, 1.0);
     mercator.xy -= u_merc_center;
     mercator.x = wrap(mercator.x, -0.5, 0.5);
     mercator = u_merc_matrix * mercator;

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -116,8 +116,13 @@ void main() {
     float occlusion_fade = occlusionFade(projectedPoint);
     gl_Position = mix(u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + offset, z, 1.0), AWAY, float(projectedPoint.w <= 0.0 || occlusion_fade == 0.0));
 
+    float projection_transition_fade = 1.0;
+#if defined(PROJECTED_POS_ON_VIEWPORT) && defined(PROJECTION_GLOBE_VIEW)
+    projection_transition_fade = 1.0 - step(EPSILON, u_zoom_transition);
+#endif
+
     v_tex = a_tex / u_texsize;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
-    v_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
+    v_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change)) * projection_transition_fade;
 }

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -135,10 +135,15 @@ void main() {
     gl_Position = mix(u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + offset, z, 1.0), AWAY, float(projectedPoint.w <= 0.0 || occlusion_fade == 0.0));
     float gamma_scale = gl_Position.w;
 
+    float projection_transition_fade = 1.0;
+#if defined(PROJECTED_POS_ON_VIEWPORT) && defined(PROJECTION_GLOBE_VIEW)
+    projection_transition_fade = 1.0 - step(EPSILON, u_zoom_transition);
+#endif
+
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
     float interpolated_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
 
     v_data0 = a_tex / u_texsize;
-    v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity);
+    v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity * projection_transition_fade);
 }

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -18,6 +18,8 @@ uniform highp float u_size_t; // used to interpolate between zoom stops when siz
 uniform highp float u_size; // used when size is both zoom and feature constant
 uniform mat4 u_matrix;
 uniform mat4 u_label_plane_matrix;
+uniform mat4 u_inv_rot_matrix;
+uniform vec2 u_merc_center;
 uniform mat4 u_coord_matrix;
 uniform bool u_is_text;
 uniform bool u_pitch_with_map;
@@ -27,6 +29,8 @@ uniform highp float u_aspect_ratio;
 uniform highp float u_camera_to_center_distance;
 uniform float u_fade_change;
 uniform vec2 u_texsize;
+uniform vec3 u_tile_id;
+uniform float u_zoom_transition;
 
 varying vec2 v_data0;
 varying vec3 v_data1;
@@ -66,9 +70,12 @@ void main() {
 
     float anchorZ = a_z_tileAnchor.x;
     vec2 tileAnchor = a_z_tileAnchor.yz;
-    float anchorElevation = elevation(tileAnchor);
-    vec3 h = elevationVector(tileAnchor) * anchorElevation;
-    vec4 projectedPoint = u_matrix * vec4(vec3(a_pos, anchorZ) + h, 1);
+    vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
+    vec3 world_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,
+        u_tile_id, u_merc_center, u_zoom_transition);
+
+    vec4 projectedPoint = u_matrix * vec4(world_pos, 1);
 
     highp float camera_to_anchor_distance = projectedPoint.w;
     // If the label is pitched with the map, layout is done in pitched space,
@@ -102,10 +109,14 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
+    vec3 proj_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_projected_pos.xy, anchorZ),
+        u_tile_id, u_merc_center, u_zoom_transition);
+
 #ifdef PROJECTED_POS_ON_VIEWPORT
-    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xy, 0.0, 1.0);
 #else
-    vec4 projected_pos = u_label_plane_matrix * vec4(vec3(a_projected_pos.xy, anchorZ) + h, 1.0);
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xyz + h, 1.0);
 #endif
 
     highp float angle_sin = sin(segment_angle + symbol_rotation);

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -1,6 +1,6 @@
 attribute vec4 a_pos_offset;
 attribute vec4 a_tex_size;
-attribute vec4 a_posz;
+attribute vec4 a_z_tile_anchor;
 attribute vec3 a_projected_pos;
 attribute float a_fade_opacity;
 
@@ -27,6 +27,10 @@ uniform highp float u_camera_to_center_distance;
 uniform float u_fade_change;
 uniform vec2 u_texsize;
 uniform vec2 u_texsize_icon;
+uniform mat4 u_inv_rot_matrix;
+uniform vec2 u_merc_center;
+uniform vec3 u_tile_id;
+uniform float u_zoom_transition;
 
 varying vec4 v_data0;
 varying vec4 v_data1;
@@ -64,8 +68,14 @@ void main() {
         size = u_size;
     }
 
-    vec3 h = elevationVector(a_pos) * elevation(a_pos);
-    vec4 projectedPoint = u_matrix * vec4(vec3(a_pos, 0) + h, 1);
+    float anchorZ = a_z_tile_anchor.x;
+    vec2 tileAnchor = a_z_tile_anchor.yz;
+    vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
+    vec3 world_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,
+        u_tile_id, u_merc_center, u_zoom_transition);
+
+    vec4 projectedPoint = u_matrix * vec4(world_pos, 1);
 
     highp float camera_to_anchor_distance = projectedPoint.w;
     // If the label is pitched with the map, layout is done in pitched space,
@@ -91,7 +101,7 @@ void main() {
         // Point labels with 'rotation-alignment: map' are horizontal with respect to tile units
         // To figure out that angle in projected space, we draw a short horizontal line in tile
         // space, project it, and measure its angle in projected space.
-        vec4 offsetProjectedPoint = u_matrix * vec4(vec3(a_pos + vec2(1, 0), 0) + h, 1);
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), anchorZ, 1);
 
         vec2 a = projectedPoint.xy / projectedPoint.w;
         vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
@@ -99,11 +109,20 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
+    vec3 proj_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_projected_pos.xy, anchorZ),
+        u_tile_id, u_merc_center, u_zoom_transition);
+
+#ifdef PROJECTED_POS_ON_VIEWPORT
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xy, 0.0, 1.0);
+#else
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xyz + h, 1.0);
+#endif
+
     highp float angle_sin = sin(segment_angle + symbol_rotation);
     highp float angle_cos = cos(segment_angle + symbol_rotation);
     mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
 
-    vec4 projected_pos = u_label_plane_matrix * vec4(vec3(a_projected_pos.xy, 0) + h, 1.0);
     float z = 0.0;
     vec2 offset = rotation_matrix * (a_offset / 32.0 * fontScale);
 #ifdef PITCH_WITH_MAP_TERRAIN

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -137,7 +137,12 @@ void main() {
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
     float interpolated_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
 
+    float projection_transition_fade = 1.0;
+#if defined(PROJECTED_POS_ON_VIEWPORT) && defined(PROJECTION_GLOBE_VIEW)
+    projection_transition_fade = 1.0 - step(EPSILON, u_zoom_transition);
+#endif
+
     v_data0.xy = a_tex / u_texsize;
     v_data0.zw = a_tex / u_texsize_icon;
-    v_data1 = vec4(gamma_scale, size, interpolated_fade_opacity, is_sdf);
+    v_data1 = vec4(gamma_scale, size, interpolated_fade_opacity * projection_transition_fade, is_sdf);
 }

--- a/src/source/worker_tile.js
+++ b/src/source/worker_tile.js
@@ -235,6 +235,7 @@ class WorkerTile {
                             this.tileID.canonical,
                             this.tileZoom,
                             getProjection(this.projection));
+                        bucket.projection = this.projection;
                     } else if (bucket.hasPattern &&
                         (bucket instanceof LineBucket ||
                          bucket instanceof FillBucket ||

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -126,7 +126,7 @@ class Style extends Evented {
     light: Light;
     terrain: ?Terrain;
     fog: ?Fog;
-    
+
     _request: ?Cancelable;
     _spriteRequest: ?Cancelable;
     _layers: {[_: string]: StyleLayer};
@@ -1558,14 +1558,7 @@ class Style extends Evented {
         for (const layerId in this._layers) {
             const layer = this._layers[layerId];
             if (layer.type === 'symbol') {
-                // this._updatedLayers[layer.id] = true;
-                const sourceCache = this._getLayerSourceCache(layer);
-                // this._updatedSources[layer.source] = 'reload';
-                // FIXME: Figure out why some tiles have stale transforms
-                // after the zoom transition
-                sourceCache.clearTiles();
-                // this._changed = true;
-                // this._updateLayer(layer);
+                this._updateLayer(layer);
             }
         }
     }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1558,7 +1558,14 @@ class Style extends Evented {
         for (const layerId in this._layers) {
             const layer = this._layers[layerId];
             if (layer.type === 'symbol') {
-                this._updateLayer(layer);
+                // this._updatedLayers[layer.id] = true;
+                const sourceCache = this._getLayerSourceCache(layer);
+                // this._updatedSources[layer.source] = 'reload';
+                // FIXME: Figure out why some tiles have stale transforms
+                // after the zoom transition
+                sourceCache.clearTiles();
+                // this._changed = true;
+                // this._updateLayer(layer);
             }
         }
     }

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -204,7 +204,7 @@ function createPoleTriangleVertices(fanSize, tiles, ws, topCap) {
     return arr;
 }
 
-function prepareBuffersForTileMesh(painter: Painter, tile: Tile, coord: OverscaledTileID) {
+function prepareBuffersForTileMesh(painter: Painter, tile: Tile, coord: OverscaledTileID, tiles: number) {
     const context = painter.context;
     const id = coord.canonical;
     const tr = painter.transform;
@@ -213,7 +213,6 @@ function prepareBuffersForTileMesh(painter: Painter, tile: Tile, coord: Overscal
         tile.globeGridBuffer = context.createVertexBuffer(gridMesh, globeLayoutAttributes, false);
     }
 
-    const tiles = Math.pow(2, coord.canonical.z);
     if (!tile.globePoleBuffer && (coord.canonical.y === 0 || coord.canonical.y === tiles - 1)) {
         const poleMesh = createPoleTriangleVertices(GLOBE_VERTEX_GRID_SIZE, tiles, tr.tileSize * tiles, coord.canonical.y === 0);
         tile.globePoleBuffer = context.createVertexBuffer(poleMesh, globeLayoutAttributes, false);
@@ -232,6 +231,16 @@ function globeMatrixForTile(id: CanonicalTileID, globeMatrix) {
     mat4.mul(posMatrix, posMatrix, decode);
 
     return posMatrix;
+}
+
+function globeUpVectorMatrix(id: CanonicalTileID, tiles: number) {
+    // Tile up vectors and can be reused for each tiles on the same x-row.
+    // i.e. for each tile id (x, y, z) use pregenerated mesh of (0, y, z).
+    // For this reason the up vectors are rotated first by 'yRotation' to
+    // place them in the correct longitude location.
+    const xOffset = id.x - tiles / 2;
+    const yRotation = xOffset / tiles * Math.PI * 2.0;
+    return mat4.fromYRotation([], yRotation);
 }
 
 function poleMatrixForTile(id: CanonicalTileID, tr) {
@@ -280,7 +289,7 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
     const skirt = skirtHeight(tr.zoom) * terrain.exaggeration();
     const globeMatrix = tr.calculateGlobeMatrix(tr.worldSize);
     const globeMercatorMatrix = tr.calculateGlobeMercatorMatrix(tr.worldSize);
-    const mercCenter = [mercatorXfromLng(tr.center.lng), mercatorYfromLat(tr.center.lat)];
+    const mercatorCenter = [mercatorXfromLng(tr.center.lng), mercatorYfromLat(tr.center.lat)];
     const batches = showWireframe ? [false, true] : [false];
 
     batches.forEach(isWireframe => {
@@ -294,7 +303,9 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
 
         for (const coord of tileIDs) {
             const tile = sourceCache.getTile(coord);
-            prepareBuffersForTileMesh(painter, tile, coord);
+            const tiles = Math.pow(2, coord.canonical.z);
+
+            prepareBuffersForTileMesh(painter, tile, coord, tiles);
 
             const stencilMode = StencilMode.disabled;
 
@@ -319,16 +330,16 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
             }
 
             const posMatrix = globeMatrixForTile(coord.canonical, globeMatrix);
+            const upvectorMatrix = globeUpVectorMatrix(coord.canonical, tiles);
 
-            const tiles = Math.pow(2, coord.canonical.z);
             const uniformValues = globeRasterUniformValues(
                 tr.projMatrix, posMatrix, globeMercatorMatrix,
                 globeToMercatorTransition(tr.zoom),
-                mercCenter);
+                mercatorCenter, upvectorMatrix);
 
             setShaderMode(shaderMode, isWireframe);
 
-            const gridTileId = new CanonicalTileID(coord.canonical.z, Math.pow(2, coord.canonical.z) / 2, coord.canonical.y);
+            const gridTileId = new CanonicalTileID(coord.canonical.z, tiles / 2, coord.canonical.y);
             elevationOptions = extend(elevationOptions, { elevationTileID: gridTileId });
             terrain.setupElevationDraw(tile, program, elevationOptions);
 
@@ -343,7 +354,7 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
 
                 const poleUniforms = globeRasterUniformValues(
                     tr.projMatrix, poleMatrix, poleMatrix,
-                    0.0, mercCenter);
+                    0.0, mercatorCenter, upvectorMatrix);
 
                 program.draw(context, primitive, depthMode, stencilMode, colorMode, CullFaceMode.backCCW,
                     poleUniforms, "globe_pole_raster", tile.globePoleBuffer, painter.globeSharedBuffers.poleIndexBuffer, painter.globeSharedBuffers.poleSegments);
@@ -438,20 +449,23 @@ function drawTerrainDepth(painter: Painter, terrain: Terrain, sourceCache: Sourc
         const depthMode = new DepthMode(gl.LESS, DepthMode.ReadWrite, painter.depthRangeFor3D);
         const globeMercatorMatrix = tr.calculateGlobeMercatorMatrix(tr.worldSize);
         const globeMatrix = tr.calculateGlobeMatrix(tr.worldSize);
-        const mercCenter = [mercatorXfromLng(tr.center.lng), mercatorYfromLat(tr.center.lat)];
+        const mercatorCenter = [mercatorXfromLng(tr.center.lng), mercatorYfromLat(tr.center.lat)];
 
         for (const coord of tileIDs) {
             const tile = sourceCache.getTile(coord);
-            prepareBuffersForTileMesh(painter, tile, coord);
+            const tiles = Math.pow(2, coord.canonical.z);
 
-            const gridTileId = new CanonicalTileID(coord.canonical.z, Math.pow(2, coord.canonical.z) / 2, coord.canonical.y);
+            prepareBuffersForTileMesh(painter, tile, coord, tiles);
+
+            const gridTileId = new CanonicalTileID(coord.canonical.z, tiles / 2, coord.canonical.y);
             const elevationOptions = { elevationTileID: gridTileId };
             terrain.setupElevationDraw(tile, program, elevationOptions);
 
             const posMatrix = globeMatrixForTile(coord.canonical, globeMatrix);
             const uniformValues = globeRasterUniformValues(
                 tr.projMatrix, posMatrix, globeMercatorMatrix,
-                globeToMercatorTransition(tr.zoom), mercCenter);
+                globeToMercatorTransition(tr.zoom), mercatorCenter,
+                globeUpVectorMatrix(coord.canonical, tiles));
 
             program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, ColorMode.unblended, CullFaceMode.backCCW,
                 uniformValues, "globe_raster_depth", tile.globeGridBuffer, painter.globeSharedBuffers.gridIndexBuffer, painter.globeSharedBuffers.gridSegments, null, null, null, null);

--- a/src/terrain/globe_raster_program.js
+++ b/src/terrain/globe_raster_program.js
@@ -18,6 +18,7 @@ export type GlobeRasterUniformsType = {|
     'u_merc_matrix': UniformMatrix4f,
     'u_zoom_transition': Uniform1f,
     'u_merc_center': Uniform2f,
+    'u_up_vector_matrix': UniformMatrix4f,
     'u_image0': Uniform1i
 |};
 
@@ -38,6 +39,7 @@ const globeRasterUniforms = (context: Context, locations: UniformLocations): Glo
     'u_merc_matrix': new UniformMatrix4f(context, locations.u_merc_matrix),
     'u_zoom_transition': new Uniform1f(context, locations.u_zoom_transition),
     'u_merc_center': new Uniform2f(context, locations.u_merc_center),
+    'u_up_vector_matrix': new UniformMatrix4f(context, locations.u_up_vector_matrix),
     'u_image0': new Uniform1i(context, locations.u_image0)
 });
 
@@ -58,12 +60,14 @@ const globeRasterUniformValues = (
     globeMercatorMatrix: Float32Array,
     zoomTransition: number,
     mercCenter: [number, number],
+    upVectorMatrix: Float32Array
 ): UniformValues<GlobeRasterUniformsType> => ({
     'u_proj_matrix': projMatrix,
     'u_globe_matrix': globeMatrix,
     'u_merc_matrix': globeMercatorMatrix,
     'u_zoom_transition': zoomTransition,
     'u_merc_center': mercCenter,
+    'u_up_vector_matrix': upVectorMatrix,
     'u_image0': 0
 });
 


### PR DESCRIPTION
Continuing on #10984 before starting porting on the globe view gl-native branch:

Apply the same process that was done on the sphere geometry on the symbols.

I investigated first a CPU approach, where symbols were projected each in their respective projections and the interpolation was done afterwards but this ended up being an issue: We would need to evaluate symbol collision boxes at every frame at runtime. Currently, only collision circles are evaluated as such. For collision boxes, we only evaluate a few properties of symbols dynamically. Updating their positions would add a non-negligible performance and complexity overhead for something that is only applied on a particular feature (globe view) and not always (between two zoom levels).

For the reason above, I eventually landed on a GPU approach that is simpler and has less overhead with the disadvantage that symbol collision boxes aren't aligned during that phase, but it is a tradeoff that we can mitigate further by introducing a fixed duration animation.

The zoom used in the video below is only representative of the feature, not the actual zoom at which we will transition:

https://user-images.githubusercontent.com/7061573/132710685-8d5d3cb2-32aa-4979-b3b0-3251864dac47.mov

