### PR TITLE
Better constraining and clamping for non-Mercator projections

### DIFF
--- a/src/geo/projection/albers.js
+++ b/src/geo/projection/albers.js
@@ -1,6 +1,7 @@
 // @flow
 import LngLat from '../lng_lat.js';
-import {clamp, degToRad, radToDeg} from '../../util/util.js';
+import {clamp, wrap, degToRad, radToDeg} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 import {vec2} from 'gl-matrix';
 
 export default {
@@ -47,11 +48,12 @@ export default {
         const x_ = (x - 1) * 2;
         const y_ = (y - 1) * -2;
         const y2 = -(y_ - b);
-        const theta = Math.atan2(x_, y2);
-        const lng = clamp(radToDeg(theta / n) + this.center[0], -180, 180);
+        const dt = degToRad(this.center[0]) * n;
+        const theta = wrap(Math.atan2(x_, y2), -Math.PI - dt, Math.PI - dt);
+        const lng = radToDeg(theta / n) + this.center[0];
         const a = x_ / Math.sin(theta);
         const s = clamp((Math.pow(a / 0.5 * n, 2) - c) / (-2 * n), -1, 1);
-        const lat = clamp(radToDeg(Math.asin(s)), -90, 90);
+        const lat = clamp(radToDeg(Math.asin(s)), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
         return new LngLat(lng, lat);
     }
 };

--- a/src/geo/projection/cylindrical_equal_area.js
+++ b/src/geo/projection/cylindrical_equal_area.js
@@ -1,6 +1,7 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp, degToRad, radToDeg} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 export default function(phi: number) {
     const cosPhi = Math.cos(degToRad(phi));
@@ -24,7 +25,7 @@ export default function(phi: number) {
             const lng = clamp(radToDeg(x_) / cosPhi, -180, 180);
             const y2 = y_ * cosPhi;
             const y3 = Math.asin(clamp(y2, -1, 1));
-            const lat = clamp(radToDeg(y3), -90, 90);
+            const lat = clamp(radToDeg(y3), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
 
             return new LngLat(lng, lat);
         }

--- a/src/geo/projection/equal_earth.js
+++ b/src/geo/projection/equal_earth.js
@@ -1,6 +1,7 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 const a1 = 1.340264;
 const a2 = -0.081106;
@@ -40,16 +41,17 @@ export default {
         for (let i = 0, delta, fy, fpy; i < 12; ++i) {
             fy = theta * (a1 + a2 * theta2 + theta6 * (a3 + a4 * theta2)) - y;
             fpy = a1 + 3 * a2 * theta2 + theta6 * (7 * a3 + 9 * a4 * theta2);
-            theta -= delta = fy / fpy;
+            delta = fy / fpy;
+            theta = clamp(theta - delta, -Math.PI / 3, Math.PI / 3);
             theta2 = theta * theta;
             theta6 = theta2 * theta2 * theta2;
             if (Math.abs(delta) < 1e-12) break;
         }
 
         const lambda = M * x * (a1 + 3 * a2 * theta2 + theta6 * (7 * a3 + 9 * a4 * theta2)) / Math.cos(theta);
-        const phi = Math.asin(clamp(Math.sin(theta) / M, -1, 1));
+        const phi = Math.asin(Math.sin(theta) / M);
         const lng = clamp(lambda * 180 / Math.PI, -180, 180);
-        const lat = clamp(phi * 180 / Math.PI, -90, 90);
+        const lat = clamp(phi * 180 / Math.PI, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
 
         return new LngLat(lng, lat);
     }

--- a/src/geo/projection/equirectangular.js
+++ b/src/geo/projection/equirectangular.js
@@ -1,6 +1,7 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 
 export default {
     name: 'equirectangular',
@@ -14,7 +15,7 @@ export default {
     },
     unproject(x: number, y: number) {
         const lng = (x - 0.5) * 360;
-        const lat = clamp((0.5 - y) * 360, -90, 90);
+        const lat = clamp((0.5 - y) * 360, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
         return new LngLat(lng, lat);
     }
 };

--- a/src/geo/projection/lambert.js
+++ b/src/geo/projection/lambert.js
@@ -1,6 +1,7 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp, degToRad, radToDeg} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
 import {vec2} from 'gl-matrix';
 
 const halfPi = Math.PI / 2;
@@ -73,7 +74,8 @@ export default {
         if (fy * n < 0) l -= Math.PI * Math.sign(x) * signFy;
 
         const lng = clamp(radToDeg(l / n), -180, 180);
-        const lat = clamp(radToDeg(2 * Math.atan(Math.pow(f / r, 1 / n)) - halfPi), -90, 90);
+        const phi = 2 * Math.atan(Math.pow(f / r, 1 / n)) - halfPi;
+        const lat = clamp(radToDeg(phi), -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
 
         return new LngLat(lng, lat);
     }

--- a/src/geo/projection/natural_earth.js
+++ b/src/geo/projection/natural_earth.js
@@ -1,6 +1,9 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp, degToRad, radToDeg} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+
+const maxPhi = degToRad(MAX_MERCATOR_LATITUDE);
 
 export default {
     name: 'naturalEarth',
@@ -36,15 +39,16 @@ export default {
         do {
             phi2 = phi * phi;
             const phi4 = phi2 * phi2;
-            phi -= delta = (phi * (1.007226 + phi2 * (0.015085 + phi4 * (-0.044475 + 0.028874 * phi2 - 0.005916 * phi4))) - y) /
+            delta = (phi * (1.007226 + phi2 * (0.015085 + phi4 * (-0.044475 + 0.028874 * phi2 - 0.005916 * phi4))) - y) /
                 (1.007226 + phi2 * (0.015085 * 3 + phi4 * (-0.044475 * 7 + 0.028874 * 9 * phi2 - 0.005916 * 11 * phi4)));
+            phi = clamp(phi - delta, -maxPhi, maxPhi);
         } while (Math.abs(delta) > epsilon && --i > 0);
 
         phi2 = phi * phi;
         const lambda = x / (0.8707 + phi2 * (-0.131979 + phi2 * (-0.013791 + phi2 * phi2 * phi2 * (0.003971 - 0.001529 * phi2))));
 
         const lng = clamp(radToDeg(lambda), -180, 180);
-        const lat = clamp(radToDeg(phi), -90, 90);
+        const lat = radToDeg(phi);
 
         return new LngLat(lng, lat);
     }

--- a/src/geo/projection/winkel_tripel.js
+++ b/src/geo/projection/winkel_tripel.js
@@ -1,6 +1,9 @@
 // @flow
 import LngLat from '../lng_lat.js';
 import {clamp, degToRad, radToDeg} from '../../util/util.js';
+import {MAX_MERCATOR_LATITUDE} from '../mercator_coordinate.js';
+
+const maxPhi = degToRad(MAX_MERCATOR_LATITUDE);
 
 export default {
     name: 'winkelTripel',
@@ -54,13 +57,11 @@ export default {
 
             dlambda = (fy * dxdphi - fx * dydphi) / denominator;
             dphi = (fx * dydlambda - fy * dxdlambda) / denominator;
-            lambda -= dlambda;
-            phi -= dphi;
+            lambda = clamp(lambda - dlambda, -Math.PI, Math.PI);
+            phi = clamp(phi - dphi, -maxPhi, maxPhi);
+
         } while ((Math.abs(dlambda) > epsilon || Math.abs(dphi) > epsilon) && --i > 0);
 
-        const lng = clamp(radToDeg(lambda), -180, 180);
-        const lat = clamp(radToDeg(phi), -90, 90);
-
-        return new LngLat(lng, lat);
+        return new LngLat(radToDeg(lambda), radToDeg(phi));
     }
 };


### PR DESCRIPTION
Partially addresses #11179. Currently, when using non-Mercator projections, we apply "constraining to world" behavior when panning/zooming in units as if it were Mercator, leading to a weird mismatch where it's not always possible to pan to an area that's clearly rendering (e.g. southern tip of South America on Albers).

This PR does several things:

- Disables Mercator-based constraining on non-Mercator maps so that we instead rely on projection clamping (map center can't go outside of the rendered world).
- Changes latitude clamping back to maximum Mercator latitude for all projections, since we can't technically render anything beyond that point and clamping to 90 is not good for user experience (e.g. they can pan to empty areas) and can be wonky on edge cases like poles.
- For each projection that has an iterative approach to `unproject` (Natural Earth, Equal Earth, Winkel Tripel), clamping happens on each iteration instead of in the end, because with edge values near poles, approximation can wildly diverge instead of approaching solution, leading to abrupt jumps e.g. from lat -85 to 85.
- For Albers, wraps calculations in a way so that the map doesn't jump if you pan quickly past the anti-meridian.

The only two known issues remaining are:
- Minimum zoom calculation is still Mercator-based — we need to come up with a better heuristic for this, but it's not a deal breaker for user experience.
- Map can behave weirdly on fast panning inertia on low zooms — this needs a separate follow-up fix once we figure out what's wrong. Not a blocker.