### PR TITLE
Fix CI for external contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
               - prepare
           filters:
             branches:
-              ignore: /.*:.*/
+              ignore: /pull\/[0-9]*/
       - lint:
           requires:
             - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - install-mbx-ci:
+          requires:
+              - prepare
+          filters:
+            tags:
+              only: /.*/
       - lint:
           requires:
             - prepare
@@ -74,6 +80,7 @@ workflows:
       - collect-stats:
           requires:
             - build
+            - install-mbx-ci
           filters:
             tags:
               ignore: /.*/
@@ -81,6 +88,7 @@ workflows:
               only: main
       - deploy-benchmarks:
           requires:
+            - install-mbx-ci
             - lint
             - build
             - test-flow
@@ -98,6 +106,7 @@ workflows:
                 - /release-.*/
       - deploy-release:
           requires:
+            - install-mbx-ci
             - lint
             - build
             - test-flow
@@ -123,12 +132,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          name: Install mbx-ci
-          command: |
-            curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > ~/mbx-ci &&
-            chmod 755 ~/mbx-ci &&
-            ~/mbx-ci aws setup
       - restore_cache:
           keys:
             - v4-yarn-{{ checksum "yarn.lock" }}
@@ -142,10 +145,22 @@ jobs:
           root: ~/
           paths:
             - mapbox-gl-js
+
+  install-mbx-ci:
+    <<: *defaults
+    steps:
+      - run:
+          name: Install mbx-ci
+          command: |
+            curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > ~/mbx-ci &&
+            chmod 755 ~/mbx-ci &&
+            ~/mbx-ci aws setup
+      - persist_to_workspace:
+          root: ~/
+          paths:
             - .ssh
             - .aws
             - mbx-ci
-
 
   lint:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,10 +201,6 @@ jobs:
       - run: yarn run build-style-spec
       - run: yarn run build-flow-types
       - run: yarn run test-build
-      - run:
-          name: Check bundle size
-          command: |
-            node build/check-bundle-size.js
       - store_artifacts:
           path: "dist"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,6 @@ workflows:
           requires:
               - prepare
           filters:
-            tags:
-              only: /.*/
             branches:
               ignore: /.*:.*/
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ workflows:
             tags:
               only: /.*/
       - install-mbx-ci:
+          requires:
+              - prepare
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ jobs:
           root: ~/
           paths:
             - mapbox-gl-js
+            - .ssh
 
   install-mbx-ci:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /.*:.*/
       - lint:
           requires:
             - prepare
@@ -26,6 +28,14 @@ workflows:
       - build:
           requires:
             - prepare
+          filters:
+            tags:
+              only: /.*/
+      - check-bundle-size:
+          requires:
+            - prepare
+            - install-mbx-ci
+            - build
           filters:
             tags:
               only: /.*/
@@ -203,6 +213,16 @@ jobs:
           root: ~/
           paths:
             - mapbox-gl-js/dist
+
+  check-bundle-size:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Check bundle size
+          command: |
+            node build/check-bundle-size.js
 
   test-flow:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ workflows:
             tags:
               only: /.*/
       - install-mbx-ci:
-          requires:
-              - prepare
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
- Separates out installing `mbx-ci` into its own separate job
- Detects fork branches by detecting the `pull/{number}` branch name format which github automatically generates for fork PR CI jobs 
- Everything else downstream of that gets skipped automatically.

Test external contributor PR for which CI worked
https://github.com/mapbox/mapbox-gl-js/pull/11012

Unblocks https://github.com/mapbox/mapbox-gl-js/pull/10954