### PR TITLE
Fix terrain cache not updating on `setFeatureState`

### DIFF
--- a/src/source/source_state.js
+++ b/src/source/source_state.js
@@ -80,7 +80,6 @@ class SourceFeatureState {
         } else {
             this.deletedStates[sourceLayer] = null;
         }
-
     }
 
     getState(sourceLayer: string, featureId: number | string) {

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -531,15 +531,9 @@ class Tile {
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 
             bucket.update(sourceLayerStates, sourceLayer, availableImages, this.imageAtlas && this.imageAtlas.patternPositions || {});
-            if (painter._terrain && painter._terrain.enabled &&
-                (bucket instanceof LineBucket ||
-                bucket instanceof FillBucket ||
-                bucket instanceof FillExtrusionBucket ||
-                bucket instanceof CircleBucket)
-                // Symbol bucket has no programConfigurations. This has to be spelled out for Flow.
-            ) {
+            if (bucket instanceof LineBucket || bucket instanceof FillBucket || bucket instanceof FillExtrusionBucket || bucket instanceof CircleBucket) {
                 const sourceCache = painter.style._getSourceCache(bucket.layers[0].source);
-                if (sourceCache && painter._terrain && bucket.programConfigurations.needsUpload) {
+                if (painter._terrain && painter._terrain.enabled && sourceCache && bucket.programConfigurations.needsUpload) {
                     painter._terrain._clearRenderCacheForTile(sourceCache.id, this.tileID);
                 }
             }

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -527,6 +527,12 @@ class Tile {
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 
             bucket.update(sourceLayerStates, sourceLayer, availableImages, this.imageAtlas && this.imageAtlas.patternPositions || {});
+            if (painter._terrain && painter._terrain.enabled && bucket.programConfigurations && bucket.programConfigurations.needsUpload) {
+                const sourceCache = painter.style._getSourceCache(bucket.layers[0].source);
+                if (sourceCache && painter._terrain) { // Always happens, just making Flow happy
+                    painter._terrain._clearRenderCacheForTile(sourceCache.id, this.tileID);
+                }
+            }
             const layer = painter && painter.style && painter.style.getLayer(id);
             if (layer) {
                 this.queryPadding = Math.max(this.queryPadding, layer.queryRadius(bucket));

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -29,9 +29,7 @@ import SegmentVector from '../data/segment.js';
 const CLOCK_SKEW_RETRY_TIMEOUT = 30000;
 
 import type {Bucket} from '../data/bucket.js';
-import CircleBucket from '../data/bucket/circle_bucket.js';
 import FillBucket from '../data/bucket/fill_bucket.js';
-import FillExtrusionBucket from '../data/bucket/fill_extrusion_bucket.js';
 import LineBucket from '../data/bucket/line_bucket.js';
 import type StyleLayer from '../style/style_layer.js';
 import type {WorkerTileResult} from './worker_source.js';
@@ -531,7 +529,7 @@ class Tile {
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 
             bucket.update(sourceLayerStates, sourceLayer, availableImages, this.imageAtlas && this.imageAtlas.patternPositions || {});
-            if (bucket instanceof LineBucket || bucket instanceof FillBucket || bucket instanceof FillExtrusionBucket || bucket instanceof CircleBucket) {
+            if (bucket instanceof LineBucket || bucket instanceof FillBucket) {
                 const sourceCache = painter.style._getSourceCache(bucket.layers[0].source);
                 if (painter._terrain && painter._terrain.enabled && sourceCache && bucket.programConfigurations.needsUpload) {
                     painter._terrain._clearRenderCacheForTile(sourceCache.id, this.tileID);

--- a/src/source/tile.js
+++ b/src/source/tile.js
@@ -29,6 +29,10 @@ import SegmentVector from '../data/segment.js';
 const CLOCK_SKEW_RETRY_TIMEOUT = 30000;
 
 import type {Bucket} from '../data/bucket.js';
+import CircleBucket from '../data/bucket/circle_bucket.js';
+import FillBucket from '../data/bucket/fill_bucket.js';
+import FillExtrusionBucket from '../data/bucket/fill_extrusion_bucket.js';
+import LineBucket from '../data/bucket/line_bucket.js';
 import type StyleLayer from '../style/style_layer.js';
 import type {WorkerTileResult} from './worker_source.js';
 import type Actor from '../util/actor.js';
@@ -527,9 +531,15 @@ class Tile {
             if (!sourceLayer || !sourceLayerStates || Object.keys(sourceLayerStates).length === 0) continue;
 
             bucket.update(sourceLayerStates, sourceLayer, availableImages, this.imageAtlas && this.imageAtlas.patternPositions || {});
-            if (painter._terrain && painter._terrain.enabled && bucket.programConfigurations && bucket.programConfigurations.needsUpload) {
+            if (painter._terrain && painter._terrain.enabled &&
+                (bucket instanceof LineBucket ||
+                bucket instanceof FillBucket ||
+                bucket instanceof FillExtrusionBucket ||
+                bucket instanceof CircleBucket)
+                // Symbol bucket has no programConfigurations. This has to be spelled out for Flow.
+            ) {
                 const sourceCache = painter.style._getSourceCache(bucket.layers[0].source);
-                if (sourceCache && painter._terrain) { // Always happens, just making Flow happy
+                if (sourceCache && painter._terrain && bucket.programConfigurations.needsUpload) {
                     painter._terrain._clearRenderCacheForTile(sourceCache.id, this.tileID);
                 }
             }

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1120,7 +1120,6 @@ class Style extends Evented {
         for (const sourceCache of sourceCaches) {
             sourceCache.setFeatureState(sourceLayer, target.id, state);
         }
-        this.fire(new Event('setfeaturestate'));
     }
 
     removeFeatureState(target: { source: string; sourceLayer?: string; id?: string | number; }, key?: string) {

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -1120,6 +1120,7 @@ class Style extends Evented {
         for (const sourceCache of sourceCaches) {
             sourceCache.setFeatureState(sourceLayer, target.id, state);
         }
+        this.fire(new Event('setfeaturestate'));
     }
 
     removeFeatureState(target: { source: string; sourceLayer?: string; id?: string | number; }, key?: string) {

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -247,6 +247,7 @@ export class Terrain extends Elevation {
 
     set style(style: Style) {
         style.on('data', this._onStyleDataEvent.bind(this));
+        style.on('setfeaturestate', this._onSetFeatureStateEvent.bind(this));
         style.on('neworder', this._checkRenderCacheEfficiency.bind(this));
         this._style = style;
         this._checkRenderCacheEfficiency();
@@ -325,6 +326,11 @@ export class Terrain extends Elevation {
         } else if (event.dataType === 'style') {
             this._invalidateRenderCache = true;
         }
+    }
+
+    _onSetFeatureStateEvent(event: any) {
+        this._invalidateRenderCache = true;
+
     }
 
     // Terrain

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -247,7 +247,6 @@ export class Terrain extends Elevation {
 
     set style(style: Style) {
         style.on('data', this._onStyleDataEvent.bind(this));
-        style.on('setfeaturestate', this._onSetFeatureStateEvent.bind(this));
         style.on('neworder', this._checkRenderCacheEfficiency.bind(this));
         this._style = style;
         this._checkRenderCacheEfficiency();
@@ -326,10 +325,6 @@ export class Terrain extends Elevation {
         } else if (event.dataType === 'style') {
             this._invalidateRenderCache = true;
         }
-    }
-
-    _onSetFeatureStateEvent(event: any) {
-        this._invalidateRenderCache = true;
     }
 
     // Terrain
@@ -987,7 +982,11 @@ export class Terrain extends Elevation {
                     const tiles = current[source];
                     const prevTiles = prev[source];
                     if (!prevTiles || prevTiles.length !== tiles.length ||
-                        tiles.some((t, index) => (t !== prevTiles[index] || (dirty[source] && dirty[source].hasOwnProperty(t.key))))) {
+                        tiles.some((t, index) =>
+                            (t !== prevTiles[index] ||
+                            (dirty[source] && dirty[source].hasOwnProperty(t.key)
+                            )))
+                    ) {
                         equal = -1;
                         break;
                     }

--- a/src/terrain/terrain.js
+++ b/src/terrain/terrain.js
@@ -330,7 +330,6 @@ export class Terrain extends Elevation {
 
     _onSetFeatureStateEvent(event: any) {
         this._invalidateRenderCache = true;
-
     }
 
     // Terrain


### PR DESCRIPTION
Closes https://github.com/mapbox/gl-js-team/issues/312

Currently, `feature-state` doesn't update on terrain until the map is zoomed a certain amount (possibly an integer zoom level).Demonstration [here](https://codepen.io/snailbones/pen/rNzYjvL).

This is because the terrain render cache doesn't update. This P.R. fixes that.

This issue is a regression introduced in 2.4, probably from https://github.com/mapbox/mapbox-gl-js/pull/10701.  https://github.com/mapbox/mapbox-gl-js/issues/10302 may be a related issue, but predates this regression.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [x] manually test the debug page
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog>Fixes `feature-state` not updating when terrain is enabled.</changelog>`
