### PR TITLE
Fix GeoJSON rendering in alternate projections

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -914,6 +914,7 @@ class Painter {
         const tileIDs = this.transform.coveringTiles({tileSize});
         for (const tileID of tileIDs) {
             newTiles[tileID.key] = oldTiles[tileID.key] || new Tile(tileID, tileSize, this.transform.tileZoom, this);
+            newTiles[tileID.key]._makeTileBoundsBuffers(this.context, this.transform.projection);
         }
         return newTiles;
     }

--- a/src/source/pixels_to_tile_units.js
+++ b/src/source/pixels_to_tile_units.js
@@ -24,7 +24,7 @@ export default function(tile: {tileID: OverscaledTileID, tileSize: number}, pixe
     return pixelValue * (EXTENT / (tile.tileSize * Math.pow(2, z - tile.tileID.overscaledZ)));
 }
 
-export function getPixelsToTileUnitsMatrix(tile: {tileID: OverscaledTileID, tileSize: number, tileTransform: TileTransform}, transform: Transform): Float32Array {
+export function getPixelsToTileUnitsMatrix(tile: {tileID: OverscaledTileID, tileSize: number, +tileTransform: TileTransform}, transform: Transform): Float32Array {
     const {scale} = tile.tileTransform;
     const s = scale * EXTENT / (tile.tileSize * Math.pow(2, transform.zoom - tile.tileID.overscaledZ + tile.tileID.canonical.z));
     return mat2.scale(new Float32Array(4), transform.inverseAdjustmentMatrix, [s, s]);

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -108,7 +108,7 @@ class Tile {
     vtLayers: {[_: string]: VectorTileLayer};
     isSymbolTile: ?boolean;
     isRaster: ?boolean;
-    tileTransform: TileTransform;
+    _tileTransform: TileTransform;
 
     neighboringTiles: ?Object;
     dem: ?DEMData;
@@ -128,6 +128,7 @@ class Tile {
     hasSymbolBuckets: boolean;
     hasRTLText: boolean;
     dependencies: Object;
+    projection: Projection;
 
     queryGeometryDebugViz: TileSpaceDebugBuffer;
     queryBoundsDebugViz: TileSpaceDebugBuffer;
@@ -165,6 +166,10 @@ class Tile {
         this.expiredRequestCount = 0;
 
         this.state = 'loading';
+
+        if (painter && painter.transform) {
+            this.projection = painter.transform.projection;
+        }
     }
 
     registerFadeDuration(duration: number) {
@@ -177,6 +182,13 @@ class Tile {
 
     wasRequested() {
         return this.state === 'errored' || this.state === 'loaded' || this.state === 'reloading';
+    }
+
+    get tileTransform() {
+        if (!this._tileTransform) {
+            this._tileTransform = tileTransform(this.tileID.canonical, this.projection);
+        }
+        return this._tileTransform;
     }
 
     /**
@@ -197,7 +209,6 @@ class Tile {
         // generate tile bounds buffers after on tile load
         if (painter && painter.context) {
             const {projection} = painter.transform;
-            this.tileTransform = tileTransform(this.tileID.canonical, projection);
             this._makeTileBoundsBuffers(painter.context, projection);
         }
 


### PR DESCRIPTION
Fixes an issue where GeoJSON layers were weirdly truncated on alternate projections — the issue was that tile buffers were destroyed on tile load, and painter fell back to mercator bounds for the stencil clipping.

The PR makes tile bounds creation lazy, so that it's only done when the tile is loaded. This also closes #11138 by avoiding creating tile buffers for tiles that never finished loading, an optimization.