### PR TITLE
skip flaky render-tests/video/projected

### DIFF
--- a/debug/projections.html
+++ b/debug/projections.html
@@ -66,10 +66,10 @@
         <fieldset>
             <label>Select projection</label>
             <select id="projection" name="projection">
-                <option value="albers">Albers</option>
+                <option value="albers" selected>Albers</option>
                 <option value="equalEarth">Equal Earth</option>
                 <option value="equirectangular">Equirectangular</option>
-                <option value="lambertConformalConic" selected>
+                <option value="lambertConformalConic">
                     Lambert Conformal Conic
                 </option>
                 <option value="mercator">Mercator</option>
@@ -101,7 +101,7 @@
         </fieldset>
         <fieldset class="conic-param-input">
             <label
-                >Southern Parallel Lat: <span id="lat1-value">30</span></label
+                >Southern Parallel Lat: <span id="lat1-value">29.5</span></label
             >
             <input
                 id="lat1"
@@ -109,12 +109,12 @@
                 min="-90"
                 max="90"
                 step="any"
-                value="30"
+                value="29.5"
             />
         </fieldset>
         <fieldset class="conic-param-input">
             <label
-                >Northern Parallel Lat: <span id="lat2-value">30</span></label
+                >Northern Parallel Lat: <span id="lat2-value">45.5</span></label
             >
             <input
                 id="lat2"
@@ -122,7 +122,7 @@
                 min="-90"
                 max="90"
                 step="any"
-                value="30"
+                value="45.5"
             />
         </fieldset>
         <fieldset>
@@ -144,9 +144,7 @@ const map = new mapboxgl.Map({
     zoom: 0,
     center: [0, 1],
     projection: {
-        name: 'lambertConformalConic',
-        center: [0, 30],
-        parallels: [30, 30]
+        name: 'albers'
     }
 });
 

--- a/test/ignores.json
+++ b/test/ignores.json
@@ -1,7 +1,7 @@
 {
   "query-tests/regressions/mapbox-gl-js#4494": "https://github.com/mapbox/mapbox-gl-js/issues/2716",
   "render-tests/background-pattern/projected": "skip - patterns not working with projections",
-  "render-tests/fill-pattern/projected": "skip - patterns not working with projections",
+  "render-tests/fill-pattern/projected": "https://github.com/mapbox/mapbox-gl-js/issues/11221",
   "render-tests/debug/tile": "skip - inconsistent text rendering with canvas on different platforms",
   "render-tests/debug/tile-overscaled": "skip - inconsistent text rendering with canvas on different platforms",
   "render-tests/fill-extrusion-pattern/1.5x-on-1x-add-image": "skip - non-deterministic on AMD graphics cards",
@@ -38,5 +38,6 @@
   "render-tests/fill-extrusion-terrain/flat-roof-over-border-of-different-zoom-zoomin": "skip - https://github.com/mapbox/mapbox-gl-js/issues/11041",
   "render-tests/fill-extrusion-terrain/flat-roof-over-border-of-different-zoom": "skip - https://github.com/mapbox/mapbox-gl-js/issues/11041",
   "render-tests/text-variable-anchor/pitched": "skip - non-deterministic symbol placement on tile boundaries",
+  "render-tests/video/projected": "https://github.com/mapbox/mapbox-gl-js/issues/11234",
   "query-tests/terrain/draped/lines/slope-occlusion-box-query": "skip - non-deterministic"
 }


### PR DESCRIPTION
ref https://github.com/mapbox/mapbox-gl-js/issues/11234

Skip the flaky video/projected render test.

And unrelatedly, switch the projections debug page to default to albers.