### PR TITLE
Disable sky after maximum projection transition to mercator

### DIFF
--- a/debug/skybox-gradient.html
+++ b/debug/skybox-gradient.html
@@ -55,7 +55,16 @@ map.on('load', function() {
                 'rgba(0,0,0,0.1)'
             ],
             'sky-gradient-center': [0, 0],
-            'sky-gradient-radius': 90
+            'sky-gradient-radius': 90,
+            'sky-opacity': [
+                'interpolate',
+                ['exponential', 0.1],
+                ['zoom'],
+                5,
+                0,
+                22,
+                1
+            ]
         }
     });
 });

--- a/debug/skybox-gradient.html
+++ b/debug/skybox-gradient.html
@@ -55,16 +55,7 @@ map.on('load', function() {
                 'rgba(0,0,0,0.1)'
             ],
             'sky-gradient-center': [0, 0],
-            'sky-gradient-radius': 90,
-            'sky-opacity': [
-                'interpolate',
-                ['exponential', 0.1],
-                ['zoom'],
-                5,
-                0,
-                22,
-                1
-            ]
+            'sky-gradient-radius': 90
         }
     });
 });

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -1912,7 +1912,8 @@ class Transform {
     }
 
     // Check if any of the four corners are off the edge of the rendered map
-    isCornerOffEdge(p0: Point, p1: Point): boolean {
+    // This function will return `false` for all non-mercator projection
+    anyCornerOffEdge(p0: Point, p1: Point): boolean {
         const minX = Math.min(p0.x, p1.x);
         const maxX = Math.max(p0.x, p1.x);
         const minY = Math.min(p0.y, p1.y);
@@ -1920,6 +1921,10 @@ class Transform {
 
         const horizon = this.horizonLineFromTop(false);
         if (minY < horizon) return true;
+
+        if (this.projection.name !== 'mercator') {
+            return false;
+        }
 
         const min = new Point(minX, minY);
         const max = new Point(maxX, maxY);
@@ -1955,6 +1960,7 @@ class Transform {
     // Checks the four corners of the frustum to see if they lie in the map's quad.
     //
     isHorizonVisible(): boolean {
+
         // we consider the horizon as visible if the angle between
         // a the top plane of the frustum and the map plane is smaller than this threshold.
         const horizonAngleEpsilon = 2;
@@ -1962,7 +1968,7 @@ class Transform {
             return true;
         }
 
-        return this.isCornerOffEdge(new Point(0, 0), new Point(this.width, this.height));
+        return this.anyCornerOffEdge(new Point(0, 0), new Point(this.width, this.height));
     }
 
     /**

--- a/src/render/draw_sky.js
+++ b/src/render/draw_sky.js
@@ -7,6 +7,7 @@ import CullFaceMode from '../gl/cull_face_mode.js';
 import Context from '../gl/context.js';
 import Texture from './texture.js';
 import Program from './program.js';
+import {smoothstep} from '../util/util.js';
 import type SourceCache from '../source/source_cache.js';
 import SkyboxGeometry from './skybox_geometry.js';
 import {skyboxUniformValues, skyboxGradientUniformValues} from './program/skybox_program.js';
@@ -18,8 +19,16 @@ import assert from 'assert';
 
 export default drawSky;
 
+const OPACITY_ZOOM_START = 7;
+const OPACITY_ZOOM_END = 8;
+
 function drawSky(painter: Painter, sourceCache: SourceCache, layer: SkyLayer) {
-    const opacity = layer.paint.get('sky-opacity');
+    const tr = painter.transform;
+    const isMercator = tr.projection.name === 'mercator';
+    // For non-mercator projection, use a forced opacity transition. This transition is set to be
+    // 1.0 after the sheer adjustment upper bound which ensures to be in the mercator projection.
+    const transitionOpacity = isMercator ? 1.0 : smoothstep(OPACITY_ZOOM_START, OPACITY_ZOOM_END, tr.zoom);
+    const opacity = layer.paint.get('sky-opacity') * transitionOpacity;
     if (opacity === 0) {
         return;
     }

--- a/src/render/draw_sky.js
+++ b/src/render/draw_sky.js
@@ -19,15 +19,15 @@ import assert from 'assert';
 
 export default drawSky;
 
-const OPACITY_ZOOM_START = 7;
-const OPACITY_ZOOM_END = 8;
+const TRANSITION_OPACITY_ZOOM_START = 7;
+const TRANSITION_OPACITY_ZOOM_END = 8;
 
 function drawSky(painter: Painter, sourceCache: SourceCache, layer: SkyLayer) {
     const tr = painter.transform;
     const isMercator = tr.projection.name === 'mercator';
     // For non-mercator projection, use a forced opacity transition. This transition is set to be
     // 1.0 after the sheer adjustment upper bound which ensures to be in the mercator projection.
-    const transitionOpacity = isMercator ? 1.0 : smoothstep(OPACITY_ZOOM_START, OPACITY_ZOOM_END, tr.zoom);
+    const transitionOpacity = isMercator ? 1.0 : smoothstep(TRANSITION_OPACITY_ZOOM_START, TRANSITION_OPACITY_ZOOM_END, tr.zoom);
     const opacity = layer.paint.get('sky-opacity') * transitionOpacity;
     if (opacity === 0) {
         return;

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -96,7 +96,7 @@
     },
     "projection": {
       "type": "projection",
-      "doc": "The projection the map should be rendered in. Suported projections are Albers, Equal Earth, Equirectangular (WGS84), Lambert conformal conic, Mercator, Natural Earth, and Winkel Tripel. Terrain, fog and CustomLayerInterface are not supported for projections other than mercator.",
+      "doc": "The projection the map should be rendered in. Suported projections are Albers, Equal Earth, Equirectangular (WGS84), Lambert conformal conic, Mercator, Natural Earth, and Winkel Tripel. Terrain, fog, sky and CustomLayerInterface are not supported for projections other than mercator.",
       "example": {
         "name": "albers",
         "center": [-154, 50],

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -852,7 +852,7 @@ class Camera extends Evented {
         const raycast = this._raycastElevationBox(point0, point1);
 
         if (!raycast) {
-            if (this.transform.isCornerOffEdge(point0, point1)) {
+            if (this.transform.anyCornerOffEdge(point0, point1)) {
                 return this;
             }
 

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -1097,7 +1097,7 @@ test('transform', (t) => {
 
     t.test('isHorizonVisible', (t) => {
 
-        t.test('isCornerOffEdge', (t) => {
+        t.test('anyCornerOffEdge', (t) => {
             const transform = new Transform();
             transform.maxPitch = 85;
             transform.resize(800, 800);
@@ -1109,21 +1109,21 @@ test('transform', (t) => {
             t.true(transform.isHorizonVisible());
 
             p0 = new Point(0, 0); p1 = new Point(10, 10);
-            t.true(transform.isCornerOffEdge(p0, p1));
+            t.true(transform.anyCornerOffEdge(p0, p1));
 
             p0 = new Point(0, 250); p1 = new Point(10, 350);
-            t.true(transform.isCornerOffEdge(p0, p1));
+            t.true(transform.anyCornerOffEdge(p0, p1));
 
             p0 = new Point(0, transform.horizonLineFromTop() - 10);
             p1 = new Point(10, transform.horizonLineFromTop() + 10);
-            t.true(transform.isCornerOffEdge(p0, p1));
+            t.true(transform.anyCornerOffEdge(p0, p1));
 
             p0 = new Point(0, 700); p1 = new Point(10, 710);
-            t.false(transform.isCornerOffEdge(p0, p1));
+            t.false(transform.anyCornerOffEdge(p0, p1));
 
             p0 = new Point(0, transform.horizonLineFromTop());
             p1 = new Point(10, transform.horizonLineFromTop() + 10);
-            t.false(transform.isCornerOffEdge(p0, p1));
+            t.false(transform.anyCornerOffEdge(p0, p1));
 
             t.end();
         });


### PR DESCRIPTION
For non-mercator projection, this PR disables the sky layer after the end range of all projections that aren't mercator (as suggested in https://github.com/mapbox/mapbox-gl-js/pull/11124#discussion_r730176549). This ensures that the sky is disabled before the end of sheer adjustment range where projections are set to mercator at high zoom levels.

Fixes https://github.com/mapbox/mapbox-gl-js/issues/11207

The motivation is to give more thoughts on whether we could use it as a background fill for empty projection space. Some options that we should consider then:
- Use a gl.clear using the background color to fill space where tiles aren't drawn
- Leverage the sky layer below the horizon line for that use case
- Transition to alpha = 0 below the horizon line when a sky is available (as mentioned by @arindam1993)
- Some other options?

## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] document any changes to public APIs
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'