### PR TITLE
Upgrade to TinySDF v2 with a fix to CJK performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/point-geometry": "^0.1.0",
-    "@mapbox/tiny-sdf": "^1.2.5",
+    "@mapbox/tiny-sdf": "^2.0.0",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/point-geometry": "^0.1.0",
-    "@mapbox/tiny-sdf": "^2.0.0",
+    "@mapbox/tiny-sdf": "^2.0.2",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",

--- a/test/unit/render/glyph_manager.test.js
+++ b/test/unit/render/glyph_manager.test.js
@@ -19,10 +19,14 @@ const TinySDF = class {
         this.fontWeight = '400';
     }
     // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
-    drawWithMetrics() {
+    draw() {
         return {
-            alphaChannel: new Uint8ClampedArray(900),
-            metrics: {width: 48, height: 48, sdfWidth: 30, sdfHeight: 30, advance: 48}
+            data: new Uint8ClampedArray(900),
+            glyphWidth: 48,
+            glyphHeight: 48,
+            width: 30,
+            height: 30,
+            glyphAdvance: 48
         };
     }
 };
@@ -168,11 +172,15 @@ test('GlyphManager caches locally generated glyphs', (t) => {
             this.fontWeight = '400';
         }
         // Return empty 30x30 bitmap (24 fontsize + 3 * 2 buffer)
-        drawWithMetrics() {
+        draw() {
             drawCallCount++;
             return {
-                alphaChannel: new Uint8ClampedArray(900),
-                metrics: {width: 48, height: 48, sdfWidth: 30, sdfHeight: 30, advance: 48}
+                data: new Uint8ClampedArray(900),
+                glyphWidth: 48,
+                glyphHeight: 48,
+                width: 30,
+                height: 30,
+                glyphAdvance: 48
             };
         }
     });
@@ -195,11 +203,15 @@ test('GlyphManager locally generates latin glyphs', (t) => {
         constructor() {
             this.fontWeight = '400';
         }
-        // Return empty 18x24 bitmap (made up glyph size + 3 * 2 buffer)
-        drawWithMetrics() {
+        // Return empty 20x24 bitmap (made up glyph size + 3 * 2 buffer)
+        draw() {
             return {
-                alphaChannel: new Uint8ClampedArray(480),
-                metrics: {width: 28, height: 36, sdfWidth: 20, sdfHeight: 24, advance: 20}
+                data: new Uint8ClampedArray(480),
+                glyphWidth: 28,
+                glyphHeight: 36,
+                width: 20,
+                height: 24,
+                glyphAdvance: 20
             };
         }
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz"
   integrity sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA==
 
-"@mapbox/tiny-sdf@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-2.0.0.tgz#1e34a94b6f4c95d877652be4d399b4476792ac44"
-  integrity sha512-2+rBo+sFynCpXuEoM8aYq2pw6bqVTyXyl6ALUgJUmBfz293fK7y3n0BvxjdOKrx3PyZRAzNH32JoLbvU2BTx8Q==
+"@mapbox/tiny-sdf@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-2.0.2.tgz#89b477f350c146be84fb263eb67f60f0ee2f59cf"
+  integrity sha512-XBQG3wvIaya9t2OHcWLFYv8cdg48roqOj8XhKzKSvAIg5D1scC+a+tlq0wGjPZkL+k6dL8TyOBR7RKDGh3kefQ==
 
 "@mapbox/unitbezier@^0.0.0":
   version "0.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz"
   integrity sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA==
 
-"@mapbox/tiny-sdf@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz"
-  integrity sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==
+"@mapbox/tiny-sdf@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-2.0.0.tgz#1e34a94b6f4c95d877652be4d399b4476792ac44"
+  integrity sha512-2+rBo+sFynCpXuEoM8aYq2pw6bqVTyXyl6ALUgJUmBfz293fK7y3n0BvxjdOKrx3PyZRAzNH32JoLbvU2BTx8Q==
 
 "@mapbox/unitbezier@^0.0.0":
   version "0.0.0"


### PR DESCRIPTION
Upgrades [TinySDF to v2](https://github.com/mapbox/tiny-sdf/releases/tag/v2.0.0). In particular, the new version: 

- Fixes a severe performance issue with CJK glyphs on certain GPU/Chrome combinations (including my MBP 2017 with Chrome 94 beta).
- Slightly improves CJK rasterization performance.
- Fixes a bug where some CJK glyphs were clipped by 1 pixel at the bottom.

@ChrisLoer please review to make sure this doesn't cause any regressions on our CJK-heavy styles.

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixed an issue with slow tile loading performance on maps with CJK glyphs on certain Chrome/GPU combinations.</changelog>`
