### PR TITLE
Write expected.png on UPDATE=1

### DIFF
--- a/test/integration/lib/query.js
+++ b/test/integration/lib/query.js
@@ -149,7 +149,7 @@ async function runTest(t) {
             ];
         }
 
-        if (!process.env.CI) browserWriteFile.postMessage(fileInfo);
+        if (!process.env.CI || process.env.UPDATE) browserWriteFile.postMessage(fileInfo);
 
     } catch (e) {
         t.error(e);

--- a/test/integration/lib/render.js
+++ b/test/integration/lib/render.js
@@ -310,7 +310,7 @@ async function runTest(t) {
             updateHTML(testMetaData);
         }
 
-        if (!process.env.CI) browserWriteFile.postMessage(fileInfo);
+        if (!process.env.CI || process.env.UPDATE) browserWriteFile.postMessage(fileInfo);
 
     } catch (e) {
         t.error(e);


### PR DESCRIPTION
Addresses #11160 by writing `expected.png` when running tests with `UPDATE=1`. Not sure if it's sufficient to close the issue, but it fixes a pain point when adding new render tests.