### PR TITLE
Globe View: Add wireframe mode + reduce vertex resolution

### DIFF
--- a/src/shaders/globe_raster.vertex.glsl
+++ b/src/shaders/globe_raster.vertex.glsl
@@ -11,12 +11,18 @@ attribute vec2 a_uv;
 
 varying vec2 v_pos0;
 
+const float wireframeOffset = 1e3;
+
 void main() {
     v_pos0 = a_uv;
 
     vec2 uv = a_uv * EXTENT;
     vec4 up_vector = u_up_vector_matrix * vec4(elevationVector(uv), 1.0);
     float height = elevation(uv);
+
+#ifdef TERRAIN_WIREFRAME
+    height += wireframeOffset;
+#endif
 
     vec4 globe = u_globe_matrix * vec4(a_globe_pos + up_vector.xyz * height, 1.0);
 


### PR DESCRIPTION
- Use GLOBE_VERTEX_GRID_SIZE = 64 (instead of 128) and consolidate vertex buffer functions in GlobeSharedBuffers struct
This uses the same vertex grid size as gl-native, refer: mapbox/mapbox-gl-native-internal#2348
- Add support for globe wireframe mode to debug the change

<img width="1019" alt="Screen Shot 2021-11-05 at 8 19 23 AM" src="https://user-images.githubusercontent.com/7061573/140534833-8e482ca3-b032-4beb-8daa-b4f75f1c5796.png">