### PR TITLE
Fix seams around alternate-projected tiles (mostly)

### DIFF
--- a/src/data/load_geometry.js
+++ b/src/data/load_geometry.js
@@ -51,16 +51,16 @@ export default function loadGeometry(feature: FeatureWithGeometry, canonical?: C
 
     function reproject(p) {
         if (isMercator || !canonical || !tileTransform || !projection) {
-            return clampPoint(new Point(Math.round(p.x * scale), Math.round(p.y * scale)));
+            return new Point(p.x * scale, p.y * scale);
         } else {
             const z2 = 1 << canonical.z;
             const lng = lngFromMercatorX((canonical.x + p.x / featureExtent) / z2);
             const lat = latFromMercatorY((canonical.y + p.y / featureExtent) / z2);
             const {x, y} = projection.project(lng, lat);
-            return clampPoint(new Point(
-                Math.round((x * tileTransform.scale - tileTransform.x) * EXTENT),
-                Math.round((y * tileTransform.scale - tileTransform.y) * EXTENT)
-            ));
+            return new Point(
+                (x * tileTransform.scale - tileTransform.x) * EXTENT,
+                (y * tileTransform.scale - tileTransform.y) * EXTENT
+            );
         }
     }
 
@@ -70,6 +70,8 @@ export default function loadGeometry(feature: FeatureWithGeometry, canonical?: C
         geometry[i] = !isMercator && feature.type !== 1 ?
             resample(geometry[i], reproject, 1) :
             geometry[i].map(reproject);
+
+        geometry[i].forEach(p => clampPoint(p._round()));
     }
 
     return geometry;

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -62,9 +62,9 @@ export type TileState =
 // a tile bounds outline used for getting reprojected tile geometry in non-mercator projections
 const BOUNDS_FEATURE = (() => {
     const c0 = new Point(0, 0);
-    const c1 = new Point(EXTENT, 0);
-    const c2 = new Point(EXTENT, EXTENT);
-    const c3 = new Point(0, EXTENT);
+    const c1 = new Point(EXTENT + 1, 0);
+    const c2 = new Point(EXTENT + 1, EXTENT + 1);
+    const c3 = new Point(0, EXTENT + 1);
     const coords = [[c0, c1, c2, c3, c0]];
     return {
         type: 2,


### PR DESCRIPTION
This mostly fixes seams between tiles in normal circumstances with two things:

- Make resampling operate on floating point coordinates, and only round at the end — this makes resampling more consistent between neighboring tiles.
- Extend the tile bounds for alternate projections clipping mask by one pixel at one side — this fixes tiny (z-fighting-like) seams in normal circumstances like the Gulf of Mexico on Albers.

Rounding tile transform scale to the closest power of two doesn't seem to help.

The seams are still visible in contrived cases like extremely distorted Albers south pole after skew adjustments, but this seems fine for now — perhaps we can come up with a better solution later.

![image](https://user-images.githubusercontent.com/25395/137301826-5703b065-d1d4-4df4-873d-e5050bdbf03a.png)