### PR TITLE
Use map container size to dynamically set the alert font size for cooperative gestures

### DIFF
--- a/src/ui/handler/scroll_zoom.js
+++ b/src/ui/handler/scroll_zoom.js
@@ -393,7 +393,7 @@ class ScrollZoomHandler {
             }
 
             // dynamically set the font size of the scroll zoom blocker alert message
-            this._alertContainer.style.fontSize = `${Math.max(10, Math.min(24, Math.floor(this._el.clientWidth * 0.05)))}px`;
+            this._alertContainer.style.fontSize = `${Math.max(10, Math.min(24, Math.floor(this._map.getContainer().clientWidth * 0.05)))}px`;
         }
     }
 

--- a/src/ui/handler/touch_pan.js
+++ b/src/ui/handler/touch_pan.js
@@ -140,7 +140,7 @@ export default class TouchPanHandler {
             this._alertContainer.textContent = this._map._getUIString('TouchPanBlocker.Message');
 
             // dynamically set the font size of the touch pan blocker alert message
-            this._alertContainer.style.fontSize = `${Math.max(10, Math.min(24, Math.floor(this._el.clientWidth * 0.05)))}px`;
+            this._alertContainer.style.fontSize = `${Math.max(10, Math.min(24, Math.floor(this._map.getContainer().clientWidth * 0.05)))}px`;
         }
     }
 


### PR DESCRIPTION
Currently, the alert for cooperative gestures uses the canvas container to set the font size. After instantiating a map in codepen with v2.6.0-beta.1, the font size was not dynamically set as expected since the clientWidth of canvas container evaluated to 0. The clientWidth of the container did evaluate to the expected value. 

This change uses the container size to dynamically set the font size of the alert.

Expected:
<img width="598" alt="Screen Shot 2021-10-27 at 10 48 42 AM" src="https://user-images.githubusercontent.com/42715836/139119563-b583892f-df07-45c4-814a-56e1ae65fc59.png">

Actual in codepen:
<img width="682" alt="Screen Shot 2021-10-27 at 10 51 41 AM" src="https://user-images.githubusercontent.com/42715836/139119590-6436375a-7ebb-422d-b7e4-37d76e7d202f.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
