### PR TITLE
Basic support for custom maxBounds in alternate projections

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1453,10 +1453,11 @@ class Transform {
         this._constraining = true;
 
         // alternate constraining for non-Mercator projections
-        if (this.maxBounds && this.projection.name !== 'mercator') {
+        const maxBounds = this.maxBounds;
+        if (this.projection.name !== 'mercator' && maxBounds) {
             const center = this.center;
-            center.lat = clamp(center.lat, this.maxBounds.getSouth(), this.maxBounds.getNorth());
-            center.lng = clamp(center.lng, this.maxBounds.getWest(), this.maxBounds.getEast());
+            center.lat = clamp(center.lat, maxBounds.getSouth(), maxBounds.getNorth());
+            center.lng = clamp(center.lng, maxBounds.getWest(), maxBounds.getEast());
             this.center = center;
             this._constraining = false;
             return;


### PR DESCRIPTION
Continuing #11092, adds basic `maxBounds` support for alternate projections (without precise screen measurements like for Mercator) by constraining the center geographically instead. This may be good enough for the initial launch, while we look for a more refined approach. 

I haven't worked on the corresponding zoom constraining because it's currently driven by FreeCamera interfering in the current state of `projections` — it constrains on zoom-out but not on other operations.