### PR TITLE
feat: add isHighAccurate property to Marker

### DIFF
--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -45,6 +45,7 @@ export const TERRAIN_OCCLUDED_OPACITY = 0.2;
  * @param {number} [options.rotation=0] The rotation angle of the marker in degrees, relative to its respective `rotationAlignment` setting. A positive value will rotate the marker clockwise.
  * @param {string} [options.pitchAlignment='auto'] `map` aligns the `Marker` to the plane of the map. `viewport` aligns the `Marker` to the plane of the viewport. `auto` automatically matches the value of `rotationAlignment`.
  * @param {string} [options.rotationAlignment='auto'] `map` aligns the `Marker`'s rotation relative to the map, maintaining a bearing as the map rotates. `viewport` aligns the `Marker`'s rotation relative to the viewport, agnostic to map rotations. `auto` is equivalent to `viewport`.
+ * @param {boolean} [options.snapToPixel=true] A boolean indicating should `Marker` position round to pixel or not.
  * @example
  * // Create a new marker.
  * const marker = new mapboxgl.Marker()

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -113,7 +113,7 @@ export default class Marker extends Evented {
         this._rotation = options && options.rotation || 0;
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
-        this._snapToPixel = options && options.snapToPixel || true;
+        this._snapToPixel = this._snapToPixel = (options && options.snapToPixel) ? !!options.snapToPixel : true;
 
         if (!options || !options.element) {
             this._defaultMarker = true;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -798,7 +798,7 @@ export default class Marker extends Evented {
     /**
      * Sets the `snapToPixel` property of the marker.
      *
-     * @param {boolean} shouldSnapToPixel
+     * @param {boolean} shouldSnapToPixel Enable or disable `snapToPixel`.
      * @returns {Marker} Returns itself to allow for method chaining.
      * @example
      * marker.setSnapToPixel(true);
@@ -811,7 +811,7 @@ export default class Marker extends Evented {
     /**
      * Returns the current `snapToPixel` property of the marker.
      *
-     * @returns {boolean}
+     * @returns {boolean} Returns the current `snapToPixel` property of the marker.
      * @example
      * const snapToPixel = marker.getSnapToPixel();
      */

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -806,6 +806,7 @@ export default class Marker extends Evented {
      */
     setSnapToPixel(shouldSnapToPixel: boolean) {
         this._snapToPixel = !!shouldSnapToPixel;
+        this._update();
         return this;
     }
 

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -113,7 +113,7 @@ export default class Marker extends Evented {
         this._rotation = options && options.rotation || 0;
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
-        this._snapToPixel = (options && options.snapToPixel) ? !!options.snapToPixel : true;
+        this._snapToPixel = (options && options.snapToPixel) === undefined ? true : !!options.snapToPixel;
 
         if (!options || !options.element) {
             this._defaultMarker = true;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -804,12 +804,12 @@ export default class Marker extends Evented {
      * marker.setSnapToPixel(true);
      */
     setSnapToPixel(shouldSnapToPixel: boolean) {
-        this._snapToPixel = shouldSnapToPixel;
+        this._snapToPixel = !!shouldSnapToPixel;
         return this;
     }
 
     /**
-     * Returns the current `snapToPixel` property of the marker.
+     * Returns the marker's current `snapToPixel` value.
      *
      * @returns {boolean} Returns the current `snapToPixel` property of the marker.
      * @example

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -82,7 +82,7 @@ export default class Marker extends Evented {
     _rotationAlignment: string;
     _originalTabIndex: ?string; // original tabindex of _element
     _fadeTimer: ?TimeoutID;
-    _snapToPixel: ?boolean; // rounding current position or not
+    _snapToPixel: ?boolean;
 
     constructor(options?: Options, legacyOptions?: Options) {
         super();
@@ -112,7 +112,7 @@ export default class Marker extends Evented {
         this._rotation = options && options.rotation || 0;
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
-        this._snapToPixel = !!(options && options.snapToPixel === undefined);
+        this._snapToPixel = options && options.snapToPixel || true;
 
         if (!options || !options.element) {
             this._defaultMarker = true;

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -25,7 +25,7 @@ type Options = {
     rotation?: number,
     rotationAlignment?: string,
     pitchAlignment?: string,
-    isHighAccurate?: boolean
+    snapToPixel?: boolean
 };
 
 export const TERRAIN_OCCLUDED_OPACITY = 0.2;
@@ -82,7 +82,7 @@ export default class Marker extends Evented {
     _rotationAlignment: string;
     _originalTabIndex: ?string; // original tabindex of _element
     _fadeTimer: ?TimeoutID;
-    _isHighAccurate:boolean; // rounding current position or not
+    _snapToPixel: ?boolean; // rounding current position or not
 
     constructor(options?: Options, legacyOptions?: Options) {
         super();
@@ -112,7 +112,7 @@ export default class Marker extends Evented {
         this._rotation = options && options.rotation || 0;
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
-        this._isHighAccurate = options && options.isHighAccurate || false;
+        this._snapToPixel = !!(options && options.snapToPixel === undefined);
 
         if (!options || !options.element) {
             this._defaultMarker = true;
@@ -536,7 +536,7 @@ export default class Marker extends Evented {
         // because rounding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
         // no arguments (when the Marker is initialized or Marker#setLngLat is invoked).
-        if (!this._isHighAccurate && (!e || e.type === "moveend")) {
+        if (this._snapToPixel && (!e || e.type === "moveend")) {
             this._pos = this._pos.round();
         }
 
@@ -796,25 +796,26 @@ export default class Marker extends Evented {
     }
 
     /**
-     * Sets the `isHighAccurate` property of the marker.
-     * @param {boolean} shouldBeHighAccurate 
+     * Sets the `snapToPixel` property of the marker.
+     *
+     * @param {boolean} shouldSnapToPixel
      * @returns {Marker} Returns itself to allow for method chaining.
      * @example
-     * marker.setIsHighAccurate(true);
+     * marker.setSnapToPixel(true);
      */
-    setIsHighAccurate(shouldBeHighAccurate: boolean){
-        this._isHighAccurate = shouldBeHighAccurate;
+    setSnapToPixel(shouldSnapToPixel: boolean) {
+        this._snapToPixel = shouldSnapToPixel;
         return this;
     }
 
-
     /**
-     * Returns the current `isHighAccurate` property of the marker.
+     * Returns the current `snapToPixel` property of the marker.
+     *
      * @returns {boolean}
      * @example
-     * const isHighAccurateMarker = marker.getIsHighAccurate();
+     * const snapToPixel = marker.getSnapToPixel();
      */
-    getIsHighAccurate(){
-        return this._isHighAccurate;
+    getSnapToPixel() {
+        return this._snapToPixel;
     }
 }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -24,7 +24,8 @@ type Options = {
     clickTolerance?: number,
     rotation?: number,
     rotationAlignment?: string,
-    pitchAlignment?: string
+    pitchAlignment?: string,
+    isHighAccurate?: boolean
 };
 
 export const TERRAIN_OCCLUDED_OPACITY = 0.2;
@@ -81,6 +82,7 @@ export default class Marker extends Evented {
     _rotationAlignment: string;
     _originalTabIndex: ?string; // original tabindex of _element
     _fadeTimer: ?TimeoutID;
+    _isHighAccurate:boolean; // rounding current position or not
 
     constructor(options?: Options, legacyOptions?: Options) {
         super();
@@ -110,6 +112,7 @@ export default class Marker extends Evented {
         this._rotation = options && options.rotation || 0;
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
+        this._isHighAccurate = options && options.isHighAccurate || false;
 
         if (!options || !options.element) {
             this._defaultMarker = true;
@@ -533,7 +536,7 @@ export default class Marker extends Evented {
         // because rounding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
         // no arguments (when the Marker is initialized or Marker#setLngLat is invoked).
-        if (!e || e.type === "moveend") {
+        if (!this._isHighAccurate && (!e || e.type === "moveend")) {
             this._pos = this._pos.round();
         }
 
@@ -790,5 +793,28 @@ export default class Marker extends Evented {
      */
     getPitchAlignment() {
         return this._pitchAlignment;
+    }
+
+    /**
+     * Sets the `isHighAccurate` property of the marker.
+     * @param {boolean} shouldBeHighAccurate 
+     * @returns {Marker} Returns itself to allow for method chaining.
+     * @example
+     * marker.setIsHighAccurate(true);
+     */
+    setIsHighAccurate(shouldBeHighAccurate: boolean){
+        this._isHighAccurate = shouldBeHighAccurate;
+        return this;
+    }
+
+
+    /**
+     * Returns the current `isHighAccurate` property of the marker.
+     * @returns {boolean}
+     * @example
+     * const isHighAccurateMarker = marker.getIsHighAccurate();
+     */
+    getIsHighAccurate(){
+        return this._isHighAccurate;
     }
 }

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -113,7 +113,7 @@ export default class Marker extends Evented {
         this._rotation = options && options.rotation || 0;
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
-        this._snapToPixel = this._snapToPixel = (options && options.snapToPixel) ? !!options.snapToPixel : true;
+        this._snapToPixel = (options && options.snapToPixel) ? !!options.snapToPixel : true;
 
         if (!options || !options.element) {
             this._defaultMarker = true;


### PR DESCRIPTION
Add `isHighAccurate` property to `Marker`. for disable rounding `marker._pos`
close #11135 
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
