### PR TITLE
Execute DOM queue tasks immediately before initial map load

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2681,7 +2681,7 @@ class Map extends Camera {
     _requestDomTask(callback: () => void) {
         // This condition means that the map is idle: the callback needs to be called right now as
         // there won't be a triggered render to run the queue.
-        if (!this.isMoving() && this.loaded()) {
+        if (!this.loaded() || (this.loaded() && !this.isMoving()) {
             callback();
         } else {
             this._domRenderTaskQueue.add(callback);

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2681,7 +2681,7 @@ class Map extends Camera {
     _requestDomTask(callback: () => void) {
         // This condition means that the map is idle: the callback needs to be called right now as
         // there won't be a triggered render to run the queue.
-        if (!this.loaded() || (this.loaded() && !this.isMoving()) {
+        if (!this.loaded() || (this.loaded() && !this.isMoving())) {
             callback();
         } else {
             this._domRenderTaskQueue.add(callback);


### PR DESCRIPTION
This PR addresses #11020, in which the DOM queue doesn't begin executing until map rendering starts. Thus, popups, markers, and the navigation control don't show the correct initial state until the map loads. This PR sidesteps the DOM queue and executes immediately before that initial load, so that markers _immediately_ show up in the correct location without having to use a workaround like _hiding_ them until initial load.

Before:

![map-load-pre-fix](https://user-images.githubusercontent.com/572717/133525292-55cf716b-3c18-4fc7-aad7-aa4b4f4d3a51.gif)

After:
![load-with-fix](https://user-images.githubusercontent.com/572717/133525299-2c59b592-5a64-49de-981a-e84271965ba2.gif)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fix regression in marker positioning before initial map load</changelog>`
