### PR TITLE
fix ImageSource when projection is changed

### DIFF
--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -242,6 +242,10 @@ class ImageSource extends Evented implements Source {
         return this;
     }
 
+    _clear() {
+        delete this._boundsArray;
+    }
+
     _makeBoundsArray() {
         const tileTr = tileTransform(this.tileID, this.map.transform.projection);
 

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -74,6 +74,7 @@ export interface Source {
     +prepare?: () => void;
 
     +afterUpdate?: () => void;
+    +_clear?: () => void;
 }
 
 type SourceStatics = {

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -806,6 +806,8 @@ class SourceCache extends Evented {
         for (const id in this._tiles)
             this._removeTile(+id);
 
+        if (this._source._clear) this._source._clear();
+
         this._cache.reset();
     }
 


### PR DESCRIPTION
When `setProjection(...)` is called, we need to clear the bounds array of the image source so that it gets reprojected with the new projection. This is needs to happen for the same reason we need to [reload all tiles](https://github.com/mapbox/mapbox-gl-js/blob/cc45792c60a452324f56925c6cfff4f332cad40f/src/style/style.js#L349-L352).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'