### PR TITLE
Changes placeholder string to `YOUR_MAPBOX_ACCESS_TOKEN` in /mapbox-gl-js README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ copy node_modules/headless-gl/deps/windows/dll/x64/*.dll c:\windows\system32
 Start the debug server
 
 ```bash
-MAPBOX_ACCESS_TOKEN={YOUR MAPBOX ACCESS TOKEN} yarn run start-debug
+MAPBOX_ACCESS_TOKEN={YOUR_MAPBOX_ACCESS_TOKEN} yarn run start-debug
 ```
 
 Open the debug page at [http://localhost:9966/debug](http://localhost:9966/debug)

--- a/bench/README.md
+++ b/bench/README.md
@@ -7,7 +7,7 @@ Benchmarks help us catch performance regressions and improve performance.
 Start the benchmark server
 
 ```bash
-MAPBOX_ACCESS_TOKEN={YOUR MAPBOX ACCESS TOKEN} yarn start
+MAPBOX_ACCESS_TOKEN={YOUR_MAPBOX_ACCESS_TOKEN} yarn start
 ```
 
 To run all benchmarks, open [the benchmark page, `http://localhost:9966/bench/versions`](http://localhost:9966/bench/versions).
@@ -21,7 +21,7 @@ By default, the benchmark page will compare the local branch against `main` and 
 Start the benchmark server
 
 ```bash
-MAPBOX_ACCESS_TOKEN={YOUR MAPBOX ACCESS TOKEN} MAPBOX_STYLES={YOUR STYLES HERE} yarn start
+MAPBOX_ACCESS_TOKEN={YOUR_MAPBOX_ACCESS_TOKEN} MAPBOX_STYLES={YOUR STYLES HERE} yarn start
 ```
 Note: `MAPBOX_STYLES` takes a comma-separated list of up to 3 Mapbox styles provided as a style URL or file system path (e.g. `./path/to/style.json,mapbox://styles/mapbox/streets-v10` or `mapbox://styles/mapbox/streets-v10,mapbox://styles/mapbox/streets-v9`)
 


### PR DESCRIPTION
Re: https://github.com/mapbox/documentation/issues/773

- Changes token placeholder strings to `YOUR_MAPBOX_ACCESS_TOKEN` to consistify this placeholder string across all Mapbox docs.