### PR TITLE
Backport v2.4.1 fix from 0a35e9

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "type": "git",
     "url": "git://github.com/mapbox/mapbox-gl-js.git"
   },
-  "engines": {
-    "node": ">=14.15.4"
-  },
   "dependencies": {
     "@mapbox/geojson-rewind": "^0.5.0",
     "@mapbox/geojson-types": "^1.0.2",


### PR DESCRIPTION
Backport of missing change in main https://github.com/mapbox/mapbox-gl-js/commit/0a35e90f012affa761595c747fa440f493f3d21c to prevent releasing v2.5.0 with the same issue.