### PR TITLE
Fixed doc usage of map.getCenter

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -172,7 +172,7 @@ class Camera extends Evented {
      * // Return a LngLat object such as {lng: 0, lat: 0}.
      * const center = map.getCenter();
      * // Access longitude and latitude values directly.
-     * const {longitude, latitude} = map.getCenter();
+     * const {lng, lat} = map.getCenter();
      * @see [Tutorial: Use Mapbox GL JS in a React app](https://docs.mapbox.com/help/tutorials/use-mapbox-gl-js-with-react/#store-the-new-coordinates)
      */
     getCenter(): LngLat { return new LngLat(this.transform.center.lng, this.transform.center.lat); }


### PR DESCRIPTION

## Description

This small change fixes a mistake in the JSDoc for `getCenter`. I think these comments get displayed as the API documentation [here](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#getcenter) too?


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] post benchmark scores
 - [x] manually test the debug page
 - [x] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [x] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
