### PR TITLE
Allow setting order of custom attribution

### DIFF
--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -176,9 +176,6 @@ class AttributionControl {
             }
         }
 
-        // remove any entries that are substrings of another entry.
-        // first sort by length so that substrings come first
-        attributions.sort((a, b) => a.length - b.length);
         attributions = attributions.filter((attrib, i) => {
             for (let j = i + 1; j < attributions.length; j++) {
                 if (attributions[j].indexOf(attrib) >= 0) { return false; }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -176,8 +176,8 @@ class AttributionControl {
 
         if (this.options.customAttribution) {
             if (Array.isArray(this.options.customAttribution)) {
-                attributions = [...this.options.customAttribution.filter(s => typeof s === 'string'), ...attributions];
-            } else if (typeof this.options.customAttribution === 'string') {
+                attributions = [...this.options.customAttribution, ...attributions];
+            } else {
                 attributions.unshift(this.options.customAttribution);
             }
         }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -146,18 +146,6 @@ class AttributionControl {
     _updateAttributions() {
         if (!this._map.style) return;
         let attributions: Array<string> = [];
-        if (this.options.customAttribution) {
-            if (Array.isArray(this.options.customAttribution)) {
-                attributions = attributions.concat(
-                    this.options.customAttribution.map(attribution => {
-                        if (typeof attribution !== 'string') return '';
-                        return attribution;
-                    })
-                );
-            } else if (typeof this.options.customAttribution === 'string') {
-                attributions.push(this.options.customAttribution);
-            }
-        }
 
         if (this._map.style.stylesheet) {
             const stylesheet: any = this._map.style.stylesheet;
@@ -176,12 +164,25 @@ class AttributionControl {
             }
         }
 
+        // remove any entries that are substrings of another entry.
+        // first sort by length so that substrings come first
+        attributions.sort((a, b) => a.length - b.length);
         attributions = attributions.filter((attrib, i) => {
             for (let j = i + 1; j < attributions.length; j++) {
                 if (attributions[j].indexOf(attrib) >= 0) { return false; }
             }
             return true;
         });
+
+        if (this.options.customAttribution) {
+            if (Array.isArray(this.options.customAttribution)) {
+                for (const attribution of this.options.customAttribution) {
+                    if (typeof attribution === 'string') attributions.unshift(attribution);
+                }
+            } else if (typeof this.options.customAttribution === 'string') {
+                attributions.unshift(this.options.customAttribution);
+            }
+        }
 
         // check if attribution string is different to minimize DOM changes
         const attribHTML = attributions.join(' | ');

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -176,7 +176,8 @@ class AttributionControl {
 
         if (this.options.customAttribution) {
             if (Array.isArray(this.options.customAttribution)) {
-                for (const attribution of this.options.customAttribution.reverse()) {
+                const customAttributionReversed = [...this.options.customAttribution].reverse();
+                for (const attribution of customAttributionReversed) {
                     if (typeof attribution === 'string') attributions.unshift(attribution);
                 }
             } else if (typeof this.options.customAttribution === 'string') {

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -176,10 +176,7 @@ class AttributionControl {
 
         if (this.options.customAttribution) {
             if (Array.isArray(this.options.customAttribution)) {
-                const customAttributionReversed = [...this.options.customAttribution].reverse();
-                for (const attribution of customAttributionReversed) {
-                    if (typeof attribution === 'string') attributions.unshift(attribution);
-                }
+                attributions = [...this.options.customAttribution.filter(s => typeof s === 'string'), ...attributions];
             } else if (typeof this.options.customAttribution === 'string') {
                 attributions.unshift(this.options.customAttribution);
             }

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -176,7 +176,7 @@ class AttributionControl {
 
         if (this.options.customAttribution) {
             if (Array.isArray(this.options.customAttribution)) {
-                for (const attribution of this.options.customAttribution) {
+                for (const attribution of this.options.customAttribution.reverse()) {
                     if (typeof attribution === 'string') attributions.unshift(attribution);
                 }
             } else if (typeof this.options.customAttribution === 'string') {

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -127,7 +127,7 @@ test('AttributionControl dedupes attributions that are substrings of others', (t
     map.on('data', (e) => {
         if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
             if (++times === 7) {
-                t.equal(attribution._innerContainer.innerHTML, 'Hello World | Another Source | Hello | GeoJSON Source');
+                t.equal(attribution._innerContainer.innerHTML, 'Hello World | Another Source | GeoJSON Source');
                 t.end();
             }
         }

--- a/test/unit/ui/control/attribution.test.js
+++ b/test/unit/ui/control/attribution.test.js
@@ -127,7 +127,7 @@ test('AttributionControl dedupes attributions that are substrings of others', (t
     map.on('data', (e) => {
         if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
             if (++times === 7) {
-                t.equal(attribution._innerContainer.innerHTML, 'Hello World | Another Source | GeoJSON Source');
+                t.equal(attribution._innerContainer.innerHTML, 'Hello World | Another Source | Hello | GeoJSON Source');
                 t.end();
             }
         }
@@ -237,7 +237,7 @@ test('AttributionControl shows all custom attributions if customAttribution arra
 
     t.equal(
         attributionControl._innerContainer.innerHTML,
-        'Custom string | Another custom string | Some very long custom string'
+        'Some very long custom string | Custom string | Another custom string'
     );
     t.end();
 });


### PR DESCRIPTION
This PR allows users to set an order for their custom attributions to appear on the map. A user may likely expect and want the order of their custom attribution to correspond to the array set in the map constructor (see: #11191). 

To do this, filtering and adding custom attributions occurs after cleaning up source attributions.  A part of cleaning up the source attributions involves sorting the attributions by length and then searching and removing duplicate substrings. This change was introduced in PR [#2453](https://github.com/mapbox/mapbox-gl-js/pull/2453) in order to remove duplicate substrings in the attribution control as a fix for [#1804](https://github.com/mapbox/mapbox-gl-js/issues/1804). This change was then also sorting custom attributions by length. 

Before:
<img width="585" alt="Screen Shot 2021-11-01 at 4 54 26 PM" src="https://user-images.githubusercontent.com/42715836/139757396-aff90e34-e249-4663-be91-ac669e1b8294.png">

After:
<img width="594" alt="Screen Shot 2021-11-01 at 4 53 26 PM" src="https://user-images.githubusercontent.com/42715836/139757414-45dea3a6-a953-467c-adb8-76133ddc9cde.png">


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Allow users to set order of custom attribution</changelog>`
