### PR TITLE
Update NavigationControl when min/maxZoom/Pitch change

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -797,7 +797,6 @@ class Map extends Camera {
                     .fire(new Event('zoomend'));
             }
 
-
             return this;
 
         } else throw new Error(`minZoom must be between ${defaultMinZoom} and the current maxZoom, inclusive`);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -789,11 +789,14 @@ class Map extends Camera {
             this.transform.minZoom = minZoom;
             this._update();
 
-            if (this.getZoom() < minZoom) this.setZoom(minZoom);
+            if (this.getZoom() < minZoom) {
+                this.setZoom(minZoom);
+            } else {
+                this.fire(new Event('zoomstart'))
+                    .fire(new Event('zoom'))
+                    .fire(new Event('zoomend'));
+            }
 
-            this.fire(new Event('zoomstart'))
-                .fire(new Event('zoom'))
-                .fire(new Event('zoomend'));
 
             return this;
 
@@ -828,11 +831,13 @@ class Map extends Camera {
             this.transform.maxZoom = maxZoom;
             this._update();
 
-            if (this.getZoom() > maxZoom) this.setZoom(maxZoom);
-
-            this.fire(new Event('zoomstart'))
-                .fire(new Event('zoom'))
-                .fire(new Event('zoomend'));
+            if (this.getZoom() > maxZoom) {
+                this.setZoom(maxZoom);
+            } else {
+                this.fire(new Event('zoomstart'))
+                    .fire(new Event('zoom'))
+                    .fire(new Event('zoomend'));
+            }
 
             return this;
 
@@ -870,7 +875,13 @@ class Map extends Camera {
             this.transform.minPitch = minPitch;
             this._update();
 
-            if (this.getPitch() < minPitch) this.setPitch(minPitch);
+            if (this.getPitch() < minPitch) {
+                this.setPitch(minPitch);
+            } else {
+                this.fire(new Event('pitchstart'))
+                    .fire(new Event('pitch'))
+                    .fire(new Event('pitchend'));
+            }
 
             return this;
 
@@ -909,7 +920,13 @@ class Map extends Camera {
             this.transform.maxPitch = maxPitch;
             this._update();
 
-            if (this.getPitch() > maxPitch) this.setPitch(maxPitch);
+            if (this.getPitch() > maxPitch) {
+                this.setPitch(maxPitch);
+            } else {
+                this.fire(new Event('pitchstart'))
+                    .fire(new Event('pitch'))
+                    .fire(new Event('pitchend'));
+            }
 
             return this;
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -791,6 +791,10 @@ class Map extends Camera {
 
             if (this.getZoom() < minZoom) this.setZoom(minZoom);
 
+            this.fire(new Event('zoomstart'))
+                .fire(new Event('zoom'))
+                .fire(new Event('zoomend'));
+
             return this;
 
         } else throw new Error(`minZoom must be between ${defaultMinZoom} and the current maxZoom, inclusive`);
@@ -825,6 +829,10 @@ class Map extends Camera {
             this._update();
 
             if (this.getZoom() > maxZoom) this.setZoom(maxZoom);
+
+            this.fire(new Event('zoomstart'))
+                .fire(new Event('zoom'))
+                .fire(new Event('zoomend'));
 
             return this;
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1146,8 +1146,27 @@ test('Map', (t) => {
 
     t.test('#setMinPitch', (t) => {
         const map = createMap(t, {pitch: 20});
+
+        const onPitchStart = t.spy();
+        const onPitch = t.spy();
+        const onPitchEnd = t.spy();
+
+        map.on('pitchstart', onPitchStart);
+        map.on('pitch', onPitch);
+        map.on('pitchend', onPitchEnd);
+
         map.setMinPitch(10);
+
+        t.ok(onPitchStart.calledOnce);
+        t.ok(onPitch.calledOnce);
+        t.ok(onPitchEnd.calledOnce);
+
         map.setPitch(0);
+
+        t.equal(onPitchStart.callCount, 2);
+        t.equal(onPitch.callCount, 2);
+        t.equal(onPitchEnd.callCount, 2);
+
         t.equal(map.getPitch(), 10);
         t.end();
     });
@@ -1180,8 +1199,27 @@ test('Map', (t) => {
 
     t.test('#setMaxPitch', (t) => {
         const map = createMap(t, {pitch: 0});
+
+        const onPitchStart = t.spy();
+        const onPitch = t.spy();
+        const onPitchEnd = t.spy();
+
+        map.on('pitchstart', onPitchStart);
+        map.on('pitch', onPitch);
+        map.on('pitchend', onPitchEnd);
+
         map.setMaxPitch(10);
+
+        t.ok(onPitchStart.calledOnce);
+        t.ok(onPitch.calledOnce);
+        t.ok(onPitchEnd.calledOnce);
+
         map.setPitch(20);
+
+        t.equal(onPitchStart.callCount, 2);
+        t.equal(onPitch.callCount, 2);
+        t.equal(onPitchEnd.callCount, 2);
+
         t.equal(map.getPitch(), 10);
         t.end();
     });

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1026,8 +1026,27 @@ test('Map', (t) => {
 
     t.test('#setMinZoom', (t) => {
         const map = createMap(t, {zoom:5});
+
+        const onZoomStart = t.spy();
+        const onZoom = t.spy();
+        const onZoomEnd = t.spy();
+
+        map.on('zoomstart', onZoomStart);
+        map.on('zoom', onZoom);
+        map.on('zoomend', onZoomEnd);
+
         map.setMinZoom(3.5);
+
+        t.ok(onZoomStart.calledOnce);
+        t.ok(onZoom.calledOnce);
+        t.ok(onZoomEnd.calledOnce);
+
         map.setZoom(1);
+
+        t.equal(onZoomStart.callCount, 2);
+        t.equal(onZoom.callCount, 2);
+        t.equal(onZoomEnd.callCount, 2);
+
         t.equal(map.getZoom(), 3.5);
         t.end();
     });
@@ -1060,8 +1079,27 @@ test('Map', (t) => {
 
     t.test('#setMaxZoom', (t) => {
         const map = createMap(t, {zoom:0});
+
+        const onZoomStart = t.spy();
+        const onZoom = t.spy();
+        const onZoomEnd = t.spy();
+
+        map.on('zoomstart', onZoomStart);
+        map.on('zoom', onZoom);
+        map.on('zoomend', onZoomEnd);
+
         map.setMaxZoom(3.5);
+
+        t.ok(onZoomStart.calledOnce);
+        t.ok(onZoom.calledOnce);
+        t.ok(onZoomEnd.calledOnce);
+
         map.setZoom(4);
+
+        t.equal(onZoomStart.callCount, 2);
+        t.equal(onZoom.callCount, 2);
+        t.equal(onZoomEnd.callCount, 2);
+
         t.equal(map.getZoom(), 3.5);
         t.end();
     });

--- a/test/unit/ui/map_events.test.js
+++ b/test/unit/ui/map_events.test.js
@@ -532,7 +532,7 @@ test(`Map#on mousedown can have default behavior prevented and still fire subseq
     map.on('click', click);
 
     simulate.click(map.getCanvas());
-    t.ok(click.callCount, 1);
+    t.equal(click.callCount, 1);
 
     map.remove();
     t.end();


### PR DESCRIPTION
See #11013 

`map.transform.minZoom` and `map.transform.maxZoom` affect the appearance of `NavigationControl`, but `map.setMinZoom()` and `map.setMaxZoom()` do not currently notify the control when these values have changed. This PR emits a sequence of dummy events (`zoomstart`, `zoom`, `zoomend`) when the values are set so that the control is updated correctly.

The same goes for min/maxPitch.

Before (note that control does not update to mach minZoom until the map is zoomed):
![pre-fix](https://user-images.githubusercontent.com/572717/133329057-6006978d-35ee-4856-84e7-13111171742a.gif)

After (control updates immediately when values are set):
![post-fix](https://user-images.githubusercontent.com/572717/133329077-76467586-72a4-4349-ba22-b1c31eb5dbc8.gif)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Update NavigationControl when min and max zoom are changed</changelog>`
