### PR TITLE
Globe support for circle and fill extrusion layer vertex shaders

### DIFF
--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -32,6 +32,19 @@ vec3 mix_globe_mercator(vec3 globe, vec3 mercator, float t) {
 #endif
 }
 
+#ifdef PROJECTION_GLOBE_VIEW
+vec3 extrudeOnGlobeSurface(vec2 extrude, float scale, vec3 pos_nomal, vec3 up_dir, float zoom_transition) {
+    // Apply extra scaling to extrusion to cover different pixel space ratios (which is dependant on the latitude)
+    extrude *= scale;
+
+    vec3 normal = normalize(mix(pos_nomal / 16384.0, up_dir, zoom_transition));
+    // Coordinate frame for the extrusion is the tangent plane at the point location on the globe surface
+    vec3 xAxis = normalize(vec3(normal.z, 0.0, -normal.x));
+    vec3 yAxis = normalize(cross(normal, xAxis));
+    return vec3(xAxis * extrude.x + yAxis * extrude.y);
+}
+#endif
+
 // Unpack a pair of values that have been packed into a single float.
 // The packed values are assumed to be 8-bit unsigned integers, and are
 // packed like so:

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -33,9 +33,8 @@ vec3 mix_globe_mercator(vec3 globe, vec3 mercator, float t) {
 }
 
 #ifdef PROJECTION_GLOBE_VIEW
-mat3 globe_surface_vectors(vec3 pos_normal, vec3 up_dir, float zoom_transition) {
-    vec3 normal = normalize(mix(pos_normal, up_dir, zoom_transition));
-    // Coordinate frame for the extrusion is the tangent plane at the point location on the globe surface
+mat3 globe_mercator_surface_vectors(vec3 pos_normal, vec3 up_dir, float zoom_transition) {
+    vec3 normal = zoom_transition == 0.0 ? pos_normal : normalize(mix(pos_normal, up_dir, zoom_transition));
     vec3 xAxis = normalize(vec3(normal.z, 0.0, -normal.x));
     vec3 yAxis = normalize(cross(normal, xAxis));
     return mat3(xAxis, yAxis, normal);

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -33,12 +33,12 @@ vec3 mix_globe_mercator(vec3 globe, vec3 mercator, float t) {
 }
 
 #ifdef PROJECTION_GLOBE_VIEW
-vec3 extrudeOnGlobeSurface(vec2 extrude, vec3 pos_normal, vec3 up_dir, float zoom_transition) {
+mat3 globe_surface_vectors(vec3 pos_normal, vec3 up_dir, float zoom_transition) {
     vec3 normal = normalize(mix(pos_normal, up_dir, zoom_transition));
     // Coordinate frame for the extrusion is the tangent plane at the point location on the globe surface
     vec3 xAxis = normalize(vec3(normal.z, 0.0, -normal.x));
     vec3 yAxis = normalize(cross(normal, xAxis));
-    return vec3(xAxis * extrude.x + yAxis * extrude.y);
+    return mat3(xAxis, yAxis, normal);
 }
 #endif
 

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -33,11 +33,8 @@ vec3 mix_globe_mercator(vec3 globe, vec3 mercator, float t) {
 }
 
 #ifdef PROJECTION_GLOBE_VIEW
-vec3 extrudeOnGlobeSurface(vec2 extrude, float scale, vec3 pos_nomal, vec3 up_dir, float zoom_transition) {
-    // Apply extra scaling to extrusion to cover different pixel space ratios (which is dependant on the latitude)
-    extrude *= scale;
-
-    vec3 normal = normalize(mix(pos_nomal / 16384.0, up_dir, zoom_transition));
+vec3 extrudeOnGlobeSurface(vec2 extrude, vec3 pos_normal, vec3 up_dir, float zoom_transition) {
+    vec3 normal = normalize(mix(pos_normal, up_dir, zoom_transition));
     // Coordinate frame for the extrusion is the tangent plane at the point location on the globe surface
     vec3 xAxis = normalize(vec3(normal.z, 0.0, -normal.x));
     vec3 yAxis = normalize(cross(normal, xAxis));

--- a/src/shaders/circle.vertex.glsl
+++ b/src/shaders/circle.vertex.glsl
@@ -144,7 +144,7 @@ void main(void) {
     gl_Position = project_vertex(extrude, world_center, projected_center, radius, stroke_width, view_scale, surface_vectors);
 
     float visibility = 0.0;
-    #if defined(TERRAIN) && !defined(PROJECTION_GLOBE_VIEW)
+    #ifdef TERRAIN
         float step = get_sample_step();
         #ifdef PITCH_WITH_MAP
             // to prevent the circle from self-intersecting with the terrain underneath on a sloped hill,
@@ -166,6 +166,11 @@ void main(void) {
         }
         visibility /= float(NUM_VISIBILITY_RINGS) * float(NUM_SAMPLES_PER_RING);
     #else
+        visibility = 1.0;
+    #endif
+    // This is a temporary overwrite until we add support for terrain occlusion for the globe view
+    // Having a separate overwrite here makes the metal shader generation simpler for the default case
+    #ifdef PROJECTION_GLOBE_VIEW
         visibility = 1.0;
     #endif
     v_visibility = visibility;

--- a/src/shaders/circle.vertex.glsl
+++ b/src/shaders/circle.vertex.glsl
@@ -137,6 +137,9 @@ void main(void) {
             view_scale = projected_center.w;
         #endif
     #endif
+    #if defined(SCALE_WITH_MAP) && defined(PROJECTION_GLOBE_VIEW)
+        view_scale *= a_scale;
+    #endif
     gl_Position = project_vertex(extrude, world_center, projected_center, radius, stroke_width, view_scale);
 
     float visibility = 0.0;

--- a/src/shaders/circle.vertex.glsl
+++ b/src/shaders/circle.vertex.glsl
@@ -103,12 +103,13 @@ void main(void) {
     // Apply extra scaling to extrusion to cover different pixel space ratios (which is dependant on the latitude)
     vec2 scaled_extrude = extrude * a_scale;
     vec3 pos_normal_3 = a_pos_normal_3 / 16384.0;
-    mat3 surface_vectors = globe_surface_vectors(pos_normal_3, u_up_dir, u_zoom_transition);
+    mat3 surface_vectors = globe_mercator_surface_vectors(pos_normal_3, u_up_dir, u_zoom_transition);
 
-    vec3 globe_surface_extrusion = scaled_extrude.x * surface_vectors[0] + scaled_extrude.y * surface_vectors[1];
+    vec3 surface_extrusion = scaled_extrude.x * surface_vectors[0] + scaled_extrude.y * surface_vectors[1];
     vec3 globe_elevation = elevationVector(circle_center) * circle_elevation(circle_center);
-    vec3 globe_pos = a_pos_3 + globe_surface_extrusion + globe_elevation;
-    vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, circle_center, u_tile_id, u_merc_center) + globe_surface_extrusion + globe_elevation;
+    vec3 globe_pos = a_pos_3 + surface_extrusion + globe_elevation;
+    vec3 mercator_elevation = u_up_dir * u_tile_up_scale * circle_elevation(circle_center);
+    vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, circle_center, u_tile_id, u_merc_center) + surface_extrusion + mercator_elevation;
     vec3 pos = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
     vec4 world_center = vec4(pos, 1);
 #else 

--- a/src/shaders/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/fill_extrusion_pattern.vertex.glsl
@@ -13,6 +13,17 @@ uniform lowp float u_lightintensity;
 attribute vec4 a_pos_normal_ed;
 attribute vec2 a_centroid_pos;
 
+#ifdef PROJECTION_GLOBE_VIEW
+attribute vec3 a_pos_3;         // Projected position on the globe
+attribute vec3 a_pos_normal_3;  // Surface normal at the position
+
+uniform mat4 u_inv_rot_matrix;
+uniform vec2 u_merc_center;
+uniform vec3 u_tile_id;
+uniform float u_zoom_transition;
+uniform vec3 u_up_dir;
+#endif
+
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec4 v_lighting;
@@ -75,6 +86,14 @@ void main() {
     vec3 p = vec3(pos_nx.xy, h);
 #else
     vec3 p = vec3(pos_nx.xy, z);
+#endif
+
+#ifdef PROJECTION_GLOBE_VIEW
+    vec3 globeNormal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
+    vec3 globePos = a_pos_3 + globeNormal * u_tile_up_scale * p.z;
+    vec3 mercPos = mercator_tile_position(u_inv_rot_matrix, p.xy, u_tile_id, u_merc_center) + u_up_dir * u_tile_up_scale * p.z;
+
+    p = mix_globe_mercator(globePos, mercPos, u_zoom_transition);
 #endif
 
     float hidden = float(centroid_pos.x == 0.0 && centroid_pos.y == 1.0);

--- a/src/shaders/heatmap.vertex.glsl
+++ b/src/shaders/heatmap.vertex.glsl
@@ -64,20 +64,12 @@ void main(void) {
     vec2 tilePos = floor(a_pos * 0.5);
 
 #ifdef PROJECTION_GLOBE_VIEW
-    // Apply extra scaling to extrusion to cover different pixel space ratios (which is dependant on the latitude)
-    extrude *= a_scale;
-
-    vec3 normal = normalize(mix(a_pos_normal_3 / 16384.0, u_up_dir, u_zoom_transition));
-
-    // Coordinate frame for the extrusion is the tangent plane at the point location on the globe surface
-    vec3 xAxis = normalize(vec3(normal.z, 0.0, -normal.x));
-    vec3 yAxis = normalize(cross(normal, xAxis));
-
     // Compute positions on both globe and mercator plane to support transition between the two modes
-    vec3 globePos = a_pos_3 + xAxis * extrude.x + yAxis * extrude.y + elevationVector(tilePos) * elevation(tilePos);
-    vec3 mercPos = mercator_tile_position(u_inv_rot_matrix, tilePos, u_tile_id, u_merc_center) + xAxis * extrude.x + yAxis * extrude.y;
-
-    vec3 pos = mix_globe_mercator(globePos, mercPos, u_zoom_transition);
+    vec3 globe_surface_extrusion = extrudeOnGlobeSurface(extrude, a_scale, a_pos_normal_3, u_up_dir, u_zoom_transition);
+    vec3 globe_elevation = elevationVector(tilePos) * elevation(tilePos);
+    vec3 globe_pos = a_pos_3 + globe_surface_extrusion + globe_elevation;
+    vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, tilePos, u_tile_id, u_merc_center) + globe_surface_extrusion + globe_elevation;
+    vec3 pos = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
 #else
     vec3 pos = vec3(tilePos + extrude, elevation(tilePos));
 #endif

--- a/src/shaders/heatmap.vertex.glsl
+++ b/src/shaders/heatmap.vertex.glsl
@@ -68,11 +68,12 @@ void main(void) {
     // Apply extra scaling to extrusion to cover different pixel space ratios (which is dependant on the latitude)
     extrude *= a_scale;
     vec3 pos_normal_3 = a_pos_normal_3 / 16384.0;
-    mat3 surface_vectors = globe_surface_vectors(pos_normal_3, u_up_dir, u_zoom_transition);
-    vec3 globe_surface_extrusion = extrude.x * surface_vectors[0] + extrude.y * surface_vectors[1];
+    mat3 surface_vectors = globe_mercator_surface_vectors(pos_normal_3, u_up_dir, u_zoom_transition);
+    vec3 surface_extrusion = extrude.x * surface_vectors[0] + extrude.y * surface_vectors[1];
     vec3 globe_elevation = elevationVector(tilePos) * elevation(tilePos);
-    vec3 globe_pos = a_pos_3 + globe_surface_extrusion + globe_elevation;
-    vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, tilePos, u_tile_id, u_merc_center) + globe_surface_extrusion + globe_elevation;
+    vec3 globe_pos = a_pos_3 + surface_extrusion + globe_elevation;
+    vec3 mercator_elevation = u_up_dir * u_tile_up_scale * elevation(tilePos);
+    vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, tilePos, u_tile_id, u_merc_center) + surface_extrusion + mercator_elevation;
     vec3 pos = mix_globe_mercator(globe_pos, merc_pos, u_zoom_transition);
 #else
     vec3 pos = vec3(tilePos + extrude, elevation(tilePos));

--- a/src/shaders/heatmap.vertex.glsl
+++ b/src/shaders/heatmap.vertex.glsl
@@ -68,7 +68,8 @@ void main(void) {
     // Apply extra scaling to extrusion to cover different pixel space ratios (which is dependant on the latitude)
     extrude *= a_scale;
     vec3 pos_normal_3 = a_pos_normal_3 / 16384.0;
-    vec3 globe_surface_extrusion = extrudeOnGlobeSurface(extrude, pos_normal_3, u_up_dir, u_zoom_transition);
+    mat3 surface_vectors = globe_surface_vectors(pos_normal_3, u_up_dir, u_zoom_transition);
+    vec3 globe_surface_extrusion = extrude.x * surface_vectors[0] + extrude.y * surface_vectors[1];
     vec3 globe_elevation = elevationVector(tilePos) * elevation(tilePos);
     vec3 globe_pos = a_pos_3 + globe_surface_extrusion + globe_elevation;
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, tilePos, u_tile_id, u_merc_center) + globe_surface_extrusion + globe_elevation;

--- a/src/shaders/heatmap.vertex.glsl
+++ b/src/shaders/heatmap.vertex.glsl
@@ -65,7 +65,10 @@ void main(void) {
 
 #ifdef PROJECTION_GLOBE_VIEW
     // Compute positions on both globe and mercator plane to support transition between the two modes
-    vec3 globe_surface_extrusion = extrudeOnGlobeSurface(extrude, a_scale, a_pos_normal_3, u_up_dir, u_zoom_transition);
+    // Apply extra scaling to extrusion to cover different pixel space ratios (which is dependant on the latitude)
+    extrude *= a_scale;
+    vec3 pos_normal_3 = a_pos_normal_3 / 16384.0;
+    vec3 globe_surface_extrusion = extrudeOnGlobeSurface(extrude, pos_normal_3, u_up_dir, u_zoom_transition);
     vec3 globe_elevation = elevationVector(tilePos) * elevation(tilePos);
     vec3 globe_pos = a_pos_3 + globe_surface_extrusion + globe_elevation;
     vec3 merc_pos = mercator_tile_position(u_inv_rot_matrix, tilePos, u_tile_id, u_merc_center) + globe_surface_extrusion + globe_elevation;


### PR DESCRIPTION
This PR enables the usage of circle and fill extrusion vertex shaders with the globe projection mode. Also creates a helper function in the vertex shader prelude for calculating the extrusion on the surface of the globe.
Otherwise doesn't have any side effects on the default circle rendering configuration.