### PR TITLE
Move blur event reset into non-touch handlers

### DIFF
--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -153,6 +153,10 @@ class BoxZoomHandler {
         }
     }
 
+    blur(e: Event) {
+        this.reset();
+    }
+
     reset() {
         this._active = false;
 

--- a/src/ui/handler/box_zoom.js
+++ b/src/ui/handler/box_zoom.js
@@ -153,7 +153,7 @@ class BoxZoomHandler {
         }
     }
 
-    blur(e: Event) {
+    blur() {
         this.reset();
     }
 

--- a/src/ui/handler/click_zoom.js
+++ b/src/ui/handler/click_zoom.js
@@ -16,7 +16,7 @@ export default class ClickZoomHandler {
         this._active = false;
     }
 
-    blur(e: Event) {
+    blur() {
         this.reset();
     }
 

--- a/src/ui/handler/click_zoom.js
+++ b/src/ui/handler/click_zoom.js
@@ -16,6 +16,10 @@ export default class ClickZoomHandler {
         this._active = false;
     }
 
+    blur(e: Event) {
+        this.reset();
+    }
+
     dblclick(e: MouseEvent, point: Point) {
         e.preventDefault();
         return {

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -45,6 +45,10 @@ class KeyboardHandler {
         this._rotationDisabled = false;
     }
 
+    blur(e: Event) {
+        this.reset();
+    }
+
     reset() {
         this._active = false;
     }

--- a/src/ui/handler/keyboard.js
+++ b/src/ui/handler/keyboard.js
@@ -45,7 +45,7 @@ class KeyboardHandler {
         this._rotationDisabled = false;
     }
 
-    blur(e: Event) {
+    blur() {
         this.reset();
     }
 

--- a/src/ui/handler/mouse.js
+++ b/src/ui/handler/mouse.js
@@ -31,7 +31,7 @@ class MouseHandler {
         this._clickTolerance = options.clickTolerance || 1;
     }
 
-    blur(e: Event) {
+    blur() {
         this.reset();
     }
 

--- a/src/ui/handler/mouse.js
+++ b/src/ui/handler/mouse.js
@@ -31,6 +31,10 @@ class MouseHandler {
         this._clickTolerance = options.clickTolerance || 1;
     }
 
+    blur(e: Event) {
+        this.reset();
+    }
+
     reset() {
         this._active = false;
         this._moved = false;

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -371,7 +371,7 @@ class ScrollZoomHandler {
         return easing;
     }
 
-    blur(e: Event) {
+    blur() {
         this.reset();
     }
 

--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -371,6 +371,10 @@ class ScrollZoomHandler {
         return easing;
     }
 
+    blur(e: Event) {
+        this.reset();
+    }
+
     reset() {
         this._active = false;
     }

--- a/src/ui/handler_manager.js
+++ b/src/ui/handler_manager.js
@@ -344,11 +344,6 @@ class HandlerManager {
 
     handleEvent(e: InputEvent | RenderFrameEvent, eventName?: string) {
 
-        if (e.type === 'blur') {
-            this.stop(true);
-            return;
-        }
-
         this._updatingCamera = true;
         assert(e.timeStamp !== undefined);
 

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -151,13 +151,15 @@ test('DragPanHandler ends a mouse-triggered drag if the window blurs', (t) => {
     map._renderTaskQueue.run();
 
     simulate.blur(window);
+    map._renderTaskQueue.run();
+
     t.equal(dragend.callCount, 1);
 
     map.remove();
     t.end();
 });
 
-test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
+test('DragPanHandler does not end a touch-triggered drag if the window blurs', (t) => {
     const map = createMap(t);
     const target = map.getCanvas();
 
@@ -171,7 +173,9 @@ test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
     map._renderTaskQueue.run();
 
     simulate.blur(window);
-    t.equal(dragend.callCount, 1);
+    map._renderTaskQueue.run();
+
+    t.equal(dragend.callCount, 0);
 
     map.remove();
     t.end();

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -492,6 +492,8 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
     t.equal(rotate.callCount, 1);
 
     simulate.blur(window);
+    map._renderTaskQueue.run();
+
     t.equal(rotateend.callCount, 1);
 
     map.remove();


### PR DESCRIPTION
Related to #11048, the tab bar toggle also emits a window `blur` event which interrupts interactions when the page is initially opened:

https://user-images.githubusercontent.com/572717/136096444-62be64aa-7ab3-4f67-bc28-50e19a129623.mp4

Simply removing all blur handling has this effect on desktop, in which interactions continue after the window is backgrounded:

![blur](https://user-images.githubusercontent.com/572717/136096531-9944343b-a828-499e-acd0-533fc24ebf8e.gif)

The solution taken by this PR is to move a blur handler into individual *non-touch* handlers, so that blur events only reset non-touch events.

The main concern here is that we lose out on a couple things that the `stop` method does:

https://github.com/mapbox/mapbox-gl-js/blob/c13e5cebd2109a2b51541313f05c13613abe5408/src/ui/handler_manager.js#L290-L300

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
