### PR TITLE
on('load') should be triggered after setStyle is called

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1498,6 +1498,7 @@ class Map extends Camera {
     setStyle(style: StyleSpecification | string | null, options?: {diff?: boolean} & StyleOptions) {
         options = extend({}, {localIdeographFontFamily: this._localIdeographFontFamily, localFontFamily: this._localFontFamily}, options);
 
+        this._loaded = false;
         if ((options.diff !== false &&
             options.localIdeographFontFamily === this._localIdeographFontFamily &&
             options.localFontFamily === this._localFontFamily) && this.style && style) {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -134,20 +134,20 @@ test('Map', (t) => {
     });
 
     t.test('emits load event after a style is set', (t) => {
-        t.stub(Map.prototype, '_detectMissingCSS');
-        t.stub(Map.prototype, '_authenticate');
-        const map = new Map({container: window.document.createElement('div'), testMode: true});
+        const style = createStyle();
+        const map = createMap(t, {style});
 
-        map.on('load', fail);
+        map.on('load', firstLoad);
 
-        setTimeout(() => {
-            map.off('load', fail);
-            map.on('load', pass);
-            map.setStyle(createStyle());
-        }, 1);
-
-        function fail() { t.ok(false); }
-        function pass() { t.end(); }
+        function firstLoad() {
+            t.ok(true);
+            map.off('load', firstLoad);
+            map.on('load', secondLoad);
+            map.setStyle(createSatelliteStyle());
+        }
+        function secondLoad() {
+            t.end();
+        }
     });
 
     t.test('#setStyle', (t) => {
@@ -1693,23 +1693,7 @@ test('Map', (t) => {
 
         t.test('sets visibility on raster layer', (t) => {
             const map = createMap(t, {
-                style: {
-                    "version": 8,
-                    "sources": {
-                        "mapbox://mapbox.satellite": {
-                            "type": "raster",
-                            "tiles": ["http://example.com/{z}/{x}/{y}.png"]
-                        }
-                    },
-                    "layers": [{
-                        "id": "satellite",
-                        "type": "raster",
-                        "source": "mapbox://mapbox.satellite",
-                        "layout": {
-                            "visibility": "none"
-                        }
-                    }]
-                }
+                style: createSatelliteStyle()
             });
 
             // Suppress errors because we're not loading tiles from a real URL.
@@ -2548,5 +2532,25 @@ function createStyle() {
         pitch: 50,
         sources: {},
         layers: []
+    };
+}
+
+function createSatelliteStyle() {
+    return {
+        "version": 8,
+        "sources": {
+            "mapbox://mapbox.satellite": {
+                "type": "raster",
+                "tiles": ["http://example.com/{z}/{x}/{y}.png"]
+            }
+        },
+        "layers": [{
+            "id": "satellite",
+            "type": "raster",
+            "source": "mapbox://mapbox.satellite",
+            "layout": {
+                "visibility": "none"
+            }
+        }]
     };
 }


### PR DESCRIPTION
## Launch Checklist

Fixes https://github.com/mapbox/mapbox-gl-js/issues/10946
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>on('load') should be triggered after setStyle is called</changelog>`

https://user-images.githubusercontent.com/6927131/133748091-40d32a2a-2f53-46fc-bf5a-92acc17659a0.mov


Although this fixes the initial issue, I found another issue where once I infinitely change the style after an interval, it starts to trigger the map load very quickly, much quicker than the interval. I wasn't sure if I implemented incorrectly but `.off()` should remove the listener and `.on()` should re-add it.

<summary>Reproducable code</summary>

<details>

```
var dark = 'mapbox://styles/mapbox/dark-v10';
var light = 'mapbox://styles/mapbox/light-v10';

var style = dark;
var map = window.map = new mapboxgl.Map({
    container: 'map',
    zoom: 2,
    center: [-77.01866, 38.888],
    style,
    hash: style
});

function onLoad() {
    setInterval(function () {
        console.log("loaded")
        style = (style === dark ? light : dark);
        map.setStyle(style);
    }, 2000);
}

map.on('load', function onLoad() {
    map.off('load', onLoad)
    map.on('load', onLoad)
})

```

</details>
