### PR TITLE
Added function call chaining to function `map.setProjection`

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1009,6 +1009,7 @@ class Map extends Camera {
      *
      * @param {ProjectionSpecification | string | null | undefined} projection The projection that the map should be rendered in.
      * This can be a {@link ProjectionSpecification} object or a string of the projection's name.
+     * @returns {Map} Returns itself to allow for method chaining.
      * @example
      * map.setProjection('albers');
      * map.setProjection({
@@ -1024,6 +1025,7 @@ class Map extends Camera {
         }
         this._runtimeProjection = projection;
         this.style.updateProjection();
+        return this;
     }
 
     /**


### PR DESCRIPTION
Addresses #11277.
The `map.setProjection` functions now return a map object to allow for function call chaining.


 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] manually test the debug page
