### PR TITLE
Hide control button overflow

### DIFF
--- a/src/css/mapbox-gl.css
+++ b/src/css/mapbox-gl.css
@@ -97,6 +97,7 @@
     box-sizing: border-box;
     background-color: transparent;
     cursor: pointer;
+    overflow: hidden;
 }
 
 .mapboxgl-ctrl-group button + button {


### PR DESCRIPTION
This PR adds a single CSS rule to hide overflow on `.mapboxgl-ctrl-group button` elements. The pitch control of `NavigationControl` is enlarged at high pitch, so that it may spill outside its container in a way that looks a bit messy.

I tested all other uses of this CSS class—FullscreenControl and GeolocateControl—manually.

Before:
<img width="58" alt="Screen Shot 2021-09-14 at 12 33 43 PM" src="https://user-images.githubusercontent.com/572717/133322739-5e5ee4d4-11bf-4ccb-8001-7863739bfaa7.png">

After:
<img width="42" alt="Screen Shot 2021-09-14 at 12 33 33 PM" src="https://user-images.githubusercontent.com/572717/133322751-ca675f60-125d-4dfd-97ac-d67ed6f86b0c.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Hide control button content that spills outside its container</changelog>`
