### PR TITLE
Fixed conditional for _isFullscreen to accommodate for Safari

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -391,7 +391,7 @@ class ScrollZoomHandler {
     }
 
     _isFullscreen() {
-        return window.document.fullscreenElement !== null;
+        return !!window.document.fullscreenElement;
     }
 
     _showBlockerAlert() {


### PR DESCRIPTION
This PR fixes a conditional check that didn't work in Safari. In the method "_isFullscreen" on the scrollZoomHandler,  `window.document.fullscreenElement` evaluates to `undefined` instead of `null` in Safari. This change now handles checking fullscreenElement accurately in Safari as well.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
