### PR TITLE
Add EqualEarth, NaturalEarth and Lambert projections

### DIFF
--- a/debug/projections.html
+++ b/debug/projections.html
@@ -43,12 +43,14 @@
         <fieldset>
             <label>Projection:</label>
             <select id="projName">
-                <option value="mercator">Mercator</option>
-                <option value="winkel">Winkel Tripel</option>
-                <option value="sinusoidal">Sinusoidal</option>
-                <option value="wgs84">WGS84</option>
-                <option value="albers" selected>Albers USA</option>
                 <option value="alaska">Albers Alaska</option>
+                <option value="albers" selected>Albers USA</option>
+                <option value="equalEarth">Equal Earth</option>
+                <option value="equirectangular">Equirectangular</option>
+                <option value="lambert">Lambert</option>
+                <option value="mercator">Mercator</option>
+                <option value="naturalEarth">Natural Earth</option>
+                <option value="winkel">Winkel Tripel</option>
             </select>
         </fieldset>
         <fieldset>
@@ -84,18 +86,24 @@ function makeMap() {
     if (map) map.remove();
     const el = document.getElementById('projName');
     const zooms = {
-        albers: 3,
         alaska: 4,
-        winkel: 1.2,
+        albers: 3,
+        equalEarth: 1.0,
+        equirectangular: 1.0,
+        lambert: 1.0,
         mercator: 1.0,
-        wgs84: 1.0
+        naturalEarth: 1.0,
+        winkel: 1.2
     };
     const centers = {
-        albers: [-122.414, 37.776],
         alaska: [-154, 63],
-        winkel: [0, 0],
+        albers: [-122.414, 37.776],
+        equalEarth: [0, 0],
+        equirectangular: [0, 0],
+        lambert: [0, 0],
         mercator: [0, 0],
-        wgs84: [0, 0]
+        naturalEarth: [0, 0],
+        winkel: [0, 0]
     };
     const projection = el.options[el.selectedIndex].value;
     const zoom = zooms[projection] || 2;

--- a/src/geo/projection/equalEarth.js
+++ b/src/geo/projection/equalEarth.js
@@ -1,0 +1,56 @@
+// @flow
+import LngLat from '../lng_lat.js';
+import {clamp} from '../../util/util.js';
+
+const a1 = 1.340264;
+const a2 = -0.081106;
+const a3 = 0.000893;
+const a4 = 0.003796;
+const M = Math.sqrt(3) / 2;
+
+export default {
+    name: 'equalEarth',
+    center: [0, 0],
+    range: [3.5, 7],
+
+    project(lng: number, lat: number) {
+        // based on https://github.com/d3/d3-geo, MIT-licensed
+        lat = lat / 180 * Math.PI;
+        lng = lng / 180 * Math.PI;
+        const theta = Math.asin(M * Math.sin(lat));
+        const theta2 = theta * theta;
+        const theta6 = theta2 * theta2 * theta2;
+        const x = lng * Math.cos(theta) / (M * (a1 + 3 * a2 * theta2 + theta6 * (7 * a3 + 9 * a4 * theta2)));
+        const y = theta * (a1 + a2 * theta2 + theta6 * (a3 + a4 * theta2));
+
+        return {
+            x: (x / Math.PI + 0.5) * 0.5,
+            y: 1 - (y / Math.PI + 0.5) * 0.5
+        };
+    },
+
+    unproject(x: number, y: number) {
+        // based on https://github.com/d3/d3-geo, MIT-licensed
+        x = (2 * x - 0.5) * Math.PI;
+        y = (2 * (1 - y) - 0.5) * Math.PI;
+        let theta = y;
+        let theta2 = theta * theta;
+        let theta6 = theta2 * theta2 * theta2;
+
+        for (let i = 0, delta, fy, fpy; i < 12; ++i) {
+            fy = theta * (a1 + a2 * theta2 + theta6 * (a3 + a4 * theta2)) - y;
+            fpy = a1 + 3 * a2 * theta2 + theta6 * (7 * a3 + 9 * a4 * theta2);
+            theta -= delta = fy / fpy;
+            theta2 = theta * theta;
+            theta6 = theta2 * theta2 * theta2;
+            if (Math.abs(delta) < 1e-12) break;
+        }
+
+        const lambda = M * x * (a1 + 3 * a2 * theta2 + theta6 * (7 * a3 + 9 * a4 * theta2)) / Math.cos(theta);
+        const phi = Math.asin(Math.sin(theta) / M);
+        const lng = clamp(lambda * 180 / Math.PI, -180, 180);
+        const lat = clamp(phi * 180 / Math.PI, -90, 90);
+
+        return new LngLat(lng, lat);
+    }
+};

--- a/src/geo/projection/equirectangular.js
+++ b/src/geo/projection/equirectangular.js
@@ -3,7 +3,7 @@ import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
 
 export default {
-    name: 'wgs84',
+    name: 'equirectangular',
     center: [0, 0],
     project(lng: number, lat: number) {
         const x = 0.5 + lng / 360;

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -1,7 +1,10 @@
 // @flow
-import {albers, alaska} from './albers.js';
+import {alaska, albers} from './albers.js';
+import equalEarth from './equalEarth.js';
+import equirectangular from './equirectangular.js';
+import lambert from './lambert.js';
 import mercator from './mercator.js';
-import wgs84 from './wgs84.js';
+import naturalEarth from './naturalEarth.js';
 import winkel from './winkelTripel.js';
 import LngLat from '../lng_lat.js';
 
@@ -14,10 +17,13 @@ export type Projection = {
 };
 
 const projections = {
-    albers,
     alaska,
+    albers,
+    equalEarth,
+    equirectangular,
+    lambert,
     mercator,
-    wgs84,
+    naturalEarth,
     winkel
 };
 

--- a/src/geo/projection/lambert.js
+++ b/src/geo/projection/lambert.js
@@ -1,0 +1,68 @@
+// @flow
+import LngLat from '../lng_lat.js';
+import {clamp} from '../../util/util.js';
+
+const halfPi = Math.PI / 2;
+
+function tany(y) {
+    return Math.tan((halfPi + y) / 2);
+}
+
+function getParams(parallels) {
+    const cy0 = Math.cos(parallels[0]);
+    const n = parallels[0] === parallels[1] ?
+        Math.sin(parallels[0]) :
+        Math.log(cy0 / Math.cos(parallels[1])) / Math.log(tany(parallels[1]) / tany(parallels[0]));
+    const f = cy0 * Math.pow(tany(parallels[0]), n) / n;
+
+    return {n, f};
+}
+
+export default {
+    name: 'lambert',
+    range: [3.5, 7],
+
+    center: [0, 30],
+    parallels: [30, 30],
+
+    project(lng: number, lat: number) {
+        // based on https://github.com/d3/d3-geo, MIT-licensed
+        lat = lat / 180 * Math.PI;
+        lng = lng / 180 * Math.PI;
+
+        const epsilon = 1e-6;
+        const {n, f} = getParams(this.parallels);
+
+        if (f > 0) {
+            if (lat < -halfPi + epsilon) lat = -halfPi + epsilon;
+        } else {
+            if (lat > halfPi - epsilon) lat = halfPi - epsilon;
+        }
+
+        const r = f / Math.pow(tany(lat), n);
+        const x = r * Math.sin(n * lng);
+        const y = f - r * Math.cos(n * lng);
+
+        return {
+            x: (x / Math.PI + 0.5) * 0.5,
+            y: 1 - (y / Math.PI + 0.5) * 0.5
+        };
+    },
+
+    unproject(x: number, y: number) {
+        // based on https://github.com/d3/d3-geo, MIT-licensed
+        x = (2 * x - 0.5) * Math.PI;
+        y = (2 * (1 - y) - 0.5) * Math.PI;
+        const {n, f} = getParams(this.parallels);
+        const fy = f - y;
+        const r = Math.sign(n) * Math.sqrt(x * x + fy * fy);
+        let l = Math.atan2(x, Math.abs(fy)) * Math.sign(fy);
+
+        if (fy * n < 0) l -= Math.PI * Math.sign(x) * Math.sign(fy);
+
+        const lng = clamp((l / n)  * 180 / Math.PI, -180, 180);
+        const lat = clamp((2 * Math.atan(Math.pow(f / r, 1 / n)) - halfPi)  * 180 / Math.PI, -90, 90);
+
+        return new LngLat(lng, lat);
+    }
+};

--- a/src/geo/projection/naturalEarth.js
+++ b/src/geo/projection/naturalEarth.js
@@ -1,0 +1,51 @@
+// @flow
+import LngLat from '../lng_lat.js';
+import {clamp} from '../../util/util.js';
+
+export default {
+    name: 'naturalEarth',
+    center: [0, 0],
+    range: [3.5, 7],
+
+    project(lng: number, lat: number) {
+        // based on https://github.com/d3/d3-geo, MIT-licensed
+        lat = lat / 180 * Math.PI;
+        lng = lng / 180 * Math.PI;
+
+        const phi2 = lat * lat;
+        const phi4 = phi2 * phi2;
+        const x = lng * (0.8707 - 0.131979 * phi2 + phi4 * (-0.013791 + phi4 * (0.003971 * phi2 - 0.001529 * phi4)));
+        const y = lat * (1.007226 + phi2 * (0.015085 + phi4 * (-0.044475 + 0.028874 * phi2 - 0.005916 * phi4)));
+
+        return {
+            x: (x / Math.PI + 0.5) * 0.5,
+            y: 1 - (y / Math.PI + 0.5) * 0.5
+        };
+    },
+
+    unproject(x: number, y: number) {
+        // based on https://github.com/d3/d3-geo, MIT-licensed
+        x = (2 * x - 0.5) * Math.PI;
+        y = (2 * (1 - y) - 0.5) * Math.PI;
+        const epsilon = 1e-6;
+        let phi = y;
+        let i = 25;
+        let delta = 0;
+        let phi2 = phi * phi;
+
+        do {
+            phi2 = phi * phi;
+            const phi4 = phi2 * phi2;
+            phi -= delta = (phi * (1.007226 + phi2 * (0.015085 + phi4 * (-0.044475 + 0.028874 * phi2 - 0.005916 * phi4))) - y) /
+                (1.007226 + phi2 * (0.015085 * 3 + phi4 * (-0.044475 * 7 + 0.028874 * 9 * phi2 - 0.005916 * 11 * phi4)));
+        } while (Math.abs(delta) > epsilon && --i > 0);
+
+        phi2 = phi * phi;
+        const lambda = x / (0.8707 + phi2 * (-0.131979 + phi2 * (-0.013791 + phi2 * phi2 * phi2 * (0.003971 - 0.001529 * phi2))));
+
+        const lng = clamp(lambda * 180 / Math.PI, -180, 180);
+        const lat = clamp(phi * 180 / Math.PI, -90, 90);
+
+        return new LngLat(lng, lat);
+    }
+};

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -268,7 +268,7 @@ const defaultOptions = {
  * @param {Object} [options.locale=null] A patch to apply to the default localization table for UI strings, e.g. control tooltips. The `locale` object maps namespaced UI string IDs to translated strings in the target language;
  *  see `src/ui/default_locale.js` for an example with all supported string IDs. The object may specify all UI strings (thereby adding support for a new translation) or only a subset of strings (thereby patching the default translation table).
  * @param {boolean} [options.testMode=false] Silences errors and warnings generated due to an invalid accessToken, useful when using the library to write unit tests.
- * @param {string} [options.projection='mercator'] The map projection to use when creating a map. Defaults to the Web Mercator ('mercator') projection. Other options are Winkel Tripel ('winkel'), Sinusoidal ('sinusoidal'), Albers ('albers'), Albers Alaska ('alaska'), and WGS84 ('wgs84').
+ * @param {string} [options.projection='mercator'] The map projection to use when creating a map. Defaults to the Web Mercator ('mercator') projection. Other options are Albers Alaska ('alaska'), Albers USA ('albers'), Equal Earth ('equalEarth'), Equirectangular/Plate Carrée/WGS84 ('equirectangular'), Lambert Conformal Conic ('lambert'), Natural Earth ('naturalEarth') and Winkel Tripel ('winkel').
  * @example
  * var map = new mapboxgl.Map({
  *   container: 'map',


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - adds Equal Earth, Natural Earth and Lambert Conformal Conical projections
    - renames WGS84 to Equirectangular
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] document any changes to public APIs
 - [x] manually test the debug page

Equal Earth
<img width="1436" alt="equalearth" src="https://user-images.githubusercontent.com/4523080/136129010-dfd9f8d5-de9d-49fd-b5bc-47916629230f.png">

Natural Earth
<img width="1439" alt="naturalearth" src="https://user-images.githubusercontent.com/4523080/136129024-61fcce92-fc40-4b4a-8409-476edd9b21e1.png">

Lambert isn't quite right but I'm not sure exactly how to fix it. It's based on the Conic Conformal projection from d3-geo. Suggestions are welcome.
<img width="1438" alt="Screen Shot 2021-10-05 at 6 56 15 PM" src="https://user-images.githubusercontent.com/4523080/136129044-a9b411e0-f4ce-4745-a176-a991fffc7dd1.png">
<img width="1437" alt="Screen Shot 2021-10-05 at 6 56 41 PM" src="https://user-images.githubusercontent.com/4523080/136129064-4b81941a-c114-450d-b54b-30fd0deb7c26.png">
