### PR TITLE
One weird JSON.parse() trick

### DIFF
--- a/build/rollup_plugin_minify_style_spec.js
+++ b/build/rollup_plugin_minify_style_spec.js
@@ -16,7 +16,7 @@ export default function minifyStyleSpec() {
             delete spec['expression_name'];
 
             return {
-                code: JSON.stringify(spec, replacer, 0),
+                code: `export default JSON.parse('${JSON.stringify(spec, replacer, 0)}');`,
                 map: {mappings: ''}
             };
         }

--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -16,7 +16,9 @@ import replace from '@rollup/plugin-replace';
 export const plugins = (minified, production, test, bench) => [
     flow(),
     minifyStyleSpec(),
-    json(),
+    json({
+        exclude: 'src/style-spec/reference/v8.json'
+    }),
     production ? strip({
         sourceMap: true,
         functions: ['PerformanceUtils.*', 'WorkerPerformanceUtils.*', 'Debug.*']


### PR DESCRIPTION
This implements
https://www.youtube.com/watch?v=ff4fgQxPaO0
for the style spec  json only. This doesn't implement it for other json objects because with those we would still like to have treeshaking.

The theory is that a static `JSON.parse(large_json_string)` is much faster than having a `large_json_object`,this is because a `large_json_object` is parsed by the full JavaScript parser since it can't know ahead of time  if an object is pure-json. 
With this change the JS parser skips that entire section since all it sees is a single string. The dedicated json parser underneath `JSON.parse` can then handle it much faster.
 Benchmap is showing a negligible but detectible improvement in `workerEvaluateScript` which is exactly where we expect to see an improvement.
 
 
<img width="943" alt="Screen Shot 2021-10-06 at 2 54 09 PM" src="https://user-images.githubusercontent.com/1449257/136289096-51161cce-6461-40fe-a803-a3b6c2cf0f21.png">


