### PR TITLE
change how stylesheet and runtime projections interact

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -19,14 +19,12 @@
 <script>
 
 var map = window.map = new mapboxgl.Map({
-        projection: 'mercator',
     container: 'map',
     zoom: 12.5,
     center: [-122.4194, 37.7749],
     style: 'mapbox://styles/mapbox/streets-v11',
     hash: true
 });
-
 
 </script>
 </body>

--- a/debug/index.html
+++ b/debug/index.html
@@ -19,12 +19,14 @@
 <script>
 
 var map = window.map = new mapboxgl.Map({
+        projection: 'mercator',
     container: 'map',
     zoom: 12.5,
     center: [-122.4194, 37.7749],
     style: 'mapbox://styles/mapbox/streets-v11',
     hash: true
 });
+
 
 </script>
 </body>

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -111,7 +111,6 @@ class Transform {
     _zoom: number;
     _cameraZoom: ?number;
     _unmodified: boolean;
-    _unmodifiedProjection: boolean;
     _renderWorldCopies: boolean;
     _minZoom: number;
     _maxZoom: number;
@@ -185,7 +184,7 @@ class Transform {
         clone._camera = this._camera.clone();
         clone._calcMatrices();
         clone.freezeTileCoverage = this.freezeTileCoverage;
-        if (!this._unmodifiedProjection) clone.setProjection(this.getProjection());
+        clone.setProjection(this.getProjection());
         return clone;
     }
 
@@ -218,7 +217,6 @@ class Transform {
     }
 
     setProjection(projection?: ?ProjectionSpecification) {
-        this._unmodifiedProjection = !projection;
         if (projection === undefined || projection === null) projection = {name: 'mercator'};
         this.projectionOptions = projection;
 

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -358,7 +358,7 @@ class Style extends Evented {
             }
         }
 
-        const projectionChanged = this.map.transform.setProjection(this._runtimeProjection || this.stylesheet.projection);
+        const projectionChanged = this.map.transform.setProjection(this._runtimeProjection || (this.stylesheet ? this.stylesheet.projection : undefined));
         if (!projectionChanged) return;
 
         this.map.painter.clearBackgroundTiles();

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -353,6 +353,7 @@ class Map extends Camera {
     _silenceAuthErrors: boolean;
     _averageElevationLastSampledAt: number;
     _averageElevation: EasedVariable;
+    _runtimeProjection: ProjectionSpecification | void | null;
 
     /** @section {Interaction handlers} */
 
@@ -1021,7 +1022,8 @@ class Map extends Camera {
         if (typeof projection === 'string') {
             projection = (({name: projection}: any): ProjectionSpecification);
         }
-        this.style.setProjection(projection, true);
+        this._runtimeProjection = projection;
+        this.style.updateProjection();
     }
 
     /**

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1021,7 +1021,7 @@ class Map extends Camera {
         if (typeof projection === 'string') {
             projection = (({name: projection}: any): ProjectionSpecification);
         }
-        this.style.setProjection(projection);
+        this.style.setProjection(projection, true);
     }
 
     /**

--- a/test/integration/render-tests/satellite-v9/z0-albers/style.json
+++ b/test/integration/render-tests/satellite-v9/z0-albers/style.json
@@ -6,6 +6,7 @@
       "height": 512,
       "allowed": 0.01,
       "operations": [
+        ["setProjection", "albers"],
         ["setStyle", "local://mapbox-gl-styles/styles/satellite-v9.json"],
         ["wait"],
         ["setPaintProperty",
@@ -16,9 +17,6 @@
         ["wait"]
       ]
     }
-  },
-  "projection": {
-    "name": "albers"
   },
   "sources": {},
   "layers": []

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -2422,7 +2422,8 @@ test('Style#setProjection', (t) => {
 
             // Runtime api overrides style projection
             // Stylesheet projection not changed by runtime apis
-            style.setProjection({name: 'winkelTripel'}, true);
+            style.map._runtimeProjection = {name: 'winkelTripel'};
+            style.updateProjection();
             t.equal(style.serialize().projection.name, 'albers');
             t.equal(style.map.transform.getProjection().name, 'winkelTripel');
 
@@ -2432,7 +2433,8 @@ test('Style#setProjection', (t) => {
             t.equal(style.map.transform.getProjection().name, 'winkelTripel');
 
             // Unsetting runtime projection reveals map projection
-            style.setProjection(null, true);
+            style.map._runtimeProjection = null;
+            style.updateProjection();
             t.equal(style.serialize().projection.name, 'naturalEarth');
             t.equal(style.map.transform.getProjection().name, 'naturalEarth');
 

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -2397,3 +2397,55 @@ test('Style#getFog', (t) => {
 
     t.end();
 });
+
+test('Style#setProjection', (t) => {
+    t.test('runtime projection overrides style projection', (t) => {
+        const style = new Style(new StubMap());
+
+        style.map.painter = {
+            clearBackgroundTiles: () => {}
+        };
+        style.map._update = () => {};
+
+        style.loadJSON({
+            "version": 8,
+            "projection": {
+                "name": "albers"
+            },
+            "sources": {},
+            "layers": []
+        });
+
+        style.on('style.load', () => {
+            t.equal(style.serialize().projection.name, 'albers');
+            t.equal(style.map.transform.getProjection().name, 'albers');
+
+            // Runtime api overrides style projection
+            // Stylesheet projection not changed by runtime apis
+            style.setProjection({name: 'winkelTripel'}, true);
+            t.equal(style.serialize().projection.name, 'albers');
+            t.equal(style.map.transform.getProjection().name, 'winkelTripel');
+
+            // Runtime api overrides style projection
+            style.setState(Object.assign({}, style.serialize(), {projection: {name: 'naturalEarth'}}));
+            t.equal(style.serialize().projection.name, 'naturalEarth');
+            t.equal(style.map.transform.getProjection().name, 'winkelTripel');
+
+            // Unsetting runtime projection reveals map projection
+            style.setProjection(null, true);
+            t.equal(style.serialize().projection.name, 'naturalEarth');
+            t.equal(style.map.transform.getProjection().name, 'naturalEarth');
+
+            // Unsetting style projection reveals mercator
+            const stylesheet = style.serialize();
+            delete stylesheet.projection;
+            style.setState(stylesheet);
+            t.equal(style.serialize().projection, undefined);
+            t.equal(style.map.transform.getProjection().name, 'mercator');
+
+            t.end();
+        });
+
+    });
+    t.end();
+});

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1421,6 +1421,29 @@ test('Map', (t) => {
             t.deepEqual(map.getProjection(), {name: 'mercator', center: [0, 0]});
             t.end();
         });
+
+        t.test('setProjection persists after new style', (t) => {
+            const map = createMap(t);
+            map.once('style.load', () => {
+                map.setProjection({name: 'albers'});
+                t.equal(map.getProjection().name, 'albers');
+
+                // setStyle with diffing
+                map.setStyle(Object.assign({}, map.getStyle(), {projection: {name: 'winkelTripel'}}));
+                t.equal(map.getProjection().name, 'albers');
+                t.equal(map.style.stylesheet.projection.name, 'winkelTripel');
+
+                // setStyle without diffing
+                const s = map.getStyle();
+                delete s.projection;
+                map.setStyle(s, {diff: false});
+                map.once('style.load', () => {
+                    t.equal(map.getProjection().name, 'albers');
+                    t.equal(map.style.stylesheet.projection, undefined);
+                    t.end();
+                });
+            });
+        });
         t.end();
     });
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -1416,10 +1416,9 @@ test('Map', (t) => {
         t.test('setProjection with no argument defaults to Mercator', (t) => {
             const map = createMap(t);
             map.setProjection({name: 'albers'});
-            t.equal(map.transform._unmodifiedProjection, false);
+            t.equal(map.getProjection().name, 'albers');
             map.setProjection();
             t.deepEqual(map.getProjection(), {name: 'mercator', center: [0, 0]});
-            t.equal(map.transform._unmodifiedProjection, true);
             t.end();
         });
         t.end();


### PR DESCRIPTION
fix #11183

### Before

The previous behavior treats projections specified in styles similar to zoom/center/bearing specified in the style. They get used as defaults on the initial load if no camera properties have been changed. For projections this meant that a followup `setStyle(...)` would never change the projection of the map, which was confusing.

### Current
This slightly changes that behavior. Internally there are now two projection settings:
- one in the stylesheet
- one that gets set by runtime apis (map constructor, map.setProjection(...))

The runtime projection, if set, always overrides the style projection. Calling map.setStyle(...) does change the style's projection, and will change rendering if no runtime projection has been set. Calling `map.setProjection(null)` unsets the runtime projection and switches to the stylesheet's projection.

The only case that may still be surprising is that `map.setStyle(...)` with a new projection does not override the runtime projection. This behavior is intentional because it makes it easy to override the projections set in a style.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
