### PR TITLE
Hide X char in popup close button [accessibility]

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -534,6 +534,7 @@ export default class Popup extends Evented {
             this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', this._content);
             this._closeButton.type = 'button';
             this._closeButton.setAttribute('aria-label', 'Close popup');
+            this._closeButton.setAttribute('aria-hidden', true);
             this._closeButton.innerHTML = '&#215;';
             this._closeButton.addEventListener('click', this._onClose);
         }

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -534,7 +534,7 @@ export default class Popup extends Evented {
             this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', this._content);
             this._closeButton.type = 'button';
             this._closeButton.setAttribute('aria-label', 'Close popup');
-            this._closeButton.setAttribute('aria-hidden', true);
+            this._closeButton.setAttribute('aria-hidden', '');
             this._closeButton.innerHTML = '&#215;';
             this._closeButton.addEventListener('click', this._onClose);
         }

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -534,7 +534,7 @@ export default class Popup extends Evented {
             this._closeButton = DOM.create('button', 'mapboxgl-popup-close-button', this._content);
             this._closeButton.type = 'button';
             this._closeButton.setAttribute('aria-label', 'Close popup');
-            this._closeButton.setAttribute('aria-hidden', '');
+            this._closeButton.setAttribute('aria-hidden', 'true');
             this._closeButton.innerHTML = '&#215;';
             this._closeButton.addEventListener('click', this._onClose);
         }


### PR DESCRIPTION
Adding the attribute 'aria-hidden' hides the X character used for the close popup button from being voiced over when enabling voice over accessibility. As mentioned in the issue #11035 , the X character is announced as 'multiplication' or 'times'. Tested debug page with accessibility voice over turned on.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
