### PR TITLE
Cutoff skybox

### DIFF
--- a/debug/projections.html
+++ b/debug/projections.html
@@ -25,7 +25,7 @@
             border: none;
             padding: 5px 0;
         }
-         
+
         select, input {
             background-color: transparent;
             border-radius: 3px;
@@ -181,6 +181,17 @@ function addGraticule() {
                 'line-opacity': document.getElementById('graticule').checked ? 1 : 0
             }
         });
+
+        map.addLayer({
+            'id': 'sky',
+            'type': 'sky',
+            'paint': {
+                'sky-opacity': 1,
+                'sky-type': 'atmosphere',
+                'sky-atmosphere-sun': [0, 85],
+                'sky-atmosphere-sun-intensity': 5,
+            }
+            });
     });
 }
 

--- a/debug/skybox-gradient.html
+++ b/debug/skybox-gradient.html
@@ -52,19 +52,11 @@ map.on('load', function() {
                 0.8,
                 'rgba(135, 206, 235, 1.0)',
                 1,
-                'rgba(0,0,0,0.1)'
+                'rgba(255,0,0,1.0)'
             ],
             'sky-gradient-center': [0, 0],
             'sky-gradient-radius': 90,
-            'sky-opacity': [
-                'interpolate',
-                ['exponential', 0.1],
-                ['zoom'],
-                5,
-                0,
-                22,
-                1
-            ]
+            'sky-opacity': 1
         }
     });
 });

--- a/debug/skybox.html
+++ b/debug/skybox.html
@@ -97,11 +97,7 @@
                 'id': 'sky',
                 'type': 'sky',
                 'paint': {
-                    'sky-opacity': ['interpolate', ['linear'],
-                        ['zoom'],
-                        0, 0,
-                        5, 0.3,
-                        8, 1],
+                    'sky-opacity': 1,
                     'sky-type': 'atmosphere',
                     'sky-atmosphere-sun': getSunPosition(),
                     'sky-atmosphere-sun-intensity': 5,

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1957,14 +1957,20 @@ class Transform {
     // Checks the four corners of the frustum to see if they lie in the map's quad.
     //
     isHorizonVisible(): boolean {
-        // we consider the horizon as visible if the angle between
-        // a the top plane of the frustum and the map plane is smaller than this threshold.
-        const horizonAngleEpsilon = 2;
-        if (this.pitch + radToDeg(this.fovAboveCenter) > (90 - horizonAngleEpsilon)) {
+        if (this.projection.name === 'mercator') {
+            // we consider the horizon as visible if the angle between
+            // a the top plane of the frustum and the map plane is smaller than this threshold.
+            const horizonAngleEpsilon = 2;
+            if (this.pitch + radToDeg(this.fovAboveCenter) > (90 - horizonAngleEpsilon)) {
+                return true;
+            }
+
+            return this.isCornerOffEdge(new Point(0, 0), new Point(this.width, this.height));
+        } else {
+            // complex shape of non-mercator maps means we cannot perform a cheap culling test
+            // so we deoptimize instead and always render the skybox.
             return true;
         }
-
-        return this.isCornerOffEdge(new Point(0, 0), new Point(this.width, this.height));
     }
 
     /**

--- a/src/shaders/skybox.fragment.glsl
+++ b/src/shaders/skybox.fragment.glsl
@@ -27,9 +27,15 @@ float map(float value, float start, float end, float new_start, float new_end) {
 void main() {
     vec3 uv = v_uv;
 
+    const float y_bias = 0.015;
+    // cutoff the skybox below the horizon
+    const float y_cutoff = 0.3;
+    const float y_cutoff_range = 0.1;
+    float biased_cutoff = y_bias + y_cutoff;
+    vec3 normalized_uv = normalize(uv);
+    float horizon_cutoff_alpha = 1.0 - smoothstep(biased_cutoff - y_cutoff_range, biased_cutoff + y_cutoff_range, -normalized_uv.y);
     // Add a small offset to prevent black bands around areas where
     // the scattering algorithm does not manage to gather lighting
-    const float y_bias = 0.015;
     uv.y += y_bias;
 
     // Inverse of the operation applied for non-linear UV parameterization
@@ -53,7 +59,7 @@ void main() {
     // Add sun disk
     sky_color += 0.1 * sun_disk(v_uv, u_sun_direction);
 
-    gl_FragColor = vec4(sky_color * u_opacity, u_opacity);
+    gl_FragColor = vec4(sky_color * u_opacity * horizon_cutoff_alpha, u_opacity * horizon_cutoff_alpha);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);


### PR DESCRIPTION
Blend the bottom half of the sky hemisphere to alpha=0 so that sky doesn't become a background.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
