### PR TITLE
Avoid reloading tiles if map.setProjection is called with current projection

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1017,6 +1017,8 @@ class Map extends Camera {
      * });
      */
     setProjection(projection?: ?ProjectionSpecification | string) {
+        const currentProjectionName = this.getProjection().name;
+        if (projection === currentProjectionName || projection && projection.name === currentProjectionName) return;
         this._lazyInitEmptyStyle();
         if (typeof projection === 'string') {
             projection = (({name: projection}: any): ProjectionSpecification);

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1397,6 +1397,8 @@ test('Map', (t) => {
             t.ok(setProjection.calledOnce);
             map.setProjection('albers');
             t.ok(setProjection.calledOnce);
+            map.setProjection({name: 'albers'});
+            t.ok(setProjection.calledOnce);
             t.end();
         });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1390,6 +1390,16 @@ test('Map', (t) => {
             t.end();
         });
 
+        t.test('is idempotent', (t) => {
+            const map = createMap(t);
+            const setProjection = t.spy(map.style, 'setProjection');
+            map.setProjection('albers');
+            t.ok(setProjection.calledOnce);
+            map.setProjection('albers');
+            t.ok(setProjection.calledOnce);
+            t.end();
+        });
+
         t.test('sets projection by options object', (t) => {
             const options = {
                 name: 'albers',


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
    - closes https://github.com/mapbox/mapbox-gl-js/issues/11166
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Avoid reloading tiles if map.setProjection is called with current projection</changelog>`
