### PR TITLE
Replaces EPSG:4326 with OGC:CRS84 in GL JS `LngLat` doc

### DIFF
--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -12,9 +12,9 @@ export const earthRadius = 6371008.8;
 
 /**
  * A `LngLat` object represents a given longitude and latitude coordinate, measured in degrees.
- * These coordinates are based on the [WGS84 (EPSG:4326 projection) standard](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84),
- * but Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude)
- * to match the [GeoJSON specification](https://datatracker.ietf.org/doc/html/rfc7946#section-4).
+ * These coordinates use longitude, latitude coordinate order (as opposed to latitude, longitude)
+ * to match the [GeoJSON specification](https://datatracker.ietf.org/doc/html/rfc7946#section-4),
+ * which is equivalent to the [OGC:CRS84 coordinate reference system](https://datatracker.ietf.org/doc/html/rfc7946#section-4).
  *
  * Note that any Mapbox GL method that accepts a `LngLat` object as an argument or option
  * can also accept an `Array` of two numbers and will perform an implicit conversion.

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -12,10 +12,9 @@ export const earthRadius = 6371008.8;
 
 /**
  * A `LngLat` object represents a given longitude and latitude coordinate, measured in degrees.
- * These coordinates are based on the [WGS84 (EPSG:4326) standard](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84).
- *
- * Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude) to match the
- * [GeoJSON specification](https://tools.ietf.org/html/rfc7946).
+ * These coordinates are based on the [WGS84 (EPSG:4326 projection) standard](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84),
+ * but Mapbox GL uses longitude, latitude coordinate order (as opposed to latitude, longitude)
+ * to match the [GeoJSON specification](https://datatracker.ietf.org/doc/html/rfc7946#section-4).
  *
  * Note that any Mapbox GL method that accepts a `LngLat` object as an argument or option
  * can also accept an `Array` of two numbers and will perform an implicit conversion.


### PR DESCRIPTION
Re: 
* https://github.com/mapbox/help/pull/3139#issuecomment-915373648
* https://github.com/mapbox/api-documentation/pull/1079#discussion_r562341798  
* https://github.com/mapbox/api-documentation/pull/1243 

## changes

@sgillies [noted that EPSG:4326 has historically](https://github.com/mapbox/help/pull/3139#issuecomment-915373648) followed both lng,lat and lat,lng coordinate orders. Referencing such a thing can add to user confusion, so this PR removes a EPSG:4326 reference in the GL JS `LngLat` doc and replaces it with a reference to OGC:CRS84.

## before/after screenshot

<img width=600 alt="screenshot" src="https://user-images.githubusercontent.com/6026447/135510706-0d7d5dab-49bd-447d-9896-e87ac22edfe6.jpg"> 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
