### PR TITLE
Fix bad shallow copy in filter splitting algorithm

### DIFF
--- a/src/style-spec/feature_filter/index.js
+++ b/src/style-spec/feature_filter/index.js
@@ -2,6 +2,7 @@
 
 import {createExpression} from '../expression/index.js';
 import {isFeatureConstant} from '../expression/is_constant.js';
+import {deepUnbundle} from '../util/unbundle_jsonlint.js';
 import latest from '../reference/latest.js';
 import type {GlobalProperties, Feature} from '../expression/index.js';
 import type {CanonicalTileID} from '../../source/tile_id.js';
@@ -133,7 +134,7 @@ function extractStaticFilter(filter: any): any {
     }
 
     // Shallow copy so we can replace expressions in-place
-    let result = filter.slice();
+    let result = deepUnbundle(filter);
 
     // 1. Union branches
     unionDynamicBranches(result);

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -557,6 +557,8 @@ test('filter', t => {
 
                 for (const testCase of testCases) {
                     t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
+                    // Ensure input doesnt get mutated
+                    t.deepInequal(testCase.dynamic, testCase.static);
                 }
 
                 t.end();
@@ -656,6 +658,8 @@ test('filter', t => {
 
                 for (const testCase of testCases) {
                     t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
+                    // Ensure input doesnt get mutated
+                    t.deepInequal(testCase.dynamic, testCase.static);
                 }
 
                 t.end();
@@ -818,6 +822,8 @@ test('filter', t => {
 
                 for (const testCase of testCases) {
                     t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
+                    // Ensure input doesnt get mutated
+                    t.deepInequal(testCase.dynamic, testCase.static);
                 }
 
                 t.end();
@@ -1011,6 +1017,8 @@ test('filter', t => {
                 ];
                 for (const testCase of testCases) {
                     t.deepEqual(extractStaticFilter(testCase.dynamic), testCase.static);
+                    // Ensure input doesnt get mutated
+                    t.deepInequal(testCase.dynamic, testCase.static);
                 }
 
                 t.end();


### PR DESCRIPTION
I was previously using `filter.slice()` to create a shallow copy of the expression array, but I overlooked the fact that this doesn't create a shallow copy of nested arrays inside the expression. This was causing the static filter conversion algorithm to mutate the filter passed to it. 
This meant the full original filter got completely lost 😅  in certain situations when a dynamic `case`, `match` or `step` was more than one level deep in the expression.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
