### PR TITLE
Update link to transpiling guide in bundle_prelude

### DIFF
--- a/rollup/bundle_prelude.js
+++ b/rollup/bundle_prelude.js
@@ -9,7 +9,7 @@ if (!shared) {
 } else if (!worker) {
     worker = chunk;
 } else {
-    var workerBundleString = "self.onerror = function() { console.error('An error occurred while parsing the WebWorker bundle. This is most likely due to improper transpilation by Babel; please see https://docs.mapbox.com/mapbox-gl-js/api/#transpiling-v2'); }; var sharedChunk = {}; (" + shared + ")(sharedChunk); (" + worker + ")(sharedChunk); self.onerror = null;"
+    var workerBundleString = "self.onerror = function() { console.error('An error occurred while parsing the WebWorker bundle. This is most likely due to improper transpilation by Babel; please see https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling'); }; var sharedChunk = {}; (" + shared + ")(sharedChunk); (" + worker + ")(sharedChunk); self.onerror = null;"
 
     var sharedChunk = {};
     shared(sharedChunk);


### PR DESCRIPTION
## Launch Checklist

We received user feedback that the link to the transpiling guide no longer works. This PR updates the link to its new page: https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling

 - [x] briefly describe the changes in this PR
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'

