### PR TITLE
Globe View: Latest shader changes for native port

### DIFF
--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -271,7 +271,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         const program = painter.useProgram(getSymbolProgramName(isSDF, isText, bucket), programConfiguration, defines);
         const size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
-        const coordId = [coord.canonical.x, coord.canonical.y, coord.canonical.z];
+        const coordId = [coord.canonical.x, coord.canonical.y, 1 << coord.canonical.z];
 
         let texSize: [number, number];
         let texSizeIcon: [number, number] = [0, 0];

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -244,11 +244,17 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
     let sortFeaturesByKey = false;
 
     const depthMode = painter.depthModeForSublayer(0, DepthMode.ReadOnly);
-
+    const mercCenter = [0, 0];
     const variablePlacement = layer.layout.get('text-variable-anchor');
-
     const tileRenderState: Array<SymbolTileRenderState> = [];
-    const defines = painter.terrain && pitchWithMap ? ['PITCH_WITH_MAP_TERRAIN'] : null;
+
+    let defines = [];
+    if (painter.terrain && pitchWithMap) {
+        defines.push('PITCH_WITH_MAP_TERRAIN');
+    }
+    if (alongLine) {
+        defines.push('PROJECTED_POS_ON_VIEWPORT');
+    }
 
     for (const coord of coords) {
         const tile = sourceCache.getTile(coord);
@@ -265,6 +271,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
 
         const program = painter.useProgram(getSymbolProgramName(isSDF, isText, bucket), programConfiguration, defines);
         const size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
+        const coordId = [coord.canonical.x, coord.canonical.y, coord.canonical.z];
 
         let texSize: [number, number];
         let texSizeIcon: [number, number] = [0, 0];
@@ -319,16 +326,19 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
             if (!bucket.iconsInText) {
                 uniformValues = symbolSDFUniformValues(sizeData.kind,
                 size, rotateInShader, pitchWithMap, painter, matrix,
-                uLabelPlaneMatrix, uglCoordMatrix, isText, texSize, true);
+                uLabelPlaneMatrix, uglCoordMatrix, isText, texSize, true,
+                coordId, 0.0, painter.identityMat, mercCenter);
             } else {
                 uniformValues = symbolTextAndIconUniformValues(sizeData.kind,
                 size, rotateInShader, pitchWithMap, painter, matrix,
-                uLabelPlaneMatrix, uglCoordMatrix, texSize, texSizeIcon);
+                uLabelPlaneMatrix, uglCoordMatrix, texSize, texSizeIcon,
+                coordId, 0.0, painter.identityMat, mercCenter);
             }
         } else {
             uniformValues = symbolIconUniformValues(sizeData.kind,
                 size, rotateInShader, pitchWithMap, painter, matrix,
-                uLabelPlaneMatrix, uglCoordMatrix, isText, texSize);
+                uLabelPlaneMatrix, uglCoordMatrix, isText, texSize,
+                coordId, 0.0, painter.identityMat, mercCenter);
         }
 
         const state = {

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -248,7 +248,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
     const variablePlacement = layer.layout.get('text-variable-anchor');
     const tileRenderState: Array<SymbolTileRenderState> = [];
 
-    let defines = [];
+    let defines = ([]: any);
     if (painter.terrain && pitchWithMap) {
         defines.push('PITCH_WITH_MAP_TERRAIN');
     }

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -248,7 +248,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
     const variablePlacement = layer.layout.get('text-variable-anchor');
     const tileRenderState: Array<SymbolTileRenderState> = [];
 
-    let defines = ([]: any);
+    const defines = ([]: any);
     if (painter.terrain && pitchWithMap) {
         defines.push('PITCH_WITH_MAP_TERRAIN');
     }

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -78,8 +78,8 @@ class Program<Us: UniformBindings> {
         let defines = configuration ? configuration.defines() : [];
         defines = defines.concat(fixedDefines.map((define) => `#define ${define}`));
 
-        const fragmentSource = defines.concat(prelude.fragmentSource, preludeCommonSource, preludeFog.fragmentSource, source.fragmentSource).join('\n');
-        const vertexSource = defines.concat(prelude.vertexSource, preludeCommonSource, preludeFog.vertexSource, preludeTerrain.vertexSource, source.vertexSource).join('\n');
+        const fragmentSource = defines.concat(preludeCommonSource, prelude.fragmentSource, preludeFog.fragmentSource, source.fragmentSource).join('\n');
+        const vertexSource = defines.concat(preludeCommonSource, prelude.vertexSource, preludeFog.vertexSource, preludeTerrain.vertexSource, source.vertexSource).join('\n');
         const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
         if (gl.isContextLost()) {
             this.failedToCreate = true;

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -1,6 +1,13 @@
 // @flow
 
-import {prelude, preludeTerrain, preludeFog, preludeCommonSource} from '../shaders/shaders.js';
+import {
+    prelude,
+    preludeFragPrecisionQualifiers,
+    preludeVertPrecisionQualifiers,
+    preludeTerrain,
+    preludeFog,
+    preludeCommonSource
+} from '../shaders/shaders.js';
 import assert from 'assert';
 import ProgramConfiguration from '../data/program_configuration.js';
 import VertexArrayObject from './vertex_array_object.js';
@@ -79,47 +86,13 @@ class Program<Us: UniformBindings> {
         defines = defines.concat(fixedDefines.map((define) => `#define ${define}`));
 
         const fragmentSource = defines.concat(
-            `#ifdef GL_ES
-            precision mediump float;
-            #else
-
-            #if !defined(lowp)
-            #define lowp
-            #endif
-
-            #if !defined(mediump)
-            #define mediump
-            #endif
-
-            #if !defined(highp)
-            #define highp
-            #endif
-
-            #endif`,
+            preludeFragPrecisionQualifiers,
             preludeCommonSource,
             prelude.fragmentSource,
             preludeFog.fragmentSource,
             source.fragmentSource).join('\n');
         const vertexSource = defines.concat(
-            `#ifdef GL_ES
-
-            precision highp float;
-
-            #else
-
-            #if !defined(lowp)
-            #define lowp
-            #endif
-
-            #if !defined(mediump)
-            #define mediump
-            #endif
-
-            #if !defined(highp)
-            #define highp
-            #endif
-
-            #endif`,
+            preludeVertPrecisionQualifiers,
             preludeCommonSource,
             prelude.vertexSource,
             preludeFog.vertexSource,

--- a/src/render/program.js
+++ b/src/render/program.js
@@ -78,8 +78,53 @@ class Program<Us: UniformBindings> {
         let defines = configuration ? configuration.defines() : [];
         defines = defines.concat(fixedDefines.map((define) => `#define ${define}`));
 
-        const fragmentSource = defines.concat(preludeCommonSource, prelude.fragmentSource, preludeFog.fragmentSource, source.fragmentSource).join('\n');
-        const vertexSource = defines.concat(preludeCommonSource, prelude.vertexSource, preludeFog.vertexSource, preludeTerrain.vertexSource, source.vertexSource).join('\n');
+        const fragmentSource = defines.concat(
+            `#ifdef GL_ES
+            precision mediump float;
+            #else
+
+            #if !defined(lowp)
+            #define lowp
+            #endif
+
+            #if !defined(mediump)
+            #define mediump
+            #endif
+
+            #if !defined(highp)
+            #define highp
+            #endif
+
+            #endif`,
+            preludeCommonSource,
+            prelude.fragmentSource,
+            preludeFog.fragmentSource,
+            source.fragmentSource).join('\n');
+        const vertexSource = defines.concat(
+            `#ifdef GL_ES
+
+            precision highp float;
+
+            #else
+
+            #if !defined(lowp)
+            #define lowp
+            #endif
+
+            #if !defined(mediump)
+            #define mediump
+            #endif
+
+            #if !defined(highp)
+            #define highp
+            #endif
+
+            #endif`,
+            preludeCommonSource,
+            prelude.vertexSource,
+            preludeFog.vertexSource,
+            preludeTerrain.vertexSource,
+            source.vertexSource).join('\n');
         const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
         if (gl.isContextLost()) {
             this.failedToCreate = true;

--- a/src/render/program/symbol_program.js
+++ b/src/render/program/symbol_program.js
@@ -4,6 +4,7 @@ import {
     Uniform1i,
     Uniform1f,
     Uniform2f,
+    Uniform3f,
     UniformMatrix4f
 } from '../uniform_binding.js';
 import {extend} from '../../util/util.js';
@@ -29,6 +30,10 @@ export type SymbolIconUniformsType = {|
     'u_is_text': Uniform1i,
     'u_pitch_with_map': Uniform1i,
     'u_texsize': Uniform2f,
+    'u_tile_id': Uniform3f,
+    'u_zoom_transition': Uniform1f,
+    'u_inv_rot_matrix': UniformMatrix4f,
+    'u_merc_center': Uniform2f,
     'u_texture': Uniform1i
 |};
 
@@ -51,6 +56,10 @@ export type SymbolSDFUniformsType = {|
     'u_texture': Uniform1i,
     'u_gamma_scale': Uniform1f,
     'u_device_pixel_ratio': Uniform1f,
+    'u_tile_id': Uniform3f,
+    'u_zoom_transition': Uniform1f,
+    'u_inv_rot_matrix': UniformMatrix4f,
+    'u_merc_center': Uniform2f,
     'u_is_halo': Uniform1i
 |};
 
@@ -96,6 +105,10 @@ const symbolIconUniforms = (context: Context, locations: UniformLocations): Symb
     'u_is_text': new Uniform1i(context, locations.u_is_text),
     'u_pitch_with_map': new Uniform1i(context, locations.u_pitch_with_map),
     'u_texsize': new Uniform2f(context, locations.u_texsize),
+    'u_tile_id': new Uniform3f(context, locations.u_tile_id),
+    'u_zoom_transition': new Uniform1f(context, locations.u_zoom_transition),
+    'u_inv_rot_matrix': new UniformMatrix4f(context, locations.u_inv_rot_matrix),
+    'u_merc_center': new Uniform2f(context, locations.u_merc_center),
     'u_texture': new Uniform1i(context, locations.u_texture)
 });
 
@@ -118,6 +131,10 @@ const symbolSDFUniforms = (context: Context, locations: UniformLocations): Symbo
     'u_texture': new Uniform1i(context, locations.u_texture),
     'u_gamma_scale': new Uniform1f(context, locations.u_gamma_scale),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
+    'u_tile_id': new Uniform3f(context, locations.u_tile_id),
+    'u_zoom_transition': new Uniform1f(context, locations.u_zoom_transition),
+    'u_inv_rot_matrix': new UniformMatrix4f(context, locations.u_inv_rot_matrix),
+    'u_merc_center': new Uniform2f(context, locations.u_merc_center),
     'u_is_halo': new Uniform1i(context, locations.u_is_halo)
 });
 
@@ -155,7 +172,11 @@ const symbolIconUniformValues = (
     labelPlaneMatrix: Float32Array,
     glCoordMatrix: Float32Array,
     isText: boolean,
-    texSize: [number, number]
+    texSize: [number, number],
+    tileID: [number, number, number],
+    zoomTransition: number,
+    invRotMatrix: Float32Array,
+    mercCenter: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {
     const transform = painter.transform;
 
@@ -175,6 +196,10 @@ const symbolIconUniformValues = (
         'u_is_text': +isText,
         'u_pitch_with_map': +pitchWithMap,
         'u_texsize': texSize,
+        'u_tile_id': tileID,
+        'u_zoom_transition': zoomTransition,
+        'u_inv_rot_matrix': invRotMatrix,
+        'u_merc_center': mercCenter,
         'u_texture': 0
     };
 };
@@ -190,13 +215,18 @@ const symbolSDFUniformValues = (
     glCoordMatrix: Float32Array,
     isText: boolean,
     texSize: [number, number],
-    isHalo: boolean
+    isHalo: boolean,
+    tileID: [number, number, number],
+    zoomTransition: number,
+    invRotMatrix: Float32Array,
+    mercCenter: [number, number]
 ): UniformValues<SymbolSDFUniformsType> => {
     const {cameraToCenterDistance, _pitch} = painter.transform;
 
     return extend(symbolIconUniformValues(functionType, size,
         rotateInShader, pitchWithMap, painter, matrix, labelPlaneMatrix,
-        glCoordMatrix, isText, texSize), {
+        glCoordMatrix, isText, texSize, tileID, zoomTransition,
+        invRotMatrix, mercCenter), {
         'u_gamma_scale': pitchWithMap ? cameraToCenterDistance * Math.cos(painter.terrain ? 0 : _pitch) : 1,
         'u_device_pixel_ratio': browser.devicePixelRatio,
         'u_is_halo': +isHalo
@@ -213,11 +243,16 @@ const symbolTextAndIconUniformValues = (
     labelPlaneMatrix: Float32Array,
     glCoordMatrix: Float32Array,
     texSizeSDF: [number, number],
-    texSizeIcon: [number, number]
+    texSizeIcon: [number, number],
+    tileID: [number, number, number],
+    zoomTransition: number,
+    invRotMatrix: Float32Array,
+    mercCenter: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {
     return extend(symbolSDFUniformValues(functionType, size,
         rotateInShader, pitchWithMap, painter, matrix, labelPlaneMatrix,
-        glCoordMatrix, true, texSizeSDF, true), {
+        glCoordMatrix, true, texSizeSDF, true, tileID, zoomTransition,
+        invRotMatrix, mercCenter), {
         'u_texsize_icon': texSizeIcon,
         'u_texture_icon': 1
     });

--- a/src/shaders/_prelude.fragment.glsl
+++ b/src/shaders/_prelude.fragment.glsl
@@ -1,20 +1,4 @@
-#ifdef GL_ES
-precision mediump float;
-#else
-
-#if !defined(lowp)
-#define lowp
-#endif
-
-#if !defined(mediump)
-#define mediump
-#endif
-
-#if !defined(highp)
-#define highp
-#endif
-
-#endif
+// NOTE: This prelude is injected in the fragment shader only
 
 highp vec3 hash(highp vec2 p) {
     highp vec3 p3 = fract(p.xyx * vec3(443.8975, 397.2973, 491.1871));

--- a/src/shaders/_prelude.glsl
+++ b/src/shaders/_prelude.glsl
@@ -4,6 +4,7 @@
 
 #define EPSILON 0.0000001
 #define PI 3.141592653589793
+#define EXTENT 8192.0
 
 #ifdef FOG
 

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -1,20 +1,4 @@
-#ifdef GL_ES
-precision highp float;
-#else
-
-#if !defined(lowp)
-#define lowp
-#endif
-
-#if !defined(mediump)
-#define mediump
-#endif
-
-#if !defined(highp)
-#define highp
-#endif
-
-#endif
+// NOTE: This prelude is injected in the vertex shader only
 
 float wrap(float n, float min, float max) {
     float d = max - min;

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -16,6 +16,37 @@ precision highp float;
 
 #endif
 
+#ifndef EXTENT
+#define EXTENT 8192.0
+#endif
+
+#ifndef PI
+#define PI 3.141592653589793
+#endif
+
+float wrap(float n, float min, float max) {
+    float d = max - min;
+    float w = mod(mod(n - min, d) + d, d) + min;
+    return (w == min) ? max : w;
+}
+
+vec3 mix_globe_mercator(mat4 matrix, vec2 tile_anchor, vec3 position, vec3 tile_id, vec2 mercator_center, float t) {
+#if defined(PROJECTION_GLOBE_VIEW) && !defined(PROJECTED_POS_ON_VIEWPORT)
+    float tiles = pow(2.0, tile_id.z);
+
+    vec2 mercator = (tile_anchor / EXTENT + tile_id.xy) / tiles;
+    mercator -= mercator_center;
+    mercator.x = wrap(mercator.x, -0.5, 0.5);
+
+    vec4 mercator_tile = vec4(mercator.xy * EXTENT, EXTENT / (2.0 * PI), 1.0);
+    mercator_tile = matrix * mercator_tile;
+
+    return mix(position, mercator_tile.xyz, vec3(t));
+#else
+    return position;
+#endif
+}
+
 // Unpack a pair of values that have been packed into a single float.
 // The packed values are assumed to be 8-bit unsigned integers, and are
 // packed like so:

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -16,14 +16,6 @@ precision highp float;
 
 #endif
 
-#ifndef EXTENT
-#define EXTENT 8192.0
-#endif
-
-#ifndef PI
-#define PI 3.141592653589793
-#endif
-
 float wrap(float n, float min, float max) {
     float d = max - min;
     float w = mod(mod(n - min, d) + d, d) + min;
@@ -41,7 +33,7 @@ vec3 mix_globe_mercator(mat4 matrix, vec2 tile_anchor, vec3 position, vec3 tile_
     vec4 mercator_tile = vec4(mercator.xy * EXTENT, EXTENT / (2.0 * PI), 1.0);
     mercator_tile = matrix * mercator_tile;
 
-    return mix(position, mercator_tile.xyz, vec3(t));
+    return mix(position, mercator_tile.xyz, t);
 #else
     return position;
 #endif

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -6,9 +6,10 @@ float wrap(float n, float min, float max) {
     return (w == min) ? max : w;
 }
 
-vec3 mix_globe_mercator(mat4 matrix, vec2 tile_anchor, vec3 position, vec3 tile_id, vec2 mercator_center, float t) {
+vec3 mercator_tile_position(mat4 matrix, vec2 tile_anchor, vec3 tile_id, vec2 mercator_center) {
 #if defined(PROJECTION_GLOBE_VIEW) && !defined(PROJECTED_POS_ON_VIEWPORT)
-    float tiles = pow(2.0, tile_id.z);
+    // tile_id.z contains pow(2.0, coord.canonical.z)
+    float tiles = tile_id.z;
 
     vec2 mercator = (tile_anchor / EXTENT + tile_id.xy) / tiles;
     mercator -= mercator_center;
@@ -17,9 +18,17 @@ vec3 mix_globe_mercator(mat4 matrix, vec2 tile_anchor, vec3 position, vec3 tile_
     vec4 mercator_tile = vec4(mercator.xy * EXTENT, EXTENT / (2.0 * PI), 1.0);
     mercator_tile = matrix * mercator_tile;
 
-    return mix(position, mercator_tile.xyz, t);
+    return mercator_tile.xyz;
 #else
-    return position;
+    return vec3(0.0);
+#endif
+}
+
+vec3 mix_globe_mercator(vec3 globe, vec3 mercator, float t) {
+#if defined(PROJECTION_GLOBE_VIEW) && !defined(PROJECTED_POS_ON_VIEWPORT)
+    return mix(globe, mercator, t);
+#else
+    return globe;
 #endif
 }
 

--- a/src/shaders/_prelude_terrain.vertex.glsl
+++ b/src/shaders/_prelude_terrain.vertex.glsl
@@ -2,6 +2,28 @@
 #define ELEVATION_SCALE 7.0
 #define ELEVATION_OFFSET 450.0
 
+#ifdef PROJECTION_GLOBE_VIEW
+
+uniform vec3 u_tile_tl_up;
+uniform vec3 u_tile_tr_up;
+uniform vec3 u_tile_br_up;
+uniform vec3 u_tile_bl_up;
+uniform float u_tile_up_scale;
+vec3 elevationVector(vec2 pos) {
+    vec2 uv = pos / EXTENT;
+    vec3 up = normalize(mix(
+        mix(u_tile_tl_up, u_tile_tr_up, uv.xxx),
+        mix(u_tile_bl_up, u_tile_br_up, uv.xxx),
+        uv.yyy));
+    return up * u_tile_up_scale;
+}
+
+#else 
+
+vec3 elevationVector(vec2 pos) { return vec3(0, 0, 1); }
+
+#endif
+
 #ifdef TERRAIN
 
 #ifdef TERRAIN_DEM_FLOAT_FORMAT
@@ -22,23 +44,8 @@ uniform float u_exaggeration;
 uniform float u_meter_to_dem;
 uniform mat4 u_label_plane_matrix_inv;
 
-uniform vec3 u_tile_tl_up;
-uniform vec3 u_tile_tr_up;
-uniform vec3 u_tile_br_up;
-uniform vec3 u_tile_bl_up;
-uniform float u_tile_up_scale;
-
 uniform sampler2D u_depth;
 uniform vec2 u_depth_size_inv;
-
-vec3 elevationVector(vec2 pos) {
-    vec2 uv = pos / EXTENT;
-    vec3 up = normalize(mix(
-        mix(u_tile_tl_up, u_tile_tr_up, uv.xxx),
-        mix(u_tile_bl_up, u_tile_br_up, uv.xxx),
-        uv.yyy));
-    return up * u_tile_up_scale;
-}
 
 vec4 tileUvToDemSample(vec2 uv, float dem_size, float dem_scale, vec2 dem_tl) {
     vec2 pos = dem_size * (uv * dem_scale + dem_tl) + 1.0;
@@ -195,6 +202,5 @@ float elevationFromUint16(float word) {
 float elevation(vec2 pos) { return 0.0; }
 bool isOccluded(vec4 frag) { return false; }
 float occlusionFade(vec4 frag) { return 1.0; }
-vec3 elevationVector(vec2 pos) { return vec3(0, 0, 1); }
 
 #endif

--- a/src/shaders/_prelude_terrain.vertex.glsl
+++ b/src/shaders/_prelude_terrain.vertex.glsl
@@ -32,7 +32,7 @@ uniform sampler2D u_depth;
 uniform vec2 u_depth_size_inv;
 
 vec3 elevationVector(vec2 pos) {
-    vec2 uv = pos / 8192.0;
+    vec2 uv = pos / EXTENT;
     vec3 up = normalize(mix(
         mix(u_tile_tl_up, u_tile_tr_up, uv.xxx),
         mix(u_tile_bl_up, u_tile_br_up, uv.xxx),

--- a/src/shaders/globe_atmosphere.fragment.glsl
+++ b/src/shaders/globe_atmosphere.fragment.glsl
@@ -3,13 +3,13 @@ uniform float u_radius;
 uniform vec2 u_screen_size;
 
 uniform float u_opacity;
-uniform float u_fadeout_range;
+uniform highp float u_fadeout_range;
 uniform vec3 u_start_color;
 uniform vec3 u_end_color;
 uniform float u_pixel_ratio;
 
 void main() {
-    vec2 fragCoord = gl_FragCoord.xy / u_pixel_ratio;
+    highp vec2 fragCoord = gl_FragCoord.xy / u_pixel_ratio;
     fragCoord.y = u_screen_size.y - fragCoord.y;
     float distFromCenter = length(fragCoord - u_center);
 

--- a/src/shaders/globe_depth.vertex.glsl
+++ b/src/shaders/globe_depth.vertex.glsl
@@ -1,10 +1,32 @@
+uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
+uniform mat4 u_merc_matrix;
+uniform mat4 u_up_vector_matrix;
+uniform float u_zoom_transition;
+uniform vec2 u_merc_center;
+
 attribute vec3 a_globe_pos;
+attribute vec2 a_merc_pos;
 attribute vec2 a_uv;
 
 varying float v_depth;
 
 void main() {
-    gl_Position = u_globe_matrix * vec4(a_globe_pos + elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0), 1.0);
+    vec2 uv = a_uv * EXTENT;
+    vec4 up_vector = u_up_vector_matrix * vec4(elevationVector(uv), 1.0);
+    float height = elevation(uv);
+
+    vec4 globe = u_globe_matrix * vec4(a_globe_pos + up_vector.xyz * height, 1.0);
+
+    vec4 mercator = vec4(a_merc_pos, height, 1.0);
+    mercator.xy -= u_merc_center;
+    mercator.x = wrap(mercator.x, -0.5, 0.5);
+    mercator = u_merc_matrix * mercator;
+
+    vec3 t = vec3(u_zoom_transition);
+    vec3 position = mix(globe.xyz, mercator.xyz, t);
+
+    gl_Position = u_proj_matrix * vec4(position, 1.0);
+
     v_depth = gl_Position.z / gl_Position.w;
 }

--- a/src/shaders/globe_depth.vertex.glsl
+++ b/src/shaders/globe_depth.vertex.glsl
@@ -23,8 +23,7 @@ void main() {
     mercator.x = wrap(mercator.x, -0.5, 0.5);
     mercator = u_merc_matrix * mercator;
 
-    vec3 t = vec3(u_zoom_transition);
-    vec3 position = mix(globe.xyz, mercator.xyz, t);
+    vec3 position = mix(globe.xyz, mercator.xyz, u_zoom_transition);
 
     gl_Position = u_proj_matrix * vec4(position, 1.0);
 

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -1,11 +1,32 @@
+uniform mat4 u_proj_matrix;
 uniform mat4 u_globe_matrix;
+uniform mat4 u_merc_matrix;
+uniform mat4 u_up_vector_matrix;
+uniform float u_zoom_transition;
+uniform vec2 u_merc_center;
 
 attribute vec3 a_globe_pos;
+attribute vec2 a_merc_pos;
 attribute vec2 a_uv;
 
 varying vec2 v_pos0;
 
 void main() {
     v_pos0 = a_uv;
-    gl_Position = u_globe_matrix * vec4(a_globe_pos + elevationVector(a_uv * 8192.0) * elevation(a_uv * 8192.0), 1.0);
+
+    vec2 uv = a_uv * EXTENT;
+    vec4 up_vector = u_up_vector_matrix * vec4(elevationVector(uv), 1.0);
+    float height = elevation(uv);
+
+    vec4 globe = u_globe_matrix * vec4(a_globe_pos + up_vector.xyz * height, 1.0);
+
+    vec4 mercator = vec4(a_merc_pos, height, 1.0);
+    mercator.xy -= u_merc_center;
+    mercator.x = wrap(mercator.x, -0.5, 0.5);
+    mercator = u_merc_matrix * mercator;
+
+    vec3 t = vec3(u_zoom_transition);
+    vec3 position = mix(globe.xyz, mercator.xyz, t);
+
+    gl_Position = u_proj_matrix * vec4(position, 1.0);
 }

--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -25,8 +25,7 @@ void main() {
     mercator.x = wrap(mercator.x, -0.5, 0.5);
     mercator = u_merc_matrix * mercator;
 
-    vec3 t = vec3(u_zoom_transition);
-    vec3 position = mix(globe.xyz, mercator.xyz, t);
+    vec3 position = mix(globe.xyz, mercator.xyz, u_zoom_transition);
 
     gl_Position = u_proj_matrix * vec4(position, 1.0);
 }

--- a/src/shaders/shaders.js
+++ b/src/shaders/shaders.js
@@ -79,6 +79,43 @@ preludeFog = compile(preludeFogFrag, preludeFogVert, true);
 export const prelude = compile(preludeFrag, preludeVert);
 export const preludeCommonSource = preludeCommon;
 
+export const preludeVertPrecisionQualifiers = `
+#ifdef GL_ES
+precision highp float;
+#else
+
+#if !defined(lowp)
+#define lowp
+#endif
+
+#if !defined(mediump)
+#define mediump
+#endif
+
+#if !defined(highp)
+#define highp
+#endif
+
+#endif`;
+export const preludeFragPrecisionQualifiers = `
+#ifdef GL_ES
+precision mediump float;
+#else
+
+#if !defined(lowp)
+#define lowp
+#endif
+
+#if !defined(mediump)
+#define mediump
+#endif
+
+#if !defined(highp)
+#define highp
+#endif
+
+#endif`;
+
 export default {
     background: compile(backgroundFrag, backgroundVert),
     backgroundPattern: compile(backgroundPatternFrag, backgroundPatternVert),

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -1,7 +1,7 @@
 attribute vec4 a_pos_offset;
 attribute vec4 a_tex_size;
 attribute vec4 a_pixeloffset;
-attribute vec4 a_z_tile_anchor;
+attribute vec4 a_z_tileAnchor;
 attribute vec3 a_projected_pos;
 attribute float a_fade_opacity;
 
@@ -14,6 +14,10 @@ uniform highp float u_pitch;
 uniform bool u_rotate_symbol;
 uniform highp float u_aspect_ratio;
 uniform float u_fade_change;
+uniform mat4 u_inv_rot_matrix;
+uniform vec2 u_merc_center;
+uniform vec3 u_tile_id;
+uniform float u_zoom_transition;
 
 uniform mat4 u_matrix;
 uniform mat4 u_label_plane_matrix;
@@ -53,10 +57,14 @@ void main() {
         size = u_size;
     }
 
-    float anchorZ = a_z_tile_anchor.x;
-    vec2 tileAnchor = a_z_tile_anchor.yz;
+    float anchorZ = a_z_tileAnchor.x;
+    vec2 tileAnchor = a_z_tileAnchor.yz;
     vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
-    vec4 projectedPoint = u_matrix * vec4(vec3(a_pos, anchorZ) + h, 1);
+    vec3 world_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,
+        u_tile_id, u_merc_center, u_zoom_transition);
+
+    vec4 projectedPoint = u_matrix * vec4(world_pos, 1);
 
     highp float camera_to_anchor_distance = projectedPoint.w;
     // See comments in symbol_sdf.vertex
@@ -83,10 +91,14 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
+    vec3 proj_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_projected_pos.xy, anchorZ),
+        u_tile_id, u_merc_center, u_zoom_transition);
+
 #ifdef PROJECTED_POS_ON_VIEWPORT
-    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xy, 0.0, 1.0);
 #else
-    vec4 projected_pos = u_label_plane_matrix * vec4(vec3(a_projected_pos.xy, anchorZ) + h, 1.0);
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xyz + h, 1.0);
 #endif
 
     highp float angle_sin = sin(segment_angle + symbol_rotation);
@@ -103,8 +115,13 @@ void main() {
     float occlusion_fade = occlusionFade(projectedPoint);
     gl_Position = mix(u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + offset, z, 1.0), AWAY, float(projectedPoint.w <= 0.0 || occlusion_fade == 0.0));
 
+    float projection_transition_fade = 1.0;
+#if defined(PROJECTED_POS_ON_VIEWPORT) && defined(PROJECTION_GLOBE_VIEW)
+    projection_transition_fade = 1.0 - step(EPSILON, u_zoom_transition);
+#endif
+
     v_tex = a_tex / u_texsize;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
-    v_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
+    v_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change)) * projection_transition_fade;
 }

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -1,7 +1,7 @@
 attribute vec4 a_pos_offset;
 attribute vec4 a_tex_size;
 attribute vec4 a_pixeloffset;
-attribute vec4 a_z_tileAnchor;
+attribute vec4 a_z_tile_anchor;
 attribute vec3 a_projected_pos;
 attribute float a_fade_opacity;
 
@@ -57,8 +57,8 @@ void main() {
         size = u_size;
     }
 
-    float anchorZ = a_z_tileAnchor.x;
-    vec2 tileAnchor = a_z_tileAnchor.yz;
+    float anchorZ = a_z_tile_anchor.x;
+    vec2 tileAnchor = a_z_tile_anchor.yz;
     vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
     vec3 world_pos = mix_globe_mercator(
         u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -60,9 +60,8 @@ void main() {
     float anchorZ = a_z_tile_anchor.x;
     vec2 tileAnchor = a_z_tile_anchor.yz;
     vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
-    vec3 world_pos = mix_globe_mercator(
-        u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,
-        u_tile_id, u_merc_center, u_zoom_transition);
+    vec3 mercator_pos = mercator_tile_position(u_inv_rot_matrix, tileAnchor, u_tile_id, u_merc_center);
+    vec3 world_pos = mix_globe_mercator(vec3(a_pos, anchorZ) + h, mercator_pos, u_zoom_transition);
 
     vec4 projectedPoint = u_matrix * vec4(world_pos, 1);
 
@@ -91,9 +90,7 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
-    vec3 proj_pos = mix_globe_mercator(
-        u_inv_rot_matrix, tileAnchor, vec3(a_projected_pos.xy, anchorZ),
-        u_tile_id, u_merc_center, u_zoom_transition);
+    vec3 proj_pos = mix_globe_mercator(vec3(a_projected_pos.xy, anchorZ), mercator_pos, u_zoom_transition);
 
 #ifdef PROJECTED_POS_ON_VIEWPORT
     vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xy, 0.0, 1.0);

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -1,7 +1,7 @@
 attribute vec4 a_pos_offset;
 attribute vec4 a_tex_size;
 attribute vec4 a_pixeloffset;
-attribute vec4 a_z_tile_anchor;
+attribute vec4 a_z_tileAnchor;
 attribute vec3 a_projected_pos;
 attribute float a_fade_opacity;
 
@@ -18,6 +18,8 @@ uniform highp float u_size_t; // used to interpolate between zoom stops when siz
 uniform highp float u_size; // used when size is both zoom and feature constant
 uniform mat4 u_matrix;
 uniform mat4 u_label_plane_matrix;
+uniform mat4 u_inv_rot_matrix;
+uniform vec2 u_merc_center;
 uniform mat4 u_coord_matrix;
 uniform bool u_is_text;
 uniform bool u_pitch_with_map;
@@ -27,6 +29,8 @@ uniform highp float u_aspect_ratio;
 uniform highp float u_camera_to_center_distance;
 uniform float u_fade_change;
 uniform vec2 u_texsize;
+uniform vec3 u_tile_id;
+uniform float u_zoom_transition;
 
 varying vec2 v_data0;
 varying vec3 v_data1;
@@ -64,10 +68,14 @@ void main() {
         size = u_size;
     }
 
-    float anchorZ = a_z_tile_anchor.x;
-    vec2 tileAnchor = a_z_tile_anchor.yz;
+    float anchorZ = a_z_tileAnchor.x;
+    vec2 tileAnchor = a_z_tileAnchor.yz;
     vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
-    vec4 projectedPoint = u_matrix * vec4(vec3(a_pos, anchorZ) + h, 1);
+    vec3 world_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,
+        u_tile_id, u_merc_center, u_zoom_transition);
+
+    vec4 projectedPoint = u_matrix * vec4(world_pos, 1);
 
     highp float camera_to_anchor_distance = projectedPoint.w;
     // If the label is pitched with the map, layout is done in pitched space,
@@ -101,10 +109,14 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
+    vec3 proj_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_projected_pos.xy, anchorZ),
+        u_tile_id, u_merc_center, u_zoom_transition);
+
 #ifdef PROJECTED_POS_ON_VIEWPORT
-    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xy, 0.0, 1.0);
 #else
-    vec4 projected_pos = u_label_plane_matrix * vec4(vec3(a_projected_pos.xy, anchorZ) + h, 1.0);
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xyz + h, 1.0);
 #endif
 
     highp float angle_sin = sin(segment_angle + symbol_rotation);
@@ -122,10 +134,15 @@ void main() {
     gl_Position = mix(u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + offset, z, 1.0), AWAY, float(projectedPoint.w <= 0.0 || occlusion_fade == 0.0));
     float gamma_scale = gl_Position.w;
 
+    float projection_transition_fade = 1.0;
+#if defined(PROJECTED_POS_ON_VIEWPORT) && defined(PROJECTION_GLOBE_VIEW)
+    projection_transition_fade = 1.0 - step(EPSILON, u_zoom_transition);
+#endif
+
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
     float interpolated_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
 
     v_data0 = a_tex / u_texsize;
-    v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity);
+    v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity * projection_transition_fade);
 }

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -1,7 +1,7 @@
 attribute vec4 a_pos_offset;
 attribute vec4 a_tex_size;
 attribute vec4 a_pixeloffset;
-attribute vec4 a_z_tileAnchor;
+attribute vec4 a_z_tile_anchor;
 attribute vec3 a_projected_pos;
 attribute float a_fade_opacity;
 
@@ -68,8 +68,8 @@ void main() {
         size = u_size;
     }
 
-    float anchorZ = a_z_tileAnchor.x;
-    vec2 tileAnchor = a_z_tileAnchor.yz;
+    float anchorZ = a_z_tile_anchor.x;
+    vec2 tileAnchor = a_z_tile_anchor.yz;
     vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
     vec3 world_pos = mix_globe_mercator(
         u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -71,9 +71,8 @@ void main() {
     float anchorZ = a_z_tile_anchor.x;
     vec2 tileAnchor = a_z_tile_anchor.yz;
     vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
-    vec3 world_pos = mix_globe_mercator(
-        u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,
-        u_tile_id, u_merc_center, u_zoom_transition);
+    vec3 mercator_pos = mercator_tile_position(u_inv_rot_matrix, tileAnchor, u_tile_id, u_merc_center);
+    vec3 world_pos = mix_globe_mercator(vec3(a_pos, anchorZ) + h, mercator_pos, u_zoom_transition);
 
     vec4 projectedPoint = u_matrix * vec4(world_pos, 1);
 
@@ -109,9 +108,7 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
-    vec3 proj_pos = mix_globe_mercator(
-        u_inv_rot_matrix, tileAnchor, vec3(a_projected_pos.xy, anchorZ),
-        u_tile_id, u_merc_center, u_zoom_transition);
+    vec3 proj_pos = mix_globe_mercator(vec3(a_projected_pos.xy, anchorZ), mercator_pos, u_zoom_transition);
 
 #ifdef PROJECTED_POS_ON_VIEWPORT
     vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xy, 0.0, 1.0);

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -27,6 +27,10 @@ uniform highp float u_camera_to_center_distance;
 uniform float u_fade_change;
 uniform vec2 u_texsize;
 uniform vec2 u_texsize_icon;
+uniform mat4 u_inv_rot_matrix;
+uniform vec2 u_merc_center;
+uniform vec3 u_tile_id;
+uniform float u_zoom_transition;
 
 varying vec4 v_data0;
 varying vec4 v_data1;
@@ -67,7 +71,11 @@ void main() {
     float anchorZ = a_z_tile_anchor.x;
     vec2 tileAnchor = a_z_tile_anchor.yz;
     vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
-    vec4 projectedPoint = u_matrix * vec4(vec3(a_pos, anchorZ) + h, 1);
+    vec3 world_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,
+        u_tile_id, u_merc_center, u_zoom_transition);
+
+    vec4 projectedPoint = u_matrix * vec4(world_pos, 1);
 
     highp float camera_to_anchor_distance = projectedPoint.w;
     // If the label is pitched with the map, layout is done in pitched space,
@@ -101,10 +109,14 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
+    vec3 proj_pos = mix_globe_mercator(
+        u_inv_rot_matrix, tileAnchor, vec3(a_projected_pos.xy, anchorZ),
+        u_tile_id, u_merc_center, u_zoom_transition);
+
 #ifdef PROJECTED_POS_ON_VIEWPORT
-    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xy, 0.0, 1.0);
 #else
-    vec4 projected_pos = u_label_plane_matrix * vec4(vec3(a_projected_pos.xy, anchorZ) + h, 1.0);
+    vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xyz + h, 1.0);
 #endif
 
     highp float angle_sin = sin(segment_angle + symbol_rotation);
@@ -125,7 +137,12 @@ void main() {
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
     float interpolated_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
 
+    float projection_transition_fade = 1.0;
+#if defined(PROJECTED_POS_ON_VIEWPORT) && defined(PROJECTION_GLOBE_VIEW)
+    projection_transition_fade = 1.0 - step(EPSILON, u_zoom_transition);
+#endif
+
     v_data0.xy = a_tex / u_texsize;
     v_data0.zw = a_tex / u_texsize_icon;
-    v_data1 = vec4(gamma_scale, size, interpolated_fade_opacity, is_sdf);
+    v_data1 = vec4(gamma_scale, size, interpolated_fade_opacity * projection_transition_fade, is_sdf);
 }

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -71,9 +71,9 @@ void main() {
     float anchorZ = a_z_tile_anchor.x;
     vec2 tileAnchor = a_z_tile_anchor.yz;
     vec3 h = elevationVector(tileAnchor) * elevation(tileAnchor);
-    vec3 world_pos = mix_globe_mercator(
-        u_inv_rot_matrix, tileAnchor, vec3(a_pos, anchorZ) + h,
-        u_tile_id, u_merc_center, u_zoom_transition);
+
+    vec3 mercator_pos = mercator_tile_position(u_inv_rot_matrix, tileAnchor, u_tile_id, u_merc_center);
+    vec3 world_pos = mix_globe_mercator(vec3(a_pos, anchorZ) + h, mercator_pos, u_zoom_transition);
 
     vec4 projectedPoint = u_matrix * vec4(world_pos, 1);
 
@@ -109,9 +109,7 @@ void main() {
         symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
     }
 
-    vec3 proj_pos = mix_globe_mercator(
-        u_inv_rot_matrix, tileAnchor, vec3(a_projected_pos.xy, anchorZ),
-        u_tile_id, u_merc_center, u_zoom_transition);
+    vec3 proj_pos = mix_globe_mercator(vec3(a_projected_pos.xy, anchorZ), mercator_pos, u_zoom_transition);
 
 #ifdef PROJECTED_POS_ON_VIEWPORT
     vec4 projected_pos = u_label_plane_matrix * vec4(proj_pos.xy, 0.0, 1.0);


### PR DESCRIPTION
Another pass pass of shader changes changes necessary for native port. The code is no-op in regular code paths and only activated with globe view (Refer the introduction of the new define `PROJECTION_GLOBE_VIEW`). For the newly added uniforms, they are added as placeholder.
