### PR TITLE
fix pitch, line-width and other properties for projections

### DIFF
--- a/src/data/bucket.js
+++ b/src/data/bucket.js
@@ -9,6 +9,7 @@ import type {FeatureStates} from '../source/source_state.js';
 import type {ImagePosition} from '../render/image_atlas.js';
 import type LineAtlas from '../render/line_atlas.js';
 import type {CanonicalTileID} from '../source/tile_id.js';
+import type {TileTransform} from '../geo/projection/tile_transform.js';
 
 export type BucketParameters<Layer: TypedStyleLayer> = {
     index: number,
@@ -78,7 +79,7 @@ export interface Bucket {
     +layers: Array<any>;
     +stateDependentLayers: Array<any>;
     +stateDependentLayerIds: Array<string>;
-    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID): void;
+    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID, tileTransform: TileTransform): void;
     update(states: FeatureStates, vtLayer: VectorTileLayer, imagePositions: {[_: string]: ImagePosition}): void;
     isEmpty(): boolean;
 

--- a/src/data/bucket/circle_bucket.js
+++ b/src/data/bucket/circle_bucket.js
@@ -28,6 +28,7 @@ import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type Point from '@mapbox/point-geometry';
 import type {FeatureStates} from '../../source/source_state.js';
 import type {ImagePosition} from '../../render/image_atlas.js';
+import type {TileTransform} from '../../geo/projection/tile_transform.js';
 
 function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
     layoutVertexArray.emplaceBack(
@@ -77,7 +78,7 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
         this.stateDependentLayerIds = this.layers.filter((l) => l.isStateDependent()).map((l) => l.id);
     }
 
-    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID) {
+    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID, tileTransform: TileTransform) {
         const styleLayer = this.layers[0];
         const bucketFeatures = [];
         let circleSortKey = null;
@@ -103,7 +104,7 @@ class CircleBucket<Layer: CircleStyleLayer | HeatmapStyleLayer> implements Bucke
                 type: feature.type,
                 sourceLayerIndex,
                 index,
-                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical),
+                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical, tileTransform),
                 patterns: {},
                 sortKey
             };

--- a/src/data/bucket/fill_bucket.js
+++ b/src/data/bucket/fill_bucket.js
@@ -31,6 +31,7 @@ import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type Point from '@mapbox/point-geometry';
 import type {FeatureStates} from '../../source/source_state.js';
 import type {ImagePosition} from '../../render/image_atlas.js';
+import type {TileTransform} from '../../geo/projection/tile_transform.js';
 
 class FillBucket implements Bucket {
     index: number;
@@ -75,7 +76,7 @@ class FillBucket implements Bucket {
         this.stateDependentLayerIds = this.layers.filter((l) => l.isStateDependent()).map((l) => l.id);
     }
 
-    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID) {
+    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID, tileTransform: TileTransform) {
         this.hasPattern = hasPattern('fill', this.layers, options);
         const fillSortKey = this.layers[0].layout.get('fill-sort-key');
         const bucketFeatures = [];
@@ -96,7 +97,7 @@ class FillBucket implements Bucket {
                 type: feature.type,
                 sourceLayerIndex,
                 index,
-                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical),
+                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical, tileTransform),
                 patterns: {},
                 sortKey
             };

--- a/src/data/bucket/fill_extrusion_bucket.js
+++ b/src/data/bucket/fill_extrusion_bucket.js
@@ -36,6 +36,7 @@ import type IndexBuffer from '../../gl/index_buffer.js';
 import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type {FeatureStates} from '../../source/source_state.js';
 import type {ImagePosition} from '../../render/image_atlas.js';
+import type {TileTransform} from '../../geo/projection/tile_transform.js';
 
 const FACTOR = Math.pow(2, 13);
 
@@ -216,7 +217,7 @@ class FillExtrusionBucket implements Bucket {
         this.enableTerrain = options.enableTerrain;
     }
 
-    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID) {
+    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID, tileTransform: TileTransform) {
         this.features = [];
         this.hasPattern = hasPattern('fill-extrusion', this.layers, options);
         this.featuresOnBorder = [];
@@ -234,7 +235,7 @@ class FillExtrusionBucket implements Bucket {
                 id,
                 sourceLayerIndex,
                 index,
-                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical),
+                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical, tileTransform),
                 properties: feature.properties,
                 type: feature.type,
                 patterns: {}

--- a/src/data/bucket/line_bucket.js
+++ b/src/data/bucket/line_bucket.js
@@ -35,6 +35,7 @@ import type VertexBuffer from '../../gl/vertex_buffer.js';
 import type {FeatureStates} from '../../source/source_state.js';
 import type {ImagePosition} from '../../render/image_atlas.js';
 import type LineAtlas from '../../render/line_atlas.js';
+import type {TileTransform} from '../../geo/projection/tile_transform.js';
 
 // NOTE ON EXTRUDE SCALE:
 // scale the extrusion vector so that the normal length is this value.
@@ -134,7 +135,7 @@ class LineBucket implements Bucket {
         this.stateDependentLayerIds = this.layers.filter((l) => l.isStateDependent()).map((l) => l.id);
     }
 
-    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID) {
+    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID, tileTransform: TileTransform) {
         this.hasPattern = hasPattern('line', this.layers, options);
         const lineSortKey = this.layers[0].layout.get('line-sort-key');
         const bucketFeatures = [];
@@ -155,7 +156,7 @@ class LineBucket implements Bucket {
                 type: feature.type,
                 sourceLayerIndex,
                 index,
-                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical),
+                geometry: needGeometry ? evaluationFeature.geometry : loadGeometry(feature, canonical, tileTransform),
                 patterns: {},
                 sortKey
             };

--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -61,6 +61,7 @@ import type {SymbolQuad} from '../../symbol/quads.js';
 import type {SizeData} from '../../symbol/symbol_size.js';
 import type {FeatureStates} from '../../source/source_state.js';
 import type {ImagePosition} from '../../render/image_atlas.js';
+import type {TileTransform} from '../../geo/projection/tile_transform.js';
 export type SingleCollisionBox = {
     x1: number;
     y1: number;
@@ -417,7 +418,7 @@ class SymbolBucket implements Bucket {
         }
     }
 
-    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID) {
+    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID, tileTransform: TileTransform) {
         const layer = this.layers[0];
         const layout = layer.layout;
 
@@ -455,7 +456,7 @@ class SymbolBucket implements Bucket {
                 continue;
             }
 
-            if (!needGeometry)  evaluationFeature.geometry = loadGeometry(feature, canonical);
+            if (!needGeometry)  evaluationFeature.geometry = loadGeometry(feature, canonical, tileTransform);
 
             let text: Formatted | void;
             if (hasText) {

--- a/src/data/evaluation_feature.js
+++ b/src/data/evaluation_feature.js
@@ -23,4 +23,3 @@ export default function toEvaluationFeature(feature: VectorTileFeature, needGeom
         properties:feature.properties,
         geometry: needGeometry ? loadGeometry(feature) : []};
 }
-//TODO fix

--- a/src/data/evaluation_feature.js
+++ b/src/data/evaluation_feature.js
@@ -23,3 +23,4 @@ export default function toEvaluationFeature(feature: VectorTileFeature, needGeom
         properties:feature.properties,
         geometry: needGeometry ? loadGeometry(feature) : []};
 }
+//TODO fix

--- a/src/data/feature_index.js
+++ b/src/data/feature_index.js
@@ -27,11 +27,13 @@ import type Transform from '../geo/transform.js';
 import type {FilterSpecification, PromoteIdSpecification} from '../style-spec/types.js';
 import type {TilespaceQueryGeometry} from '../style/query_geometry.js';
 import type {FeatureIndex as FeatureIndexStruct} from './array_types.js';
+import type {TileTransform} from '../geo/projection/tile_transform.js';
 
 type QueryParameters = {
     pixelPosMatrix: Float32Array,
     transform: Transform,
     tileResult: TilespaceQueryGeometry,
+    tileTransform: TileTransform,
     params: {
         filter: FilterSpecification,
         layers: Array<string>,
@@ -148,7 +150,7 @@ class FeatureIndex {
                 sourceFeatureState,
                 (feature: VectorTileFeature, styleLayer: StyleLayer, featureState: Object, layoutVertexArrayOffset: number = 0) => {
                     if (!featureGeometry) {
-                        featureGeometry = loadGeometry(feature);
+                        featureGeometry = loadGeometry(feature, this.tileID.canonical, args.tileTransform);
                     }
 
                     return styleLayer.queryIntersectsFeature(tilespaceGeometry, feature, featureState, featureGeometry, this.z, args.transform, args.pixelPosMatrix, elevationHelper, layoutVertexArrayOffset);

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -8,6 +8,7 @@ import getProjection from '../geo/projection/index.js';
 import tileTransform from '../geo/projection/tile_transform.js';
 import Point from '@mapbox/point-geometry';
 import type {CanonicalTileID} from '../source/tile_id.js';
+import type {TileTransform} from '../geo/projection/tile_transform.js';
 
 // These bounds define the minimum and maximum supported coordinate values.
 // While visible coordinates are within [0, EXTENT], tiles may theoretically
@@ -16,12 +17,6 @@ import type {CanonicalTileID} from '../source/tile_id.js';
 const BITS = 15;
 const MAX = Math.pow(2, BITS - 1) - 1;
 const MIN = -MAX - 1;
-
-let projection;
-
-export function setProjection(config: {name: string} | string) {
-    projection = getProjection(config);
-}
 
 function clampPoint(point: Point) {
     const {x, y} = point;
@@ -54,10 +49,11 @@ type FeatureWithGeometry = {
  * @param {VectorTileFeature} feature
  * @private
  */
-export default function loadGeometry(feature: FeatureWithGeometry, canonical?: CanonicalTileID): Array<Array<Point>> {
+export default function loadGeometry(feature: FeatureWithGeometry, canonical?: CanonicalTileID, cs: TileTransform): Array<Array<Point>> {
     const featureExtent = feature.extent;
     const scale = EXTENT / featureExtent;
-    let cs, z2;
+    const {projection} = cs;
+    let z2;
     const isMercator = !projection || projection.name === 'mercator';
     if (canonical && !isMercator) {
         cs = tileTransform(canonical, projection);

--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -4,8 +4,6 @@ import {warnOnce, clamp} from '../util/util.js';
 
 import EXTENT from './extent.js';
 import {lngFromMercatorX, latFromMercatorY} from '../geo/mercator_coordinate.js';
-import getProjection from '../geo/projection/index.js';
-import tileTransform from '../geo/projection/tile_transform.js';
 import Point from '@mapbox/point-geometry';
 import type {CanonicalTileID} from '../source/tile_id.js';
 import type {TileTransform} from '../geo/projection/tile_transform.js';
@@ -49,27 +47,26 @@ type FeatureWithGeometry = {
  * @param {VectorTileFeature} feature
  * @private
  */
-export default function loadGeometry(feature: FeatureWithGeometry, canonical?: CanonicalTileID, cs: TileTransform): Array<Array<Point>> {
+export default function loadGeometry(feature: FeatureWithGeometry, canonical?: CanonicalTileID, tileTransform?: TileTransform): Array<Array<Point>> {
     const featureExtent = feature.extent;
     const scale = EXTENT / featureExtent;
-    const {projection} = cs;
+    const projection = tileTransform ? tileTransform.projection : undefined;
     let z2;
     const isMercator = !projection || projection.name === 'mercator';
     if (canonical && !isMercator) {
-        cs = tileTransform(canonical, projection);
         z2 = Math.pow(2, canonical.z);
     }
 
     function reproject(p) {
-        if (isMercator || !canonical) {
+        if (isMercator || !canonical || !tileTransform || !projection) {
             return new Point(Math.round(p.x * scale), Math.round(p.y * scale));
         } else {
             const lng = lngFromMercatorX((canonical.x + p.x / featureExtent) / z2);
             const lat = latFromMercatorY((canonical.y + p.y / featureExtent) / z2);
             const {x, y} = projection.project(lng, lat);
             return new Point(
-                Math.round((x * cs.scale - cs.x) * EXTENT),
-                Math.round((y * cs.scale - cs.y) * EXTENT)
+                Math.round((x * tileTransform.scale - tileTransform.x) * EXTENT),
+                Math.round((y * tileTransform.scale - tileTransform.y) * EXTENT)
             );
         }
     }

--- a/src/geo/projection/tile_transform.js
+++ b/src/geo/projection/tile_transform.js
@@ -3,6 +3,15 @@ import {lngFromMercatorX, latFromMercatorY} from '../mercator_coordinate.js';
 import {number as interpolate} from '../../style-spec/util/interpolate.js';
 import type {Projection} from './index.js';
 
+export type TileTransform = {
+    scale: number,
+    x: number,
+    y: number,
+    x2: number,
+    y2: number,
+    projection: Projection
+};
+
 export default function tileTransform(id: Object, projection: Projection) {
     const s = Math.pow(2, -id.z);
     const x1 = (id.x) * s;
@@ -41,6 +50,7 @@ export default function tileTransform(id: Object, projection: Projection) {
         x: minX * scale,
         y: minY * scale,
         x2: maxX * scale,
-        y2: maxY * scale
+        y2: maxY * scale,
+        projection
     };
 }

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1283,7 +1283,7 @@ class Transform {
             scale = 1;
             scaledX = cs.x;
             scaledY = cs.y;
-            mat4.scale(posMatrix, posMatrix, [scale / cs.scale, scale / cs.scale, 1]);
+            mat4.scale(posMatrix, posMatrix, [scale / cs.scale, scale / cs.scale, this.pixelsPerMeter / this.worldSize]);
         }
 
         mat4.translate(posMatrix, posMatrix, [scaledX, scaledY, 0]);

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -14,6 +14,7 @@ import {Aabb, Frustum, Ray} from '../util/primitives.js';
 import EdgeInsets from './edge_insets.js';
 import {FreeCamera, FreeCameraOptions, orientationFromFrame} from '../ui/free_camera.js';
 import assert from 'assert';
+import getProjectionAdjustments, {getProjectionAdjustmentInverted} from './projection/adjustments.js';
 
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
 import type {Elevation} from '../terrain/elevation.js';
@@ -87,6 +88,8 @@ class Transform {
 
     // Inverse of glCoordMatrix, from NDC to screen coordinates, [-1, 1] x [-1, 1] --> [0, w] x [h, 0]
     labelPlaneMatrix: Float32Array;
+
+    inverseAdjustmentMatrix: Array<number>;
 
     freezeTileCoverage: boolean;
     cameraElevationReference: ElevationReference;
@@ -1556,7 +1559,7 @@ class Transform {
         // seems to solve z-fighting issues in deckgl while not clipping buildings too close to the camera.
         const nearZ = this.height / 50;
 
-        const worldToCamera = this._camera.getWorldToCamera(this.worldSize, pixelsPerMeter, this);
+        const worldToCamera = this._camera.getWorldToCamera(this.worldSize, pixelsPerMeter);
         const cameraToClip = this._camera.getCameraToClipPerspective(this._fov, this.width / this.height, nearZ, farZ);
 
         // Apply center of perspective offset
@@ -1564,6 +1567,20 @@ class Transform {
         cameraToClip[9] = offset.y * 2 / this.height;
 
         let m = mat4.mul([], cameraToClip, worldToCamera);
+
+        if (this.projection.name !== 'mercator') {
+            // Projections undistort as you zoom in (shear, scale, rotate).
+            // Apply the undistortion around the center of the map.
+            const mc = this.locationCoordinate(this.center);
+            const adjustments = mat4.identity([]);
+            mat4.translate(adjustments, adjustments, [mc.x * this.worldSize, mc.y * this.worldSize, 0]);
+            mat4.multiply(adjustments, adjustments, getProjectionAdjustments(this));
+            mat4.translate(adjustments, adjustments, [-mc.x * this.worldSize, -mc.y * this.worldSize, 0]);
+            mat4.multiply(m, m, adjustments);
+            this.inverseAdjustmentMatrix = getProjectionAdjustmentInverted(this);
+        } else {
+            this.inverseAdjustmentMatrix = [1, 0, 0, 1];
+        }
 
         // The mercatorMatrix can be used to transform points from mercator coordinates
         // ([0, 0] nw, [1, 1] se) to GL coordinates.

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -4,7 +4,6 @@ import Point from '@mapbox/point-geometry';
 import drawCollisionDebug from './draw_collision_debug.js';
 
 import SegmentVector from '../data/segment.js';
-import pixelsToTileUnits from '../source/pixels_to_tile_units.js';
 import * as symbolProjection from '../symbol/projection.js';
 import * as symbolSize from '../symbol/symbol_size.js';
 import {mat4} from 'gl-matrix';

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -126,8 +126,8 @@ function updateVariableAnchors(coords, painter, layer, sourceCache, rotationAlig
         const sizeData = bucket.textSizeData;
         const size = symbolSize.evaluateSizeForZoom(sizeData, tr.zoom);
 
-        const pixelToTileScale = pixelsToTileUnits(tile, 1, painter.transform.zoom);
-        const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.projMatrix, pitchWithMap, rotateWithMap, painter.transform, pixelToTileScale);
+        const pixelsToTileUnits = painter.transform.calculatePixelsToTileUnitsMatrix(tile);
+        const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.projMatrix, pitchWithMap, rotateWithMap, painter.transform, pixelsToTileUnits);
         const updateTextFitIcon = layer.layout.get('icon-text-fit') !== 'none' &&  bucket.hasIconData();
 
         if (size) {
@@ -291,7 +291,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
             texSize = tile.imageAtlasTexture.size;
         }
 
-        const s = pixelsToTileUnits(tile, 1, painter.transform.zoom);
+        const s = painter.transform.calculatePixelsToTileUnitsMatrix(tile);
         const labelPlaneMatrix = symbolProjection.getLabelPlaneMatrix(coord.projMatrix, pitchWithMap, rotateWithMap, painter.transform, s);
         // labelPlaneMatrixInv is used for converting vertex pos to tile coordinates needed for sampling elevation.
         const labelPlaneMatrixInv = painter.terrain && pitchWithMap && alongLine ? mat4.invert(new Float32Array(16), labelPlaneMatrix) : identityMat4;

--- a/src/render/program/circle_program.js
+++ b/src/render/program/circle_program.js
@@ -2,10 +2,9 @@
 
 import {
     Uniform1f,
-    Uniform2f,
+    UniformMatrix2f,
     UniformMatrix4f
 } from '../uniform_binding.js';
-import pixelsToTileUnits from '../../source/pixels_to_tile_units.js';
 
 import type Context from '../../gl/context.js';
 import type {UniformValues, UniformLocations} from '../uniform_binding.js';
@@ -17,7 +16,7 @@ import browser from '../../util/browser.js';
 
 export type CircleUniformsType = {|
     'u_camera_to_center_distance': Uniform1f,
-    'u_extrude_scale': Uniform2f,
+    'u_extrude_scale': UniformMatrix2f,
     'u_device_pixel_ratio': Uniform1f,
     'u_matrix': UniformMatrix4f
 |};
@@ -26,7 +25,7 @@ export type CircleDefinesType = 'PITCH_WITH_MAP' | 'SCALE_WITH_MAP';
 
 const circleUniforms = (context: Context, locations: UniformLocations): CircleUniformsType => ({
     'u_camera_to_center_distance': new Uniform1f(context, locations.u_camera_to_center_distance),
-    'u_extrude_scale': new Uniform2f(context, locations.u_extrude_scale),
+    'u_extrude_scale': new UniformMatrix2f(context, locations.u_extrude_scale),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix)
 });
@@ -39,12 +38,15 @@ const circleUniformValues = (
 ): UniformValues<CircleUniformsType> => {
     const transform = painter.transform;
 
-    let extrudeScale: [number, number];
+    let extrudeScale;
     if (layer.paint.get('circle-pitch-alignment') === 'map') {
-        const pixelRatio = pixelsToTileUnits(tile, 1, transform.zoom);
-        extrudeScale = [pixelRatio, pixelRatio];
+        extrudeScale = transform.calculatePixelsToTileUnitsMatrix(tile);
     } else {
-        extrudeScale = transform.pixelsToGLUnits;
+        extrudeScale = new Float32Array([
+            transform.pixelsToGLUnits[0],
+            0,
+            0,
+            transform.pixelsToGLUnits[1]]);
     }
 
     return {

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -5,9 +5,10 @@ import {
     Uniform1f,
     Uniform2f,
     Uniform3f,
+    UniformMatrix2f,
     UniformMatrix4f
 } from '../uniform_binding.js';
-import pixelsToTileUnits from '../../source/pixels_to_tile_units.js';
+import pixelsToTileUnits, {getPixelsToTileUnitsMatrix} from '../../source/pixels_to_tile_units.js';
 import {extend} from '../../util/util.js';
 import browser from '../../util/browser.js';
 
@@ -21,7 +22,7 @@ import type {CrossfadeParameters} from '../../style/evaluation_parameters.js';
 
 export type LineUniformsType = {|
     'u_matrix': UniformMatrix4f,
-    'u_ratio': Uniform1f,
+    'u_pixels_to_tile_units': UniformMatrix2f,
     'u_device_pixel_ratio': Uniform1f,
     'u_units_to_pixels': Uniform2f
 |};
@@ -59,7 +60,7 @@ export type LineSDFUniformsType = {|
 
 const lineUniforms = (context: Context, locations: UniformLocations): LineUniformsType => ({
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
-    'u_ratio': new Uniform1f(context, locations.u_ratio),
+    'u_pixels_to_tile_units': new UniformMatrix2f(context, locations.u_pixels_to_tile_units),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
     'u_units_to_pixels': new Uniform2f(context, locations.u_units_to_pixels)
 });
@@ -102,10 +103,11 @@ const lineUniformValues = (
     matrix: ?Float32Array
 ): UniformValues<LineUniformsType> => {
     const transform = painter.transform;
+    const pixelsToTileUnits = getPixelsToTileUnitsMatrix(tile, transform);
 
     return {
         'u_matrix': calculateMatrix(painter, tile, layer, matrix),
-        'u_ratio': 1 / pixelsToTileUnits(tile, 1, transform.zoom),
+        'u_pixels_to_tile_units': pixelsToTileUnits,
         'u_device_pixel_ratio': browser.devicePixelRatio,
         'u_units_to_pixels': [
             1 / transform.pixelsToGLUnits[0],

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -29,7 +29,7 @@ export type LineUniformsType = {|
 
 export type LineGradientUniformsType = {|
     'u_matrix': UniformMatrix4f,
-    'u_ratio': Uniform1f,
+    'u_pixels_to_tile_units': UniformMatrix2f,
     'u_device_pixel_ratio': Uniform1f,
     'u_units_to_pixels': Uniform2f,
     'u_image': Uniform1i,
@@ -39,7 +39,7 @@ export type LineGradientUniformsType = {|
 export type LinePatternUniformsType = {|
     'u_matrix': UniformMatrix4f,
     'u_texsize': Uniform2f,
-    'u_ratio': Uniform1f,
+    'u_pixels_to_tile_units': UniformMatrix2f,
     'u_device_pixel_ratio': Uniform1f,
     'u_units_to_pixels': Uniform2f,
     'u_image': Uniform1i,
@@ -50,7 +50,7 @@ export type LinePatternUniformsType = {|
 export type LineSDFUniformsType = {|
     'u_matrix': UniformMatrix4f,
     'u_texsize': Uniform2f,
-    'u_ratio': Uniform1f,
+    'u_pixels_to_tile_units': UniformMatrix2f,
     'u_device_pixel_ratio': Uniform1f,
     'u_units_to_pixels': Uniform2f,
     'u_scale': Uniform3f,
@@ -67,7 +67,7 @@ const lineUniforms = (context: Context, locations: UniformLocations): LineUnifor
 
 const lineGradientUniforms = (context: Context, locations: UniformLocations): LineGradientUniformsType => ({
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
-    'u_ratio': new Uniform1f(context, locations.u_ratio),
+    'u_pixels_to_tile_units': new UniformMatrix2f(context, locations.u_pixels_to_tile_units),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
     'u_units_to_pixels': new Uniform2f(context, locations.u_units_to_pixels),
     'u_image': new Uniform1i(context, locations.u_image),
@@ -77,7 +77,7 @@ const lineGradientUniforms = (context: Context, locations: UniformLocations): Li
 const linePatternUniforms = (context: Context, locations: UniformLocations): LinePatternUniformsType => ({
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
     'u_texsize': new Uniform2f(context, locations.u_texsize),
-    'u_ratio': new Uniform1f(context, locations.u_ratio),
+    'u_pixels_to_tile_units': new UniformMatrix2f(context, locations.u_pixels_to_tile_units),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
     'u_image': new Uniform1i(context, locations.u_image),
     'u_units_to_pixels': new Uniform2f(context, locations.u_units_to_pixels),
@@ -88,7 +88,7 @@ const linePatternUniforms = (context: Context, locations: UniformLocations): Lin
 const lineSDFUniforms = (context: Context, locations: UniformLocations): LineSDFUniformsType => ({
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix),
     'u_texsize': new Uniform2f(context, locations.u_texsize),
-    'u_ratio': new Uniform1f(context, locations.u_ratio),
+    'u_pixels_to_tile_units': new UniformMatrix2f(context, locations.u_pixels_to_tile_units),
     'u_device_pixel_ratio': new Uniform1f(context, locations.u_device_pixel_ratio),
     'u_units_to_pixels': new Uniform2f(context, locations.u_units_to_pixels),
     'u_image': new Uniform1i(context, locations.u_image),

--- a/src/render/program/line_program.js
+++ b/src/render/program/line_program.js
@@ -8,7 +8,7 @@ import {
     UniformMatrix2f,
     UniformMatrix4f
 } from '../uniform_binding.js';
-import pixelsToTileUnits, {getPixelsToTileUnitsMatrix} from '../../source/pixels_to_tile_units.js';
+import pixelsToTileUnits from '../../source/pixels_to_tile_units.js';
 import {extend} from '../../util/util.js';
 import browser from '../../util/browser.js';
 
@@ -103,7 +103,7 @@ const lineUniformValues = (
     matrix: ?Float32Array
 ): UniformValues<LineUniformsType> => {
     const transform = painter.transform;
-    const pixelsToTileUnits = getPixelsToTileUnitsMatrix(tile, transform);
+    const pixelsToTileUnits = transform.calculatePixelsToTileUnitsMatrix(tile);
 
     return {
         'u_matrix': calculateMatrix(painter, tile, layer, matrix),
@@ -142,7 +142,7 @@ const linePatternUniformValues = (
         'u_matrix': calculateMatrix(painter, tile, layer, matrix),
         'u_texsize': tile.imageAtlasTexture.size,
         // camera zoom ratio
-        'u_ratio': 1 / pixelsToTileUnits(tile, 1, transform.zoom),
+        'u_pixels_to_tile_units': transform.calculatePixelsToTileUnitsMatrix(tile),
         'u_device_pixel_ratio': browser.devicePixelRatio,
         'u_image': 0,
         'u_scale': [tileZoomRatio, crossfade.fromScale, crossfade.toScale],

--- a/src/render/uniform_binding.js
+++ b/src/render/uniform_binding.js
@@ -151,6 +151,24 @@ class UniformMatrix3f extends Uniform<Float32Array> {
     }
 }
 
+const emptyMat2 = new Float32Array(4);
+class UniformMatrix2f extends Uniform<Float32Array> {
+    constructor(context: Context, location: WebGLUniformLocation) {
+        super(context, location);
+        this.current = emptyMat2;
+    }
+
+    set(v: Float32Array): void {
+        for (let i = 0; i < 4; i++) {
+            if (v[i] !== this.current[i]) {
+                this.current = v;
+                this.gl.uniformMatrix2fv(this.location, false, v);
+                break;
+            }
+        }
+    }
+}
+
 export {
     Uniform,
     Uniform1i,
@@ -159,6 +177,7 @@ export {
     Uniform3f,
     Uniform4f,
     UniformColor,
+    UniformMatrix2f,
     UniformMatrix3f,
     UniformMatrix4f
 };

--- a/src/shaders/circle.vertex.glsl
+++ b/src/shaders/circle.vertex.glsl
@@ -5,7 +5,7 @@
 #define NUM_SAMPLES_PER_RING 16
 
 uniform mat4 u_matrix;
-uniform vec2 u_extrude_scale;
+uniform mat2 u_extrude_scale;
 uniform lowp float u_device_pixel_ratio;
 uniform highp float u_camera_to_center_distance;
 

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -10,7 +10,7 @@ attribute vec2 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
-uniform mediump float u_ratio;
+uniform mat2 u_pixels_to_tile_units;
 uniform vec2 u_units_to_pixels;
 uniform lowp float u_device_pixel_ratio;
 
@@ -69,8 +69,8 @@ void main() {
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
 
-    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
-    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+    vec4 projected_extrude = u_matrix * vec4(dist * u_pixels_to_tile_units, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 * u_pixels_to_tile_units, 0.0, 1.0) + projected_extrude;
 
 #ifndef RENDER_TO_TEXTURE
     // calculate how much the perspective view squishes or stretches the extrude

--- a/src/shaders/line_gradient.vertex.glsl
+++ b/src/shaders/line_gradient.vertex.glsl
@@ -12,7 +12,7 @@ attribute float a_uv_x;
 attribute float a_split_index;
 
 uniform mat4 u_matrix;
-uniform mediump float u_ratio;
+uniform mat2 u_pixels_to_tile_units;
 uniform lowp float u_device_pixel_ratio;
 uniform vec2 u_units_to_pixels;
 uniform float u_image_height;
@@ -76,8 +76,8 @@ void main() {
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
 
-    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
-    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+    vec4 projected_extrude = u_matrix * vec4(dist * u_pixels_to_tile_units, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 * u_pixels_to_tile_units, 0.0, 1.0) + projected_extrude;
 
 #ifndef RENDER_TO_TEXTURE
     // calculate how much the perspective view squishes or stretches the extrude

--- a/src/shaders/line_pattern.vertex.glsl
+++ b/src/shaders/line_pattern.vertex.glsl
@@ -12,7 +12,7 @@ attribute float a_linesofar;
 
 uniform mat4 u_matrix;
 uniform vec2 u_units_to_pixels;
-uniform mediump float u_ratio;
+uniform mat2 u_pixels_to_tile_units;
 uniform lowp float u_device_pixel_ratio;
 
 varying vec2 v_normal;
@@ -82,8 +82,8 @@ void main() {
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
 
-    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
-    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+    vec4 projected_extrude = u_matrix * vec4(dist * u_pixels_to_tile_units, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 * u_pixels_to_tile_units, 0.0, 1.0) + projected_extrude;
 
 #ifndef RENDER_TO_TEXTURE
     // calculate how much the perspective view squishes or stretches the extrude

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -11,7 +11,7 @@ attribute vec4 a_data;
 attribute float a_linesofar;
 
 uniform mat4 u_matrix;
-uniform mediump float u_ratio;
+uniform mat2 u_pixels_to_tile_units;
 uniform lowp float u_device_pixel_ratio;
 uniform vec2 u_units_to_pixels;
 
@@ -82,8 +82,8 @@ void main() {
     mediump float t = 1.0 - abs(u);
     mediump vec2 offset2 = offset * a_extrude * EXTRUDE_SCALE * normal.y * mat2(t, -u, u, t);
 
-    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
-    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+    vec4 projected_extrude = u_matrix * vec4(dist * u_pixels_to_tile_units, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 * u_pixels_to_tile_units, 0.0, 1.0) + projected_extrude;
 
 #ifndef RENDER_TO_TEXTURE
     // calculate how much the perspective view squishes or stretches the extrude

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -98,5 +98,5 @@ void main() {
     v_tex = a_tex / u_texsize;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
-    v_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
+    v_fade_opacity = 1.0;//max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
 }

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -98,5 +98,5 @@ void main() {
     v_tex = a_tex / u_texsize;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
-    v_fade_opacity = 1.0;//max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
+    v_fade_opacity = max(0.0, min(occlusion_fade, fade_opacity[0] + fade_change));
 }

--- a/src/source/pixels_to_tile_units.js
+++ b/src/source/pixels_to_tile_units.js
@@ -1,8 +1,12 @@
 // @flow
 
+import {mat2} from 'gl-matrix';
+
 import EXTENT from '../data/extent.js';
+import tileTransform from '../geo/projection/tile_transform.js';
 
 import type {OverscaledTileID} from './tile_id.js';
+import type Transform from '../geo/transform.js';
 
 /**
  * Converts a pixel value at a the given zoom level to tile units.
@@ -18,4 +22,10 @@ import type {OverscaledTileID} from './tile_id.js';
  */
 export default function(tile: {tileID: OverscaledTileID, tileSize: number}, pixelValue: number, z: number): number {
     return pixelValue * (EXTENT / (tile.tileSize * Math.pow(2, z - tile.tileID.overscaledZ)));
+}
+
+export function getPixelsToTileUnitsMatrix(tile: {tileID: OverscaledTileID, tileSize: number}, transform: Transform): Float32Array {
+    const {scale} = tileTransform(tile.tileID.canonical, transform.projection);
+    const s = scale * EXTENT / (tile.tileSize * Math.pow(2, transform.zoom - tile.tileID.overscaledZ + tile.tileID.canonical.z));
+    return mat2.scale(new Float32Array(4), transform.inverseAdjustmentMatrix, [s, s]);
 }

--- a/src/source/pixels_to_tile_units.js
+++ b/src/source/pixels_to_tile_units.js
@@ -3,10 +3,10 @@
 import {mat2} from 'gl-matrix';
 
 import EXTENT from '../data/extent.js';
-import tileTransform from '../geo/projection/tile_transform.js';
 
 import type {OverscaledTileID} from './tile_id.js';
 import type Transform from '../geo/transform.js';
+import type {TileTransform} from '../geo/projection/tile_transform.js';
 
 /**
  * Converts a pixel value at a the given zoom level to tile units.
@@ -24,7 +24,7 @@ export default function(tile: {tileID: OverscaledTileID, tileSize: number}, pixe
     return pixelValue * (EXTENT / (tile.tileSize * Math.pow(2, z - tile.tileID.overscaledZ)));
 }
 
-export function getPixelsToTileUnitsMatrix(tile: {tileID: OverscaledTileID, tileSize: number}, transform: Transform): Float32Array {
+export function getPixelsToTileUnitsMatrix(tile: {tileID: OverscaledTileID, tileSize: number, tileTransform: TileTransform}, transform: Transform): Float32Array {
     const {scale} = tile.tileTransform;
     const s = scale * EXTENT / (tile.tileSize * Math.pow(2, transform.zoom - tile.tileID.overscaledZ + tile.tileID.canonical.z));
     return mat2.scale(new Float32Array(4), transform.inverseAdjustmentMatrix, [s, s]);

--- a/src/source/pixels_to_tile_units.js
+++ b/src/source/pixels_to_tile_units.js
@@ -25,7 +25,7 @@ export default function(tile: {tileID: OverscaledTileID, tileSize: number}, pixe
 }
 
 export function getPixelsToTileUnitsMatrix(tile: {tileID: OverscaledTileID, tileSize: number}, transform: Transform): Float32Array {
-    const {scale} = tileTransform(tile.tileID.canonical, transform.projection);
+    const {scale} = tile.tileTransform;
     const s = scale * EXTENT / (tile.tileSize * Math.pow(2, transform.zoom - tile.tileID.overscaledZ + tile.tileID.canonical.z));
     return mat2.scale(new Float32Array(4), transform.inverseAdjustmentMatrix, [s, s]);
 }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -378,7 +378,8 @@ class Tile {
             tileResult,
             pixelPosMatrix,
             transform,
-            params
+            params,
+            tileTransform: this.tileTransform
         }, layers, serializedLayers, sourceFeatureState);
     }
 

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -168,7 +168,9 @@ class Tile {
         if (painter) {
             const {projection} = painter.transform;
             this.tileTransform = tileTransform(tileID.canonical, projection);
-            this._makeTileBoundsBuffers(painter.context, projection);
+            if (painter.context) {
+                this._makeTileBoundsBuffers(painter.context, projection);
+            }
         }
     }
 

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -2,7 +2,6 @@
 
 import Actor from '../util/actor.js';
 
-import {setProjection} from '../data/load_geometry.js';
 import StyleLayerIndex from '../style/style_layer_index.js';
 import VectorTileWorkerSource from './vector_tile_worker_source.js';
 import RasterDEMTileWorkerSource from './raster_dem_tile_worker_source.js';
@@ -13,6 +12,7 @@ import {enforceCacheSizeLimit} from '../util/tile_request_cache.js';
 import {extend} from '../util/util.js';
 import {PerformanceUtils} from '../util/performance.js';
 import {Event} from '../util/evented.js';
+import getProjection from '../geo/projection/index.js';
 
 import type {
     WorkerSource,
@@ -27,6 +27,7 @@ import type {WorkerGlobalScopeInterface} from '../util/web_worker.js';
 import type {Callback} from '../types/callback.js';
 import type {LayerSpecification} from '../style-spec/types.js';
 import type {PluginState} from './rtl_text_plugin.js';
+import type {Projection} from '../geo/projection/index.js';
 
 /**
  * @private
@@ -39,6 +40,7 @@ export default class Worker {
     workerSourceTypes: {[_: string]: Class<WorkerSource> };
     workerSources: {[_: string]: {[_: string]: {[_: string]: WorkerSource } } };
     demWorkerSources: {[_: string]: {[_: string]: RasterDEMTileWorkerSource } };
+    projections: {[_: string]: Projection };
     isSpriteLoaded: boolean;
     referrer: ?string;
     terrain: ?boolean;
@@ -49,6 +51,7 @@ export default class Worker {
         this.actor = new Actor(self, this);
 
         this.layerIndexes = {};
+        this.projections = {};
         this.availableImages = {};
         this.isSpriteLoaded = false;
 
@@ -118,7 +121,7 @@ export default class Worker {
     }
 
     setProjection(mapId: string, config: {name: string} | string) {
-        setProjection(config);
+        this.projections[mapId] = getProjection(config);
     }
 
     setLayers(mapId: string, layers: Array<LayerSpecification>, callback: WorkerTileCallback) {
@@ -134,6 +137,7 @@ export default class Worker {
     loadTile(mapId: string, params: WorkerTileParameters & {type: string}, callback: WorkerTileCallback) {
         assert(params.type);
         const p = this.enableTerrain ? extend({enableTerrain: this.terrain}, params) : params;
+        p.projection = this.projections[mapId];
         this.getWorkerSource(mapId, params.type, params.source).loadTile(p, callback);
     }
 

--- a/src/source/worker.js
+++ b/src/source/worker.js
@@ -149,6 +149,7 @@ export default class Worker {
     reloadTile(mapId: string, params: WorkerTileParameters & {type: string}, callback: WorkerTileCallback) {
         assert(params.type);
         const p = this.enableTerrain ? extend({enableTerrain: this.terrain}, params) : params;
+        p.projection = this.projections[mapId];
         this.getWorkerSource(mapId, params.type, params.source).reloadTile(p, callback);
     }
 

--- a/src/source/worker_source.js
+++ b/src/source/worker_source.js
@@ -13,6 +13,7 @@ import type DEMData from '../data/dem_data.js';
 import type {StyleGlyph} from '../style/style_glyph.js';
 import type {StyleImage} from '../style/style_image.js';
 import type {PromoteIdSpecification} from '../style-spec/types.js';
+import type {Projection} from '../geo/projection/index.js';
 import window from '../util/window.js';
 const {ImageBitmap} = window;
 
@@ -38,7 +39,8 @@ export type WorkerTileParameters = RequestedTileParameters & {
     showCollisionBoxes: boolean,
     collectResourceTiming?: boolean,
     returnDependencies?: boolean,
-    enableTerrain?: boolean
+    enableTerrain?: boolean,
+    projection?: Projection
 };
 
 export type WorkerDEMTileParameters = TileParameters & {

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -8,7 +8,6 @@ import {getAnchorJustification, evaluateVariableOffset} from './symbol_layout.js
 import {getAnchorAlignment, WritingMode} from './shaping.js';
 import {mat4} from 'gl-matrix';
 import assert from 'assert';
-import pixelsToTileUnits from '../source/pixels_to_tile_units.js';
 import Point from '@mapbox/point-geometry';
 import type Transform from '../geo/transform.js';
 import type StyleLayer from '../style/style_layer.js';

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -237,7 +237,7 @@ export class Placement {
 
         const pitchWithMap = layout.get('text-pitch-alignment') === 'map';
         const rotateWithMap = layout.get('text-rotation-alignment') === 'map';
-        const pixelsToTiles = pixelsToTileUnits(tile, 1, this.transform.zoom);
+        const pixelsToTiles = this.transform.calculatePixelsToTileUnitsMatrix(tile);
 
         const textLabelPlaneMatrix = projection.getLabelPlaneMatrix(posMatrix,
                 pitchWithMap,

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -78,10 +78,14 @@ function getLabelPlaneMatrix(posMatrix: mat4,
                              pitchWithMap: boolean,
                              rotateWithMap: boolean,
                              transform: Transform,
-                             pixelsToTileUnits: number) {
+                             pixelsToTileUnits: Float32Array) {
     const m = mat4.create();
     if (pitchWithMap) {
-        mat4.scale(m, m, [1 / pixelsToTileUnits, 1 / pixelsToTileUnits, 1]);
+        const s = mat2.invert([], pixelsToTileUnits);
+        m[0] = s[0];
+        m[1] = s[1];
+        m[4] = s[2];
+        m[5] = s[3];
         if (!rotateWithMap) {
             mat4.rotateZ(m, m, transform.angle);
         }
@@ -98,10 +102,15 @@ function getGlCoordMatrix(posMatrix: mat4,
                           pitchWithMap: boolean,
                           rotateWithMap: boolean,
                           transform: Transform,
-                          pixelsToTileUnits: number) {
+                          pixelsToTileUnits: Float32Array) {
     if (pitchWithMap) {
         const m = mat4.clone(posMatrix);
-        mat4.scale(m, m, [pixelsToTileUnits, pixelsToTileUnits, 1]);
+        const s = mat4.identity([]);
+        s[0] = pixelsToTileUnits[0];
+        s[1] = pixelsToTileUnits[1];
+        s[4] = pixelsToTileUnits[2];
+        s[5] = pixelsToTileUnits[3];
+        mat4.multiply(m, m, s);
         if (!rotateWithMap) {
             mat4.rotateZ(m, m, -transform.angle);
         }

--- a/src/symbol/projection.js
+++ b/src/symbol/projection.js
@@ -2,7 +2,7 @@
 
 import Point from '@mapbox/point-geometry';
 
-import {mat4, vec4} from 'gl-matrix';
+import {mat2, mat4, vec4} from 'gl-matrix';
 import * as symbolSize from './symbol_size.js';
 import {addDynamicAttributes} from '../data/bucket/symbol_bucket.js';
 

--- a/src/ui/free_camera.js
+++ b/src/ui/free_camera.js
@@ -3,9 +3,7 @@
 import MercatorCoordinate, {mercatorZfromAltitude} from '../geo/mercator_coordinate.js';
 import {degToRad, wrap} from '../util/util.js';
 import {vec3, vec4, quat, mat4} from 'gl-matrix';
-import getProjectionAdjustments from '../geo/projection/adjustments.js';
 import type {Elevation} from '../terrain/elevation.js';
-import type Transform from '../geo/transform.js';
 
 import type {LngLatLike} from '../geo/lng_lat.js';
 
@@ -243,9 +241,9 @@ class FreeCamera {
         return [col[0], col[1], col[2]];
     }
 
-    getCameraToWorld(worldSize: number, pixelsPerMeter: number, transform: Transform): Float64Array {
+    getCameraToWorld(worldSize: number, pixelsPerMeter: number): Float64Array {
         const cameraToWorld = new Float64Array(16);
-        mat4.invert(cameraToWorld, this.getWorldToCamera(worldSize, pixelsPerMeter, transform));
+        mat4.invert(cameraToWorld, this.getWorldToCamera(worldSize, pixelsPerMeter));
         return cameraToWorld;
     }
 
@@ -263,7 +261,7 @@ class FreeCamera {
         return matrix;
     }
 
-    getWorldToCamera(worldSize: number, pixelsPerMeter: number, transform: Transform): Float64Array {
+    getWorldToCamera(worldSize: number, pixelsPerMeter: number): Float64Array {
         // transformation chain from world space to camera space:
         // 1. Height value (z) of renderables is in meters. Scale z coordinate by pixelsPerMeter
         // 2. Transform from pixel coordinates to camera space with cameraMatrix^-1
@@ -281,9 +279,6 @@ class FreeCamera {
         vec3.scale(invPosition, invPosition, -worldSize);
 
         mat4.fromQuat(matrix, invOrientation);
-
-        const adjustments = getProjectionAdjustments(transform);
-        mat4.multiply(matrix, matrix, adjustments);
 
         mat4.translate(matrix, matrix, invPosition);
 

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -13,6 +13,7 @@ import Tile from '../../../src/source/tile.js';
 import CrossTileSymbolIndex from '../../../src/symbol/cross_tile_symbol_index.js';
 import FeatureIndex from '../../../src/data/feature_index.js';
 import {createSymbolBucket} from '../../util/create_symbol_layer.js';
+import getProjection from '../../../src/geo/projection/index.js';
 
 import {fileURLToPath} from 'url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -42,11 +43,12 @@ test('SymbolBucket', (t) => {
     const placement = new Placement(transform, 0, true);
     const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
     const crossTileSymbolIndex = new CrossTileSymbolIndex();
+    const painter = {transform: {projection: getProjection({name: 'mercator'})}};
 
     // add feature from bucket A
     bucketA.populate([{feature}], options);
     performSymbolLayout(bucketA, stacks, {});
-    const tileA = new Tile(tileID, 512);
+    const tileA = new Tile(tileID, 512, 0, painter);
     tileA.latestFeatureIndex = new FeatureIndex(tileID);
     tileA.buckets = {test: bucketA};
     tileA.collisionBoxArray = collisionBoxArray;
@@ -54,7 +56,7 @@ test('SymbolBucket', (t) => {
     // add same feature from bucket B
     bucketB.populate([{feature}], options);
     performSymbolLayout(bucketB, stacks, {});
-    const tileB = new Tile(tileID, 512);
+    const tileB = new Tile(tileID, 512, 0, painter);
     tileB.buckets = {test: bucketB};
     tileB.collisionBoxArray = collisionBoxArray;
 

--- a/test/unit/source/geojson_worker_source.test.js
+++ b/test/unit/source/geojson_worker_source.test.js
@@ -3,6 +3,7 @@ import GeoJSONWorkerSource from '../../../src/source/geojson_worker_source.js';
 import StyleLayerIndex from '../../../src/style/style_layer_index.js';
 import {OverscaledTileID} from '../../../src/source/tile_id.js';
 import perf from '../../../src/util/performance.js';
+import getProjection from '../../../src/geo/projection/index.js';
 
 const actor = {send: () => {}};
 
@@ -34,7 +35,8 @@ test('reloadTile', (t) => {
             source: 'sourceId',
             uid: 0,
             tileID: new OverscaledTileID(0, 0, 0, 0, 0),
-            maxZoom: 10
+            maxZoom: 10,
+            projection: getProjection({name: 'mercator'})
         };
 
         function addData(callback) {

--- a/test/unit/source/vector_tile_worker_source.test.js
+++ b/test/unit/source/vector_tile_worker_source.test.js
@@ -6,6 +6,7 @@ import {test} from '../../util/test.js';
 import VectorTileWorkerSource from '../../../src/source/vector_tile_worker_source.js';
 import StyleLayerIndex from '../../../src/style/style_layer_index.js';
 import perf from '../../../src/util/performance.js';
+import getProjection from '../../../src/geo/projection/index.js';
 
 import {fileURLToPath} from 'url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -19,6 +20,7 @@ test('VectorTileWorkerSource#abortTile aborts pending request', (t) => {
         source: 'source',
         uid: 0,
         tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
+        projection: getProjection({name: 'mercator'}),
         request: {url: 'http://localhost:2900/abort'}
     }, (err, res) => {
         t.false(err);
@@ -46,7 +48,8 @@ test('VectorTileWorkerSource#abortTile aborts pending async request', (t) => {
 
     source.loadTile({
         uid: 0,
-        tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}}
+        tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
+        projection: getProjection({name: 'mercator'})
     }, (err, res) => {
         t.false(err);
         t.false(res);
@@ -246,6 +249,7 @@ test('VectorTileWorkerSource provides resource timing information', (t) => {
         source: 'source',
         uid: 0,
         tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
+        projection: getProjection({name: 'mercator'}),
         request: {url: 'http://localhost:2900/faketile.pbf', collectResourceTiming: true}
     }, (err, res) => {
         t.false(err);

--- a/test/unit/source/worker.test.js
+++ b/test/unit/source/worker.test.js
@@ -10,6 +10,7 @@ test('load tile', (t) => {
     t.test('calls callback on error', (t) => {
         window.useFakeXMLHttpRequest();
         const worker = new Worker(_self);
+        worker.setProjection(0, {name: 'mercator'});
         worker.loadTile(0, {
             type: 'vector',
             source: 'source',

--- a/test/unit/source/worker_tile.test.js
+++ b/test/unit/source/worker_tile.test.js
@@ -3,6 +3,7 @@ import WorkerTile from '../../../src/source/worker_tile.js';
 import Wrapper from '../../../src/source/geojson_wrapper.js';
 import {OverscaledTileID} from '../../../src/source/tile_id.js';
 import StyleLayerIndex from '../../../src/style/style_layer_index.js';
+import getProjection from '../../../src/geo/projection/index.js';
 
 function createWorkerTile() {
     return new WorkerTile({
@@ -12,7 +13,8 @@ function createWorkerTile() {
         tileSize: 512,
         source: 'source',
         tileID: new OverscaledTileID(1, 0, 1, 1, 1),
-        overscaling: 1
+        overscaling: 1,
+        projection: getProjection({name: 'mercator'})
     });
 }
 


### PR DESCRIPTION
This fixes various things when an alternate projection is set:
- pitching (previously the center of the map would move as you pitch)
- line-width and other line properties
- map-aligned symbols (one-way arrows)
- map-aligned circles
- fill-extrusions (which were previously way too tall)


The undistortion is applied relative to the center, instead of relative to the camera (translate center to origin, undistort, translate back). The undistortion block is also  now completely bypassed for mercator.

The style-spec property sizes are fixed by replacing `pixelsToTileUnits` with a 2x2 matrix that accounts for the shearing and scaling. There may be a couple more spots we need to make this change but I addressed all the major places this matters.

This also fixes support for multiple maps on a single page and optimizes geometry loading by avoiding tileTransform recalculations.

<details>
<summary>Before/After/Reference images</summary>

### Pitching

Previously, the center was wrong.

mercator (reference):
![Screen Shot 2021-10-04 at 11 10 01 AM](https://user-images.githubusercontent.com/1421652/135876754-ba9d4643-6887-400d-ae72-61c8f2e7a2f0.png)
new:
![Screen Shot 2021-10-04 at 11 09 53 AM](https://user-images.githubusercontent.com/1421652/135876757-aaf3ed6e-30b9-40ac-be80-c056a8d5d0f1.png)
old:
![Screen Shot 2021-10-04 at 11 10 21 AM](https://user-images.githubusercontent.com/1421652/135876751-b9e8759d-83c4-44cf-8c53-dcde4d038ff8.png)

### Style spec property sizes

Compare the line widths and the skewness of the one-way arrows.

mercator (reference):
![Screen Shot 2021-10-04 at 11 08 53 AM](https://user-images.githubusercontent.com/1421652/135876759-bb7b6db3-4af0-4884-a827-c1ccc1a83aeb.png)
new:
![Screen Shot 2021-10-04 at 11 08 41 AM](https://user-images.githubusercontent.com/1421652/135876764-e5ae33f6-3e3b-4ff3-bb38-7bb3f2c78b9f.png)
old:
![Screen Shot 2021-10-04 at 11 08 31 AM](https://user-images.githubusercontent.com/1421652/135876745-af8daa9d-b169-4099-ae5d-6f3a746ca485.png)
</details>
