### PR TITLE
fix disabling fog when projections set

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -516,7 +516,7 @@ class Painter {
         // Clear buffers in preparation for drawing to the main framebuffer
         // If fog is enabled, use the fog color as default clear color.
         let clearColor = Color.transparent;
-        if (this.style.fog) {
+        if (this.style.fog && this.style.fog.getOpacity(this.transform.pitch)) {
             clearColor = this.style.fog.properties.get('color');
         }
         this.context.clear({color: options.showOverdrawInspector ? Color.black : clearColor, depth: 1});

--- a/src/style/fog.js
+++ b/src/style/fog.js
@@ -35,15 +35,15 @@ class Fog extends Evented {
     properties: PossiblyEvaluated<Props>;
 
     // Alternate projections do not yet support fog.
-    // Disable fog rendering until they do.
-    _disabledForProjections: boolean;
+    // Hold on to transform so that we know whether a projection is set.
+    _transform: Transform;
 
-    constructor(fogOptions?: FogSpecification) {
+    constructor(fogOptions?: FogSpecification, transform: Transform) {
         super();
         this._transitionable = new Transitionable(fogProperties);
         this.set(fogOptions);
         this._transitioning = this._transitionable.untransitioned();
-        this._disabledForProjections = false;
+        this._transform = transform;
     }
 
     get state(): FogState {
@@ -74,7 +74,7 @@ class Fog extends Evented {
     }
 
     getOpacity(pitch: number): number {
-        if (this._disabledForProjections) return 0;
+        if (this._transform.projection.name !== 'mercator') return 0;
         const fogColor = (this.properties && this.properties.get('color')) || 1.0;
         const pitchFactor = smoothstep(FOG_PITCH_START, FOG_PITCH_END, pitch);
         return pitchFactor * fogColor.a;

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -354,9 +354,6 @@ class Style extends Evented {
         this.map.transform.setProjection(projection);
         this.dispatcher.broadcast('setProjection', this.map.transform.projectionOptions);
 
-        const fog = this.fog;
-        if (fog) fog._disabledForProjections = Boolean(projection && projection.name !== 'mercator');
-
         this.map._update(true);
     }
 
@@ -1472,7 +1469,7 @@ class Style extends Evented {
     }
 
     _createFog(fogOptions: FogSpecification) {
-        const fog = this.fog = new Fog(fogOptions);
+        const fog = this.fog = new Fog(fogOptions, this.map.transform);
         this.stylesheet.fog = fogOptions;
         const parameters = {
             now: browser.now(),


### PR DESCRIPTION
fix #11186

Fog was being disabled only if the projection was set after the fog. If fog is set after the projection, it wasn't getting disabled. Fix this by checking the projection directly.

Before

![](https://user-images.githubusercontent.com/61150/139274746-2bf25480-baca-4f1e-924b-40c56270809e.png)

After

![Screen Shot 2021-11-02 at 11 29 37 AM](https://user-images.githubusercontent.com/1421652/139878054-d652de7a-e8cd-42d7-bb10-8115affdc2f3.png)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'