### PR TITLE
disable free camera apis with non-mercator projections

### DIFF
--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -101,6 +101,8 @@ export type ElevationBoxRaycast = {
     maxAltitude: number
 };
 
+const freeCameraNotSupportedWarning = 'map.setFreeCameraOptions(...) and map.getFreeCameraOptions() are not yet supported for non-mercator projections.';
+
 /**
  * Options for setting padding on calls to methods such as {@link Map#fitBounds}, {@link Map#fitScreenCoordinates}, and {@link Map#setPadding}. Adjust these options to set the amount of padding in pixels added to the edges of the canvas. Set a uniform padding on all edges or individual values for each edge. All properties of this object must be
  * non-negative integers.
@@ -1001,6 +1003,9 @@ class Camera extends Evented {
      * map.setFreeCameraOptions(camera);
      */
     getFreeCameraOptions(): FreeCameraOptions {
+        if (this.transform.projection.name !== 'mercator') {
+            warnOnce(freeCameraNotSupportedWarning);
+        }
         return this.transform.getFreeCameraOptions();
     }
 
@@ -1038,9 +1043,15 @@ class Camera extends Evented {
      * map.setFreeCameraOptions(camera);
      */
     setFreeCameraOptions(options: FreeCameraOptions, eventData?: Object) {
+        const tr = this.transform;
+
+        if (tr.projection.name !== 'mercator') {
+            warnOnce(freeCameraNotSupportedWarning);
+            return;
+        }
+
         this.stop();
 
-        const tr = this.transform;
         const prevZoom = tr.zoom;
         const prevPitch = tr.pitch;
         const prevBearing = tr.bearing;

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -989,6 +989,8 @@ class Camera extends Evented {
     /**
      * Returns position and orientation of the camera entity.
      *
+     * This method is not supported for projections other than mercator.
+     *
      * @memberof Map#
      * @returns {FreeCameraOptions} The camera state.
      * @example
@@ -1016,6 +1018,8 @@ class Camera extends Evented {
      * if the conversion to the pitch and bearing presentation is ambiguous. For example orientation
      * can be invalid if it leads to the camera being upside down, the quaternion has zero length,
      * or the pitch is over the maximum pitch limit.
+     *
+     * This method is not supported for projections other than mercator.
      *
      * @memberof Map#
      * @param {FreeCameraOptions} options `FreeCameraOptions` object.


### PR DESCRIPTION
FreeCamera apis don't work correctly with non-mercator projections. They accept and return projected coordinates, not mercator coords. We don't provide a way for users to project to these coordinates. Even if we did, their non-conformal space is not great for the main users of FreeCamera.

Disable the two methods with non-mercator projections are enabled.

setFreeCameraOptions(...) becomes a no-op
getFreeCameraOptions() still returns an object with meaningless values to avoid breaking the method signature

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
