### PR TITLE
Prevent fullscreen video source in iOS

### DIFF
--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -79,6 +79,9 @@ class VideoSource extends ImageSource {
                 this.video = video;
                 this.video.loop = true;
 
+                // Prevent the video from taking over the screen in iOS
+                this.video.setAttribute('playsinline', '');
+
                 // Start repainting when video starts playing. hasTransition() will then return
                 // true to trigger additional frames as long as the videos continues playing.
                 this.video.addEventListener('playing', () => {


### PR DESCRIPTION
iOS video issues are not new (see: https://github.com/mapbox/mapbox-gl-js/issues/6443, https://github.com/mapbox/mapbox-gl-js/issues/6152) but usually come down to carefully following the [Autoplay guide for media and Web Audio APIs](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide) docs.

While working through the release tests, we noticed that _video sources have an internal video element which opts for fullscreen_ in iOS (with possible dependence on iOS version and iPad vs. iPhone) 😱 . I personally observed the issue in iOS 15 on an iPhone 7 but _not_ on an iPad with iOS 12.5.4.

The issue can be seen on this page: https://docs.mapbox.com/mapbox-gl-js/example/video-on-a-map/

Before this fix, video sources require user input to play and then take over the whole screen:

https://user-images.githubusercontent.com/572717/135360651-ea979dbb-fd30-4f2b-9cab-b7105831ffab.mp4

Adding `video.playsinline = ''` (see: [playsinline](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-playsinline) docs), the video now autoplays as expected:

https://user-images.githubusercontent.com/572717/135360691-a2475006-5a39-4a15-91bc-a0738936b66e.mp4

This fix results in correct behavior (autoplay; no fullscreen) on both devices I have access to:
iPhone 7 with iOS 15
iPad Mini with iOS 12.5.4

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Prevent video sources from entering fullscreen on iOS Safari</changelog>`
