### PR TITLE
don't reload tiles when projection doesn't change

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -6,7 +6,7 @@ import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAlt
 import {getProjection} from './projection/index.js';
 import tileTransform from '../geo/projection/tile_transform.js';
 import Point from '@mapbox/point-geometry';
-import {wrap, clamp, pick, radToDeg, degToRad, getAABBPointSquareDist, furthestTileCorner, warnOnce} from '../util/util.js';
+import {wrap, clamp, pick, radToDeg, degToRad, getAABBPointSquareDist, furthestTileCorner, warnOnce, deepEqual} from '../util/util.js';
 import {number as interpolate} from '../style-spec/util/interpolate.js';
 import EXTENT from '../data/extent.js';
 import {vec4, mat4, mat2, vec3, quat} from 'gl-matrix';
@@ -221,8 +221,15 @@ class Transform {
         this._unmodifiedProjection = !projection;
         if (projection === undefined || projection === null) projection = {name: 'mercator'};
         this.projectionOptions = projection;
+
+        const oldProjection = this.projection ? this.getProjection() : undefined;
         this.projection = getProjection(projection);
+
+        if (deepEqual(oldProjection, this.getProjection())) {
+            return false;
+        }
         this._calcMatrices();
+        return true;
     }
 
     get minZoom(): number { return this._minZoom; }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -346,12 +346,15 @@ class Style extends Evented {
     }
 
     setProjection(projection?: ?ProjectionSpecification) {
+
+        const projectionChanged = this.map.transform.setProjection(projection);
+        if (!projectionChanged) return;
+
         this.map.painter.clearBackgroundTiles();
         for (const id in this._sourceCaches) {
             this._sourceCaches[id].clearTiles();
         }
 
-        this.map.transform.setProjection(projection);
         this.dispatcher.broadcast('setProjection', this.map.transform.projectionOptions);
 
         const fog = this.fog;

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -1587,5 +1587,20 @@ test('transform', (t) => {
         t.end();
     });
 
+    t.test("setProjection", (t) => {
+        const transform = new Transform();
+        t.equal(transform.getProjection().name, 'mercator');
+
+        // correctly returns indication of whether projection changed
+        t.equal(transform.setProjection({name: 'albers'}), true);
+        t.equal(transform.setProjection({name: 'albers'}), false);
+        t.equal(transform.setProjection({name: 'albers', center: [-96, 37.5]}), false);
+        t.equal(transform.setProjection({name: 'albers', center: [-100, 37.5]}), true);
+        t.equal(transform.setProjection({name: 'mercator'}), true);
+        t.equal(transform.setProjection(), false);
+
+        t.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
When `setProjection(...)` doesn't actually change the projection, skip reloading tiles.

fix #11166

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 