### PR TITLE
Use smoothstep for projection transition

### DIFF
--- a/src/geo/projection/adjustments.js
+++ b/src/geo/projection/adjustments.js
@@ -3,7 +3,7 @@
 import LngLat from '../lng_lat.js';
 import MercatorCoordinate, {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 import {mat4, mat2} from 'gl-matrix';
-import {clamp} from '../../util/util.js';
+import {clamp, smoothstep} from '../../util/util.js';
 import type {Projection} from './index.js';
 import type Transform from '../transform.js';
 
@@ -41,7 +41,7 @@ function getInterpolationT(transform: Transform) {
     const rangeAdjustment = Math.log(size / 1024) / Math.LN2;
     const zoomA = range[0] + rangeAdjustment;
     const zoomB = range[1] + rangeAdjustment;
-    const t = clamp((transform.zoom - zoomA) / (zoomB - zoomA), 0, 1);
+    const t = smoothstep(zoomA, zoomB, transform.zoom);
     return t;
 }
 


### PR DESCRIPTION
The discontinuous first derivative in the projection transition seems to give it a little kick when you enter or exit the transition region. So that the transition isn't so noticeable, this PR applies a smoothstep for projection transitions rather than a linear step.

A possible consideration is that this slightly increases the rate of the transition, but improvement due to continuous second derivatives seem much more noticeable than the marginal increase in rate. For reference, smoothstep vs. linearstep:

<img width="464" alt="Screen Shot 2021-10-20 at 1 56 59 PM" src="https://user-images.githubusercontent.com/572717/138170901-3a9715d7-ab53-4ea3-b268-9a56da5c41cc.png">

Before (which I feel like doesn't quite capture the abruptness compared to interactive framerates):
![linearstep](https://user-images.githubusercontent.com/572717/138171452-ba68a144-562e-46b3-be5c-62282dcadc25.gif)

After:
![smoothstep](https://user-images.githubusercontent.com/572717/138171461-c46f54b5-c8d2-49d4-b6eb-aeeca3e324f7.gif)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
