### PR TITLE
Fix tile buffer destroyed but not reset

### DIFF
--- a/build/generate-struct-arrays.js
+++ b/build/generate-struct-arrays.js
@@ -130,6 +130,7 @@ import lineAttributesExt from '../src/data/bucket/line_attributes_ext.js';
 import patternAttributes from '../src/data/bucket/pattern_attributes.js';
 import dashAttributes from '../src/data/bucket/dash_attributes.js';
 import skyboxAttributes from '../src/render/skybox_attributes.js';
+import tileBoundsAttributes from '../src/data/bounds_attributes.js';
 import {fillExtrusionAttributes, centroidAttributes} from '../src/data/bucket/fill_extrusion_attributes.js';
 
 // layout vertex arrays
@@ -208,6 +209,9 @@ createStructArrayType('line_strip_index', createLayout([
 // skybox vertex array
 createStructArrayType(`skybox_vertex`, skyboxAttributes);
 
+// tile bounds vertex array
+createStructArrayType(`tile_bounds`, tileBoundsAttributes);
+
 // paint vertex arrays
 
 // used by SourceBinder for float properties
@@ -244,7 +248,6 @@ fs.writeFileSync('src/data/array_types.js',
 import assert from 'assert';
 import {Struct, StructArray} from '../util/struct_array.js';
 import {register} from '../util/web_worker_transfer.js';
-import Point from '@mapbox/point-geometry';
 
 ${layouts.map(structArrayLayoutJs).join('\n')}
 ${arraysWithStructAccessors.map(structArrayJs).join('\n')}

--- a/src/data/array_types.js
+++ b/src/data/array_types.js
@@ -817,41 +817,6 @@ register('StructArrayLayout1ui2', StructArrayLayout1ui2);
 
 /**
  * Implementation of the StructArray layout:
- * [0]: Float32[5]
- *
- * @private
- */
-class StructArrayLayout5f20 extends StructArray {
-    uint8: Uint8Array;
-    float32: Float32Array;
-
-    _refreshViews() {
-        this.uint8 = new Uint8Array(this.arrayBuffer);
-        this.float32 = new Float32Array(this.arrayBuffer);
-    }
-
-    emplaceBack(v0: number, v1: number, v2: number, v3: number, v4: number) {
-        const i = this.length;
-        this.resize(i + 1);
-        return this.emplace(i, v0, v1, v2, v3, v4);
-    }
-
-    emplace(i: number, v0: number, v1: number, v2: number, v3: number, v4: number) {
-        const o4 = i * 5;
-        this.float32[o4 + 0] = v0;
-        this.float32[o4 + 1] = v1;
-        this.float32[o4 + 2] = v2;
-        this.float32[o4 + 3] = v3;
-        this.float32[o4 + 4] = v4;
-        return i;
-    }
-}
-
-StructArrayLayout5f20.prototype.bytesPerElement = 20;
-register('StructArrayLayout5f20', StructArrayLayout5f20);
-
-/**
- * Implementation of the StructArray layout:
  * [0]: Float32[2]
  *
  * @private
@@ -1227,12 +1192,10 @@ export {
     StructArrayLayout1ul3ui12,
     StructArrayLayout2ui4,
     StructArrayLayout1ui2,
-    StructArrayLayout5f20,
     StructArrayLayout2f8,
     StructArrayLayout4f16,
     StructArrayLayout2i4 as PosArray,
     StructArrayLayout4i8 as RasterBoundsArray,
-    StructArrayLayout4i8 as TileBoundsArray,
     StructArrayLayout2i4 as CircleLayoutArray,
     StructArrayLayout2i4 as FillLayoutArray,
     StructArrayLayout4i8 as FillExtrusionLayoutArray,
@@ -1252,6 +1215,6 @@ export {
     StructArrayLayout3ui6 as TriangleIndexArray,
     StructArrayLayout2ui4 as LineIndexArray,
     StructArrayLayout1ui2 as LineStripIndexArray,
-    StructArrayLayout5f20 as GlobeVertexArray,
-    StructArrayLayout3f12 as SkyboxVertexArray
+    StructArrayLayout3f12 as SkyboxVertexArray,
+    StructArrayLayout4i8 as TileBoundsArray
 };

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -132,8 +132,8 @@ class Tile {
     queryGeometryDebugViz: TileSpaceDebugBuffer;
     queryBoundsDebugViz: TileSpaceDebugBuffer;
 
-    _tileDebugBuffer: VertexBuffer;
-    _tileBoundsBuffer: VertexBuffer;
+    _tileDebugBuffer: ?VertexBuffer;
+    _tileBoundsBuffer: ?VertexBuffer;
     _tileDebugIndexBuffer: IndexBuffer;
     _tileBoundsIndexBuffer: IndexBuffer;
     _tileDebugSegments: SegmentVector;
@@ -305,12 +305,14 @@ class Tile {
             this._tileBoundsBuffer.destroy();
             this._tileBoundsIndexBuffer.destroy();
             this._tileBoundsSegments.destroy();
+            this._tileBoundsBuffer = null;
         }
 
         if (this._tileDebugBuffer) {
             this._tileDebugBuffer.destroy();
             this._tileDebugIndexBuffer.destroy();
             this._tileDebugSegments.destroy();
+            this._tileDebugBuffer = null;
         }
 
         Debug.run(() => {


### PR DESCRIPTION
- Fix a potential corrupt access to destroyed buffer: We may access `this._tileBoundsBuffer` after it's destroyed, triggering a WebGL error when it's being accessed for tile clipping (we only check for existence there)
- Add TileBoundsArray to use `tileBoundsAttributes` so further codegen run are up to date