### PR TITLE
Skip flaky render test

### DIFF
--- a/test/ignores.json
+++ b/test/ignores.json
@@ -34,5 +34,6 @@
   "render-tests/skybox/atmosphere-padding": "skip - https://github.com/mapbox/mapbox-gl-js/issues/10314",
   "render-tests/terrain/symbol-draping/style.json": "skip - https://github.com/mapbox/mapbox-gl-js/issues/10365",
   "render-tests/fill-extrusion-terrain/flat-roof-over-border-of-different-zoom-zoomin": "skip - https://github.com/mapbox/mapbox-gl-js/issues/11041",
-  "render-tests/fill-extrusion-terrain/flat-roof-over-border-of-different-zoom": "skip - https://github.com/mapbox/mapbox-gl-js/issues/11041"
+  "render-tests/fill-extrusion-terrain/flat-roof-over-border-of-different-zoom": "skip - https://github.com/mapbox/mapbox-gl-js/issues/11041",
+  "render-tests/text-variable-anchor/pitched": "skip - non-deterministic symbol placement on tile boundaries"
 }


### PR DESCRIPTION
Follow up https://github.com/mapbox/mapbox-gl-js/pull/11111#issuecomment-941278555, two builds failed on `main` since yesterday due to this flaky test:
- https://app.circleci.com/pipelines/github/mapbox/mapbox-gl-js/8149/workflows/79bb6249-cee6-4fc9-87fd-38d68e6682dd/jobs/104787
- https://app.circleci.com/pipelines/github/mapbox/mapbox-gl-js/8167/workflows/954ae26f-48a3-491a-8cd0-cc746ec6cc45/jobs/105018 