### PR TITLE
Skip rendering of fully clipped symbol buckets

### DIFF
--- a/src/data/bucket/symbol_bucket.js
+++ b/src/data/bucket/symbol_bucket.js
@@ -327,6 +327,7 @@ class SymbolBucket implements Bucket {
     bucketInstanceId: number;
     justReloaded: boolean;
     hasPattern: boolean;
+    fullyClipped: boolean;
 
     textSizeData: SizeData;
     iconSizeData: SizeData;
@@ -374,6 +375,7 @@ class SymbolBucket implements Bucket {
         this.sourceLayerIndex = options.sourceLayerIndex;
         this.hasPattern = false;
         this.hasRTLText = false;
+        this.fullyClipped = false;
         this.sortKeyRanges = [];
 
         this.collisionCircleArray = [];

--- a/src/render/draw_symbol.js
+++ b/src/render/draw_symbol.js
@@ -260,7 +260,7 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         const bucket: SymbolBucket = (tile.getBucket(layer): any);
         if (!bucket) continue;
         const buffers = isText ? bucket.text : bucket.icon;
-        if (!buffers || !buffers.segments.get().length) continue;
+        if (!buffers || bucket.fullyClipped || !buffers.segments.get().length) continue;
         const programConfiguration = buffers.programConfigurations.get(layer.id);
 
         const isSDF = isText || bucket.sdfIcons;

--- a/src/symbol/placement.js
+++ b/src/symbol/placement.js
@@ -945,6 +945,8 @@ export class Placement {
             }
         };
 
+        let visibleInstanceCount = 0;
+
         for (let s = 0; s < bucket.symbolInstances.length; s++) {
             const symbolInstance = bucket.symbolInstances.get(s);
             const {
@@ -972,6 +974,7 @@ export class Placement {
             const placedOrientation = this.placedOrientations[symbolInstance.crossTileID];
             const horizontalHidden = placedOrientation === WritingMode.vertical;
             const verticalHidden = placedOrientation === WritingMode.horizontal || placedOrientation === WritingMode.horizontalOnly;
+            if ((hasText || hasIcon) && !opacityState.isHidden()) visibleInstanceCount++;
 
             if (hasText) {
                 const packedOpacity = packOpacity(opacityState.text);
@@ -1088,7 +1091,7 @@ export class Placement {
                 }
             }
         }
-
+        bucket.fullyClipped = visibleInstanceCount === 0;
         bucket.sortFeatures(this.transform.angle);
         if (this.retainedQueryData[bucket.bucketInstanceId]) {
             this.retainedQueryData[bucket.bucketInstanceId].featureSortOrder = bucket.featureSortOrder;


### PR DESCRIPTION
Fixes #11227

With the introduction of `pitch` and `distance-from-center` expressions, its now far more likely that `Placement` completely hides every symbol in the tile.
This PR adds a change that tracks that, and skips the rendering of the tile as a performance optimization.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] post benchmark scores
 - [x] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
