### PR TITLE
Globe View: Remove globe specific code path from Mercator

### DIFF
--- a/src/geo/projection/globe.js
+++ b/src/geo/projection/globe.js
@@ -133,10 +133,6 @@ class GlobeTileTransform {
         return pixelsPerMeterECEF * maxTileScale;
     }
 
-    tileSpaceUpVectorScale(): number {
-        return mercatorZfromAltitude(1, this._tr.center.lat) * this._tr.worldSize;
-    }
-
     _calculateGlobeMatrix() {
         const localRadius = EXTENT / (2.0 * Math.PI);
         const wsRadius = this._worldSize / (2.0 * Math.PI);

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -5,6 +5,8 @@ import {mat4, vec3} from 'gl-matrix';
 import {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id.js';
 import {Aabb} from '../../util/primitives.js';
 import Transform from '../transform.js';
+import LngLat from '../lng_lat.js';
+import Point from '@mapbox/point-geometry';
 import MercatorCoordinate from '../mercator_coordinate.js';
 
 export type TileTransform = {
@@ -27,13 +29,15 @@ export type TileTransform = {
 
 export type Projection = {
     name: string,
-    project: (lng: number, lat: number) => {x: number, y: number, z: number},
-
-    projectTilePoint: (x: number, y: number, id: CanonicalTileID) => {x: number, y: number, z: number},
-
     requiresDraping: boolean,
     supportsWorldCopies: boolean,
     zAxisUnit: "meters" | "pixels",
+
+    project: (lng: number, lat: number) => {x: number, y: number, z: number},
+
+    locationPoint: (tr: Transform, lngLat: LngLat) => Point,
+
+    projectTilePoint: (x: number, y: number, id: CanonicalTileID) => {x: number, y: number, z: number},
 
     pixelsPerMeter: (lat: number, worldSize: number) => number,
 

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -22,9 +22,7 @@ export type TileTransform = {
 
     upVectorScale: (id: CanonicalTileID) => number,
 
-    pointCoordinate: (x: number, y: number, z?: number) => MercatorCoordinate,
-
-    tileSpaceUpVectorScale: () => number
+    pointCoordinate: (x: number, y: number, z?: number) => MercatorCoordinate
 };
 
 export type Projection = {

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -2,6 +2,7 @@
 import assert from 'assert';
 import {mat4, vec3} from 'gl-matrix';
 import {clamp} from '../../util/util.js';
+import LngLat from '../lng_lat.js';
 import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from '../mercator_coordinate.js';
 import EXTENT from '../../data/extent.js';
 import type Transform from '../../geo/transform.js';
@@ -98,6 +99,9 @@ class MercatorTileTransform {
 
 export default {
     name: 'mercator',
+    requiresDraping: false,
+    supportsWorldCopies: true,
+    zAxisUnit: "meters",
 
     project(lng: number, lat: number) {
         const x = mercatorXfromLng(lng);
@@ -109,9 +113,9 @@ export default {
         return {x, y, z: 0};
     },
 
-    requiresDraping: false,
-    supportsWorldCopies: true,
-    zAxisUnit: "meters",
+    locationPoint(tr: Transform, lngLat: LngLat): Point {
+        return tr._coordinatePoint(tr.locationCoordinate(lngLat), false);
+    },
 
     pixelsPerMeter(lat: number, worldSize: number) {
         return mercatorZfromAltitude(1, lat) * worldSize;

--- a/src/geo/projection/mercator.js
+++ b/src/geo/projection/mercator.js
@@ -94,10 +94,6 @@ class MercatorTileTransform {
     upVectorScale(): number {
         return 1;
     }
-
-    tileSpaceUpVectorScale(): number {
-        return 1;
-    }
 }
 
 export default {

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -952,7 +952,7 @@ class Transform {
      * @private
      */
     locationPoint(lnglat: LngLat) {
-        return this._coordinatePoint(this.locationCoordinate(lnglat), false);
+        return this.projection.locationPoint(this, lnglat);
     }
 
     /**
@@ -1292,44 +1292,6 @@ class Transform {
         };
 
         return cache[distanceDataKey];
-    }
-
-    calculateGlobeMatrix(worldSize: number): mat4 {
-        const localRadius = EXTENT / (2.0 * Math.PI);
-        const wsRadius = worldSize / (2.0 * Math.PI);
-        const s = wsRadius / localRadius;
-
-        const lat = clamp(this.center.lat, -this.maxValidLatitude, this.maxValidLatitude);
-        const point = new Point(
-            mercatorXfromLng(this.center.lng) * worldSize,
-            mercatorYfromLat(lat) * worldSize);
-
-        // transform the globe from reference coordinate space to world space
-        const posMatrix = mat4.identity(new Float64Array(16));
-        mat4.translate(posMatrix, posMatrix, [point.x, point.y, -wsRadius]);
-        mat4.scale(posMatrix, posMatrix, [s, s, s]);
-        mat4.rotateX(posMatrix, posMatrix, degToRad(-this._center.lat));
-        mat4.rotateY(posMatrix, posMatrix, degToRad(-this._center.lng));
-
-        return posMatrix;
-    }
-
-    calculateGlobeMercatorMatrix(worldSize: number): mat4 {
-        const lat = clamp(this.center.lat, -this.maxValidLatitude, this.maxValidLatitude);
-        const point = new Point(
-            mercatorXfromLng(this.center.lng) * worldSize,
-            mercatorYfromLat(lat) * worldSize);
-
-        const mercatorZ = mercatorZfromAltitude(1, this.center.lat) * worldSize;
-        const projectionScaler = mercatorZ / this.pixelsPerMeter;
-        const zScale = this.pixelsPerMeter;
-        const ws = worldSize / projectionScaler;
-
-        const posMatrix = mat4.identity(new Float64Array(16));
-        mat4.translate(posMatrix, posMatrix, [point.x, point.y, 0.0]);
-        mat4.scale(posMatrix, posMatrix, [ws, ws, zScale]);
-
-        return posMatrix;
     }
 
     /**

--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -17,7 +17,6 @@ import type {Projection} from '../geo/projection/index.js';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
 import type {Elevation} from '../terrain/elevation.js';
 import type {PaddingOptions} from './edge_insets.js';
-import {latLngToECEF} from './projection/globe.js';
 import type {FeatureDistanceData} from '../style-spec/feature_filter/index.js';
 
 const NUM_WORLD_COPIES = 3;
@@ -954,19 +953,6 @@ class Transform {
      */
     locationPoint(lnglat: LngLat) {
         return this._coordinatePoint(this.locationCoordinate(lnglat), false);
-    }
-
-    locationPointGlobe(lnglat: LngLat) {
-        const ecefLoc = latLngToECEF(lnglat.lat, lnglat.lng);
-        const up = vec3.normalize([], ecefLoc);
-        const elevation = this.elevation ? this.elevation.getAtPointOrZero(this.locationCoordinate(lnglat), this._centerAltitude) : this._centerAltitude;
-        vec3.scaleAndAdd(ecefLoc, ecefLoc, up, mercatorZfromAltitude(1, 0.0) * 8192.0 * elevation);
-        const matrix = this.calculateGlobeMatrix(this.worldSize);
-        mat4.multiply(matrix, this.pixelMatrix, matrix);
-
-        const p = [...ecefLoc, 1.0];
-        vec3.transformMat4(p, p, matrix);
-        return new Point(p[0], p[1]);
     }
 
     /**

--- a/src/render/draw_sky.js
+++ b/src/render/draw_sky.js
@@ -7,6 +7,7 @@ import CullFaceMode from '../gl/cull_face_mode.js';
 import Context from '../gl/context.js';
 import Texture from './texture.js';
 import Program from './program.js';
+import {calculateGlobeMatrix} from './../geo/projection/globe.js';
 import type SourceCache from '../source/source_cache.js';
 import SkyboxGeometry from './skybox_geometry.js';
 import {skyboxUniformValues, skyboxGradientUniformValues} from './program/skybox_program.js';
@@ -28,10 +29,9 @@ function drawGlobeAtmosphere(painter: Painter) {
     const program = painter.useProgram('globeAtmosphere');
 
     // Compute center and approximate radius of the globe on screen coordinates
-    const globeMatrix = transform.calculateGlobeMatrix(transform.worldSize);
     const viewMatrix = transform._camera.getWorldToCamera(transform.worldSize, 1.0);
     const viewToProj = transform._camera.getCameraToClipPerspective(transform._fov, transform.width / transform.height, transform._nearZ, transform._farZ);
-    const globeToView = mat4.mul([], viewMatrix, globeMatrix);
+    const globeToView = mat4.mul([], viewMatrix, calculateGlobeMatrix(transform, transform.worldSize));
     const viewToScreen = mat4.mul([], transform.labelPlaneMatrix, viewToProj);
 
     const centerOnViewSpace = vec3.transformMat4([], [0, 0, 0], globeToView);

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -21,7 +21,9 @@ import {
     tileBoundsOnGlobe,
     denormalizeECEF,
     globeToMercatorTransition,
-    GlobeSharedBuffers
+    GlobeSharedBuffers,
+    calculateGlobeMatrix,
+    calculateGlobeMercatorMatrix
 } from '../geo/projection/globe.js';
 import extend from '../style-spec/util/extend.js';
 
@@ -222,8 +224,8 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
     const depthMode = new DepthMode(gl.LEQUAL, DepthMode.ReadWrite, painter.depthRangeFor3D);
     vertexMorphing.update(now);
     const tr = painter.transform;
-    const globeMatrix = tr.calculateGlobeMatrix(tr.worldSize);
-    const globeMercatorMatrix = tr.calculateGlobeMercatorMatrix(tr.worldSize);
+    const globeMatrix = calculateGlobeMatrix(tr, tr.worldSize);
+    const globeMercatorMatrix = calculateGlobeMercatorMatrix(tr);
     const mercatorCenter = [mercatorXfromLng(tr.center.lng), mercatorYfromLat(tr.center.lat)];
     const batches = showWireframe ? [false, true] : [false];
     const sharedBuffers = painter.globeSharedBuffers;
@@ -396,8 +398,8 @@ function drawTerrainDepth(painter: Painter, terrain: Terrain, sourceCache: Sourc
         context.clear({depth: 1});
         const program = painter.useProgram('globeDepth');
         const depthMode = new DepthMode(gl.LESS, DepthMode.ReadWrite, painter.depthRangeFor3D);
-        const globeMercatorMatrix = tr.calculateGlobeMercatorMatrix(tr.worldSize);
-        const globeMatrix = tr.calculateGlobeMatrix(tr.worldSize);
+        const globeMercatorMatrix = calculateGlobeMercatorMatrix(tr);
+        const globeMatrix = calculateGlobeMatrix(tr, tr.worldSize);
         const mercatorCenter = [mercatorXfromLng(tr.center.lng), mercatorYfromLat(tr.center.lat)];
         const sharedBuffers = painter.globeSharedBuffers;
 

--- a/src/terrain/draw_terrain_raster.js
+++ b/src/terrain/draw_terrain_raster.js
@@ -1,6 +1,5 @@
 // @flow
 
-import {mat4} from 'gl-matrix';
 import DepthMode from '../gl/depth_mode.js';
 import CullFaceMode from '../gl/cull_face_mode.js';
 import {terrainRasterUniformValues} from './terrain_raster_program.js';
@@ -8,9 +7,7 @@ import {globeRasterUniformValues} from './globe_raster_program.js';
 import {Terrain} from './terrain.js';
 import Tile from '../source/tile.js';
 import assert from 'assert';
-import type VertexBuffer from '../gl/vertex_buffer.js';
-import {members as globeLayoutAttributes} from './globe_attributes.js';
-import {easeCubicInOut, degToRad} from '../util/util.js';
+import {easeCubicInOut} from '../util/util.js';
 import {mercatorXfromLng, mercatorYfromLat} from '../geo/mercator_coordinate.js';
 import type Painter from '../render/painter.js';
 import type SourceCache from '../source/source_cache.js';
@@ -18,12 +15,13 @@ import {OverscaledTileID, CanonicalTileID} from '../source/tile_id.js';
 import StencilMode from '../gl/stencil_mode.js';
 import ColorMode from '../gl/color_mode.js';
 import {
-    tileBoundsOnGlobe,
-    denormalizeECEF,
-    globeToMercatorTransition,
-    GlobeSharedBuffers,
     calculateGlobeMatrix,
-    calculateGlobeMercatorMatrix
+    calculateGlobeMercatorMatrix,
+    globeBuffersForTileMesh,
+    globeToMercatorTransition,
+    globeMatrixForTile,
+    globeUpVectorMatrix,
+    globePoleMatrixForTile
 } from '../geo/projection/globe.js';
 import extend from '../style-spec/util/extend.js';
 
@@ -137,69 +135,6 @@ const shaderDefines = {
     "2": 'TERRAIN_WIREFRAME'
 };
 
-function prepareGlobeBuffersForTileMesh(painter: Painter, tile: Tile, coord: OverscaledTileID, tiles: number): [VertexBuffer, VertexBuffer] {
-    const context = painter.context;
-    const id = coord.canonical;
-    const tr = painter.transform;
-    let gridBuffer = tile.globeGridBuffer;
-    let poleBuffer = tile.globePoleBuffer;
-
-    if (!gridBuffer) {
-        const gridMesh = GlobeSharedBuffers.createGridVertices(id.x, id.y, id.z);
-        gridBuffer = tile.globeGridBuffer = context.createVertexBuffer(gridMesh, globeLayoutAttributes, false);
-    }
-
-    if (!poleBuffer) {
-        const poleMesh = GlobeSharedBuffers.createPoleTriangleVertices(tiles, tr.tileSize * tiles, coord.canonical.y === 0);
-        poleBuffer = tile.globePoleBuffer = context.createVertexBuffer(poleMesh, globeLayoutAttributes, false);
-    }
-
-    return [gridBuffer, poleBuffer];
-}
-
-function globeMatrixForTile(id: CanonicalTileID, globeMatrix) {
-    const gridTileId = new CanonicalTileID(id.z, Math.pow(2, id.z) / 2, id.y);
-    const bounds = tileBoundsOnGlobe(gridTileId);
-    const decode = denormalizeECEF(bounds);
-    const posMatrix = mat4.clone(globeMatrix);
-    mat4.mul(posMatrix, posMatrix, decode);
-
-    return posMatrix;
-}
-
-function globeUpVectorMatrix(id: CanonicalTileID, tiles: number) {
-    // Tile up vectors and can be reused for each tiles on the same x-row.
-    // i.e. for each tile id (x, y, z) use pregenerated mesh of (0, y, z).
-    // For this reason the up vectors are rotated first by 'yRotation' to
-    // place them in the correct longitude location.
-    const xOffset = id.x - tiles / 2;
-    const yRotation = xOffset / tiles * Math.PI * 2.0;
-    return mat4.fromYRotation([], yRotation);
-}
-
-function poleMatrixForTile(id: CanonicalTileID, south, tr) {
-    const poleMatrix = mat4.identity(new Float64Array(16));
-
-    const tileDim = Math.pow(2, id.z);
-    const xOffset = id.x - tileDim / 2;
-    const yRotation = xOffset / tileDim * Math.PI * 2.0;
-
-    const point = tr.point;
-    const ws = tr.worldSize;
-    const s = tr.worldSize / (tr.tileSize * tileDim);
-
-    mat4.translate(poleMatrix, poleMatrix, [point.x, point.y, -(ws / Math.PI / 2.0)]);
-    mat4.scale(poleMatrix, poleMatrix, [s, s, s]);
-    mat4.rotateX(poleMatrix, poleMatrix, degToRad(-tr._center.lat));
-    mat4.rotateY(poleMatrix, poleMatrix, degToRad(-tr._center.lng));
-    mat4.rotateY(poleMatrix, poleMatrix, yRotation);
-    if (south) {
-        mat4.scale(poleMatrix, poleMatrix, [1, -1, 1]);
-    }
-
-    return poleMatrix;
-}
-
 function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: SourceCache, tileIDs: Array<OverscaledTileID>, now: number) {
     const context = painter.context;
     const gl = context.gl;
@@ -241,7 +176,7 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
         for (const coord of tileIDs) {
             const tile = sourceCache.getTile(coord);
             const tiles = Math.pow(2, coord.canonical.z);
-            const [gridBuffer, poleBuffer] = prepareGlobeBuffersForTileMesh(painter, tile, coord, tiles);
+            const [gridBuffer, poleBuffer] = globeBuffersForTileMesh(painter, tile, coord, tiles);
             const stencilMode = StencilMode.disabled;
 
             const prevDemTile = terrain.prevTerrainTileForTile[coord.key];
@@ -291,8 +226,8 @@ function drawTerrainForGlobe(painter: Painter, terrain: Terrain, sourceCache: So
             if (!isWireframe) {
                 // Fill poles by extrapolating adjacent border tiles
                 const poleMatrices = [
-                    coord.canonical.y === 0 ? poleMatrixForTile(coord.canonical, false, tr) : null,
-                    coord.canonical.y === tiles - 1 ? poleMatrixForTile(coord.canonical, true, tr) : null
+                    coord.canonical.y === 0 ? globePoleMatrixForTile(coord.canonical, false, tr) : null,
+                    coord.canonical.y === tiles - 1 ? globePoleMatrixForTile(coord.canonical, true, tr) : null
                 ];
 
                 for (const poleMatrix of poleMatrices) {
@@ -407,7 +342,7 @@ function drawTerrainDepth(painter: Painter, terrain: Terrain, sourceCache: Sourc
             const tile = sourceCache.getTile(coord);
             const tiles = Math.pow(2, coord.canonical.z);
 
-            const [gridBuffer] = prepareGlobeBuffersForTileMesh(painter, tile, coord, tiles);
+            const [gridBuffer] = globeBuffersForTileMesh(painter, tile, coord, tiles);
 
             const gridTileId = new CanonicalTileID(coord.canonical.z, tiles / 2, coord.canonical.y);
             const elevationOptions = {elevationTileID: gridTileId};

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -1152,8 +1152,7 @@ class Camera extends Evented {
 
         if (options.around) {
             around = LngLat.convert(options.around);
-            //aroundPoint = tr.locationPoint(around);
-            aroundPoint = tr.locationPointGlobe(around);
+            aroundPoint = tr.locationPoint(around);
         }
 
         const currently = {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2396,7 +2396,7 @@ class Map extends Camera {
         this._transitionFromGlobe = false;
 
         if (projection.requiresDraping) {
-            this._setTerrain({source: 'mapbox-dem', exaggeration: 5.0}, "projection");
+            this._setTerrain({source: 'mapbox-dem', exaggeration: 0.0}, "projection");
         } else {
             this._setTerrain(null, "projection");
         }

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -2396,7 +2396,7 @@ class Map extends Camera {
         this._transitionFromGlobe = false;
 
         if (projection.requiresDraping) {
-            this._setTerrain({source: 'mapbox-dem', exaggeration: 0.0}, "projection");
+            this._setTerrain({source: 'mapbox-dem', exaggeration: 5.0}, "projection");
         } else {
             this._setTerrain(null, "projection");
         }

--- a/test/unit/ui/camera.test.js
+++ b/test/unit/ui/camera.test.js
@@ -503,7 +503,7 @@ test('camera', (t) => {
             const camera = createCamera();
             camera.zoomTo(3.2, {around: [5, 0], duration: 0});
             t.equal(camera.getZoom(), 3.2);
-            t.deepEqual(fixedLngLat(camera.getCenter()), fixedLngLat({lng: 4.456596223, lat: 0}));
+            t.deepEqual(fixedLngLat(camera.getCenter()), fixedLngLat({lng: 4.455905898, lat: 0}));
             t.end();
         });
 
@@ -566,7 +566,7 @@ test('camera', (t) => {
             const camera = createCamera({zoom: 3});
             camera.rotateTo(90, {around: [5, 0], duration: 0});
             t.equal(camera.getBearing(), 90);
-            t.deepEqual(fixedLngLat(camera.getCenter()), fixedLngLat({lng: 5, lat: 4.987344483}));
+            t.deepEqual(fixedLngLat(camera.getCenter()), fixedLngLat({lng: 5, lat: 4.993665859}));
             t.end();
         });
 
@@ -670,15 +670,13 @@ test('camera', (t) => {
             t.end();
         });
 
-        // eslint-disable-next-line no-warning-comments
-        // FIXME(globe-view)
-        // t.test('zooms around a point', (t) => {
-        //     const camera = createCamera();
-        //     camera.easeTo({around: [100, 0], zoom: 3, duration: 0});
-        //     t.deepEqual(fixedLngLat(camera.getCenter()), fixedLngLat({lng: 87.5, lat: 0}));
-        //     t.equal(camera.getZoom(), 3);
-        //     t.end();
-        // });
+        t.test('zooms around a point', (t) => {
+            const camera = createCamera();
+            camera.easeTo({around: [100, 0], zoom: 3, duration: 0});
+            t.deepEqual(fixedLngLat(camera.getCenter()), fixedLngLat({lng: 87.5, lat: 0}));
+            t.equal(camera.getZoom(), 3);
+            t.end();
+        });
 
         t.test('pans and rotates', (t) => {
             const camera = createCamera();


### PR DESCRIPTION
One last PR before continuing with the rebase, to remove all globe specific code from the default code path and the transform class:
- Remove and inline GlobeTile class:
  - Now interpolation vector directly used in `upVector`, removing an extraneous object creation
- Remove unused `tileSpaceUpVectorScale` from common interface
- Share code between `TileTransform::_calculateGlobeMatrix` and `transform.calculateGlobeMatrix`
  - Also removes globe specific code from transform
- Move `calculateGlobeMatrix`, `calculateGlobeMercatorMatrix`, `globeBuffersForTileMesh`, `globeMatrixForTile`, `globeUpVectorMatrix` and `globePoleMatrixForTile`. We may find a better place for this as we should avoid any rendering specific there, but this consolidates it for now.
- Add `locationPoint` to common projection interface, and remove globe specific code path from gesture code. This removes all globe specific code from the transform class and resolves a FIXME unit test.