### PR TITLE
Add placementTime metric

### DIFF
--- a/src/style/pauseable_placement.js
+++ b/src/style/pauseable_placement.js
@@ -3,6 +3,7 @@
 import browser from '../util/browser.js';
 
 import {Placement} from '../symbol/placement.js';
+import {PerformanceUtils} from '../util/performance.js';
 
 import type Transform from '../geo/transform.js';
 import type StyleLayer from './style_layer.js';
@@ -80,6 +81,7 @@ class PauseablePlacement {
         this._forceFullPlacement = forceFullPlacement;
         this._showCollisionBoxes = showCollisionBoxes;
         this._done = false;
+        PerformanceUtils.markPlacementStart();
     }
 
     isDone(): boolean {
@@ -122,6 +124,7 @@ class PauseablePlacement {
         }
 
         this._done = true;
+        PerformanceUtils.markPlacementEnd();
     }
 
     commit(now: number) {

--- a/src/style/pauseable_placement.js
+++ b/src/style/pauseable_placement.js
@@ -12,8 +12,6 @@ import type Tile from '../source/tile.js';
 import type {BucketPart} from '../symbol/placement.js';
 import type {FogState} from './fog_helpers.js';
 
-let placementId = 1;
-
 class LayerPlacement {
     _sortAcrossTiles: boolean;
     _currentTileIndex: number;
@@ -63,7 +61,6 @@ class LayerPlacement {
 
 class PauseablePlacement {
     placement: Placement;
-    _id: number;
     _done: boolean;
     _currentPlacementIndex: number;
     _forceFullPlacement: boolean;
@@ -83,7 +80,6 @@ class PauseablePlacement {
         this._forceFullPlacement = forceFullPlacement;
         this._showCollisionBoxes = showCollisionBoxes;
         this._done = false;
-        this._id = placementId++;
     }
 
     isDone(): boolean {
@@ -113,7 +109,7 @@ class PauseablePlacement {
                 const pausePlacement = this._inProgressLayer.continuePlacement(layerTiles[layer.source], this.placement, this._showCollisionBoxes, layer, shouldPausePlacement);
 
                 if (pausePlacement) {
-                    PerformanceUtils.recordPlacementTime(this._id, browser.now() - startTime);
+                    PerformanceUtils.recordPlacementTime(browser.now() - startTime);
                     // We didn't finish placing all layers within 2ms,
                     // but we can keep rendering with a partial placement
                     // We'll resume here on the next frame
@@ -125,7 +121,7 @@ class PauseablePlacement {
 
             this._currentPlacementIndex--;
         }
-        PerformanceUtils.recordPlacementTime(this._id, browser.now() - startTime);
+        PerformanceUtils.recordPlacementTime(browser.now() - startTime);
         this._done = true;
     }
 

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -76,11 +76,6 @@ export const PerformanceUtils = {
         placementTime += time;
     },
     frame(timestamp: number, isRenderFrame: boolean) {
-        // Ignore frametimes during loading
-        if (!fullLoadFinished) {
-            return;
-        }
-
         const currTimestamp = timestamp;
         if (lastFrameTime != null) {
             const frameTime = currTimestamp - lastFrameTime;

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -101,8 +101,7 @@ export const PerformanceUtils = {
     clearMetrics() {
         lastFrameTime = null;
         frameTimes = [];
-        lastPlacementStart = null;
-        placementTimes = [];
+        placementTimes = {};
         fullLoadFinished = false;
 
         performance.clearMeasures('loadTime');

--- a/src/util/performance.js
+++ b/src/util/performance.js
@@ -30,7 +30,7 @@ export const PerformanceMarkers = {
 let lastFrameTime = null;
 let fullLoadFinished = false;
 let frameTimes = [];
-let placementTimes = {};
+let placementTime = 0;
 const frameSequences = [frameTimes];
 let i = 0;
 
@@ -67,16 +67,13 @@ export const PerformanceUtils = {
     endMeasure(m: { name: string, mark: string }) {
         performance.measure(m.name, m.mark);
     },
-    recordPlacementTime(id: number, time: number) {
+    recordPlacementTime(time: number) {
         // Ignore placementTimes during loading
         if (!fullLoadFinished) {
             return;
         }
-        if (placementTimes[id] == null) {
-            placementTimes[id] = [];
-        }
 
-        placementTimes[id].push(time);
+        placementTime += time;
     },
     frame(timestamp: number, isRenderFrame: boolean) {
         // Ignore frametimes during loading
@@ -101,7 +98,7 @@ export const PerformanceUtils = {
     clearMetrics() {
         lastFrameTime = null;
         frameTimes = [];
-        placementTimes = {};
+        placementTime = 0;
         fullLoadFinished = false;
 
         performance.clearMeasures('loadTime');
@@ -175,10 +172,6 @@ export const PerformanceUtils = {
             metrics.cpuFrameBudgetExceeded += Math.max(0, renderFrame.duration - CPU_FRAME_BUDGET);
         }
 
-        let placementTime = 0;
-        for (const placement in placementTimes) {
-            placementTime += placementTimes[placement].reduce((prev, curr) => prev + curr, 0);
-        }
         metrics.placementTime = placementTime;
 
         return metrics;


### PR DESCRIPTION
Adding this metric to better quantify the impact of https://github.com/mapbox/mapbox-gl-js/pull/10795 .

Since `PausablePlacement` is has a time budget per frame, any regressions in performance there might not surface upto observable framerate directly. 
~This measures the average time required for placement to fully finish, including the time it stays paused between frames.~

Based on some suggestions from @ansis , I changed this to instead measure total time spent during placement.
In the same convo we also discussed how both this and frameTimes would be better if we only measured them after the `full-load` has happened and during an animation.
~This PR also adds the changes for that.~
We decided to skip the frameTime measurement changes for now and focus on just the changes for the placementTime metric.