### PR TITLE
Ignore slope-occlusion-box-query test

### DIFF
--- a/test/ignores.json
+++ b/test/ignores.json
@@ -35,5 +35,6 @@
   "render-tests/terrain/symbol-draping/style.json": "skip - https://github.com/mapbox/mapbox-gl-js/issues/10365",
   "render-tests/fill-extrusion-terrain/flat-roof-over-border-of-different-zoom-zoomin": "skip - https://github.com/mapbox/mapbox-gl-js/issues/11041",
   "render-tests/fill-extrusion-terrain/flat-roof-over-border-of-different-zoom": "skip - https://github.com/mapbox/mapbox-gl-js/issues/11041",
-  "render-tests/text-variable-anchor/pitched": "skip - non-deterministic symbol placement on tile boundaries"
+  "render-tests/text-variable-anchor/pitched": "skip - non-deterministic symbol placement on tile boundaries",
+  "query-tests/terrain/draped/lines/slope-occlusion-box-query": "skip - non-deterministic"
 }


### PR DESCRIPTION
Ref #11156. This test fails almost every other time, and is constantly at the top of the [flaky tests](https://app.circleci.com/insights/github/mapbox/mapbox-gl-js/workflows/default/tests) CircleCI chart. Let's ignore it for now because constantly restarting workflows is not fun. cc @arindam1993 