### PR TITLE
Fix mismatching symbol vertex layouts

### DIFF
--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -1,5 +1,6 @@
 attribute vec4 a_pos_offset;
 attribute vec4 a_tex_size;
+attribute vec4 a_z_tile_anchor;
 attribute vec3 a_projected_pos;
 attribute float a_fade_opacity;
 
@@ -63,8 +64,10 @@ void main() {
         size = u_size;
     }
 
-    vec3 h = elevationVector(a_pos) * elevation(a_pos);
-    vec4 projectedPoint = u_matrix * vec4(vec3(a_pos, 0) + h, 1);
+    float anchorZ = a_z_tile_anchor.x;
+    vec2 tileAnchor = a_z_tile_anchor.yz;
+    vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
+    vec4 projectedPoint = u_matrix * vec4(vec3(a_pos, anchorZ) + h, 1);
 
     highp float camera_to_anchor_distance = projectedPoint.w;
     // If the label is pitched with the map, layout is done in pitched space,
@@ -90,7 +93,7 @@ void main() {
         // Point labels with 'rotation-alignment: map' are horizontal with respect to tile units
         // To figure out that angle in projected space, we draw a short horizontal line in tile
         // space, project it, and measure its angle in projected space.
-        vec4 offsetProjectedPoint = u_matrix * vec4(vec3(a_pos.x + 1.0, a_pos.y, 0) + h, 1);
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), anchorZ, 1);
 
         vec2 a = projectedPoint.xy / projectedPoint.w;
         vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
@@ -98,11 +101,16 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
+#ifdef PROJECTED_POS_ON_VIEWPORT
+    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+#else
+    vec4 projected_pos = u_label_plane_matrix * vec4(vec3(a_projected_pos.xy, anchorZ) + h, 1.0);
+#endif
+
     highp float angle_sin = sin(segment_angle + symbol_rotation);
     highp float angle_cos = cos(segment_angle + symbol_rotation);
     mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
 
-    vec4 projected_pos = u_label_plane_matrix * vec4(vec3(a_projected_pos.xy, 0) + h, 1.0);
     float z = 0.0;
     vec2 offset = rotation_matrix * (a_offset / 32.0 * fontScale);
 #ifdef PITCH_WITH_MAP_TERRAIN


### PR DESCRIPTION
As per discussion on slack, and a follow up to #10956 : prevent a potential mismatching of vertex layouts for symbol_text_and_icon.vertex shader. I haven't (yet) found an issue with that in practice (or found the style combination that may trigger any substantial issue with that), if I manage to do so I'll add a render test for it.

I still consider this mismatching a release blocker due to the potential risk involved with sampling incorrect data, or dealing with rendering artifacts. 