### PR TITLE
Fix circle and heatmap on alternate projections

### DIFF
--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -103,7 +103,7 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
                 type: feature.type,
                 sourceLayerIndex,
                 index,
-                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature),
+                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical),
                 patterns: {},
                 sortKey
             };

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -234,7 +234,7 @@ class FillExtrusionBucket implements Bucket {
                 id,
                 sourceLayerIndex,
                 index,
-                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature),
+                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical),
                 properties: feature.properties,
                 type: feature.type,
                 patterns: {}

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -58,13 +58,14 @@ export default function loadGeometry(feature: FeatureWithGeometry, canonical?: C
     const featureExtent = feature.extent;
     const scale = EXTENT / featureExtent;
     let cs, z2;
-    if (canonical) {
+    const isMercator = !projection || projection.name === 'mercator';
+    if (canonical && !isMercator) {
         cs = tileTransform(canonical, projection);
         z2 = Math.pow(2, canonical.z);
     }
 
     function reproject(p) {
-        if (projection && projection.name === 'mercator' || !canonical) {
+        if (isMercator || !canonical) {
             return new Point(Math.round(p.x * scale), Math.round(p.y * scale));
         } else {
             const lng = lngFromMercatorX((canonical.x + p.x / featureExtent) / z2);


### PR DESCRIPTION
This turned out to be a tiny omission — with this fix, both `circle` and `heatmap` layers work relatively well on alternate projections. `fill-extrusion` now positions correctly, but I can't yet figure out why the height goes to infinity. Also, I didn't add render tests for this yet because I think we need to come up with a common set of basic tests covering each layer in a separate PR.