### PR TITLE
Globe View: Replace tile backface culling by far plane adjustment for frustum culling

### DIFF
--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -5,7 +5,6 @@ import {mat4, vec3} from 'gl-matrix';
 import {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id.js';
 import {Aabb} from '../../util/primitives.js';
 import Transform from '../transform.js';
-import {FreeCamera} from '../../ui/free_camera.js';
 import MercatorCoordinate from '../mercator_coordinate.js';
 
 export type TileTransform = {
@@ -25,9 +24,7 @@ export type TileTransform = {
 
     pointCoordinate: (x: number, y: number, z?: number) => MercatorCoordinate,
 
-    tileSpaceUpVectorScale: () => number,
-
-    cullTile: (aabb: Aabb, id: CanonicalTileID, zoom: number, camera: FreeCamera) => boolean
+    tileSpaceUpVectorScale: () => number
 };
 
 export type Projection = {
@@ -41,6 +38,8 @@ export type Projection = {
     zAxisUnit: "meters" | "pixels",
 
     pixelsPerMeter: (lat: number, worldSize: number) => number,
+
+    farthestPixelDistance: (tr: Transform) => number,
 
     createTileTransform: (tr: Transform, worldSize: number) => TileTransform,
 };

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -269,10 +269,11 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
     const setShaderMode = (mode, isWireframe) => {
         if (programMode === mode)
             return;
-        const defines = [shaderDefines[mode]];
+        const defines = ([]: any);
         if (isWireframe) {
             defines.push(shaderDefines[showWireframe]);
         }
+        defines.push(shaderDefines[mode]);
         defines.push('PROJECTION_GLOBE_VIEW');
         program = painter.useProgram('globeRaster', null, defines);
         programMode = mode;

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -269,9 +269,12 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
     const setShaderMode = (mode, isWireframe) => {
         if (programMode === mode)
             return;
-        const modes = [shaderDefines[mode]];
-        if (isWireframe) modes.push(shaderDefines[showWireframe]);
-        program = painter.useProgram('globeRaster', null, modes);
+        const defines = [shaderDefines[mode]];
+        if (isWireframe) {
+            defines.push(shaderDefines[showWireframe]);
+        }
+        defines.push('PROJECTION_GLOBE_VIEW');
+        program = painter.useProgram('globeRaster', null, defines);
         programMode = mode;
     };
 


### PR DESCRIPTION
- Replace tile backface culling by far plane adjustment for frustum culling
- Add ray closest point on sphere
- Add common projection interface farthestPixelDistance
- Fixed a rebase regression, added `PROJECTION_GLOBE_VIEW` define when globe rendering is enabled to allow terrain rendering to work by enabling the `elevationVector` function in shader code

https://user-images.githubusercontent.com/7061573/140375904-177c9b88-0c7c-4221-9677-6149584152da.mov
