### PR TITLE
disable custom layers for non-mercator projections

### DIFF
--- a/src/render/draw_custom.js
+++ b/src/render/draw_custom.js
@@ -4,6 +4,7 @@ export default drawCustom;
 
 import DepthMode from '../gl/depth_mode.js';
 import StencilMode from '../gl/stencil_mode.js';
+import {warnOnce} from '../util/util.js';
 
 import type Painter from './painter.js';
 import type SourceCache from '../source/source_cache.js';
@@ -13,6 +14,11 @@ function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomSty
 
     const context = painter.context;
     const implementation = layer.implementation;
+
+    if (painter.transform.projection.name !== 'mercator') {
+        warnOnce('Custom layers are not yet supported with non-mercator projections. Use mercator to enable custom layers.');
+        return;
+    }
 
     if (painter.renderPass === 'offscreen') {
 

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -96,7 +96,7 @@
     },
     "projection": {
       "type": "projection",
-      "doc": "The projection the map should be rendered in. Suported projections are Albers, Equal Earth, Equirectangular (WGS84), Lambert conformal conic, Mercator, Natural Earth, and Winkel Tripel. Terrain and fog are not supported for projections other than mercator.",
+      "doc": "The projection the map should be rendered in. Suported projections are Albers, Equal Earth, Equirectangular (WGS84), Lambert conformal conic, Mercator, Natural Earth, and Winkel Tripel. Terrain, fog and CustomLayerInterface are not supported for projections other than mercator.",
       "example": {
         "name": "albers",
         "center": [-154, 50],


### PR DESCRIPTION
fix #11159

Disable custom layers with non-mercator projections.

![Screen Shot 2021-11-02 at 4 13 28 PM](https://user-images.githubusercontent.com/1421652/139945271-9104ad24-9d34-4515-ae57-7e575a5d4da0.png)